### PR TITLE
DNM: Bump Morango version on 0.13.x to 0.5.4 for use in KDP

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -275,6 +275,11 @@ base_option_spec = {
             "envvars": ("KOLIBRI_HTTP_PORT", "KOLIBRI_LISTEN_PORT"),
         },
         "RUN_MODE": {"type": "string", "envvars": ("KOLIBRI_RUN_MODE",)},
+        "DISABLE_PING": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("KOLIBRI_DISABLE_PING",),
+        },
         "URL_PATH_PREFIX": {
             "type": "string",
             "default": "/",

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -11,6 +11,7 @@ from cherrypy.process.plugins import SimplePlugin
 from django.conf import settings
 
 import kolibri
+from .conf import OPTIONS
 from .system import kill_pid
 from .system import pid_exists
 from kolibri.core.content.utils import paths
@@ -86,10 +87,12 @@ class ServicesPlugin(SimplePlugin):
         # Initialize the iceqube scheduler to handle scheduled tasks
         scheduler.clear_scheduler()
 
-        # schedule the pingback job
-        from kolibri.core.analytics.utils import schedule_ping
+        if not OPTIONS["Deployment"]["DISABLE_PING"]:
 
-        schedule_ping()
+            # schedule the pingback job
+            from kolibri.core.analytics.utils import schedule_ping
+
+            schedule_ping()
 
         # schedule the vacuum job
         schedule_vacuum()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.4.12
+morango==0.5.2
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.4
+morango==0.5.5
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.2
+morango==0.5.4
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5


### PR DESCRIPTION
Need an upgraded version of Morango to fix deserialization woes on KDP, but KDP and 0.14 aren't ready for each other yet.

Opening this PR to get a build asset for use in KDP. Do not merge.