### PR TITLE
Fix unselectable Facility Radio button when importing Facility from remote peer

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectFacilityForm.vue
@@ -74,7 +74,8 @@
     },
     data() {
       return {
-        selectedFacilityId: '',
+        // Need to initialize to non-empty string to fix #7595
+        selectedFacilityId: 'selectedFacilityId',
         facilities: [],
         shouldValidate: false,
         formDisabled: false,


### PR DESCRIPTION
Fixes #7595



### Summary

This tries to fix #7595, by initializing the `currentValue` prop for `KRadioButtons` in a a group. In IE11, these components will not emit any change events if that prop is not set (not sure why).


### Reviewer guidance

1. Does the affected part of the Setup Wizard work in IE11
1. Does it work in other browsers still?

### References

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
