### PR TITLE
create Freedesktop Desktop file and channel icon when importing channel

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -8,6 +8,7 @@ from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import set_content_invisible
+from kolibri.core.content.utils.freedesktop import delete_channel_freedesktop_files
 from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.content.utils.paths import get_content_database_file_path
@@ -50,6 +51,7 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
 
     if delete_all_metadata:
         logger.info("Deleting all channel metadata")
+        delete_channel_freedesktop_files(channel.id)
         with db_task_write_lock:
             channel.delete_content_tree_and_files()
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -7,6 +7,7 @@ from django.core.management.base import CommandError
 from le_utils.constants import content_kinds
 
 from ...utils import annotation
+from ...utils import freedesktop
 from ...utils import paths
 from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
@@ -413,6 +414,8 @@ class Command(AsyncCommand):
 
             if self.is_cancelled():
                 self.cancel()
+            elif resources_after_transfer > 0:
+                freedesktop.create_channel_freedesktop_files(channel_id)
 
     def _start_file_transfer(self, f, filetransfer):
         """

--- a/kolibri/core/content/utils/freedesktop.py
+++ b/kolibri/core/content/utils/freedesktop.py
@@ -1,0 +1,74 @@
+import base64
+import mimetypes
+import os
+
+from django.forms.models import model_to_dict
+
+from .paths import get_content_share_dir_path
+from kolibri.core.content.models import ChannelMetadata
+
+
+def _get_freedesktop_file_path(child):
+    file_path = os.path.join(get_content_share_dir_path(), child)
+
+    file_dirname = os.path.dirname(file_path)
+    if not os.path.isdir(file_dirname):
+        os.makedirs(file_dirname)
+
+    return file_path
+
+
+def _get_desktop_file_path(channel):
+    return _get_freedesktop_file_path(
+        os.path.join(
+            "applications",
+            "org.learningequality.Kolibri.Channel.{}.desktop".format(channel.id)
+        )
+    )
+
+
+def _get_icon_file_path(channel):
+    extension = mimetypes.guess_extension(channel.thumbnail.split(';')[0].split(':')[1])
+    return _get_freedesktop_file_path(
+        os.path.join(
+            "icons",
+            "org.learningequality.Kolibri.Channel.{}{}".format(channel.id, extension)
+        )
+    )
+
+
+def create_channel_freedesktop_files(channel_id):
+    channel = ChannelMetadata.objects.get(id=channel_id)
+
+    # Create Desktop file
+    with open(_get_desktop_file_path(channel), "w") as f:
+        f.write("""[Desktop Entry]
+Version=1.0
+Type=Application
+Name={name}
+Exec=gio open "kolibri:{id}"
+X-Endless-LaunchMaximized=true
+Categories=Education;
+""".format(**model_to_dict(channel)))
+
+        if channel.thumbnail:
+            f.write("Icon=org.learningequality.Kolibri.Channel.{}\n".format(channel.id))
+
+    # Create channel icon
+    if channel.thumbnail:
+        with open(_get_icon_file_path(channel), "wb") as f:
+            f.write(base64.b64decode(channel.thumbnail.split(';')[1].split(',')[1]))
+
+
+def delete_channel_freedesktop_files(channel_id):
+    channel = ChannelMetadata.objects.get(id=channel_id)
+
+    try:
+        os.remove(_get_desktop_file_path(channel))
+    except OSError:
+        pass
+
+    try:
+        os.remove(_get_icon_file_path(channel))
+    except OSError:
+        pass

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -151,6 +151,20 @@ def get_annotated_content_database_file_path(
     )
 
 
+def get_content_share_dir_path(datafolder=None, contentfolder=None):
+    """
+    Returns the path to the directory where Freedesktop files (like .desktop launchers
+    and AppData) are in
+    ($HOME/.kolibri/content/share on POSIX systems, by default)
+    """
+    path = os.path.join(
+        get_content_dir_path(datafolder=datafolder, contentfolder=contentfolder),
+        "share",
+    )
+    _maybe_makedirs(path)
+    return path
+
+
 def get_content_storage_dir_path(datafolder=None, contentfolder=None):
     path = os.path.join(
         get_content_dir_path(datafolder=datafolder, contentfolder=contentfolder),


### PR DESCRIPTION
This is a draft, don't merge until we discuss all the TODOs and the motivation in general.

### Summary

This PR add support for creating desktop launchers compatible with [Freedesktop's Desktop Entry Specificatioin](https://specifications.freedesktop.org/desktop-entry-spec/). This basically creates the folder `KOLIBRI_HOME/content/share` to add the desktop files and export the channel icons there. Then the OS will add that directory to its `XDG_DATA_DIRS` env variable.

The motivation is to have a better desktop integration for Kolibri, in this particular case, for Linux (or Freedesktop based DE), having Kolibri channels as desktop launchers.

### TODOs

- [ ] Discuss support for something like this in different platforms (is it wanted?). Right now, one particularity of this is that no user are affect unless the OS opt-in by adding the new directory to `XDG_DATA_DIRS`.
- [ ] Using channel thumbnail for launcher icon may be not suitable for desktop launchers due to the different restrictions they had compared to the desktop specification. We could mitigate that either by:
    - Adding restrictions to the thumbnail (make existing channels that don't fit the restrictions broken)
    - Creating a new field for channels, being `icon`, fallback to `thumbnail`.
    - Crop the thumbnail the best we can when exporting the launcher icon (thinking of libraries like [autocrop](https://github.com/leblancfg/autocrop)), this is compatible with the previous item.

### Reviewer guidance

To test these changes you have to add `KOLIBRI_HOME/content/share` to `XDG_DATA_DIRS`. This can be achieved by, for example, in a modern `systemd` based system, by creating the following executable file in `/usr/lib/systemd/user-environment-generators/61-kolibri`:

```
#!/bin/bash

# This will work for Flatpak Kolibri, change it if required
XDG_DATA_DIRS="$HOME/.var/app/org.learningequality.Kolibri/data/kolibri/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"
```

Then reboot the computer and add/delete channels to see the launchers.

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
