### PR TITLE
Fixing 6916: Copies of lessons don't reflect recent deletions or reordering of resources

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -193,11 +193,15 @@
         this.showSnackbarNotification('resourceOrderSaved');
       },
       autoSave(id, resources) {
-        this.saveLessonResources({ lessonId: id, resources: resources }).catch(() => {
-          this.updateCurrentLesson(id).then(currentLesson => {
-            this.setWorkingResources(currentLesson.resources);
+        this.saveLessonResources({ lessonId: id, resources: resources })
+          .then(() => {
+            this.updateCurrentLesson(id);
+          })
+          .catch(() => {
+            this.updateCurrentLesson(id).then(currentLesson => {
+              this.setWorkingResources(currentLesson.resources);
+            });
           });
-        });
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary
Problem: when saving the changes made to the resources, the currentLesson was not updated.
* Added an updateCurrentLesson also when the resources save succeeds to ensure that the memory image is aligned with the changes

### Reviewer guidance
* An alternate approach is to directly push the changes to currentLesson. This is probably more performant. This approach is probably more failsafe.
* There are no visible frontend changes

### References
* Fixes #6916

### Contributor Checklist

PR process:

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
