### PR TITLE
Add Python 3.9 support to analytics and automated testing matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["**.py", "requirements/*.txt"]'
+          paths: '["**.py", "requirements/*.txt", ".github/workflows/tox.yml", "tox.ini"]'
   unit_test:
     name: Python unit tests
     needs: pre_job
@@ -23,7 +23,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import math
+import sys
 
 import requests
 from django.core.serializers.json import DjangoJSONEncoder
@@ -228,10 +229,19 @@ def extract_facility_statistics(facility):
         dataset_id=dataset_id, learners=False
     )
 
+    if sys.version_info[0] >= 3:
+        # encodestring is a deprecated alias for
+        # encodebytes, which was finally removed
+        # in Python 3.9
+        encodestring = base64.encodebytes
+    else:
+        # encodebytes does not exist in Python 2.7
+        encodestring = base64.encodestring
+
     # fmt: off
     return {
         # facility_id
-        "fi": base64.encodestring(hashlib.md5(facility.id.encode()).digest())[:10].decode(),
+        "fi": encodestring(hashlib.md5(facility.id.encode()).digest())[:10].decode(),
         # settings
         "s": settings,
         # learners_count

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,3.8}, postgres
+envlist = py{2.7,3.4,3.5,3.6,3.7,3.8,3.9}, postgres
 
 [testenv]
 usedevelop = True
@@ -19,6 +19,7 @@ basepython =
     py3.6: python3.6
     py3.7: python3.7
     py3.8: python3.8
+    py3.9: python3.9
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
## Summary
Adds Python 3.9 support

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
