### PR TITLE
Default to flushing sync sessions greater than one day in past

### DIFF
--- a/kolibri/core/auth/management/commands/flushsyncsessions.py
+++ b/kolibri/core/auth/management/commands/flushsyncsessions.py
@@ -1,6 +1,9 @@
 import logging
+from datetime import timedelta
 
+from dateutil.parser import isoparse
 from django.db.models import Q
+from django.utils import timezone
 from morango.models import Buffer
 from morango.models import RecordMaxCounterBuffer
 from morango.models import SyncSession
@@ -18,16 +21,36 @@ class Command(AsyncCommand):
     help = "This command initiates the deletion process for temporary sync session buffers."
 
     def add_arguments(self, parser):
+        default_date = timezone.now() - timedelta(days=1)
         parser.add_argument("--noninteractive", action="store_true")
+        parser.add_argument(
+            "--before-date",
+            type=str,
+            default=default_date.isoformat(),
+            help="Filter sync sessions with last activity before this ISO 8601 timestamp",
+        )
 
     def handle_async(self, *args, **options):
         noninteractive = options["noninteractive"]
+        before_date = options["before_date"]
+
+        before_datetime = (
+            isoparse(before_date) if before_date != "now" else timezone.now()
+        )
 
         if not noninteractive:
             # ensure the user REALLY wants to do this!
-            confirm_or_exit("Are you sure you wish to delete all sync session buffers?")
+            confirm_or_exit(
+                "Are you sure you wish to delete all sync session buffers before {}?".format(
+                    before_datetime.isoformat()
+                )
+            )
 
-        delete_group = GroupDeletion("Main", sleep=1, groups=self._get_delete_groups())
+        sync_sessions = SyncSession.objects.filter(
+            last_activity_timestamp__lt=before_datetime
+        )
+        groups, sync_session_ids = self._get_delete_groups(sync_sessions)
+        delete_group = GroupDeletion("Main", sleep=1, groups=groups)
 
         # run the counting step
         with self.start_progress(total=delete_group.group_count()) as update_progress:
@@ -39,10 +62,16 @@ class Command(AsyncCommand):
             update_progress(increment=0, message="Deleting database objects")
             delete_group.delete(update_progress)
 
+        # lastly, mark them all inactive
+        sync_sessions.filter(active=True).update(active=False)
+        TransferSession.objects.filter(
+            sync_session_id__in=sync_session_ids, active=True
+        ).update(active=False)
+
         logger.info("Deletion complete.")
 
-    def _get_delete_groups(self):
-        sync_session_ids = SyncSession.objects.all().values_list("id", flat=True)
+    def _get_delete_groups(self, sync_sessions):
+        sync_session_ids = sync_sessions.values_list("id", flat=True)
         groups = []
 
         for sync_session_id in sync_session_ids:
@@ -62,4 +91,4 @@ class Command(AsyncCommand):
                 )
             )
 
-        return groups
+        return groups, sync_session_ids


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds `--before-date` option to filter last activity before
- Defaults before date to remove only those sync sessions that haven't been active in the last 24 hours


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://learningequality.slack.com/archives/CB37UM23A/p1595279384239400

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
