### PR TITLE
Fix login and signup redirects

### DIFF
--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -84,7 +84,7 @@
           return '/';
         } else {
           const currentURL = window.encodeURIComponent(window.location.href);
-          return `${this.userPluginUrl()}?next=${currentURL}`;
+          return `${this.userPluginUrl()}#/signin?next=${currentURL}`;
         }
       },
     },

--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -84,7 +84,7 @@
           return '/';
         } else {
           const currentURL = window.encodeURIComponent(window.location.href);
-          return `${this.userPluginUrl()}?redirect=${currentURL}`;
+          return `${this.userPluginUrl()}?next=${currentURL}`;
         }
       },
     },

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -76,7 +76,7 @@ describe('auth message component', () => {
     const wrapper = makeWrapper();
     const link = wrapper.find('kexternallink-stub');
     expect(link.attributes()).toMatchObject({
-      href: 'http://localhost:8000/en/user/?redirect=http%3A%2F%2Fkolibri.time%2F',
+      href: 'http://localhost:8000/en/user/#/signin?next=http%3A%2F%2Fkolibri.time%2F',
       text: 'Sign in to Kolibri',
     });
     delete urls['kolibri:kolibri.plugins.user:user'];

--- a/kolibri/plugins/user/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/user/assets/src/modules/pluginModule.js
@@ -7,7 +7,6 @@ export default {
   state() {
     return {
       facilityId: Lockr.get('facilityId') || null,
-      redirect: null,
       pageName: '',
       appBarTitle: '',
     };
@@ -57,9 +56,6 @@ export default {
     },
     SET_APPBAR_TITLE(state, appBarTitle) {
       state.appBarTitle = appBarTitle;
-    },
-    SET_REDIRECT(state, redirect) {
-      state.redirect = redirect;
     },
   },
   modules: {

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -160,6 +160,7 @@
   import { ComponentMap } from '../constants';
   import LanguageSwitcherFooter from '../views/LanguageSwitcherFooter';
   import AuthSelect from './AuthSelect';
+  import getUrlParameter from './getUrlParameter';
   import plugin_data from 'plugin_data';
 
   export default {
@@ -207,6 +208,14 @@
       },
       canSignUp() {
         return this.facilityConfig.learner_can_sign_up;
+      },
+      nextParam() {
+        // query is after hash
+        if (this.$route.query.next) {
+          return this.$route.query.next;
+        }
+        // query is before hash
+        return getUrlParameter('next');
       },
       signUpPage() {
         const signUpRoute = this.$router.getRoute(ComponentMap.SIGN_UP);

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -218,7 +218,6 @@
   import AuthBase from '../AuthBase';
   import UsersList from '../UsersList';
   import SignInHeading from './SignInHeading';
-  import plugin_data from 'plugin_data';
 
   const MAX_USERS_FOR_LISTING_VIEW = 16;
 
@@ -260,7 +259,6 @@
     computed: {
       ...mapGetters(['selectedFacility', 'isAppContext']),
       ...mapState('signIn', ['hasMultipleFacilities']),
-      ...mapState(['redirect']),
       backToFacilitySelectionRoute() {
         const facilityRoute = this.$router.getRoute(ComponentMap.FACILITY_SELECT);
         const whereToNext = this.$router.getRoute(ComponentMap.SIGN_IN);
@@ -503,11 +501,8 @@
           facility: this.selectedFacility.id,
         };
 
-        if (plugin_data.oidcProviderEnabled) {
+        if (this.nextParam) {
           sessionPayload['next'] = this.nextParam;
-        } else if (this.redirect && !this.nextParam) {
-          // Go to URL in 'redirect' query param, if arriving from AuthMessage
-          sessionPayload['next'] = this.redirect;
         }
 
         this.kolibriLogin(sessionPayload)

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -128,7 +128,6 @@
   import AuthSelect from './AuthSelect';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
   import getUrlParameter from './getUrlParameter';
-  import plugin_data from 'plugin_data';
 
   const { DEFERRED } = DemographicConstants;
 
@@ -167,7 +166,7 @@
     computed: {
       ...mapGetters(['selectedFacility', 'facilityConfig']),
       atFirstStep() {
-        return !this.$route.query.step;
+        return !this.$route.query.step || this.$route.query.step === 1;
       },
       firstStepIsValid() {
         return every([this.nameValid, this.usernameValid, this.passwordValid]);
@@ -229,13 +228,23 @@
         }
       },
       goToFirstStep() {
-        if (this.$router.query != undefined) this.$router.replace({ query: {} });
+        this.$router.replace({
+          query: {
+            ...this.$route.query,
+            step: 1,
+          },
+        });
       },
       goToSecondStep() {
         if (this.firstStepIsValid) {
           this.checkForDuplicateUsername(this.username).then(() => {
             if (this.firstStepIsValid) {
-              this.$router.push({ query: { step: 2 } });
+              this.$router.push({
+                query: {
+                  ...this.$route.query,
+                  step: 2,
+                },
+              });
             } else {
               this.focusOnInvalidField();
             }
@@ -266,12 +275,13 @@
             gender: this.gender || DEFERRED,
             birth_year: this.birthYear || DEFERRED,
           };
-          if (plugin_data.oidcProviderEnabled) {
-            payload['next'] = this.nextParam;
-          }
           SignUpResource.saveModel({ data: payload })
             .then(() => {
-              redirectBrowser();
+              if (this.nextParam) {
+                redirectBrowser(this.nextParam);
+              } else {
+                redirectBrowser();
+              }
             })
             .catch(error => {
               this.busy = false;


### PR DESCRIPTION
### Summary
* Standardizes 'next' GET parameter for redirects
* Ensures that 'next' parameter is used for redirecting when signing up
* Ensures that 'next' parameter is persisted when the signup flow changes steps
* Ensures that the 'next' parameter is always passed into kolibriLogin action

### Reviewer guidance
- Access a page you are not authorized to view while not logged in
- Follow the AuthMessage link to login and ensure you return to the right page
- Sign up for an account with a `next` parameter set to an external site like `https://www.google.com`
- Ensure that after sign up you are redirected to the external site

### References
Fixes #7488

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
