### PR TITLE
Documentation: install git lfs and basic PostreSQL configuration

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -365,6 +365,7 @@ You can initialize the server using:
 
   kolibri manage migrate
 
+To use a PostgreSQL database, you would edit the `options.ini` file in `KOLIBRI_HOME`, setting options under the `[Database]` section to appropriate values. For the `DATABASE_ENGINE` option, use the value `postgres`.
 
 .. _workflow_intro:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -45,16 +45,16 @@ Next, initialize Git LFS:
 
 .. code-block:: bash
 
+  cd kolibri  # Enter the Kolibri directory
   git lfs install
 
 Finally, add the Learning Equality repo as a remote. That way you can keep your local checkout updated with the most recent changes:
 
 .. code-block:: bash
 
-  cd kolibri  # Enter the Kolibri directory
   git remote add upstream git@github.com:learningequality/kolibri.git
   git fetch --all  # Check if there are changes upstream
-  git checkout develop # Checkout the development branch
+  git checkout --track origin/develop # Checkout the development branch of your fork
 
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. The command `git lfs install` needs to be run within a directory that contains a git repository. This is a minor correction to the docs to make sure that the user is instructed to change directories after cloning and before running `git lfs install`.

2. There didn't seem to be any information about how to go about setting up a PostgreSQL database (at least, not under the Databases section), so I added information regarding `options.ini` to that portion of the docs.

### Reviewer guidance
I tested these changes by walking through what's described in the [Getting Started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) section of the development docs in a pristine container.

### References
#6545


----

### Contributor Checklist


PR process:

- [?] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
