### PR TITLE
Change "Network name" to "Name" in SelectAddressModal

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/AddAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/AddAddressForm.vue
@@ -142,7 +142,7 @@
       errorInvalidAddress: 'Please enter a valid IP address, URL, or hostname',
       header: 'New address',
       nameDesc: 'Choose a name for this address so you can remember it later:',
-      nameLabel: 'Network name',
+      nameLabel: 'Name',
       namePlaceholder: 'e.g. House network',
       submitButtonLabel: 'Add',
       tryingToConnect: 'Trying to connect to server…',

--- a/kolibri/locale/ar/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/ar/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "الرجاء إدخال عنوان بروتوكل الإنترنت، أو عنوان رابط، أو اسم مضيف صالح",
   "AddAddressForm.header": "عنوان شبكة جديد",
   "AddAddressForm.nameDesc": "اختر اسماً لهذا العنوان لتتمكن من تذكّره لاحقاً:",
-  "AddAddressForm.nameLabel": "اسم الشبكة",
+  "AddAddressForm.nameLabel": "الاسم",
   "AddAddressForm.namePlaceholder": "مثال: شبكة المنزل",
   "AddAddressForm.submitButtonLabel": "إضافة",
   "AddAddressForm.tryingToConnect": "جاري محاولة الاتصال بالخادم…",

--- a/kolibri/locale/bg_BG/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/bg_BG/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Моля, въведи валиден IP адрес, URL или име на хост",
   "AddAddressForm.header": "Нов адрес",
   "AddAddressForm.nameDesc": "Избери кратко име за адреса, което да можеш лесно да запомниш:",
-  "AddAddressForm.nameLabel": "Име на мрежата",
+  "AddAddressForm.nameLabel": "Име",
   "AddAddressForm.namePlaceholder": "например Домашна мрежа",
   "AddAddressForm.submitButtonLabel": "Добави",
   "AddAddressForm.tryingToConnect": "Опит за свързване към сървъра…",

--- a/kolibri/locale/bn_BD/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/bn_BD/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "অনুগ্রহ করে একটি বৈধ আইপি ঠিকানা, ইউআরএল বা হোস্টনেম লিখুন",
   "AddAddressForm.header": "নতুন ঠিকানা",
   "AddAddressForm.nameDesc": "এই ঠিকানাটিকে একটি নাম দিন যাতে এটা মনে রাখতে পারেন:",
-  "AddAddressForm.nameLabel": "নেটওয়ার্কের নাম",
+  "AddAddressForm.nameLabel": "নাম",
   "AddAddressForm.namePlaceholder": "যেমন বাড়ির নেটওয়ার্ক",
   "AddAddressForm.submitButtonLabel": "যোগ করুন",
   "AddAddressForm.tryingToConnect": "সার্ভারের সাথে যোগাযোগ করার চেষ্টা করা হচ্ছে…",

--- a/kolibri/locale/de/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/de/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Geben Sie eine gültige IP-Adresse, URL oder einen Hostnamen ein",
   "AddAddressForm.header": "Neue Adresse",
   "AddAddressForm.nameDesc": "Wählen Sie einen Namen für diese Adresse für eine zukünftige Verwendung:",
-  "AddAddressForm.nameLabel": "Netzwerkname",
+  "AddAddressForm.nameLabel": "Name",
   "AddAddressForm.namePlaceholder": "z. B. Heimnetzwerk",
   "AddAddressForm.submitButtonLabel": "Hinzufügen",
   "AddAddressForm.tryingToConnect": "Verbindung zum Server wird hergestellt…",

--- a/kolibri/locale/es_419/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/es_419/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Por favor introduzca una URL, una dirección IP válida, o un nombre de equipo",
   "AddAddressForm.header": "Nueva dirección",
   "AddAddressForm.nameDesc": "Ponga un nombre a esta dirección para poder recordarla después:",
-  "AddAddressForm.nameLabel": "Nombre de la red",
+  "AddAddressForm.nameLabel": "Nombre",
   "AddAddressForm.namePlaceholder": "por ejemplo, La red de mi casa",
   "AddAddressForm.submitButtonLabel": "Añadir",
   "AddAddressForm.tryingToConnect": "Intentando conectar al servidor…",

--- a/kolibri/locale/es_ES/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/es_ES/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Por favor introduce una URL, la dirección IP válida, o el nombre de host",
   "AddAddressForm.header": "Nueva dirección",
   "AddAddressForm.nameDesc": "Pon un nombre a esta dirección para poder recordarla después:",
-  "AddAddressForm.nameLabel": "Nombre de la red",
+  "AddAddressForm.nameLabel": "Nombre",
   "AddAddressForm.namePlaceholder": "por ejemplo, La red de mi casa",
   "AddAddressForm.submitButtonLabel": "Añadir",
   "AddAddressForm.tryingToConnect": "Intentando conectar al servidor…",

--- a/kolibri/locale/fa/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/fa/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "لطفن یک آدرس IP، URL یا نام میزبان (hostname) معتبر وارد کنید",
   "AddAddressForm.header": "آدرس جدید",
   "AddAddressForm.nameDesc": "یک نام برای این آدرس انتخاب کنید تا در آینده بتوانید آن را به یاد داشته باشید:",
-  "AddAddressForm.nameLabel": "نام شبکه",
+  "AddAddressForm.nameLabel": "نام",
   "AddAddressForm.namePlaceholder": "برای مثال شبکه‌ی خانگی",
   "AddAddressForm.submitButtonLabel": "افزودن",
   "AddAddressForm.tryingToConnect": "تلاش برای اتصال به سِرور…",

--- a/kolibri/locale/ff_CM/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/ff_CM/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Nastin innde hoɗorde IP no haani, koo URL, koo hostname",
   "AddAddressForm.header": "Innde hoɗorde heyre",
   "AddAddressForm.nameDesc": "Suɓtu innde hoɗorde nde numtata yeeso:",
-  "AddAddressForm.nameLabel": "Innde henndu kompiita",
+  "AddAddressForm.nameLabel": "Innde",
   "AddAddressForm.namePlaceholder": "misaalu henndu kompiita nder suudu",
   "AddAddressForm.submitButtonLabel": "Ɓeydu",
   "AddAddressForm.tryingToConnect": "E ɗum haɓda hawtugo bee senndirɗum…",

--- a/kolibri/locale/fr_FR/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/fr_FR/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Veuillez entrer une adresse IP valide, une URL ou un nom d’hôte",
   "AddAddressForm.header": "Nouvelle adresse",
   "AddAddressForm.nameDesc": "Choisisser un nom pour cette adresse pour vous en souvenir plus tard :",
-  "AddAddressForm.nameLabel": "Nom du réseau",
+  "AddAddressForm.nameLabel": "Nom",
   "AddAddressForm.namePlaceholder": "par exemple le réseau Maison",
   "AddAddressForm.submitButtonLabel": "Ajouter",
   "AddAddressForm.tryingToConnect": "En cours de connexion au serveur…",

--- a/kolibri/locale/gu_IN/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/gu_IN/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "કૃપા કરી માન્ય IP સરનામું, URL અથવા હોસ્ટનું નામ દાખલ કરો",
   "AddAddressForm.header": "નવું સરનામું",
   "AddAddressForm.nameDesc": "આ સરનામાં માટે નામ પસંદ કરો જેથી તમે તેને પછીથી યાદ રાખી શકો:",
-  "AddAddressForm.nameLabel": "નેટવર્ક નું નામ",
+  "AddAddressForm.nameLabel": "નામ",
   "AddAddressForm.namePlaceholder": "દા.ત. ઘરનું નેટવર્ક",
   "AddAddressForm.submitButtonLabel": "ઉમેરો",
   "AddAddressForm.tryingToConnect": "સર્વરથી કનેક્ટ કરવાનો પ્રયાસ કરી રહ્યું છે…",

--- a/kolibri/locale/hi_IN/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/hi_IN/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "कृपया कोई मान्य IP पता, URL या होस्ट नाम दर्ज करें",
   "AddAddressForm.header": "नया पता",
   "AddAddressForm.nameDesc": "इस पते के लिए कोई नाम चुनें ताकि आप इसे बाद में याद रख सकें:",
-  "AddAddressForm.nameLabel": "नेटवर्क नाम",
+  "AddAddressForm.nameLabel": "नाम",
   "AddAddressForm.namePlaceholder": "जैसे: हाउस नेटवर्क",
   "AddAddressForm.submitButtonLabel": "जोड़ें",
   "AddAddressForm.tryingToConnect": "सर्वर से कनेक्ट करने का प्रयास कर रहा है...",

--- a/kolibri/locale/it/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/it/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Inserisci un indirizzo IP, un URL o un nome host validi",
   "AddAddressForm.header": "Nuovo indirizzo",
   "AddAddressForm.nameDesc": "Scegli un nome per questo indirizzo in modo da poterlo ricordare in seguito:",
-  "AddAddressForm.nameLabel": "Nome rete",
+  "AddAddressForm.nameLabel": "Nome",
   "AddAddressForm.namePlaceholder": "per esempio: Rete domestica",
   "AddAddressForm.submitButtonLabel": "Aggiungi",
   "AddAddressForm.tryingToConnect": "Tentativo di connessione al server...",

--- a/kolibri/locale/km/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/km/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "សូមបញ្ចូល IP address, URL ឬ hostname ដែលត្រឹមត្រូវ",
   "AddAddressForm.header": "អាសយដ្ឋាន​ថ្មីណនានា",
   "AddAddressForm.nameDesc": "ជ្រើសរើសឈ្មោះសម្រាប់អាសយដ្ឋាននេះដើម្បីឲអ្នកអាចចងចាំពេលក្រោយ៖",
-  "AddAddressForm.nameLabel": "ឈ្មោះបណ្ដាញ",
+  "AddAddressForm.nameLabel": "ឈ្មោះ",
   "AddAddressForm.namePlaceholder": "ឧ៖ បណ្តាញក្នុងផ្ទះ",
   "AddAddressForm.submitButtonLabel": "បន្ថែម",
   "AddAddressForm.tryingToConnect": "កំពុងព្យាយាមភ្ជាប់ទៅម៉ាស៊ីន Server…",

--- a/kolibri/locale/ko/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/ko/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "유효한 IP주소나, URL, 혹은 호스트네임을 입력하세요",
   "AddAddressForm.header": "새 주소",
   "AddAddressForm.nameDesc": "나중에 기억하기 위해 주소의 이름을 선택하세요",
-  "AddAddressForm.nameLabel": "네트워크 이름",
+  "AddAddressForm.nameLabel": "이름",
   "AddAddressForm.namePlaceholder": "예) 집 네트워크",
   "AddAddressForm.submitButtonLabel": "추가",
   "AddAddressForm.tryingToConnect": "서버에 접속하는 중..",

--- a/kolibri/locale/mr/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/mr/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "कृपया वैध आयपी अड्रेस, यूआरएल किंवा होस्ट नेम प्रविष्ट करा",
   "AddAddressForm.header": "नवीन पत्ता",
   "AddAddressForm.nameDesc": "या पत्त्यासाठी नाव निवडा जेणेकरून भविष्यात तुमच्या लक्षात राहील:",
-  "AddAddressForm.nameLabel": "नेटवर्कचे नाव",
+  "AddAddressForm.nameLabel": "नाव",
   "AddAddressForm.namePlaceholder": "उदा. हाउस नेटवर्क",
   "AddAddressForm.submitButtonLabel": "जोडा",
   "AddAddressForm.tryingToConnect": "सर्व्हरशी संपर्क प्रस्थापित करण्याचा प्रयत्न करत आहोत…",

--- a/kolibri/locale/my/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/my/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "ကျေးဇူးပြု၍မှန်ကန်တဲ့ IP လိပ်စာ, URL နှင့် hostname တို့ဖြင့်၀င်ပါ။",
   "AddAddressForm.header": "လိပ်စာအသစ်",
   "AddAddressForm.nameDesc": "ဒီလိပ်စာအတွက် အမည်တစ်ခုခုရွေးပါ။ သို့မှသာ သင်သည်နောက်ပိုင်းတွင်မှတ်မိလွယ်သည်",
-  "AddAddressForm.nameLabel": "ကွန်ယက်အမည်",
+  "AddAddressForm.nameLabel": "အမည်",
   "AddAddressForm.namePlaceholder": "ဥပမာ၊ အိမ်သုံးကွန်ယက်",
   "AddAddressForm.submitButtonLabel": "ပေါင်း",
   "AddAddressForm.tryingToConnect": "server ကိုချိတ်ဆက်ရန်ကြိုးစားနေသည်။",

--- a/kolibri/locale/nyn/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/nyn/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Lembani IP adiresi, URL, kapena dzina la netiweki lolondola",
   "AddAddressForm.header": "Adiresi yatsopano",
   "AddAddressForm.nameDesc": "Sankhani dzina la adiresi iyi kuti mudzayikumbukire:",
-  "AddAddressForm.nameLabel": "Dzina la netiweki",
+  "AddAddressForm.nameLabel": "Dzina",
   "AddAddressForm.namePlaceholder": "mwachitsanzo, Netiweki ya panyumba",
   "AddAddressForm.submitButtonLabel": "Wonjezerani",
   "AddAddressForm.tryingToConnect": "Tikuyesa kulumikiza ku seva…",

--- a/kolibri/locale/pt_BR/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/pt_BR/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Por favor, insira um endereço IP, URL ou nome de host válido",
   "AddAddressForm.header": "Novo endereço",
   "AddAddressForm.nameDesc": "Dê um nome para este endereço para que você se lembre dele posteriormente:",
-  "AddAddressForm.nameLabel": "Nome da rede",
+  "AddAddressForm.nameLabel": "Nome",
   "AddAddressForm.namePlaceholder": "por exemplo, Rede Casa",
   "AddAddressForm.submitButtonLabel": "Adicionar",
   "AddAddressForm.tryingToConnect": "Tentando se conectar ao servidor…",

--- a/kolibri/locale/sw_TZ/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/sw_TZ/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Tafadhali ingiza anwani ya IP halali, URL au jina la mwenyeji",
   "AddAddressForm.header": "Anwani mpya",
   "AddAddressForm.nameDesc": "Chagua jina la anwani hii ili uweze kukumbuka baadaye:",
-  "AddAddressForm.nameLabel": "Jina la mtandao",
+  "AddAddressForm.nameLabel": "Jina",
   "AddAddressForm.namePlaceholder": "k.m Mtandao wa nyumba",
   "AddAddressForm.submitButtonLabel": "Ongeza",
   "AddAddressForm.tryingToConnect": "Kujaribu kuunganisha kwenye seva…",

--- a/kolibri/locale/te/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/te/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "దయచేసి చెల్లుబాటయ్యే IP చిరునామా, URL లేదా హోస్ట్ పేరుని నమోదు చేయండి",
   "AddAddressForm.header": "కొత్త చిరునామా",
   "AddAddressForm.nameDesc": "ఈ చిరునామాకి ఒక పేరుని ఎంచుకోండి తద్వారా మీరు దీనిని తర్వాత గుర్తుంచుకోవచ్చు:",
-  "AddAddressForm.nameLabel": "నెట్‌వర్క్ పేరు",
+  "AddAddressForm.nameLabel": "పేరు",
   "AddAddressForm.namePlaceholder": "ఉదా. హౌస్ నెట్‌వర్క్",
   "AddAddressForm.submitButtonLabel": "జోడించండి",
   "AddAddressForm.tryingToConnect": "సర్వర్‌కి అనుసంధానమయ్యేందుకు ప్రయత్నిస్తోంది…",

--- a/kolibri/locale/ur_PK/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/ur_PK/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "ایک جائز آئی پی ایڈرس، یو آر ایل یا ہوسٹ نیم داخل کریں",
   "AddAddressForm.header": "نیا ایڈریس",
   "AddAddressForm.nameDesc": "اس پتے کے لئے ایک نام منتخب کریں جو آپ بعد میں یاد کرسکتے ہوں:",
-  "AddAddressForm.nameLabel": "نیٹ ورک کا نام",
+  "AddAddressForm.nameLabel": "نام",
   "AddAddressForm.namePlaceholder": "مثلا گھر کا نیٹ ورک",
   "AddAddressForm.submitButtonLabel": "شامل کیجئے",
   "AddAddressForm.tryingToConnect": "سرور سے رابطے کی کوشش…",

--- a/kolibri/locale/vi/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/vi/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Vui lòng nhập địa chỉ IP, URL hoặc tên máy chủ hợp lệ",
   "AddAddressForm.header": "Địa chỉ mới",
   "AddAddressForm.nameDesc": "Chọn tên cho địa chỉ này để sau này bạn có thể ghi nhớ:",
-  "AddAddressForm.nameLabel": "Tên mạng",
+  "AddAddressForm.nameLabel": "Tên",
   "AddAddressForm.namePlaceholder": "ví dụ: mạng nhà",
   "AddAddressForm.submitButtonLabel": "Thêm",
   "AddAddressForm.tryingToConnect": "Đang thử kết nối đến máy chủ…",

--- a/kolibri/locale/yo/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/yo/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "Jọ̀wọ́ fi ojúlé IP, URL, tàbí orúkọibùdó tí ó tọ́ sílẹ̀ ",
   "AddAddressForm.header": "Ojúlé titun",
   "AddAddressForm.nameDesc": "Yan orúkọ fún ojúlé yìí kí o ba rántí rẹ̀ bí ó bá yá:",
-  "AddAddressForm.nameLabel": "Orúkọ ìṣàsopọ̀ ",
+  "AddAddressForm.nameLabel": "Oruko",
   "AddAddressForm.namePlaceholder": "bí àpẹẹrẹ Ìṣàsopọ̀ ilé",
   "AddAddressForm.submitButtonLabel": "Fi kún",
   "AddAddressForm.tryingToConnect": "Ìgbìyànjú láti so pọ̀ mọ́ apèsè…",

--- a/kolibri/locale/zh_Hans/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/zh_Hans/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -6,7 +6,7 @@
   "AddAddressForm.errorInvalidAddress": "请输入有效的 IP 地址，URL，或主机名",
   "AddAddressForm.header": "新的地址",
   "AddAddressForm.nameDesc": "命名这个地址，这样您以后就可以记住它：",
-  "AddAddressForm.nameLabel": "网络名称",
+  "AddAddressForm.nameLabel": "姓名",
   "AddAddressForm.namePlaceholder": "例：家庭网络",
   "AddAddressForm.submitButtonLabel": "添加",
   "AddAddressForm.tryingToConnect": "尝试连接到服务器......",


### PR DESCRIPTION

### Summary

Based on feedback from @jamalex, myself, and others, rename "Network name" to just "Name" during initial facility import.

This change mirrors updates that @radinamatic and I already made in Crowdin


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
