### PR TITLE
Breadcrumb link fix - force fetch contentnode

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -48,7 +48,7 @@ export function showTopicsTopic(store, { id, isRoot = false }) {
   return store.dispatch('loading').then(() => {
     store.commit('SET_PAGE_NAME', isRoot ? PageNames.TOPICS_CHANNEL : PageNames.TOPICS_TOPIC);
     const promises = [
-      ContentNodeResource.fetchModel({ id }), // the topic
+      ContentNodeResource.fetchModel({ id, force: true }), // the topic
       ContentNodeResource.fetchCollection({
         getParams: {
           parent: id,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Force fetching ContentNodeResource to ensure we have proper tree data for generating the breadcrumbs.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Verify it doesn't work without this fix first: `git checkout upstream/release-v0.14.x`

1. Go to Learn -> Channels -> then drill down through a couple topics (but not into a piece of content).
2. Copy the URL and open a new tab, enter the URL in that tab.
3. Click one of the breadcrumbs to back in the topic tree and you should see an error.

Now: `git checkout THIS/BRANCH` and repeat 1-3 above.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7315 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
