### PR TITLE
Update pre-commit linting to be selective again and write.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
         description: This hook handles all frontend linting for Kolibri
         entry: yarn run lint-frontend:format
         language: system
-        files: \.(js|vue|scss|css)$
         pass_filenames: false
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,9 @@ repos:
     -   id: lint-frontend
         name: Linting of JS, Vue, SCSS and CSS files
         description: This hook handles all frontend linting for Kolibri
-        entry: yarn run lint-frontend
+        entry: yarn run lint-frontend:format
         language: system
+        files: \.(js|vue|scss|css)$
         pass_filenames: false
 - repo: local
   hooks:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt",
     "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
     "preinstall": "node ./packages/kolibri-tools/lib/npm_deprecation_warning.js",
-    "lint-frontend": "kolibri-tools lint '{kolibri*/**/assets,packages,build_tools}/**/*.{js,vue,scss,less,css}' --ignore '**/node_modules/**','**/static/**','**/packages/kolibri-core-for-export/**'",
+    "lint-frontend": "kolibri-tools lint --pattern '{kolibri*/**/assets,packages,build_tools}/**/*.{js,vue,scss,less,css}' --ignore '**/node_modules/**','**/static/**','**/packages/kolibri-core-for-export/**'",
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",
     "lint-frontend:watch:format": "yarn run lint-frontend --monitor --write",


### PR DESCRIPTION
### Summary
* Recent updates to linting, #7401, updated the pre-commit to use `yarn frontend-lint`
* This doesn't write changes to the files, so does not make auto formatting updates when possible
* This also lints every file that matches the glob pattern, so can take a lot of time
* This PR restricts the linting again and reinstates the write behaviour in the pre-commit hook

### Reviewer guidance

Does linting all files work? Does linting individual files work?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
