### PR TITLE
pr/7456 In `LearnerClassEnrollmentPage` and `CoachClassAssignmentPage`, place "Confirm" button in fixed bottom bar

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -1,4 +1,4 @@
-<template>
+<template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
 
   <form @submit.prevent="$emit('submit', selectedUsers)">
 
@@ -16,15 +16,15 @@
         />
       </template>
     </PaginatedListContainer>
-
-    <div class="footer">
-      <KButton
-        :text="coreString('confirmAction')"
-        :primary="true"
-        type="submit"
-        :disabled="selectedUsers.length === 0"
-      />
-    </div>
+    <SelectionBottomBar :counts="selectedUsers.length" type="learner" />
+    <!--<div class="footer">-->
+    <!--<KButton-->
+    <!--:text="coreString('confirmAction')"-->
+    <!--:primary="true"-->
+    <!--type="submit"-->
+    <!--:disabled="selectedUsers.length === 0"-->
+    <!--/>-->
+    <!--</div>-->
 
   </form>
 
@@ -38,11 +38,13 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import { userMatchesFilter, filterAndSortUsers } from '../userSearchUtils';
+  import SelectionBottomBar from './SelectionBottomBar';
   import UserTable from './UserTable';
 
   export default {
     name: 'ClassEnrollForm',
     components: {
+      SelectionBottomBar,
       PaginatedListContainer,
       UserTable,
     },

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -17,7 +17,7 @@
       </template>
     </PaginatedListContainer>
     <SelectionBottomBar
-      :counts="selectedUsers.length"
+      :count="selectedUsers.length"
       :type="pageType"
       @click-confirm="$emit('submit', selectedUsers)"
     />

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -1,6 +1,6 @@
 <template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
 
-  <form @submit.prevent="$emit('submit', selectedUsers)">
+  <form>
 
     <PaginatedListContainer
       :items="usersNotInClass"
@@ -16,16 +16,11 @@
         />
       </template>
     </PaginatedListContainer>
-    <SelectionBottomBar :counts="selectedUsers.length" type="learner" />
-    <!--<div class="footer">-->
-    <!--<KButton-->
-    <!--:text="coreString('confirmAction')"-->
-    <!--:primary="true"-->
-    <!--type="submit"-->
-    <!--:disabled="selectedUsers.length === 0"-->
-    <!--/>-->
-    <!--</div>-->
-
+    <SelectionBottomBar
+      :counts="selectedUsers.length"
+      :type="pageType"
+      @click-confirm="$emit('submit', selectedUsers)"
+    />
   </form>
 
 </template>
@@ -58,6 +53,10 @@
         type: Array,
         required: true,
       },
+      pageType: {
+        type: String,
+        required: true,
+      },
     },
     data() {
       return {
@@ -66,6 +65,8 @@
     },
     computed: {
       usersNotInClass() {
+        console.log(this.facilityUsers);
+        console.log(this.classUsers);
         return differenceWith(this.facilityUsers, this.classUsers, (a, b) => a.id === b.id);
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -65,8 +65,6 @@
     },
     computed: {
       usersNotInClass() {
-        console.log(this.facilityUsers);
-        console.log(this.classUsers);
         return differenceWith(this.facilityUsers, this.classUsers, (a, b) => a.id === b.id);
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -1,4 +1,4 @@
-<template xmlns:v-slot="http://www.w3.org/1999/XSL/Transform">
+<template>
 
   <form>
 

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -6,6 +6,7 @@
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
       :classUsers="classUsers"
+      pageType="coaches"
       @submit="assignCoaches"
     />
   </KPageContainer>

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -6,6 +6,7 @@
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
       :classUsers="classUsers"
+      pageType="learners"
       @submit="enrollLearners"
     />
   </KPageContainer>

--- a/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
+++ b/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
@@ -6,7 +6,7 @@
       :disabled="$attrs.disabled || buttonsDisabled"
       :text="coreString('confirmAction')"
       :primary="true"
-      @click="$emit('clickconfirm')"
+      @click="$emit('click-confirm')"
     />
   </BottomAppBar>
 
@@ -15,9 +15,7 @@
 
 <script>
 
-  import sumBy from 'lodash/sumBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
@@ -38,7 +36,7 @@
         type: String,
         required: true,
         validator(value) {
-          return value === 'learner' || value === 'coach';
+          return value === 'learners' || value === 'coaches';
         },
       },
     },
@@ -52,9 +50,7 @@
           : this.$tr('selectedMessage', { counts: this.counts, type: this.type });
       },
     },
-    watch: {},
     $trs: {
-      confirmAction: 'Confirm',
       zeroSelectedMessage: '0 {type} selected',
       selectedMessage: '{counts} {type} selected',
     },

--- a/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
+++ b/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
@@ -17,16 +17,15 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   export default {
     name: 'SelectionBottomBar',
     components: {
       BottomAppBar,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     props: {
-      counts: {
+      count: {
         type: Number,
         required: true,
       },
@@ -40,17 +39,19 @@
     },
     computed: {
       buttonsDisabled() {
-        return this.counts === 0;
+        return this.count === 0;
       },
       selectedMessage() {
-        return this.counts === 0
-          ? this.$tr('zeroSelectedMessage', { type: this.type })
-          : this.$tr('selectedMessage', { counts: this.counts, type: this.type });
+        return this.type === 'learners'
+          ? this.$tr('learnersSelectedMessage', { count: this.count })
+          : this.$tr('coachesSelectedMessage', { count: this.count });
       },
     },
     $trs: {
-      zeroSelectedMessage: '0 {type} selected',
-      selectedMessage: '{counts} {type} selected',
+      coachesSelectedMessage:
+        '{count, number} {count, plural, one {coach} other {coaches}} selected',
+      learnersSelectedMessage:
+        '{count, number} {count, plural, one {learner} other {learners}} selected',
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
+++ b/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
@@ -1,0 +1,73 @@
+<template>
+
+  <BottomAppBar>
+    <span class="message">{{ selectedMessage }}</span>
+    <KButton
+      :disabled="$attrs.disabled || buttonsDisabled"
+      :text="coreString('confirmAction')"
+      :primary="true"
+      @click="$emit('clickconfirm')"
+    />
+  </BottomAppBar>
+
+</template>
+
+
+<script>
+
+  import sumBy from 'lodash/sumBy';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import bytesForHumans from 'kolibri.utils.bytesForHumans';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
+  // Shows a 'EXPORT', 'IMPORT', or 'DELETE' button next to a message
+  // of how many items are selected plus their size.
+  export default {
+    name: 'SelectionBottomBar',
+    components: {
+      BottomAppBar,
+    },
+    mixins: [commonCoreStrings, responsiveWindowMixin],
+    props: {
+      counts: {
+        type: Number,
+        required: true,
+      },
+      type: {
+        type: String,
+        required: true,
+        validator(value) {
+          return value === 'learner' || value === 'coach';
+        },
+      },
+    },
+    computed: {
+      buttonsDisabled() {
+        return this.counts === 0;
+      },
+      selectedMessage() {
+        return this.counts === 0
+          ? this.$tr('zeroSelectedMessage', { type: this.type })
+          : this.$tr('selectedMessage', { counts: this.counts, type: this.type });
+      },
+    },
+    watch: {},
+    $trs: {
+      confirmAction: 'Confirm',
+      zeroSelectedMessage: '0 {type} selected',
+      selectedMessage: '{counts} {type} selected',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .message {
+    display: inline-block;
+    margin-right: 16px;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
+++ b/kolibri/plugins/facility/assets/src/views/SelectionBottomBar.vue
@@ -19,8 +19,6 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
-  // Shows a 'EXPORT', 'IMPORT', or 'DELETE' button next to a message
-  // of how many items are selected plus their size.
   export default {
     name: 'SelectionBottomBar',
     components: {


### PR DESCRIPTION
issue #7456 

changes: 
<img width="1164" alt="Screen Shot 2020-08-18 at 12 19 39 PM" src="https://user-images.githubusercontent.com/31061195/90556157-4683de00-e14d-11ea-84da-0644791dc9aa.png">
<img width="1098" alt="Screen Shot 2020-08-18 at 12 19 52 PM" src="https://user-images.githubusercontent.com/31061195/90556170-4be12880-e14d-11ea-97d7-47444faa3ac2.png">

Added a SelectionBottomBar component in facility. The component is a fixed bottom bar for LearnerClassEnrollmentPage and CoachClassAssignmentPage