### PR TITLE
Translation error fixes @ #7273

### DIFF
--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -72,7 +72,7 @@
 
             <p v-if="!hideCreateAccount && canSignUp" class="create">
               <KRouterLink
-                :text="$tr('createAccountAction')"
+                :text="AuthBaseStrings.$tr('createAccountAction')"
                 :to="signUpPage"
                 :primary="false"
                 appearance="raised-button"
@@ -155,8 +155,10 @@
   import branding from 'kolibri.utils.branding';
   import loginComponents from 'kolibri.utils.loginComponents';
   import urls from 'kolibri.urls';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { ComponentMap } from '../constants';
   import LanguageSwitcherFooter from '../views/LanguageSwitcherFooter';
+  import AuthSelect from './AuthSelect';
   import plugin_data from 'plugin_data';
 
   export default {
@@ -178,6 +180,9 @@
     },
     computed: {
       ...mapGetters(['facilityConfig']),
+      AuthBaseStrings() {
+        return crossComponentTranslator(AuthSelect);
+      },
       backgroundImageStyle() {
         if (this.$kolibriBranding.signIn.background) {
           const scrimOpacity =
@@ -228,6 +233,8 @@
     },
     $trs: {
       accessAsGuest: 'Explore without account',
+      // This is in the eslint-disabling section because we crossComponentTranslator @ AuthSelect
+      // eslint-disable-next-line kolibri/vue-no-unused-translations
       createAccountAction: 'Create an account',
       oidcGenericExplanation:
         'Kolibri is an e-learning platform. You can also use your Kolibri account to log in to some third-party applications.',

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -72,7 +72,7 @@
 
             <p v-if="!hideCreateAccount && canSignUp" class="create">
               <KRouterLink
-                :text="AuthBaseStrings.$tr('createAccountAction')"
+                :text="AuthSelectStrings.$tr('createAccountAction')"
                 :to="signUpPage"
                 :primary="false"
                 appearance="raised-button"
@@ -180,7 +180,7 @@
     },
     computed: {
       ...mapGetters(['facilityConfig']),
-      AuthBaseStrings() {
+      AuthSelectStrings() {
         return crossComponentTranslator(AuthSelect);
       },
       backgroundImageStyle() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

@radinamatic noted in #7273 that some translations weren't showing up in the Sign In flow.

I seem to have moved the `createAccountAction` string to a different component before or after string freeze. I'm not so sure how or when this happened, but this ought to fix it. Happy that the string was translated and came through from Crowdin as expected.

So now that string is put where it needs to be with `crossComponentTranslator`

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

`make i18n-download branch=release-v0.14.x`

Make sure you have your CROWDIN_API_KEY set.

Check the languages mentioned in #7273 to see that the "Create Account" button is translated properly on the Sign In flow.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#7273

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
