### PR TITLE
Fix checkbox select for adding exercises to a quiz

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -421,9 +421,9 @@
           this.removeFromSelectedExercises(this.allExercises);
         }
       },
-      toggleSelected({ checked, contentId }) {
+      toggleSelected({ content, checked }) {
         let exercises;
-        const contentNode = this.contentList.find(item => item.id === contentId);
+        const contentNode = this.contentList.find(item => item.id === content.id);
         const isTopic = contentNode.kind === ContentNodeKinds.TOPIC;
         if (checked && isTopic) {
           this.showError = false;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -353,7 +353,7 @@
         }
         return '';
       },
-      toggleSelected({ checked, content }) {
+      toggleSelected({ content, checked }) {
         if (checked) {
           this.addToSelectedResources(content);
         } else {


### PR DESCRIPTION
### Summary

Fixed checkbox toggle for adding / removing exercises in a quiz. It also affects addition and removal in lesson resources.

### References

#7536 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
