### PR TITLE
fix morango id subquery, by removing "-" characters

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -15,10 +15,12 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
+from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import TextField
+from django.db.models import Value
 from django.db.models.functions import Cast
 from django.db.models.query import F
 from django.http import Http404
@@ -355,7 +357,13 @@ class FacilityViewSet(ValuesViewset):
             .annotate(
                 last_synced=Subquery(
                     TransferSession.objects.filter(
-                        filter=Cast(OuterRef("dataset"), TextField())
+                        filter=Func(
+                            Cast(OuterRef("dataset"), TextField()),
+                            Value("-"),
+                            Value(""),
+                            function="replace",
+                            output_field=TextField(),
+                        )
                     )
                     .order_by("-last_activity_timestamp")
                     .values("last_activity_timestamp")


### PR DESCRIPTION
### Summary
In Postgresql , we use the `uuid` type to store ids. When it's converted (casted) to text it adds dashes to the resulting string.
However in sqlite the id fields are stored as `char` that does not contain dashes.
In Morango, the `TransferSession` model stores information in the filter field. When syncing between a sqlite and a postgresql database ids are not equal because of the dashes.
This pr removes the dashes in the query that produces the last_synced annotation.


### Reviewer guidance
Setup kolibri on a postgreql server and sync a facility from a server using sqlite. The list of facilities must show correctly the last synced information

### References
Closes #7415 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
