### PR TITLE
Checks madison returns repo info

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -549,7 +549,7 @@ def installation_type(cmd_line=None):  # noqa:C901
         try:
             check_output(["apt-cache", "show", "kolibri"])
             apt_repo = str(check_output(["apt-cache", "madison", "kolibri"]))
-            if apt_repo:
+            if len(apt_repo) > 4:  # repo will have at least http
                 install_type = "apt"
         except (
             CalledProcessError,

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -555,7 +555,8 @@ def installation_type(cmd_line=None):  # noqa:C901
             CalledProcessError,
             FileNotFoundError,
         ):  # kolibri package not installed!
-            install_type = "whl"
+            if sys.path[-1] != "/usr/lib/python3/dist-packages":
+                install_type = "whl"
         return install_type
 
     def is_kolibri_server():


### PR DESCRIPTION
### Summary
`subprocess.check_output` function returns a binary string instead of a string
With Python 3 versions, conversion from a binary string to string contains` 'b""'` thus the empty output is not really checked as False. This PR does not rely on being an empty string, but in having some chars in it (any apt resource will have at least four chars, with the _http_ or _file_ strings in it)

### Reviewer guidance
With no apt repositories configured to install kolibri in a Debian based distribution, install the package using dpkg.
In Kolibri, device/#/info should say the installer is dpkg:
![image](https://user-images.githubusercontent.com/1008178/90037749-d72d6a80-dcc4-11ea-9938-df0bcb49da3d.png)

### References
Fixes #7449 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
