### PR TITLE
Bump tzlocal version to work properly with Python 3.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,7 +21,7 @@ jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
 morango==0.5.5
-tzlocal==1.5.1
+tzlocal==2.1
 pytz==2018.5
 python-dateutil==2.7.5
 sqlalchemy==1.3.17


### PR DESCRIPTION
### Summary
The pinned tzlocal version for Kolibri is from 2017 and shows multiple error warnings when running kolibri with Python 3.8.
This  new version has been tested to work well in Python 2.7 and 3.8


### Reviewer guidance
Do tests pass in all python versions?

### References
Thanks to @arky for his solution at ##7425
Closes #7427 , #7415 
[tzlocal changelog](https://pypi.org/project/tzlocal/2.1/)

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
