### PR TITLE
Add 30 second TTL to ProcessLock redis keys

### DIFF
--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -26,12 +26,12 @@ class ProcessLock(object):
     def __init__(self, key, expire=None):
         """
         :param key: The lock key
-        :param expire: The cache key expiration in seconds
+        :param expire: The cache key expiration in seconds (defaults to the CACHE_LOCK_TTL option if not set)
         :type key: str
         :type expire: int
         """
         self.key = key
-        self.expire = expire
+        self.expire = expire if expire else OPTIONS["Cache"]["CACHE_LOCK_TTL"]
 
         self._lock_object = None
 
@@ -39,7 +39,7 @@ class ProcessLock(object):
     def _lock(self):
         if self._lock_object is None:
             if OPTIONS["Cache"]["CACHE_BACKEND"] == "redis":
-                expire = self.expire * 1000 if self.expire is not None else None
+                expire = self.expire * 1000
                 # if we're using Redis, be sure we use Redis' locking mechanism which uses
                 # `SET NX` under the hood. See redis.lock.Lock
                 # The Django RedisCache backend provide the lock method to proxy this

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -11,6 +11,7 @@ CACHE_TIMEOUT
 CACHE_MAX_ENTRIES
 CACHE_PASSWORD
 CACHE_LOCATION
+CACHE_LOCK_TTL
 CACHE_REDIS_MIN_DB
 CACHE_REDIS_MAX_POOL_SIZE
 CACHE_REDIS_POOL_TIMEOUT
@@ -214,6 +215,11 @@ base_option_spec = {
             "type": "string",
             "default": "localhost:6379",
             "envvars": ("KOLIBRI_CACHE_LOCATION",),
+        },
+        "CACHE_LOCK_TTL": {
+            "type": "integer",
+            "default": 30,
+            "envvars": ("KOLIBRI_CACHE_LOCK_TTL",),
         },
         "CACHE_REDIS_MIN_DB": {
             "type": "integer",


### PR DESCRIPTION
This PR adds a 30 second TTL to the redis keys created by the ProcessLock object. This can be overriden through a new option called `OPTIONS["Cache"]["CACHE_LOCK_TTL"]`.

As an extra, we also pin `drf-yasg` to a specific version so it remains compatible with our pinned drf version.