### PR TITLE
Redirect to ‘Select Content Page’ after updating a channel with new content

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -226,6 +226,8 @@
         // Create the import channel task
         return TaskResource.postListEndpoint('startchannelupdate', updateParams)
           .then(taskResponse => {
+            // If there are new resources in the new version, wait until the new
+            // metadata DB is loaded, then redirect to the "Import More from Studio" flow
             if (this.newResources) {
               this.loadingTask = true;
               const taskId = taskResponse.data.id;
@@ -234,7 +236,7 @@
                 const match = tasks.find(task => task.id === taskId) || {};
                 if (match && match.database_ready) {
                   stopWatching();
-                  this.$router.push(this.$router.getRoute(PageNames.MANAGE_CHANNEL));
+                  this.$router.push(this.$router.getRoute('SELECT_CONTENT'));
                 } else if (match.status === TaskStatuses.FAILED) {
                   stopWatching();
                   this.$router.push(this.$router.getRoute('MANAGE_TASKS'));

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -37,7 +37,7 @@
           <th>{{ $tr('resourcesToBeDeleted') }}</th>
           <td>
             <span
-              :class="{ 'count-deleted': deletedResources }"
+              :class="{ 'count-deleted': deletedResources > 0 }"
               :style="{ color: $themeTokens.error }"
             >
               {{ deletedResources }}
@@ -66,15 +66,6 @@
         :delay="false"
       />
 
-      <BottomAppBar>
-        <KButton
-          :text="$tr('updateChannelAction')"
-          appearance="raised-button"
-          :primary="true"
-          :disabled="loadingChannel || loadingTask"
-          @click="showModal = true"
-        />
-      </BottomAppBar>
     </section>
 
     <dl>
@@ -99,13 +90,17 @@
     >
       <p>{{ $tr('updateConfirmationQuestion', { channelName, version: nextVersion }) }}</p>
     </KModal>
+
+    <BottomAppBar>
+      <KButton
+        :text="$tr('updateChannelAction')"
+        appearance="raised-button"
+        :primary="true"
+        :disabled="loadingChannel || loadingTask"
+        @click="showModal = true"
+      />
+    </BottomAppBar>
   </div>
-  <KLinearLoader
-    v-else
-    :indeterminate="true"
-    :delay="false"
-    class="main-loader"
-  />
 
 </template>
 
@@ -120,7 +115,7 @@
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { taskIsClearable, PageNames, TaskStatuses } from '../../constants';
+  import { taskIsClearable, TaskStatuses } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
 
   export default {
@@ -227,7 +222,7 @@
         return TaskResource.postListEndpoint('startchannelupdate', updateParams)
           .then(taskResponse => {
             // If there are new resources in the new version, wait until the new
-            // metadata DB is loaded, then redirect to the "Import More from Studio" flow
+            // metadata DB is loaded, then redirect to the "Import More from Studio" flow.
             if (this.newResources) {
               this.loadingTask = true;
               const taskId = taskResponse.data.id;

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -167,12 +167,13 @@
         });
       },
       sortedFilteredVersionNotes() {
+        // Show version notes for all versions since the current one
         const versionArray = map(this.versionNotes, (val, key) => {
           return {
             version: Number(key),
             notes: val,
           };
-        }).filter(note => note.version >= this.currentVersion);
+        }).filter(note => note.version > this.currentVersion);
         return sortBy(versionArray, note => -note.version);
       },
       watchedTaskHasFinished() {


### PR DESCRIPTION
### Summary

1. Fixes #7369 by redirecting users to the "SELECT_CONTENT" route instead of the "MANAGE_CHANNEL" route.
1. Remove the current version from the channel notes (previously, it was showing all versions from latest to current)
1. Cleans up the Vue template (it had this un-rendered linear loader and a fixed-position bottom bar in the middle of the code)

### Reviewer guidance

1. This is a simple change, could anything go wrong?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
