### PR TITLE
Add pool_pre_ping argument when connecting to Postgres with SQLAlchemy.

### DIFF
--- a/kolibri/core/content/test/sqlalchemytesting.py
+++ b/kolibri/core/content/test/sqlalchemytesting.py
@@ -1,5 +1,4 @@
 from sqlalchemy import create_engine
-from sqlalchemy.pool import NullPool
 
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import SharingPool
@@ -11,5 +10,5 @@ def django_connection_engine():
             get_default_db_string(), poolclass=SharingPool, convert_unicode=True
         )
     return create_engine(
-        get_default_db_string(), poolclass=NullPool, convert_unicode=True
+        get_default_db_string(), convert_unicode=True, pool_pre_ping=True
     )

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -94,17 +94,20 @@ def get_engine(connection_string):
     Get a SQLAlchemy engine that allows us to connect to a database.
     """
     # Set echo to False, as otherwise we get full SQL Query outputted, which can overwhelm the terminal
-    engine = create_engine(
-        connection_string,
-        echo=False,
+    engine_kwargs = {
+        "echo": False,
+        "convert_unicode": True,
+    }
+
+    if connection_string.startswith("sqlite"):
         # Set timeout to 60s, as with most of our content import write operations
         # it is more important to complete, than to do so quickly.
-        connect_args={"check_same_thread": False, "timeout": 60}
-        if connection_string.startswith("sqlite")
-        else {},
-        poolclass=NullPool,
-        convert_unicode=True,
-    )
+        engine_kwargs["connect_args"] = {"check_same_thread": False, "timeout": 60}
+        engine_kwargs["poolclass"] = NullPool
+    else:
+        engine_kwargs["pool_pre_ping"] = True
+
+    engine = create_engine(connection_string, **engine_kwargs)
     if connection_string == get_default_db_string() and connection_string.startswith(
         "sqlite"
     ):

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -373,6 +373,7 @@ class Bridge(object):
         self.session.close()
         if self.connection:
             self.connection.close()
+        self.engine.dispose()
 
 
 def filter_by_uuids(field, ids, validate=True, vendor=None):

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -41,7 +41,8 @@ elif conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres":
                 port=":" + conf.OPTIONS["Database"]["DATABASE_PORT"]
                 if conf.OPTIONS["Database"]["DATABASE_PORT"]
                 else "",
-            )
+            ),
+            pool_pre_ping=True,
         )
 
 


### PR DESCRIPTION
### Summary
* Adds the `pool_pre_ping` argument to engine creation for SQLAlchemy to ensure that a connection in the pool has not been disconnected on the server side.

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [ ] Contributor has fully tested the PR manually
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
