### PR TITLE
Fix user menu & side nav escape button closing

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -43,7 +43,7 @@
           class="user-menu-button"
           :class="$computedClass({ ':focus': $coreOutline })"
           :ariaLabel="$tr('userMenu')"
-          @click="userMenuDropdownIsOpen = !userMenuDropdownIsOpen"
+          @click="handleUserMenuButtonClick"
         >
           <KIcon
             slot="icon"
@@ -174,6 +174,15 @@
       window.removeEventListener('click', this.handleWindowClick);
     },
     methods: {
+      handleUserMenuButtonClick(event) {
+        this.userMenuDropdownIsOpen = !this.userMenuDropdownIsOpen;
+        if (this.userMenuDropdownIsOpen) {
+          this.$nextTick(() => {
+            this.$refs.userMenuDropdown.$el.focus();
+          });
+        }
+        return event;
+      },
       handleWindowClick(event) {
         if (
           !this.$refs.userMenuDropdown.$el.contains(event.target) &&
@@ -186,8 +195,8 @@
       },
       handleCoreMenuClose() {
         this.userMenuDropdownIsOpen = false;
-        if (this.$refs.userMenuButton.$refs.button) {
-          this.$refs.userMenuButton.$refs.button.focus();
+        if (this.$refs.userMenuButton) {
+          this.$refs.userMenuButton.$el.focus();
         }
       },
       handleChangeLanguage() {

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div @keydown.esc="$emit('close')">
+  <div tabindex="0" @keyup.esc="$emit('close')">
     <ul
       role="menu"
       class="ui-menu"
@@ -86,7 +86,6 @@
         };
       },
     },
-
     watch: {
       isOpen(val) {
         if (val === false) {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div ref="sideNav" class="side-nav-wrapper" @keyup.esc="toggleNav">
+  <div ref="sideNav" class="side-nav-wrapper" tabindex="0" @keyup.esc="toggleNav">
     <transition name="side-nav">
       <div
         v-show="navShown"


### PR DESCRIPTION
### Summary

Added tabindex to sidenav div. Added tabindex to user menu, made user menu focus after button click and fixed button focus after user menu closing.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/94083590-3e822280-fe0c-11ea-82eb-d95a814fac83.gif)

### References

#7111 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
