### PR TITLE
kolibri-tools bug fix & packages published bumped versions

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "eslint-plugin-import": "^2.20.0",
-    "kolibri-tools": "0.13.0-dev.10",
+    "kolibri-tools": "0.14.5-dev.4",
     "responselike": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "private": true,
   "devDependencies": {
     "@types/jest": "^24.0.12",
-    "kolibri-tools": "0.13.0-dev.10",
+    "kolibri-tools": "0.14.5-dev.4",
     "xhr-mock": "^2.5.1",
     "yarn-run-all": "^3.1.1"
   },

--- a/packages/eslint-plugin-kolibri/package.json
+++ b/packages/eslint-plugin-kolibri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-kolibri",
-  "version": "0.13.0-dev.10",
+  "version": "0.14.5-dev.4",
   "description": "Custom rules.",
   "author": "Learning Equality",
   "main": "lib/index.js",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri",
-  "version": "0.13.0-dev.10",
+  "version": "0.14.5-dev.4",
   "description": "The Kolibri core API",
   "repository": "github.com/learningequality/kolibri",
   "author": "Learning Equality",
@@ -15,9 +15,10 @@
     "date-fns": "^1.28.2",
     "fontfaceobserver": "^2.0.13",
     "frame-throttle": "^3.0.0",
+    "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:nucleogenesis/kolibri-design-system-1#big-keen-ui-vendoring",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",
@@ -34,6 +35,6 @@
     "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {
-    "kolibri-tools": "0.13.0-dev.10"
+    "kolibri-tools": "0.14.5-dev.4"
   }
 }

--- a/packages/kolibri-tools/lib/i18n/intl_code_gen.js
+++ b/packages/kolibri-tools/lib/i18n/intl_code_gen.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const fs = require('fs');
-const { lint } = require('kolibri-tools/lib/lint');
+const { lint } = require('../lint');
 
-const languageInfo = require('../../kolibri/locale/language_info.json');
+const languageInfo = require('./language_info.json');
 
 const commonHeader = `
 /*
@@ -41,10 +41,7 @@ const vueIntlFooter = `
 const vueIntlModule =
   commonHeader + vueIntlHeader + languageInfo.map(generateVueIntlItems).join('') + vueIntlFooter;
 
-const vueIntlModulePath = path.resolve(
-  __dirname,
-  '../../kolibri/core/assets/src/utils/vue-intl-locale-data.js'
-);
+const vueIntlModulePath = path.resolve('./vue-intl-locale-data.js');
 
 const intlHeader = `module.exports = function(locale) {
   switch (locale) {`;
@@ -123,10 +120,7 @@ const intlFooter = `
 const intlModule =
   commonHeader + intlHeader + languageInfo.map(generateIntlItems).join('') + intlFooter;
 
-const intlModulePath = path.resolve(
-  __dirname,
-  '../../kolibri/core/assets/src/utils/intl-locale-data.js'
-);
+const intlModulePath = path.resolve('./intl-locale-data.js');
 
 fs.writeFileSync(vueIntlModulePath, vueIntlModule, { encoding: 'utf-8' });
 

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kolibri-tools",
-  "version": "0.13.0-dev.10",
+  "version": "0.14.5-dev.4",
   "description": "Tools for building Kolibri frontend plugins",
   "main": "lib/cli.js",
   "repository": "github.com/learningequality/kolibri",
@@ -38,7 +38,7 @@
     "eslint-config-vue": "^2.0.2",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^23.3.0",
-    "eslint-plugin-kolibri": "0.13.0-dev.10",
+    "eslint-plugin-kolibri": "0.14.5-dev.4",
     "eslint-plugin-vue": "^6.1.2",
     "espree": "^5.0.1",
     "esquery": "^1.0.1",
@@ -100,6 +100,6 @@
     "readline-sync": "^1.4.9"
   },
   "optionalDependencies": {
-    "kolibri": "0.13.0-dev.10"
+    "kolibri": "0.14.5-dev.4"
   }
 }


### PR DESCRIPTION
Bumps packages versions based on latest npm release for each. 

There were some Kolibri-specific relative paths in some of the i18n code ported to `kolibri-tools` that you wouldn't run into if you were `yarn linking` the package because symlinks. Those are fixed here.

I got all screwed up with the package publishing the first couple times - then since I was already in 3 versions I might as well make one with the latest fix and point Studio there.