### PR TITLE
Fix grouping of boolean exprs for `isAndroidWebView`

### DIFF
--- a/kolibri/core/assets/src/utils/browserInfo.js
+++ b/kolibri/core/assets/src/utils/browserInfo.js
@@ -185,7 +185,7 @@ export const userAgent =
  */
 const isAndroid = /Android/.test(userAgent);
 export const isAndroidWebView =
-  (isAndroid && /wv/.test(userAgent)) || /Version\/\d+\.\d+/.test(userAgent);
+  isAndroid && (/wv/.test(userAgent) || /Version\/\d+\.\d+/.test(userAgent));
 
 /**
  * Embedded WebViews on Mac have no app identifier, while all the major browsers do, so check


### PR DESCRIPTION
Fixes #7538, where the user and activity log sections of the Facility Data page would not be shown on Safari.
