### PR TITLE
Remove code that's on the plugin setup.py responsability

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -2,7 +2,6 @@ import importlib
 import logging
 import os
 import shutil
-from pkgutil import iter_modules
 
 from django.apps import AppConfig
 from django.apps import apps
@@ -13,7 +12,6 @@ from django.core.urlresolvers import reverse
 from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
 from pkg_resources import iter_entry_points
-from pkg_resources import resource_exists
 from semver import VersionInfo
 
 import kolibri
@@ -469,14 +467,3 @@ def iterate_plugins():
         if _can_import_plugin(name) and name not in plugins:
             plugins.add(name)
             yield name
-    for module_loader, name, is_pkg in iter_modules():
-        try:
-            if (
-                is_pkg
-                and name not in plugins
-                and resource_exists(name, "kolibri_plugin.py")
-                and _can_import_plugin(name)
-            ):
-                yield name
-        except Exception:
-            pass


### PR DESCRIPTION
### Summary

This PR removes code that's not needed anymore if the plugin has the right setup.py configuration.
This code was interfering with other python modules in the system that might use the plugins namespace
Example:
```
pi@raspberrypi:~ $ kolibri plugin list
WARNING:root:No C Extensions available for this platform.
INFO     Option RUN_MODE in section [Deployment] being overridden by environment variable KOLIBRI_RUN_MODE
pygame 1.9.4.post1
Hello from the pygame community. https://www.pygame.org/contribute.html
Exception ignored in: <function Cap1xxx.__del__ at 0xb05644b0>
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cap1xxx.py", line 522, in __del__
    self.stop_watching()
  File "/usr/lib/python3/dist-packages/cap1xxx.py", line 405, in stop_watching
    if not self.alert_pin == -1:
AttributeError: 'Cap1166' object has no attribute 'alert_pin'
...

```
### Reviewer guidance
can you think of any side effect?


### References
Kolibri plugins must have a `"kolibri.plugins"` section in the setup.py `entry_points` as the one at https://github.com/learningequality/kolibri-opensearch-plugin/blob/master/setup.py#L56-L58 or https://github.com/learningequality/kolibri/blob/release-v0.14.x/setup.py#L81 




### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
