### PR TITLE
Pass filenames to only lint changed files in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
         description: This hook handles all frontend linting for Kolibri
         entry: yarn run lint-frontend:format
         language: system
+        files: \.(js|vue|scss|css)$
 - repo: local
   hooks:
   - id: no-auto-migrations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
         description: This hook handles all frontend linting for Kolibri
         entry: yarn run lint-frontend:format
         language: system
-        pass_filenames: false
 - repo: local
   hooks:
   - id: no-auto-migrations


### PR DESCRIPTION
### Summary
Pre-commit is still linting all files, rather than just changed files.

Makes pre-commit pass filenames again to make this happen.

### Reviewer guidance
Does Travis still pass?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
