### PR TITLE
Remove schema validation from KolibriApp

### DIFF
--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -1,6 +1,5 @@
 import { sync } from 'vuex-router-sync';
 import forEach from 'lodash/forEach';
-import isPlainObject from 'lodash/isPlainObject';
 import router from 'kolibri.coreVue.router';
 import logger from 'kolibri.lib.logging';
 import Vue from 'kolibri.lib.vue';
@@ -9,59 +8,6 @@ import heartbeat from 'kolibri.heartbeat';
 import KolibriModule from 'kolibri_module';
 
 export const logging = logger.getLogger(__filename);
-
-function _registerSchema(schema, moduleName, subPaths = []) {
-  forEach(schema, (subSchema, propertyName) => {
-    // Must be a plain object to be a valid schema spec
-    // And have at least a default key, and one of type or validator
-    if (isPlainObject(subSchema)) {
-      if (
-        typeof subSchema.default !== 'undefined' &&
-        (subSchema.type || (subSchema.validator && subSchema.validator instanceof Function))
-      ) {
-        /* eslint-disable no-inner-declarations */
-        function getter(state) {
-          if (moduleName) {
-            state = state[moduleName];
-          }
-          subPaths.forEach(path => {
-            state = state[path];
-          });
-          return state[propertyName];
-        }
-        function callback(newValue) {
-          let fail = false;
-          if (subSchema.type) {
-            if (subSchema.type === Object) {
-              if (!isPlainObject(newValue)) {
-                fail = true;
-              }
-            } else {
-              fail = !(newValue instanceof subSchema.type);
-            }
-          }
-          if (subSchema.validator) {
-            if (!subSchema.validator(newValue)) {
-              fail = true;
-            }
-          }
-          if (fail) {
-            logging.error(
-              `Validation failed for property: ${[...subPaths, propertyName]} in module ${
-                moduleName ? moduleName : 'root'
-              }`
-            );
-          }
-        }
-        /* eslint-enable */
-        store.watch(getter, callback);
-      } else {
-        // Otherwise assume it is just a nested object structure
-        _registerSchema(subSchema, moduleName, [...subPaths, propertyName]);
-      }
-    }
-  });
-}
 
 /*
  * A class for single page apps that control routing and vuex state.
@@ -131,18 +77,6 @@ export default class KolibriApp extends KolibriModule {
     forEach(this.pluginModule.modules, (module, name) => {
       store.registerModule(name, module);
     });
-
-    if (process.env.NODE_ENV !== 'production') {
-      // Register any schemas we have defined for vuex state
-      if (this.pluginModule.state && this.pluginModule.state.schema) {
-        _registerSchema(this.pluginModule.state.schema);
-      }
-      forEach(this.pluginModule.modules, (module, name) => {
-        if (module.schema) {
-          _registerSchema(module.schema, name);
-        }
-      });
-    }
 
     return heartbeat.startPolling().then(() => {
       this.store.dispatch('getNotifications');


### PR DESCRIPTION
### Summary

Removes code for validating schemas in Vuex modules, since feature is not being used anywhere + removing it will make it easier to implement #7239 , which requires converting all `state` options to a function in vuex modules, thus invalidating the assumption that a `state.schema` value generally exists

### Reviewer guidance

1. Are there any schemas somewhere in the codebase that I just didn't find?

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
