### PR TITLE
update notification styling

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -10,14 +10,15 @@
     />
 
     <template v-if="channel">
-      <NewChannelVersionBanner
-        v-if="availableVersions.studioLatest > availableVersions.installed"
-        class="banner"
-        :version="availableVersions.studioLatest"
-        @click="handleClickViewNewVersion"
-      />
 
-      <ChannelContentsSummary :channel="channel" />
+      <ChannelContentsSummary :channel="channel">
+        <NewChannelVersionBanner
+          v-if="availableVersions.studioLatest > availableVersions.installed"
+          class="banner"
+          :version="availableVersions.studioLatest"
+          @click="handleClickViewNewVersion"
+        />
+      </ChannelContentsSummary>
 
       <div style="text-align: right">
         <KButton

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
@@ -1,16 +1,6 @@
 <template>
 
-  <div
-    class="new-version-banner"
-    :style="{ backgroundColor: $themePalette.lightblue.v_100 }"
-  >
-    <!-- stubs -->
-    <template v-if="false">
-      <UpdateChannelModal />
-      <NewChannelVersionPage />
-      {{ strings }}
-    </template>
-    <!-- end stubs -->
+  <div>
     <span class="version">
       <KIcon
         class="icon"
@@ -23,7 +13,7 @@
     </span>
     <KButton
       :text="$tr('viewChangesAction')"
-      appearance="flat-button"
+      appearance="basic-link"
       :primary="false"
       @click="$emit('click')"
     />
@@ -34,26 +24,12 @@
 
 <script>
 
-  import channelUpdateStrings from './channelUpdateStrings.js';
-  import UpdateChannelModal from './UpdateChannelModal';
-  import NewChannelVersionPage from './NewChannelVersionPage';
-
   export default {
     name: 'NewChannelVersionBanner',
-    components: {
-      UpdateChannelModal,
-      NewChannelVersionPage,
-    },
     props: {
       version: {
         type: Number,
         required: true,
-      },
-    },
-    computed: {
-      // Stubbed out
-      strings() {
-        return channelUpdateStrings;
       },
     },
     $trs: {
@@ -71,25 +47,14 @@
 
 <style lang="scss" scoped>
 
-  .new-version-banner {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    padding: 0 16px;
-  }
-
-  .version {
-    display: flex;
-    align-items: center;
-    // Slight nudge to align with button text
-    margin-bottom: 4px;
+  .version-available {
+    margin-right: 8px;
   }
 
   .icon {
-    margin-right: 16px;
-    margin-bottom: 4px;
+    position: relative;
+    top: 6px;
+    margin-right: 8px;
   }
 
   svg.icon {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
@@ -2,11 +2,13 @@
 
   <div>
     <span class="version">
-      <KIcon
-        class="icon"
-        icon="error"
-        :style="{ fill: $themePalette.lightblue.v_500 }"
-      />
+      <span
+        class="new-label"
+        :style="{ color: $themeTokens.textInverted, backgroundColor: $themeTokens.success }"
+      >
+        {{ newString }}
+      </span>
+
       <span class="version-available">
         {{ $tr('versionAvailable', { version }) }}
       </span>
@@ -24,12 +26,22 @@
 
 <script>
 
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import ChannelUpdateAnnotations from '../SelectContentPage/ChannelUpdateAnnotations';
+
+  const UpdateStrings = crossComponentTranslator(ChannelUpdateAnnotations);
+
   export default {
     name: 'NewChannelVersionBanner',
     props: {
       version: {
         type: Number,
         required: true,
+      },
+    },
+    computed: {
+      newString() {
+        return UpdateStrings.$tr('newResource');
       },
     },
     $trs: {
@@ -49,17 +61,16 @@
 
   .version-available {
     margin-right: 8px;
+    font-weight: bold;
   }
 
-  .icon {
-    position: relative;
-    top: 6px;
+  .new-label {
+    display: inline-block;
+    padding: 2px 8px;
     margin-right: 8px;
-  }
-
-  svg.icon {
-    width: 24px;
-    height: 24px;
+    font-size: 14px;
+    font-weight: bold;
+    border-radius: 2px;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionBanner.vue
@@ -41,6 +41,7 @@
     },
     computed: {
       newString() {
+        // eslint-disable-next-line kolibri/vue-no-undefined-string-uses
         return UpdateStrings.$tr('newResource');
       },
     },

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -24,10 +24,10 @@
 
       <KFixedGrid numCols="4">
         <KFixedGridItem span="1" class="version">
-          {{ $tr('version', { version: versionNumber }) }}
+          <p>{{ $tr('version', { version: versionNumber }) }}</p>
         </KFixedGridItem>
         <KFixedGridItem span="3" alignment="right">
-          <slot></slot>
+          <p><slot></slot></p>
         </KFixedGridItem>
       </KFixedGrid>
 

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -21,9 +21,16 @@
           />
         </h1>
       </div>
-      <p class="version">
-        {{ $tr('version', { version: versionNumber }) }}
-      </p>
+
+      <KFixedGrid numCols="4">
+        <KFixedGridItem span="1" class="version">
+          {{ $tr('version', { version: versionNumber }) }}
+        </KFixedGridItem>
+        <KFixedGridItem span="3" alignment="right">
+          <slot></slot>
+        </KFixedGridItem>
+      </KFixedGrid>
+
       <p dir="auto">
         {{ channel.description }}
       </p>
@@ -120,8 +127,6 @@
   }
 
   .version {
-    margin-bottom: 32px;
-    font-size: 14px;
     font-weight: bold;
   }
 

--- a/kolibri/plugins/device/assets/test/views/SelectContentPage.spec.js
+++ b/kolibri/plugins/device/assets/test/views/SelectContentPage.spec.js
@@ -42,7 +42,7 @@ describe('SelectContentPage', () => {
     expect(summary.find('h1').text()).toEqual('Awesome Channel');
     const pTags = summary.findAll('p');
     expect(pTags.at(0).text()).toEqual('Version 10');
-    expect(pTags.at(1).text()).toEqual('An awesome channel');
+    expect(pTags.at(2).text()).toEqual('An awesome channel');
   });
 
   it('shows the total size of the channel', () => {


### PR DESCRIPTION
### Summary

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/88312274-cc377980-ccc6-11ea-8c2e-3a567b1ea944.png)| ![image](https://user-images.githubusercontent.com/2367265/88322693-ed539680-ccd5-11ea-8bbc-bfcb2cd7e779.png) |


### Reviewer guidance

make sense?

any regressions? 



----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
