### PR TITLE
Use `yarn run lint-frontend` script in `frontend-lint` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         language_version: python2.7
 -   repo: local
     hooks:
-    -   id: frontend-lint
+    -   id: lint-frontend
         name: Linting of JS, Vue, SCSS and CSS files
         description: This hook handles all frontend linting for Kolibri
         entry: yarn run lint-frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,9 @@ repos:
     -   id: frontend-lint
         name: Linting of JS, Vue, SCSS and CSS files
         description: This hook handles all frontend linting for Kolibri
-        entry: yarn run kolibri-tools lint --write
+        entry: yarn run lint-frontend
         language: system
-        files: \.(js|vue|scss|css)$
-        exclude: '^kolibri/core/static/assets/fonts/.+?\.css$|^kolibri/core/content/static/assets/'
+        pass_filenames: false
 - repo: local
   hooks:
   - id: no-auto-migrations

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt",
     "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
     "preinstall": "node ./packages/kolibri-tools/lib/npm_deprecation_warning.js",
-    "lint-frontend": "kolibri-tools lint '{kolibri*/**/assets,packages}/**/*.{js,vue,scss,less,css}' --ignore '**/node_modules/**','**/static/**','**/packages/kolibri-core-for-export/**'",
+    "lint-frontend": "kolibri-tools lint '{kolibri*/**/assets,packages,build_tools}/**/*.{js,vue,scss,less,css}' --ignore '**/node_modules/**','**/static/**','**/packages/kolibri-core-for-export/**'",
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",
     "lint-frontend:watch:format": "yarn run lint-frontend --monitor --write",


### PR DESCRIPTION
### Summary

1. Simplifies the `frontend-lint` pre-commit hook to simply run the `yarn run frontend-lint` script. This makes the output less verbose when it fails.
1. Renames the hook to `lint-frontend` to match the yarn script.

With the current implementation, whenever the hook fails, the command with the expanded `files` regex will appear in the Travis logs

```
$ /Users/jon/Github/kolibri/node_modules/.bin/kolibri-tools lint --write packages/eslint-plugin-kolibri/lib/rules/vue-filename-and-component-name-match.js kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue kolibri/plugins/media_player/assets/src/views/MediaPlayerCaptions/transcriptMenuItem.js packages/kolibri-tools/lib/webpack.config.base.js kolibri/core/assets/src/views/ProgressBar.vue kolibri/plugins/epub_viewer/assets/src/views/NextButton.vue kolibri/plugins/epub_viewer/assets/src/views/TocButton.vue kolibri/core/assets/src/api-resources/channel.js kolibri/core/assets/test/progress-icon.spec.js kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue kolibri/plugins/device/assets/src/modules/managePermissions/index.js 
... 50 or so more lines...

<The actual errors>
```

By running the command as is, the only thing logged is the original script being run in node, which does not expand the glob into the terminal. This has the benefits:

1. It's easier to see the problem in the Travis logs (not only is a single `kolibri-tools lint` call pretty verbose, for some reason it's logged 3 times)
1. The pre-commit hook matches the `yarn run frontend-lint` script most people are using, so it's a little more predictable and consistent.

### Reviewer guidance

Does this still basically work the same? Does the "include" glob in the script match the original `files` field. Similarly the `--ignore` glob match the `exclude` regex?

I added one commit at the end to test that it will cause the tox lint env to fail.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
