### PR TITLE
Disable search results filters in Quiz/Lessons workflow if there are no options for filter; fix navigation when switching to "All" filter

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
@@ -12,7 +12,7 @@
           :label="$tr('contentKindFilterLabel')"
           :options="contentKindFilterOptions"
           :inline="true"
-          :disabled="!contentKindFilterOptions.length"
+          :disabled="contentKindFilterOptions.length === 1"
           :value="contentKindValue"
           class="filter"
           @change="updateFilter('kind', $event)"
@@ -25,7 +25,7 @@
           :label="$tr('channelFilterLabel')"
           :options="channelFilterOptions"
           :inline="true"
-          :disabled="!channelFilterOptions.length"
+          :disabled="channelFilterOptions.length === 1"
           :value="channelValue"
           class="filter"
           @change="updateFilter('channel', $event)"
@@ -97,12 +97,16 @@
       ...mapGetters({
         channels: 'getChannels',
       }),
+      noResults() {
+        return this.searchResults.results.length === 0;
+      },
       searchResultsSubheader() {
-        const msg =
-          this.searchResults.results.length === 0
-            ? 'noSearchResultsMessage'
-            : 'searchResultsMessage';
-        return this.$tr(msg, { searchTerm: this.searchTerm });
+        const trOptions = { searchTerm: this.searchTerm };
+        if (this.noResults) {
+          return this.$tr('noSearchResultsMessage', trOptions);
+        } else {
+          return this.$tr('searchResultsMessage', trOptions);
+        }
       },
       allFilter() {
         return { label: this.coreString('allLabel'), value: null };
@@ -164,11 +168,8 @@
       topics: 'Topics',
       videos: 'Videos',
       hideAction: 'Hide',
-      // Linter will not find these dynamic uses.
-      /* eslint-disable kolibri/vue-no-unused-translations */
       searchResultsMessage: `Results for '{searchTerm}'`,
       noSearchResultsMessage: `No results for '{searchTerm}'`,
-      /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -243,8 +243,12 @@
         this.debouncedSaveResources();
       },
       filters(newVal) {
+        const newQuery = {
+          ...this.$route.query,
+          ...newVal,
+        };
         this.$router.push({
-          query: { ...this.$route.query, ...pickBy(newVal) },
+          query: pickBy(newQuery),
         });
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -155,7 +155,7 @@
       channelFilterStyle() {
         const maxWidth = 375;
         // If window is small, just let it have its default width
-        if (this.elementWidth < maxWidth + 32) {
+        if (this.channelFilterOptions.length === 0 || this.elementWidth < maxWidth + 32) {
           return {};
         }
         // Otherwise, adjust the width based on the longest channel name,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Updates logic on `LessonSearchFilters.vue` to disable filters if the only filter is "All", since it is the only option.
1. Fixes a JS error in the learn page search channel filter when there are no search results (error results from an undefined reference when computing a CSS `width` rule that adapts to the names of channels)
1. Refactors a component to avoid having to comment out an "unused translation" eslint rule
1. Fixes bug in `LessonResourceSelectionPage.watch.filter`, where selecting the "All" filter option after first selecting a different filter would not correctly update the URL's query params (specifically, it would not remove an existing query param applying the previous filter). (Fixes #5882, Fixes #6173, Fixes #7601)

#### Quiz Screenshots
![CleanShot 2020-10-14 at 11 37 55@2x](https://user-images.githubusercontent.com/10248067/96031726-97911500-0e12-11eb-8e52-d76e6fc8761a.png)
![CleanShot 2020-10-14 at 11 38 26@2x](https://user-images.githubusercontent.com/10248067/96031739-9bbd3280-0e12-11eb-86c8-f77805610541.png)


#### Lesson screenshots
![CleanShot 2020-10-14 at 11 37 01@2x](https://user-images.githubusercontent.com/10248067/96031748-9f50b980-0e12-11eb-8f76-999817a8d6c3.png)
![CleanShot 2020-10-14 at 11 38 53@2x](https://user-images.githubusercontent.com/10248067/96031763-a4156d80-0e12-11eb-8d17-e5c23b18fa49.png)


### Reviewer guidance

1. Use the search functionality for making a quiz or lesson; the filters should be enabled/disabled if there are results or none, respectively.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
