### PR TITLE
 Concurrent import file download

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -1,7 +1,7 @@
-import concurrent.futures
 import logging
 import os
 
+import concurrent.futures
 import requests
 from django.core.management.base import CommandError
 from le_utils.constants import content_kinds
@@ -336,8 +336,11 @@ class Command(AsyncCommand):
             with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
                 future_file_transfers = {}
                 for f, filetransfer in file_transfers:
-                    future = executor.submit(self._start_file_transfer,
-                        f, filetransfer, overall_progress_update
+                    future = executor.submit(
+                        self._start_file_transfer,
+                        f,
+                        filetransfer,
+                        overall_progress_update,
                     )
                     future_file_transfers[future] = (f, filetransfer)
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -286,8 +286,6 @@ class Command(AsyncCommand):
         with self.start_progress(
             total=total_bytes_to_transfer + dummy_bytes_for_annotation
         ) as overall_progress_update:
-            exception = None  # Exception that is not caught by the retry logic
-
             if method == DOWNLOAD_METHOD:
                 session = requests.Session()
 
@@ -370,7 +368,7 @@ class Command(AsyncCommand):
                             number_of_skipped_files += 1
                             continue
                         else:
-                            exception = e
+                            self.exception = e
                             break
 
             with db_task_write_lock:
@@ -406,8 +404,8 @@ class Command(AsyncCommand):
 
             overall_progress_update(dummy_bytes_for_annotation)
 
-            if exception:
-                raise exception
+            if self.exception:
+                raise self.exception
 
             if self.is_cancelled():
                 self.cancel()

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -417,13 +417,10 @@ class Command(AsyncCommand):
             * FILE_TRANSFERRED - successfully transfer the file.
             * FILE_SKIPPED - the file does not exist so it is skipped.
         """
-        with filetransfer, self.start_progress(
-            total=filetransfer.total_size
-        ) as file_dl_progress_update:
+        with filetransfer:
             for chunk in filetransfer:
                 length = len(chunk)
                 overall_progress_update(length)
-                file_dl_progress_update(length)
 
             # Ensure that if for some reason the total file size for the transfer
             # is less than what we have marked in the database that we make up

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -717,9 +717,11 @@ class ImportContentTestCase(TestCase):
         ).update(file_size=1)
         path_mock.side_effect = [local_dest_path, local_src_path]
         files_to_transfer_mock.return_value = (
-            [LocalFile.objects.filter(
-                files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
-            ).first()],
+            [
+                LocalFile.objects.filter(
+                    files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
+                ).first()
+            ],
             10,
         )
         call_command(
@@ -908,7 +910,7 @@ class ImportContentTestCase(TestCase):
     @patch(
         "kolibri.core.content.management.commands.importcontent.AsyncCommand.is_cancelled",
         # We have to return False for 30 1-second checks to ensure we actually retry.
-        side_effect=[False] * 32 + [True] * 5
+        side_effect=[False] * 32 + [True] * 5,
     )
     def test_remote_import_file_compressed_on_gcs(
         self,

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -425,7 +425,6 @@ class ImportContentTestCase(TestCase):
         cancel_mock.assert_called_with()
         annotation_mock.set_content_visibility.assert_called()
 
-    @patch("kolibri.core.content.management.commands.importcontent.len")
     @patch(
         "kolibri.core.content.utils.transfer.Transfer.next",
         side_effect=ConnectionError("connection error"),
@@ -440,7 +439,6 @@ class ImportContentTestCase(TestCase):
         is_cancelled_mock,
         cancel_mock,
         next_mock,
-        len_mock,
         annotation_mock,
         files_to_transfer_mock,
         channel_list_status_mock,
@@ -467,7 +465,6 @@ class ImportContentTestCase(TestCase):
             node_ids=["32a941fb77c2576e8f6b294cde4c3b0c"],
         )
         cancel_mock.assert_called_with()
-        len_mock.assert_not_called()
         annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.core.content.management.commands.importcontent.logger.warning")
@@ -587,7 +584,6 @@ class ImportContentTestCase(TestCase):
             self.the_channel_id, [], node_ids=None, exclude_node_ids=None, public=False
         )
 
-    @patch("kolibri.core.content.management.commands.importcontent.len")
     @patch("kolibri.core.content.utils.transfer.sleep")
     @patch(
         "kolibri.core.content.utils.transfer.Transfer.next",
@@ -604,7 +600,6 @@ class ImportContentTestCase(TestCase):
         cancel_mock,
         error_mock,
         sleep_mock,
-        len_mock,
         annotation_mock,
         files_to_transfer_mock,
         channel_list_status_mock,
@@ -631,7 +626,6 @@ class ImportContentTestCase(TestCase):
             node_ids=["32a941fb77c2576e8f6b294cde4c3b0c"],
         )
         cancel_mock.assert_called_with()
-        len_mock.assert_not_called()
         annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.core.content.management.commands.importcontent.logger.warning")

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -82,6 +82,7 @@ class Transfer(object):
         # record whether the destination file already exists, so it can be checked, but don't error out
         self.dest_exists = os.path.isfile(dest)
 
+    def start(self):
         # open the destination file for writing
         self.dest_file_obj = open(self.dest_tmp, "wb")
 
@@ -159,6 +160,7 @@ class FileDownload(Transfer):
         super(FileDownload, self).__init__(*args, **kwargs)
 
     def start(self):
+        super(FileDownload, self).start()
         # initiate the download, check for status errors, and calculate download size
         try:
             self.response = self.session.get(
@@ -276,6 +278,7 @@ class FileCopy(Transfer):
         assert (
             not self.started
         ), "File copy has already been started, and cannot be started again"
+        super(FileCopy, self).start()
         self.total_size = os.path.getsize(self.source)
         self.source_file_obj = open(self.source, "rb")
         self.started = True

--- a/kolibri/core/tasks/management/commands/base.py
+++ b/kolibri/core/tasks/management/commands/base.py
@@ -97,6 +97,12 @@ class AsyncCommand(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         self.progresstrackers = []
+
+        # The importcontent command stores an unhandled exception and re-raises it
+        # later. We check it in is_cancelled so that we cancel remaining tasks once
+        # an unhandled exception has occurred.
+        self.exception = None
+
         super(AsyncCommand, self).__init__(*args, **kwargs)
 
     def _update_all_progress(self, progress_fraction, progress):
@@ -129,6 +135,8 @@ class AsyncCommand(BaseCommand):
         return tracker
 
     def is_cancelled(self):
+        if self.exception is not None:
+            return True
         try:
             self.check_for_cancel()
             return False


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Changes the importcontent command to download files concurrently, using 5 threads.

After our recent discussions about the slow download profiling, I spent a bit of a time over the weekend seeing how hard it might be, and what gains we might get, if downloads were run concurrently instead of one-by-one. By switching to `ThreadPoolExecutor`, I was able to reduce African Storybooks download time from ~75min to ~21min, and based on my local connection speed test, I had estimated ~18min if the connection was fully utilized. I haven't tested this on python 2, but I believe we already have the python 2 backport of concurrent.futures in Kolibri.

Note that I'm still working on updating some tests, but can confirm the failures come from a change to the number and order of calls to `is_cancelled`, along with the removal of some `time.sleep` calls. It is taking time because I want to make sure we give the right number and order of values for each call.

Note that I haven't tested this on Python 2, and have not done any disk copy testing aside from running the unit tests. I am hoping to play around with this some more this coming weekend, but posting so that people are aware of the work and so that if anyone wants to play with this, they can.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
