### PR TITLE
Clear snackbar state whenever GlobalSnackbar hides or is destroyed

### DIFF
--- a/kolibri/core/assets/src/views/GlobalSnackbar.vue
+++ b/kolibri/core/assets/src/views/GlobalSnackbar.vue
@@ -40,11 +40,18 @@
         return JSON.stringify(options) + new Date();
       },
     },
+    destroyed() {
+      this.clearSnackbarState();
+    },
     methods: {
+      clearSnackbarState() {
+        this.$store.commit('CORE_CLEAR_SNACKBAR');
+      },
       hideCallback() {
         if (this.snackbarOptions.hideCallback) {
           this.snackbarOptions.hideCallback();
         }
+        this.clearSnackbarState();
       },
     },
   };

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -47,8 +47,7 @@
           :disabled="formDisabled"
           appearance="raised-button"
           :primary="false"
-
-          @click="$router.push($router.getRoute('PROFILE'))"
+          @click="$router.push($router.getRoute(ComponentMap.PROFILE))"
         />
       </KButtonGroup>
     </form>
@@ -99,6 +98,7 @@
         formSubmitted: false,
         status: '',
         userCopy: {},
+        ComponentMap,
       };
     },
     computed: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Fixes #7562 by clearing out the `core.snackbar` module whenever hides itself via its `hideCallback` prop or when GlobalSnackbar is destroyed (in case it happens before the `hideCallback` is called).
1. Fixes a reference to the `PROFILE` page route in the ProfileEditPage's cancel button. The previous behavior was "correct", but was causing an error to show in the console.

### Reviewer guidance

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
