### PR TITLE
fixes permissions for non-superadmins in device tab

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -35,6 +35,7 @@
       />
     </NavbarLink>
     <NavbarLink
+      v-if="isSuperuser"
       :title="$tr('infoLabel')"
       :link="$router.getRoute('DEVICE_INFO_PAGE')"
     >
@@ -45,6 +46,7 @@
       />
     </NavbarLink>
     <NavbarLink
+      v-if="isSuperuser"
       :title="$tr('settingsLabel')"
       :link="$router.getRoute('DEVICE_SETTINGS_PAGE')"
     >


### PR DESCRIPTION
# Summary

Added additional logic to check whether user is a super-admin so that "info" and "settings" tabs are visible/disabled in Device:

- If user is super-admin, they can see those tabs.
- If user can "manage content" but is not a super-admin, they cannot see those tabs

**Steps taken to check:**

- Made a learner account and gave the learner "can manage content" permission.
- Logged in as learner to see if those two tabs were visible.
- Checked other accounts that could/could not manage content to see if changes worked.

**Screenshot**
Learner with "can manage" permissions can no longer see the "info" and "settings" tabs.

![Screen Shot 2020-11-25 at 2 54 32 PM](https://user-images.githubusercontent.com/13563002/100292986-0e9fea00-2f37-11eb-839c-8897baccac20.png)

…

### Reviewer guidance
Please test different user accounts with different permissions (can manage, coach, super-admin, etc.)
…

### References
Fixes #6650

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
