### PR TITLE
Add additional guards and simplify class -> topic redirection

### DIFF
--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -4,7 +4,6 @@ import { UserKinds } from '../../constants';
 export const baseSessionState = {
   app_context: false,
   can_manage_content: false,
-  can_access_unassigned_content: false,
   facility_id: undefined,
   full_name: '',
   id: undefined,
@@ -38,9 +37,6 @@ export default {
     },
     canManageContent(state) {
       return state.can_manage_content;
-    },
-    canAccessUnassignedContent(state, getters) {
-      return state.can_access_unassigned_content && getters.allowAccess;
     },
     isSuperuser(state) {
       return state.kind.includes(UserKinds.SUPERUSER);

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -69,7 +69,6 @@ from .permissions.general import IsOwn
 from .permissions.general import IsSelf
 from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
-from kolibri.core.device.utils import allow_learner_unassigned_resource_access
 from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import set_device_settings
@@ -493,10 +492,6 @@ class KolibriAbstractBaseUser(AbstractBaseUser):
             "Subclasses of KolibriAbstractBaseUser must override the `can_delete` method."
         )
 
-    @property
-    def can_access_unassigned_content(self):
-        return allow_learner_unassigned_resource_access()
-
 
 class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
     """
@@ -514,7 +509,6 @@ class KolibriAnonymousUser(AnonymousUser, KolibriAbstractBaseUser):
             "user_id": None,
             "facility_id": getattr(Facility.get_default_facility(), "id", None),
             "kind": [user_kinds.ANONYMOUS],
-            "can_access_unassigned_content": self.can_access_unassigned_content,
         }
 
     def is_member_of(self, coll):
@@ -730,18 +724,12 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
         if not roles:
             roles = [user_kinds.LEARNER]
 
-        can_access_unassigned_content = self.can_access_unassigned_content
-
-        if len(set(roles).difference({user_kinds.LEARNER, user_kinds.ANONYMOUS})) > 0:
-            can_access_unassigned_content = True
-
         return {
             "username": self.username,
             "full_name": self.full_name,
             "user_id": self.id,
             "kind": roles,
             "can_manage_content": self.can_manage_content,
-            "can_access_unassigned_content": can_access_unassigned_content,
             "facility_id": self.facility_id,
         }
 

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
@@ -20,3 +20,12 @@ export function pageMode(state) {
   }
   return undefined;
 }
+
+export function canAccessUnassignedContent(state, getters) {
+  return (
+    state.canAccessUnassignedContentSetting ||
+    getters.isCoach ||
+    getters.isAdmin ||
+    getters.isSuperUser
+  );
+}

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -11,12 +11,15 @@ import search from './search';
 import topicsRoot from './topicsRoot';
 import topicsTree from './topicsTree';
 
+import plugin_data from 'plugin_data';
+
 export default {
   state: {
     pageName: '',
     examAttemptLogs: {},
     examLog: {},
     memberships: [],
+    canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
   },
   actions,
   getters,

--- a/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
@@ -1,17 +1,29 @@
 import store from 'kolibri.coreVue.vuex.store';
-import { ClassesPageNames } from '../constants';
+import router from 'kolibri.coreVue.router';
+import { ClassesPageNames, PageNames } from '../constants';
 import { showLessonPlaylist, showLessonResourceViewer } from '../modules/lessonPlaylist/handlers';
 import { showClassAssignmentsPage } from '../modules/classAssignments/handlers';
 import { showAllClassesPage } from '../modules/classes/handlers';
 import { showExam } from '../modules/examViewer/handlers';
 import { showExamReport } from '../modules/examReportViewer/handlers';
 
+function noClassesGuard() {
+  const { memberships } = store.state;
+  const { canAccessUnassignedContent } = store.getters;
+  if (memberships.length === 0 && canAccessUnassignedContent) {
+    // If there are no memberships and it is allowed, redirect to topics page
+    return router.replace({ name: PageNames.TOPICS_ROOT });
+  }
+  // Otherwise return nothing
+  return;
+}
+
 export default [
   {
     name: ClassesPageNames.ALL_CLASSES,
     path: '/classes',
     handler: () => {
-      return showAllClassesPage(store);
+      return noClassesGuard() || showAllClassesPage(store);
     },
   },
   {
@@ -19,7 +31,7 @@ export default [
     path: '/classes/:classId',
     handler: toRoute => {
       const { classId } = toRoute.params;
-      return showClassAssignmentsPage(store, classId);
+      return noClassesGuard() || showClassAssignmentsPage(store, classId);
     },
   },
   {
@@ -27,13 +39,16 @@ export default [
     path: '/classes/:classId/lesson/:lessonId',
     handler: toRoute => {
       const { classId, lessonId } = toRoute.params;
-      return showLessonPlaylist(store, { classId, lessonId });
+      return noClassesGuard() || showLessonPlaylist(store, { classId, lessonId });
     },
   },
   {
     name: ClassesPageNames.LESSON_RESOURCE_VIEWER,
     path: '/classes/:classId/lesson/:lessonId/item/:resourceNumber',
     handler: toRoute => {
+      if (noClassesGuard()) {
+        return noClassesGuard();
+      }
       const { lessonId, resourceNumber } = toRoute.params;
       showLessonResourceViewer(store, { lessonId, resourceNumber });
     },
@@ -42,6 +57,9 @@ export default [
     name: ClassesPageNames.EXAM_VIEWER,
     path: '/classes/:classId/exam/:examId/:questionNumber',
     handler: (toRoute, fromRoute) => {
+      if (noClassesGuard()) {
+        return noClassesGuard();
+      }
       const alreadyOnQuiz =
         fromRoute.name === ClassesPageNames.EXAM_VIEWER &&
         toRoute.params.examId === fromRoute.params.examId &&
@@ -53,6 +71,9 @@ export default [
     name: ClassesPageNames.EXAM_REPORT_VIEWER,
     path: '/classes/:classId/examReport/:examId/:questionNumber/:questionInteraction',
     handler: toRoute => {
+      if (noClassesGuard()) {
+        return noClassesGuard();
+      }
       showExamReport(store, toRoute.params);
     },
   },

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -18,6 +18,16 @@ import RecommendedPage from '../views/RecommendedPage';
 import RecommendedSubpage from '../views/RecommendedSubpage';
 import classesRoutes from './classesRoutes';
 
+function unassignedContentGuard() {
+  const { canAccessUnassignedContent } = store.getters;
+  if (!canAccessUnassignedContent) {
+    // If there are no memberships and it is allowed, redirect to topics page
+    return router.replace({ name: ClassesPageNames.ALL_CLASSES });
+  }
+  // Otherwise return nothing
+  return;
+}
+
 export default [
   ...classesRoutes,
   {
@@ -40,6 +50,9 @@ export default [
     name: PageNames.TOPICS_ROOT,
     path: '/topics',
     handler: () => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showChannels(store);
     },
   },
@@ -47,6 +60,9 @@ export default [
     name: PageNames.RECOMMENDED,
     path: '/recommended',
     handler: () => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showRecommended(store);
     },
     component: RecommendedPage,
@@ -55,6 +71,9 @@ export default [
     name: PageNames.SEARCH,
     path: '/search',
     handler: toRoute => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showSearch(store, { ...toRoute.query });
     },
   },
@@ -71,6 +90,9 @@ export default [
     name: PageNames.TOPICS_CHANNEL,
     path: '/topics/:channel_id',
     handler: toRoute => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showTopicsChannel(store, toRoute.params.channel_id);
     },
   },
@@ -78,6 +100,9 @@ export default [
     name: PageNames.TOPICS_TOPIC,
     path: '/topics/t/:id',
     handler: toRoute => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showTopicsTopic(store, { id: toRoute.params.id });
     },
   },
@@ -85,6 +110,9 @@ export default [
     name: PageNames.TOPICS_CONTENT,
     path: '/topics/c/:id',
     handler: toRoute => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showTopicsContent(store, toRoute.params.id);
     },
   },
@@ -92,6 +120,9 @@ export default [
     name: PageNames.RECOMMENDED_POPULAR,
     path: '/recommended/popular',
     handler: () => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showPopularPage(store);
     },
     component: RecommendedSubpage,
@@ -100,6 +131,9 @@ export default [
     name: PageNames.RECOMMENDED_RESUME,
     path: '/recommended/resume',
     handler: () => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showResumePage(store);
     },
     component: RecommendedSubpage,
@@ -108,6 +142,9 @@ export default [
     name: PageNames.RECOMMENDED_NEXT_STEPS,
     path: '/recommended/nextsteps',
     handler: () => {
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
       showNextStepsPage(store);
     },
     component: RecommendedSubpage,

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -65,8 +65,7 @@ describe('learn plugin index page', () => {
     store.state.pageName = pageName;
   };
   const setCanAccessUnassignedContent = canAccess => {
-    store.state.core.session.can_access_unassigned_content = canAccess;
-    store.state.core.allowRemoteAccess = canAccess;
+    store.state.canAccessUnassignedContentSetting = canAccess;
   };
 
   beforeEach(() => {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.auth.constants.user_kinds import LEARNER
 from kolibri.core.content.hooks import ContentNodeDisplayHook
+from kolibri.core.device.utils import allow_learner_unassigned_resource_access
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import is_landing_page
 from kolibri.core.device.utils import LANDING_PAGE_LEARN
@@ -47,7 +48,10 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 
     @property
     def plugin_data(self):
-        return {"allowGuestAccess": get_device_setting("allow_guest_access")}
+        return {
+            "allowGuestAccess": get_device_setting("allow_guest_access"),
+            "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
+        }
 
 
 @register_hook


### PR DESCRIPTION
### Summary
* Simplifies logic for unassigned content setting
* Adds router guards for all routes in the classes page to redirect to topics if no memberships and accessing unassigned content is allowed

### Reviewer guidance
* Activate the unassigned content device setting
* Check that being logged in with a user that has no memberships goes to the classes page
* Turn off the unassigned content device setting
* Check that being logged in with a user that has no memberships gets redirected to the topics page
* Check that directly navigating to any classes url in learn also redirects you to the topics page

### References
Fixes #7154

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
