### PR TITLE
Allow sentry plugin to work again

### DIFF
--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -4,7 +4,7 @@ import time
 import uuid
 
 from kolibri.core.tasks import compat
-from kolibri.core.utils.cache import get_process_lock
+from kolibri.core.utils.cache import ProcessLock
 
 
 # An object on which to store data about the current job
@@ -120,4 +120,4 @@ class InfiniteLoopThread(compat.Thread):
         self.stop()
 
 
-db_task_write_lock = get_process_lock("db_task_write_lock")
+db_task_write_lock = ProcessLock("db_task_write_lock")

--- a/kolibri/core/test/test_utils.py
+++ b/kolibri/core/test/test_utils.py
@@ -4,8 +4,8 @@ from django.core.cache.backends.base import BaseCache
 from django.test import TestCase
 from redis import Redis
 
-from kolibri.core.utils.cache import get_process_lock
 from kolibri.core.utils.cache import NamespacedCacheProxy
+from kolibri.core.utils.cache import ProcessLock
 from kolibri.core.utils.cache import RedisSettingsHelper
 
 
@@ -21,7 +21,7 @@ class GetProcessLockTestCase(TestCase):
         self.setup_opts(options, redis=True)
         lock = mock.Mock()
         process_cache.lock.return_value = lock
-        self.assertEqual(lock, get_process_lock("test_key", expire=2))
+        self.assertEqual(lock, ProcessLock("test_key", expire=2)._lock)
         process_cache.lock.assert_called_once_with(
             "test_key",
             timeout=2000,
@@ -34,15 +34,15 @@ class GetProcessLockTestCase(TestCase):
         self.setup_opts(options, redis=False)
         sub_cache = mock.Mock()
         process_cache.cache.return_value = sub_cache
-        lock = get_process_lock("test_key", expire=2)
-        self.assertIsInstance(lock, RLock)
+        lock = ProcessLock("test_key", expire=2)
+        self.assertIsInstance(lock._lock, RLock)
         process_cache.cache.assert_called_once_with("locks")
-        self.assertEqual(sub_cache, lock._cache)
-        self.assertEqual("test_key", lock._key)
-        self.assertEqual(2, lock._expire)
+        self.assertEqual(sub_cache, lock._lock._cache)
+        self.assertEqual("test_key", lock._lock._key)
+        self.assertEqual(2, lock._lock._expire)
 
 
-@mock.patch("kolibri.core.utils.cache.get_process_lock")
+@mock.patch("kolibri.core.utils.cache.ProcessLock")
 class NamespacedCacheProxyTestCase(TestCase):
     def setUp(self):
         self.lock = mock.MagicMock(spec=RLock)

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -242,7 +242,15 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
     def _return_module(self, module_name):
         if module_has_submodule(sys.modules[self.module_path], module_name):
             models_module_name = "%s.%s" % (self.module_path, module_name)
-            return import_module(models_module_name)
+            try:
+                return import_module(models_module_name)
+            except Exception as e:
+                logging.warn(
+                    "Tried to import module {module_name} from {plugin} but an error was raised".format(
+                        plugin=self.module_path, module_name=module_name,
+                    )
+                )
+                logging.exception(e)
 
         return None
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from zeroconf import get_all_addresses
 
 import kolibri
-from .conf import OPTIONS
 from .system import kill_pid
 from .system import pid_exists
 from kolibri.core.content.utils import paths
@@ -87,7 +86,7 @@ class ServicesPlugin(SimplePlugin):
         # Initialize the iceqube scheduler to handle scheduled tasks
         scheduler.clear_scheduler()
 
-        if not OPTIONS["Deployment"]["DISABLE_PING"]:
+        if not conf.OPTIONS["Deployment"]["DISABLE_PING"]:
 
             # schedule the pingback job
             from kolibri.core.analytics.utils import schedule_ping


### PR DESCRIPTION
### Summary
* Catches errors during module import in plugin machinery
* Wraps our locks in a wrapper class to prevent early access to Django caches

### Reviewer guidance
Run:
```
pip install kolibri-sentry-plugin
kolibri plugin enable kolibri_sentry_plugin
kolibri start --foreground
```
Check that kolibri starts normally

### References
Fixes #7379

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
