### PR TITLE
Restrict API for device info for non-superadmin users

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -113,6 +113,19 @@ class DeviceInfoView(views.APIView):
         info["python_version"] = "{major}.{minor}.{micro}".format(
             major=version_info.major, minor=version_info.minor, micro=version_info.micro
         )
+
+        if not request.user.is_superuser:
+            # If user is not superuser, return just free space available
+            info.pop("version")
+            info.pop("urls")
+            info.pop("database_path")
+            info.pop("device_id")
+            info.pop("os")
+            info.pop("server_time")
+            info.pop("server_timezone")
+            info.pop("installer")
+            info.pop("python_version")
+
         return Response(info)
 
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -115,16 +115,19 @@ class DeviceInfoView(views.APIView):
         )
 
         if not request.user.is_superuser:
-            # If user is not superuser, return just free space available
-            info.pop("version")
-            info.pop("urls")
-            info.pop("database_path")
-            info.pop("device_id")
-            info.pop("os")
-            info.pop("server_time")
-            info.pop("server_timezone")
-            info.pop("installer")
-            info.pop("python_version")
+            # If user is not superuser, return just free space available and kolibri version
+            keys_to_remove = [
+                "urls",
+                "database_path",
+                "device_id",
+                "os",
+                "server_time",
+                "server_timezone",
+                "installer",
+                "python_version",
+            ]
+            for key in keys_to_remove:
+                info.pop(key)
 
         return Response(info)
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -127,7 +127,7 @@ class DeviceInfoView(views.APIView):
                 "python_version",
             ]
             for key in keys_to_remove:
-                info.pop(key)
+                del info[key]
 
         return Response(info)
 

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -86,7 +86,7 @@ const routes = [
   },
   {
     name: PageNames.DEVICE_INFO_PAGE,
-    component: withAuthMessage(DeviceInfoPage, 'contentManager'),
+    component: withAuthMessage(DeviceInfoPage, 'superuser'),
     path: '/info',
     handler: ({ name }) => {
       store.dispatch('preparePage', { name });


### PR DESCRIPTION
### Summary

1. Added check to remove privileged information from `Device Info` endpoint for non-superadmin users: `/api/device/deviceinfo/` now only returns the free space available. Superadmin users still can see all device info.
2. For frontend, added restricted, "unauthorized" message for non-superadmins in case there is a frontend issue, similar to: ![image](https://user-images.githubusercontent.com/2367265/76391360-9f448480-632c-11ea-936c-65c8d689aa62.png)

…

### Reviewer guidance

**Check that the endpoint is still reachable and returns 'free space' by the following users:**

1. Coach
2. Learner that can manage content
3. Admin

**Check that the endpoint is still reachable and returns all device info by the following user:**
1. Superadmin

…

### References

Addresses #6650 

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
