### PR TITLE
Update pyzeroconf to allow for more interruptability and quicker shutdown

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,4 +1,5 @@
 import socket
+import threading
 
 import mock
 from django.test import TransactionTestCase
@@ -46,7 +47,8 @@ class MockZeroconf(Zeroconf):
     def __init__(self, *args, **kwargs):
         self.browsers = {}
         self.services = {}
-        self._GLOBAL_DONE = True
+        self._GLOBAL_DONE = threading.Event()
+        self._GLOBAL_DONE.set()
 
     def get_service_info(self, type_, name, timeout=3000):
         id = _id_from_name(name)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,6 +29,6 @@ semver==2.8.1
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-zeroconf-py2compat==0.19.8
+zeroconf-py2compat==0.19.9
 ifcfg==0.21
 Click==7.0


### PR DESCRIPTION
### Summary
Brings in update to pyzeroconf that allows for more interruptability inside its child threads.
Allows for quicker shutdown of Kolibri as a consequence.

### Reviewer guidance
Ensure that Kolibri properly starts and shuts down.
For more intensive testing see bash commands in the associated issue.

### References
Fixes #6809

Dependency diff: https://github.com/learningequality/python-zeroconf-py2compat/compare/28a8a381cbe6d0903d0801c7bad2d803b09bcd86...learningequality:master

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
