### PR TITLE
Add snackbar notifications when saving server settings

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -16,22 +16,6 @@
     </section>
 
     <section>
-      <UiAlert
-        v-if="saveStatus === 'SUCCESS'"
-        type="success"
-        @dismiss="resetSaveStatus"
-      >
-        {{ $tr('saveSuccessNotification') }}
-      </UiAlert>
-      <UiAlert
-        v-if="saveStatus === 'ERROR'"
-        type="error"
-        @dismiss="resetSaveStatus"
-      >
-        {{ $tr('saveFailureNotification') }}
-      </UiAlert>
-    </section>
-    <section>
       <KSelect
         v-model="language"
         :label="$tr('selectedLanguageLabel')"
@@ -122,7 +106,6 @@
   import find from 'lodash/find';
   import urls from 'kolibri.urls';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import { LandingPageChoices } from '../../constants';
@@ -135,9 +118,6 @@
         title: this.$tr('pageHeader'),
       };
     },
-    components: {
-      UiAlert,
-    },
     mixins: [commonCoreStrings],
     data() {
       return {
@@ -147,7 +127,6 @@
         allowLearnerUnassignedResourceAccess: null,
         allowPeerUnlistedChannelImport: null,
         allowOtherBrowsersToConnect: null,
-        saveStatus: null,
         landingPageChoices: LandingPageChoices,
         browserDefaultOption: {
           value: null,
@@ -214,9 +193,6 @@
       });
     },
     methods: {
-      resetSaveStatus() {
-        this.saveStatus = null;
-      },
       getFacilitySettingsPath(facilityId = '') {
         const getUrl = urls['kolibri:kolibri.plugins.facility:facility_management'];
         if (getUrl) {
@@ -237,7 +213,6 @@
           allowOtherBrowsersToConnect,
         } = this;
 
-        this.resetSaveStatus();
         this.saveDeviceSettings({
           languageId: language.value,
           landingPage,
@@ -247,10 +222,10 @@
           allowOtherBrowsersToConnect,
         })
           .then(() => {
-            this.saveStatus = 'SUCCESS';
+            this.$store.dispatch('createSnackbar', this.$tr('saveSuccessNotification'));
           })
           .catch(() => {
-            this.saveStatus = 'ERROR';
+            this.$store.dispatch('createSnackbar', this.$tr('saveFailureNotification'));
           });
       },
       getDeviceSettings,
@@ -296,6 +271,7 @@
   .save-button {
     margin-left: 0;
   }
+
   .description {
     width: 100%;
     font-size: 12px;


### PR DESCRIPTION
### Summary

Replace the server settings old-style alert with snackbar notifications.

![Screenshot_2020-09-29 Device settings - Kolibri](https://user-images.githubusercontent.com/3750511/94572173-62fd5500-0279-11eb-81e1-7d32efd3ccd1.png)

### References

#6339 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
