### PR TITLE
periodically check for cancelation during import retry logic

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -596,7 +596,7 @@ class ImportContentTestCase(TestCase):
     @patch("kolibri.core.content.management.commands.importcontent.AsyncCommand.cancel")
     @patch(
         "kolibri.core.content.management.commands.importcontent.AsyncCommand.is_cancelled",
-        side_effect=[False, False, False, True, True],
+        side_effect=[False, False, False, True, True, True],
     )
     def test_remote_import_chunkedencodingerror(
         self,
@@ -908,7 +908,7 @@ class ImportContentTestCase(TestCase):
     @patch("kolibri.core.content.management.commands.importcontent.AsyncCommand.cancel")
     @patch(
         "kolibri.core.content.management.commands.importcontent.AsyncCommand.is_cancelled",
-        side_effect=[False, False, False, True, True, True],
+        side_effect=[False] * 32 + [True, True, True],
     )
     def test_remote_import_file_compressed_on_gcs(
         self,
@@ -938,7 +938,7 @@ class ImportContentTestCase(TestCase):
             # Check if truncate() is called since byte-range file resuming is not supported
             open_mock.assert_called_with("test/test.transfer", "wb")
             open_mock.return_value.truncate.assert_called_once()
-            sleep_mock.assert_called_once()
+            sleep_mock.assert_called()
             annotation_mock.set_content_visibility.assert_called_with(
                 self.the_channel_id,
                 [],

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -219,15 +219,14 @@ class FileDownload(Transfer):
         super(FileDownload, self).close()
 
     def resume(self):
-        if self.cancel_check():
-            return
+        logger.info("Waiting 30s before retrying import: {}".format(self.source))
+        for i in range(30):
+            if self.cancel_check():
+                logger.info("Canceling import: {}".format(self.source))
+                return
+            sleep(1)
+
         try:
-            logger.info(
-                "Waiting for 30 seconds before retrying import: {}\n".format(
-                    self.source
-                )
-            )
-            sleep(30)
 
             byte_range_resume = None
             # When internet connection is lost at the beginning of start(),


### PR DESCRIPTION

### Summary

observed that shutting down the mac app took nearly 30s

Appears that it was caught in an edge case where the task was waiting to retry and not checking for cancelation

### Reviewer guidance

tested and appears to work. does the code make sense?

### References

https://www.notion.so/learningequality/Shutting-down-Mac-app-took-30s-cc7a3cbe7eaf44d9a80273c08a255d6e

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
