### PR TITLE
Fix inaccurate "completion requirement" on Learner report page

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -70,16 +70,27 @@ export const InteractionTypes = {
   error: 'error',
 };
 
+// enum values for `assessmentdata.mastery_model.type` field
+// from le-utils/le_utils/constants/exercises.py
+export const MasteryModelTypes = Object.freeze({
+  do_all: 'do_all',
+  num_correct_in_a_row_2: 'num_correct_in_a_row_2',
+  num_correct_in_a_row_3: 'num_correct_in_a_row_3',
+  num_correct_in_a_row_5: 'num_correct_in_a_row_5',
+  num_correct_in_a_row_10: 'num_correct_in_a_row_10',
+  m_of_n: 'm_of_n',
+});
+
 export const MasteryModelGenerators = {
-  do_all: assessmentIds => ({
+  [MasteryModelTypes.do_all]: assessmentIds => ({
     m: assessmentIds.length,
     n: assessmentIds.length,
   }),
-  num_correct_in_a_row_10: () => ({ m: 10, n: 10 }),
-  num_correct_in_a_row_3: () => ({ m: 3, n: 3 }),
-  num_correct_in_a_row_5: () => ({ m: 5, n: 5 }),
-  num_correct_in_a_row_2: () => ({ m: 2, n: 2 }),
-  m_of_n: (assessmentIds, masteryModel) => masteryModel,
+  [MasteryModelTypes.num_correct_in_a_row_2]: () => ({ m: 2, n: 2 }),
+  [MasteryModelTypes.num_correct_in_a_row_3]: () => ({ m: 3, n: 3 }),
+  [MasteryModelTypes.num_correct_in_a_row_5]: () => ({ m: 5, n: 5 }),
+  [MasteryModelTypes.num_correct_in_a_row_10]: () => ({ m: 10, n: 10 }),
+  [MasteryModelTypes.m_of_n]: (assessmentIds, masteryModel) => masteryModel,
 };
 
 // How many points is a completed content item worth?

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
@@ -25,7 +25,11 @@
               {{ coachString('masteryModelLabel') }}
             </template>
             <template v-slot:value>
-              <MasteryModel />
+              <MasteryModel
+                :model="exercise.assessmentmetadata.mastery_model.type"
+                :m="exercise.assessmentmetadata.mastery_model.m"
+                :n="exercise.assessmentmetadata.mastery_model.n"
+              />
             </template>
           </HeaderTableRow>
           <HeaderTableRow>
@@ -91,6 +95,7 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
+  import MasteryModel from './MasteryModel';
 
   export default {
     name: 'LearnerExerciseReport',
@@ -99,6 +104,7 @@
       InteractionList,
       MultiPaneLayout,
       CoachContentLabel,
+      MasteryModel,
     },
     mixins: [commonCoach, commonCoreStrings],
     data() {

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
@@ -20,22 +20,15 @@
           />
         </p>
         <HeaderTable>
-          <HeaderTableRow>
-            <template v-slot:key>
-              {{ coachString('masteryModelLabel') }}
-            </template>
+          <HeaderTableRow
+            v-if="exercise.assessmentmetadata.mastery_model"
+            :keyText="coachString('masteryModelLabel')"
+          >
             <template v-slot:value>
-              <MasteryModel
-                :model="exercise.assessmentmetadata.mastery_model.type"
-                :m="exercise.assessmentmetadata.mastery_model.m"
-                :n="exercise.assessmentmetadata.mastery_model.n"
-              />
+              <MasteryModel :masteryModel="exercise.assessmentmetadata.mastery_model" />
             </template>
           </HeaderTableRow>
-          <HeaderTableRow>
-            <template v-slot:key>
-              {{ coachString('statusLabel') }}
-            </template>
+          <HeaderTableRow :keyText="coachString('statusLabel')">
             <template v-slot:value>
               <StatusSimple :status="status" />
             </template>

--- a/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
@@ -9,44 +9,56 @@
 
   import { MasteryModelTypes } from 'kolibri.coreVue.vuex.constants';
 
+  function masteryModelValidator({ type, m, n }) {
+    let isValid = true;
+    const typeIsValid = Object.values(MasteryModelTypes).includes(type);
+    if (!typeIsValid) {
+      // eslint-disable-next-line no-console
+      console.error(`Invalid mastery model type: ${type}`);
+      isValid = false;
+    }
+    if (type === MasteryModelTypes.m_of_n) {
+      if (typeof n !== 'number' || typeof m !== 'number') {
+        // eslint-disable-next-line no-console
+        console.error(`Invalid value of m and/or n. m: ${m}, n: ${n}`);
+        isValid = false;
+      }
+    }
+    return isValid;
+  }
+
   export default {
     name: 'MasteryModel',
     props: {
-      model: {
-        type: String,
-        default: MasteryModelTypes.m_of_n,
-        validator(value) {
-          return Object.values(MasteryModelTypes).includes(value);
-        },
-      },
-      m: {
-        type: Number,
-        default: 1,
-      },
-      n: {
-        type: Number,
-        default: 1,
+      masteryModel: {
+        type: Object,
+        required: false,
+        validator: masteryModelValidator,
       },
     },
     computed: {
       text() {
-        if (this.model === MasteryModelTypes.m_of_n) {
-          if (this.m === this.n) {
-            if (this.m === 1) {
+        if (!this.masteryModel) {
+          return '';
+        }
+        const { type, m, n } = this.masteryModel;
+        if (type === MasteryModelTypes.m_of_n) {
+          if (m === n) {
+            if (m === 1) {
               return this.$tr('one');
             }
-            return this.$tr('streak', { m: this.m });
+            return this.$tr('streak', { count: m });
           }
-          return this.$tr('mOfN', { M: this.m, N: this.n });
-        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_10) {
+          return this.$tr('mOfN', { M: m, N: n });
+        } else if (type === MasteryModelTypes.num_correct_in_a_row_10) {
           return this.$tr('streak', { count: 10 });
-        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_2) {
+        } else if (type === MasteryModelTypes.num_correct_in_a_row_2) {
           return this.$tr('streak', { count: 2 });
-        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_3) {
+        } else if (type === MasteryModelTypes.num_correct_in_a_row_3) {
           return this.$tr('streak', { count: 3 });
-        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_5) {
+        } else if (type === MasteryModelTypes.num_correct_in_a_row_5) {
           return this.$tr('streak', { count: 5 });
-        } else if (this.model === MasteryModelTypes.do_all) {
+        } else if (type === MasteryModelTypes.do_all) {
           return this.$tr('doAll');
         } else {
           return this.$tr('unknown');
@@ -55,7 +67,7 @@
     },
     $trs: {
       one: 'Get one question correct',
-      // TODO add pluralized versions of 'streak', and 'mofN'
+      // TODO(i18n) add pluralized versions of 'streak', and 'mofN'
       streak: 'Get {count, number, integer} questions in a row correct',
       mOfN: 'Get {M, number, integer} of the last {N, number, integer} questions correct',
       doAll: 'Get every question correct',

--- a/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
@@ -7,31 +7,16 @@
 
 <script>
 
-  // from le-utils/le_utils/constants/exercises.py
-  const DO_ALL = 'do_all';
-  const NUM_CORRECT_IN_A_ROW_10 = 'num_correct_in_a_row_10';
-  const NUM_CORRECT_IN_A_ROW_2 = 'num_correct_in_a_row_2';
-  const NUM_CORRECT_IN_A_ROW_3 = 'num_correct_in_a_row_3';
-  const NUM_CORRECT_IN_A_ROW_5 = 'num_correct_in_a_row_5';
-  const M_OF_N = 'm_of_n';
-
-  const models = [
-    DO_ALL,
-    NUM_CORRECT_IN_A_ROW_10,
-    NUM_CORRECT_IN_A_ROW_2,
-    NUM_CORRECT_IN_A_ROW_3,
-    NUM_CORRECT_IN_A_ROW_5,
-    M_OF_N,
-  ];
+  import { MasteryModelTypes } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     name: 'MasteryModel',
     props: {
       model: {
         type: String,
-        default: M_OF_N,
+        default: MasteryModelTypes.m_of_n,
         validator(value) {
-          return models.includes(value);
+          return Object.values(MasteryModelTypes).includes(value);
         },
       },
       m: {
@@ -45,7 +30,7 @@
     },
     computed: {
       text() {
-        if (this.model === M_OF_N) {
+        if (this.model === MasteryModelTypes.m_of_n) {
           if (this.m === this.n) {
             if (this.m === 1) {
               return this.$tr('one');
@@ -53,15 +38,15 @@
             return this.$tr('streak', { m: this.m });
           }
           return this.$tr('mOfN', { M: this.m, N: this.n });
-        } else if (this.model === NUM_CORRECT_IN_A_ROW_10) {
+        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_10) {
           return this.$tr('streak', { count: 10 });
-        } else if (this.model === NUM_CORRECT_IN_A_ROW_2) {
+        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_2) {
           return this.$tr('streak', { count: 2 });
-        } else if (this.model === NUM_CORRECT_IN_A_ROW_3) {
+        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_3) {
           return this.$tr('streak', { count: 3 });
-        } else if (this.model === NUM_CORRECT_IN_A_ROW_5) {
+        } else if (this.model === MasteryModelTypes.num_correct_in_a_row_5) {
           return this.$tr('streak', { count: 5 });
-        } else if (this.model === DO_ALL) {
+        } else if (this.model === MasteryModelTypes.do_all) {
           return this.$tr('doAll');
         } else {
           return this.$tr('unknown');
@@ -70,6 +55,7 @@
     },
     $trs: {
       one: 'Get one question correct',
+      // TODO add pluralized versions of 'streak', and 'mofN'
       streak: 'Get {count, number, integer} questions in a row correct',
       mOfN: 'Get {M, number, integer} of the last {N, number, integer} questions correct',
       doAll: 'Get every question correct',

--- a/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/MasteryModel.vue
@@ -26,7 +26,6 @@
 
   export default {
     name: 'MasteryModel',
-    components: {},
     props: {
       model: {
         type: String,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -44,9 +44,20 @@
         </KGridItem>
       </KGrid>
       <CoachContentLabel :value="content.num_coach_contents" :isTopic="false" />
-      <p v-if="completionRequirements">
-        {{ completionRequirements }}
-      </p>
+      <HeaderTable>
+        <HeaderTableRow
+          v-if="completionData"
+          :keyText="coachString('masteryModelLabel')"
+        >
+          <template #value>
+            <MasteryModel
+              :model="completionData.type"
+              :m="completionData.m"
+              :n="completionData.n"
+            />
+          </template>
+        </HeaderTableRow>
+      </HeaderTable>
       <!-- eslint-disable-next-line vue/no-v-html -->
       <p v-if="description" dir="auto" v-html="description"></p>
       <ul class="meta">
@@ -103,6 +114,8 @@
     licenseDescriptionForConsumer,
   } from 'kolibri.utils.licenseTranslations';
   import markdownIt from 'markdown-it';
+  import MasteryModel from '../../common/MasteryModel';
+  import commonCoach from '../../common';
   import QuestionList from './QuestionList';
   import ContentArea from './ContentArea';
 
@@ -119,8 +132,9 @@
       CoachContentLabel,
       InfoIcon,
       MultiPaneLayout,
+      MasteryModel,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonCoach],
     props: {
       currentContentNode: {
         type: Object,
@@ -161,13 +175,6 @@
           return this.questions[this.selectedQuestionIndex];
         }
         return '';
-      },
-      completionRequirements() {
-        if (this.completionData) {
-          const { m: correct, n: total } = this.completionData;
-          return this.$tr('completionRequirements', { correct, total });
-        }
-        return false;
       },
       description() {
         if (this.content) {
@@ -213,7 +220,6 @@
       },
     },
     $trs: {
-      completionRequirements: 'Completion: {correct, number} out of {total, number} correct',
       authorDataHeader: 'Author',
       licenseDataHeader: 'License',
       copyrightHolderDataHeader: 'Copyright holder',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -50,11 +50,7 @@
           :keyText="coachString('masteryModelLabel')"
         >
           <template #value>
-            <MasteryModel
-              :model="completionData.type"
-              :m="completionData.m"
-              :n="completionData.n"
-            />
+            <MasteryModel :masteryModel="completionData" />
           </template>
         </HeaderTableRow>
       </HeaderTable>


### PR DESCRIPTION
### Summary

#### Changed
1. Move mastery model related constants out of `MasteryModel.vue` into core constants module
1. Change interface to `MasteryModel.vue` to take a single `masteryModel` prop that should match the `mastery_model` field for assessment metadata.
1. In `LessonContentPreviewPage`, replace the completion requirement section with `MasteryModel` for consistency 

#### Fixed
1. Exercise mastery criteria wasn't being passed into `MasteryModel` in `LearnerExerciseReport` (Fixes #7400

#### Preview Page before/after
![CleanShot 2020-08-28 at 13 09 15@2x](https://user-images.githubusercontent.com/10248067/91612669-c0c51700-e932-11ea-833d-95c6168a522c.png)
![CleanShot 2020-08-28 at 13 07 26@2x](https://user-images.githubusercontent.com/10248067/91612680-c28eda80-e932-11ea-8c09-d2e2d486a260.png)


#### Learner report page before/after

![CleanShot 2020-08-28 at 13 08 49@2x](https://user-images.githubusercontent.com/10248067/91612686-c7538e80-e932-11ea-9b03-e791e273f645.png)
![CleanShot 2020-08-28 at 13 08 10@2x](https://user-images.githubusercontent.com/10248067/91612689-c884bb80-e932-11ea-9558-5d45ba9acef7.png)

### Reviewer guidance

1. Does the refactor to the core constants module break anything else?
1. Is #7400 fixed for all types of exercises?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
