### PR TITLE
No guest access allowed? Not logged in? No contentnode API calls for you!

### DIFF
--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -3,6 +3,7 @@ import RootVue from './views/LearnIndex';
 import routes from './routes';
 import { setFacilitiesAndConfig, prepareLearnApp } from './modules/coreLearn/actions';
 import pluginModule from './modules/pluginModule';
+import { PageNames } from './constants';
 import KolibriApp from 'kolibri_app';
 
 class LearnModule extends KolibriApp {
@@ -19,6 +20,20 @@ class LearnModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
+    // If we are not logged in and are forbidden from accessing as guest
+    // redirect to CONTENT_UNAVAILABLE.
+    router.beforeEach((to, from, next) => {
+      if (
+        to.name !== PageNames.CONTENT_UNAVAILABLE &&
+        !this.store.state.allowGuestAccess &&
+        !this.store.getters.isUserLoggedIn
+      ) {
+        router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+      } else {
+        next();
+      }
+    });
+
     // after every navigation, block double-clicks
     router.afterEach((toRoute, fromRoute) => {
       this.store.dispatch('blockDoubleClicks');

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -20,6 +20,7 @@ export default {
     examLog: {},
     memberships: [],
     canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
+    allowGuestAccess: plugin_data.allowGuestAccess,
   },
   actions,
   getters,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes https://github.com/learningequality/kolibri/issues/7314

Adds and applies guard to router in Learn that avoids entering any of the route handlers before finding out that you actually don't belong here and sending you to the 404 "please sign in" CONTENT_UNAVAILABLE page.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

When your device setting is to disallow guest access and you're not logged in, do you see any API calls for content?

Also another smoke test of various Learn routes (like if you have classes, lessons, exams - what happens if you use a link directly to them in a new tab?) for some additional assurance would be welcome.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/7314

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
