### PR TITLE
Optimize tests with ‘setUpTestData’

### DIFF
--- a/kolibri/core/analytics/test/test_api.py
+++ b/kolibri/core/analytics/test/test_api.py
@@ -14,10 +14,13 @@ from kolibri.core.auth.test.test_api import FacilityUserFactory
 
 
 class PingbackNotificationTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.user = FacilityUserFactory(facility=self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.user = FacilityUserFactory(facility=cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.user.username, password=DUMMY_PASSWORD, facility=self.facility
         )
@@ -28,6 +31,9 @@ class PingbackNotificationTestCase(APITestCase):
             "source": PINGBACK,
         }
         self.notification = PingbackNotification.objects.create(**data)
+
+    def tearDown(self):
+        self.notification.delete()
 
     def test_get_notification(self):
         response = self.client.get(
@@ -65,12 +71,15 @@ class PingbackNotificationTestCase(APITestCase):
 
 
 class PingbackNotificationDismissedTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.admin = FacilityUserFactory(facility=self.facility)
-        self.facility.add_role(self.admin, role_kinds.ADMIN)
-        self.user = FacilityUserFactory(facility=self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.admin = FacilityUserFactory(facility=cls.facility)
+        cls.facility.add_role(cls.admin, role_kinds.ADMIN)
+        cls.user = FacilityUserFactory(facility=cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.admin.username,
             password=DUMMY_PASSWORD,
@@ -84,6 +93,9 @@ class PingbackNotificationDismissedTestCase(APITestCase):
             "source": PINGBACK,
         }
         self.notification = PingbackNotification.objects.create(**data)
+
+    def tearDown(self):
+        self.notification.delete()
 
     def test_create_notification(self):
         response = self.client.post(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -66,18 +66,21 @@ class FacilityUserFactory(factory.DjangoModelFactory):
 
 
 class LearnerGroupAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.classrooms = [
-            ClassroomFactory.create(parent=self.facility) for _ in range(3)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.classrooms = [
+            ClassroomFactory.create(parent=cls.facility) for _ in range(3)
         ]
-        self.learner_groups = []
-        for classroom in self.classrooms:
-            self.learner_groups += [
+        cls.learner_groups = []
+        for classroom in cls.classrooms:
+            cls.learner_groups += [
                 LearnerGroupFactory.create(parent=classroom) for _ in range(5)
             ]
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -161,14 +164,17 @@ class LearnerGroupAPITestCase(APITestCase):
 
 
 class ClassroomAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.classrooms = [
-            ClassroomFactory.create(parent=self.facility) for _ in range(10)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.classrooms = [
+            ClassroomFactory.create(parent=cls.facility) for _ in range(10)
         ]
-        self.learner_group = LearnerGroupFactory.create(parent=self.classrooms[0])
+        cls.learner_group = LearnerGroupFactory.create(parent=cls.classrooms[0])
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -281,13 +287,14 @@ class ClassroomAPITestCase(APITestCase):
 
 
 class FacilityAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility1 = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility1)
-        self.facility2 = FacilityFactory.create()
-        self.user1 = FacilityUserFactory.create(facility=self.facility1)
-        self.user2 = FacilityUserFactory.create(facility=self.facility2)
+        cls.facility1 = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility1)
+        cls.facility2 = FacilityFactory.create()
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility1)
+        cls.user2 = FacilityUserFactory.create(facility=cls.facility2)
 
     def test_sanity(self):
         self.assertTrue(
@@ -412,10 +419,13 @@ class FacilityAPITestCase(APITestCase):
 
 
 class UserCreationTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -479,16 +489,22 @@ class UserCreationTestCase(APITestCase):
 
 
 class UserUpdateTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+    def setUp(self):
         self.user = FacilityUserFactory.create(facility=self.facility)
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
             facility=self.facility,
         )
+
+    def tearDown(self):
+        self.user.delete()
 
     def test_user_update_info(self):
         self.client.patch(
@@ -551,16 +567,22 @@ class UserUpdateTestCase(APITestCase):
 
 
 class UserDeleteTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+    def setUp(self):
         self.user = FacilityUserFactory.create(facility=self.facility)
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
             facility=self.facility,
         )
+
+    def tearDown(self):
+        self.user.delete()
 
     def test_user_delete(self):
         response = self.client.delete(
@@ -580,12 +602,15 @@ class UserDeleteTestCase(APITestCase):
 
 
 class UserRetrieveTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.facility.add_admin(self.superuser)
-        self.user = FacilityUserFactory.create(facility=self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.facility.add_admin(cls.superuser)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -631,30 +656,33 @@ class UserRetrieveTestCase(APITestCase):
 
 
 class FacilityUserFilterTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
         # Fixtures: 2 facilities with 1 learner + 1 admin each
-        self.facility_1 = FacilityFactory.create()
-        self.facility_2 = FacilityFactory.create()
+        cls.facility_1 = FacilityFactory.create()
+        cls.facility_2 = FacilityFactory.create()
 
-        self.user_1 = FacilityUserFactory.create(
-            facility=self.facility_1, username="learner_1"
+        cls.user_1 = FacilityUserFactory.create(
+            facility=cls.facility_1, username="learner_1"
         )
-        self.admin_1 = FacilityUserFactory.create(
-            facility=self.facility_1, username="admin_1"
+        cls.admin_1 = FacilityUserFactory.create(
+            facility=cls.facility_1, username="admin_1"
         )
-        self.facility_1.add_admin(self.admin_1)
+        cls.facility_1.add_admin(cls.admin_1)
 
-        self.user_2 = FacilityUserFactory.create(
-            facility=self.facility_2, username="learner_2"
+        cls.user_2 = FacilityUserFactory.create(
+            facility=cls.facility_2, username="learner_2"
         )
-        self.admin_2 = FacilityUserFactory.create(
-            facility=self.facility_2, username="admin_2"
+        cls.admin_2 = FacilityUserFactory.create(
+            facility=cls.facility_2, username="admin_2"
         )
-        self.facility_2.add_admin(self.admin_2)
+        cls.facility_2.add_admin(cls.admin_2)
 
         # Superuser is in facility 1
-        self.superuser = create_superuser(self.facility_1, username="a_superuser")
+        cls.superuser = create_superuser(cls.facility_1, username="a_superuser")
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -676,16 +704,17 @@ class FacilityUserFilterTestCase(APITestCase):
 
 
 class LoginLogoutTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
-        self.admin = FacilityUserFactory.create(facility=self.facility, password="bar")
-        self.facility.add_admin(self.admin)
-        self.cr = ClassroomFactory.create(parent=self.facility)
-        self.cr.add_coach(self.admin)
-        self.session_store = import_module(settings.SESSION_ENGINE).SessionStore()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.admin = FacilityUserFactory.create(facility=cls.facility, password="bar")
+        cls.facility.add_admin(cls.admin)
+        cls.cr = ClassroomFactory.create(parent=cls.facility)
+        cls.cr.add_coach(cls.admin)
+        cls.session_store = import_module(settings.SESSION_ENGINE).SessionStore()
 
     def test_login_and_logout_superuser(self):
         self.client.post(
@@ -771,8 +800,9 @@ class LoginLogoutTestCase(APITestCase):
 
 
 class AnonSignUpTestCase(APITestCase):
-    def setUp(self):
-        self.facility = FacilityFactory.create()
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
         provision_device()
 
     def post_to_sign_up(self, data):
@@ -856,14 +886,15 @@ class AnonSignUpTestCase(APITestCase):
 
 
 class FacilityDatasetAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.facility2 = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.admin = FacilityUserFactory.create(facility=self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
-        self.facility.add_admin(self.admin)
+        cls.facility = FacilityFactory.create()
+        cls.facility2 = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
 
     def test_return_all_datasets_for_an_admin(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
@@ -921,23 +952,24 @@ class FacilityDatasetAPITestCase(APITestCase):
 
 
 class MembershipCascadeDeletion(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
-        self.other_user = FacilityUserFactory.create(facility=self.facility)
-        self.classroom = ClassroomFactory.create(parent=self.facility)
-        self.lg = LearnerGroupFactory.create(parent=self.classroom)
-        self.classroom_membership = models.Membership.objects.create(
-            collection=self.classroom, user=self.user
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.other_user = FacilityUserFactory.create(facility=cls.facility)
+        cls.classroom = ClassroomFactory.create(parent=cls.facility)
+        cls.lg = LearnerGroupFactory.create(parent=cls.classroom)
+        cls.classroom_membership = models.Membership.objects.create(
+            collection=cls.classroom, user=cls.user
         )
-        models.Membership.objects.create(collection=self.lg, user=self.user)
+        models.Membership.objects.create(collection=cls.lg, user=cls.user)
         # create other user memberships
-        models.Membership.objects.create(
-            collection=self.classroom, user=self.other_user
-        )
-        models.Membership.objects.create(collection=self.lg, user=self.other_user)
+        models.Membership.objects.create(collection=cls.classroom, user=cls.other_user)
+        models.Membership.objects.create(collection=cls.lg, user=cls.other_user)
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -977,22 +1009,25 @@ class MembershipCascadeDeletion(APITestCase):
 
 
 class GroupMembership(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
-        self.classroom1 = ClassroomFactory.create(parent=self.facility)
-        self.classroom2 = ClassroomFactory.create(parent=self.facility)
-        self.lg11 = LearnerGroupFactory.create(parent=self.classroom1)
-        self.lg12 = LearnerGroupFactory.create(parent=self.classroom1)
-        self.lg21 = LearnerGroupFactory.create(parent=self.classroom2)
-        self.classroom1_membership = models.Membership.objects.create(
-            collection=self.classroom1, user=self.user
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.classroom1 = ClassroomFactory.create(parent=cls.facility)
+        cls.classroom2 = ClassroomFactory.create(parent=cls.facility)
+        cls.lg11 = LearnerGroupFactory.create(parent=cls.classroom1)
+        cls.lg12 = LearnerGroupFactory.create(parent=cls.classroom1)
+        cls.lg21 = LearnerGroupFactory.create(parent=cls.classroom2)
+        cls.classroom1_membership = models.Membership.objects.create(
+            collection=cls.classroom1, user=cls.user
         )
-        self.classroom2_membership = models.Membership.objects.create(
-            collection=self.classroom2, user=self.user
+        cls.classroom2_membership = models.Membership.objects.create(
+            collection=cls.classroom2, user=cls.user
         )
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -10,11 +10,12 @@ from ..models import FacilityUser
 
 
 class FacilityUserBackendTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        user = self.user = FacilityUser(username="Mike", facility=self.facility)
-        user.set_password("foo")
-        user.save()
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.user = FacilityUser(username="Mike", facility=cls.facility)
+        cls.user.set_password("foo")
+        cls.user.save()
 
     def test_facility_user_authenticated(self):
         self.assertEqual(

--- a/kolibri/core/auth/test/test_bulk_export.py
+++ b/kolibri/core/auth/test/test_bulk_export.py
@@ -55,17 +55,18 @@ def test_map_output():
 
 
 class UserExportTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data(
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data(
             classroom_count=CLASSROOMS, learnergroup_count=1
         )
-        self.facility = self.data["facility"]
+        cls.facility = cls.data["facility"]
 
-        _, self.filepath = tempfile.mkstemp(suffix=".csv")
+        _, cls.filepath = tempfile.mkstemp(suffix=".csv")
 
-        self.csv_rows = []
-        for row in b.csv_file_generator(self.facility, self.filepath, True):
-            self.csv_rows.append(row)
+        cls.csv_rows = []
+        for row in b.csv_file_generator(cls.facility, cls.filepath, True):
+            cls.csv_rows.append(row)
 
     def test_exported_rows(self):
         # total number of users created by create_dummy_facility_data:

--- a/kolibri/core/auth/test/test_delete_user.py
+++ b/kolibri/core/auth/test/test_delete_user.py
@@ -18,24 +18,25 @@ class UserDeleteTestCase(TestCase):
     Tests for deleteuser command.
     """
 
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        user = FacilityUser.objects.create(username="user", facility=self.facility)
-        Membership.objects.create(collection=self.facility, user=user)
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.facility_2 = Facility.objects.create()
+        cls.user = FacilityUser.objects.create(username="user", facility=cls.facility)
+        Membership.objects.create(collection=cls.facility, user=cls.user)
         ContentSessionLogFactory.create(
-            user=user, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex
+            user=cls.user, content_id=uuid.uuid4().hex, channel_id=uuid.uuid4().hex
         )
 
-    @mock.patch("django.utils.six.moves.input", new=lambda x: "yes")
     def test_user_delete(self):
         utils.input = mock.MagicMock(name="input", return_value="yes")
         call_command("deleteuser", "user")
         self.assertFalse(FacilityUser.objects.exists())
         # sanity checks to make sure cascade deletion still works
+        # TODO add more objects that should be deleted in cascade like Roles
         self.assertFalse(Membership.objects.exists())
         self.assertFalse(ContentSessionLog.objects.exists())
 
-    @mock.patch("django.utils.six.moves.input", new=lambda x: "yes")
     def test_user_delete_with_facility(self):
         utils.input = mock.MagicMock(name="input", return_value="yes")
         call_command("deleteuser", "user", facility=self.facility.id)
@@ -46,7 +47,6 @@ class UserDeleteTestCase(TestCase):
             call_command("deleteuser", "kolibri")
 
     def test_user_delete_multiple_users(self):
-        self.facility2 = Facility.objects.create()
-        FacilityUser.objects.create(username="user", facility=self.facility2)
         with self.assertRaisesRegexp(CommandError, "There is more than one user"):
+            FacilityUser.objects.create(username="user", facility=self.facility_2)
             call_command("deleteuser", "user")

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -257,22 +257,22 @@ class CollectionRoleMembershipDeletionTestCase(TestCase):
 
 
 class CollectionRelatedObjectTestCase(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
 
-        self.facility = Facility.objects.create()
-
-        users = self.users = [
-            FacilityUser.objects.create(username="foo%s" % i, facility=self.facility)
+        users = cls.users = [
+            FacilityUser.objects.create(username="foo%s" % i, facility=cls.facility)
             for i in range(10)
         ]
 
-        self.facility.add_admins(users[8:9])
+        cls.facility.add_admins(users[8:9])
 
-        self.cr = Classroom.objects.create(parent=self.facility)
-        self.cr.add_coaches(users[5:8])
+        cls.cr = Classroom.objects.create(parent=cls.facility)
+        cls.cr.add_coaches(users[5:8])
 
-        self.lg = LearnerGroup.objects.create(parent=self.cr)
-        self.lg.add_learners(users[0:5])
+        cls.lg = LearnerGroup.objects.create(parent=cls.cr)
+        cls.lg.add_learners(users[0:5])
 
     def test_get_learner_groups(self):
         self.assertSetEqual(
@@ -289,9 +289,10 @@ class CollectionRelatedObjectTestCase(TestCase):
 
 
 class CollectionsTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        self.classroom = Classroom.objects.create(parent=self.facility)
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.classroom = Classroom.objects.create(parent=cls.facility)
 
     def test_add_and_remove_admin(self):
         user = FacilityUser.objects.create(username="foo", facility=self.facility)
@@ -458,15 +459,16 @@ class RoleErrorTestCase(TestCase):
 
 
 class SuperuserRoleMembershipTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        self.classroom = Classroom.objects.create(parent=self.facility)
-        self.learner_group = LearnerGroup.objects.create(parent=self.classroom)
-        self.facility_user = FacilityUser.objects.create(
-            username="blah", password="#", facility=self.facility
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.classroom = Classroom.objects.create(parent=cls.facility)
+        cls.learner_group = LearnerGroup.objects.create(parent=cls.classroom)
+        cls.facility_user = FacilityUser.objects.create(
+            username="blah", password="#", facility=cls.facility
         )
-        self.superuser = create_superuser(self.facility)
-        self.superuser2 = create_superuser(self.facility, username="superuser2")
+        cls.superuser = create_superuser(cls.facility)
+        cls.superuser2 = create_superuser(cls.facility, username="superuser2")
 
     def test_superuser_is_not_member_of_any_sub_collection(self):
         self.assertFalse(self.superuser.is_member_of(self.classroom))
@@ -501,49 +503,49 @@ class SuperuserRoleMembershipTestCase(TestCase):
 
 
 class SuperuserTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.superuser = create_superuser(cls.facility, username="the_superuser")
 
     def test_superuser_is_superuser(self):
-        superuser = create_superuser(self.facility)
-        self.assertTrue(superuser.is_superuser)
+        self.assertTrue(self.superuser.is_superuser)
 
     def test_superuser_manager_supports_superuser_creation(self):
-        superusername = "boss"
-        create_superuser(self.facility, username=superusername)
-        self.assertEqual(FacilityUser.objects.get().username, superusername)
+        self.assertEqual(FacilityUser.objects.get().username, "the_superuser")
 
     def test_superuser_has_all_django_perms_for_django_admin(self):
-        superuser = create_superuser(self.facility)
-        self.assertTrue(superuser.has_perm("someperm", object()))
-        self.assertTrue(superuser.has_perms(["someperm"], object()))
-        self.assertTrue(superuser.has_module_perms("module.someapp"))
+        fake_permission = "fake_permission"
+        fake_module = "module.someapp"
+        self.assertTrue(self.superuser.has_perm(fake_permission, object()))
+        self.assertTrue(self.superuser.has_perms([fake_permission], object()))
+        self.assertTrue(self.superuser.has_module_perms(fake_module))
 
 
 class StringMethodTestCase(TestCase):
-    def setUp(self):
-
-        self.facility = Facility.objects.create(name="Arkham")
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="Arkham")
 
         learner, classroom_coach, facility_admin = (
-            self.learner,
-            self.classroom_coach,
-            self.facility_admin,
+            cls.learner,
+            cls.classroom_coach,
+            cls.facility_admin,
         ) = (
-            FacilityUser.objects.create(username="foo", facility=self.facility),
-            FacilityUser.objects.create(username="bar", facility=self.facility),
-            FacilityUser.objects.create(username="baz", facility=self.facility),
+            FacilityUser.objects.create(username="foo", facility=cls.facility),
+            FacilityUser.objects.create(username="bar", facility=cls.facility),
+            FacilityUser.objects.create(username="baz", facility=cls.facility),
         )
 
-        self.facility.add_admin(facility_admin)
+        cls.facility.add_admin(facility_admin)
 
-        self.cr = Classroom.objects.create(name="Classroom X", parent=self.facility)
-        self.cr.add_coach(classroom_coach)
+        cls.cr = Classroom.objects.create(name="Classroom X", parent=cls.facility)
+        cls.cr.add_coach(classroom_coach)
 
-        self.lg = LearnerGroup.objects.create(name="Oodles of Fun", parent=self.cr)
-        self.lg.add_learner(learner)
+        cls.lg = LearnerGroup.objects.create(name="Oodles of Fun", parent=cls.cr)
+        cls.lg.add_learner(learner)
 
-        self.superuser = create_superuser(self.facility)
+        cls.superuser = create_superuser(cls.facility)
 
     def test_facility_user_str_method(self):
         self.assertEqual(str(self.learner), '"foo"@"Arkham"')

--- a/kolibri/core/auth/test/test_permissions.py
+++ b/kolibri/core/auth/test/test_permissions.py
@@ -28,11 +28,12 @@ class ImproperUsageIsProperlyHandledTestCase(TestCase):
     Tests that error cases and misuse of the interface are properly caught.
     """
 
-    def setUp(self):
-        self.data1 = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data()
-        self.superuser = self.data1["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data1 = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data()
+        cls.superuser = cls.data1["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_that_checking_creation_perms_on_invalid_model_returns_false(self):
         # cannot create a LearnerGroup with invalid attribute name
@@ -80,11 +81,12 @@ class FacilityDatasetPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying FacilityData instances
     """
 
-    def setUp(self):
-        self.data1 = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data()
-        self.superuser = self.data1["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data1 = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data()
+        cls.superuser = cls.data1["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_facility_users_and_anon_users_cannot_create_facility_dataset(self):
         """ FacilityUsers can't create new Facilities, regardless of their roles """
@@ -178,11 +180,12 @@ class FacilityPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying Facility instances
     """
 
-    def setUp(self):
-        self.data1 = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data(allow_sign_ups=True)
-        self.superuser = self.data1["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data1 = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data(allow_sign_ups=True)
+        cls.superuser = cls.data1["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_facility_users_and_anon_users_cannot_create_facility(self):
         """ FacilityUsers can't create new Facilities, regardless of their roles """
@@ -300,15 +303,16 @@ class ClassroomPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying Classroom instances
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.own_classroom = self.data["classrooms"][0]
-        self.other_classroom = self.data["classrooms"][1]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.superuser = self.data["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.own_classroom = cls.data["classrooms"][0]
+        cls.other_classroom = cls.data["classrooms"][1]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.superuser = cls.data["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_only_facility_admin_can_create_classroom(self):
         """ The only FacilityUser who can create a Classroom is a facility admin for the Facility """
@@ -398,18 +402,19 @@ class LearnerGroupPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying LearnerGroup instances
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.own_learnergroup = self.data["learnergroups"][0][0]
-        self.other_learnergroup = self.data["learnergroups"][1][1]
-        self.own_classroom = self.data["classrooms"][0]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.other_classroom_admin = self.data["classroom_admins"][1]
-        self.other_classroom_coach = self.data["classroom_coaches"][1]
-        self.superuser = self.data["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.own_learnergroup = cls.data["learnergroups"][0][0]
+        cls.other_learnergroup = cls.data["learnergroups"][1][1]
+        cls.own_classroom = cls.data["classrooms"][0]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.other_classroom_admin = cls.data["classroom_admins"][1]
+        cls.other_classroom_coach = cls.data["classroom_coaches"][1]
+        cls.superuser = cls.data["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_facility_or_classroom_admins_or_classroom_coach_can_create_learnergroup(
         self,
@@ -499,19 +504,20 @@ class FacilityUserPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying FacilityUser instances
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.member2 = self.data2["learners_one_group"][0][0]
-        self.other_member = self.data["learners_one_group"][1][1]
-        self.own_learnergroup = self.data["learnergroups"][0][0]
-        self.own_classroom = self.data["classrooms"][0]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.other_classroom_admin = self.data["classroom_admins"][1]
-        self.superuser = self.data["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.member2 = cls.data2["learners_one_group"][0][0]
+        cls.other_member = cls.data["learners_one_group"][1][1]
+        cls.own_learnergroup = cls.data["learnergroups"][0][0]
+        cls.own_classroom = cls.data["classrooms"][0]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.other_classroom_admin = cls.data["classroom_admins"][1]
+        cls.superuser = cls.data["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_only_facility_admins_can_create_facility_user(self):
         """ The only FacilityUser who can create a FacilityUser is a facility admin for the Facility """
@@ -713,14 +719,15 @@ class SuperuserPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying superuser permissions
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.superuser = self.data["superuser"]
-        self.superuser2 = create_superuser(self.data["facility"], username="ubermensch")
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.superuser = cls.data["superuser"]
+        cls.superuser2 = create_superuser(cls.data["facility"], username="ubermensch")
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_non_superusers_cannot_create_superuser(self):
         """ Users who are not Superusers cannot create a DevicePermissions """
@@ -845,18 +852,19 @@ class RolePermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying Role instances
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.own_classroom = self.data["classrooms"][0]
-        self.other_classroom = self.data["classrooms"][1]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.other_classroom_coach = self.data["classroom_coaches"][1]
-        self.other_classroom_admin = self.data["classroom_admins"][1]
-        self.superuser = self.data["superuser"]
-        self.role_user = self.data["unattached_users"][0]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.own_classroom = cls.data["classrooms"][0]
+        cls.other_classroom = cls.data["classrooms"][1]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.other_classroom_coach = cls.data["classroom_coaches"][1]
+        cls.other_classroom_admin = cls.data["classroom_admins"][1]
+        cls.superuser = cls.data["superuser"]
+        cls.role_user = cls.data["unattached_users"][0]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_facility_admin_can_create_facility_admin_role(self):
         new_role_data = {
@@ -1039,19 +1047,20 @@ class MembershipPermissionsTestCase(TestCase):
     Tests of permissions for reading/modifying Membership instances
     """
 
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.member = self.data["learners_one_group"][0][0]
-        self.own_classroom = self.data["classrooms"][0]
-        self.other_classroom = self.data["classrooms"][1]
-        self.own_learnergroup = self.data["learnergroups"][0][0]
-        self.other_learnergroup = self.data["learnergroups"][1][1]
-        self.own_classroom_coach = self.data["classroom_coaches"][0]
-        self.own_classroom_admin = self.data["classroom_admins"][0]
-        self.other_classroom_coach = self.data["classroom_coaches"][1]
-        self.other_classroom_admin = self.data["classroom_admins"][1]
-        self.superuser = self.data["superuser"]
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.member = cls.data["learners_one_group"][0][0]
+        cls.own_classroom = cls.data["classrooms"][0]
+        cls.other_classroom = cls.data["classrooms"][1]
+        cls.own_learnergroup = cls.data["learnergroups"][0][0]
+        cls.other_learnergroup = cls.data["learnergroups"][1][1]
+        cls.own_classroom_coach = cls.data["classroom_coaches"][0]
+        cls.own_classroom_admin = cls.data["classroom_admins"][0]
+        cls.other_classroom_coach = cls.data["classroom_coaches"][1]
+        cls.other_classroom_admin = cls.data["classroom_admins"][1]
+        cls.superuser = cls.data["superuser"]
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_admin_or_coach_for_user_can_create_membership(self):
         # try adding member of own_classroom as a member of other_classroom

--- a/kolibri/core/auth/test/test_permissions_classes.py
+++ b/kolibri/core/auth/test/test_permissions_classes.py
@@ -16,15 +16,16 @@ from .helpers import create_superuser
 
 
 class BasePermissionsThrowExceptionsTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        self.object = object()  # shouldn't matter what the object is, for these tests
-        self.facility_user = FacilityUser.objects.create(
-            username="qqq", facility=self.facility
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.object = object()  # shouldn't matter what the object is, for these tests
+        cls.facility_user = FacilityUser.objects.create(
+            username="qqq", facility=cls.facility
         )
-        self.superuser = create_superuser(self.facility)
-        self.anon_user = KolibriAnonymousUser()
-        self.permissions = BasePermissions()
+        cls.superuser = create_superuser(cls.facility)
+        cls.anon_user = KolibriAnonymousUser()
+        cls.permissions = BasePermissions()
 
     def test_user_cannot_create(self):
         with self.assertRaises(NotImplementedError):
@@ -84,13 +85,14 @@ class BasePermissionsThrowExceptionsTestCase(TestCase):
 
 
 class TestBooleanOperationsOnPermissionClassesTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create()
-        self.obj = object()
-        self.user = FacilityUser.objects.create(
-            username="dummyuser", facility=self.facility
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create()
+        cls.obj = object()
+        cls.user = FacilityUser.objects.create(
+            username="dummyuser", facility=cls.facility
         )
-        self.queryset = FacilityUser.objects.all()
+        cls.queryset = FacilityUser.objects.all()
 
     def assertAllowAll(self, perms, test_filtering=True):
         self.assertTrue(perms.user_can_create_object(self.user, self.obj))

--- a/kolibri/core/auth/test/test_roles_and_membership.py
+++ b/kolibri/core/auth/test/test_roles_and_membership.py
@@ -26,8 +26,9 @@ def flatten(lst):
 
 
 class RolesWithinFacilityTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
 
     def test_admin_has_admin_role_for_own_facility(self):
         admin = self.data["facility_admin"]
@@ -61,14 +62,13 @@ class RolesWithinFacilityTestCase(TestCase):
 
 
 class ImplicitMembershipTestCase(TestCase):
-    def setUp(self):
-        self.facility = Facility.objects.create(name="My Facility")
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
-        )
-        self.facility.add_admin(self.admin)
-        self.learner = FacilityUser.objects.create(
-            username="learner", facility=self.facility
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="My Facility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
+        cls.learner = FacilityUser.objects.create(
+            username="learner", facility=cls.facility
         )
 
     def test_has_admin_role_for_learner(self):
@@ -89,21 +89,19 @@ class ImplicitMembershipTestCase(TestCase):
 
 
 class ExplicitMembershipTestCase(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="My Facility")
 
-        self.facility = Facility.objects.create(name="My Facility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.classroom = Classroom.objects.create(name="Class", parent=cls.facility)
+        cls.classroom.add_admin(cls.admin)
 
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
+        cls.learner = FacilityUser.objects.create(
+            username="learner", facility=cls.facility
         )
-        self.classroom = Classroom.objects.create(name="Class", parent=self.facility)
-        self.classroom.add_admin(self.admin)
-
-        self.learner = FacilityUser.objects.create(
-            username="learner", facility=self.facility
-        )
-        self.group = LearnerGroup.objects.create(name="Group", parent=self.classroom)
-        self.group.add_member(self.learner)
+        cls.group = LearnerGroup.objects.create(name="Group", parent=cls.classroom)
+        cls.group.add_member(cls.learner)
 
     def test_has_admin_role_for_learner(self):
         self.assertTrue(self.admin.has_role_for(role_kinds.ADMIN, self.learner))
@@ -123,9 +121,10 @@ class ExplicitMembershipTestCase(TestCase):
 
 
 class RolesAcrossFacilitiesTestCase(TestCase):
-    def setUp(self):
-        self.data1 = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data1 = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data()
 
     def test_no_roles_between_users_across_facilities(self):
         users1 = self.data1["all_users"]
@@ -153,9 +152,10 @@ class RolesAcrossFacilitiesTestCase(TestCase):
 
 
 class MembershipWithinFacilityTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_facility_membership(self):
         actual_members = flatten(
@@ -207,9 +207,10 @@ class MembershipWithinFacilityTestCase(TestCase):
 
 
 class MembershipAcrossFacilitiesTestCase(TestCase):
-    def setUp(self):
-        self.data1 = create_dummy_facility_data()
-        self.data2 = create_dummy_facility_data()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data1 = create_dummy_facility_data()
+        cls.data2 = create_dummy_facility_data()
 
     def test_users_are_not_members_of_other_facility(self):
         for user in self.data1["all_users"]:
@@ -225,10 +226,11 @@ class MembershipAcrossFacilitiesTestCase(TestCase):
 
 
 class SuperuserRolesTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.superuser = self.data["superuser"]
-        self.superuser2 = create_superuser(self.data["facility"], username="superuser2")
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.superuser = cls.data["superuser"]
+        cls.superuser2 = create_superuser(cls.data["facility"], username="superuser2")
 
     def test_superuser_has_admin_role_for_everyone(self):
         for user in self.data["all_users"]:
@@ -246,9 +248,10 @@ class SuperuserRolesTestCase(TestCase):
 
 
 class AnonymousUserRolesTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.anon_user = KolibriAnonymousUser()
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.anon_user = KolibriAnonymousUser()
 
     def test_anon_user_has_no_admin_role_for_anyone(self):
         for user in self.data["all_users"]:

--- a/kolibri/core/auth/test/test_users.py
+++ b/kolibri/core/auth/test/test_users.py
@@ -14,7 +14,7 @@ class UserSanityTestCase(TestCase):
     Sanity checks basic functionality of user models.
     """
 
-    def setUp(self):
+    def test_facility_user(self):
         self.facility = Facility.objects.create()
         self.user = FacilityUser.objects.create(
             username="mike",
@@ -23,12 +23,6 @@ class UserSanityTestCase(TestCase):
             facility=self.facility,
         )
         self.do = create_superuser(self.facility)
-
-    def test_facility_user(self):
         self.assertFalse(self.user.is_superuser)
-
-    def test_device_owner(self):
         self.assertTrue(self.do.is_superuser)
-
-    def test_short_name(self):
         self.assertEqual(self.user.get_short_name(), "Mike")

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -17,8 +17,9 @@ class GetFacilityTestCase(TestCase):
     Tests getting facility or by ID.
     """
 
-    def setUp(self):
-        self.facility = Facility.objects.create(name="facility")
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="facility")
 
     def test_get_facility_with_id(self):
         self.assertEqual(
@@ -32,11 +33,6 @@ class GetFacilityTestCase(TestCase):
     def test_get_facility_with_no_id(self):
         self.assertEqual(self.facility, utils.get_facility())
 
-    def test_get_facility_no_facilities(self):
-        self.facility.delete()
-        with self.assertRaisesRegexp(CommandError, "no facilities"):
-            utils.get_facility()
-
     def test_get_facility_multiple_facilities_noninteractive(self):
         Facility.objects.create(name="facility2")
         with self.assertRaisesRegexp(CommandError, "multiple facilities"):
@@ -48,3 +44,9 @@ class GetFacilityTestCase(TestCase):
         Facility.objects.create(name="a_facility")
         Facility.objects.create(name="b_facility")
         self.assertEqual(self.facility, utils.get_facility())
+
+
+class GetFacilityFailureTestCase(TestCase):
+    def test_get_facility_no_facilities(self):
+        with self.assertRaisesRegexp(CommandError, "no facilities"):
+            utils.get_facility()

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -172,15 +172,14 @@ class ContentNodeQuerysetTestCase(TestCase):
     fixtures = ["content_test.json"]
     the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = Facility.objects.create(name="facility")
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
-        )
-        self.admin.set_password(DUMMY_PASSWORD)
-        self.admin.save()
-        self.facility.add_admin(self.admin)
+        cls.facility = Facility.objects.create(name="facility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
 
     def test_filter_uuid(self):
         content_ids = content.ContentNode.objects.values_list("id", flat=True)
@@ -205,15 +204,14 @@ class ContentNodeAPITestCase(APITestCase):
     fixtures = ["content_test.json"]
     the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = Facility.objects.create(name="facility")
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
-        )
-        self.admin.set_password(DUMMY_PASSWORD)
-        self.admin.save()
-        self.facility.add_admin(self.admin)
+        cls.facility = Facility.objects.create(name="facility")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
 
     def test_prerequisite_for_filter(self):
         c1_id = content.ContentNode.objects.get(title="c1").id
@@ -1494,16 +1492,20 @@ def mock_patch_decorator(func):
 
 
 class KolibriStudioAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         DeviceSettings.objects.create(is_provisioned=True)
-        self.facility = Facility.objects.create(name="facility")
+        cls.facility = Facility.objects.create(name="facility")
         superuser = FacilityUser.objects.create(
-            username="superuser", facility=self.facility
+            username="superuser", facility=cls.facility
         )
         superuser.set_password(DUMMY_PASSWORD)
         superuser.save()
+        cls.superuser = superuser
         DevicePermissions.objects.create(user=superuser, is_superuser=True)
-        self.client.login(username=superuser.username, password=DUMMY_PASSWORD)
+
+    def setUp(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
 
     @mock_patch_decorator
     def test_channel_list(self):

--- a/kolibri/core/content/test/test_deletechannel.py
+++ b/kolibri/core/content/test/test_deletechannel.py
@@ -17,27 +17,15 @@ class DeleteChannelTestCase(TestCase):
     def delete_channel(self):
         call_command("deletechannel", self.the_channel_id)
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_channelmetadata_delete_remove_metadata_object(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_channelmetadata_delete_remove_metadata_object(self):
         self.delete_channel()
         self.assertEquals(0, content.ChannelMetadata.objects.count())
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_channelmetadata_delete_remove_contentnodes(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_channelmetadata_delete_remove_contentnodes(self):
         self.delete_channel()
         self.assertEquals(0, content.ContentNode.objects.count())
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_channelmetadata_delete_leave_unrelated_contentnodes(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_channelmetadata_delete_leave_unrelated_contentnodes(self):
         c2c1 = content.ContentNode.objects.get(title="c2c1")
         new_id = c2c1.id[:-1] + "1"
         content.ContentNode.objects.create(
@@ -51,11 +39,7 @@ class DeleteChannelTestCase(TestCase):
         self.delete_channel()
         self.assertEquals(1, content.ContentNode.objects.count())
 
-    @patch("kolibri.core.content.models.paths.get_content_storage_file_path")
-    @patch("kolibri.core.content.models.os.remove")
-    def test_channelmetadata_delete_remove_file_objects(
-        self, os_remove_mock, content_file_path
-    ):
+    def test_channelmetadata_delete_remove_file_objects(self):
         self.delete_channel()
         self.assertEquals(0, content.File.objects.count())
 

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -170,19 +170,22 @@ class DeviceProvisionTestCase(APITestCase):
 
 
 class DeviceSettingsTestCase(APITestCase):
-    settings = {
-        "language_id": "en",
-        "allow_guest_access": False,
-        "allow_peer_unlisted_channel_import": True,
-        "allow_learner_unassigned_resource_access": False,
-    }
+    @classmethod
+    def setUpTestData(cls):
+        cls.settings = {
+            "language_id": "en",
+            "allow_guest_access": False,
+            "allow_peer_unlisted_channel_import": True,
+            "allow_learner_unassigned_resource_access": False,
+        }
+
+        cls.facility = FacilityFactory.create()
+        provision_device(language_id="es", default_facility=cls.facility)
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
 
     def setUp(self):
         super(DeviceSettingsTestCase, self).setUp()
-        self.facility = FacilityFactory.create()
-        provision_device(language_id="es", default_facility=self.facility)
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -227,11 +230,14 @@ class DeviceSettingsTestCase(APITestCase):
 
 
 class DevicePermissionsTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -299,11 +305,14 @@ class FreeSpaceTestCase(APITestCase):
 
 
 class DeviceInfoTestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
         DatabaseIDModel.objects.create()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+    def setUp(self):
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -393,14 +402,16 @@ class DeviceInfoTestCase(APITestCase):
 
 
 class DeviceNameTestCase(APITestCase):
-    device_name = {"name": "test device"}
+    @classmethod
+    def setUpTestData(cls):
+        cls.device_name = {"name": "test device"}
+        cls.facility = FacilityFactory.create()
+        provision_device(language_id="es", default_facility=cls.facility)
+        cls.superuser = create_superuser(cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
 
     def setUp(self):
         super(DeviceNameTestCase, self).setUp()
-        self.facility = FacilityFactory.create()
-        provision_device(language_id="es", default_facility=self.facility)
-        self.superuser = create_superuser(self.facility)
-        self.user = FacilityUserFactory.create(facility=self.facility)
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -441,8 +452,8 @@ class DeviceNameTestCase(APITestCase):
         )
 
     def test_device_name_max_length(self):
-        exceeds_max_length_name = {"name": "a" * 60}
         with self.assertRaises(ValidationError):
+            exceeds_max_length_name = {"name": "a" * 60}
             self.client.patch(
                 reverse("kolibri:core:devicename"),
                 exceeds_max_length_name,

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -23,18 +23,19 @@ from kolibri.core.auth.test.test_api import FacilityUserFactory
 @mock.patch.object(connections, "check_connection_info", mock_device_info)
 @mock.patch.object(connections, "check_if_port_open", lambda *a: True)
 class NetworkLocationAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
-        self.learner = FacilityUserFactory(facility=self.facility)
-        self.existing_happy_netloc = models.NetworkLocation.objects.create(
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.learner = FacilityUserFactory(facility=cls.facility)
+        cls.existing_happy_netloc = models.NetworkLocation.objects.create(
             base_url="https://kolibrihappyurl.qqq/"
         )
-        self.existing_nonkolibri_netloc = models.NetworkLocation.objects.create(
+        cls.existing_nonkolibri_netloc = models.NetworkLocation.objects.create(
             base_url="https://nonkolibrihappyurl.qqq/"
         )
-        self.existing_sad_netloc = models.NetworkLocation.objects.create(
+        cls.existing_sad_netloc = models.NetworkLocation.objects.create(
             base_url="https://sadurl.qqq/"
         )
 

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -19,21 +19,20 @@ DUMMY_PASSWORD = "password"
 
 
 class ExamAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = Facility.objects.create(name="MyFac")
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
-        )
-        self.admin.set_password(DUMMY_PASSWORD)
-        self.admin.save()
-        self.facility.add_admin(self.admin)
-        self.exam = models.Exam.objects.create(
+        cls.facility = Facility.objects.create(name="MyFac")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
+        cls.exam = models.Exam.objects.create(
             title="title",
             question_count=1,
             active=True,
-            collection=self.facility,
-            creator=self.admin,
+            collection=cls.facility,
+            creator=cls.admin,
         )
 
     def make_basic_exam(self):

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -18,20 +18,19 @@ DUMMY_PASSWORD = "password"
 
 
 class LessonAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = Facility.objects.create(name="MyFac")
-        self.admin = FacilityUser.objects.create(
-            username="admin", facility=self.facility
-        )
-        self.admin.set_password(DUMMY_PASSWORD)
-        self.admin.save()
-        self.facility.add_admin(self.admin)
-        self.lesson = models.Lesson.objects.create(
+        cls.facility = Facility.objects.create(name="MyFac")
+        cls.admin = FacilityUser.objects.create(username="admin", facility=cls.facility)
+        cls.admin.set_password(DUMMY_PASSWORD)
+        cls.admin.save()
+        cls.facility.add_admin(cls.admin)
+        cls.lesson = models.Lesson.objects.create(
             title="title",
             is_active=True,
-            collection=self.facility,
-            created_by=self.admin,
+            collection=cls.facility,
+            created_by=cls.admin,
         )
 
     def test_logged_in_user_lesson_no_delete(self):

--- a/kolibri/core/lessons/test/test_lesson_create.py
+++ b/kolibri/core/lessons/test/test_lesson_create.py
@@ -22,20 +22,21 @@ class LessonCreationTestCase(APITestCase):
     Tests for creating and fetching new Lessons
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = Facility.objects.create(name="My Facility")
-        self.classroom = Classroom.objects.create(
-            name="My Classroom", parent=self.facility
+        cls.facility = Facility.objects.create(name="My Facility")
+        cls.classroom = Classroom.objects.create(
+            name="My Classroom", parent=cls.facility
         )
 
-        self.admin_user = FacilityUser.objects.create(
-            username="admin", facility=self.facility
+        cls.admin_user = FacilityUser.objects.create(
+            username="admin", facility=cls.facility
         )
-        self.admin_user.set_password("password")
-        self.admin_user.save()
+        cls.admin_user.set_password("password")
+        cls.admin_user.save()
 
-        self.facility.add_coach(self.admin_user)
+        cls.facility.add_coach(cls.admin_user)
 
         channel_id = "15f32edcec565396a1840c5413c92450"
         content_ids = [
@@ -50,7 +51,7 @@ class LessonCreationTestCase(APITestCase):
         ]
 
         # Available ContentNode
-        self.available_node = ContentNode.objects.create(
+        cls.available_node = ContentNode.objects.create(
             title="Available Content",
             available=True,
             id=contentnode_ids[0],
@@ -59,7 +60,7 @@ class LessonCreationTestCase(APITestCase):
         )
 
         # Unavailable ContentNode
-        self.unavailable_node = ContentNode.objects.create(
+        cls.unavailable_node = ContentNode.objects.create(
             title="Unavailable Content",
             available=False,
             id=contentnode_ids[1],

--- a/kolibri/core/logger/test/test_permissions.py
+++ b/kolibri/core/logger/test/test_permissions.py
@@ -12,10 +12,11 @@ from kolibri.core.auth.test.helpers import create_dummy_facility_data
 
 
 class ContentSessionLogPermissionsTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.data["interaction_log"] = ContentSessionLogFactory.create(
-            user=self.data["learners_one_group"][0][0],
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.data["interaction_log"] = ContentSessionLogFactory.create(
+            user=cls.data["learners_one_group"][0][0],
             content_id=uuid.uuid4().hex,
             channel_id=uuid.uuid4().hex,
         )
@@ -61,10 +62,11 @@ class ContentSessionLogPermissionsTestCase(TestCase):
 
 
 class ContentSummaryLogPermissionsTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.data["summary_log"] = ContentSummaryLogFactory.create(
-            user=self.data["learners_one_group"][0][1],
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.data["summary_log"] = ContentSummaryLogFactory.create(
+            user=cls.data["learners_one_group"][0][1],
             content_id=uuid.uuid4().hex,
             channel_id=uuid.uuid4().hex,
         )
@@ -102,10 +104,11 @@ class ContentSummaryLogPermissionsTestCase(TestCase):
 
 
 class UserSessionLogPermissionsTestCase(TestCase):
-    def setUp(self):
-        self.data = create_dummy_facility_data()
-        self.data["session_log"] = UserSessionLogFactory.create(
-            user=self.data["learners_one_group"][1][1]
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = create_dummy_facility_data()
+        cls.data["session_log"] = UserSessionLogFactory.create(
+            user=cls.data["learners_one_group"][1][1]
         )
 
     def test_facilityadmin_sessionlog_permissions(self):

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -36,10 +36,13 @@ from kolibri.utils.time_utils import local_now
 
 
 class NotificationsAPITestCase(APITestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.facility = FacilityFactory.create()
-        self.superuser = create_superuser(self.facility)
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+
+    def setUp(self):
         self.user1 = FacilityUserFactory.create(facility=self.facility)
         self.user2 = FacilityUserFactory.create(facility=self.facility)
         # create classroom, learner group, add user1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Replaces, in most of the Python test suite, `setUp` with `setUpClassData` class method to avoid replacing test data that is not modified during the tests, thus saving time.

### Reviewer guidance

Does this refactor mess up the intent of any tests?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
