### PR TITLE
Move facility name input outside of radio buttons in setup wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -6,6 +6,11 @@
       :description="$tr('facilityPermissionsSetupFormDescription')"
       @submit="handleSubmit"
     >
+      <FacilityNameTextbox
+        ref="facility-name"
+        class="facility-name-form"
+      />
+
       <KRadioButton
         ref="first-button"
         v-model="selected"
@@ -14,11 +19,6 @@
         :label="$tr('nonFormalLabel')"
         :description="$tr('nonFormalDescription')"
       />
-      <FacilityNameTextbox
-        v-show="nonformalIsSelected"
-        ref="facility-name-nonformal"
-        class="facility-name-form"
-      />
 
       <KRadioButton
         v-model="selected"
@@ -26,11 +26,6 @@
         :value="Presets.FORMAL"
         :label="$tr('formalLabel')"
         :description="$tr('formalDescription')"
-      />
-      <FacilityNameTextbox
-        v-show="formalIsSelected"
-        ref="facility-name-formal"
-        class="facility-name-form"
       />
     </OnboardingForm>
   </div>
@@ -64,10 +59,8 @@
         return this.selected === Presets.NONFORMAL;
       },
       submittedFacilityName() {
-        if (this.nonformalIsSelected) {
-          return this.$refs['facility-name-nonformal'].facilityName;
-        } else if (this.formalIsSelected) {
-          return this.$refs['facility-name-formal'].facilityName;
+        if (this.nonformalIsSelected || this.formalIsSelected) {
+          return this.$refs['facility-name'].facilityName;
         } else {
           // Will be turned into a default "Home Facility {{ full name }}" after it is provided
           // in SuperuserCredentialsForm
@@ -90,11 +83,7 @@
     },
     methods: {
       focusOnTextbox() {
-        if (this.nonformalIsSelected) {
-          return this.$refs['facility-name-nonformal'].focus();
-        } else if (this.formalIsSelected) {
-          return this.$refs['facility-name-formal'].focus();
-        }
+        return this.$refs['facility-name'].focus();
       },
       handleSubmit() {
         if (this.formIsValid) {
@@ -146,10 +135,6 @@
 <style lang="scss" scoped>
 
   $margin-of-radio-button-text: 32px;
-
-  .facility-name-form {
-    margin-left: 32px;
-  }
 
   .permission-preset {
     cursor: pointer;

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -71,13 +71,6 @@
         return this.submittedFacilityName !== '';
       },
     },
-    watch: {
-      selected() {
-        return this.$nextTick().then(() => {
-          this.focusOnTextbox();
-        });
-      },
-    },
     mounted() {
       this.focusOnTextbox();
     },

--- a/kolibri/plugins/setup_wizard/assets/test/views/FacilityPermissionsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/FacilityPermissionsForm.spec.js
@@ -11,8 +11,7 @@ function makeWrapper() {
   const els = {
     nonFormalRadioButton: () => wrapper.findAllComponents({ name: 'KRadioButton' }).at(0),
     formalRadioButton: () => wrapper.findAllComponents({ name: 'KRadioButton' }).at(1),
-    nonFormalTextbox: () => wrapper.findAllComponents({ name: 'FacilityNameTextbox' }).at(0),
-    formalTextbox: () => wrapper.findAllComponents({ name: 'FacilityNameTextbox' }).at(1),
+    facilityNameTextbox: () => wrapper.findAllComponents({ name: 'FacilityNameTextbox' }).at(0),
   }
   const actions = {
     simulateSubmit: () => wrapper.findComponent({ name: 'OnboardingForm' }).vm.$emit('submit'),
@@ -23,20 +22,21 @@ function makeWrapper() {
 }
 
 describe('FacilityPermissionsForm', () => {
-  it('"non-formal" option is selected by default and facility name textbox is visible', () => {
+  it('"non-formal" option is selected by default and facility name textbox is focused', () => {
     const { els } = makeWrapper();
     expect(els.nonFormalRadioButton().vm.isChecked).toEqual(true);
-    expect(els.nonFormalTextbox().element).toBeVisible();
+    const elementThatIsFocused = document.activeElement;
+    expect(elementThatIsFocused.classList.contains('ui-textbox-input')).toBe(true);
   });
 
-  it('selecting "formal" shows facility name textbox', async () => {
+  it('selecting "formal" focuses on facility name textbox', async () => {
     const { els, actions, wrapper } = makeWrapper();
     actions.selectPreset('formal');
     await wrapper.vm.$nextTick();
     expect(els.nonFormalRadioButton().vm.isChecked).toEqual(false);
-    expect(els.nonFormalTextbox().element).not.toBeVisible();
     expect(els.formalRadioButton().vm.isChecked).toEqual(true);
-    expect(els.formalTextbox().element).toBeVisible();
+    const elementThatIsFocused = document.activeElement;
+    expect(elementThatIsFocused.classList.contains('ui-textbox-input')).toBe(true);
   });
 
   describe('submitting', () => {
@@ -48,8 +48,7 @@ describe('FacilityPermissionsForm', () => {
 
     it('does not submit if "non-formal" and facility name is empty', () => {
       const { els, actions, wrapper } = makeWrapper();
-      els.nonFormalTextbox().setData({ facilityName: '' });
-      els.formalTextbox().setData({ facilityName: 'Unused Name' });
+      els.facilityNameTextbox().setData({ facilityName: '' });
       actions.simulateSubmit();
       expect(wrapper.vm.$emit).not.toHaveBeenCalled();
     });
@@ -57,15 +56,14 @@ describe('FacilityPermissionsForm', () => {
     it('does not submit if "formal" and facility name is empty', () => {
       const { els, actions, wrapper } = makeWrapper();
       actions.selectPreset('formal');
-      els.formalTextbox().setData({ facilityName: '' });
-      els.nonFormalTextbox().setData({ facilityName: 'Unused Name' });
+      els.facilityNameTextbox().setData({ facilityName: '' });
       actions.simulateSubmit();
       expect(wrapper.vm.$emit).not.toHaveBeenCalled();
     });
 
     it('submitting with "non-formal" updates vuex correctly', () => {
       const { els, actions, store, wrapper } = makeWrapper();
-      els.nonFormalTextbox().setData({
+      els.facilityNameTextbox().setData({
         facilityName: 'Non-Formal Facility',
       });
       actions.simulateSubmit();
@@ -78,7 +76,7 @@ describe('FacilityPermissionsForm', () => {
     it('submitting with "formal" updates vuex correctly', () => {
       const { els, actions, store, wrapper } = makeWrapper();
       actions.selectPreset('formal');
-      els.formalTextbox().setData({
+      els.facilityNameTextbox().setData({
         facilityName: 'Formal Facility',
       });
       actions.simulateSubmit();

--- a/kolibri/plugins/setup_wizard/assets/test/views/FacilityPermissionsForm.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/test/views/FacilityPermissionsForm.spec.js
@@ -29,16 +29,6 @@ describe('FacilityPermissionsForm', () => {
     expect(elementThatIsFocused.classList.contains('ui-textbox-input')).toBe(true);
   });
 
-  it('selecting "formal" focuses on facility name textbox', async () => {
-    const { els, actions, wrapper } = makeWrapper();
-    actions.selectPreset('formal');
-    await wrapper.vm.$nextTick();
-    expect(els.nonFormalRadioButton().vm.isChecked).toEqual(false);
-    expect(els.formalRadioButton().vm.isChecked).toEqual(true);
-    const elementThatIsFocused = document.activeElement;
-    expect(elementThatIsFocused.classList.contains('ui-textbox-input')).toBe(true);
-  });
-
   describe('submitting', () => {
     function testVuex(store, wrapper, expected) {
       expect(store.state.onboardingData.facility.name).toEqual(expected.name);


### PR DESCRIPTION
### Summary

Moved facility name input outside of radio buttons in setup wizard.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/94919720-99c3ad00-04bd-11eb-8337-0adaff9b0ff5.gif)

### References

#7448 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
