### PR TITLE
Offset user menu from window edge

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -250,7 +250,7 @@
 
   .user-menu-dropdown {
     position: fixed;
-    right: 20px;
+    right: 8px;
     z-index: 8;
 
     // Holdover from previous CoreMenuOption format. Will keep the profile

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -250,7 +250,7 @@
 
   .user-menu-dropdown {
     position: fixed;
-    right: 0;
+    right: 20px;
     z-index: 8;
 
     // Holdover from previous CoreMenuOption format. Will keep the profile


### PR DESCRIPTION
### Summary

Offset user menu from window edge.

![Screenshot_2020-09-24 Device settings - Kolibri](https://user-images.githubusercontent.com/3750511/94257695-5f459780-ff34-11ea-9be0-1990b1ffc1ca.png)

![Screenshot_2020-09-24 ڈیوایس کی ترتیبات - کولبری](https://user-images.githubusercontent.com/3750511/94257703-640a4b80-ff34-11ea-9523-ef3a2ac3ee18.png)

### References

Fixes #7298 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
