### PR TITLE
In `provisiondevice`, save user-provided facility name as-typed

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -86,17 +86,21 @@ def create_facility(facility_name=None, preset=None, interactive=False):
             sys.exit(1)
 
     if facility_name:
-        facility, created = Facility.objects.get_or_create(name__iexact=facility_name)
+        facility_query = Facility.objects.filter(name__iexact=facility_name)
 
-        if not created:
+        if facility_query.exists():
+            facility = facility_query.get()
             logger.warn(
                 "Facility with name '{name}' already exists, not modifying preset.".format(
                     name=facility.name
                 )
             )
             return facility
-
-        logger.info("Facility with name '{name}' created.".format(name=facility_name))
+        else:
+            facility = Facility.objects.create(name=facility_name)
+            logger.info(
+                "Facility with name '{name}' created.".format(name=facility.name)
+            )
 
         if preset is None and interactive:
             preset = get_user_response(


### PR DESCRIPTION
### Summary

1. Modifies the facility name input handler in the interactive CLI so that the facility name provided is not converted to lower-case. This matches the behavior of the CLI when a `--facility` flag is set
1. Changes query for searching facilities, so that the facility name ignores case _after_ the facility is created.
1. Wraps user input in quotes when messages are logged
1. Updates the settings update utility function so that it doesn't log any thing if no settings were changed

### Reviewer guidance

1. Does this fix the original issue #7564 ?
1. Do the other changes improve the UX?

### References

Fixes #7564

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
