### PR TITLE
Show full device ID under advanced

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -108,6 +108,7 @@
           `Free disk space:   ${this.deviceInfo.content_storage_free_space}`,
           `Server time:       ${this.deviceInfo.server_time}`,
           `Server timezone:   ${this.deviceInfo.server_timezone}`,
+          `Device ID:         ${this.deviceInfo.device_id}`,
         ].join('\n');
       },
       deviceNameWithId() {


### PR DESCRIPTION
### Summary
 * I displayed the full device_id (as given in this.deviceInfo) at the bottom of the advanced section. This is for the device info page. 
 * As shown below, it appears to work on chrome. I also tested it on a mobile device and it worked as expected. 

#### After: (for before, please see #7132 ) 
<img width="1001" alt="KolibriDeviceId" src="https://user-images.githubusercontent.com/41556074/91148324-52503280-e66e-11ea-9f41-e6060fd567b3.png">

### Reviewer guidance
 * Test by going to the devices page and clicking on Advanced. See the new item at the bottom of that list. 
 * I am not sure if the develop branch is where this task should have gone (I didn't see the task labeled under a milestone, just in the upcoming patch, so I just used the generic develop branch). 
 * I couldn't figure out how to label this as needs review, so I could use some help with that if possible. Thanks, I appreciate all the work you guys are doing and i'm hoping to contribute more in the future! 

### References
* fixes #7132


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
