### PR TITLE
Load ScopedDefinition objects before attempting a facility import via REST API

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -15,6 +15,7 @@ from django.http.response import Http404
 from django.http.response import HttpResponseBadRequest
 from django.utils.translation import get_language_from_request
 from django.utils.translation import gettext_lazy as _
+from morango.models import ScopeDefinition
 from morango.sync.controller import MorangoProfileController
 from requests.exceptions import HTTPError
 from rest_framework import decorators
@@ -1039,6 +1040,10 @@ def validate_and_prepare_peer_sync_job(request, **kwargs):
     facility_id = job_data.get("facility")
     username = request.data.get("username", None)
     password = request.data.get("password", None)
+
+    # call this in case user directly syncs without migrating database
+    if not ScopeDefinition.objects.filter():
+        call_command("loaddata", "scopedefinitions")
 
     controller = MorangoProfileController(PROFILE_FACILITY_DATA)
     network_connection = controller.create_network_connection(baseurl)


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Makes the REST API to the `sync` command (i.e. `api/tasks/startpeerfacilityimport` and `/api/tasks/startpeerfacilitysync`) more similar to the CLI by calling `            call_command("loaddata", "scopedefinitions")` if there are no `ScopedDefinitions` objects.

Rel #7410

### Reviewer guidance

Does this actually address #7410 (need steps to reproduce it reliably)

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
