### PR TITLE
Make padding in AuthBase more consistent; remove unused styles

### DIFF
--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -308,7 +308,7 @@
     @extend %dropshadow-16dp;
 
     width: 360px;
-    padding: 24px 32px;
+    padding: 32px;
     margin: 16px auto;
     border-radius: $radius;
   }
@@ -318,7 +318,8 @@
   }
 
   .create {
-    margin: 24px auto 16px;
+    margin-top: 24px;
+    margin-bottom: 0;
   }
 
   .guest {

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -567,46 +567,6 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .fh {
-    height: 100%;
-  }
-
-  .wrapper-table {
-    display: table;
-    width: 100%;
-    height: 100%;
-    text-align: center;
-  }
-
-  .table-row {
-    display: table-row;
-  }
-
-  .main-row {
-    text-align: center;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: cover;
-  }
-
-  .table-cell {
-    display: table-cell;
-  }
-
-  .main-cell {
-    height: 100%;
-    vertical-align: middle;
-  }
-
-  .box {
-    @extend %dropshadow-16dp;
-
-    width: 300px;
-    padding: 16px 32px;
-    margin: 16px auto;
-    border-radius: $radius;
-  }
-
   .login-form {
     text-align: left;
   }
@@ -614,34 +574,6 @@
   .login-btn {
     width: 100%;
     margin-top: 16px;
-  }
-
-  .create {
-    margin-top: 32px;
-    margin-bottom: 8px;
-  }
-
-  .guest {
-    margin-top: 8px;
-    margin-bottom: 16px;
-  }
-
-  .small-text {
-    font-size: 0.8em;
-  }
-
-  .version-string {
-    white-space: nowrap;
-  }
-
-  .footer-cell {
-    @extend %dropshadow-8dp;
-
-    padding: 16px;
-  }
-
-  .footer-cell .small-text {
-    margin-top: 8px;
   }
 
   .suggestions-wrapper {
@@ -660,45 +592,6 @@
     // Move up snug against the textbox
     margin-top: -2em;
     list-style-type: none;
-  }
-
-  .textbox-enter-active {
-    transition: opacity 0.5s;
-  }
-
-  .textbox-enter {
-    opacity: 0;
-  }
-
-  .list-leave-active {
-    transition: opacity 0.1s;
-  }
-
-  .textbox-leave {
-    transition: opacity 0s;
-  }
-
-  .logo {
-    width: 100%;
-    max-width: 65vh; // not compatible with older browsers
-    height: auto;
-  }
-
-  .kolibri-title {
-    margin-top: 0;
-    margin-bottom: 8px;
-    font-size: 24px;
-    font-weight: 100;
-  }
-
-  .footer-logo {
-    position: relative;
-    top: -1px;
-    display: inline-block;
-    height: 24px;
-    margin-right: 10px;
-    margin-left: 8px;
-    vertical-align: middle;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
1. Remove unused styles from `SignInPage`
1. Make padding in AuthBase more consistent (so it's 32px all around for all of the different steps). Fixes #7491


#### After screenshots (see #7491) for before screenshots

![CleanShot 2020-08-31 at 11 46 35@2x](https://user-images.githubusercontent.com/10248067/91755794-8b156d80-eb80-11ea-9aa1-b795bca18377.png)
![CleanShot 2020-08-31 at 11 44 50@2x](https://user-images.githubusercontent.com/10248067/91755805-9072b800-eb80-11ea-8c0b-a6deb0dd7314.png)

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
