### PR TITLE
Demo server banner & Sign in page routing updates

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -30,10 +30,6 @@ export function pageSessionId(state) {
   return state.pageSessionId;
 }
 
-export function demoBannerVisible(state, getters, rootState) {
-  return state.demoBannerVisible && rootState.pageName === 'SIGN_IN';
-}
-
 export function allowAccess(state, getters, rootState, rootGetters) {
   return state.allowRemoteAccess || rootGetters.isAppContext;
 }

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -36,7 +36,4 @@ export default {
   CORE_SET_PAGE_VISIBILITY(state, visible) {
     state.pageVisible = visible;
   },
-  SET_CORE_BANNER_VISIBLE(state) {
-    state.demoBannerVisible = true;
-  },
 };

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -67,7 +67,7 @@
       :class="fullScreen ? 'scrolling-pane' : 'content'"
       :style="contentStyles"
     >
-      <CoreBanner v-if="demoBannerVisible">
+      <CoreBanner v-if="coreBannerComponent && showDemoBanner">
         <template slot-scope="props">
           <component :is="coreBannerComponent" :bannerClosed="props.bannerClosed" />
         </template>
@@ -279,6 +279,11 @@
         required: false,
         default: 1000,
       },
+      showDemoBanner: {
+        type: Boolean,
+        default: false,
+        required: false,
+      },
     },
     data() {
       return {
@@ -293,7 +298,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isAdmin', 'isSuperuser', 'demoBannerVisible']),
+      ...mapGetters(['isAdmin', 'isSuperuser']),
       ...mapState({
         error: state => state.core.error,
         loading: state => state.core.loading,

--- a/kolibri/plugins/demo_server/assets/src/module.js
+++ b/kolibri/plugins/demo_server/assets/src/module.js
@@ -1,4 +1,3 @@
-import store from 'kolibri.coreVue.vuex.store';
 import coreBannerContent from 'kolibri.utils.coreBannerContent';
 import DemoServerBannerContent from './DemoServerBannerContent';
 import KolibriModule from 'kolibri_module';
@@ -6,7 +5,6 @@ import KolibriModule from 'kolibri_module';
 class DemoServerModule extends KolibriModule {
   ready() {
     coreBannerContent.register(DemoServerBannerContent);
-    store.commit('SET_CORE_BANNER_VISIBLE', !store.getters.isUserLoggedIn);
   }
 }
 

--- a/kolibri/plugins/user/assets/src/modules/signIn/index.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/index.js
@@ -1,8 +1,6 @@
 export default {
   namespaced: true,
   state: {
-    username: '',
-    password: '',
     hasMultipleFacilities: null,
   },
   mutations: {
@@ -11,16 +9,6 @@ export default {
     },
     RESET_STATE(state) {
       state.hasMultipleFacilities = null;
-    },
-    RESET_FORM_VALUES(state) {
-      state.username = '';
-      state.password = '';
-    },
-    SET_USERNAME(state, payload) {
-      state.username = payload;
-    },
-    SET_PASSWORD(state, payload) {
-      state.password = payload;
     },
   },
 };

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -73,7 +73,7 @@
             <p v-if="!hideCreateAccount && canSignUp" class="create">
               <router-link :to="signUpPage">
                 <KButton
-                  :text="$tr('createAccountAction')"
+                  :text="AuthSelectStrings.$tr('createAccountAction')"
                   :to="signUpPage"
                   :primary="false"
                   appearance="raised-button"

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -71,14 +71,18 @@
             <slot></slot>
 
             <p v-if="!hideCreateAccount && canSignUp" class="create">
-              <KRouterLink
-                :text="AuthSelectStrings.$tr('createAccountAction')"
-                :to="signUpPage"
-                :primary="false"
-                appearance="raised-button"
-                style="width: 100%;"
-                data-test="createUser"
-              />
+              <router-link :to="signUpPage">
+                <KButton
+                  :text="$tr('createAccountAction')"
+                  :to="signUpPage"
+                  :primary="false"
+                  appearance="raised-button"
+                  :disabled="busy"
+                  style="width: 100%;"
+                  data-test="createUser"
+                />
+              </router-link>
+
             </p>
 
             <div slot="options">
@@ -167,6 +171,11 @@
     mixins: [commonCoreStrings],
     props: {
       hideCreateAccount: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      busy: {
         type: Boolean,
         required: false,
         default: false,

--- a/kolibri/plugins/user/assets/src/views/AuthSelect.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthSelect.vue
@@ -1,53 +1,46 @@
 <template>
 
-  <CoreBase
-    :immersivePage="false"
-    :immersivePagePrimary="false"
-    :fullScreen="true"
-  >
-    <AuthBase :hideCreateAccount="true">
-      <div class="auth-select">
-        <div>
-          <div class="label">
-            {{ $tr("signInPrompt") }}
-          </div>
-          <KRouterLink
-            :text="coreString('signInLabel')"
-            :to="signInRoute"
-            appearance="raised-button"
-            style="width: 100%;"
-            :primary="true"
-          />
+  <AuthBase :hideCreateAccount="true">
+    <div class="auth-select">
+      <div>
+        <div class="label">
+          {{ $tr("signInPrompt") }}
         </div>
-        <div class="sign-up-prompt">
-          <div class="label">
-            {{ $tr("newUserPrompt") }}
-          </div>
-          <KRouterLink
-            :text="$tr('createAccountAction')"
-            :to="signUpRoute"
-            :primary="false"
-            style="width: 100%;"
-            appearance="raised-button"
-          />
-        </div>
+        <KRouterLink
+          :text="coreString('signInLabel')"
+          :to="signInRoute"
+          appearance="raised-button"
+          style="width: 100%;"
+          :primary="true"
+        />
       </div>
-    </AuthBase>
-  </CoreBase>
+      <div class="sign-up-prompt">
+        <div class="label">
+          {{ $tr("newUserPrompt") }}
+        </div>
+        <KRouterLink
+          :text="$tr('createAccountAction')"
+          :to="signUpRoute"
+          :primary="false"
+          style="width: 100%;"
+          appearance="raised-button"
+        />
+      </div>
+    </div>
+  </AuthBase>
 
 </template>
 
 
 <script>
 
-  import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { ComponentMap } from '../constants';
   import AuthBase from './AuthBase';
 
   export default {
     name: 'AuthSelect',
-    components: { AuthBase, CoreBase },
+    components: { AuthBase },
     mixins: [commonCoreStrings],
     computed: {
       signUpRoute() {

--- a/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
@@ -1,57 +1,53 @@
 <template>
 
-  <CoreBase
-    :immersivePage="false"
-    :immersivePagePrimary="false"
-    :fullScreen="true"
-  >
-    <AuthBase :hideCreateAccount="true">
-      <div class="facility-select">
-        <KRouterLink class="backlink" :to="backTo" :text="coreString('goBackAction')" icon="back" />
-        <div>
-          <p class="label">
-            {{ label }}
-          </p>
-          <div v-for="facility in facilityList['enabled']" :key="facility.id" class="facility-name">
-            <KButton
-              appearance="raised-button"
-              :primary="false"
-              @click="setFacility(facility.id)"
-            >
-              <KIcon slot="icon" icon="facility" style="margin-right: 16px;" />
-              {{ facility.name }}
-            </KButton>
-          </div>
-        </div>
-        <div v-if="facilityList['disabled'].length" class="disabled-facilities">
-          <p class="label">
-            {{ $tr('askAdminForAccountLabel') }}
-          </p>
-          <div
-            v-for="facility in facilityList['disabled']"
-            :key="facility.id"
-            class="facility-name"
+  <AuthBase :hideCreateAccount="true">
+    <div class="facility-select">
+      <KRouterLink class="backlink" :to="backTo" :text="coreString('goBackAction')" icon="back" />
+      <div v-if="facilityList['enabled'].length">
+        <p class="label">
+          {{ label }}
+        </p>
+        <div v-for="facility in facilityList['enabled']" :key="facility.id" class="facility-name">
+          <KButton
+            appearance="raised-button"
+            :primary="false"
+            @click="setFacility(facility.id)"
           >
-            <KButton
-              :disabled="true"
-              :primary="false"
-              appearance="raised-button"
-            >
-              <KIcon slot="icon" icon="facility" style="margin-right: 16px;" />
-              {{ facility.name }}
-            </KButton>
-          </div>
+            <KIcon slot="icon" icon="facility" style="margin-right: 16px;" />
+            {{ facility.name }}
+          </KButton>
         </div>
       </div>
-    </AuthBase>
-  </CoreBase>
+      <div
+        v-if="facilityList['disabled'].length"
+        :class="{ 'disabled-facilities': facilityList['enabled'].length }"
+      >
+        <p class="label">
+          {{ $tr('askAdminForAccountLabel') }}
+        </p>
+        <div
+          v-for="facility in facilityList['disabled']"
+          :key="facility.id"
+          class="facility-name"
+        >
+          <KButton
+            :disabled="true"
+            :primary="false"
+            appearance="raised-button"
+          >
+            <KIcon slot="icon" icon="facility" style="margin-right: 16px;" />
+            {{ facility.name }}
+          </KButton>
+        </div>
+      </div>
+    </div>
+  </AuthBase>
 
 </template>
 
 
 <script>
 
-  import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import partition from 'lodash/partition';
@@ -60,7 +56,7 @@
 
   export default {
     name: 'FacilitySelect',
-    components: { AuthBase, CoreBase },
+    components: { AuthBase },
     mixins: [commonCoreStrings],
     props: {
       // This component is interstitial and needs to know where to go when it's done

--- a/kolibri/plugins/user/assets/src/views/SignInPage/SignInHeading.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/SignInHeading.vue
@@ -32,7 +32,7 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapGetters } from 'vuex';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import SignInPage from './index';
 
@@ -47,10 +47,13 @@
         type: Boolean,
         required: true,
       },
+      username: {
+        type: String,
+        required: true,
+      },
     },
     computed: {
       ...mapGetters(['selectedFacility']),
-      ...mapState('signIn', ['username']),
       strings() {
         // Gross
         return crossComponentTranslator(SignInPage);

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -1,25 +1,21 @@
 <template>
 
-  <CoreBase
-    :immersivePage="false"
-    :immersivePagePrimary="false"
-    :fullScreen="true"
-  >
-    <AuthBase>
-      <!--
+  <AuthBase :busy="busy">
+    <!--
         Unless we know the user needs to create a password enter this div
         block for the main flow - see the v-else below for the create password flow
       -->
-      <div v-if="!needsToCreatePassword">
-        <!-- ** Text and Backlinks ** -->
+    <div v-if="!needsToCreatePassword">
+      <!-- ** Text and Backlinks ** -->
 
+      <div style="width: 100%; text-align: left; display: block;">
         <!-- In MFD show return to facility select when not asking for password -->
         <KRouterLink
           v-if="hasMultipleFacilities && !showPasswordForm"
           icon="back"
           :text="$tr('changeFacility')"
           :to="backToFacilitySelectionRoute"
-          style="margin-top: 24px; text-align: left; width: 100%;"
+          style="margin-top: 24px;"
         />
 
         <!-- When password form shows, show a change user link -->
@@ -29,104 +25,106 @@
           icon="back"
           appearance="basic-link"
           :text="$tr('changeUser')"
-          style="text-align: left; width: 100%; margin-top: 24px;"
+          style="margin-top: 24px;"
           @click="clearUser"
         />
+      </div>
 
-        <SignInHeading
-          :showFacilityName="showFacilityName"
-          :showPasswordForm="showPasswordForm"
-        />
+      <SignInHeading
+        :showFacilityName="showFacilityName"
+        :showPasswordForm="showPasswordForm"
+        :username="username"
+      />
 
-        <!-- END Text & Backlinks -->
+      <!-- END Text & Backlinks -->
 
-        <!--
+      <!--
           USERNAME FORM
           Presented to user **unless** we are in app context AND have <= 16 users in the facility
           TODO: Extract this into a separate component. We're post string freeze and short on
           time right now
         -->
-        <form ref="form" class="login-form" @submit.prevent="signIn">
-          <div v-show="showUsernameForm">
-            <transition name="textbox">
-              <KTextbox
-                id="username"
-                ref="username"
-                v-model="username"
-                autocomplete="username"
-                :autofocus="true"
-                :label="coreString('usernameLabel')"
-                :invalid="usernameIsInvalid"
-                :invalidText="usernameIsInvalidText"
-                @blur="handleUsernameBlur"
-                @input="showDropdown = true"
-                @keydown="handleKeyboardNav"
-              />
-            </transition>
-            <transition name="list">
-              <div class="suggestions-wrapper">
-                <ul
-                  v-if="simpleSignIn && suggestions.length"
-                  v-show="showDropdown"
-                  class="suggestions"
-                  :style="{ backgroundColor: $themeTokens.surface }"
-                >
-                  <UiAutocompleteSuggestion
-                    v-for="(suggestion, i) in suggestions"
-                    :key="i"
-                    :suggestion="suggestion"
-                    :style="suggestionStyle(i)"
-                    @mousedown.native="fillUsername(suggestion)"
-                  />
-                </ul>
-              </div>
-            </transition>
-            <div>
-              <KButton
-                class="login-btn"
-                :text="$tr('nextLabel')"
-                :primary="true"
-                :disabled="busy"
-                @click="signIn"
-              />
+      <form ref="form" class="login-form" @submit.prevent="signIn">
+        <div v-show="showUsernameForm">
+          <transition name="textbox">
+            <KTextbox
+              id="username"
+              ref="username"
+              v-model="username"
+              autocomplete="username"
+              :autofocus="true"
+              :label="coreString('usernameLabel')"
+              :invalid="usernameIsInvalid"
+              :invalidText="usernameIsInvalidText"
+              @blur="handleUsernameBlur"
+              @input="showDropdown = true"
+              @keydown="handleKeyboardNav"
+            />
+          </transition>
+          <transition name="list">
+            <div class="suggestions-wrapper">
+              <ul
+                v-if="simpleSignIn && suggestions.length"
+                v-show="showDropdown"
+                class="suggestions"
+                :style="{ backgroundColor: $themeTokens.surface }"
+              >
+                <UiAutocompleteSuggestion
+                  v-for="(suggestion, i) in suggestions"
+                  :key="i"
+                  :suggestion="suggestion"
+                  :style="suggestionStyle(i)"
+                  @mousedown.native="fillUsername(suggestion)"
+                />
+              </ul>
             </div>
+          </transition>
+          <div>
+            <KButton
+              class="login-btn"
+              :text="$tr('nextLabel')"
+              :primary="true"
+              :disabled="busy"
+              @click="signIn"
+            />
           </div>
-          <div v-if="showPasswordForm">
-            <UiAlert
-              v-if="invalidCredentials"
-              type="error"
-              :dismissible="false"
-            >
-              {{ $tr('signInError') }}
-            </UiAlert>
-            <transition name="textbox">
-              <KTextbox
-                id="password"
-                ref="password"
-                v-model="password"
-                type="password"
-                autocomplete="current-password"
-                :label="coreString('passwordLabel')"
-                :autofocus="true"
-                :invalid="passwordIsInvalid"
-                :invalidText="passwordIsInvalidText"
-                :floatingLabel="false"
-                @blur="handlePasswordBlur"
-              />
-            </transition>
-            <div>
-              <KButton
-                class="login-btn"
-                type="submit"
-                :text="coreString('signInLabel')"
-                :primary="true"
-                :disabled="busy"
-              />
-            </div>
+        </div>
+        <div v-if="showPasswordForm">
+          <UiAlert
+            v-if="invalidCredentials"
+            type="error"
+            :dismissible="false"
+          >
+            {{ $tr('signInError') }}
+          </UiAlert>
+          <transition name="textbox">
+            <KTextbox
+              id="password"
+              ref="password"
+              v-model="password"
+              type="password"
+              autocomplete="current-password"
+              :label="coreString('passwordLabel')"
+              :autofocus="true"
+              :invalid="passwordIsInvalid"
+              :invalidText="passwordIsInvalidText"
+              :floatingLabel="false"
+              @blur="handlePasswordBlur"
+            />
+          </transition>
+          <div>
+            <KButton
+              class="login-btn"
+              type="submit"
+              :text="coreString('signInLabel')"
+              :primary="true"
+              :disabled="busy"
+            />
           </div>
-        </form>
+        </div>
+      </form>
 
-        <!--
+      <!--
           USERS LIST
           Shows users in a list of buttons to be selected from.
           Shown in App Context in a Facility with <= 16 users
@@ -135,69 +133,69 @@
           integrate this better with that component in next pass for
           state management and event (signIn) handling
         -->
-        <UsersList
-          v-if="showUsersList && !showPasswordForm"
-          :users="usernamesForCurrentFacility"
-          :busy="busy"
-          @userSelected="setSelectedUsername"
-        />
-      </div>
+      <UsersList
+        v-if="showUsersList && !showPasswordForm"
+        :users="usernamesForCurrentFacility"
+        :busy="busy"
+        @userSelected="setSelectedUsername"
+      />
+    </div>
 
-      <!-- TODO: This can be its own separate component -->
-      <!--
+    <!-- TODO: This can be its own separate component -->
+    <!--
         Learner was created without a password, but now must create one.
         This ought to be routed separately.
       -->
-      <div v-else style="text-align: left">
-        <KButton
-          appearance="basic-link"
-          text=""
-          style="margin-bottom: 16px;"
-          @click="clearUser"
-        >
-          <KIcon
-            slot="icon"
-            icon="back"
-            :style="{
-              fill: $themeTokens.primary,
-              height: '1.125em',
-              width: '1.125em',
-              position: 'relative',
-              marginRight: '8px',
-              top: '2px',
-            }"
-          />{{ coreString('goBackAction') }}
-        </KButton>
-        <p>{{ $tr("needToMakeNewPasswordLabel", { user: username }) }}</p>
-        <PasswordTextbox
-          ref="createPassword"
-          :autofocus="true"
-          :disabled="busy"
-          :value.sync="createdPassword"
-          :isValid.sync="createdPasswordConfirmation"
-          :shouldValidate="busy"
-          @submitNewPassword="updatePasswordAndSignIn"
-        />
-        <KButton
-          appearance="raised-button"
-          :primary="true"
-          :text="coreString('continueAction')"
-          style="width: 100%; margin: 24px auto 0; display:block;"
-          :disabled="busy"
-          @click="updatePasswordAndSignIn"
-        />
-      </div>
-      <!-- End TODO about making this its own component -->
+    <div v-else style="text-align: left">
+      <KButton
+        appearance="basic-link"
+        text=""
+        style="margin-bottom: 16px;"
+        @click="clearUser"
+      >
+        <KIcon
+          slot="icon"
+          icon="back"
+          :style="{
+            fill: $themeTokens.primary,
+            height: '1.125em',
+            width: '1.125em',
+            position: 'relative',
+            marginRight: '8px',
+            top: '2px',
+          }"
+        />{{ coreString('goBackAction') }}
+      </KButton>
 
-    </AuthBase>
-  </CoreBase>
+      <p>{{ $tr("needToMakeNewPasswordLabel", { user: username }) }}</p>
+
+      <PasswordTextbox
+        ref="createPassword"
+        :autofocus="true"
+        :disabled="busy"
+        :value.sync="createdPassword"
+        :isValid.sync="createdPasswordConfirmation"
+        :shouldValidate="busy"
+        @submitNewPassword="updatePasswordAndSignIn"
+      />
+      <KButton
+        appearance="raised-button"
+        :primary="true"
+        :text="coreString('continueAction')"
+        style="width: 100%; margin: 24px auto 0; display:block;"
+        :disabled="busy"
+        @click="updatePasswordAndSignIn"
+      />
+    </div>
+    <!-- End TODO about making this its own component -->
+
+  </AuthBase>
 
 </template>
 
 
 <script>
 
-  import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { FacilityUsernameResource } from 'kolibri.resources';
   import get from 'lodash/get';
@@ -226,7 +224,6 @@
     },
     components: {
       AuthBase,
-      CoreBase,
       PasswordTextbox,
       SignInHeading,
       UiAutocompleteSuggestion,
@@ -236,6 +233,8 @@
     mixins: [responsiveWindowMixin, commonCoreStrings],
     data() {
       return {
+        username: '',
+        password: '',
         usernameSuggestions: [],
         usernamesForCurrentFacility: [],
         suggestionTerm: '',
@@ -255,22 +254,6 @@
       ...mapGetters(['selectedFacility', 'isAppContext']),
       ...mapState('signIn', ['hasMultipleFacilities']),
       ...mapState(['redirect']),
-      username: {
-        get() {
-          return this.$store.state.signIn.username;
-        },
-        set(username) {
-          this.$store.commit('signIn/SET_USERNAME', username);
-        },
-      },
-      password: {
-        get() {
-          return this.$store.state.signIn.password;
-        },
-        set(password) {
-          this.$store.commit('signIn/SET_PASSWORD', password);
-        },
-      },
       backToFacilitySelectionRoute() {
         const facilityRoute = this.$router.getRoute(ComponentMap.FACILITY_SELECT);
         const whereToNext = this.$router.getRoute(ComponentMap.SIGN_IN);
@@ -368,25 +351,6 @@
         }
       },
     },
-    // Clear the username when entering the route.
-    // username may be held over if you select a user from UsersList
-    // then change to a facility that doesn't use UsersList
-    //
-    // TODO: If we want to clear the username whenever we switch facilities,
-    // then we can remove the `beforeRouteEnter` and use the commented out
-    // `beforeRouteLeave` below
-    beforeRouteEnter(to, from, next) {
-      next(vm => vm.$store.commit('signIn/RESET_FORM_VALUES'));
-    },
-    // Clear the username before changing routes to FacilitySelect?
-    /*
-    beforeRouteLeave(to, from, next) {
-      if(to.name === ComponentMap.FACILITY_SELECT) {
-        this.$store.commit('signIn/RESET_FORM_VALUES')
-      }
-      next();
-    },
-    */
     created() {
       // Only fetch if we should fetch for this facility
       if (this.showUsersList) {
@@ -406,6 +370,8 @@
         // changed so far and clearing the errors, if any
         this.username = '';
         this.password = '';
+        this.createdPassword = '';
+        this.createdPasswordConfirmation = '';
         // This ensures we don't get '<field> required' when going back
         // and forth
         this.usernameBlurred = false;

--- a/kolibri/plugins/user/assets/src/views/UserIndex.vue
+++ b/kolibri/plugins/user/assets/src/views/UserIndex.vue
@@ -1,19 +1,47 @@
 <template>
 
-  <router-view />
+  <div>
+    <CoreBase
+      v-if="coreBaseRoute"
+      :showDemoBanner="demoBannerRoute"
+      :immersivePage="false"
+      :immersivePagePrimary="false"
+      :fullScreen="coreBaseRoute"
+    >
+      <router-view />
+    </CoreBase>
+    <router-view v-else />
+  </div>
 
 </template>
 
 
 <script>
 
+  import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { ComponentMap } from '../constants';
 
   export default {
     name: 'UserIndex',
+    components: { CoreBase },
     mixins: [commonCoreStrings],
     computed: {
+      coreBaseRoute() {
+        return [
+          ComponentMap.SIGN_IN,
+          ComponentMap.FACILITY_SELECT,
+          ComponentMap.AUTH_SELECT,
+          ComponentMap.SIGN_UP,
+        ].includes(this.$route.name);
+      },
+      demoBannerRoute() {
+        return [
+          ComponentMap.SIGN_IN,
+          ComponentMap.FACILITY_SELECT,
+          ComponentMap.AUTH_SELECT,
+        ].includes(this.$route.name);
+      },
       redirect: {
         get() {
           return this.$store.state.signIn.redirect;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
--> 

1. Fixes issue where Demo Server stopped working
2. Fixes scroll jumping issue in User auth flow.
3. Also sneaking in some quick clean up on SignIn state management and fixing a bug with the "Create Account" button I saw where it wouldn't be disabled whenever the form is submitted for Sign In.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

There are 1-3 interesting pages, depending on if you are in a multiple-facility device or not. This really only affects multiple-facility, but **please test a single facility** device as well to be safe.

1. AUTH_SELECT: The page where it says "Sign in if you have an existing account"
2. FACILITY_SELECT: Listing the facilities you may choose from
3. SIGN_IN: Where you sign in with your username and password and where a Learner who needs to create a password may do so.

Below, when I will say "navigate back and forth" those are the pages I'm referring to.

---

Enable the demo_server plugin:
`kolibri plugin enable kolibri.plugins.demo_server`

Then run `kolibri plugin list` to make sure you see  `kolibri.plugins.demo_server         ENABLED`

In an Incognito / Private Browsing / etc window, go to log into your multi-facility device.

Go back and forth throughout the process to make sure:

1. You see the Demo Server banner.
2. When you navigate through the form in any direction, your scroll position does not change. The banner remains opened or closed while you navigate through.
3. You can use back/forward on your browser without losing scroll position.

KNOWN ISSUES
- Going back from Create Account to the previous page is not 100% consistent for me at times. The last commit intends to make that more reliable. I think the UX in that case isn't the worst thing in the world. This PR fixes the really ugly jumping noted in the relevant issue.
- Demo Banner Open/Close state will not persist if you go to Create Account and then back - it always is open on page load.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes https://github.com/learningequality/kolibri/issues/7176

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
