### PR TITLE
Add tests for `root_redirect` hook when logging in as coach

### DIFF
--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -59,6 +59,32 @@ class KolibriTagNavigationTestCase(APITestCase):
             response.get("location"), reverse("kolibri:kolibri.plugins.learn:learn")
         )
 
+    def test_redirect_coach_role_to_coach_root(self):
+        facility = FacilityFactory.create()
+        user = FacilityUserFactory.create(facility=facility)
+        facility.add_role(user, "coach")
+
+        provision_device()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse("kolibri:core:root_redirect"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"), reverse("kolibri:kolibri.plugins.coach:coach")
+        )
+
+    def test_redirect_class_coach_role_to_coach_root(self):
+        facility = FacilityFactory.create()
+        user = FacilityUserFactory.create(facility=facility)
+        facility.add_role(user, "classroom assignable coach")
+
+        provision_device()
+        self.client.login(username=user.username, password=DUMMY_PASSWORD)
+        response = self.client.get(reverse("kolibri:core:root_redirect"))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.get("location"), reverse("kolibri:kolibri.plugins.coach:coach")
+        )
+
 
 class AllUrlsTest(APITransactionTestCase):
 

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -19,71 +19,58 @@ from kolibri.core.device.translation import get_settings_language
 from kolibri.deployment.default.urls import urlpatterns
 
 
-class KolibriTagNavigationTestCase(APITestCase):
+class BeforeDeviceProvisionTests(APITestCase):
     def test_redirect_to_setup_wizard(self):
-        with patch("kolibri.core.views.is_provisioned", return_value=False):
-            response = self.client.get(reverse("kolibri:core:root_redirect"))
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(
-                response.get("location"),
-                reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
-            )
-
-    def test_redirect_root_to_user_if_not_logged_in(self):
-        provision_device()
-        response = self.client.get(reverse("kolibri:core:root_redirect"))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.get("location"), reverse("kolibri:kolibri.plugins.user:user")
-        )
-
-    def test_redirect_root_to_device_if_superuser_logged_in(self):
-        facility = FacilityFactory.create()
-        do = create_superuser(facility)
-        provision_device()
-        self.client.login(username=do.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse("kolibri:core:root_redirect"))
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.get("location"),
-            reverse("kolibri:kolibri.plugins.device:device_management"),
+            reverse("kolibri:kolibri.plugins.setup_wizard:setupwizard"),
         )
 
-    def test_redirect_root_to_learn_if_logged_in(self):
-        do = FacilityUserFactory.create()
+
+class KolibriTagNavigationTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
         provision_device()
-        self.client.login(username=do.username, password=DUMMY_PASSWORD)
+        facility = cls.facility = FacilityFactory.create()
+        cls.learner = FacilityUserFactory.create(facility=facility)
+        cls.facility_coach = FacilityUserFactory.create(facility=facility)
+        facility.add_role(cls.facility_coach, "coach")
+        cls.class_coach = FacilityUserFactory.create(facility=facility)
+        facility.add_role(cls.class_coach, "classroom assignable coach")
+        cls.superuser = create_superuser(cls.facility)
+
+    def tearDown(self):
+        self.client.logout()
+
+    def _assert_location_reverse_url(self, url_name):
         response = self.client.get(reverse("kolibri:core:root_redirect"))
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.get("location"), reverse("kolibri:kolibri.plugins.learn:learn")
+        self.assertEqual(response.get("location"), reverse(url_name))
+
+    def test_anonymous_user_is_redirected_to_user_plugin(self):
+        self._assert_location_reverse_url("kolibri:kolibri.plugins.user:user")
+
+    def test_superuser_is_redirected_to_device_plugin(self):
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+        self._assert_location_reverse_url(
+            "kolibri:kolibri.plugins.device:device_management"
         )
 
-    def test_redirect_coach_role_to_coach_root(self):
-        facility = FacilityFactory.create()
-        user = FacilityUserFactory.create(facility=facility)
-        facility.add_role(user, "coach")
+    def test_learner_is_redirected_to_learn_plugin(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        self._assert_location_reverse_url("kolibri:kolibri.plugins.learn:learn")
 
-        provision_device()
-        self.client.login(username=user.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:core:root_redirect"))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.get("location"), reverse("kolibri:kolibri.plugins.coach:coach")
+    def test_facility_coach_is_redirected_to_coach_plugin(self):
+        self.client.login(
+            username=self.facility_coach.username, password=DUMMY_PASSWORD
         )
+        self._assert_location_reverse_url("kolibri:kolibri.plugins.coach:coach")
 
-    def test_redirect_class_coach_role_to_coach_root(self):
-        facility = FacilityFactory.create()
-        user = FacilityUserFactory.create(facility=facility)
-        facility.add_role(user, "classroom assignable coach")
-
-        provision_device()
-        self.client.login(username=user.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:core:root_redirect"))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.get("location"), reverse("kolibri:kolibri.plugins.coach:coach")
-        )
+    def test_class_coach_is_redirected_to_coach_plugin(self):
+        self.client.login(username=self.class_coach.username, password=DUMMY_PASSWORD)
+        self._assert_location_reverse_url("kolibri:kolibri.plugins.coach:coach")
 
 
 class AllUrlsTest(APITransactionTestCase):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Following up on https://github.com/learningequality/kolibri/pull/7620#issuecomment-716781258, this

1. adds two tests to verify that facility and class coaches get redirected to the coach plugin when they login.
1. refactors the TestCase class and renames the individual test cases

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
