### PR TITLE
Add new watched prop to consolidate logic in 'disabled'

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -247,7 +247,7 @@
     watch: {
       addresses(addresses) {
         this.availableAddressIds = addresses
-          .filter(address => address.available || address.hasContent)
+          .filter(address => address.available)
           .map(address => address.id);
         this.resetSelectedAddress();
       },
@@ -275,9 +275,6 @@
             this.savedAddresses = addresses;
             this.stage = this.Stages.FETCHING_SUCCESSFUL;
             this.savedAddressesInitiallyFetched = true;
-            if (this.savedAddresses.find(({ id }) => this.selectedId === id)) {
-              this.selectedAddressId = this.selectedId;
-            }
           })
           .catch(() => {
             this.stage = this.Stages.FETCHING_FAILED;
@@ -285,7 +282,9 @@
       },
       resetSelectedAddress() {
         if (this.availableAddressIds.length !== 0) {
-          this.selectedAddressId = this.availableAddressIds[0];
+          const selectedId = this.selectedId ? this.selectedId : this.selectedAddressId;
+          this.selectedAddressId =
+            this.availableAddressIds.find(id => selectedId === id) || this.availableAddressIds[0];
         } else {
           this.selectedAddressId = '';
         }

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -45,7 +45,7 @@
             :value="a.id"
             :label="a.nickname"
             :description="a.base_url"
-            :disabled="formDisabled || !a.available || !a.hasContent"
+            :disabled="formDisabled || !isAddressAvailable(a.id)"
           />
           <KButton
             v-if="!hideSavedAddresses"
@@ -69,7 +69,7 @@
             :value="d.instance_id"
             :label="formatNameAndId(d.device_name, d.id)"
             :description="d.base_url"
-            :disabled="formDisabled || !d.available || discoveryFailed || !d.hasContent"
+            :disabled="formDisabled || discoveryFailed || !isAddressAvailable(d.id)"
           />
         </div>
       </template>
@@ -166,6 +166,7 @@
     },
     data() {
       return {
+        availableAddressIds: [],
         savedAddresses: [],
         savedAddressesInitiallyFetched: false,
         discoveredAddresses: [],
@@ -190,6 +191,11 @@
       addresses() {
         return this.savedAddresses.concat(this.discoveredAddresses);
       },
+      isAddressAvailable() {
+        return function(addressId) {
+          return Boolean(this.availableAddressIds.find(id => id === addressId));
+        };
+      },
       initialFetchingComplete() {
         return this.savedAddressesInitiallyFetched && this.discoveredAddressesInitiallyFetched;
       },
@@ -198,7 +204,8 @@
           this.selectedAddressId === '' ||
           this.stage === this.Stages.FETCHING_ADDRESSES ||
           this.stage === this.Stages.DELETING_ADDRESS ||
-          this.discoveryStage === this.Stages.PEER_DISCOVERY_FAILED
+          this.discoveryStage === this.Stages.PEER_DISCOVERY_FAILED ||
+          this.availableAddressIds.length === 0
         );
       },
       newAddressButtonDisabled() {
@@ -237,6 +244,14 @@
         return null;
       },
     },
+    watch: {
+      addresses(addresses) {
+        this.availableAddressIds = addresses
+          .filter(address => address.available || address.hasContent)
+          .map(address => address.id);
+        this.resetSelectedAddress();
+      },
+    },
     beforeMount() {
       this.startDiscoveryPolling();
       return this.refreshSavedAddressList();
@@ -258,7 +273,6 @@
         return fetchStaticAddresses(this.fetchAddressArgs)
           .then(addresses => {
             this.savedAddresses = addresses;
-            this.resetSelectedAddress();
             this.stage = this.Stages.FETCHING_SUCCESSFUL;
             this.savedAddressesInitiallyFetched = true;
             if (this.savedAddresses.find(({ id }) => this.selectedId === id)) {
@@ -270,9 +284,8 @@
           });
       },
       resetSelectedAddress() {
-        const availableAddress = find(this.addresses, { available: true });
-        if (availableAddress) {
-          this.selectedAddressId = availableAddress.id;
+        if (this.availableAddressIds.length !== 0) {
+          this.selectedAddressId = this.availableAddressIds[0];
         } else {
           this.selectedAddressId = '';
         }
@@ -282,7 +295,6 @@
         return deleteAddress(id)
           .then(() => {
             this.savedAddresses = this.savedAddresses.filter(a => a.id !== id);
-            this.resetSelectedAddress(this.savedAddresses);
             this.stage = this.Stages.DELETING_SUCCESSFUL;
             this.$emit('removed_address');
           })


### PR DESCRIPTION

### Summary

#### Description of Change
- Adds new watch property to "watch" for changes in `addresses()`
- Creates new list to hold address ids that are either available or have content
- Adds a check for logic in `submitDisabled()` so that 'Continue' button will stay disabled
- Updates template for `disabled` attributes

#### Manual verification steps performed
- Tested with server that is offline, servers that are always available (beta and demo), and self server. See screenshots below.

1. If server is unreachable, it is disabled and radio button is not selected.
2. If server is reachable or has content, radio button for first available is selected and user can switch between available servers.
3. Continue button is clickable.

![Screen Shot 2020-11-13 at 1 45 49 PM](https://user-images.githubusercontent.com/13563002/99124930-f388be00-25b7-11eb-8da0-4d922f96aa4a.png)

1. If server is unreachable, server is disabled, radio button is not selected.
2. 'Continue' button is also disabled.

![Screen Shot 2020-11-13 at 1 46 07 PM](https://user-images.githubusercontent.com/13563002/99124931-f4b9eb00-25b7-11eb-957e-bca275f43586.png)

…

### Reviewer guidance
- Please test with additional online/offline servers to verify

…

### References
Fixes #7376 
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
