### PR TITLE
Informal facilities get 'Create an Account' button visible by default

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Name | Github user |
 |------|-------------|
 | Eli Dai | 66eli77 |
+| Adam Stasiw | AdamStasiw |
 | Akshay Mahajan | akshaymahajans |
 | Alan Chen | alanchenz |
 | Alexandros Metaxas | alexMet |

--- a/kolibri/core/auth/constants/facility_configuration_presets.json
+++ b/kolibri/core/auth/constants/facility_configuration_presets.json
@@ -27,7 +27,7 @@
       "learner_can_edit_username": true,
       "learner_can_edit_name": true,
       "learner_can_edit_password": true,
-      "learner_can_sign_up": false,
+      "learner_can_sign_up": true,
       "learner_can_delete_account": true,
       "learner_can_login_with_no_password": false,
       "show_download_button_in_learn": true

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -73,7 +73,7 @@ class DeviceProvisionTestCase(APITestCase):
         self.assertEqual(settings.learner_can_edit_username, True)
         self.assertEqual(settings.learner_can_edit_name, True)
         self.assertEqual(settings.learner_can_edit_password, True)
-        self.assertEqual(settings.learner_can_sign_up, False)
+        self.assertEqual(settings.learner_can_sign_up, True)
         self.assertEqual(settings.learner_can_delete_account, True)
         self.assertEqual(settings.learner_can_login_with_no_password, False)
         self.assertEqual(settings.show_download_button_in_learn, True)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is to fix #7505, such that facilities created with the "informal" settings will allow the creation of new learners by default. This way, when doing initial setup with the "Quick start" [approach](https://kolibri.readthedocs.io/en/latest/install/initial_setup.html), the admin doesn't need to activate this setting manually, and users will be able to create accounts by default.

Steps Taken:
1. Initialize the app with a fresh database
2. Create a new facility using "Quick start"
3. Logout of the resulting admin account
4. Observe the log-in landing page

Before:
![Screen Shot 2020-10-09 at 5 51 11 PM](https://user-images.githubusercontent.com/72569271/95637621-2cd18980-0a60-11eb-899c-36479d7a2d0a.png)

After:
![Screen Shot 2020-10-09 at 6 16 30 PM](https://user-images.githubusercontent.com/72569271/95637630-3529c480-0a60-11eb-91dc-185c057a983a.png)

Clicking on "Create an Account" proceeds to the user creation page:
![Screen Shot 2020-10-09 at 6 16 50 PM](https://user-images.githubusercontent.com/72569271/95637649-44a90d80-0a60-11eb-958a-1ec9816cdad8.png)


I also modified the test_personal_setup_defaults test to account for this new default value. Running `pytest kolibri/core/device/test/test_api.py` completed successfully.


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Since I'm brand new to the codebase (and this is actually my very first open source contribution ever!), I'm not sure if I should run other tests or if the CR tool runs them for me. To be safe, I ran `tox` and `pytest` to try running everything. I got mostly all successes, but then a collection of failures/errors before the tests started to hang on `discovery/test/test_connection_check.py` - though I tried again on the base `develop` branch without my changes, and got the exact same errors:

```
kolibri/core/content/test/test_import_export.py .........FFFFFF.F.FFFFFFEEEEEEEEEEE                                                                                                                                                  [ 50%]
kolibri/core/content/test/test_importability.py FF                                                                                                                                                                                   [ 50%]
kolibri/core/content/test/test_movedirectory.py FFFFFFF                                                                                                                                                                              [ 51%]
kolibri/core/content/test/test_redirectcontent.py EEEEEEEEEEEE                                                                                                                                                                       [ 51%]
kolibri/core/content/test/test_sqlalchemy_bridge.py ...........................                                                                                                                                                      [ 53%]
kolibri/core/content/test/test_upgrade.py FFFFFFFFFF                                                                                                                                                                                 [ 54%]
kolibri/core/content/test/test_zipcontent.py FFFFFFFFFFFFFFFFFFFFFFFFFF
```

Not sure if this is something I'm doing wrong in my local testing?  

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

See #7505 for the original issue / motivation for the change

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone (I don't think I have the ability to add a milestone?)
- [ ] PR has 'needs review' or 'work-in-progress' label (Similarly, I couldn't find how to add a label to this Pull Request)
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
