### PR TITLE
Set Redis memory policy first and warn about forced cache size decrease

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -10,7 +10,6 @@ from morango.models import InstanceIDModel
 from morango.models import ScopeDefinition
 from morango.sync.controller import MorangoProfileController
 
-from ..utils import bytes_for_humans
 from ..utils import create_superuser_and_provision_device
 from ..utils import get_baseurl
 from ..utils import get_client_and_server_certs
@@ -21,6 +20,7 @@ from kolibri.core.auth.constants.morango_sync import State
 from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.management.utils import run_once
 from kolibri.core.auth.models import dataset_cache
+from kolibri.core.logger.utils.data import bytes_for_humans
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import db_task_write_lock

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -249,26 +249,6 @@ def create_superuser_and_provision_device(username, dataset_id, noninteractive=F
         )
 
 
-BYTES_PREFIXES = ("", "K", "M", "G", "T")
-PREFIX_FACTOR_BYTES = 1024.0
-
-
-def bytes_for_humans(size, suffix="B"):
-    """
-    Function to get bytes in more human readable format, untranslated, for logging purposes.
-    :type size: int
-    :type suffix: str
-    :rtype: str
-    """
-    for prefix in BYTES_PREFIXES:
-        if size < PREFIX_FACTOR_BYTES:
-            if prefix == "":
-                return "{}{}".format(size, suffix)
-            return "{:.2f}{}{}".format(size, prefix, suffix)
-        size /= PREFIX_FACTOR_BYTES
-    return "{:.2f}{}{}".format(size, "P", suffix)
-
-
 def run_once(f):
     """
     Runs a function once, useful for connection once to a signal

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -48,28 +48,3 @@ class GetFacilityTestCase(TestCase):
         Facility.objects.create(name="a_facility")
         Facility.objects.create(name="b_facility")
         self.assertEqual(self.facility, utils.get_facility())
-
-
-class BytesForHumans(TestCase):
-    def test_bytes(self):
-        self.assertEqual("132B", utils.bytes_for_humans(132))
-
-    def test_kilobytes(self):
-        self.assertEqual("242.10KB", utils.bytes_for_humans(242.1 * 1024))
-
-    def test_megabytes(self):
-        self.assertEqual("377.10MB", utils.bytes_for_humans(377.1 * 1024 * 1024))
-
-    def test_gigabytes(self):
-        self.assertEqual("421.50GB", utils.bytes_for_humans(421.5 * 1024 * 1024 * 1024))
-
-    def test_terabytes(self):
-        self.assertEqual(
-            "555.00TB", utils.bytes_for_humans(555 * 1024 * 1024 * 1024 * 1024)
-        )
-
-    def test_petabytes(self):
-        self.assertEqual(
-            "611.77PB",
-            utils.bytes_for_humans(611.77 * 1024 * 1024 * 1024 * 1024 * 1024),
-        )

--- a/kolibri/core/logger/test/test_utils.py
+++ b/kolibri/core/logger/test/test_utils.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from ..utils.data import bytes_for_humans
+
+
+class BytesForHumans(TestCase):
+    def test_bytes(self):
+        self.assertEqual("132B", bytes_for_humans(132))
+
+    def test_kilobytes(self):
+        self.assertEqual("242.10KB", bytes_for_humans(242.1 * 1024))
+
+    def test_megabytes(self):
+        self.assertEqual("377.10MB", bytes_for_humans(377.1 * 1024 * 1024))
+
+    def test_gigabytes(self):
+        self.assertEqual("421.50GB", bytes_for_humans(421.5 * 1024 * 1024 * 1024))
+
+    def test_terabytes(self):
+        self.assertEqual("555.00TB", bytes_for_humans(555 * 1024 * 1024 * 1024 * 1024))
+
+    def test_petabytes(self):
+        self.assertEqual(
+            "611.77PB", bytes_for_humans(611.77 * 1024 * 1024 * 1024 * 1024 * 1024),
+        )

--- a/kolibri/core/logger/utils/data.py
+++ b/kolibri/core/logger/utils/data.py
@@ -1,0 +1,18 @@
+BYTES_PREFIXES = ("", "K", "M", "G", "T")
+PREFIX_FACTOR_BYTES = 1024.0
+
+
+def bytes_for_humans(size, suffix="B"):
+    """
+    Function to get bytes in more human readable format, untranslated, for logging purposes only.
+    :type size: int
+    :type suffix: str
+    :rtype: str
+    """
+    for prefix in BYTES_PREFIXES:
+        if size < PREFIX_FACTOR_BYTES:
+            if prefix == "":
+                return "{}{}".format(size, suffix)
+            return "{:.2f}{}{}".format(size, prefix, suffix)
+        size /= PREFIX_FACTOR_BYTES
+    return "{:.2f}{}{}".format(size, "P", suffix)

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -144,3 +144,9 @@ class RedisSettingsHelperTestCase(TestCase):
         self.helper.save()
         self.client.config_rewrite.assert_called()
         self.assertFalse(self.helper.changed)
+
+    @mock.patch("kolibri.core.utils.cache.logger")
+    def test_get_used_memory(self, mock_logger):
+        self.client.info.return_value = {"used_memory": 123}
+        self.assertEqual(123, self.helper.get_used_memory())
+        self.client.info.assert_called_once_with(section="memory")

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -153,6 +153,9 @@ class RedisSettingsHelper(object):
         logger.info("Configuring Redis: {} {}".format(key, value))
         return self.client.config_set(key, value)
 
+    def get_used_memory(self):
+        return self.client.info(section="memory").get("used_memory")
+
     def get_maxmemory(self):
         return int(self.get("maxmemory", default_value=0))
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
When Redis has used more memory than the setting configured through Kolibri, it could fail if the policy was `noeviction`. So we'll set the policy first and then warn about the cache size change.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Setup Kolibri to use Redis with generous `maxmemory`
2.  Generate a significant amount of data in Redis
3. Stop Kolibri
3. Configure `maxmemory` of half of `$ redis-cli INFO MEMORY`
4. Start Kolibri
5. Ensure you see a warning about it decreasing
6. Ensure the `maxmemory` setting was configured

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Resolves: https://github.com/learningequality/kolibri/pull/7300#issuecomment-663105412

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
