### PR TITLE
Customize session middleware to allow exempting views from session middleware.

### DIFF
--- a/kolibri/core/auth/test/test_session_middleware.py
+++ b/kolibri/core/auth/test/test_session_middleware.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.http import HttpRequest
+from django.http import HttpResponse
+from django.test import SimpleTestCase
+
+from kolibri.core.auth.middleware import KolibriSessionMiddleware
+from kolibri.core.auth.middleware import session_exempt
+
+
+def view(request):
+    return HttpResponse()
+
+
+class CsrfViewMiddlewareTestMixin(SimpleTestCase):
+
+    mw = KolibriSessionMiddleware()
+
+    def test_process_request(self):
+        req = HttpRequest()
+        self.mw.process_request(req)
+        req2 = self.mw.process_view(req, view, (), {})
+        self.assertIsNone(req2)
+        self.assertFalse(self.mw._is_exempt(req))
+
+    def test_process_request_session_exempt_view(self):
+        req = HttpRequest()
+        self.mw.process_request(req)
+        req2 = self.mw.process_view(req, session_exempt(view), (), {})
+        self.assertIsNone(req2)
+        self.assertTrue(self.mw._is_exempt(req))

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -35,6 +35,7 @@ from rest_framework.response import Response
 
 from kolibri.core.api import ValuesViewset
 from kolibri.core.auth.constants import user_kinds
+from kolibri.core.auth.middleware import session_exempt
 from kolibri.core.content import models
 from kolibri.core.content import serializers
 from kolibri.core.content.permissions import CanManageContent
@@ -91,11 +92,11 @@ def cache_forever(some_func):
             if any(
                 map(lambda x: x in request.path, ["popular", "next_steps", "resume"])
             ):
-                timeout = 600
+                timeout = 0
         patch_response_headers(response, cache_timeout=timeout)
         return response
 
-    return wrapper_func
+    return session_exempt(wrapper_func)
 
 
 class ChannelMetadataFilter(FilterSet):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -89,10 +89,10 @@ def cache_forever(some_func):
         except IndexError:
             request = kwargs.get("request", None)
         if isinstance(request, HttpRequest):
-            if any(
-                map(lambda x: x in request.path, ["popular", "next_steps", "resume"])
-            ):
+            if any(map(lambda x: x in request.path, ["next_steps", "resume"])):
                 timeout = 0
+            elif "popular" in request.path:
+                timeout = 600
         patch_response_headers(response, cache_timeout=timeout)
         return response
 

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1208,13 +1208,13 @@ class ContentNodeAPITestCase(APITestCase):
         response_content_ids = [node["content_id"] for node in response.json()]
         self.assertEqual([], response_content_ids)
 
-    def test_resume_ten_minute_cache(self):
+    def test_resume_zero_cache(self):
         user, expected_content_ids = self._create_summary_logs()
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
         response = self.client.get(
             reverse("kolibri:core:contentnode-resume", kwargs={"pk": user.id})
         )
-        self.assertEqual(response["Cache-Control"], "max-age=600")
+        self.assertEqual(response["Cache-Control"], "max-age=0")
 
     def test_next_steps_prereq(self):
         facility = Facility.objects.create(name="MyFac")
@@ -1239,7 +1239,7 @@ class ContentNodeAPITestCase(APITestCase):
         response_content_ids = set(node["content_id"] for node in response.json())
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
-    def test_next_steps_prereq_ten_minute_cache(self):
+    def test_next_steps_prereq_zero_cache(self):
         facility = Facility.objects.create(name="MyFac")
         user = FacilityUser.objects.create(username="user", facility=facility)
         root = content.ContentNode.objects.get(title="root")
@@ -1257,7 +1257,7 @@ class ContentNodeAPITestCase(APITestCase):
         response = self.client.get(
             reverse("kolibri:core:contentnode-next-steps", kwargs={"pk": user.id})
         )
-        self.assertEqual(response["Cache-Control"], "max-age=600")
+        self.assertEqual(response["Cache-Control"], "max-age=0")
 
     def test_next_steps_prereq_wrong_id(self):
         facility = Facility.objects.create(name="MyFac")

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -92,7 +92,7 @@ MIDDLEWARE = [
     "kolibri.core.device.middleware.ProvisioningErrorHandler",
     "django.middleware.cache.UpdateCacheMiddleware",
     "kolibri.core.analytics.middleware.MetricsMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
+    "kolibri.core.auth.middleware.KolibriSessionMiddleware",
     "kolibri.core.device.middleware.KolibriLocaleMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
### Summary
* It is possible for heavily cached endpoints to include session expiry headers
* This means that a response with those session expiry headers could be stored in a long term cache
* This will then cause anyone accessing those endpoints to be immediately logged out
* This fixes that by exempting long running caches from session middleware
* To prevent cache collisions for recommendation endpoints, caching is removed from them

…

### Reviewer guidance
- Login to the devserver
- Change `SESSION_COOKIE_AGE` in base settings to 1
- Request the channelmetadata endpoint /api/content/channel/
- Note that the set-cookie header is not set

…
