### PR TITLE
SignInPage - no error when password is autofilled

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -91,7 +91,7 @@
               />
             </div>
           </div>
-          <div v-show="showPasswordForm">
+          <div v-if="showPasswordForm">
             <UiAlert
               v-if="invalidCredentials"
               type="error"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Noted during bug bash:

- When the password field is auto-filled by the browser, validation message about invalid credentials shows.

I used `v-show` on the input fields which allows the password to be filled out before it is rendered in the first place.

In my testing, I noted that the password field does not render filled - but rather it renders, then the password pops pretty quickly after appearing.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Set and save some autofill username + password combinations using:

- Your browser's default autofill
- LastPass

Then - submit your auto-filled username and you should transition to the password section - which will then autofill without any shown error messages.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

16 Jul 2020 - Bug bash note. I didn't see it in the list but it was noted by @rtibbles and others during demo.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
