### PR TITLE
Keyboard navigation focus outline

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -62,6 +62,7 @@
             ':hover': {
               backgroundColor: this.$themeBrand.primary.v_100,
             },
+            ':focus': this.$coreOutline,
           };
         }
         return {

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -69,6 +69,7 @@
           ':hover': {
             backgroundColor: this.$themeBrand.primary.v_50,
           },
+          ':focus': this.$coreOutline,
         };
       },
       optionIconStyle() {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -1,6 +1,12 @@
 <template>
 
-  <div ref="sideNav" class="side-nav-wrapper" tabindex="0" @keyup.esc="toggleNav">
+  <div
+    v-show="navShown"
+    ref="sideNav"
+    class="side-nav-wrapper"
+    tabindex="0"
+    @keyup.esc="toggleNav"
+  >
     <transition name="side-nav">
       <div
         v-show="navShown"

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -4,6 +4,7 @@
     :to="link"
     class="card-main-wrapper"
     :style="cardStyle"
+    :class="$computedClass({ ':focus': $coreOutline })"
   >
 
     <h3

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -3,7 +3,10 @@
   <router-link
     :to="link"
     class="card"
-    :class="{ 'mobile-card': isMobile }"
+    :class="[
+      { 'mobile-card': isMobile },
+      $computedClass({ ':focus': $coreOutline })
+    ]"
     :style="{ backgroundColor: $themeTokens.surface }"
   >
     <CardThumbnail

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -71,18 +71,15 @@
             <slot></slot>
 
             <p v-if="!hideCreateAccount && canSignUp" class="create">
-              <router-link :to="signUpPage">
-                <KButton
-                  :text="AuthSelectStrings.$tr('createAccountAction')"
-                  :to="signUpPage"
-                  :primary="false"
-                  appearance="raised-button"
-                  :disabled="busy"
-                  style="width: 100%;"
-                  data-test="createUser"
-                />
-              </router-link>
-
+              <KRouterLink
+                :text="AuthSelectStrings.$tr('createAccountAction')"
+                :to="signUpPage"
+                :primary="false"
+                appearance="raised-button"
+                :disabled="busy"
+                style="width: 100%;"
+                data-test="createUser"
+              />
             </p>
 
             <div slot="options">


### PR DESCRIPTION
## Summary

Added keyboard focus outline to Channel card, Content cards and core menu links, removed the extra tab key press after the Navbar.

<img src="https://user-images.githubusercontent.com/3750511/98131268-c8b9ae00-1ec3-11eb-8626-0cdc529c8e2e.gif" height=500>

Removed an extra tab key press in the sign in page.

Before:
<img src="https://user-images.githubusercontent.com/3750511/98135325-5dbea600-1ec8-11eb-8877-90b34599b2ff.gif" height=550>

After:
<img src="https://user-images.githubusercontent.com/3750511/98135297-55666b00-1ec8-11eb-9b06-52ac97b829dd.gif" height=550>


### References

#7651 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
