### PR TITLE
Give zombies a chance to finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
   include:
     - python: "3.6"
       env:
-        - TOX_ENV=startup_provision_shutdown_without_zombies
+        - TOX_ENV=timely_shutdown_no_zombies
       script:
        - tox -e $TOX_ENV
     - python: "2.7"

--- a/test/ensure_kolibri_stops_within_time.sh
+++ b/test/ensure_kolibri_stops_within_time.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+MAX=0
+for i in {1..$2}
+do
+  kolibri start --port=$3 > /dev/null 2>&1
+  START_TIME=$SECONDS
+  kolibri stop > /dev/null 2>&1
+  ELAPSED_TIME=$(($SECONDS - $START_TIME))
+  MAX=$(( MAX > ELAPSED_TIME ? MAX : ELAPSED_TIME ))
+  echo "Kolibri stopped in $ELAPSED_TIME seconds"
+done
+echo "Kolibri stopped in a maximum of $MAX seconds"
+if [ "$MAX" -gt "$1" ]; then
+  echo "Kolibri took longer than $1 seconds to shutdown!"
+  exit 1
+else
+  exit 0
+fi

--- a/test/ensure_kolibri_stops_within_time.sh
+++ b/test/ensure_kolibri_stops_within_time.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MAX=0
-for i in {1..$2}
+for i in $(seq 1 $2)
 do
   kolibri start --port=$3 > /dev/null 2>&1
   START_TIME=$SECONDS

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ basepython =
     node10.x: python2.7
     nocext: python2.7
     cext: python2.7
-    startup_provision_shutdown_without_zombies: python3.6
+    timely_shutdown_no_zombies: python3.6
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt
@@ -89,7 +89,7 @@ commands =
     # Run just tests in test/
     py.test --cov=kolibri --cov-report= --cov-append --color=no test/
 
-[testenv:startup_provision_shutdown_without_zombies]
+[testenv:timely_shutdown_no_zombies]
 passenv = TOX_ENV
 whitelist_externals =
     fuser
@@ -99,11 +99,9 @@ deps =
     -r{toxinidir}/requirements/base.txt
 commands =
     - fuser 8082/tcp -k
-    kolibri start --port=8082
-    sleep 5
-    python test/do_mock_provisioning.py
-    kolibri stop
-    sleep 20
+
+    # ensure kolibri stops within 20 seconds 10 times in a row
+    {toxinidir}/test/ensure_kolibri_stops_within_time.sh 20 10 8082
     {toxinidir}/test/ensure_no_kolibris_running_on_port.sh 8082
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ commands =
     sleep 5
     python test/do_mock_provisioning.py
     kolibri stop
-    sleep 5
+    sleep 20
     {toxinidir}/test/ensure_no_kolibris_running_on_port.sh 8082
 
 


### PR DESCRIPTION
### Summary
In #7391, we made a change that causes shutdown times to be a little longer in exchange for more stable peer discovery.  As a result, every once in a while, Kolibri will take ~10 seconds to shutdown.  According to #6809, in order to support battery powered RACHEL implementations, it's important that shutdown times not get too large.  

This PR modifies the "zombie" tox test to ensure that Kolibri shuts down in under 20 seconds 10 times in a row. This is using an adaptation of the script in #7391.

### Reviewer guidance
The relevant tox test has been renamed to `timely_shutdown_no_zombies`.

PR process:

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
