### PR TITLE
Add command to flush sync session data

### DIFF
--- a/kolibri/core/auth/management/commands/flushsyncsessions.py
+++ b/kolibri/core/auth/management/commands/flushsyncsessions.py
@@ -1,0 +1,78 @@
+import logging
+from contextlib import contextmanager
+
+from django.db import transaction
+from django.db.models import Q
+from morango.models import Buffer
+from morango.models import RecordMaxCounterBuffer
+from morango.models import SyncSession
+from morango.models import TransferSession
+
+from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.management.utils import GroupDeletion
+from kolibri.core.auth.utils import confirm_or_exit
+from kolibri.core.tasks.management.commands.base import AsyncCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(AsyncCommand):
+    help = "This command initiates the deletion process for all temporary sync session data."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--noninteractive", action="store_true")
+
+    def handle_async(self, *args, **options):
+        noninteractive = options["noninteractive"]
+
+        if not noninteractive:
+            # ensure the user REALLY wants to do this!
+            confirm_or_exit("Are you sure you wish to delete all sync session data?")
+
+        delete_group = GroupDeletion("Main", sleep=1, groups=self._get_delete_groups())
+
+        with self._delete_context():
+            # run the counting step
+            with self.start_progress(
+                total=delete_group.group_count()
+            ) as update_progress:
+                update_progress(increment=0, message="Counting database objects")
+                total_count = delete_group.count(update_progress)
+
+            # no the deleting step
+            with self.start_progress(total=total_count) as update_progress:
+                update_progress(increment=0, message="Deleting database objects")
+                delete_group.delete(update_progress)
+
+        logger.info("Deletion complete.")
+
+    @contextmanager
+    def _delete_context(self):
+        with DisablePostDeleteSignal(), transaction.atomic():
+            yield
+
+    def _get_delete_groups(self):
+        sync_session_ids = SyncSession.objects.all().values_list("id", flat=True)
+        groups = []
+
+        for sync_session_id in sync_session_ids:
+            transfer_sessions = TransferSession.objects.filter(
+                sync_session_id=sync_session_id
+            )
+            transfer_session_filter = Q(
+                transfer_session_id__in=transfer_sessions.values_list("pk", flat=True)
+            )
+            groups.append(
+                GroupDeletion(
+                    sync_session_id,
+                    querysets=[
+                        RecordMaxCounterBuffer.objects.filter(transfer_session_filter),
+                        Buffer.objects.filter(transfer_session_filter),
+                        transfer_sessions,
+                        SyncSession.objects.filter(id=sync_session_id),
+                    ],
+                )
+            )
+
+        return groups

--- a/kolibri/core/auth/management/commands/flushsyncsessions.py
+++ b/kolibri/core/auth/management/commands/flushsyncsessions.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(AsyncCommand):
-    help = "This command initiates the deletion process for all temporary sync session data."
+    help = "This command initiates the deletion process for temporary sync session buffers."
 
     def add_arguments(self, parser):
         parser.add_argument("--noninteractive", action="store_true")
@@ -25,7 +25,7 @@ class Command(AsyncCommand):
 
         if not noninteractive:
             # ensure the user REALLY wants to do this!
-            confirm_or_exit("Are you sure you wish to delete all sync session data?")
+            confirm_or_exit("Are you sure you wish to delete all sync session buffers?")
 
         delete_group = GroupDeletion("Main", sleep=1, groups=self._get_delete_groups())
 
@@ -58,8 +58,6 @@ class Command(AsyncCommand):
                     querysets=[
                         RecordMaxCounterBuffer.objects.filter(transfer_session_filter),
                         Buffer.objects.filter(transfer_session_filter),
-                        transfer_sessions,
-                        SyncSession.objects.filter(id=sync_session_id),
                     ],
                 )
             )

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -2,6 +2,8 @@
 Utility methods for syncing.
 """
 import getpass
+import logging
+import time
 from functools import wraps
 
 import requests
@@ -21,6 +23,9 @@ from kolibri.core.device.utils import provision_device
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import URLParseError
+
+
+logger = logging.getLogger(__name__)
 
 
 class DisablePostDeleteSignal(object):
@@ -280,3 +285,86 @@ def run_once(f):
 
     wrapper.has_run = False
     return wrapper
+
+
+class GroupDeletion(object):
+    """
+    Helper to manage deleting many models, or groups of models
+    """
+
+    def __init__(self, name, groups=None, querysets=None, sleep=None):
+        """
+        :type groups: GroupDeletion[]
+        :type querysets: QuerySet[]
+        :type sleep: int
+        """
+        self.name = name
+        groups = [] if groups is None else groups
+        if querysets is not None:
+            groups.extend(querysets)
+        self.groups = groups
+        self.sleep = sleep
+
+    def count(self, progress_updater):
+        """
+        :type progress_updater: function
+        :rtype: int
+        """
+        sum = 0
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count = qs.count(progress_updater)
+                logger.debug("Counted {} in group `{}`".format(count, qs.name))
+            else:
+                count = qs.count()
+                progress_updater(increment=1)
+                logger.debug(
+                    "Counted {} of `{}`".format(count, qs.model._meta.model_name)
+                )
+
+            sum += count
+
+        return sum
+
+    def group_count(self):
+        """
+        :rtype: int
+        """
+        return sum(
+            [
+                qs.group_count() if isinstance(qs, GroupDeletion) else 1
+                for qs in self.groups
+            ]
+        )
+
+    def delete(self, progress_updater, sleep=None):
+        """
+        :type progress_updater: function
+        :type sleep: int
+        :rtype: tuple(int, dict)
+        """
+        total_count = 0
+        all_deletions = dict()
+        sleep = self.sleep if sleep is None else sleep
+
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count, deletions = qs.delete(progress_updater)
+                debug_msg = "Deleted {} of `{}` in group `{}`"
+                name = qs.name
+            else:
+                count, deletions = qs.delete()
+                debug_msg = "Deleted {} of `{}` with model `{}`"
+                name = qs.model._meta.model_name
+
+            total_count += count
+            progress_updater(increment=count)
+
+            for obj_name, count in deletions.items():
+                if not isinstance(qs, GroupDeletion):
+                    logger.debug(debug_msg.format(count, obj_name, name))
+                all_deletions.update({obj_name: all_deletions.get(obj_name, 0) + count})
+            if self.sleep is not None:
+                time.sleep(sleep)
+
+        return total_count, all_deletions


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
When sync sessions do not complete properly, they can leave lots of data in the Morango buffers. This is a command that will easily clean those tables.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Run a few syncs, cancelling them after some has transferred, then run this command.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Helps: https://github.com/learningequality/kolibri/issues/7270

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
