### PR TITLE
Avoid database lock errors by always updating progress in the main thread

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -761,7 +761,6 @@ class ImportContentTestCase(TestCase):
         local_src_path = tempfile.mkstemp()[1]
         with open(local_src_path, "w") as f:
             f.write("This is just a test")
-        src_file_size = os.path.getsize(local_src_path)
         expected_file_size = 10000
         local_dest_path = tempfile.mkstemp()[1]
         os.remove(local_dest_path)
@@ -798,7 +797,7 @@ class ImportContentTestCase(TestCase):
                 node_ids=["32a941fb77c2576e8f6b294cde4c3b0c"],
             )
 
-            mock_overall_progress.assert_any_call(expected_file_size - src_file_size)
+            mock_overall_progress.assert_any_call(expected_file_size)
 
     @patch(
         "kolibri.core.content.management.commands.importcontent.transfer.FileDownload.finalize"


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

It's possible to encounter SQLite database locked errors when concurrently writing progress updates from multiple threads. This fix prevents this from happening by having the main import thread perform all db updates.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Testing import when running Kolibri on slower devices like Raspberry Pi and Android with larger channel imports should be enough to confirm that this is fixed. 

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7673 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
