### PR TITLE
Update permissions for NetworkLocationViewSet et al. so Admins can use p2p sync

### DIFF
--- a/kolibri/core/assets/src/mixins/commonSyncElements.js
+++ b/kolibri/core/assets/src/mixins/commonSyncElements.js
@@ -86,8 +86,10 @@ export default {
       });
     },
     startPeerImportTask(data) {
-      const { facility, facility_name, baseurl, username, password } = data;
+      const { facility, facility_name, baseurl, username, password, device_name, device_id } = data;
       return FacilityTaskResource.startpeerfacilityimport({
+        device_name,
+        device_id,
         facility,
         facility_name,
         baseurl,

--- a/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
@@ -100,7 +100,6 @@
       startImport() {
         this.shouldValidate = true;
         if (this.formIsValid) {
-          // return Promise.resolve(true);
           return this.startPeerImportTask({
             device_name: this.device.name,
             device_id: this.device.id,

--- a/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
+++ b/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
@@ -80,9 +80,13 @@
         this.startKdpSyncTask({
           id: this.facilityForSync.id,
           name: this.facilityForSync.name,
-        }).then(task => {
-          this.$emit('success', task.id);
-        });
+        })
+          .then(task => {
+            this.$emit('success', task.id);
+          })
+          .catch(() => {
+            this.$emit('failure');
+          });
       },
       startPeerSync(peerData) {
         this.syncSubmitDisabled = true;
@@ -92,9 +96,13 @@
           device_name: peerData.device_name,
           device_id: peerData.id,
           baseurl: peerData.base_url,
-        }).then(task => {
-          this.$emit('success', task.id);
-        });
+        })
+          .then(task => {
+            this.$emit('success', task.id);
+          })
+          .catch(() => {
+            this.$emit('failure');
+          });
       },
     },
   };

--- a/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
+++ b/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
@@ -70,6 +70,9 @@
         }
       },
       handleAddressSubmit(data) {
+        if (!data.device_name) {
+          data.device_name = data.nickname;
+        }
         this.startPeerSync(data);
       },
       closeModal() {

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -7,12 +7,12 @@ from .models import DynamicNetworkLocation
 from .models import NetworkLocation
 from .models import StaticNetworkLocation
 from .serializers import NetworkLocationSerializer
-from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.device.permissions import NotProvisionedHasPermission
+from .permissions import NetworkLocationPermissions
 
 
 class NetworkLocationViewSet(viewsets.ModelViewSet):
-    permission_classes = [CanManageContent | NotProvisionedHasPermission]
+    permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.all()
 
@@ -26,8 +26,7 @@ class StaticNetworkLocationViewSet(NetworkLocationViewSet):
 
 
 class NetworkLocationFacilitiesView(viewsets.GenericViewSet):
-    # TODO Tighten the first permission to be for superusers only
-    permission_classes = [CanManageContent | NotProvisionedHasPermission]
+    permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
 
     def retrieve(self, request, pk=None):
         """

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -6,9 +6,9 @@ from rest_framework.response import Response
 from .models import DynamicNetworkLocation
 from .models import NetworkLocation
 from .models import StaticNetworkLocation
+from .permissions import NetworkLocationPermissions
 from .serializers import NetworkLocationSerializer
 from kolibri.core.device.permissions import NotProvisionedHasPermission
-from .permissions import NetworkLocationPermissions
 
 
 class NetworkLocationViewSet(viewsets.ModelViewSet):

--- a/kolibri/core/discovery/permissions.py
+++ b/kolibri/core/discovery/permissions.py
@@ -1,0 +1,21 @@
+from rest_framework.permissions import BasePermission
+from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
+
+
+class NetworkLocationPermissions(BasePermission):
+    """
+    A user can access NetworkLocation objects if:
+    1. User can manage content (to get import/export peers)
+    2. User is a facility admin (to be able to sync facility with peer)
+    """
+
+    def has_permission(self, request, view):
+        return request.user.can_manage_content or _user_is_admin_for_own_facility(
+            request.user
+        )
+
+    def has_object_permission(self, request, view, obj):
+        # Don't pass `obj` because locations don't have facilities attached to them
+        return request.user.can_manage_content or _user_is_admin_for_own_facility(
+            request.user
+        )

--- a/kolibri/core/discovery/permissions.py
+++ b/kolibri/core/discovery/permissions.py
@@ -1,4 +1,5 @@
 from rest_framework.permissions import BasePermission
+
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
 
 

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -848,8 +848,9 @@ class FacilityTasksViewSet(BaseViewSet):
         # All other permissions are deferred to permissions_classes decorator
         return []
 
-    @decorators.permission_classes([FacilitySyncPermissions])
-    @decorators.action(methods=["post"], detail=False)
+    @decorators.action(
+        methods=["post"], detail=False, permission_classes=[FacilitySyncPermissions]
+    )
     def startdataportalsync(self, request):
         """
         Initiate a PUSH sync with Kolibri Data Portal.
@@ -862,8 +863,7 @@ class FacilityTasksViewSet(BaseViewSet):
         resp = _job_to_response(facility_queue.fetch_job(job_id))
         return Response(resp)
 
-    @decorators.permission_classes([IsSuperuser])
-    @decorators.action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False, permission_classes=[IsSuperuser])
     def startdataportalbulksync(self, request):
         """
         Initiate a PUSH sync with Kolibri Data Portal for ALL registered facilities.
@@ -879,8 +879,7 @@ class FacilityTasksViewSet(BaseViewSet):
 
         return Response(responses)
 
-    @decorators.permission_classes([IsSuperuser])
-    @decorators.action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False, permission_classes=[IsSuperuser])
     def startpeerfacilityimport(self, request):
         """
         Initiate a PULL of a specific facility from another device.
@@ -897,8 +896,9 @@ class FacilityTasksViewSet(BaseViewSet):
         resp = _job_to_response(facility_queue.fetch_job(job_id))
         return Response(resp)
 
-    @decorators.permission_classes([FacilitySyncPermissions])
-    @decorators.action(methods=["post"], detail=False)
+    @decorators.action(
+        methods=["post"], detail=False, permission_classes=[FacilitySyncPermissions]
+    )
     def startpeerfacilitysync(self, request):
         """
         Initiate a SYNC (PULL + PUSH) of a specific facility from another device.

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -46,6 +46,7 @@ from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.content.utils.upgrade import diff_stats
 from kolibri.core.device.permissions import IsSuperuser
+from kolibri.core.device.permissions import NotProvisionedCanPost
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
@@ -845,7 +846,7 @@ class FacilityTasksViewSet(BaseViewSet):
         if self.action in ["list", "retrieve"]:
             return [p | FacilitySyncPermissions for p in permission_classes]
 
-        # All other permissions are deferred to permissions_classes decorator
+        # All other permissions are deferred to permission_classes decorator
         return []
 
     @decorators.action(
@@ -879,7 +880,12 @@ class FacilityTasksViewSet(BaseViewSet):
 
         return Response(responses)
 
-    @decorators.action(methods=["post"], detail=False, permission_classes=[IsSuperuser])
+    # Method needs to be available in Setup Wizard as well
+    @decorators.action(
+        methods=["post"],
+        detail=False,
+        permission_classes=[IsSuperuser | NotProvisionedCanPost],
+    )
     def startpeerfacilityimport(self, request):
         """
         Initiate a PULL of a specific facility from another device.

--- a/kolibri/core/tasks/permissions.py
+++ b/kolibri/core/tasks/permissions.py
@@ -1,0 +1,20 @@
+from rest_framework.permissions import BasePermission
+
+from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
+
+
+class FacilitySyncPermissions(BasePermission):
+    """
+    A user can sync a facility with a peer or KDP if they are an admin in their
+    own facility or a superuser
+    """
+
+    def has_permission(self, request, view):
+        return request.user.is_superuser or _user_is_admin_for_own_facility(
+            request.user
+        )
+
+    def has_object_permission(self, request, view):
+        return request.user.is_superuser or _user_is_admin_for_own_facility(
+            request.user
+        )

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -163,7 +163,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         response = self.client.get(
             reverse("kolibri:core:facilitytask-list"), format="json"
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_startdataportalsync(self, facility_queue):
         user = self._setup_device()
@@ -451,9 +451,14 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         facility1 = Facility.objects.create(name="facility1")
         Facility.objects.create(name="facility2")
 
-        user = FacilityUser.objects.create(username="superuser", facility=facility1)
+        user = FacilityUser.objects.create(username="notasuperuser", facility=facility1)
         user.set_password(DUMMY_PASSWORD)
         user.save()
+
+        DevicePermissions.objects.create(
+            user=user, is_superuser=False, can_manage_content=True
+        )
+        self.client.logout()
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
 
         response = self.client.post(

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilityTaskPanelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilityTaskPanelDetails.vue
@@ -72,7 +72,7 @@
       </p>
     </div>
 
-    <KButtonGroup :class="{ 'button-lift': Boolean(loaderType) }">
+    <KButtonGroup class="nowrap" :class="{ 'button-lift': Boolean(loaderType) }">
 
       <KButton
         v-if="buttonSet === 'cancel'"
@@ -282,6 +282,10 @@
   .buttons-lift {
     // Lift button a little to align with progress bar
     margin-top: -24px;
+  }
+
+  .nowrap {
+    white-space: nowrap;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -60,7 +60,9 @@ export function syncFacilityTaskDisplayInfo(task) {
   const facilityName = formatNameWithId(task.facility_name, task.facility);
 
   // Device info isn't shown on the Setup Wizard version of panel
-  if (task.device_name) {
+  if (task.type === TaskTypes.SYNCDATAPORTAL) {
+    deviceNameMsg = 'Kolibri Data Portal';
+  } else if (task.device_name) {
     deviceNameMsg = coreString('quotedPhrase', {
       phrase: formatNameWithId(task.device_name, task.device_id),
     });

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -70,6 +70,7 @@
       :facilityForSync="theFacility"
       @close="closeModal"
       @success="handleSyncFacilitySuccess"
+      @failure="handleSyncFacilityFailure"
     />
 
   </KPageContainer>
@@ -171,6 +172,10 @@
         this.isSyncing = true;
         this.syncTaskId = taskId;
         this.pollSyncTask();
+        this.closeModal();
+      },
+      handleSyncFacilityFailure() {
+        this.syncHasFailed = true;
         this.closeModal();
       },
     },

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -127,5 +127,6 @@ class SetupWizardFacilityImportTaskView(FacilityTasksViewSet):
     # Remove all the endpoints we don't want in setup wizard
     startdataportalsync = property()
     startdataportalbulksync = property()
+    # startpeerfacilityimport: not overwritten
     startpeerfacilitysync = property()
     startdeletefacility = property()


### PR DESCRIPTION
### Summary

**Main changes**
1. Modifies permissions on `FacilityTaskViewset`, `NetworkLocationViewSet` and `NetworkLocationFacilitiesViewset` to be accessible from Setup Wizard, Device > Facilities page, _and_ Facility > Data (fixes #7380)
1. Cherry picks a commit from @bjester, fixing `permission_classes` on the method-based views.
1. Adds more specific permissions for different methods on the `FacilityTaskViewset`.  (e.g. methods that should be superuser-only were previously available to the lower "can manage content" permission)
1. Fixes bug in Task Manager where device name/ID metadata was not being displayed

**Bonus fixes**
1. Fixes bug in Device > Facilities > Task Manager where button group buttons had a breaking space between them
1. Adds a "failure" event to the SyncInterface's Sync Modal to handle errors that might happen before the sync task is started.

### Reviewer guidance

1. (1) is implemented by creating new Permissions classes that try to be custom tailored to how we want different endpoints are accessible to different roles. Does the implementation of the class include everybody we want to include and exclude no one we don't want to exclude.
1. Will all types of tasks that have a device (import + sync) get the right device metadata on the Task manager?


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
