### PR TITLE
Prevent SearchButton components from overlapping in EPUB Renderer

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -23,6 +23,7 @@
         ref="topBar"
         class="top-bar-component"
         :isInFullscreen="isInFullscreen"
+        :hideSearchButton="searchSideBarIsOpen"
         @tableOfContentsButtonClicked="handleTocToggle"
         @settingsButtonClicked="handleSettingToggle"
         @searchButtonClicked="handleSearchToggle"
@@ -777,7 +778,9 @@
   }
 
   .search-button {
-    right: 36px;
+    // Positioned to be in the exact same spot as the TopBar's SearchButton,
+    // which is given opacity: 0 when this button is shown
+    right: 32px;
   }
 
   .bottom-bar {

--- a/kolibri/plugins/epub_viewer/assets/src/views/TopBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/TopBar.vue
@@ -38,6 +38,7 @@
 
         <SearchButton
           ref="searchButton"
+          :class="{ invisible: $attrs.hideSearchButton }"
           @click="$emit('searchButtonClicked')"
         />
 
@@ -109,6 +110,12 @@
 <style lang="scss" scoped>
 
   @import './EpubStyles';
+
+  .invisible {
+    // When the SearchSideBar is shown, hide this SearchButton so it does not appear
+    // under the second SearchButton rendered inside EpubRendererIndex
+    opacity: 0;
+  }
 
   .top-bar {
     z-index: 1;


### PR DESCRIPTION
### Summary

1. When the Search Sidebar is open in an epub renderer, hides the second Search Button on the TopNav component with an `opacity: 0` CSS rule. This way, only the Search Button that is part of the focus trap with the search sidebar is shown (before, _both_ would be visible). Also adjusts the position of the Search Sidebar's button so it is not obvious that the buttons have been swapped.

GIF of new behavior (see referenced issue for a "before" screenshot)

![CleanShot 2020-10-27 at 15 01 20](https://user-images.githubusercontent.com/10248067/97367436-52370380-1866-11eb-8702-0a99c1dc7a20.gif)


### Reviewer guidance

Test this manually on different browsers and find ways to get the button to shift when toggling the search sidebar.

Note that the EPUB Renderer will only run locally using the `yarn run devserver` command. (not the `-hot` version)

### References

Fixes #7627

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
