### PR TITLE
fix superuser creation in provisiondevice command

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import os
+import sys
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 from django.db import transaction
@@ -77,6 +79,8 @@ def create_facility(facility_name=None, preset=None, interactive=False):
             facility_name = get_user_response(
                 "What do you wish to name your facility? "
             )
+        else:
+            sys.exit(1)
 
     if facility_name:
         facility, created = Facility.objects.get_or_create(name=facility_name)
@@ -123,7 +127,7 @@ def update_facility_settings(facility, new_settings):
     logger.info("Facility settings updated with {}".format(new_settings))
 
 
-def create_superuser(username=None, password=None, interactive=False):
+def create_superuser(username=None, password=None, interactive=False, facility=None):
     if username is None and interactive:
         username = get_user_response("Enter a username for the super user: ")
 
@@ -134,15 +138,17 @@ def create_superuser(username=None, password=None, interactive=False):
             confirm = get_user_response("Confirm password for the super user: ")
 
     if username and password:
-        if not FacilityUser.objects.filter(username__icontains=username).exists():
-            FacilityUser.objects.create_superuser(username, password)
+        try:
+            FacilityUser.objects.create_superuser(username, password, facility=facility)
             logger.info(
-                "Superuser created with username {username}.".format(username=username)
+                "Superuser created with username {username} in facility {facility}.".format(
+                    username=username, facility=facility
+                )
             )
-        else:
+        except ValidationError:
             logger.warn(
-                "An account with username {username} already exists, not creating user account.".format(
-                    username=username
+                "An account with username {username} already exists in facility {facility}, not creating user account.".format(
+                    username=username, facility=facility
                 )
             )
 
@@ -262,4 +268,5 @@ class Command(BaseCommand):
                 username=options["superusername"],
                 password=options["superuserpassword"],
                 interactive=options["interactive"],
+                facility=facility,
             )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR is to fix the superuser creation when running `provisiondevice` command. It includes
- pass the new facility to `create_superuser` function so we create the superuser in the new facility instead of the default facility
- exit the program when user gets asked about `What do you wish to name your facility?` and user input is `n` 
- directly call `FacilityUser.objects.create_superuser` and catch the exception if the superuser has existed instead of checking the existence of the superuser first. This is because we check the existence of the superuser in the function `FacilityUser.objects.create_superuser()` already. We can avoid making the same query twice in this case.
https://github.com/learningequality/kolibri/blob/release-v0.14.x/kolibri/core/auth/models.py#L595-L596
- when creating the superuser in the new facility, instead of checking whether there are similar usernames using `username__icontains=username`, we check the exact name using `username__iexact=username` in the `FacilityUser.objects.create_superuser()` function (linked above)
This can avoid the issue that when user `ad` exists, we cannot create user `a` as it's similar to `ad`.
(If there is a specific reason that we check similar names instead of the exact name, please feel free to let me know :) thank you!)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
run `kolibri start` and set up facility in the web ui
run `kolibri manage provisiondevice`
please check if running `provisiondevice` would create a superuser on the new facility instead of the default facility

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7320

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
