### PR TITLE
Disable form on submit for leaner enrollment and coach assignment

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/actions.js
@@ -11,8 +11,6 @@ export function enrollLearnersInClass(store, { classId, users }) {
       collection: classId,
       user: userId,
     })),
-  }).catch(err => {
-    store.dispatch('handleApiError', err, { root: true });
   });
 }
 
@@ -26,7 +24,5 @@ export function assignCoachesToClass(store, { classId, coaches }) {
       user: userId,
       kind: UserKinds.COACH,
     })),
-  }).catch(err => {
-    store.dispatch('handleApiError', err, { root: true });
   });
 }

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -12,6 +12,7 @@
           v-model="selectedUsers"
           :users="items"
           :selectable="true"
+          :disabled="disabled"
           :emptyMessage="emptyMessageForItems(items, filterInput)"
         />
       </template>
@@ -22,7 +23,7 @@
         :text="coreString('confirmAction')"
         :primary="true"
         type="submit"
-        :disabled="selectedUsers.length === 0"
+        :disabled="disabled || selectedUsers.length === 0"
       />
     </div>
 
@@ -55,6 +56,10 @@
       classUsers: {
         type: Array,
         required: true,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -6,6 +6,7 @@
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
       :classUsers="classUsers"
+      :disabled="formIsDisabled"
       @submit="assignCoaches"
     />
   </KPageContainer>
@@ -30,6 +31,11 @@
       ClassEnrollForm,
     },
     mixins: [commonCoreStrings],
+    data() {
+      return {
+        formIsDisabled: false,
+      };
+    },
     computed: {
       ...mapState('classAssignMembers', ['class', 'classUsers', 'facilityUsers']),
       className() {
@@ -39,12 +45,18 @@
     methods: {
       ...mapActions('classAssignMembers', ['assignCoachesToClass']),
       assignCoaches(coaches) {
-        this.assignCoachesToClass({ classId: this.class.id, coaches }).then(() => {
-          // do this in action?
-          this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage).then(() => {
-            this.showSnackbarNotification('coachesAssignedNoCount', { count: coaches.length });
+        this.formIsDisabled = true;
+        this.assignCoachesToClass({ classId: this.class.id, coaches })
+          .then(() => {
+            // do this in action?
+            this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage).then(() => {
+              this.showSnackbarNotification('coachesAssignedNoCount', { count: coaches.length });
+            });
+          })
+          .catch(() => {
+            this.formIsDisabled = false;
+            this.$store.dispatch('createSnackbar', this.coreString('changesNotSavedNotification'));
           });
-        });
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -6,6 +6,7 @@
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
       :classUsers="classUsers"
+      :disabled="formIsDisabled"
       @submit="enrollLearners"
     />
   </KPageContainer>
@@ -30,6 +31,11 @@
       ClassEnrollForm,
     },
     mixins: [commonCoreStrings],
+    data() {
+      return {
+        formIsDisabled: false,
+      };
+    },
     computed: {
       ...mapState('classAssignMembers', ['class', 'facilityUsers', 'classUsers']),
       className() {
@@ -39,13 +45,19 @@
     methods: {
       ...mapActions('classAssignMembers', ['enrollLearnersInClass']),
       enrollLearners(selectedUsers) {
-        this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers }).then(() => {
-          this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage).then(() => {
-            this.showSnackbarNotification('learnersEnrolledNoCount', {
-              count: selectedUsers.length,
+        this.formIsDisabled = true;
+        this.enrollLearnersInClass({ classId: this.class.id, users: selectedUsers })
+          .then(() => {
+            this.$router.push(this.$store.getters.facilityPageLinks.ClassEditPage).then(() => {
+              this.showSnackbarNotification('learnersEnrolledNoCount', {
+                count: selectedUsers.length,
+              });
             });
+          })
+          .catch(() => {
+            this.formIsDisabled = false;
+            this.$store.dispatch('createSnackbar', this.coreString('changesNotSavedNotification'));
           });
-        });
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserTable.vue
@@ -14,7 +14,7 @@
               :showLabel="true"
               :checked="allAreSelected"
               class="overflow-label"
-              :disabled="users.length === 0"
+              :disabled="disabled || users.length === 0"
               @change="selectAll($event)"
             />
           </th>
@@ -66,6 +66,7 @@
             <KCheckbox
               :label="$tr('userCheckboxLabel')"
               :showLabel="false"
+              :disabled="disabled"
               :checked="userIsSelected(user.id)"
               @change="selectUser(user.id, $event)"
             />
@@ -177,6 +178,10 @@
       },
       // If true, shows ID number, gender, and birth year columns
       showDemographicInfo: {
+        type: Boolean,
+        default: false,
+      },
+      disabled: {
         type: Boolean,
         default: false,
       },


### PR DESCRIPTION
### Summary

Disable the form, all the checkboxes and the confirm button, after submitting, for learner enrollment and coach assignment. Show a generic error message ("Changes not saved") when the API throws an error.

![simplescreenrecorder](https://user-images.githubusercontent.com/3750511/97369303-5b02f600-18b5-11eb-8976-ce889354c059.gif)


### Reviewer guidance

Should the error handling do something else, besides only showing a message?


### References

#7347 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
