### PR TITLE
Increase zeroconf service info fetch timeout to reduce missed fetches.

### DIFF
--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -106,7 +106,7 @@ class KolibriZeroconfListener(object):
     instances = {}
 
     def add_service(self, zeroconf, type, name):
-        timeout = 5000
+        timeout = 10000
         info = zeroconf.get_service_info(type, name, timeout=timeout)
         if info is None:
             logger.warn(


### PR DESCRIPTION
### Summary
Changes to zeroconf to improve interruptibility led to a slightly longer average time for a service info fetch, meaning the current timeout was more likely to get passed during the fetch. This doubles it from 5 seconds to 10 seconds.

### Reviewer guidance
Run two kolibri servers and make sure they can see each other on zeroconf (can do this just by checking the terminal while running in foreground and looking for the service registration messages).

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
