### PR TITLE
channel cards

### DIFF
--- a/kolibri/core/assets/src/views/CoachContentLabel.vue
+++ b/kolibri/core/assets/src/views/CoachContentLabel.vue
@@ -63,6 +63,8 @@
 <style lang="scss" scoped>
 
   .counter {
+    position: relative;
+    left: -4px;
     font-size: 11px;
   }
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -35,7 +35,8 @@
       <div>
         <slot name="abovedescription"></slot>
         <p class="description" dir="auto">
-          {{ channel.description || $tr('defaultDescription') }}
+          <span v-if="channel.description">{{ channel.description }}</span>
+          <span v-else :style="{ color: $themeTokens.annotation }">{{ $tr('defaultDescription') }}</span>
         </p>
         <p class="coach-content">
           <CoachContentLabel

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -230,7 +230,7 @@
 
   .options-btn {
     margin: 0;
-    margin-right: 16px;
+    margin-right: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -42,13 +42,7 @@
           :layout8="{ span: 6 }"
           :layout12="{ span: 9 }"
         >
-          <TextTruncator
-            v-if="tagline"
-            class="text"
-            :text="tagline"
-            :maxHeight="150"
-            :showTooltip="false"
-          />
+          {{ tagline }}
         </KGridItem>
       </div>
 
@@ -187,7 +181,7 @@
     width: 100%;
     // Height set to ensure consistent text height
     // calculated from 150
-    height: 172px;
+    min-height: 172px;
     padding: $margin;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -2,65 +2,47 @@
 
   <router-link
     :to="link"
-    class="card"
-    :style="{ backgroundColor: $themeTokens.surface, color: $themeTokens.text }"
+    class="card-main-wrapper"
+    :style="cardStyle"
   >
 
-    <KGrid :gridStyle="{ marginLeft: 0, marginRight: 0 }">
+    <ProgressIcon
+      v-if="progress > 0"
+      class="progress-icon"
+      :progress="progress"
+    />
 
-      <KGridItem
-        class="card-heading"
-        :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
-        :layout4="{ span: 4 }"
-        :layout8="{ span: 8 }"
-        :layout12="{ span: 12 }"
-      >
-        <h3 class="title" dir="auto">
-          <TextTruncator
-            :text="title"
-            :maxHeight="50"
-          />
-        </h3>
-      </KGridItem>
+    <CoachContentLabel
+      v-if="true || isUserLoggedIn && !isLearner"
+      class="coach-content-label"
+      :value="numCoachContents"
+      :isTopic="isTopic"
+    />
 
-      <div class="card-content">
-        <KGridItem
-          :layout4="{ span: 1 }"
-          :layout8="{ span: 2 }"
-          :layout12="{ span: 3 }"
-        >
-          <CardThumbnail
-            class="thumbnail"
-            v-bind="{ thumbnail, progress, kind, isMobile, showContentIcon }"
-            :showTooltip="false"
-            :showContentIcon="false"
-          />
-        </KGridItem>
+    <h3
+      class="title"
+      dir="auto"
+      :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
+    >
+      <TextTruncator
+        :text="title"
+        :maxHeight="50"
+      />
+    </h3>
 
-        <KGridItem
-          :layout4="{ span: 3 }"
-          :layout8="{ span: 6 }"
-          :layout12="{ span: 9 }"
-        >
-          {{ tagline }}
-        </KGridItem>
-      </div>
-
-      <KGridItem
-        class="card-footer"
-        :layout4="{ span: 4 }"
-        :layout8="{ span: 8 }"
-        :layout12="{ span: 12 }"
-      >
-        <CoachContentLabel
-          v-if="isUserLoggedIn && !isLearner"
-          class="coach-content-label"
-          :value="numCoachContents"
-          :isTopic="isTopic"
+    <KFixedGrid numCols="4" gutter="16" style="margin: 0 16px;">
+      <KFixedGridItem span="1">
+        <CardThumbnail
+          class="thumbnail"
+          v-bind="{ thumbnail, kind, isMobile }"
+          :showTooltip="false"
+          :showContentIcon="false"
         />
-      </KGridItem>
-
-    </KGrid>
+      </KFixedGridItem>
+      <KFixedGridItem span="3">
+        {{ tagline }}
+      </KFixedGridItem>
+    </KFixedGrid>
 
   </router-link>
 
@@ -71,9 +53,11 @@
 
   import { mapGetters } from 'vuex';
   import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import CardThumbnail from './ContentCard/CardThumbnail';
 
   export default {
@@ -82,7 +66,9 @@
       CardThumbnail,
       CoachContentLabel,
       TextTruncator,
+      ProgressIcon,
     },
+    mixins: [responsiveWindowMixin],
     props: {
       title: {
         type: String,
@@ -100,10 +86,6 @@
         type: String,
         required: true,
         validator: validateContentNodeKind,
-      },
-      showContentIcon: {
-        type: Boolean,
-        default: true,
       },
       // ContentNode.coach_content will be `0` if not a coach content leaf node,
       // or a topic without coach content. It will be a positive integer if a topic
@@ -135,6 +117,13 @@
       isTopic() {
         return this.kind === ContentNodeKinds.TOPIC || this.kind === ContentNodeKinds.CHANNEL;
       },
+      cardStyle() {
+        return {
+          backgroundColor: this.$themeTokens.surface,
+          color: this.$themeTokens.text,
+          marginBottom: `${this.windowGutter}px`,
+        };
+      },
     },
   };
 
@@ -149,16 +138,20 @@
   $margin: 16px;
 
   .coach-content-label {
+    position: absolute;
+    bottom: $margin;
+    left: $margin;
     display: inline-block;
   }
 
-  .card {
+  .card-main-wrapper {
     @extend %dropshadow-1dp;
 
+    position: relative;
     display: inline-block;
     width: 100%;
-    min-height: 222px; // Defined in Figma
-    margin-bottom: 24px;
+    min-height: 240px;
+    padding-bottom: 24px;
     text-decoration: none;
     vertical-align: top;
     border-radius: $radius;
@@ -172,9 +165,15 @@
     }
   }
 
-  .card-heading {
-    padding: 0 $margin !important;
+  .title {
+    padding: 0 48px 8px $margin;
     border-bottom: 2px solid #cecece;
+  }
+
+  .progress-icon {
+    position: absolute;
+    top: 12px;
+    right: $margin;
   }
 
   .card-content {
@@ -183,27 +182,6 @@
     // calculated from 150
     min-height: 172px;
     padding: $margin;
-  }
-
-  .thumbnail {
-    position: relative;
-    display: inline-block;
-  }
-
-  .text {
-    position: relative;
-    display: inline-block;
-    padding: 0 0 0 $margin;
-    margin: 0;
-    vertical-align: top;
-  }
-
-  .card-footer {
-    display: block;
-    width: 100%;
-    height: 48px;
-    padding: $margin;
-    font-size: 12px;
   }
 
   /deep/.card-thumbnail-wrapper {

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -1,10 +1,10 @@
 <template>
 
-  <KFixedGrid numCols="2">
-    <KFixedGridItem
+  <KGrid>
+    <KGridItem
       v-for="content in contents"
       :key="content.id"
-      :span="windowIsLarge ? 1 : 2"
+      :layout="{ span: cardColumnSpan }"
     >
       <ChannelCard
         :isMobile="windowIsSmall"
@@ -19,7 +19,7 @@
         :copiesCount="content.copies_count"
         @openCopiesModal="openCopiesModal"
       />
-    </KFixedGridItem>
+    </KGridItem>
 
     <CopiesModal
       v-if="modalIsOpen"
@@ -27,7 +27,7 @@
       :sharedContentId="sharedContentId"
       @submit="modalIsOpen = false"
     />
-  </KFixedGrid>
+  </KGrid>
 
 </template>
 
@@ -65,6 +65,15 @@
       sharedContentId: null,
       uniqueId: null,
     }),
+    computed: {
+      cardColumnSpan() {
+        if (this.windowBreakpoint <= 1) return 4;
+        if (this.windowBreakpoint === 2) return 8;
+        if (this.windowBreakpoint <= 4) return 6;
+        if (this.windowBreakpoint <= 6) return 4;
+        return 3;
+      },
+    },
     methods: {
       openCopiesModal(contentId) {
         this.sharedContentId = contentId;

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -6,6 +6,7 @@
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
     v-bind="immersivePageProps"
+    :maxMainWidth="maxWidth"
   >
     <template slot="app-bar-actions">
       <ActionBarSearchBox v-if="showSearch" />
@@ -249,6 +250,14 @@
         const isAssessment = content && content.assessment;
         // height of .attempts-container in AssessmentWrapper
         return isAssessment ? ASSESSMENT_FOOTER : 0;
+      },
+      maxWidth() {
+        // ref: https://www.figma.com/file/zbxBoJUUkOynZtgK0wO9KD/Channel-descriptions?node-id=281%3A1270
+        if (this.pageName !== PageNames.TOPICS_ROOT) return undefined;
+        if (this.windowBreakpoint <= 2) return 400;
+        if (this.windowBreakpoint <= 4) return 800;
+        if (this.windowBreakpoint <= 6) return 1200;
+        return 1600;
       },
       profileNeedsUpdate() {
         return (

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -54,12 +54,7 @@
           :layout8="{ span: topicOrChannel['thumbnail'] ? 6 : 8 }"
           :layout12="{ span: topicOrChannel['thumbnail'] ? 10 : 12 }"
         >
-          <TextTruncator
-            :text="getTagline"
-            :maxHeight="100"
-            :showTooltip="false"
-            dir="auto"
-          />
+          {{ getTagline }}
         </KGridItem>
 
         <KGridItem


### PR DESCRIPTION
### Summary

This PR doesn't match the specs exactly, but but it gets very close to them. I think it would make sense to get it merged and tested.

Deviation from specs:

* exact card sizes are not quite the same
* thumbnails are still square, not 16:9
* added a fourth card column at very large screen sizes

![2020-07-23 12 44 57](https://user-images.githubusercontent.com/2367265/88332319-2fcfa000-cce3-11ea-983c-6a4c5059cb26.gif)


### References

https://www.figma.com/file/zbxBoJUUkOynZtgK0wO9KD/Channel-descriptions?node-id=281%3A1270

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
