### PR TITLE
pr/7283 setting doesn't get disabled in valid state

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -69,3 +69,4 @@ Please feel free to add your name to this list if you make a PR
 * Julián Duque (julianduque)
 * Brian Kwon (br-kwon)
 * Jacob Pierce (nucleogenesis)
+* Leo Lin (mdctleo)

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -55,7 +55,12 @@
                 :key="setting"
                 :label="$tr('learnerNeedPasswordToLogin')"
                 :checked="!settings['learner_can_login_with_no_password']"
-                @change="toggleSetting('learner_can_login_with_no_password')"
+                @change="() => {
+                  toggleSetting('learner_can_login_with_no_password')
+                  settings['learner_can_edit_password'] &&
+                    !settings['learner_can_login_with_no_password'] ?
+                      toggleSetting('learner_can_edit_password') : null
+                }"
               />
               <KCheckbox
                 :key="setting + 'learner_can_edit_password'"

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -55,12 +55,7 @@
                 :key="setting"
                 :label="$tr('learnerNeedPasswordToLogin')"
                 :checked="!settings['learner_can_login_with_no_password']"
-                @change="() => {
-                  toggleSetting('learner_can_login_with_no_password')
-                  settings['learner_can_edit_password'] &&
-                    !settings['learner_can_login_with_no_password'] ?
-                      toggleSetting('learner_can_edit_password') : null
-                }"
+                @change="toggleLearnerLoginPassword()"
               />
               <KCheckbox
                 :key="setting + 'learner_can_edit_password'"
@@ -213,6 +208,16 @@
           name: settingName,
           value: !this.settings[settingName],
         });
+      },
+
+      toggleLearnerLoginPassword() {
+        this.toggleSetting('learner_can_login_with_no_password');
+        if (
+          this.settings['learner_can_edit_password'] &&
+          !this.settings['learner_can_login_with_no_password']
+        ) {
+          this.toggleSetting('learner_can_edit_password');
+        }
       },
       dismissNotification() {
         this.$store.commit('facilityConfig/CONFIG_PAGE_NOTIFY', null);

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -61,7 +61,8 @@
                 :key="setting + 'learner_can_edit_password'"
                 :disabled="enableChangePassword"
                 :label="$tr('learnerCanEditPassword')"
-                :checked="!settings['learner_can_login_with_no_password'] && settings['learner_can_edit_password']"
+                :checked="!settings['learner_can_login_with_no_password']
+                  && settings['learner_can_edit_password']"
                 class="checkbox-password"
                 @change="toggleSetting('learner_can_edit_password')"
               />

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -61,7 +61,7 @@
                 :key="setting + 'learner_can_edit_password'"
                 :disabled="enableChangePassword"
                 :label="$tr('learnerCanEditPassword')"
-                :checked="settings['learner_can_edit_password']"
+                :checked="!settings['learner_can_login_with_no_password'] && settings['learner_can_edit_password']"
                 class="checkbox-password"
                 @change="toggleSetting('learner_can_edit_password')"
               />


### PR DESCRIPTION

### Summary
setting doesn't get disabled in valid state #7283 

![Aug-06-2020 01-03-15](https://user-images.githubusercontent.com/31061195/89507220-1158b280-d781-11ea-9ace-dad5177928ac.gif)

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
