### PR TITLE
Add snackbar notifications when saving facility settings

### DIFF
--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -25,12 +25,6 @@ export const Modals = {
   DELETE_USER: 'DELETE_USER',
 };
 
-export const notificationTypes = {
-  PAGELOAD_FAILURE: 'PAGELOAD_FAILURE',
-  SAVE_FAILURE: 'SAVE_FAILURE',
-  SAVE_SUCCESS: 'SAVE_SUCCESS',
-};
-
 export const pageNameToModuleMap = {
   [PageNames.CLASS_MGMT_PAGE]: 'classManagement',
   [PageNames.CLASS_EDIT_MGMT_PAGE]: 'classEditManagement',

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -1,7 +1,5 @@
 import { FacilityDatasetResource, FacilityResource } from 'kolibri.resources';
 
-import { notificationTypes } from '../../constants';
-
 export function saveFacilityName(store, payload) {
   return FacilityResource.saveModel({
     id: payload.id,
@@ -25,7 +23,6 @@ export function saveFacilityName(store, payload) {
 }
 
 export function saveFacilityConfig(store) {
-  store.commit('CONFIG_PAGE_NOTIFY', null);
   const { facilityDatasetId, settings } = store.state;
   const resourceRequests = [
     FacilityDatasetResource.saveModel({
@@ -33,15 +30,9 @@ export function saveFacilityConfig(store) {
       data: settings,
     }),
   ];
-  return Promise.all(resourceRequests)
-    .then(function onSuccess() {
-      store.commit('CONFIG_PAGE_NOTIFY', notificationTypes.SAVE_SUCCESS);
-      store.commit('CONFIG_PAGE_COPY_SETTINGS');
-    })
-    .catch(function onFailure() {
-      store.commit('CONFIG_PAGE_NOTIFY', notificationTypes.SAVE_FAILURE);
-      store.commit('CONFIG_PAGE_UNDO_SETTINGS_CHANGE');
-    });
+  return Promise.all(resourceRequests).then(function onSuccess() {
+    store.commit('CONFIG_PAGE_COPY_SETTINGS');
+  });
 }
 
 export function resetFacilityConfig(store) {

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -1,5 +1,4 @@
 import { FacilityResource, FacilityDatasetResource } from 'kolibri.resources';
-import { notificationTypes } from '../../constants';
 
 export function showFacilityConfigPage(store, toRoute) {
   const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
@@ -21,7 +20,6 @@ export function showFacilityConfigPage(store, toRoute) {
         settings: { ...dataset },
         // this copy is kept for the purpose of undoing if save fails
         settingsCopy: { ...dataset },
-        notification: null,
         facilities: facilities,
       });
 
@@ -31,7 +29,6 @@ export function showFacilityConfigPage(store, toRoute) {
       store.commit('facilityConfig/SET_STATE', {
         facilityName: '',
         settings: null,
-        notification: notificationTypes.PAGELOAD_FAILURE,
       });
       store.commit('CORE_SET_PAGE_LOADING', false);
     });

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
@@ -5,7 +5,6 @@ function defaultState() {
     facilityDatasetId: '',
     facilityId: '',
     facilityName: '',
-    notification: null,
     settings: {},
     settingsCopy: {},
     facilityNameSaved: false,
@@ -23,9 +22,6 @@ export default {
     },
     RESET_STATE(state) {
       Object.assign(state, defaultState());
-    },
-    CONFIG_PAGE_NOTIFY(state, notificationType) {
-      state.notification = notificationType;
     },
     CONFIG_PAGE_UNDO_SETTINGS_CHANGE(state) {
       state.settings = Object.assign({}, state.settingsCopy);

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfigPageNotifications.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfigPageNotifications.vue
@@ -1,58 +1,16 @@
-<template>
-
-  <div>
-    <UiAlert
-      v-if="notification === notificationTypes.PAGELOAD_FAILURE"
-      type="error"
-      @dismiss="dismiss()"
-    >
-      {{ $tr('pageloadFailure') }}
-    </UiAlert>
-
-    <UiAlert
-      v-if="notification === notificationTypes.SAVE_SUCCESS"
-      type="success"
-      @dismiss="dismiss()"
-    >
-      {{ $tr('saveSuccess') }}
-    </UiAlert>
-
-    <UiAlert
-      v-if="notification === notificationTypes.SAVE_FAILURE"
-      type="error"
-      @dismiss="dismiss()"
-    >
-      {{ $tr('saveFailure') }}
-    </UiAlert>
-  </div>
-
-</template>
-
-
 <script>
 
-  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import { notificationTypes } from '../../constants';
+  // TODO: This component is kept for $trs strings, delete on 0.15 version
+  // Strings should be moved to FacilityConfigPage/index.vue and translations updated
 
   export default {
     name: 'ConfigPageNotifications',
-    components: { UiAlert },
-    props: {
-      notification: {
-        type: String,
-        required: false,
-      },
-    },
-    computed: { notificationTypes: () => notificationTypes },
-    methods: {
-      dismiss() {
-        this.$emit('dismiss');
-      },
-    },
     $trs: {
+      /* eslint-disable kolibri/vue-no-unused-translations */
       saveFailure: 'There was a problem saving your settings',
       saveSuccess: 'Facility settings updated',
       pageloadFailure: 'There was a problem loading your settings',
+      /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -227,7 +227,7 @@
           .catch(() => {
             // eslint-disable-next-line kolibri/vue-no-undefined-string-uses
             this.createSnackbar(this.NotificationsStrings.$tr('saveFailure'));
-            this.$store.commit('CONFIG_PAGE_UNDO_SETTINGS_CHANGE');
+            this.$store.commit('facilityConfig/CONFIG_PAGE_UNDO_SETTINGS_CHANGE');
           });
       },
       resetToDefaultSettings() {

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -143,7 +143,7 @@ describe('facility config page actions', () => {
 
     it('when save fails', () => {
       const saveStub = DatasetStub.__getModelSaveReturns('heck no', true);
-      return store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
+      return store.dispatch('facilityConfig/saveFacilityConfig').catch(() => {
         expect(saveStub).toHaveBeenCalled();
         expect(store.state.facilityConfig.settings).toEqual({
           learner_can_edit_name: true,

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -83,7 +83,6 @@ describe('facility config page actions', () => {
       const expectedState = {
         facilityName: '',
         settings: null,
-        notification: 'PAGELOAD_FAILURE',
       };
       it('when fetching Facility fails', () => {
         FacilityStub.__getModelFetchReturns('incomprehensible error', true);
@@ -139,7 +138,6 @@ describe('facility config page actions', () => {
       return store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
         expect(DatasetStub.getModel).toHaveBeenCalledWith(1000, {});
         expect(saveStub).toHaveBeenCalledWith(expect.objectContaining(expectedRequest), false);
-        expect(store.state.facilityConfig.notification).toEqual('SAVE_SUCCESS');
       });
     });
 
@@ -147,7 +145,6 @@ describe('facility config page actions', () => {
       const saveStub = DatasetStub.__getModelSaveReturns('heck no', true);
       return store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
         expect(saveStub).toHaveBeenCalled();
-        expect(store.state.facilityConfig.notification).toEqual('SAVE_FAILURE');
         expect(store.state.facilityConfig.settings).toEqual({
           learner_can_edit_name: true,
           learner_can_edit_username: false,

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -98,8 +98,9 @@ describe('facility config page view', () => {
     assertModalIsUp(wrapper);
     confirmResetModal().vm.$emit('submit');
     await wrapper.vm.$nextTick();
-    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenCalledTimes(2);
     expect(mock).toHaveBeenCalledWith('facilityConfig/resetFacilityConfig');
+    expect(mock).toHaveBeenCalledWith('createSnackbar', 'Facility settings updated');
     assertModalIsDown(wrapper);
   });
   // not tested: notifications


### PR DESCRIPTION
### Summary

Replace the facility settings old-style alert with snackbar notifications.

![Screenshot_2020-09-30 Configure Facility - Kolibri](https://user-images.githubusercontent.com/3750511/94619709-03716a80-02b6-11eb-9c30-0927ad6e84c6.png)

### Reviewer guidance

I haven't accounted for pageLoadFailure. I don't know how to handle that case.

### References

#7134 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
