### PR TITLE
 Correcting tag name generation for GH links | v0.13.x <- v0.12.x

### DIFF
--- a/.buildkite/create_integration_testing_worksheet.py
+++ b/.buildkite/create_integration_testing_worksheet.py
@@ -20,14 +20,16 @@ SPREADSHEET_CREDENTIALS = os.getenv("GOOGLE_SPREADSHEET_CREDENTIALS")
 SPREADSHEET_TPL_KEY = "1kVhg0evo9EV2aDo10KdIIjwqsoT4rISR7dJzf6s_-RM"
 SPREADSHEET_TITLE = "Integration testing with Gherkin scenarios"
 
+
 # Use to get the Kolibri version, for the integration testing spreadsheet
 def get_tag_name():
     if os.getenv("BUILDKITE_TAG"):
         return os.getenv("BUILDKITE_TAG")
     elif os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH"):
         return os.getenv("BUILDKITE_PULL_REQUEST_BASE_BRANCH")
-    else:
-        return "develop"
+    elif os.getenv("BUILDKITE_BRANCH"):
+        return os.getenv("BUILDKITE_BRANCH")
+    return "develop"
 
 
 SHEET_TAG = get_tag_name()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Issue, reported by @radinamatic, where the links in the generated sheet don't correspond to the correct branch on GH. A bit of an edge case, as this only happens when you navigate to a specific commit's checks and trigger. Fixing the script to handle that case. 

Note: this will be a waterfall merge.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Once this PR is merged, navigate to the build corresponding to the commit that merged PR and let it build. Once it reaches the final `block`, trigger the sheet generation. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- #7365 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
