### PR TITLE
Prevent runtime error in UserType.js if FacilityUser has an incomplete set of Roles

### DIFF
--- a/kolibri/core/assets/src/utils/UserType.js
+++ b/kolibri/core/assets/src/utils/UserType.js
@@ -9,5 +9,19 @@ export default function UserType(userObject) {
   }
 
   // get first role associated with this facility
-  return userObject.roles.find(role => role.collection === userObject.facility).kind;
+  const firstRole = userObject.roles.find(role => role.collection === userObject.facility);
+
+  if (firstRole) {
+    return firstRole.kind;
+  } else {
+    // HACK check for edge case where the User has a Classroom-level COACH role in
+    // spite of not having a Facility-level ASSIGNABLE_COACH role
+    const coachRole = userObject.roles.find(role => role.kind === UserKinds.COACH);
+    if (coachRole) {
+      return UserKinds.ASSIGNABLE_COACH;
+    } else {
+      // If all else fails, display user as a LEARNER
+      return UserKinds.LEARNER;
+    }
+  }
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Adds some handling to this `UserType` utility if some potentially-faulty assumptions about `FacilityUsers` and `Roles` are not true. Namely, in the unusual situation where a User has a `COACH` role for a Classroom-level `Collection`, but not a corresponding `ASSIGNABLE_COACH` role for the Facility, then we still display that user as an assignable coach on the Facility > Users page.

And more importantly, the whole page won't crash.

If there is some other unknown way a user somehow has a Role for a different facility, then there is a catch-all branch to just annotate them as a Learner.

I'll follow up with an issue to implement this business rule (you must have an `ASSIGNABLE` coach role if you have a Classroom-level `COACH` role) on the services layer so we can be more consistent and remove some of the code on the front-end (e.g. `UserType.js` and `updateFacilityLevelRoles` in `userManagement/utils.js`) that tries to implement it.

### Reviewer guidance

1. I re-created the scenario of having a Classroom-`COACH` role without the Facility-`ASSIGNABLE_COACH` role by making a coach, then deleting their `ASSIGNABLE_COACH` role in the DB. This should cause this page to crash, per #7419. With this PR, it will not crash and display the user as a "Coach".
1. Any other situation where the user has `ADMIN` or `ASSIGNABLE_COACH` for a Classroom or a completely different Facility would not make sense in normal usage, but should be handled by displaying the user as a Learner.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
