### PR TITLE
Limit TransferSession subquery to a single row.

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -366,7 +366,7 @@ class FacilityViewSet(ValuesViewset):
                         )
                     )
                     .order_by("-last_activity_timestamp")
-                    .values("last_activity_timestamp")
+                    .values("last_activity_timestamp")[:1]
                 )
             )
         )


### PR DESCRIPTION
### Summary
Normally there is only one TransferSession in the DB for a Facility, but it seems this can sometimes not be the case.

### Reviewer guidance
Do the tests all pass for this endpoint still?

### References
Fixes #7701 
----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
