### PR TITLE
Change assignable coach landing page after login

### DIFF
--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -149,7 +149,7 @@ class RootURLRedirectView(View):
             )
             if user_kinds.ADMIN in roles:
                 url = url or get_url_by_role(user_kinds.ADMIN)
-            if user_kinds.COACH in roles:
+            if user_kinds.COACH in roles or user_kinds.ASSIGNABLE_COACH in roles:
                 url = url or get_url_by_role(user_kinds.COACH)
             url = url or get_url_by_role(user_kinds.LEARNER)
         else:


### PR DESCRIPTION
### Summary

Change the assignable coach landing page after logging in from learn to coach.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/97219432-ae504800-17d2-11eb-9ff1-f957f604d925.gif)


### References

#7611 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
