### PR TITLE
Fixing #6560: In postgres, importing changing channel content moves channel to top of list

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -4,6 +4,7 @@ import os
 from itertools import groupby
 from math import ceil
 
+from django.db.models import Max
 from django.db.models import Sum
 from le_utils.constants import content_kinds
 from sqlalchemy import and_
@@ -749,11 +750,10 @@ def calculate_included_languages(channel):
 
 
 def calculate_next_order(channel, model=ChannelMetadata):
-    latest_order = model.objects.latest("order").order
-    if latest_order is None:
-        channel.order = 1
-
     if channel.order is None or channel.order == 0:
-        channel.order = latest_order + 1
+        max_order = model.objects.aggregate(Max("order")).get("order__max", 0)
+        if max_order is None:
+            max_order = 0
+        channel.order = max_order + 1
 
     channel.save()


### PR DESCRIPTION
### Summary
The root cause is explained [here](https://github.com/learningequality/kolibri/issues/6560#issuecomment-725359351).
- replaced `latest` by `max`, should be more db independent
- rewrote the function to prevent the query from being executed on every call to this function.

BTW. To get rid of the bad orders of you have to reorder them once after the patch is installed.

### Reviewer guidance
Following tests have been executed:
* adding new channels on existing channel list. (Postgres)
* adding a channel on a new kolibri set up. (Postgres)
* re-order the channels and added channels after that. 
* Ran the pytest suite (for sqlite compatibility)
If there are more test I need to run let me know.

No migration is provided.

### References
* #6560
* #7615 (I close this pull request: my previous attempt)

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
