### PR TITLE
Fix issue with Facility status displaying "Deleting" while actually "Syncing"

### DIFF
--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
@@ -93,7 +93,7 @@ export default {
             task =>
               task.type === TaskTypes.DELETEFACILITY &&
               taskFacilityMatch(task, facility) &&
-              !taskIsClearable(task.status)
+              !taskIsClearable(task)
           )
         );
       };

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -123,7 +123,7 @@
   } from 'kolibri.coreVue.componentSets.sync';
   import TasksBar from '../ManageContentPage/TasksBar';
   import HeaderWithOptions from '../HeaderWithOptions';
-  import { TaskStatuses, TaskTypes } from '../../constants';
+  import { TaskStatuses, TaskTypes, taskIsClearable } from '../../constants';
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';
@@ -154,7 +154,6 @@
       TasksBar,
     },
     mixins: [commonCoreStrings, commonSyncElements, facilityTaskQueue],
-    props: {},
     data() {
       return {
         showSyncAllModal: false,
@@ -185,6 +184,11 @@
               if (match) {
                 this.$set(match, 'syncHasFailed', true);
               }
+            }
+          } else {
+            // Add tasks that aren't being watched yet
+            if (!taskIsClearable(task)) {
+              this.taskIdsToWatch.push(task.id);
             }
           }
         }


### PR DESCRIPTION

### Summary

1. Fixes #7454, which was caused by a typo
1. Fixes another issue where facility import tasks (which cause an immediate navigation to the Task Manager) would not be watched by the Facility Page. As a result, when the facility import task finished, it would not tell the Facility Page to reload the facilities (and so the newly-imported facility would not show up)

### Reviewer guidance

1. To test (1), follow the scenario in #7454 (Delete a facility, Re-Import it, then sync it. Remember to _not_ clear out any tasks
1. To test (2), import a facility. When it takes you to the Task Manager page, _immediately_ navigate back to the Facilities Page. When the task completes, the new facility should appear in the list.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
