### PR TITLE
Setup Wizard UX and Bug Fixes (wrong facility preset, "stuck" import tasks, saving superuser credentials)

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -71,7 +71,7 @@ languages = dict(settings.LANGUAGES)
 def create_facility(facility_name=None, preset=None, interactive=False):
     if facility_name is None and interactive:
         answer = get_user_response(
-            "Do you wish to create a facility? [yn] ", ["y", "n"]
+            "Do you wish to create a facility? [y/n] ", ["y", "n"]
         )
         if answer == "y":
             facility_name = get_user_response(
@@ -94,7 +94,7 @@ def create_facility(facility_name=None, preset=None, interactive=False):
         if preset is None and interactive:
             preset = get_user_response(
                 "Which preset do you wish to use? [{presets}]: ".format(
-                    presets=",".join(presets.keys())
+                    presets="/".join(presets.keys())
                 ),
                 valid_answers=presets,
             )
@@ -102,6 +102,7 @@ def create_facility(facility_name=None, preset=None, interactive=False):
         # Only set preset data if we have created the facility, otherwise leave previous data intact
         if preset:
             dataset_data = mappings[preset]
+            facility.dataset.preset = preset
             for key, value in dataset_data.items():
                 check_facility_setting(key)
                 setattr(facility.dataset, key, value)

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -75,6 +75,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
             facility = Facility.objects.create(**validated_data.pop("facility"))
             preset = validated_data.pop("preset")
             dataset_data = mappings[preset]
+            facility.dataset.preset = preset
             for key, value in dataset_data.items():
                 setattr(facility.dataset, key, value)
             # overwrite the settings in dataset_data with validated_data.settings

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -74,21 +74,18 @@
       },
     },
     beforeMount() {
-      this.startPolling();
+      this.pollTask();
     },
     methods: {
-      startPolling() {
+      pollTask() {
         SetupTasksResource.fetchCollection({ force: true }).then(tasks => {
           this.loadingTask = {
             ...tasks[0],
             facility_name: this.facilityName,
           };
         });
-        if (this.loadingTask.status) {
-          return;
-        }
         setTimeout(() => {
-          this.startPolling();
+          this.pollTask();
         }, 2000);
       },
       retryImport() {
@@ -104,9 +101,6 @@
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);
-          })
-          .then(() => {
-            this.startPolling();
           });
       },
       cancelTask() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
@@ -143,7 +143,12 @@
         const $credentialsForm = this.$refs.credentialsForm;
         if ($credentialsForm) {
           // The form makes the call to the startpeerfacilityimport endpoint
-          return $credentialsForm.startImport();
+          return $credentialsForm.startImport().then(() => {
+            return {
+              username: $credentialsForm.username,
+              password: $credentialsForm.password,
+            };
+          });
         } else {
           return Promise.resolve(false);
         }

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
@@ -143,11 +143,15 @@
         const $credentialsForm = this.$refs.credentialsForm;
         if ($credentialsForm) {
           // The form makes the call to the startpeerfacilityimport endpoint
-          return $credentialsForm.startImport().then(() => {
-            return {
-              username: $credentialsForm.username,
-              password: $credentialsForm.password,
-            };
+          return $credentialsForm.startImport().then(importStarted => {
+            if (importStarted) {
+              return {
+                username: $credentialsForm.username,
+                password: $credentialsForm.password,
+              };
+            } else {
+              return false;
+            }
           });
         } else {
           return Promise.resolve(false);

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
@@ -127,7 +127,14 @@
         return FacilityImportResource.facilityadmins()
           .then(admins => {
             this.facilityAdmins = [...admins];
-            this.selected = { ...this.dropdownOptions[0] };
+            // NOTE: We don't have the facility user ID on hand to disambiguate if
+            // a duplicate username is used
+            this.selected =
+              this.dropdownOptions.find(({ label }) => label === this.facility.username) ||
+              this.dropdownOptions[0];
+            this.$nextTick().then(() => {
+              this.resetFormAndRefocus();
+            });
             this.loading = false;
           })
           .catch(error => {
@@ -138,6 +145,9 @@
         this.shouldValidate = false;
         if (this.$refs.password) {
           this.$refs.password.resetAndFocus();
+          if (this.selected.label === this.facility.username) {
+            this.password = this.facility.password;
+          }
         }
       },
       handleClickNextImportedUser() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
@@ -112,7 +112,11 @@
       },
     },
     watch: {
-      selected() {
+      selected(newVal) {
+        // If the previously-saved admin is chosen, auto-fill their password
+        if (newVal.label === this.facility.username) {
+          this.setSavedAdminPassword();
+        }
         this.resetFormAndRefocus();
       },
     },
@@ -123,15 +127,25 @@
       uniqueUsernameValidator(username) {
         return !this.facilityAdmins.find(admin => admin.username === username);
       },
+      setSavedAdminPassword() {
+        this.password = this.facility.password;
+      },
       fetchFacilityAdmins() {
         return FacilityImportResource.facilityadmins()
           .then(admins => {
             this.facilityAdmins = [...admins];
             // NOTE: We don't have the facility user ID on hand to disambiguate if
             // a duplicate username is used
-            this.selected =
-              this.dropdownOptions.find(({ label }) => label === this.facility.username) ||
-              this.dropdownOptions[0];
+            const superuserMatch = this.dropdownOptions.find(
+              ({ label }) => label === this.facility.username
+            );
+            if (superuserMatch) {
+              this.selected = superuserMatch;
+              this.setSavedAdminPassword();
+            } else {
+              this.selected = this.dropdownOptions[0];
+              this.password = '';
+            }
             this.$nextTick().then(() => {
               this.resetFormAndRefocus();
             });
@@ -144,9 +158,9 @@
       resetFormAndRefocus() {
         this.shouldValidate = false;
         if (this.$refs.password) {
-          this.$refs.password.resetAndFocus();
-          if (this.selected.label === this.facility.username) {
-            this.password = this.facility.password;
+          // If password was set to the facility.password in handler
+          if (this.selected.label !== this.facility.username) {
+            this.$refs.password.resetAndFocus();
           }
         }
       },


### PR DESCRIPTION
### Summary

Some updates to the Setup Wizard

1. Fixes faulty polling logic when displaying FacilityImport task progress
1. "remembers" the the super user/admin credentials provided at the beginning of the facility import flow at the end when creating a device super admin. 
1. Fixes a bug where the `facility.dataset.preset` value was not being saved. Fixed in REST and CLI interfaces for device provisioning

### Reviewer guidance

1. Is it still possible to get "stuck" in the facility import step?
1. Once a device is provisioned, does the UI reflect the preset + settings you chose?
1. Is it possible to put the Device Superadmin credentials step in a bad state in terms of the "remembered" credentials from the previous step (providing facility/superuser credentials prior to importing from a peer)

### References

Fixes #7303 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
