### PR TITLE
Fix minor issue in Channel Upgrade test

### DIFF
--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -302,7 +302,7 @@ class ChannelBuilder(object):
                 node = self.generate_leaf(parent_id)
             else:
                 node = self.generate_topic(parent_id=parent_id)
-                node["children"] = self.recurse_and_generate(parent_id, levels - 1)
+                node["children"] = self.recurse_and_generate(node["id"], levels - 1)
             children.append(node)
         return children
 


### PR DESCRIPTION
### Summary
* Fixes bug where the parent_id passed into the function was passed down through all recursively loops, resulting in an unnested tree.

### Reviewer guidance
* If tests still pass this is good to go.

### References
* Discovered when this code was ported to Studio - similar error fixed here: https://github.com/learningequality/studio/pull/2158

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
