### PR TITLE
Update RecipientBehavior behavior; fix bugs when copying Quizzes with individual learner-assignments

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -63,7 +63,7 @@
                 </p>
               </template>
             </KFixedGridItem>
-            <KFixedGridItem span="3" alignment="right">
+            <KFixedGridItem :style="{ 'padding-top': '16px' }" span="3" alignment="right">
               <KButton
                 :text="coreString('removeAction')"
                 appearance="flat-button"

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -180,7 +180,7 @@
           .trim();
 
         const className = find(this.classList, { id: classroomId }).name;
-        const assignments = serverAssignmentPayload(groupIds, this.classId);
+        const assignments = serverAssignmentPayload(groupIds, classroomId);
 
         this.$store
           .dispatch('examReport/copyExam', {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -1,16 +1,18 @@
 <template>
 
   <div>
+    <!-- Main checkbox -->
     <KCheckbox
       key="adHocLearners"
-      :checked="showAsChecked"
+      :checked="isVisible"
       :disabled="disabled"
-      @change="toggleChecked"
+      @change="$emit('togglevisibility', $event)"
     >
       <KLabeledIcon icon="people" :label="$tr('individualLearnersLabel')" />
     </KCheckbox>
 
-    <div v-if="showAsChecked">
+    <!-- Paginated list of learners -->
+    <div v-if="isVisible">
       <div class="table-title">
         {{ $tr("selectedIndividualLearnersLabel") }}
       </div>
@@ -121,6 +123,11 @@
     components: { CoreTable, PaginatedListContainer },
     mixins: [commonCoreStrings, commonCoachStrings],
     props: {
+      // If true, the main checkbox is checked and the list of learners is shown
+      isVisible: {
+        type: Boolean,
+        required: true,
+      },
       selectedGroupIds: {
         type: Array,
         required: true,
@@ -196,9 +203,6 @@
         // in RecipientSelector, then disable their row
         return flatMap(this.selectedGroupIds, groupId => this.currentGroupMap[groupId].member_ids);
       },
-      showAsChecked() {
-        return this.entireClassIsSelected ? false : this.isChecked;
-      },
       allOfCurrentPageIsSelected() {
         const selectedVisibleLearners = this.currentPageLearners.filter(visible => {
           return this.selectedAdHocIds.includes(visible.id);
@@ -229,7 +233,7 @@
       entireClassIsSelected(newVal) {
         // If the "Individual learners" option is unselected, return to the first page
         if (newVal && this.isChecked) {
-          this.toggleChecked();
+          this.toggleLearnersAreVisible();
           this.currentPage = 1;
         }
       },
@@ -250,7 +254,7 @@
           this.fetchingOutside = false;
         });
       },
-      toggleChecked(checked) {
+      toggleLearnersAreVisible(checked) {
         this.isChecked = checked;
         this.$emit('updateLearners', this.isChecked ? this.selectedAdHocIds : []);
         this.$emit('change', this.isChecked);

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -60,7 +60,7 @@
                     :label="learner.name"
                     :checked="learnerIsSelected(learner)"
                     :disabled="learnerIsNotSelectable(learner)"
-                    @change="toggleSelectedLearnerId($event, learner.id)"
+                    @change="toggleLearner($event, learner)"
                   />
                 </td>
                 <td class="table-data">
@@ -212,14 +212,14 @@
         });
       },
       // Event handlers
-      toggleSelectedLearnerId(checked, learnerId) {
-        let newIds = [...this.selectedLearnerIds];
+      toggleLearner(checked, { id }) {
+        let newLearnerIds = [...this.selectedLearnerIds];
         if (checked) {
-          newIds.push(learnerId);
+          newLearnerIds.push(id);
         } else {
-          newIds = newIds.filter(id => id !== learnerId);
+          newLearnerIds = newLearnerIds.filter(learnerId => learnerId !== id);
         }
-        this.$emit('update:selectedLearnerIds', newIds);
+        this.$emit('update:selectedLearnerIds', newLearnerIds);
       },
       selectVisiblePage() {
         let newIds = [...this.selectedLearnerIds];

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -30,13 +30,14 @@
 
     <!-- Individual learners -->
     <IndividualLearnerSelector
+      :isVisible="individualSelectorIsVisible"
       :selectedGroupIds="selectedGroupIds"
       :entireClassIsSelected="entireClassIsSelected"
       :initialAdHocLearners="initialAdHocLearners"
       :targetClassId="classId"
       :disabled="disabled"
       @updateLearners="learners => $emit('updateLearners', learners)"
-      @change="toggleGroup"
+      @togglevisibility="toggleIndividualSelector"
     />
   </div>
 
@@ -88,6 +89,11 @@
         default: new Array(),
       },
     },
+    data() {
+      return {
+        individualSelectorIsVisible: false,
+      };
+    },
     computed: {
       entireClassIsSelected() {
         return isEqual(this.value, [this.classId]);
@@ -97,6 +103,9 @@
       },
     },
     methods: {
+      toggleIndividualSelector(isChecked) {
+        this.individualSelectorIsVisible = Boolean(isChecked);
+      },
       groupIsChecked(groupId) {
         return this.value.includes(groupId);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -32,11 +32,9 @@
     <IndividualLearnerSelector
       :isVisible="individualSelectorIsVisible"
       :selectedGroupIds="selectedGroupIds"
-      :entireClassIsSelected="entireClassIsSelected"
-      :initialAdHocLearners="initialAdHocLearners"
+      :selectedLearnerIds.sync="selectedLearnerIds"
       :targetClassId="classId"
       :disabled="disabled"
-      @updateLearners="learners => $emit('updateLearners', learners)"
       @togglevisibility="toggleIndividualSelector"
     />
   </div>
@@ -91,25 +89,40 @@
     },
     data() {
       return {
-        individualSelectorIsVisible: false,
+        individualSelectorIsVisible: this.initialAdHocLearners.length > 0,
+        selectedLearnerIds: [...this.initialAdHocLearners],
       };
     },
     computed: {
       entireClassIsSelected() {
-        return isEqual(this.value, [this.classId]);
+        return this.selectedLearnerIds.length === 0 && isEqual(this.value, [this.classId]);
       },
       selectedGroupIds() {
         return this.groups.filter(group => this.groupIsChecked(group.id)).map(group => group.id);
       },
     },
+    watch: {
+      selectedLearnerIds(newVal) {
+        this.$emit('updateLearners', newVal);
+      },
+    },
     methods: {
       toggleIndividualSelector(isChecked) {
-        this.individualSelectorIsVisible = Boolean(isChecked);
+        if (!isChecked) {
+          this.closeIndividualSelector();
+        } else {
+          this.individualSelectorIsVisible = true;
+        }
       },
       groupIsChecked(groupId) {
         return this.value.includes(groupId);
       },
+      closeIndividualSelector() {
+        this.selectedLearnerIds = [];
+        this.individualSelectorIsVisible = false;
+      },
       selectEntireClass() {
+        this.closeIndividualSelector();
         this.$emit('input', [this.classId]);
       },
       toggleGroup(isChecked, newId) {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -18,7 +18,7 @@
     <KCheckbox
       v-for="group in groups"
       :key="group.id"
-      :checked="groupIsChecked(group.id)"
+      :checked="groupIdIsSelected(group.id)"
       :disabled="disabled"
       @change="toggleGroup($event, group.id)"
     >
@@ -45,6 +45,7 @@
 <script>
 
   import isEqual from 'lodash/isEqual';
+  import every from 'lodash/every';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
   import IndividualLearnerSelector from './IndividualLearnerSelector';
 
@@ -59,17 +60,12 @@
         type: Array,
         required: true,
       },
-      // Array of objects, each with 'group' and 'name'
+      // Array of objects, each with (group) 'id' and 'name'
       groups: {
         type: Array,
         required: true,
         validator(value) {
-          for (let i = 0; i < value.length; i++) {
-            if (!value[i].name || !value[i].id) {
-              return false;
-            }
-          }
-          return true;
+          return every(value, val => val.name && val.id);
         },
       },
       // For the 'Entire Class' option
@@ -90,6 +86,8 @@
     data() {
       return {
         individualSelectorIsVisible: this.initialAdHocLearners.length > 0,
+        // This is .sync'd with IndividualLearnerSelector, but not with AssignmentDetailsModal
+        // which recieves updates via handler in watch.selectedLearnerIds
         selectedLearnerIds: [...this.initialAdHocLearners],
       };
     },
@@ -98,7 +96,7 @@
         return this.selectedLearnerIds.length === 0 && isEqual(this.value, [this.classId]);
       },
       selectedGroupIds() {
-        return this.groups.filter(group => this.groupIsChecked(group.id)).map(group => group.id);
+        return this.groups.filter(group => this.groupIdIsSelected(group.id)).map(group => group.id);
       },
     },
     watch: {
@@ -114,7 +112,7 @@
           this.individualSelectorIsVisible = true;
         }
       },
-      groupIsChecked(groupId) {
+      groupIdIsSelected(groupId) {
         return this.value.includes(groupId);
       },
       closeIndividualSelector() {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div>
+    <!-- Entire class -->
     <KRadioButton
       :value="true"
       :currentValue="entireClassIsSelected"
@@ -12,6 +13,8 @@
         icon="classes"
       />
     </KRadioButton>
+
+    <!-- Learner groups -->
     <KCheckbox
       v-for="group in groups"
       :key="group.id"
@@ -24,6 +27,8 @@
         icon="group"
       />
     </KCheckbox>
+
+    <!-- Individual learners -->
     <IndividualLearnerSelector
       :selectedGroupIds="selectedGroupIds"
       :entireClassIsSelected="entireClassIsSelected"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/RecipientSelector.vue
@@ -18,9 +18,9 @@
     <KCheckbox
       v-for="group in groups"
       :key="group.id"
-      :checked="groupIdIsSelected(group.id)"
+      :checked="groupIsSelected(group)"
       :disabled="disabled"
-      @change="toggleGroup($event, group.id)"
+      @change="toggleGroup($event, group)"
     >
       <KLabeledIcon
         :label="group.name"
@@ -44,7 +44,6 @@
 
 <script>
 
-  import isEqual from 'lodash/isEqual';
   import every from 'lodash/every';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
   import IndividualLearnerSelector from './IndividualLearnerSelector';
@@ -85,60 +84,62 @@
     },
     data() {
       return {
+        // Determines whether the individual learner table is visible.
+        // Is initially open if item is assigned to individuals.
         individualSelectorIsVisible: this.initialAdHocLearners.length > 0,
         // This is .sync'd with IndividualLearnerSelector, but not with AssignmentDetailsModal
         // which recieves updates via handler in watch.selectedLearnerIds
         selectedLearnerIds: [...this.initialAdHocLearners],
+        // Determines whether the group's checkbox is checked and affects which
+        // learners are selectable in IndividualLearnerSelector
+        selectedGroupIds: this.value.filter(id => id !== this.classId),
       };
     },
     computed: {
       entireClassIsSelected() {
-        return this.selectedLearnerIds.length === 0 && isEqual(this.value, [this.classId]);
+        return this.selectedLearnerIds.length === 0 && this.selectedGroupIds.length === 0;
       },
-      selectedGroupIds() {
-        return this.groups.filter(group => this.groupIdIsSelected(group.id)).map(group => group.id);
+      currentCollectionIds() {
+        if (this.entireClassIsSelected) {
+          return [this.classId];
+        } else {
+          return this.selectedGroupIds;
+        }
       },
     },
     watch: {
       selectedLearnerIds(newVal) {
         this.$emit('updateLearners', newVal);
       },
+      currentCollectionIds(newVal) {
+        this.$emit('input', newVal);
+      },
     },
     methods: {
       toggleIndividualSelector(isChecked) {
         if (!isChecked) {
-          this.closeIndividualSelector();
+          this.clearLearnerIds();
         } else {
           this.individualSelectorIsVisible = true;
         }
       },
-      groupIdIsSelected(groupId) {
-        return this.value.includes(groupId);
+      groupIsSelected({ id }) {
+        return this.value.includes(id);
       },
-      closeIndividualSelector() {
+      clearLearnerIds() {
         this.selectedLearnerIds = [];
         this.individualSelectorIsVisible = false;
       },
       selectEntireClass() {
-        this.closeIndividualSelector();
-        this.$emit('input', [this.classId]);
+        this.clearLearnerIds();
+        this.selectedGroupIds = [];
       },
-      toggleGroup(isChecked, newId) {
-        let newValue;
+      toggleGroup(isChecked, { id }) {
         if (isChecked) {
-          // If a group is selected, remove classId if it is there
-          newValue = this.value.filter(id => id !== this.classId);
-          if (newId) {
-            newValue.push(newId);
-          }
+          this.selectedGroupIds.push(id);
         } else {
-          newValue = this.value.filter(groupId => newId !== groupId);
-          // If un-selecting the last group, auto-select 'Entire Class'
-          if (newValue.length === 0) {
-            newValue = [this.classId];
-          }
+          this.selectedGroupIds = this.selectedGroupIds.filter(groupId => groupId !== id);
         }
-        this.$emit('input', newValue);
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

See the video in #7580 for previous behavior. Here's a GIF of how the controls work now. Basically, it everything works the same, except that the "Individual learners" section stays open as long as its checked, and until the "Entire class" radio button is selected again.

![CleanShot 2020-10-29 at 17 23 14](https://user-images.githubusercontent.com/10248067/97646027-c52daf00-1a0b-11eb-9070-43173230e6de.gif)

To make these changes easier, I reorganized the props and data within the `RecipientSelector` and `IndividualLearnerSelector` to make `RecipientSelector` the primary control point for the whole part of the form, then also changed up the internals of that component to make it more independent from _its_ parents and easier to reason about.

Also fixed #7608, which was due to passing the wrong classroom ID to the Vuex action that creates copies of assignments.

### Reviewer guidance

Here's a checklist I used to manually test it

- [ ] Create quiz/lesson to same class (entire class)
- [ ] Create quiz/lesson to same class (groups only)
- [ ] Create quiz/lesson to same class (learners only)
- [ ] Create quiz/lesson to same class (groups and learners)
- [ ] Copy quiz/lesson to same class (entire class)
- [ ] Copy quiz/lesson to same class (groups only)
- [ ] Copy quiz/lesson to same class (learners only)
- [ ] Copy quiz/lesson to same class (groups and learners)
- [ ] Copy quiz/lesson to different class (entire class)
- [ ] Copy quiz/lesson to different class (groups only)
- [ ] Copy quiz/lesson to different class (learners only)
- [ ] Copy quiz/lesson to different class (groups and learners)

For each item, I would check to see if the Reports + Plan pages worked still and that I could still edit them. Other areas to test would be if assignments are reflected correctly on the Learn page.

### References

Fixes #7608 
Fixes #7580

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
