### PR TITLE
Batch tree processing for resource count and file for transfer processing.

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -37,10 +37,14 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
             channel.id,
             node_ids,
             exclude_node_ids,
-            True,
+            # Don't filter by availability as we have set nodes invisible
+            # above, but the localfiles we are trying to delete are still
+            # available
+            None,
             renderable_only=False,
             topic_thumbnails=False,
         )
+
         with db_task_write_lock:
             propagate_forced_localfile_removal(unused_files)
 

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -8,7 +8,7 @@ from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import set_content_invisible
-from kolibri.core.content.utils.import_export_content import get_files_to_transfer
+from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.tasks.management.commands.base import AsyncCommand
@@ -33,8 +33,13 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
         # Do this before we delete all the metadata, as otherwise we lose
         # track of which local files were associated with the channel we
         # just deleted.
-        unused_files, _ = get_files_to_transfer(
-            channel.id, node_ids, exclude_node_ids, True, renderable_only=False
+        _, unused_files, _ = get_import_export_data(
+            channel.id,
+            node_ids,
+            exclude_node_ids,
+            True,
+            renderable_only=False,
+            topic_thumbnails=False,
         )
         with db_task_write_lock:
             propagate_forced_localfile_removal(unused_files)

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -1,13 +1,10 @@
 import logging
 import os
 
-from le_utils.constants import content_kinds
-
 from ...utils import paths
 from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
-from kolibri.core.content.utils.import_export_content import calculate_files_to_transfer
-from kolibri.core.content.utils.import_export_content import get_nodes_to_transfer
+from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
 
@@ -71,19 +68,15 @@ class Command(AsyncCommand):
             "Exporting content for channel id {} to {}".format(channel_id, data_dir)
         )
 
-        nodes_for_transfer = get_nodes_to_transfer(
-            channel_id, node_ids, exclude_node_ids, True
-        )
-
-        total_resource_count = (
-            nodes_for_transfer.exclude(kind=content_kinds.TOPIC)
-            .values("content_id")
-            .distinct()
-            .count()
-        )
-
-        (files, total_bytes_to_transfer) = calculate_files_to_transfer(
-            nodes_for_transfer, True
+        (
+            total_resource_count,
+            files,
+            total_bytes_to_transfer,
+        ) = get_import_export_data(
+            channel_id,
+            node_ids,
+            exclude_node_ids,
+            False,
         )
 
         self.update_job_metadata(total_bytes_to_transfer, total_resource_count)

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -72,12 +72,7 @@ class Command(AsyncCommand):
             total_resource_count,
             files,
             total_bytes_to_transfer,
-        ) = get_import_export_data(
-            channel_id,
-            node_ids,
-            exclude_node_ids,
-            False,
-        )
+        ) = get_import_export_data(channel_id, node_ids, exclude_node_ids, True)
 
         self.update_job_metadata(total_bytes_to_transfer, total_resource_count)
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -12,9 +12,8 @@ from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.file_availability import LocationError
-from kolibri.core.content.utils.import_export_content import calculate_files_to_transfer
 from kolibri.core.content.utils.import_export_content import compare_checksums
-from kolibri.core.content.utils.import_export_content import get_nodes_to_transfer
+from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.upgrade import get_import_data_for_update
 from kolibri.core.tasks.management.commands.base import AsyncCommand
@@ -204,7 +203,11 @@ class Command(AsyncCommand):
     ):
         try:
             if not import_updates:
-                nodes_for_transfer = get_nodes_to_transfer(
+                (
+                    total_resource_count,
+                    files_to_download,
+                    total_bytes_to_transfer,
+                ) = get_import_export_data(
                     channel_id,
                     node_ids,
                     exclude_node_ids,
@@ -213,17 +216,6 @@ class Command(AsyncCommand):
                     drive_id=drive_id,
                     peer_id=peer_id,
                 )
-                total_resource_count = (
-                    nodes_for_transfer.exclude(kind=content_kinds.TOPIC)
-                    .values("content_id")
-                    .distinct()
-                    .count()
-                )
-
-                (
-                    files_to_download,
-                    total_bytes_to_transfer,
-                ) = calculate_files_to_transfer(nodes_for_transfer, False)
             else:
                 (
                     total_resource_count,

--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -123,6 +123,7 @@ class DeleteContentTestCase(TransactionTestCase):
         )
 
     def _setup_test_node(self, node, available=True):
+        node.available = available
         node.id = uuid.uuid4().hex
         node.channel_id = uuid.uuid4().hex
         node.available = available
@@ -143,11 +144,14 @@ class DeleteContentTestCase(TransactionTestCase):
         call_command("deletecontent", test_channel_id, **kwargs)
 
     def test_include_all_nodes_all_deleted(self):
+        LocalFile.objects.all().update(available=True)
         ContentNode.objects.all().update(available=True)
         call_command("deletecontent", test_channel_id, node_ids=self._get_node_ids())
         self.assertEqual(ContentNode.objects.all().count(), 0)
 
     def test_include_all_nodes_other_channel_node_still_available(self):
+        LocalFile.objects.all().update(available=True)
+        ContentNode.objects.all().update(available=True)
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
         test = self._setup_test_node(test)
@@ -157,6 +161,8 @@ class DeleteContentTestCase(TransactionTestCase):
         self.assertTrue(test.available)
 
     def test_include_all_nodes_force_delete_other_channel_node_not_available(self):
+        LocalFile.objects.all().update(available=True)
+        ContentNode.objects.all().update(available=True)
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
         test = self._setup_test_node(test)
@@ -168,6 +174,8 @@ class DeleteContentTestCase(TransactionTestCase):
     def test_exclude_all_nodes_force_delete_other_channel_node_not_available_no_delete(
         self,
     ):
+        LocalFile.objects.all().update(available=True)
+        ContentNode.objects.all().update(available=True)
         test = ContentNode.objects.filter(kind=content_kinds.VIDEO).first()
         original_id = test.id
         test = self._setup_test_node(test, available=False)

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1003,7 +1003,7 @@ class ExportChannelTestCase(TestCase):
 
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
-@patch("kolibri.core.content.management.commands.importcontent.get_import_export_data")
+@patch("kolibri.core.content.management.commands.exportcontent.get_import_export_data")
 class ExportContentTestCase(TestCase):
     """
     Test case for the exportcontent management command.

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -93,7 +93,9 @@ def _generate_MPTT_descendants_statement(mptt_values, ContentNodeTable):
     return queries
 
 
-def _MPTT_descendant_ids_statement(bridge, node_ids, min_boundary, max_boundary):
+def _MPTT_descendant_ids_statement(
+    bridge, channel_id, node_ids, min_boundary, max_boundary
+):
     ContentNodeTable = bridge.get_table(ContentNode)
     connection = bridge.get_connection()
     # Setup list to collect queries
@@ -104,6 +106,7 @@ def _MPTT_descendant_ids_statement(bridge, node_ids, min_boundary, max_boundary)
     non_topic_results = connection.execute(
         select([ContentNodeTable.c.id]).where(
             and_(
+                ContentNodeTable.c.channel_id == channel_id,
                 filter_by_uuids(ContentNodeTable.c.id, node_ids),
                 # Also filter by the boundary conditions
                 # We are only interested in non-topic nodes that
@@ -143,6 +146,7 @@ def _MPTT_descendant_ids_statement(bridge, node_ids, min_boundary, max_boundary)
         )
         .where(
             and_(
+                ContentNodeTable.c.channel_id == channel_id,
                 filter_by_uuids(ContentNodeTable.c.id, node_ids),
                 # Add constraints specific to our requirements, in terms of batching:
                 # Also filter by the boundary conditions
@@ -196,7 +200,7 @@ def _create_batch_update_statement(
         # Construct a statement that restricts which nodes we update
         # in this batch by the specified inclusion constraints
         node_ids_statement = _MPTT_descendant_ids_statement(
-            bridge, node_ids, min_boundary, max_boundary
+            bridge, channel_id, node_ids, min_boundary, max_boundary
         )
         # Add this statement to the query
         batch_statement = batch_statement.where(
@@ -207,7 +211,7 @@ def _create_batch_update_statement(
         # Construct a statement that restricts nodes we update
         # in this batch by the specified exclusion constraints
         exclude_node_ids_statement = _MPTT_descendant_ids_statement(
-            bridge, exclude_node_ids, min_boundary, max_boundary
+            bridge, channel_id, exclude_node_ids, min_boundary, max_boundary
         )
         # Add this statement to the query
         batch_statement = batch_statement.where(
@@ -656,8 +660,8 @@ def calculate_dummy_progress_for_annotation(node_ids, exclude_node_ids, total_pr
     return int(annotation_proportion * total_progress / (100 - annotation_proportion))
 
 
-def propagate_forced_localfile_removal(localfiles):
-    files = File.objects.filter(supplementary=False, local_file__in=localfiles)
+def propagate_forced_localfile_removal(localfiles_list):
+    files = File.objects.filter(supplementary=False, local_file__in=localfiles_list)
     ContentNode.objects.filter(files__in=files).update(available=False)
     for channel_id in ChannelMetadata.objects.all().values_list("id", flat=True):
         recurse_annotation_up_tree(channel_id)

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -126,8 +126,10 @@ def get_import_export_data(
         channel_id, node_ids, exclude_node_ids
     )
 
-    nodes_to_include = ContentNode.objects.filter(channel_id=channel_id).exclude(
-        kind=content_kinds.TOPIC
+    nodes_to_include = ContentNode.objects.filter(
+        channel_id=channel_id, available=available
+    ).exclude(
+        kind=content_kinds.TOPIC,
     )
 
     nodes_to_include = filter_by_file_availability(


### PR DESCRIPTION
### Summary
* #7555 introduced a mechanism to include ancestor thumbnails in files for import
* This increased the query complexity, particularly for large trees to the point that it would overwhelm the DB
* This PR brings in the batch processing that has previously been used for availability annotation and upgrade logic into the files for transfer workflow
* It also separates calculation of resource files from topic files
* Adds a special flag to exclude topic_thumbnails from the calculation, which is necessary for the functions use in the deletecontent command
* Calculates the topic thumbnails based on descendant and ancestor relationships
* Batches calculation so that complex selection patterns involving large numbers of node_ids and exclude_node_ids will not overwhelm the DB

### Reviewer guidance
* First check that you can select the Math topic in the Khan Academy channel without resulting in a 500 error from the importexportsize endpoint
* Make sure that importing imports what you expect
* One slight concern I had is that the current unit tests do a poor job of testing this functionality, mostly because of the poor testing data we have in place

### References
* Fixes #7686

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [X] Contributor has fully tested the PR manually
- [X] Critical and brittle code paths are covered by unit tests (see caveat above)

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
