### PR TITLE
Update pre-commit config for `black` hook, remove `black-fmt` dependency

### DIFF
--- a/.buildkite/create_integration_testing_worksheet.py
+++ b/.buildkite/create_integration_testing_worksheet.py
@@ -114,9 +114,9 @@ def create_artifact(str_arg):
 
 def fetch_feature_files():
     """
-        Fetch all the .features scenarios at the Integration testing directory
-        The order of the scenarios at the spreadsheet will based on the ORDER.txt
-        This will return a list and a count of .features scenarios
+    Fetch all the .features scenarios at the Integration testing directory
+    The order of the scenarios at the spreadsheet will based on the ORDER.txt
+    This will return a list and a count of .features scenarios
     """
     feature_dir = get_feature_dir_path()
     order_name = "/ORDER.txt"
@@ -162,8 +162,8 @@ def fetch_feature_files():
 
 def sheet_insert_rows(sheet, wrk_sheet, start_index=0, end_index=0):
     """
-        REF: https://github.com/burnash/gspread
-        I reuse the gspread function to make this API request.
+    REF: https://github.com/burnash/gspread
+    I reuse the gspread function to make this API request.
     """
     body = {
         "requests": [
@@ -184,8 +184,8 @@ def sheet_insert_rows(sheet, wrk_sheet, start_index=0, end_index=0):
 
 def rename_worksheet(sheet, wrk_sheet, sheet_name):
     """
-        REF: https://github.com/burnash/gspread
-        I reuse the gspread function to make this API request.
+    REF: https://github.com/burnash/gspread
+    I reuse the gspread function to make this API request.
     """
     body = {
         "requests": [
@@ -202,8 +202,8 @@ def rename_worksheet(sheet, wrk_sheet, sheet_name):
 
 def search_file_name(file_name):
     """
-        REF: https://github.com/burnash/gspread
-        I reuse the gspread function to make this API request.
+    REF: https://github.com/burnash/gspread
+    I reuse the gspread function to make this API request.
     """
     self = G_ACCESS
     files = []
@@ -229,8 +229,8 @@ def search_file_name(file_name):
 
 def create_sheet_container(file_id, dir_name):
     """
-        REF: https://github.com/burnash/gspread
-        I reuse the gspread function to make this API request.
+    REF: https://github.com/burnash/gspread
+    I reuse the gspread function to make this API request.
     """
     self = G_ACCESS
     payload = {
@@ -244,8 +244,8 @@ def create_sheet_container(file_id, dir_name):
 
 def sheet_copy(file_id, dist_id, title=None, copy_permissions=False):
     """
-        REF: https://github.com/burnash/gspread
-        I reuse the gspread function to make this request.
+    REF: https://github.com/burnash/gspread
+    I reuse the gspread function to make this request.
     """
     self = G_ACCESS
 
@@ -282,7 +282,7 @@ def sheet_copy(file_id, dist_id, title=None, copy_permissions=False):
 
 def sheet_container():
     """
-        Return the spreadsheet container ID.
+    Return the spreadsheet container ID.
     """
     drive_search = search_file_name(SHEET_TAG)
     if len(drive_search) == 0:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         kolibri/core/logger/migrations/0003_auto_20170531_1140\.py|
         kolibri/core/logger/migrations/0005_auto_20180514_1419\.py|
       )$
--   repo: https://github.com/psf/black
+-   repo: git@github.com:psf/black.git
     rev: stable
     hooks:
     - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         kolibri/core/logger/migrations/0003_auto_20170531_1140\.py|
         kolibri/core/logger/migrations/0005_auto_20180514_1419\.py|
       )$
--   repo: git@github.com:psf/black.git
-    rev: stable
+-   repo: https://github.com/python/black
+    rev: 20.8b1
     hooks:
     - id: black

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -338,9 +338,7 @@ class FacilityViewSet(ValuesViewset):
             dataset[stripped_key] = facility.pop(dataset_key)
         return dataset
 
-    field_map = {
-        "dataset": _map_dataset,
-    }
+    field_map = {"dataset": _map_dataset}
 
     def annotate_queryset(self, queryset):
         return (

--- a/kolibri/core/auth/filters.py
+++ b/kolibri/core/auth/filters.py
@@ -240,10 +240,12 @@ class HierarchyRelationsFilter(object):
             else ""
         )
 
-        joined_condition = "EXISTS (SELECT * FROM {tables} {left_join_tables} WHERE {where})".format(
-            tables=", ".join(self.tables),
-            left_join_tables=left_join_sql,
-            where=self._join_with_logical_operator(self.where, "AND"),
+        joined_condition = (
+            "EXISTS (SELECT * FROM {tables} {left_join_tables} WHERE {where})".format(
+                tables=", ".join(self.tables),
+                left_join_tables=left_join_sql,
+                where=self._join_with_logical_operator(self.where, "AND"),
+            )
         )
 
         return self.queryset.extra(where=[joined_condition])

--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -213,7 +213,7 @@ class Command(AsyncCommand):
 
     def _get_morango_models(self, dataset_id):
         querysets = [
-            DatabaseMaxCounter.objects.filter(partition__startswith=dataset_id),
+            DatabaseMaxCounter.objects.filter(partition__startswith=dataset_id)
         ]
 
         stores = Store.objects.filter(partition__startswith=dataset_id)

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -181,14 +181,10 @@ class Command(AsyncCommand):
         try:
             # pull from server
             if not no_pull:
-                self._handle_pull(
-                    sync_session_client, noninteractive, dataset_id,
-                )
+                self._handle_pull(sync_session_client, noninteractive, dataset_id)
             # and push our own data to server
             if not no_push:
-                self._handle_push(
-                    sync_session_client, noninteractive, dataset_id,
-                )
+                self._handle_push(sync_session_client, noninteractive, dataset_id)
 
             if not no_provision:
                 with self._lock():
@@ -228,9 +224,7 @@ class Command(AsyncCommand):
         if self.is_cancelled() and (not self.job or self.job.cancellable):
             raise UserCancelledError()
 
-    def _handle_pull(
-        self, sync_session_client, noninteractive, dataset_id,
-    ):
+    def _handle_pull(self, sync_session_client, noninteractive, dataset_id):
         """
         :type sync_session_client: morango.sync.syncsession.SyncSessionClient
         :type noninteractive: bool
@@ -270,9 +264,7 @@ class Command(AsyncCommand):
         with self._lock():
             sync_client.finalize()
 
-    def _handle_push(
-        self, sync_session_client, noninteractive, dataset_id,
-    ):
+    def _handle_push(self, sync_session_client, noninteractive, dataset_id):
         """
         :type sync_session_client: morango.sync.syncsession.SyncSessionClient
         :type noninteractive: bool

--- a/kolibri/core/auth/migrations/0018_no_i18n_collection_kinds.py
+++ b/kolibri/core/auth/migrations/0018_no_i18n_collection_kinds.py
@@ -8,9 +8,7 @@ from django.db import models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("kolibriauth", "0017_remove_facilitydataset_allow_guest_access"),
-    ]
+    dependencies = [("kolibriauth", "0017_remove_facilitydataset_allow_guest_access")]
 
     operations = [
         migrations.AlterField(
@@ -25,5 +23,5 @@ class Migration(migrations.Migration):
                 ],
                 max_length=20,
             ),
-        ),
+        )
     ]

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -620,13 +620,17 @@ def validate_birth_year(value):
 
     try:
         if int(value) < 1900:
-            error = "Birth year {value} is invalid, as it is prior to the year 1900".format(
-                value=value
+            error = (
+                "Birth year {value} is invalid, as it is prior to the year 1900".format(
+                    value=value
+                )
             )
 
         elif int(value) > 3000:
-            error = "Birth year {value} is invalid, as it is after the year 3000".format(
-                value=value
+            error = (
+                "Birth year {value} is invalid, as it is after the year 3000".format(
+                    value=value
+                )
             )
 
     except ValueError:

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -312,9 +312,7 @@ class ContentNodeViewset(ValuesViewset):
         "tree_id",
     )
 
-    field_map = {
-        "lang": map_lang,
-    }
+    field_map = {"lang": map_lang}
 
     read_only = True
 

--- a/kolibri/core/content/migrations/0026_contentnode_options.py
+++ b/kolibri/core/content/migrations/0026_contentnode_options.py
@@ -9,14 +9,12 @@ import kolibri.core.fields
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("content", "0025_add_h5p_kind"),
-    ]
+    dependencies = [("content", "0025_add_h5p_kind")]
 
     operations = [
         migrations.AddField(
             model_name="contentnode",
             name="options",
             field=kolibri.core.fields.JSONField(blank=True, default={}, null=True),
-        ),
+        )
     ]

--- a/kolibri/core/content/migrations/0027_channelmetadata_tagline.py
+++ b/kolibri/core/content/migrations/0027_channelmetadata_tagline.py
@@ -8,14 +8,12 @@ from django.db import models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("content", "0026_contentnode_options"),
-    ]
+    dependencies = [("content", "0026_contentnode_options")]
 
     operations = [
         migrations.AddField(
             model_name="channelmetadata",
             name="tagline",
             field=models.CharField(blank=True, max_length=150, null=True),
-        ),
+        )
     ]

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -180,7 +180,7 @@ class ChannelBuilder(object):
                 new_localfiles.append(thumbnail)
         self.node_to_files_map[node["id"]] = list(
             filter(
-                lambda x: x not in keys_to_remove, self.node_to_files_map[node["id"]],
+                lambda x: x not in keys_to_remove, self.node_to_files_map[node["id"]]
             )
         )
         return new_localfiles
@@ -308,7 +308,7 @@ class ChannelBuilder(object):
 
     def generate_topic(self, parent_id=None):
         data = self.contentnode_data(
-            kind=content_kinds.TOPIC, root=parent_id is None, parent_id=parent_id,
+            kind=content_kinds.TOPIC, root=parent_id is None, parent_id=parent_id
         )
         thumbnail = self.localfile_data(extension="png")
         self.file_data(
@@ -386,7 +386,7 @@ class ChannelBuilder(object):
         return data
 
     def contentnode_data(
-        self, node_id=None, content_id=None, parent_id=None, kind=None, root=False,
+        self, node_id=None, content_id=None, parent_id=None, kind=None, root=False
     ):
         return {
             "options": "{}",
@@ -522,12 +522,8 @@ class ChannelDeleteAllTestCase(ChannelUpdateTestBase):
         )
 
         self.assertEqual(new_resource_ids, [])
-        self.assertEqual(
-            new_resource_content_ids, [],
-        )
-        self.assertEqual(
-            new_resource_total_size, 0,
-        )
+        self.assertEqual(new_resource_content_ids, [])
+        self.assertEqual(new_resource_total_size, 0)
 
     def test_deleted_resources(self):
         resources_to_be_deleted_count = count_removed_resources(
@@ -595,7 +591,7 @@ class ChannelMixedTestCase(ChannelUpdateTestBase):
 
         self.assertEqual(
             new_resource_total_size,
-            sum(map(lambda x: x["file_size"], new_resource_local_files,)),
+            sum(map(lambda x: x["file_size"], new_resource_local_files)),
         )
 
     def test_deleted_resources(self):
@@ -660,9 +656,7 @@ class ChannelDuplicateTestCase(ChannelUpdateTestBase):
             set(new_resource_ids),
             set(map(lambda x: x["id"], self.upgraded_channel.duplicated_resources)),
         )
-        self.assertEqual(
-            set(new_resource_content_ids), set(),
-        )
+        self.assertEqual(set(new_resource_content_ids), set())
 
         self.assertEqual(new_resource_total_size, 0)
 
@@ -680,12 +674,8 @@ class ChannelDuplicateTestCase(ChannelUpdateTestBase):
             updated_resource_total_size,
         ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
 
-        self.assertEqual(
-            set(updated_resource_ids), set(),
-        )
-        self.assertEqual(
-            set(updated_resource_content_ids), set(),
-        )
+        self.assertEqual(set(updated_resource_ids), set())
+        self.assertEqual(set(updated_resource_content_ids), set())
         self.assertEqual(updated_resource_total_size, 0)
 
 
@@ -717,9 +707,7 @@ class ChannelNodesMovedTestCase(ChannelUpdateTestBase):
             set(map(lambda x: x["id"], self.upgraded_channel.moved_resources)),
         )
 
-        self.assertEqual(
-            set(new_resource_content_ids), set(),
-        )
+        self.assertEqual(set(new_resource_content_ids), set())
 
         self.assertEqual(new_resource_total_size, 0)
 
@@ -739,10 +727,6 @@ class ChannelNodesMovedTestCase(ChannelUpdateTestBase):
             updated_resource_total_size,
         ) = get_automatically_updated_resources(self.content_db_path, self.channel_id)
 
-        self.assertEqual(
-            set(updated_resource_ids), set(),
-        )
-        self.assertEqual(
-            set(updated_resource_content_ids), set(),
-        )
+        self.assertEqual(set(updated_resource_ids), set())
+        self.assertEqual(set(updated_resource_content_ids), set())
         self.assertEqual(updated_resource_total_size, 0)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -753,7 +753,7 @@ class ContentNodeAPITestCase(APITestCase):
         node_id = content.ContentNode.objects.get(title="c2c2").id
         response = self.client.get(
             reverse(
-                "kolibri:core:contentnode-recommendations-for", kwargs={"pk": node_id},
+                "kolibri:core:contentnode-recommendations-for", kwargs={"pk": node_id}
             )
         )
         self.assertEqual(len(response.data), 2)
@@ -765,7 +765,7 @@ class ContentNodeAPITestCase(APITestCase):
         node_id = node.id
         response = self.client.get(
             reverse(
-                "kolibri:core:contentnode-recommendations-for", kwargs={"pk": node_id},
+                "kolibri:core:contentnode-recommendations-for", kwargs={"pk": node_id}
             )
         )
         self.assertEqual(response.status_code, 404)

--- a/kolibri/core/content/utils/file_availability.py
+++ b/kolibri/core/content/utils/file_availability.py
@@ -103,8 +103,10 @@ def get_available_checksums_from_disk(channel_id, drive_id):
     except KeyError:
         raise LocationError("Drive with id {} does not exist".format(drive_id))
     PER_DISK_CACHE_KEY = "DISK_AVAILABLE_CHECKSUMS_{basepath}".format(basepath=basepath)
-    PER_DISK_PER_CHANNEL_CACHE_KEY = "DISK_AVAILABLE_CHECKSUMS_{basepath}_{channel_id}".format(
-        basepath=basepath, channel_id=channel_id
+    PER_DISK_PER_CHANNEL_CACHE_KEY = (
+        "DISK_AVAILABLE_CHECKSUMS_{basepath}_{channel_id}".format(
+            basepath=basepath, channel_id=channel_id
+        )
     )
     if PER_DISK_PER_CHANNEL_CACHE_KEY not in process_cache:
         if PER_DISK_CACHE_KEY not in process_cache:

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -94,10 +94,7 @@ def get_engine(connection_string):
     Get a SQLAlchemy engine that allows us to connect to a database.
     """
     # Set echo to False, as otherwise we get full SQL Query outputted, which can overwhelm the terminal
-    engine_kwargs = {
-        "echo": False,
-        "convert_unicode": True,
-    }
+    engine_kwargs = {"echo": False, "convert_unicode": True}
 
     if connection_string.startswith("sqlite"):
         # Set timeout to 60s, as with most of our content import write operations
@@ -181,10 +178,7 @@ def set_all_class_defaults(Base):
             pass
 
 
-__SQLALCHEMY_CLASSES_PATH = (
-    "contentschema",
-    "versions",
-)
+__SQLALCHEMY_CLASSES_PATH = ("contentschema", "versions")
 
 __SQLALCHEMY_CLASSES_MODULE_NAME = "content_schema_{name}"
 

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -198,7 +198,7 @@ def get_new_resources_available_for_import(destination, channel_id):
     # Set everything to False to start with
     connection.execute(
         ContentNodeTable.update()
-        .where(ContentNodeTable.c.channel_id == channel_id,)
+        .where(ContentNodeTable.c.channel_id == channel_id)
         .values(available=False)
     )
 
@@ -213,7 +213,7 @@ def get_new_resources_available_for_import(destination, channel_id):
                         ContentNodeTable.c.id, node_ids, vendor=bridge.engine.name
                     ),
                     ContentNodeTable.c.channel_id == channel_id,
-                ),
+                )
             )
             .values(available=True)
         )
@@ -318,7 +318,7 @@ def get_new_resources_available_for_import(destination, channel_id):
                         vendor=bridge.engine.name,
                     ),
                     ContentNodeTable.c.channel_id == channel_id,
-                ),
+                )
             )
             .values(available=True)
         )

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -257,8 +257,8 @@ class ParamValidator(object):
 
 def query_params_required(**kwargs):
     """
-        Request fn decorator that builds up a list of params and automatically returns a 400 if they are invalid.
-        The validated params are passed to the wrapped function as kwargs.
+    Request fn decorator that builds up a list of params and automatically returns a 400 if they are invalid.
+    The validated params are passed to the wrapped function as kwargs.
     """
     validators = {}
 

--- a/kolibri/core/device/migrations/0008_devicesettings_allow_other_browsers_to_connect.py
+++ b/kolibri/core/device/migrations/0008_devicesettings_allow_other_browsers_to_connect.py
@@ -10,9 +10,7 @@ import kolibri.core.device.models
 
 class Migration(migrations.Migration):
 
-    dependencies = [
-        ("device", "0007_deviceappkey"),
-    ]
+    dependencies = [("device", "0007_deviceappkey")]
 
     operations = [
         migrations.AddField(
@@ -21,5 +19,5 @@ class Migration(migrations.Migration):
             field=models.BooleanField(
                 default=kolibri.core.device.models.app_is_enabled
             ),
-        ),
+        )
     ]

--- a/kolibri/core/discovery/utils/network/urls.py
+++ b/kolibri/core/discovery/utils/network/urls.py
@@ -31,8 +31,7 @@ def is_valid_hostname(hostname):
 
 # from https://stackoverflow.com/a/319293
 def is_valid_ipv4_address(ip):
-    """Validates IPv4 addresses.
-    """
+    """Validates IPv4 addresses."""
     pattern = re.compile(
         r"""
         ^
@@ -75,8 +74,7 @@ def is_valid_ipv4_address(ip):
 
 # from https://stackoverflow.com/a/319293
 def is_valid_ipv6_address(ip):
-    """Validates IPv6 addresses.
-    """
+    """Validates IPv6 addresses."""
     pattern = re.compile(
         r"""
         ^

--- a/kolibri/core/exams/api.py
+++ b/kolibri/core/exams/api.py
@@ -74,9 +74,7 @@ class ExamViewset(ValuesViewset):
         "learners_see_fixed_order",
     )
 
-    field_map = {
-        "assignments": "assignment_collections",
-    }
+    field_map = {"assignments": "assignment_collections"}
 
     def get_queryset(self):
         return models.Exam.objects.all()
@@ -97,7 +95,7 @@ class ExamViewset(ValuesViewset):
             )
             adhoc_assignments = {
                 a["exam"]: a
-                for a in adhoc_assignments.values("collection", "exam", "learner_ids",)
+                for a in adhoc_assignments.values("collection", "exam", "learner_ids")
             }
             for item in items:
                 if item["id"] in adhoc_assignments:

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -36,9 +36,7 @@ class QuestionSourceSerializer(Serializer):
 class ExamSerializer(ModelSerializer):
 
     assignments = ListField(
-        child=PrimaryKeyRelatedField(
-            read_only=False, queryset=Collection.objects.all()
-        ),
+        child=PrimaryKeyRelatedField(read_only=False, queryset=Collection.objects.all())
     )
     learner_ids = ListField(
         child=PrimaryKeyRelatedField(

--- a/kolibri/core/lessons/viewsets.py
+++ b/kolibri/core/lessons/viewsets.py
@@ -76,9 +76,7 @@ class LessonViewset(ValuesViewset):
             )
             adhoc_assignments = {
                 a["lesson"]: a
-                for a in adhoc_assignments.values(
-                    "collection", "lesson", "learner_ids",
-                )
+                for a in adhoc_assignments.values("collection", "lesson", "learner_ids")
             }
             for item in items:
                 if item["id"] in adhoc_assignments:

--- a/kolibri/core/logger/models.py
+++ b/kolibri/core/logger/models.py
@@ -189,8 +189,10 @@ class UserSessionLog(BaseLogModel):
             except ObjectDoesNotExist:
                 user_session_log = None
 
-            if not user_session_log or timezone.now() - user_session_log.last_interaction_timestamp > timedelta(
-                minutes=5
+            if (
+                not user_session_log
+                or timezone.now() - user_session_log.last_interaction_timestamp
+                > timedelta(minutes=5)
             ):
                 user_session_log = cls(user=user)
             user_session_log.last_interaction_timestamp = local_now()

--- a/kolibri/core/logger/test/test_utils.py
+++ b/kolibri/core/logger/test/test_utils.py
@@ -25,5 +25,5 @@ class BytesForHumans(TestCase):
 
     def test_petabytes(self):
         self.assertEqual(
-            "611.77PB", bytes_for_humans(611.77 * 1024 * 1024 * 1024 * 1024 * 1024),
+            "611.77PB", bytes_for_humans(611.77 * 1024 * 1024 * 1024 * 1024 * 1024)
         )

--- a/kolibri/core/logger/utils/user_data.py
+++ b/kolibri/core/logger/utils/user_data.py
@@ -106,7 +106,7 @@ def get_or_create_classrooms(**options):
                 # P2P sync tests. The facility name already has the device_name prepended.
                 class_name = "{0} {1}".format(facility, class_name)
             classroom, created = Classroom.objects.get_or_create(
-                parent=facility, name=class_name,
+                parent=facility, name=class_name
             )
             if created:
                 logger_info("==> CREATED Class {c}".format(c=classroom), verbosity)

--- a/kolibri/core/notifications/migrations/0005_learnerprogressnotification_assignment_collections.py
+++ b/kolibri/core/notifications/migrations/0005_learnerprogressnotification_assignment_collections.py
@@ -41,7 +41,7 @@ def migrate_collection_ids(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("notifications", "0004_learnerprogressnotification_quiz_num_answered"),
+        ("notifications", "0004_learnerprogressnotification_quiz_num_answered")
     ]
 
     operations = [

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -223,10 +223,12 @@ class Job(object):
             return self.progress
 
     def __repr__(self):
-        return "<Job id: {id} state: {state} progress: {p}/{total} func: {func}>".format(
-            id=self.job_id,
-            state=self.state,
-            func=self.func,
-            p=self.progress,
-            total=self.total_progress,
+        return (
+            "<Job id: {id} state: {state} progress: {p}/{total} func: {func}>".format(
+                id=self.job_id,
+                state=self.state,
+                func=self.func,
+                p=self.progress,
+                total=self.total_progress,
+            )
         )

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -174,7 +174,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             state="testing",
             percentage_progress=42,
             cancellable=False,
-            extra_metadata=dict(this_is_extra=True,),
+            extra_metadata=dict(this_is_extra=True),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
 
@@ -219,7 +219,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             state="testing",
             percentage_progress=42,
             cancellable=False,
-            extra_metadata=dict(this_is_extra=True,),
+            extra_metadata=dict(this_is_extra=True),
         )
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
 
@@ -314,13 +314,13 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             state="testing",
             percentage_progress=42,
             cancellable=False,
-            extra_metadata=dict(this_is_extra=True,),
+            extra_metadata=dict(this_is_extra=True),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
 
         req_data = dict(
-            facility=self.facility.id, baseurl="https://some.server.test/extra/stuff",
+            facility=self.facility.id, baseurl="https://some.server.test/extra/stuff"
         )
 
         response = self.client.post(
@@ -332,13 +332,13 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         self.assertJobResponse(fake_job_data, response)
 
         validate_and_prepare_peer_sync_job.assert_has_calls(
-            [call(ANY, no_push=True, no_provision=True, extra_metadata=extra_metadata,)]
+            [call(ANY, no_push=True, no_provision=True, extra_metadata=extra_metadata)]
         )
         facility_queue.enqueue.assert_called_with(call_command, "sync", **prepared_data)
 
     @patch("kolibri.core.tasks.api.validate_and_prepare_peer_sync_job")
     def test_startpeerfacilitysync(
-        self, validate_and_prepare_peer_sync_job, facility_queue,
+        self, validate_and_prepare_peer_sync_job, facility_queue
     ):
         user = self._setup_device()
 
@@ -372,13 +372,13 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
             state="testing",
             percentage_progress=42,
             cancellable=False,
-            extra_metadata=dict(this_is_extra=True,),
+            extra_metadata=dict(this_is_extra=True),
         )
         fake_job_data["extra_metadata"].update(extra_metadata)
         facility_queue.fetch_job.return_value = fake_job(**fake_job_data)
 
         req_data = dict(
-            facility=self.facility.id, baseurl="https://some.server.test/extra/stuff",
+            facility=self.facility.id, baseurl="https://some.server.test/extra/stuff"
         )
 
         response = self.client.post(
@@ -390,7 +390,7 @@ class FacilityTaskAPITestCase(BaseAPITestCase):
         self.assertJobResponse(fake_job_data, response)
 
         validate_and_prepare_peer_sync_job.assert_has_calls(
-            [call(ANY, extra_metadata=extra_metadata,)]
+            [call(ANY, extra_metadata=extra_metadata)]
         )
         facility_queue.enqueue.assert_called_with(call_command, "sync", **prepared_data)
 
@@ -584,14 +584,14 @@ class FacilityTaskHelperTestCase(TestCase):
         )
 
     def test_validate_and_prepare_peer_sync_job__no_baseurl(self):
-        req = Mock(spec=Request, data=dict(facility=123,),)
+        req = Mock(spec=Request, data=dict(facility=123))
 
         with self.assertRaises(ParseError, msg="Missing `baseurl` parameter"):
             validate_and_prepare_peer_sync_job(req)
 
     def test_validate_and_prepare_peer_sync_job__bad_url(self):
         req = Mock(
-            spec=Request, data=dict(facility=123, baseurl="/com.bad.url.www//:sptth",),
+            spec=Request, data=dict(facility=123, baseurl="/com.bad.url.www//:sptth")
         )
 
         with self.assertRaises(ParseError, msg="Invalid URL"):
@@ -600,8 +600,7 @@ class FacilityTaskHelperTestCase(TestCase):
     @patch("kolibri.core.tasks.api.NetworkClient")
     def test_validate_and_prepare_peer_sync_job__cannot_connect(self, NetworkClient):
         req = Mock(
-            spec=Request,
-            data=dict(facility=123, baseurl="https://www.notfound.never",),
+            spec=Request, data=dict(facility=123, baseurl="https://www.notfound.never")
         )
 
         NetworkClient.side_effect = NetworkLocationNotFound()
@@ -650,7 +649,7 @@ class FacilityTaskHelperTestCase(TestCase):
     ):
         req = Mock(
             spec=Request,
-            data=dict(facility=123, baseurl="https://some.server.test/extra/stuff",),
+            data=dict(facility=123, baseurl="https://some.server.test/extra/stuff"),
         )
 
         client = NetworkClient.return_value

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -247,7 +247,7 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
             except Exception as e:
                 logging.warn(
                     "Tried to import module {module_name} from {plugin} but an error was raised".format(
-                        plugin=self.module_path, module_name=module_name,
+                        plugin=self.module_path, module_name=module_name
                     )
                 )
                 logging.exception(e)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -101,10 +101,7 @@ class ClassroomNotificationsViewset(ValuesViewset):
         "notification_event",
     )
 
-    field_map = {
-        "object": "notification_object",
-        "event": "notification_event",
-    }
+    field_map = {"object": "notification_object", "event": "notification_event"}
 
     def check_after(self):
         """

--- a/kolibri/plugins/setup_wizard/api_urls.py
+++ b/kolibri/plugins/setup_wizard/api_urls.py
@@ -8,8 +8,6 @@ from .api import SetupWizardFacilityImportTaskView
 router = routers.DefaultRouter()
 
 router.register(r"facilityimport", FacilityImportViewSet, base_name="facilityimport")
-router.register(
-    r"tasks", SetupWizardFacilityImportTaskView, base_name="tasks",
-)
+router.register(r"tasks", SetupWizardFacilityImportTaskView, base_name="tasks")
 
 urlpatterns = [url(r"^", include(router.urls))]

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",
     "lint-frontend:watch:format": "yarn run lint-frontend --monitor --write",
-    "fmt-backend": "yarn run black-fmt",
-    "fmt-backend:check": "yarn run black-fmt --check",
-    "fmt-backend:watch": "yarn run black-fmt --watch",
     "build-kolibri-tools": "yarn workspace kolibri-tools run build-kolibri-tools",
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
@@ -53,7 +50,6 @@
   "private": true,
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "black-fmt": "https://github.com/learningequality/black-fmt#v0.1.3",
     "kolibri-tools": "0.13.0-dev.10",
     "xhr-mock": "^2.5.1",
     "yarn-run-all": "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,16 +2877,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-"black-fmt@https://github.com/learningequality/black-fmt#v0.1.3":
-  version "0.1.1"
-  resolved "https://github.com/learningequality/black-fmt#ded2a7fedf227d331a7806489473daf70843deb4"
-  dependencies:
-    chokidar "^2.1.5"
-    commander "^2.19.0"
-    glob "^7.1.3"
-    npmlog "^4.1.2"
-    request "^2.88.0"
-
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -3447,7 +3437,7 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-chokidar@^2.0.4, chokidar@^2.1.5, chokidar@^2.1.8:
+chokidar@^2.0.4, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -9983,7 +9973,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.1.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

I was noticing that running the `black` CLI didn't match what was happening when running `pre-commit`, and I think it's because the `repo` field for the `black` hook should be a `git://` address.

This changes that config, and on subsequent `pre-commit run --all-files`, it downloads the stable version and applies the formatting as of version 20 or so of `black`.

This also removes the npm scripts for `fmt-backend` as its use of `black-fmt` is not consistent with the pre-commit behavior and might be confusing.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
