### PR TITLE
Bump Morango to 0.5.4

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.2
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.3
+morango==0.5.4
 tzlocal==1.5.1
 pytz==2018.5
 python-dateutil==2.7.5


### PR DESCRIPTION
### Summary

This PR bumps the Morango version in 0.14 to address two issues we're seeing:
- Cache the instance ID on app load, to avoid lockup issues we were seeing: https://github.com/learningequality/morango/pull/87
- Don't die on session deletion when transfersession.records_total is None: https://github.com/learningequality/morango/pull/88

### Reviewer guidance

To test the first piece, Kolibri needs to be under load, with syncing and other stuff happening at the same time. With SQLite, you'll start seeing Database Locked errors -- e.g. on the Device -> info tab. That should be greatly reduced with this update.

For the second piece, it seems it only happens with 0.13.x or earlier syncing against 0.14.x. It's a bit of an edge case, but something that's important for KDP in particular, and is a very minimal/low-risk change (with a regression test).

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
