### PR TITLE
On setup wizard, fix new facility and device name validation

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
@@ -42,7 +42,7 @@
         if (!this.shouldValidate) {
           return '';
         }
-        if (this.value === '') {
+        if (this.value.trim() === '') {
           return this.coreString('requiredFieldError');
         }
         return '';

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityNameTextbox.vue
@@ -27,7 +27,7 @@
     },
     computed: {
       facilityNameErrorMessage() {
-        if (this.facilityName === '') {
+        if (this.facilityName.trim() === '') {
           return this.$tr('facilityNameFieldEmptyErrorMessage');
         }
         if (this.facilityName.length > 100) {
@@ -47,8 +47,8 @@
        * @public
        */
       focus() {
-        if (this.$refs['facilityName']) {
-          this.$refs['facilityName'].focus();
+        if (this.$refs.facilityName) {
+          this.$refs.facilityName.focus();
         }
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -6,10 +6,7 @@
       :description="$tr('facilityPermissionsSetupFormDescription')"
       @submit="handleSubmit"
     >
-      <FacilityNameTextbox
-        ref="facility-name"
-        class="facility-name-form"
-      />
+      <FacilityNameTextbox ref="facility-name" />
 
       <KRadioButton
         ref="first-button"
@@ -68,7 +65,7 @@
         }
       },
       formIsValid() {
-        return this.submittedFacilityName !== '';
+        return !this.$refs['facility-name'].facilityNameIsInvalid;
       },
     },
     mounted() {
@@ -79,6 +76,7 @@
         return this.$refs['facility-name'].focus();
       },
       handleSubmit() {
+        this.$refs['facility-name'].validateFacilityName();
         if (this.formIsValid) {
           this.$store.commit('SET_FACILITY_NAME', this.submittedFacilityName);
 


### PR DESCRIPTION
### Summary

On setup wizard, fix new facility name validation. Also, removed an unused CSS class.

![simplescreenrecorder-(2)](https://user-images.githubusercontent.com/3750511/96387634-3c617880-11ac-11eb-958d-6b942bb5258a.gif)


### References

Fixes #7565 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
