### PR TITLE
Replace ‘text-align: end’ rule with ‘justify-content: flex-end’ for desired button position on IE11

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -99,7 +99,8 @@
 <style lang="scss" scoped>
 
   .footer {
-    text-align: end;
+    display: flex;
+    justify-content: flex-end;
   }
 
 </style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -444,8 +444,9 @@
     right: 0;
     left: 0;
     z-index: 24;
+    display: flex;
+    justify-content: flex-end;
     height: $controls-height;
-    text-align: end;
   }
 
   .slide-enter-active {


### PR DESCRIPTION
…etter ie11 support


<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Replaces the two uses of the `text-align: rule` with `display: flex + justify-items: flex-end` to get the desired button placement in LTR + RTL directions on all browser (including IE11, where `text-align: end` isn't supported). Note that in RTL, it even orders the buttons correctly (from RTL, it's "plus", "minus", "fullscreen")
1. Made no changes on the vertical-alignment issue, since it no problems were visible in IE11 as of now.

Note that there are a lot of places where we use `text-align: right` (e.g. in the `BottomBar` components, where the buttons are _always_ placed on the right edge even in RTL)

#### Screenshots (from IE11 via Browserstack)

PDF renderer/ ar-locale (buttons are on the left)

<img width="1204" alt="CleanShot 2020-07-22 at 13 50 10@2x" src="https://user-images.githubusercontent.com/10248067/88229855-4e239600-cc26-11ea-992d-a14992dace8b.png">

PDF renderer/ en-locale (buttons are on the right)
<img width="1107" alt="CleanShot 2020-07-22 at 13 57 22@2x" src="https://user-images.githubusercontent.com/10248067/88229921-672c4700-cc26-11ea-9f68-9151587d191b.png">

Class Enroll Form/ ar-locale
<img width="1184" alt="CleanShot 2020-07-22 at 14 00 06@2x" src="https://user-images.githubusercontent.com/10248067/88229955-74e1cc80-cc26-11ea-83ca-469278a4b7e3.png">

Class Enroll Form/ en-locale
<img width="1391" alt="CleanShot 2020-07-22 at 14 03 44@2x" src="https://user-images.githubusercontent.com/10248067/88229999-7f9c6180-cc26-11ea-8a0f-14dd5d9ae0f4.png">
### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
Fixes #7142


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
