### PR TITLE
Fix new lesson creation title false error

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
@@ -36,6 +36,8 @@
 <script>
 
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
+  import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AssignmentDetailsModal from '../assignments/AssignmentDetailsModal';
   import LessonRootPage from '../LessonsRootPage';
@@ -65,6 +67,14 @@
           })
           .then(() => {
             this.showSnackbarNotification('lessonCreated');
+          })
+          .catch(error => {
+            const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
+            if (errors) {
+              this.$refs.detailsModal.handleSubmitTitleFailure();
+            } else {
+              this.$refs.detailsModal.handleSubmitFailure();
+            }
           });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -58,13 +58,13 @@
           :text="coreString('cancelAction')"
           appearance="flat-button"
           :primary="false"
-          :disabled="disabled"
+          :disabled="disabled || formIsSubmitted"
           @click="$emit('cancel')"
         />
         <KButton
           :text="coreString('saveChangesAction')"
           :primary="true"
-          :disabled="disabled"
+          :disabled="disabled || formIsSubmitted"
           @click="submitData"
         />
       </KButtonGroup>
@@ -156,7 +156,7 @@
     computed: {
       titleIsInvalidText() {
         // submission is handled because "blur" event happens on submit
-        if (!this.disabled && this.titleIsVisited) {
+        if (!this.disabled && !this.formIsSubmitted && this.titleIsVisited) {
           if (this.title === '') {
             return this.coreString('requiredFieldError');
           }
@@ -220,6 +220,7 @@
         }
 
         if (this.formIsValid) {
+          this.formIsSubmitted = true;
           this.$emit('submit', {
             title: this.title,
             description: this.description,


### PR DESCRIPTION
### Summary

Fixed the incorrect error on new lesson creation.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/95557311-4a313400-0a1d-11eb-9992-bf27bb23c315.gif)


Also, added an error catch if somehow a lesson gets created with the same name while you are creating your new lesson.

![simplescreenrecorder-(2)](https://user-images.githubusercontent.com/3750511/95558074-5e296580-0a1e-11eb-8059-ebf93255ed2a.gif)


### References

#6593 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
