### PR TITLE
Don't show the import button if the loaded CSV does not introduce changes

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
+++ b/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
@@ -147,7 +147,7 @@
           @click="reset"
         />
         <KButton
-          v-if="!isError"
+          v-if="!isError & hasChanges"
           :text="$tr('import')"
           appearance="raised-button"
           primary
@@ -176,6 +176,11 @@
     computed: {
       isError() {
         return this.status === CSVImportStatuses.ERRORS;
+      },
+      hasChanges() {
+        const classes_changes = Object.values(this.classes_report).reduce((a, b) => a + b, 0);
+        const user_changes = Object.values(this.users_report).reduce((a, b) => a + b, 0);
+        return classes_changes + user_changes != 0;
       },
       isFinished() {
         return this.status === CSVImportStatuses.FINISHED;


### PR DESCRIPTION
### Summary

When importing a Facility data CSV file, the import button is shown whenever the csv has no errors.
This PR hides thie import button whether importing CSV file does not add any change to the users or classrooms

### Reviewer guidance
As explained in #7363 , download, your current Facility's user info as CSV and try to re-import it without modifications (e.g. no changes).

### References
Closes: #7363


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
