### PR TITLE
Fix lesson content preview add button

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -148,17 +148,19 @@ export function showLessonResourceContentPreview(store, params) {
 
 export function showLessonSelectionContentPreview(store, params, query = {}) {
   const { classId, lessonId, contentId } = params;
+
   return store.dispatch('loading').then(() => {
     const pendingSelections = store.state.lessonSummary.workingResources || [];
+
     return Promise.all([
       _prepLessonContentPreview(store, classId, lessonId, contentId),
       store.dispatch('lessonSummary/updateCurrentLesson', lessonId),
     ])
       .then(([contentNode, lesson]) => {
         // TODO state mapper
-        const preselectedResources = lesson.resources.map(({ contentnode_id }) => contentnode_id);
-
+        const preselectedResources = lesson.resources;
         const { searchTerm, ...otherQueryParams } = query;
+
         if (searchTerm) {
           store.commit('SET_TOOLBAR_ROUTE', {
             name: LessonsPageNames.SELECTION_SEARCH,

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -148,10 +148,8 @@ export function showLessonResourceContentPreview(store, params) {
 
 export function showLessonSelectionContentPreview(store, params, query = {}) {
   const { classId, lessonId, contentId } = params;
-
   return store.dispatch('loading').then(() => {
     const pendingSelections = store.state.lessonSummary.workingResources || [];
-
     return Promise.all([
       _prepLessonContentPreview(store, classId, lessonId, contentId),
       store.dispatch('lessonSummary/updateCurrentLesson', lessonId),
@@ -160,7 +158,6 @@ export function showLessonSelectionContentPreview(store, params, query = {}) {
         // TODO state mapper
         const preselectedResources = lesson.resources;
         const { searchTerm, ...otherQueryParams } = query;
-
         if (searchTerm) {
           store.commit('SET_TOOLBAR_ROUTE', {
             name: LessonsPageNames.SELECTION_SEARCH,

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanLessonSelectionContentPreview.vue
@@ -75,7 +75,9 @@
           return true;
         }
         if (this.workingResources && this.currentContentNode && this.currentContentNode.id) {
-          return this.workingResources.includes(this.currentContentNode.id);
+          return this.workingResources.some(
+            resource => resource.contentnode_id === this.currentContentNode.id
+          );
         }
         return false;
       },


### PR DESCRIPTION
### Summary

Fix the add button in lesson content preview. If the resource is already in lesson, show the correct remove button.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/94998740-d4f8d580-05bc-11eb-958c-cd4829262b24.gif)

### Reviewer guidance

#7475 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
