### PR TITLE
Ignore drives where shutil.disk_usage fails

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -43,6 +43,7 @@ FILESYSTEM_BLACKLIST = set(
         "ecryptfs",
         "fuse",
         "fuse.gvfsd-fuse",
+        "fuse.portal",
         "fusectl",
         "hugetlbfs",
         "mqueue",

--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -116,7 +116,12 @@ def get_drive_list():
             continue
 
         # attempt to get some additional metadata about the drive
-        usage = _get_drive_usage(path)
+        try:
+            usage = _get_drive_usage(path)
+        except OSError:
+            # skip if we don't have access to get drive usage
+            continue
+
         dbus_drive_info = _try_to_get_drive_info_from_dbus(drive["device"])
         diskutil_info = _try_to_get_drive_info_from_diskutil(drive["device"])
 


### PR DESCRIPTION
### Summary

In some environments (such as inside a Flatpak), Kolibri will discover virtual filesystems for which `statvfs` will fail with a permissions error. With this change, we will handle that exception and assume, if it happens, the filesystem does not represent an external disk inserted by the user.

### Reviewer guidance

Please make sure I haven't broken any expected use cases with that assumption.

I used OSError here instead of PermissionError for compatibility with Python 2.

### References

I haven't filed a bug report about this particular issue since I just happened across it now, but hopefully it's a simple enough change :)

This is related to flathub/org.learningequality.Kolibri#11.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
