### PR TITLE
adjust tooltip positions

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -13,6 +13,7 @@
     <CoreInfoIcon
       class="info-icon"
       :tooltipText="$tr('birthYearTooltip')"
+      :tooltipPlacement="tooltipPlacement"
       :iconAriaLabel="$tr('birthyearAriaLabel')"
     />
 
@@ -28,6 +29,7 @@
   import { now } from 'kolibri.utils.serverClock';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
 
   const { NOT_SPECIFIED } = DemographicConstants;
@@ -50,7 +52,7 @@
     components: {
       CoreInfoIcon,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
       value: {
         type: String,
@@ -75,6 +77,12 @@
           ...extraYears,
           ...yearOptions,
         ];
+      },
+      tooltipPlacement() {
+        if (this.windowIsSmall) {
+          return 'left';
+        }
+        return 'bottom';
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
+++ b/kolibri/plugins/facility/assets/src/views/IdentifierTextbox.vue
@@ -12,6 +12,7 @@
     <CoreInfoIcon
       class="info-icon"
       :tooltipText="coreString('identifierInputTooltip')"
+      :tooltipPlacement="tooltipPlacement"
       :iconAriaLabel="coreString('identifierAriaLabel')"
     />
   </div>
@@ -23,16 +24,25 @@
 
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   export default {
     name: 'IdentifierTextbox',
     components: {
       CoreInfoIcon,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
       value: {
         type: String,
+      },
+    },
+    computed: {
+      tooltipPlacement() {
+        if (this.windowIsSmall) {
+          return 'left';
+        }
+        return 'bottom';
       },
     },
     $trs: {


### PR DESCRIPTION


### Summary

dynamically adjust tooltip position based on screen size

| before | after |
|--|--|
|  ![image](https://user-images.githubusercontent.com/2367265/89093609-eaf5da00-d370-11ea-8e25-5ae077220128.png) | ![image](https://user-images.githubusercontent.com/2367265/89093602-d44f8300-d370-11ea-8e30-931806053462.png) |

The not-small version is the same:

![image](https://user-images.githubusercontent.com/2367265/89093613-f517d880-d370-11ea-935c-5cbc65adb7ef.png) 



### References

After https://github.com/learningequality/kolibri/pull/7420 is merged, fixes https://github.com/learningequality/kolibri/issues/6888

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
