### PR TITLE
Add `KOptionalText` component to replace `<KEmptyPlaceholder v-else >` pattern

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -22,6 +22,7 @@ import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import heartbeat from 'kolibri.heartbeat';
 import KContentPlugin from 'kolibri-design-system/lib/content/KContentPlugin';
 import KSelect from '../views/KSelect';
+import KOptionalText from '../views/KOptionalText';
 import { i18nSetup, languageDirection } from '../utils/i18n';
 import ContentRendererErrorComponent from '../views/ContentRenderer/ContentRendererError';
 import apiSpec from './apiSpec';
@@ -86,6 +87,7 @@ Vue.use(KContentPlugin, {
 });
 
 Vue.component('KSelect', KSelect);
+Vue.component('KOptionalText', KOptionalText);
 
 // Start the heartbeat polling here, as any URL needs should be set by now
 heartbeat.startPolling();

--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <KOptionalText :text="data ? $formatRelative(ceilingDate, { now }) : ''" />
+  <KOptionalText :text="date ? $formatRelative(ceilingDate, { now }) : ''" />
 
 </template>
 

--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <span v-if="date">
-    {{ $formatRelative(ceilingDate, { now: now }) }}
-  </span>
-  <KEmptyPlaceholder v-else />
+  <KOptionalText :text="data ? $formatRelative(ceilingDate, { now }) : ''" />
 
 </template>
 

--- a/kolibri/core/assets/src/views/KOptionalText.js
+++ b/kolibri/core/assets/src/views/KOptionalText.js
@@ -1,0 +1,27 @@
+import get from 'lodash/get';
+
+export default {
+  name: 'KOptionalText',
+  functional: true,
+  props: {
+    // eslint-disable-next-line
+    text: {
+      type: String,
+      required: false,
+    },
+  },
+  render(createElement, context) {
+    // If the 'text' prop or default slot is an empty string, we render KEmptyPlaceholder
+    let innerText;
+    if (typeof context.props.text === 'string') {
+      innerText = context.props.text.trim();
+    } else {
+      innerText = get(context.slots(), 'default[0].text', '').trim();
+    }
+    if (innerText === '') {
+      return createElement('KEmptyPlaceholder');
+    } else {
+      return createElement('span', [innerText]);
+    }
+  },
+};

--- a/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <span v-if="isSpecified && birthYear">
-    {{ birthYear }}
-  </span>
-  <KEmptyPlaceholder v-else />
+  <KOptionalText :text="isSpecified ? birthYear : ''" />
 
 </template>
 

--- a/kolibri/core/assets/src/views/userAccounts/GenderDisplayText.vue
+++ b/kolibri/core/assets/src/views/userAccounts/GenderDisplayText.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <span v-if="isSpecified && displayText">
-    {{ displayText }}
-  </span>
-  <KEmptyPlaceholder v-else />
+  <KOptionalText :text="isSpecified ? displayText : ''" />
 
 </template>
 
@@ -33,7 +30,7 @@
         } else if (this.gender === FEMALE) {
           return this.coreString('genderOptionFemale');
         }
-        return null;
+        return '';
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -48,10 +48,7 @@
           {{ coachString('descriptionLabel') }}
         </KGridItem>
         <KGridItem :layout12="layout12Value">
-          <template v-if="lesson.description">
-            {{ lesson.description }}
-          </template>
-          <KEmptyPlaceholder v-else />
+          <KOptionalText :text="lesson.description || ''" />
         </KGridItem>
       </div>
     </KGrid>

--- a/kolibri/plugins/coach/assets/src/views/common/Score.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/Score.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <span>
-    <KEmptyPlaceholder v-if="value === undefined || value === null" />
-    <template v-else>{{ coachString('percentage', { value }) }}</template>
-  </span>
+  <KOptionalText :text="scoreText" />
 
 </template>
 
@@ -22,6 +19,15 @@
         validator(value) {
           return value >= 0 && value <= 1;
         },
+      },
+    },
+    computed: {
+      scoreText() {
+        if (this.value === undefined || this.value === null) {
+          return '';
+        } else {
+          return this.coachString('percentage', { value: this.value });
+        }
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/TimeDuration.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TimeDuration.vue
@@ -1,7 +1,6 @@
 <template>
 
-  <span v-if="seconds">{{ formattedTime }}</span>
-  <KEmptyPlaceholder v-else />
+  <KOptionalText :text="formattedTime" />
 
 </template>
 
@@ -22,7 +21,9 @@
     },
     computed: {
       formattedTime() {
-        if (this.seconds < 2 * MINUTE) {
+        if (!this.seconds) {
+          return '';
+        } else if (this.seconds < 2 * MINUTE) {
           return this.$tr('seconds', { value: Math.floor(this.seconds) });
         } else if (this.seconds < HOUR) {
           return this.$tr('minutes', { value: Math.floor(this.seconds / MINUTE) });

--- a/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
@@ -1,20 +1,19 @@
 <template>
 
-  <KEmptyPlaceholder v-if="!items.length" />
-  <div v-else class="items-label">
-    <span v-if="items.length === 1">
+  <KOptionalText class="items-label">
+    <template v-if="items.length === 1">
       {{ items[0] }}
-    </span>
-    <span v-else-if="items.length === 2">
+    </template>
+    <template v-else-if="items.length === 2">
       {{ $tr('twoItems', { item1: items[0], item2: items[1] }) }}
-    </span>
-    <span v-else-if="items.length === 3">
+    </template>
+    <template v-else-if="items.length === 3">
       {{ $tr('threeItems', { item1: items[0], item2: items[1], item3: items[2] }) }}
-    </span>
-    <span v-else>
+    </template>
+    <template v-else>
       {{ $tr('manyItems', { item1: items[0], item2: items[1], count: items.length - 2 }) }}
-    </span>
-  </div>
+    </template>
+  </KOptionalText>
 
 </template>
 

--- a/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/TruncatedItemList.vue
@@ -1,19 +1,21 @@
 <template>
 
-  <KOptionalText class="items-label">
-    <template v-if="items.length === 1">
-      {{ items[0] }}
-    </template>
-    <template v-else-if="items.length === 2">
-      {{ $tr('twoItems', { item1: items[0], item2: items[1] }) }}
-    </template>
-    <template v-else-if="items.length === 3">
-      {{ $tr('threeItems', { item1: items[0], item2: items[1], item3: items[2] }) }}
-    </template>
-    <template v-else>
-      {{ $tr('manyItems', { item1: items[0], item2: items[1], count: items.length - 2 }) }}
-    </template>
-  </KOptionalText>
+  <div class="items-label">
+    <KOptionalText>
+      <template v-if="items.length === 1">
+        {{ items[0] }}
+      </template>
+      <template v-else-if="items.length === 2">
+        {{ $tr('twoItems', { item1: items[0], item2: items[1] }) }}
+      </template>
+      <template v-else-if="items.length === 3">
+        {{ $tr('threeItems', { item1: items[0], item2: items[1], item3: items[2] }) }}
+      </template>
+      <template v-else>
+        {{ $tr('manyItems', { item1: items[0], item2: items[1], count: items.length - 2 }) }}
+      </template>
+    </KOptionalText>
+  </div>
 
 </template>
 

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -25,9 +25,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
         </td>
         <td><span>92 seconds</span></td>
         <!---->
-        <td><span>
-  yesterday
-</span></td>
+        <td><span>yesterday</span></td>
       </tr>
       <tr data-test="entry">
         <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner2</span>
@@ -41,9 +39,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
         </td>
         <td><span>17 seconds</span></td>
         <!---->
-        <td><span>
-  3 hours ago
-</span></td>
+        <td><span>3 hours ago</span></td>
       </tr>
     </transition-group-stub>
   </table>
@@ -77,13 +73,9 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
         </td>
         <td><span>92 seconds</span></td>
         <td>
-          <div class="items-label"><span>
-    group1, group2
-  </span></div>
+          <div class="items-label"><span>group1, group2</span></div>
         </td>
-        <td><span>
-  yesterday
-</span></td>
+        <td><span>yesterday</span></td>
       </tr>
       <tr data-test="entry">
         <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner2</span>
@@ -97,13 +89,9 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
         </td>
         <td><span>17 seconds</span></td>
         <td>
-          <div class="items-label"><span>
-    group2
-  </span></div>
+          <div class="items-label"><span>group2</span></div>
         </td>
-        <td><span>
-  3 hours ago
-</span></td>
+        <td><span>3 hours ago</span></td>
       </tr>
     </transition-group-stub>
   </table>

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsResourceLearners.spec.js.snap
@@ -24,9 +24,7 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
         </td>
         <td><span>92 seconds</span></td>
         <!---->
-        <td><span>
-  yesterday
-</span></td>
+        <td><span>yesterday</span></td>
       </tr>
       <tr>
         <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><span>learner2</span></span></span> <span class="icon-after"><!----></span></span></td>
@@ -39,9 +37,7 @@ exports[`ReportsResourceLearners doesn't render groups information when show gro
         </td>
         <td><span>17 seconds</span></td>
         <!---->
-        <td><span>
-  3 hours ago
-</span></td>
+        <td><span>3 hours ago</span></td>
       </tr>
     </transition-group-stub>
   </table>
@@ -74,13 +70,9 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
         </td>
         <td><span>92 seconds</span></td>
         <td>
-          <div class="items-label"><span>
-    group1, group2
-  </span></div>
+          <div class="items-label"><span>group1, group2</span></div>
         </td>
-        <td><span>
-  yesterday
-</span></td>
+        <td><span>yesterday</span></td>
       </tr>
       <tr>
         <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><span>learner2</span></span></span> <span class="icon-after"><!----></span></span></td>
@@ -93,13 +85,9 @@ exports[`ReportsResourceLearners renders all entries 1`] = `
         </td>
         <td><span>17 seconds</span></td>
         <td>
-          <div class="items-label"><span>
-    group2
-  </span></div>
+          <div class="items-label"><span>group2</span></div>
         </td>
-        <td><span>
-  3 hours ago
-</span></td>
+        <td><span>3 hours ago</span></td>
       </tr>
     </transition-group-stub>
   </table>

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -63,10 +63,11 @@
           </td>
           <td>
             <span :ref="`coachNames${classroom.id}`">
-              <template v-if="coachNames(classroom).length">
-                {{ formattedCoachNames(classroom) }}
-              </template>
-              <KEmptyPlaceholder v-else />
+              <KOptionalText>
+                <template v-if="coachNames(classroom).length">
+                  {{ formattedCoachNames(classroom) }}
+                </template>
+              </KOptionalText>
             </span>
             <KTooltip
               v-if="formattedCoachNamesTooltip(classroom)"

--- a/kolibri/plugins/facility/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserTable.vue
@@ -96,10 +96,7 @@
           </td>
           <template v-if="showDemographicInfo">
             <td class="id-col">
-              <span v-if="user.id_number">
-                {{ user.id_number }}
-              </span>
-              <KEmptyPlaceholder v-else />
+              <KOptionalText :text="user.id_number || ''" />
             </td>
             <td>
               <GenderDisplayText :gender="user.gender" />

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -12,6 +12,7 @@ import { i18nSetup } from 'kolibri.utils.i18n';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import KContentPlugin from 'kolibri-design-system/lib/content/KContentPlugin';
 import KSelect from '../../../kolibri/core/assets/src/views/KSelect';
+import KOptionalText from '../../../kolibri/core/assets/src/views/KOptionalText';
 
 global.beforeEach(() => {
   return new Promise(resolve => {
@@ -36,6 +37,7 @@ Vue.use(VueMeta);
 Vue.use(KThemePlugin);
 Vue.use(KContentPlugin);
 Vue.component('KSelect', KSelect);
+Vue.component('KOptionalText', KOptionalText);
 
 Vue.config.silent = true;
 Vue.config.devtools = false;


### PR DESCRIPTION
### Summary

`KEmptyPlaceholder` is always used with a `v-else` directive next to another text block.

This `KOptionalText` component will either take a `text` prop or a `template` in the default slot and then either display the text in the prop/slot or the `KEmptyPlacehlder` if it's an empty string.

### Reviewer guidance

1. Does this refactor still work for all the current usages of `KEmptyPlaceholder`. 
1. Is it extensible for any future usages of this pattern.
1. Can we/should we make it smarter so we can be a little looser about accepting `text` props that are null or undefined, rather than preferring it strictly be a string?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
