### PR TITLE
Add the ability to scroll to a specific part of the page when routing

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -1,5 +1,6 @@
 import VueRouter from 'vue-router';
 import logger from 'kolibri.lib.logging';
+import { result } from 'lodash';
 
 const logging = logger.getLogger(__filename);
 
@@ -30,11 +31,17 @@ class Router {
       return new Promise(resolve => {
         setTimeout(() => {
           document.documentElement.style.scrollBehavior = 'smooth';
-          resolve({ selector: to.params.scrollTo, offset: { y: 60 } });
+          if (typeof to.params.scrollTo === 'string') {
+            // assume that `params.scrollTo` is a selector and that the top header will be shown
+            resolve({ selector: to.params.scrollTo, offset: { y: 70 } });
+          } else {
+            // otherwise assume that `params.scrollTo` is a `scrollBehavior` compatible object
+            result(to.params.scrollTo);
+          }
           setTimeout(() => {
             document.documentElement.style.scrollBehavior = 'auto';
           }, 2000);
-        }, 250);
+        }, 100);
       });
     };
     if (this._vueRouter === null) {

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -1,6 +1,5 @@
 import VueRouter from 'vue-router';
 import logger from 'kolibri.lib.logging';
-import { result } from 'lodash';
 
 const logging = logger.getLogger(__filename);
 
@@ -27,22 +26,13 @@ class Router {
 
   initRouter(options = {}) {
     options.scrollBehavior = to => {
-      // return false;
-      return new Promise(resolve => {
-        setTimeout(() => {
-          document.documentElement.style.scrollBehavior = 'smooth';
-          if (typeof to.params.scrollTo === 'string') {
-            // assume that `params.scrollTo` is a selector and that the top header will be shown
-            resolve({ selector: to.params.scrollTo, offset: { y: 70 } });
-          } else {
-            // otherwise assume that `params.scrollTo` is a `scrollBehavior` compatible object
-            result(to.params.scrollTo);
-          }
-          setTimeout(() => {
-            document.documentElement.style.scrollBehavior = 'auto';
-          }, 2000);
-        }, 100);
-      });
+      if (typeof to.params.scrollTo === 'string') {
+        // assume that `params.scrollTo` is a selector and that the top header will be shown
+        return { selector: to.params.scrollTo, offset: { y: 70 } };
+      } else {
+        // otherwise assume that `params.scrollTo` is a `scrollBehavior` compatible object
+        return to.params.scrollTo;
+      }
     };
     if (this._vueRouter === null) {
       this._vueRouter = new VueRouter(options);

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -26,10 +26,15 @@ class Router {
 
   initRouter(options = {}) {
     options.scrollBehavior = to => {
+      // return false;
       return new Promise(resolve => {
         setTimeout(() => {
-          resolve({ selector: to.params.scrollTo, offset: { y: 70 } });
-        }, 200);
+          document.documentElement.style.scrollBehavior = 'smooth';
+          resolve({ selector: to.params.scrollTo, offset: { y: 60 } });
+          setTimeout(() => {
+            document.documentElement.style.scrollBehavior = 'auto';
+          }, 2000);
+        }, 250);
       });
     };
     if (this._vueRouter === null) {

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -25,6 +25,13 @@ class Router {
   }
 
   initRouter(options = {}) {
+    options.scrollBehavior = to => {
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve({ selector: to.params.scrollTo, offset: { y: 70 } });
+        }, 200);
+      });
+    };
     if (this._vueRouter === null) {
       this._vueRouter = new VueRouter(options);
     }

--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -61,7 +61,7 @@
       resetSkipNextUpdateDebounced() {
         return debounce(() => {
           this.$emit('update:skipNextUpdate', false);
-        }, 100);
+        }, 500);
       },
       classes() {
         return {

--- a/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
+++ b/kolibri/core/assets/src/views/CoreBase/ScrollingHeader.vue
@@ -39,6 +39,11 @@
         type: Boolean,
         default: false,
       },
+      // This can be used to override automatic hiding/showing updates
+      skipNextUpdate: {
+        type: Boolean,
+        default: false,
+      },
     },
     data() {
       return {
@@ -52,6 +57,11 @@
       },
       resetDistanceDebounced() {
         return debounce(this.resetDistance, 500);
+      },
+      resetSkipNextUpdateDebounced() {
+        return debounce(() => {
+          this.$emit('update:skipNextUpdate', false);
+        }, 100);
       },
       classes() {
         return {
@@ -86,6 +96,11 @@
     },
     methods: {
       handleNewScrollPosition(newVal, oldVal) {
+        if (this.skipNextUpdate) {
+          this.resetSkipNextUpdateDebounced();
+          return;
+        }
+
         const delta = newVal - oldVal;
 
         // If delta shouldn't cause a change in isHidden, then do nothing

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -172,12 +172,10 @@
 
   const scrollTo = ({ top, left, behavior }) => {
     document.documentElement.style.scrollBehavior = behavior;
-    setTimeout(() => {
-      window.scrollTo(left, top);
-    }, 10);
-    setTimeout(() => {
-      document.documentElement.style.scrollBehavior = 'auto';
-    }, 2000);
+    // delaying the scrolling is important for preventing glitchy behavior in firefox
+    // setTimeout(() => {
+    window.scrollTo(left ? left : 0, top ? top : 0);
+    // }, delay);
   };
 
   export default {
@@ -508,8 +506,7 @@
         this.updateScrollHeight();
         let scrollPosition = scrollPositions.getScrollPosition();
         if (scrollPosition.querySelector) {
-          scrollPosition.top =
-            this.$el.querySelector(scrollPosition.querySelector).offsetTop - this.headerHeight;
+          scrollPosition.top = this.$el.querySelector(scrollPosition.querySelector).offsetTop - 70;
           console.log('scrolling to', scrollPosition.top);
         }
         this.headerSkipNextUpdate = true;

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -413,8 +413,7 @@
         // the vue-router via `scrollBehavior`.
         if (this.$route.params.scrollTo) {
           // Show the header by default when navigating with a scrollTo parameter.
-          this.headerIsHidden = false;
-          this.headerSkipNextUpdate = true;
+          this.showHeader();
           return;
         }
         // Set a watcher so that if the router sets a new
@@ -481,16 +480,24 @@
           this.$refs.mainWrapper.scrollHeight
         );
       },
+      updateHeaderHidden(isHidden) {
+        // This provides a mechanism to tell the `ScrollingHeader` component to
+        // ignore scroll changes triggered here in `CoreBase` e.g. during usage of
+        // the forward/back buttons.
+
+        this.headerSkipNextUpdate = true;
+        this.headerIsHidden = isHidden;
+      },
+      showHeader() {
+        this.updateHeaderHidden(false);
+      },
       setScroll() {
         this.updateScrollHeight();
         window.scrollTo(0, scrollPositions.getScrollPosition().y);
         this.scrollPosition = window.pageYOffset;
         // If recorded scroll is applied, immediately un-hide the header
-        this.headerSkipNextUpdate = true;
         if (this.scrollPosition > 0) {
-          this.$nextTick().then(() => {
-            this.headerIsHidden = false;
-          });
+          this.$nextTick().then(this.showHeader);
         }
       },
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/manageContentLinks.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/manageContentLinks.js
@@ -5,6 +5,7 @@ export function selectContentTopicLink(topicNode, query, channelId) {
     name: ContentWizardPages.SELECT_CONTENT,
     params: {
       node: topicNode,
+      scrollTo: '.content-tree-viewer',
     },
     query: {
       ...query,

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -251,6 +251,9 @@
             query: {
               node: node.id,
             },
+            params: {
+              scrollTo: '.content-tree-viewer',
+            },
           };
         } else {
           return selectContentTopicLink(node, this.$route.query, this.$route.params.channel_id);

--- a/kolibri/plugins/user/assets/src/views/AuthSelect.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthSelect.vue
@@ -62,13 +62,6 @@
         return this.$router.getRoute(ComponentMap.FACILITY_SELECT);
       },
     },
-    methods: {
-      route(whereToNext) {
-        const route = this.facilitySelectRoute;
-        route.params = { whereToNext };
-        return route;
-      },
-    },
     $trs: {
       createAccountAction: 'Create an account',
       newUserPrompt: {


### PR DESCRIPTION
### Summary
Sometimes it's desirable to link to a specific part of the page.  See [here](https://github.com/learningequality/kolibri/issues/6889) for a detailed example.

This PR lets a developer specify exactly where to link to by including a `route.params.scrollTo` parameter, which can either be a querySelector string or a conventional [vue-router position object](https://router.vuejs.org/guide/advanced/scroll-behavior.html).

By default, when scrolling to a specific part of the page, the header is always shown.  In the future, it may be possible to include a smooth transition, but there were some challenges getting Firefox consistently execute the smooth scrolling transition, so this is held off for now.  I'll make a followup draft PR that enables smooth scrolling.

##### Before:
![jumpy-scroll-is-distracting](https://user-images.githubusercontent.com/389782/87716322-4f5f4980-c774-11ea-80e8-73317a8cfc4b.gif)

##### After:
![link with scroll-to](https://user-images.githubusercontent.com/389782/87716330-538b6700-c774-11ea-8712-097e3d2c501a.gif)


### Reviewer guidance
1. Navigate to the "Device" area and find some content to browse
  - This can be done either by clicking "import" and selecting a channel from there or by clicking "manage" for a pre-imported channel
2. Zoom in to simulate a small screen and navigate to the bottom of the topic list
3. Navigate into a topic by clicking on it
4. Make sure that the scroll position for the newly showing topic is aligned so that the top bar is showing and the topic name right underneath it.

### References
#6889 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
