### PR TITLE
Fix lesson resource removal and lesson deletion bugs

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -145,6 +145,9 @@ export default {
   getRecipientNamesForLesson(state) {
     return function(lesson) {
       const fullLesson = state.lessonMap[lesson.id];
+      if (!fullLesson) {
+        return [];
+      }
       const recipientsForGroups = fullLesson.groups.length
         ? this.getLearnersForGroups(fullLesson.groups)
         : [];

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
@@ -48,7 +48,9 @@ export default {
     },
     REMOVE_FROM_WORKING_RESOURCES(state, resources) {
       state.workingResources = state.workingResources.filter(
-        workingResource => !resources.find(r => r.id === workingResource.contentnode_id)
+        // Resources could either be a content node or a resource item from a lesson
+        workingResource =>
+          !resources.find(r => (r.id || r.contentnode_id) === workingResource.contentnode_id)
       );
     },
     ADD_TO_RESOURCE_CACHE(state, { node, channelTitle }) {

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -64,10 +64,10 @@
     computed: {
       ...mapState('classSummary', ['examMap', 'lessonMap']),
       exam() {
-        return this.examMap[this.$route.params.quizId];
+        return this.examMap[this.$route.params.quizId] || {};
       },
       lesson() {
-        return this.lessonMap[this.$route.params.lessonId];
+        return this.lessonMap[this.$route.params.lessonId] || {};
       },
       resource() {
         return this.examOrLesson === 'lesson' ? this.lesson : this.exam;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -357,7 +357,7 @@
         if (checked) {
           this.addToSelectedResources(content);
         } else {
-          this.removeFromSelectedResources(content);
+          this.removeFromSelectedResources([content]);
         }
       },
       handleSearchTerm(searchTerm) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -335,7 +335,7 @@
       saveResources() {
         return this.saveLessonResources({
           lessonId: this.lessonId,
-          resourceIds: this.workingResources,
+          resources: this.workingResources,
         });
       },
       selectionMetadata(content) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -63,7 +63,7 @@
               <KButton
                 :text="coreString('removeAction')"
                 appearance="flat-button"
-                @click="removeResource(resource.contentnode_id)"
+                @click="removeResource(resource)"
               />
             </KFixedGridItem>
           </KFixedGrid>
@@ -141,9 +141,9 @@
       resourceKind(resourceId) {
         return this.resourceContentNodes[resourceId].kind;
       },
-      removeResource(resourceId) {
-        this.firstRemovalTitle = this.resourceTitle(resourceId);
-        this.removeFromWorkingResources(resourceId);
+      removeResource(resource) {
+        this.firstRemovalTitle = this.resourceTitle(resource.contentnode_id);
+        this.removeFromWorkingResources([resource]);
 
         this.autoSave(this.lessonId, this.workingResources);
 


### PR DESCRIPTION
### Summary

* Fixes regression that prevented resource removal from the ResourceListTable component
* Fixes attempt to access properties on undefined after lesson deletion

### Reviewer guidance
* Confirm that resources can be removed from the resource table in: Plan -> Lessons -> Lesson
* Confirm that deleting a lesson from the same page does not result in any console errors

### References
Fixes #7451
Fixes #7465

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
