### PR TITLE
Underline back to channels in task manager

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -36,7 +36,9 @@
         <slot name="abovedescription"></slot>
         <p class="description" dir="auto">
           <span v-if="channel.description">{{ channel.description }}</span>
-          <span v-else :style="{ color: $themeTokens.annotation }">{{ $tr('defaultDescription') }}</span>
+          <span v-else :style="{ color: $themeTokens.annotation }">
+            {{ $tr('defaultDescription') }}
+          </span>
         </p>
         <p class="coach-content">
           <CoachContentLabel

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/BackLink.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/BackLink.vue
@@ -2,14 +2,12 @@
 
   <!-- TODO: move this to be a core KBackLink -->
   <span class="offset">
-    <router-link :to="to">
-      <KLabeledIcon
-        icon="back"
-        :label="text"
-        :color="$themeTokens.primary"
-        :style="`text-decoration: underline; color: ${$themeTokens.primary}`"
-      />
-    </router-link>
+    <KRouterLink
+      icon="back"
+      :text="text"
+      :color="$themeTokens.primary"
+      :to="to"
+    />
   </span>
 
 </template>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Use `<KRouterLink>` to make sure the "Back to channels" is underlined.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See https://github.com/learningequality/kolibri/issues/7355#issuecomment-663073317 and see that it is fixed. You'll need to start an import then see it on the manage tasks page.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

No Issue to fix with this, let me know if I'm mistaken.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
