### PR TITLE
KDS & Kolibri design and style bug fixes

### DIFF
--- a/kolibri/core/assets/src/views/CoreSnackbar/index.vue
+++ b/kolibri/core/assets/src/views/CoreSnackbar/index.vue
@@ -155,7 +155,7 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 16;
+    z-index: 24; // material dialog - ensures we cover KModal
     background-color: rgba(0, 0, 0, 0.7);
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -29,11 +29,15 @@
             </KFixedGridItem>
             <KFixedGridItem span="4">
               <div class="resource-title">
-                <ContentIcon :kind="resourceKind(resourceId)" />
-                <KRouterLink
-                  :text="resourceTitle(resourceId)"
-                  :to="$router.getRoute('RESOURCE_CONTENT_PREVIEW', { contentId: resourceId })"
-                />
+                <div class="content-icon">
+                  <ContentIcon :kind="resourceKind(resourceId)" />
+                </div>
+                <div class="content-link">
+                  <KRouterLink
+                    :text="resourceTitle(resourceId)"
+                    :to="$router.getRoute('RESOURCE_CONTENT_PREVIEW', { contentId: resourceId })"
+                  />
+                </div>
                 <p dir="auto" class="channel-title" :style="{ color: $themeTokens.annotation }">
                   <dfn class="visuallyhidden"> {{ $tr('parentChannelLabel') }} </dfn>
                   {{ resourceChannelTitle(resourceId) }}
@@ -290,6 +294,17 @@
 
   .list-move {
     transition: transform $core-time ease;
+  }
+
+  .content-icon {
+    display: inline-block;
+    width: 16px; // match the icon
+    vertical-align: top;
+  }
+
+  .content-link {
+    display: inline-block;
+    width: calc(100% - 16px);
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
@@ -19,13 +19,18 @@
           :text="coreString('cancelAction')"
           @click="$emit('cancel')"
         />
-        <KButton
-          ref="syncbutton"
-          :text="coreString('syncAction')"
-          primary
-          type="submit"
-        />
-        <!-- TODO make tooltips appear when hovering over disabled buttons-->
+        <!--
+          Wrap the KButton in a span w/ a ref so we listen for mouseovers even when
+          the underlying button is disabled - disabled elements don't fire events
+        -->
+        <span ref="syncbutton">
+          <KButton
+            :text="coreString('syncAction')"
+            :disabled="submitDisabled"
+            primary
+            type="submit"
+          />
+        </span>
         <KTooltip
           v-if="submitDisabled"
           reference="syncbutton"

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -15,19 +15,26 @@
           icon="back"
           :text="$tr('changeFacility')"
           :to="backToFacilitySelectionRoute"
-          style="margin-top: 24px;"
+          style="margin-top: 24px; margin-left: -4px;"
         />
 
         <!-- When password form shows, show a change user link -->
         <!-- Not using v-else here to be more explicit -->
         <KButton
           v-if="showPasswordForm"
-          icon="back"
           appearance="basic-link"
           :text="$tr('changeUser')"
-          style="margin-top: 24px;"
+          style="margin-top: 24px;margin-left: 4px;"
           @click="clearUser"
-        />
+        >
+          <KIcon
+            slot="icon"
+            style="width: 24px; height: 24px; top: 6px; right: 8px;"
+            icon="back"
+            :color="$themeTokens.primary"
+          />
+        </KButton>
+
       </div>
 
       <SignInHeading


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

A bunch of fixes incoming, will list them and connect all appropriate issues as I progress. Feel free to click the checkbox next to something you tested if you want to just jump in to test something you have expertise on.

I'll mark the commit(s) where each item is/are fixed to help code review.

Each commit's message has more details about each fix.

The following fixes do not require you to link a specific KDS branch, but are 100% Kolibri, despite the issues being reported in KDS:

- [x] Commit 2de6579 fixes https://github.com/learningequality/kolibri-design-system/issues/75 - Snackbar overlaid by KModal
- [x] Commit 9feae54 fixes https://github.com/learningequality/kolibri/issues/6971 - Icon & link on Lesson Resource list now look good
- [x] Commit d83e12c fixes https://github.com/learningequality/kolibri-design-system/issues/36 - KTooltip didn't show when referencing a disabled KButton 
- [x] Commit 98e9022 fixes an issue reported somewhere not in Github. The "<- Change User" link during password entry had a black and badly aligned arrow icon attached to it, now it looks just like the "<- Change facility" button on the page where you enter your username.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Look at the issue reported listed above and see that it is fixed.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

A KDS PR that will likely be relevant here as I continue: https://github.com/learningequality/kolibri-design-system/pull/83

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
