### PR TITLE
Update authors.md file with table of users, and simplified introduction

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,15 +1,11 @@
+# Contributors
 
-# Credits
+Kolibri is copyrighted by Learning Equality under the MIT License.
 
-## Development Lead and Copyright Holder
-
-Learning Equality – info@learningequality.org
-
-## Community
-
-Please feel free to add your name to this list if you make a PR
+If you have contributed to Kolibri, feel free to add your name and Github account to this list:
 
 | Name | Github user |
+|------|-------------|
 | Eli Dai | 66eli77 |
 | Akshay Mahajan | akshaymahajans |
 | Alan Chen | alanchenz |

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,62 +9,63 @@ Learning Equality – info@learningequality.org
 
 Please feel free to add your name to this list if you make a PR
 
-* Eli Dai (66eli77)
-* Akshay Mahajan (akshaymahajans)
-* Alan Chen (alanchenz)
-* Eduard James Aban (arceduardvincent)
-* Arky (arky)
-* Aron Fyodor Asor (aronasorman)
-* Kapya (Aypak)
-* Benjamin Bach (benjaoming)
-* Boni Đukić (bonidjukic)
-* John (BruvaJ)
-* Chao-Wen Tan (chaowentan)
-* Christian Memije (christianmemije)
-* Cyril Pauya (cpauya)
-* David Hu (divad12)
-* Derek Lobo (dlobo)
-* David Cañas (DXCanas)
-* Mingqi Zhu (EmanekaT)
-* Gerardo Soto (GCodeON)
-* Geoff Rich (geoffrey1218)
-* Hans Gamboa (HansGam)
-* Devon Rueckner (indirectlylit)
-* (inflrscns)
-* Ivan Savov (ivanistheone)
-* Jamie Alexandre (jamalex)
-* Jason Tame (JasonTame)
-* Jordan Yoshihara (jayoshih)
-* Jessica Aceret (jessicaaceret)
-* Jonathan Boiser (jonboiser)
-* José L. Redrejo Rodríguez (jredrejo)
-* Jessica Aceret (jtamiace)
-* Karla Avila (k2avila)
-* Kevin Ollivier (kollivier)
-* Paul Luna (luna215)
-* Lingyi Wang (lyw07)
-* Magali Boizot-Roche (magali-br)
-* Maureen Hernandez (MauHernandez)
-* Michael Gallaspy (MCGallaspy)
-* Michael Gamlem III (mgamlem3)
-* Michaela Robosova (MisRob)
-* Eduard James Aban (mrpau-eduard)
-* Eugene Oliveros (mrpau-eugene)
-* Julius legaspi (mrpau-julius)
-* Richard Amodia (mrpau-richard)
-* Nick Cannariato (nickcannariato)
-* Radina Matic (radinamatic)
-* Rafael Aguayo (ralphiee22)
-* Hyun Ahn (rationality6)
-* Rachel Kim (rayykim)
-* Richard Tibbles (rtibbles)
-* Shanavas M (shanavas786)
-* Whitney Zhu (whitzhu)
-* Carol Willing (willingc)
-* Yixuan Liu (yil039)
-* Blaine Jester (bjester)
-* Brandon Nguyen (bransgithub)
-* Chris Castle (crcastle)
-* Julián Duque (julianduque)
-* Brian Kwon (br-kwon)
-* Jacob Pierce (nucleogenesis)
+| Name | Github user |
+| Eli Dai | 66eli77 |
+| Akshay Mahajan | akshaymahajans |
+| Alan Chen | alanchenz |
+| Eduard James Aban | arceduardvincent |
+| Arky | arky |
+| Aron Fyodor Asor | aronasorman |
+| Kapya | Aypak |
+| Benjamin Bach | benjaoming |
+| Blaine Jester | bjester |
+| Boni Đukić | bonidjukic |
+| Brian Kwon | br-kwon |
+| Brandon Nguyen | bransgithub |
+| John | BruvaJ |
+| Chao-Wen Tan | chaowentan |
+| Christian Memije | christianmemije |
+| Cyril Pauya | cpauya |
+| Chris Castle | crcastle |
+| David Hu | divad12 |
+| Derek Lobo | dlobo |
+| David Cañas | DXCanas |
+| Mingqi Zhu | EmanekaT |
+| Gerardo Soto | GCodeON |
+| Geoff Rich | geoffrey1218 |
+| Hans Gamboa | HansGam |
+| Devon Rueckner | indirectlylit |
+| inflrscns | inflrscns |
+| Ivan Savov | ivanistheone |
+| Jamie Alexandre | jamalex |
+| Jason Tame | JasonTame |
+| Jordan Yoshihara | jayoshih |
+| Jessica Aceret | jessicaaceret |
+| Jonathan Boiser | jonboiser |
+| José L. Redrejo Rodríguez | jredrejo |
+| Jessica Aceret | jtamiace |
+| Julián Duque | julianduque |
+| Karla Avila | k2avila |
+| Kevin Ollivier | kollivier |
+| Paul Luna | luna215 |
+| Lingyi Wang | lyw07 |
+| Magali Boizot-Roche | magali-br |
+| Maureen Hernandez | MauHernandez |
+| Michael Gallaspy | MCGallaspy |
+| Michael Gamlem III | mgamlem3 |
+| Michaela Robosova | MisRob |
+| Eduard James Aban | mrpau-eduard |
+| Eugene Oliveros | mrpau-eugene |
+| Julius legaspi | mrpau-julius |
+| Richard Amodia | mrpau-richard |
+| Nick Cannariato | nickcannariato |
+| Jacob Pierce | nucleogenesis |
+| Radina Matic | radinamatic |
+| Rafael Aguayo | ralphiee22 |
+| Hyun Ahn | rationality6 |
+| Rachel Kim | rayykim |
+| Richard Tibbles | rtibbles |
+| Shanavas M | shanavas786 |
+| Whitney Zhu | whitzhu |
+| Carol Willing | willingc |
+| Yixuan Liu | yil039 |


### PR DESCRIPTION
Fixes #7474 .

The table of users was made by copying the original table to Google Sheets, parsing the lines, sorting, then reconstructing the markdown table. One line was edited for a user who only provided a github username.