### PR TITLE
Pin ubuntu to 18.04 for tox tests for Python3.4 compatibility.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,7 @@ jobs:
     name: Python unit tests
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       max-parallel: 5
       matrix:
@@ -48,7 +48,7 @@ jobs:
     name: Python postgres unit tests
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       # Label used to access the service container
       postgres:


### PR DESCRIPTION
### Summary
* Python setup action requires ubuntu 18.04 for Python34
* We were using ubuntu-latest which recently updated to 20.04
* This pins the tox action to ubuntu 18.04

### Reviewer guidance
* Do tests run?
