### PR TITLE
Fixing #6560: In postgres, importing changing channel content moves channel to top of list

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -37,7 +37,7 @@
 
       <div class="channels-list">
         <ChannelPanel
-          v-for="channel in sortedChannels"
+          v-for="channel in installedChannelsWithResources"
           :key="channel.id"
           :channel="channel"
           :disabled="channelIsBeingDeleted(channel.id)"
@@ -67,7 +67,6 @@
 
   import find from 'lodash/find';
   import get from 'lodash/get';
-  import sortBy from 'lodash/sortBy';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
@@ -109,14 +108,6 @@
       ...mapState('manageContent/wizard', ['pageName']),
       doneTasks() {
         return this.managedTasks.filter(task => task.status === TaskStatuses.COMPLETED).length;
-      },
-      sortedChannels() {
-        return sortBy(this.installedChannelsWithResources, channel => {
-          // Push Channels with Tasks to the top
-          const order = -this.channelOrders[channel.id];
-          // Need to explicitly return a number to correctly sort in Firefox
-          return Number.isNaN(order) ? 1 : order;
-        });
       },
       channelsAreInstalled() {
         return this.installedChannelsWithResources.length > 0;


### PR DESCRIPTION


<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
kolibri/plugins/device/assets/src/ManageContentPage/index.vue
  - Not (re-)sorting the channels before showing them on the page
  - remove the sortedChannels procedure
  - the channel panel uses the installedChannelsWithResources instead of sortedChannels
  - import SortBy no longer needed

But compared to the problem statement in the issue, based on the proposed fix, this is not Postgres related, The order resolves itself if the "new" content, is no longer new.

### Reviewer guidance
Follow the description in the ticket.
The changes are local to the file mentioned

### References
* #6560
* [Screenshot](https://drive.google.com/file/d/1gw5y3Bxq78pDTAIuA35o4mpiD3t324kb/view?usp=sharing)

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
