### PR TITLE
Cherry-pick commits from visual-issues branch to `release-v0.14.x`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Paul Luna | luna215 |
 | Lingyi Wang | lyw07 |
 | Magali Boizot-Roche | magali-br |
+| Marcella Maki | marcellamaki |
 | Maureen Hernandez | MauHernandez |
 | Michael Gallaspy | MCGallaspy |
 | Michael Gamlem III | mgamlem3 |
@@ -64,6 +65,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Hyun Ahn | rationality6 |
 | Rachel Kim | rayykim |
 | Richard Tibbles | rtibbles |
+| Sairina Merino Tsui | sairina |
 | Shanavas M | shanavas786 |
 | Whitney Zhu | whitzhu |
 | Carol Willing | willingc |

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -1,14 +1,16 @@
 <template>
 
-  <KPageContainer style="padding-top: 16px;">
+  <KPageContainer
+    style="padding-top: 24px;"
+  >
     <BackLink
       :to="backlink"
       :text="backlinkLabel"
     />
 
     <!-- Cheating to get the same layout effect but not
-         using a backlink...
-    -->
+           using a backlink...
+      -->
     <HeaderWithOptions>
       <div slot="header">
         <h1 class="exam-title">

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -5,11 +5,17 @@
     :allLinkRoute="$router.getRoute('HomeActivityPage')"
     :showAllLink="notifications.length > 0"
   >
-    <template v-slot:title>
+    <!-- <template v-slot:title>
       {{ $tr('classActivityLabel') }}
-    </template>
+    </template> -->
+
+    <KLabeledIcon slot="title" :label="$tr('classActivityLabel')" />
+
 
     <ContentIcon slot="icon" :kind="ContentNodeKinds.ACTIVITY" />
+    <p v-if="notifications.length === 0">
+      {{ $tr('noActivityLabel') }}
+    </p>
     <transition-group name="list">
       <BlockItem
         v-for="notification in notifications"
@@ -21,9 +27,6 @@
         />
       </BlockItem>
     </transition-group>
-    <div v-if="notifications.length === 0">
-      {{ $tr('noActivityLabel') }}
-    </div>
   </Block>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -5,17 +5,15 @@
     :allLinkRoute="$router.getRoute('HomeActivityPage')"
     :showAllLink="notifications.length > 0"
   >
-    <!-- <template v-slot:title>
-      {{ $tr('classActivityLabel') }}
-    </template> -->
 
     <KLabeledIcon slot="title" :label="$tr('classActivityLabel')" />
 
-
     <ContentIcon slot="icon" :kind="ContentNodeKinds.ACTIVITY" />
+
     <p v-if="notifications.length === 0">
       {{ $tr('noActivityLabel') }}
     </p>
+
     <transition-group name="list">
       <BlockItem
         v-for="notification in notifications"

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ActivityBlock.vue
@@ -6,9 +6,13 @@
     :showAllLink="notifications.length > 0"
   >
 
-    <KLabeledIcon slot="title" :label="$tr('classActivityLabel')" />
+    <template #title>
+      <KLabeledIcon :label="$tr('classActivityLabel')" />
+    </template>
 
-    <ContentIcon slot="icon" :kind="ContentNodeKinds.ACTIVITY" />
+    <template #icon>
+      <ContentIcon :kind="ContentNodeKinds.ACTIVITY" />
+    </template>
 
     <p v-if="notifications.length === 0">
       {{ $tr('noActivityLabel') }}

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -63,7 +63,6 @@
               <KButton
                 :text="coreString('removeAction')"
                 appearance="flat-button"
-                class="remove-resource-button"
                 @click="removeResource(resource)"
               />
             </KFixedGridItem>
@@ -298,10 +297,6 @@
   .content-link {
     display: inline-block;
     width: calc(100% - 16px);
-  }
-
-  .remove-resource-button {
-    padding-top: 10px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -59,7 +59,7 @@
                 </p>
               </template>
             </KFixedGridItem>
-            <KFixedGridItem span="3" alignment="right">
+            <KFixedGridItem :style="{ 'padding-top': '16px' }" span="3" alignment="right">
               <KButton
                 :text="coreString('removeAction')"
                 appearance="flat-button"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -63,6 +63,7 @@
               <KButton
                 :text="coreString('removeAction')"
                 appearance="flat-button"
+                class="remove-resource-button"
                 @click="removeResource(resource)"
               />
             </KFixedGridItem>
@@ -297,6 +298,10 @@
   .content-link {
     display: inline-block;
     width: calc(100% - 16px);
+  }
+
+  .remove-resource-button {
+    padding-top: 10px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -62,10 +62,12 @@
                       :disabled="true"
                     />
                   </td>
-                  <td class="table-username">
+                  <td class="table-data">
                     {{ learner.username }}
                   </td>
-                  <td> {{ groupsForLearner(learner.id) }} </td>
+                  <td class="table-data">
+                    {{ groupsForLearner(learner.id) }}
+                  </td>
                 </template>
                 <template v-else>
                   <td>
@@ -77,10 +79,12 @@
                       @change="toggleSelectedLearnerId(learner.id)"
                     />
                   </td>
-                  <td class="table-username">
+                  <td class="table-data">
                     {{ learner.username }}
                   </td>
-                  <td> {{ groupsForLearner(learner.id) }} </td>
+                  <td class="table-data">
+                    {{ groupsForLearner(learner.id) }}
+                  </td>
                 </template>
               </tr>
             </tbody>
@@ -351,17 +355,13 @@
     font-size: 16px;
   }
 
-  .table-username {
+  .table-data {
     padding-top: 6px;
     vertical-align: middle;
   }
 
   .filter-input {
     margin-top: 16px;
-  }
-
-  .table-data {
-    padding: 24px 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -62,8 +62,12 @@
                       :disabled="true"
                     />
                   </td>
-                  <td> {{ learner.username }} </td>
-                  <td> {{ groupsForLearner(learner.id) }} </td>
+                  <td class="table-data">
+                    {{ learner.username }}
+                  </td>
+                  <td class="table-data">
+                    {{ groupsForLearner(learner.id) }}
+                  </td>
                 </template>
                 <template v-else>
                   <td>
@@ -75,8 +79,12 @@
                       @change="toggleSelectedLearnerId(learner.id)"
                     />
                   </td>
-                  <td> {{ learner.username }} </td>
-                  <td> {{ groupsForLearner(learner.id) }} </td>
+                  <td class="table-data">
+                    {{ learner.username }}
+                  </td>
+                  <td class="table-data">
+                    {{ groupsForLearner(learner.id) }}
+                  </td>
                 </template>
               </tr>
             </tbody>
@@ -349,6 +357,10 @@
 
   .filter-input {
     margin-top: 16px;
+  }
+
+  .table-data {
+    padding: 24px 0;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -62,12 +62,10 @@
                       :disabled="true"
                     />
                   </td>
-                  <td class="table-data">
+                  <td class="table-username">
                     {{ learner.username }}
                   </td>
-                  <td class="table-data">
-                    {{ groupsForLearner(learner.id) }}
-                  </td>
+                  <td> {{ groupsForLearner(learner.id) }} </td>
                 </template>
                 <template v-else>
                   <td>
@@ -79,12 +77,10 @@
                       @change="toggleSelectedLearnerId(learner.id)"
                     />
                   </td>
-                  <td class="table-data">
+                  <td class="table-username">
                     {{ learner.username }}
                   </td>
-                  <td class="table-data">
-                    {{ groupsForLearner(learner.id) }}
-                  </td>
+                  <td> {{ groupsForLearner(learner.id) }} </td>
                 </template>
               </tr>
             </tbody>
@@ -353,6 +349,11 @@
   .table-description {
     margin-bottom: 8px;
     font-size: 16px;
+  }
+
+  .table-username {
+    padding-top: 6px;
+    vertical-align: middle;
   }
 
   .filter-input {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -65,7 +65,7 @@
 
   .report-controls {
     position: relative;
-    min-height: 10px;
+    min-height: 40px;
     padding-right: 80px;
   }
 


### PR DESCRIPTION
Cherry-picks commits from #7664 (based on `develop) to the `release-v0.14.x` branch.

Reference the original PR for #7664. Since that branch has been fast-forwarded to the latest 0.14.4 changes, it has diffs from extra files that can be ignored.

Original PR summary:

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

- Issue: "username" was not vertically aligned in cell (also fixes "group" not vertically aligned in cell)
![Screen Shot 2020-11-02 at 3 05 20 PM](https://user-images.githubusercontent.com/13563002/98180202-2d214100-1eb5-11eb-8cef-a3349faec8c5.png)

- Issue: Padding for empty state message in "Class Activity" did not match "Lessons" and "Quizzes"
![Screen Shot 2020-11-03 at 8 36 06 PM](https://user-images.githubusercontent.com/13563002/98180246-4f1ac380-1eb5-11eb-9dda-0455775e9cb3.png)

- Issue: "Remove" button was not centered with "drag" icon
![Screen Shot 2020-11-02 at 1 09 45 PM](https://user-images.githubusercontent.com/13563002/98180298-678ade00-1eb5-11eb-8bcd-7c5204f78a51.png)

- Issue: Link was too close to top edge of container
![Screen Shot 2020-11-02 at 11 59 13 AM](https://user-images.githubusercontent.com/13563002/98180384-9ef98a80-1eb5-11eb-8159-e4fad4b0fc21.png)

- Issue: Buttons overlapped with the table
![Screen Shot 2020-11-03 at 8 37 13 PM](https://user-images.githubusercontent.com/13563002/98180422-b173c400-1eb5-11eb-86ff-36697926219d.png)
…

### Reviewer guidance
- Check UI on different browsers
…

### References
- Fixes learningequality/kolibri#7399
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
