### PR TITLE
Return 0 for current interactions when interaction history is undefined.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -198,7 +198,10 @@ oriented data synchronization.
       ...mapGetters(['isUserLoggedIn']),
       ...mapState({
         mastered: state => state.core.logging.mastery.complete,
-        currentInteractions: state => state.core.logging.attempt.interaction_history.length,
+        currentInteractions: state =>
+          state.core.logging.attempt.interaction_history
+            ? state.core.logging.attempt.interaction_history.length
+            : 0,
         totalattempts: state => state.core.logging.mastery.totalattempts,
         pastattempts: state =>
           (state.core.logging.mastery.pastattempts || []).filter(attempt => attempt.error !== true),


### PR DESCRIPTION
### Summary
* Fixes bug where an undefined interaction history would give undefined for currentInteraction value

### Reviewer guidance
* Open an exercise without being logged in
* Don't attempt any questions
* Navigate away from the exercise

### References
Fixes #7467 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
