### PR TITLE
Remove ContentNode filters with no implementation

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -144,17 +144,11 @@ class IdFilter(FilterSet):
 
 
 class ContentNodeFilter(IdFilter):
-    recommendations_for = CharFilter(method="filter_recommendations_for")
-    next_steps = CharFilter(method="filter_next_steps")
-    popular = CharFilter(method="filter_popular")
-    resume = CharFilter(method="filter_resume")
     kind = ChoiceFilter(
         method="filter_kind",
         choices=(content_kinds.choices + (("content", _("Resource")),)),
     )
     user_kind = ChoiceFilter(method="filter_user_kind", choices=user_kinds.choices)
-    in_lesson = CharFilter(method="filter_in_lesson")
-    in_exam = CharFilter(method="filter_in_exam")
     exclude_content_ids = CharFilter(method="filter_exclude_content_ids")
     kind_in = CharFilter(method="filter_kind_in")
     parent = UUIDFilter("parent")
@@ -167,10 +161,6 @@ class ContentNodeFilter(IdFilter):
             "has_prerequisite",
             "related",
             "exclude_content_ids",
-            "recommendations_for",
-            "next_steps",
-            "popular",
-            "resume",
             "ids",
             "content_id",
             "channel_id",


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Removes some filters from the `ContentNodeFilter` that don't appear to have an implementing `method` and have been supplanted by other API endpoints.

### Reviewer guidance

Does this break anything?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
