### PR TITLE
Define `pluginModule.state` as function and re-order module registration to address Vuex warnings

### DIFF
--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -67,10 +67,14 @@ export default class KolibriApp extends KolibriModule {
       mutations: this.pluginModule.mutations || {},
     });
 
-    // Add the plugin state
+    if (typeof this.pluginModule.state !== 'function') {
+      throw TypeError('pluginModule.state must be a function returning a state object');
+    }
+
+    // Add the plugin state to the initial core module state
     this.store.replaceState({
       ...this.store.state,
-      ...this.pluginModule.state,
+      ...this.pluginModule.state(),
     });
 
     // Register plugin sub-modules

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -8,22 +8,24 @@ import mutations from './mutations';
 import plugin_data from 'plugin_data';
 
 export default {
-  state: {
-    error: '',
-    blockDoubleClicks: false,
-    loading: true,
-    pageSessionId: 0,
-    totalProgress: null,
-    notifications: [],
-    channels: {
-      list: [],
-      currentId: null,
-    },
-    allowRemoteAccess: plugin_data.allowRemoteAccess,
-    // facility
-    facilityConfig: {},
-    facilities: [],
-    pageVisible: true,
+  state() {
+    return {
+      error: '',
+      blockDoubleClicks: false,
+      loading: true,
+      pageSessionId: 0,
+      totalProgress: null,
+      notifications: [],
+      channels: {
+        list: [],
+        currentId: null,
+      },
+      allowRemoteAccess: plugin_data.allowRemoteAccess,
+      // facility
+      facilityConfig: {},
+      facilities: [],
+      pageVisible: true,
+    };
   },
   getters,
   actions,

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -21,15 +21,16 @@ export function coreStoreFactory(pluginModule) {
       getters: pluginModule.getters || {},
       mutations: pluginModule.mutations || {},
     });
-    store.replaceState({
-      ...(pluginModule.state || {}),
-    });
+
+    if (typeof pluginModule.state !== 'function') {
+      throw TypeError('pluginModule.state must be a function returning a state object');
+    }
+    store.replaceState(pluginModule.state());
     // Registers any modules defined in `pluginModule`. Their state objects will be organized
     // under `state.submoduleState`. Actions, getters, and mutations can be namespaced.
     forEach(pluginModule.modules, (module, name) => {
       store.registerModule(name, module);
     });
-
   }
 
   // Register core module last

--- a/kolibri/core/assets/src/state/store.js
+++ b/kolibri/core/assets/src/state/store.js
@@ -12,11 +12,7 @@ Vue.use(Vuex);
 export function coreStoreFactory(pluginModule) {
   // Core state is organized under `state.core`, but actions, getters, and mutations
   // are not namespaced.
-  const store = new Vuex.Store({
-    modules: {
-      core: coreModule,
-    },
-  });
+  const store = new Vuex.Store();
   // Appends any pluginModule components to the store. `pluginModule.state`
   // is added to `state`. Actions, getters, and mutations cannot be namespaced.
   if (pluginModule) {
@@ -26,7 +22,6 @@ export function coreStoreFactory(pluginModule) {
       mutations: pluginModule.mutations || {},
     });
     store.replaceState({
-      core: { ...coreModule.state },
       ...(pluginModule.state || {}),
     });
     // Registers any modules defined in `pluginModule`. Their state objects will be organized
@@ -34,7 +29,12 @@ export function coreStoreFactory(pluginModule) {
     forEach(pluginModule.modules, (module, name) => {
       store.registerModule(name, module);
     });
+
   }
+
+  // Register core module last
+  store.registerModule('core', coreModule);
+
   return store;
 }
 

--- a/kolibri/core/assets/test/kolibri_app.spec.js
+++ b/kolibri/core/assets/test/kolibri_app.spec.js
@@ -24,8 +24,10 @@ jest.mock('kolibri.heartbeat', () => ({
 class TestApp extends KolibriApp {
   get pluginModule() {
     return {
-      state: {
-        count: 0,
+      state() {
+        return {
+          count: 0,
+        };
       },
       getters: {
         countGetter(state) {

--- a/kolibri/core/assets/test/kolibri_app.spec.js
+++ b/kolibri/core/assets/test/kolibri_app.spec.js
@@ -50,7 +50,7 @@ class TestApp extends KolibriApp {
 describe('KolibriApp', function() {
   it('it should register the core vuex component', () => {
     const app = new TestApp();
-    expect(app.store.state.core).toMatchObject(coreModule.state);
+    expect(app.store.state.core).toMatchObject(coreModule.state());
     // just checking on keys, since vuex transforms the actions
     expect(Object.keys(app.store._actions)).toEqual(Object.keys(coreModule.actions));
     // only checks intersection with core getters; doesn't include sub-modules

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/index.js
@@ -12,7 +12,7 @@ function defaultState() {
 
 export default {
   namespaced: true,
-  state: defaultState(),
+  state: defaultState,
   getters: {
     getChannelForNode(state, getters, rootState) {
       return function getter(node) {

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -18,12 +18,14 @@ import questionList from './questionList';
 const logging = logger.getLogger(__filename);
 
 export default {
-  state: {
-    busy: false,
-    classList: [],
-    pageName: '',
-    toolbarRoute: {},
-    toolbarTitle: '',
+  state() {
+    return {
+      busy: false,
+      classList: [],
+      pageName: '',
+      toolbarRoute: {},
+      toolbarTitle: '',
+    };
   },
   mutations: {
     SET_PAGE_NAME(state, pageName) {

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -15,7 +15,7 @@ function defaultState() {
 
 export default {
   namespaced: true,
-  state: defaultState(),
+  state: defaultState,
   mutations: {
     SET_STATE(state, payload) {
       Object.assign(state, payload);

--- a/kolibri/plugins/device/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/device/assets/src/modules/pluginModule.js
@@ -6,9 +6,11 @@ import userPermissions from './userPermissions';
 import coreBase from './coreBase';
 
 export default {
-  state: {
-    pageName: '',
-    welcomeModalVisible: false,
+  state() {
+    return {
+      pageName: '',
+      welcomeModalVisible: false,
+    };
   },
   mutations: {
     SET_PAGE_NAME(state, name) {

--- a/kolibri/plugins/device/assets/src/modules/wizard/index.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/index.js
@@ -32,7 +32,7 @@ function defaultState() {
 
 export default {
   namespaced: true,
-  state: defaultState(),
+  state: defaultState,
   actions: {
     ...availableChannelsActions,
     ...contentTreeViewerActions,

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -9,7 +9,9 @@ import manageCSV from './manageCSV';
 import importCSV from './importCSV';
 
 export default {
-  state: {},
+  state() {
+    return {};
+  },
   actions: {
     preparePage(store, options = {}) {
       const { isAsync = true } = options;

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/index.js
@@ -3,9 +3,11 @@ import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 
 export default {
   namespaced: true,
-  state: {
-    contentNodes: [],
-    currentLesson: {},
+  state() {
+    return {
+      contentNodes: [],
+      currentLesson: {},
+    };
   },
   mutations: {
     SET_LESSON_CONTENTNODES(state, contentNodes) {

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -14,13 +14,15 @@ import topicsTree from './topicsTree';
 import plugin_data from 'plugin_data';
 
 export default {
-  state: {
-    pageName: '',
-    examAttemptLogs: {},
-    examLog: {},
-    memberships: [],
-    canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
-    allowGuestAccess: plugin_data.allowGuestAccess,
+  state() {
+    return {
+      pageName: '',
+      examAttemptLogs: {},
+      examLog: {},
+      memberships: [],
+      canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
+      allowGuestAccess: plugin_data.allowGuestAccess,
+    };
   },
   actions,
   getters,

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -12,39 +12,41 @@ const SetupStrings = createTranslator('SetupStrings', {
 });
 
 export default {
-  state: {
-    started: false,
-    // The shape of onboardingData needs to match the DevisionProvisionSerializer
-    onboardingData: {
-      // If device name is null, it will default to hostname. Blank names aren't allowed.
-      device_name: null,
-      // Set in DefaultLanguageForm
-      language_id: currentLanguage,
-      // Set in FacilityPermissionsForm
-      facility: {
-        name: '',
+  state() {
+    return {
+      started: false,
+      // The shape of onboardingData needs to match the DevisionProvisionSerializer
+      onboardingData: {
+        // If device name is null, it will default to hostname. Blank names aren't allowed.
+        device_name: null,
+        // Set in DefaultLanguageForm
+        language_id: currentLanguage,
+        // Set in FacilityPermissionsForm
+        facility: {
+          name: '',
+        },
+        preset: null,
+        // Set in GuessAccessForm
+        allow_guest_access: null,
+        // Keys match schema of FacilityDatasetModel
+        settings: {
+          // Set in CreateLearnerAccountForm
+          learner_can_sign_up: null,
+          learner_can_edit_name: null,
+          learner_can_edit_username: null,
+          // Set in RequirePasswordForLearnersForm
+          learner_can_login_with_no_password: null,
+        },
+        // Set in SuperuserCredentialsForm
+        superuser: {
+          full_name: '',
+          username: '',
+          password: '',
+        },
       },
-      preset: null,
-      // Set in GuessAccessForm
-      allow_guest_access: null,
-      // Keys match schema of FacilityDatasetModel
-      settings: {
-        // Set in CreateLearnerAccountForm
-        learner_can_sign_up: null,
-        learner_can_edit_name: null,
-        learner_can_edit_username: null,
-        // Set in RequirePasswordForLearnersForm
-        learner_can_login_with_no_password: null,
-      },
-      // Set in SuperuserCredentialsForm
-      superuser: {
-        full_name: '',
-        username: '',
-        password: '',
-      },
-    },
-    loading: false,
-    error: false,
+      loading: false,
+      error: false,
+    };
   },
   actions: {
     logIntoImportedFacility(store, credentials) {

--- a/kolibri/plugins/user/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user/assets/src/modules/pluginModule.js
@@ -4,11 +4,13 @@ import profile from './profile';
 import signIn from './signIn';
 
 export default {
-  state: {
-    facilityId: Lockr.get('facilityId') || null,
-    redirect: null,
-    pageName: '',
-    appBarTitle: '',
+  state() {
+    return {
+      facilityId: Lockr.get('facilityId') || null,
+      redirect: null,
+      pageName: '',
+      appBarTitle: '',
+    };
   },
   actions: {
     reset(store) {

--- a/kolibri/plugins/user/assets/test/views/user-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/user-page.spec.js
@@ -3,16 +3,13 @@ import VueRouter from 'vue-router';
 import Vuex from 'vuex';
 import UserIndex from '../../src/views/UserIndex';
 import makeStore from '../makeStore';
-import routes from '../../src/routes';
-
-jest.mock('kolibri.urls');
 
 const localVue = createLocalVue();
 
 localVue.use(VueRouter);
 localVue.use(Vuex);
 
-const router = new VueRouter({ routes });
+const router = new VueRouter();
 
 function makeWrapper() {
   return mount(UserIndex, {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixes #7239 

### Reviewer guidance

1. To verify it cleans up the test output, run `yarn run test`. There should be no more warnings.
1. We need to verify that this refactor doesn't cause any regressions on the actual running app too. The quick way to do this is just to make sure all the plugin SPAs don't have any obvious breakages when using it. The more in-depth way is to compare the top-level state in the devtools before and after, to verify that Vuex is being setup correctly in the `KolibriApp` class.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
