### PR TITLE
Get port number for zeroconf from cherrypy.server

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -502,6 +502,26 @@ def start(port, background):
     Start the server on given port.
     """
 
+    start_with_ready_cb(port, background, ready_cb=_on_ready)
+
+
+def _on_ready(urls, bind_addr=None, bind_port=None):
+    if not urls:
+        logger.error(
+            "Could not detect an IP address that Kolibri binds to, but try "
+            "opening up the following addresses:\n"
+        )
+        urls = [
+            "http://{}:{}".format(ip, bind_port) for ip in ("localhost", "127.0.0.1")
+        ]
+    else:
+        logger.info("Kolibri running on:\n")
+    for addr in urls:
+        sys.stderr.write("\t{}\n".format(addr))
+    sys.stderr.write("\n")
+
+
+def start_with_ready_cb(port, background, ready_cb=None):
     # Check if there is an options.ini file exist inside the KOLIBRI_HOME folder
     sanity_checks.check_default_options_exist()
 
@@ -528,25 +548,6 @@ def start(port, background):
     else:
         logger.info("Running Kolibri as background process")
 
-    if serve_http:
-
-        __, urls = server.get_urls(listen_port=port)
-        if not urls:
-            logger.error(
-                "Could not detect an IP address that Kolibri binds to, but try "
-                "opening up the following addresses:\n"
-            )
-            urls = [
-                "http://{}:{}".format(ip, port) for ip in ("localhost", "127.0.0.1")
-            ]
-        else:
-            logger.info("Kolibri running on:\n")
-        for addr in urls:
-            sys.stderr.write("\t{}\n".format(addr))
-        sys.stderr.write("\n")
-    else:
-        logger.info("Starting Kolibri background workers")
-
     # Daemonize at this point, no more user output is needed
     if background:
 
@@ -564,7 +565,7 @@ def start(port, background):
 
         become_daemon(**kwargs)
 
-    server.start(port=port, serve_http=serve_http)
+    server.start(port=port, serve_http=serve_http, ready_cb=ready_cb)
 
 
 @main.command(cls=KolibriCommand, help="Stop the Kolibri process")

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -80,12 +80,11 @@ class NotRunning(Exception):
 
 
 class ServicesPlugin(SimplePlugin):
-    def __init__(self, bus, port):
+    def __init__(self, bus):
         self.bus = bus
-        self.port = port
         self.workers = None
 
-    def start(self):
+    def start(self, *args, **kwargs):
         # Initialize the iceqube scheduler to handle scheduled tasks
         scheduler.clear_scheduler()
 
@@ -107,13 +106,6 @@ class ServicesPlugin(SimplePlugin):
         self.workers = initialize_workers()
 
         scheduler.start_scheduler()
-
-        # Register the Kolibri zeroconf service so it will be discoverable on the network
-        from kolibri.core.discovery.utils.network.search import (
-            register_zeroconf_service,
-        )
-
-        register_zeroconf_service(port=self.port)
 
     def stop(self):
         scheduler.shutdown_scheduler()
@@ -146,7 +138,7 @@ class CleanUpPIDPlugin(SimplePlugin):
         _rm_pid_file(PID_FILE)
 
 
-def start(port=8080, serve_http=True):
+def start(port=8080, serve_http=True, ready_cb=None):
     """
     Starts the server.
 
@@ -158,7 +150,7 @@ def start(port=8080, serve_http=True):
 
     logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
 
-    run_server(port=port, serve_http=serve_http)
+    run_server(port=port, serve_http=serve_http, ready_cb=ready_cb)
 
 
 def stop(pid=None, force=False):
@@ -337,7 +329,7 @@ def configure_http_server(port):
     alt_port_server.subscribe()
 
 
-def run_server(port, serve_http=True):
+def run_server(port, serve_http=True, ready_cb=None):
     # Unsubscribe the default server
     cherrypy.server.unsubscribe()
 
@@ -366,7 +358,7 @@ def run_server(port, serve_http=True):
         configure_http_server(port)
 
     # Setup plugin for services
-    service_plugin = ServicesPlugin(cherrypy.engine, port)
+    service_plugin = ServicesPlugin(cherrypy.engine)
     service_plugin.subscribe()
 
     # Setup plugin for handling PID file cleanup
@@ -395,6 +387,24 @@ def run_server(port, serve_http=True):
 
     # Start the server engine (Option 1 *and* 2)
     cherrypy.engine.start()
+
+    cherrypy.server.wait()
+    bind_addr, bind_port = cherrypy.server.bound_addr
+
+    # Write the PID file again, in case the port number has changed
+    _write_pid_file(PID_FILE, port=bind_port)
+
+    # Register the Kolibri zeroconf service so it will be discoverable on the network
+    from kolibri.core.discovery.utils.network.search import (
+        register_zeroconf_service,
+    )
+
+    register_zeroconf_service(port=bind_port)
+
+    if callable(ready_cb):
+        __, urls = get_urls(listen_port=bind_port)
+        ready_cb(urls, bind_addr=bind_addr, bind_port=bind_port)
+
     cherrypy.engine.block()
 
 
@@ -541,7 +551,7 @@ def get_urls(listen_port=None):
                         other running instances.
     """
     try:
-        if listen_port:
+        if listen_port is not None:
             port = listen_port
         else:
             __, __, port = get_status()


### PR DESCRIPTION
### Summary

With this change, it is possible to set `KOLIBRI_HTTP_PORT=0`, or pass Kolibri a socket through socket activation, and have it detect the assigned port number. This affects flathub/org.learningequality.Kolibri#16.

### Reviewer guidance

I added a callback mechanism to the start command. This is really useful for the Kolibri front-end apps (https://github.com/learningequality/kolibri-installer-mac / https://github.com/learningequality/kolibri-installer-gnome) since it means the server will tell us the moment it is listening, and what URL it can be reached at. I am not sure if the way I did that is very kosher here since I was really just cobbling it together until it worked. Guidance on how to do this better (even if it's more complicated) would be appreciated.

### References

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
