### PR TITLE
Fix search in lesson resource management

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -92,7 +92,7 @@
         this.$refs.searchinput.focus();
       },
       search() {
-        if (this.searchTerm !== '') {
+        if (this.searchTerm !== '' && this.searchTermHasChanged) {
           this.$emit('searchterm', this.searchTerm);
         }
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -165,7 +165,7 @@
         return this.pageName === LessonsPageNames.SELECTION_SEARCH;
       },
       searchTerm() {
-        return this.$route.params.searchTerm;
+        return this.$route.params.searchTerm || '';
       },
       routerParams() {
         return { classId: this.classId, lessonId: this.lessonId };


### PR DESCRIPTION
### Summary

Fixes search term prop initialization. Also, fixes redundant redirect when hitting enter again with the same search term.

![simplescreenrecorder-(3)](https://user-images.githubusercontent.com/3750511/95655582-1df6df80-0b11-11eb-95e1-e149bb8ca5f1.gif)


### References

#7439 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
