### PR TITLE
authmessage go back home str on facility select

### DIFF
--- a/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
@@ -2,7 +2,12 @@
 
   <AuthBase :hideCreateAccount="true">
     <div class="facility-select">
-      <KRouterLink class="backlink" :to="backTo" :text="coreString('goBackAction')" icon="back" />
+      <KRouterLink
+        class="backlink"
+        :to="backTo"
+        :text="AuthMessageStrings.$tr('goBackToHomeAction')"
+        icon="back"
+      />
       <div v-if="facilityList['enabled'].length">
         <p class="label">
           {{ label }}
@@ -50,7 +55,9 @@
 
   import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import partition from 'lodash/partition';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { ComponentMap } from '../constants';
   import AuthBase from './AuthBase';
 
@@ -92,6 +99,9 @@
         return this.whereToNext.name === ComponentMap.SIGN_UP
           ? this.$tr('canSignUpForFacilityLabel')
           : this.$tr('selectFacilityLabel');
+      },
+      AuthMessageStrings() {
+        return crossComponentTranslator(AuthMessage);
       },
     },
     methods: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Corrects a string per this issue's note: https://github.com/learningequality/kolibri/issues/7366

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See that the string noted there is correct.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/learningequality/kolibri/issues/7366 (does not fix all)

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
