### PR TITLE
Make `CoreTable` compatiable with Vue 3 slot syntax + change API to make headers less nested

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -1,5 +1,7 @@
 <script>
 
+  import get from 'lodash/get';
+
   export default {
     name: 'CoreTable',
     props: {
@@ -40,15 +42,19 @@
     },
     render(createElement) {
       let tableHasRows = true;
-      this.$slots.thead.forEach(thead => {
-        thead.data.style = Object.assign(thead.data.style || {}, this.tHeadStyle);
-      });
 
-      this.$slots.tbody.forEach(tbody => {
+      // create <thead> element with #headers slot
+      const theadEl = createElement('thead', { style: this.tHeadStyle }, [
+        createElement('tr', {}, this.$slots.headers),
+      ]);
+
+      const tbodyCopy = [...this.$slots.tbody];
+      tbodyCopy.forEach(tbody => {
         // Need to check componentOptions if wrapped in <transition-group>, or just children
         // if in regular <tbody>
-        if (tbody.componentOptions && tbody.componentOptions.children) {
-          tableHasRows = tbody.componentOptions.children.length > 0;
+        const tgroupChildren = get(tbody, 'componentOptions.children');
+        if (tgroupChildren) {
+          tableHasRows = tgroupChildren.length > 0;
         }
 
         if (tbody.children) {
@@ -74,8 +80,8 @@
       return createElement('div', { class: 'core-table-container' }, [
         createElement('table', { class: 'core-table' }, [
           ...(this.$slots.default || []),
-          this.$slots.thead,
-          this.$slots.tbody,
+          theadEl,
+          tbodyCopy,
         ]),
         showEmptyMessage && createElement('p', this.emptyMessage),
       ]);

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -11,27 +11,27 @@
     <KPageContainer>
       <h1>{{ coreString('facilitiesLabel') }} </h1>
       <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th>{{ coreString('nameLabel') }}</th>
-            <th>{{ coreString('classesLabel') }}</th>
-          </tr>
-        </thead>
-        <tbody slot="tbody">
-          <tr v-for="facility in facilities" :key="facility.id">
-            <td>
-              <KLabeledIcon icon="facility">
-                <KRouterLink
-                  :text="facility.name"
-                  :to="coachClassListPageLink(facility)"
-                />
-              </KLabeledIcon>
-            </td>
-            <td>
-              {{ $formatNumber(facility.num_classrooms) }}
-            </td>
-          </tr>
-        </tbody>
+        <template #headers>
+          <th>{{ coreString('nameLabel') }}</th>
+          <th>{{ coreString('classesLabel') }}</th>
+        </template>
+        <template #tbody>
+          <tbody>
+            <tr v-for="facility in facilities" :key="facility.id">
+              <td>
+                <KLabeledIcon icon="facility">
+                  <KRouterLink
+                    :text="facility.name"
+                    :to="coachClassListPageLink(facility)"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                {{ $formatNumber(facility.num_classrooms) }}
+              </td>
+            </tr>
+          </tbody>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -37,31 +37,31 @@
       </p>
 
       <CoreTable v-else>
-        <thead slot="thead">
-          <tr>
-            <th>{{ coreString('classNameLabel') }}</th>
-            <th>{{ coreString('coachesLabel') }}</th>
-            <th>{{ coreString('learnersLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="classObj in classList" :key="classObj.id">
-            <td>
-              <KLabeledIcon icon="classes">
-                <KRouterLink
-                  :text="classObj.name"
-                  :to="$router.getRoute('HomePage', { classId: classObj.id })"
-                />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
-            </td>
-            <td>
-              {{ coachString('integer', { value: classObj.learner_count }) }}
-            </td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coreString('classNameLabel') }}</th>
+          <th>{{ coreString('coachesLabel') }}</th>
+          <th>{{ coreString('learnersLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="classObj in classList" :key="classObj.id">
+              <td>
+                <KLabeledIcon icon="classes">
+                  <KRouterLink
+                    :text="classObj.name"
+                    :to="$router.getRoute('HomePage', { classId: classObj.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
+              </td>
+              <td>
+                {{ coachString('integer', { value: classObj.learner_count }) }}
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -34,60 +34,60 @@
         />
       </div>
       <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coachString('recipientsLabel') }}</th>
-            <th class="center-text">
-              {{ coachString('statusLabel') }}
-            </th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr
-            v-for="exam in filteredExams"
-            :key="exam.id"
-          >
-            <td>
-              <KLabeledIcon icon="quiz">
-                <KRouterLink
-                  :to="$router.getRoute('QuizSummaryPage', { quizId: exam.id })"
-                  appearance="basic-link"
-                  :text="exam.title"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ coachString('recipientsLabel') }}</th>
+          <th class="center-text">
+            {{ coachString('statusLabel') }}
+          </th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr
+              v-for="exam in filteredExams"
+              :key="exam.id"
+            >
+              <td>
+                <KLabeledIcon icon="quiz">
+                  <KRouterLink
+                    :to="$router.getRoute('QuizSummaryPage', { quizId: exam.id })"
+                    appearance="basic-link"
+                    :text="exam.title"
+                  />
+                </KLabeledIcon>
+              </td>
+
+              <td>
+                <Recipients
+                  :groupNames="getRecipientNamesForExam(exam)"
+                  :hasAssignments="exam.assignments.length > 0"
                 />
-              </KLabeledIcon>
-            </td>
+              </td>
 
-            <td>
-              <Recipients
-                :groupNames="getRecipientNamesForExam(exam)"
-                :hasAssignments="exam.assignments.length > 0"
-              />
-            </td>
+              <td class="button-col center-text core-table-button-col">
+                <!-- Open quiz button -->
+                <KButton
+                  v-if="!exam.active && !exam.archive"
+                  :text="coachString('openQuizLabel')"
+                  appearance="flat-button"
+                  @click="showOpenConfirmationModal = true; modalQuizId = exam.id"
+                />
+                <!-- Close quiz button -->
+                <KButton
+                  v-if="exam.active && !exam.archive"
+                  :text="coachString('closeQuizLabel')"
+                  appearance="flat-button"
+                  @click="showCloseConfirmationModal = true; modalQuizId = exam.id;"
+                />
+                <!-- Closed quiz label -->
+                <div v-if="exam.archive">
+                  {{ coachString('quizClosedLabel') }}
+                </div>
+              </td>
 
-            <td class="button-col center-text core-table-button-col">
-              <!-- Open quiz button -->
-              <KButton
-                v-if="!exam.active && !exam.archive"
-                :text="coachString('openQuizLabel')"
-                appearance="flat-button"
-                @click="showOpenConfirmationModal = true; modalQuizId = exam.id"
-              />
-              <!-- Close quiz button -->
-              <KButton
-                v-if="exam.active && !exam.archive"
-                :text="coachString('closeQuizLabel')"
-                appearance="flat-button"
-                @click="showCloseConfirmationModal = true; modalQuizId = exam.id;"
-              />
-              <!-- Closed quiz label -->
-              <div v-if="exam.archive">
-                {{ coachString('quizClosedLabel') }}
-              </div>
-            </td>
-
-          </tr>
-        </transition-group>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
 
       <p v-if="!exams.length">

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -43,42 +43,37 @@
         </KFixedGrid>
 
         <CoreTable>
-          <thead slot="thead">
-            <tr>
-              <th>
-                {{ coreString('fullNameLabel') }}
-              </th>
-              <th>
-                {{ coreString('usernameLabel') }}
-              </th>
-              <th></th>
-            </tr>
+          <template #headers>
+            <th>{{ coreString('fullNameLabel') }}</th>
+            <th>{{ coreString('usernameLabel') }}</th>
+            <th></th>
+          </template>
 
-          </thead>
-
-          <tbody slot="tbody">
-            <p v-if="currentGroup.users.length === 0">
-              {{ $tr('noLearnersInGroup') }}
-            </p>
-            <tr
-              v-for="user in currentGroup.users"
-              :key="user.id"
-            >
-              <td>
-                <KLabeledIcon icon="person" :label="user.full_name" />
-              </td>
-              <td>
-                {{ user.username }}
-              </td>
-              <td class="core-table-button-col">
-                <KButton
-                  :text="coreString('removeAction')"
-                  appearance="flat-button"
-                  @click="userForRemoval = user"
-                />
-              </td>
-            </tr>
-          </tbody>
+          <template #tbody>
+            <tbody>
+              <p v-if="currentGroup.users.length === 0">
+                {{ $tr('noLearnersInGroup') }}
+              </p>
+              <tr
+                v-for="user in currentGroup.users"
+                :key="user.id"
+              >
+                <td>
+                  <KLabeledIcon icon="person" :label="user.full_name" />
+                </td>
+                <td>
+                  {{ user.username }}
+                </td>
+                <td class="core-table-button-col">
+                  <KButton
+                    :text="coreString('removeAction')"
+                    appearance="flat-button"
+                    @click="userForRemoval = user"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </template>
         </CoreTable>
         <RemoveFromGroupModal
           v-if="userForRemoval"

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -21,27 +21,22 @@
       </div>
 
       <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th>
-              {{ coachString('nameLabel') }}
-            </th>
-            <th>
-              {{ coreString('learnersLabel') }}
-            </th>
-            <th></th>
-          </tr>
-
-        </thead>
-        <tbody slot="tbody">
-          <GroupRowTr
-            v-for="group in sortedGroups"
-            :key="group.id"
-            :group="group"
-            @rename="openRenameGroupModal"
-            @delete="openDeleteGroupModal"
-          />
-        </tbody>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coreString('learnersLabel') }}</th>
+          <th></th>
+        </template>
+        <template #tbody>
+          <tbody>
+            <GroupRowTr
+              v-for="group in sortedGroups"
+              :key="group.id"
+              :group="group"
+              @rename="openRenameGroupModal"
+              @delete="openDeleteGroupModal"
+            />
+          </tbody>
+        </template>
       </CoreTable>
 
       <p v-if="!sortedGroups.length">

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -35,46 +35,46 @@
       </div>
 
       <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ $tr('size') }}</th>
-            <th>{{ coachString('recipientsLabel') }}</th>
-            <th>{{ $tr('visibleToLearnersLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr
-            v-for="lesson in sortedLessons"
-            v-show="showLesson(lesson)"
-            :key="lesson.id"
-          >
-            <td>
-              <KLabeledIcon icon="lesson">
-                <KRouterLink
-                  :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
-                  :text="lesson.title"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ $tr('size') }}</th>
+          <th>{{ coachString('recipientsLabel') }}</th>
+          <th>{{ $tr('visibleToLearnersLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr
+              v-for="lesson in sortedLessons"
+              v-show="showLesson(lesson)"
+              :key="lesson.id"
+            >
+              <td>
+                <KLabeledIcon icon="lesson">
+                  <KRouterLink
+                    :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
+                    :text="lesson.title"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>{{ coachString('numberOfResources', { value: lesson.resources.length }) }}</td>
+              <td>
+                <Recipients
+                  :groupNames="getRecipientNamesForLesson(lesson)"
+                  :hasAssignments="lesson.lesson_assignments.length > 0 ||
+                    lesson.learner_ids.length > 0"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>{{ coachString('numberOfResources', { value: lesson.resources.length }) }}</td>
-            <td>
-              <Recipients
-                :groupNames="getRecipientNamesForLesson(lesson)"
-                :hasAssignments="lesson.lesson_assignments.length > 0 ||
-                  lesson.learner_ids.length > 0"
-              />
-            </td>
-            <td>
-              <KSwitch
-                name="toggle-lesson-visibility"
-                :checked="lesson.is_active"
-                :value="lesson.is_active"
-                @change="handleToggleVisibility(lesson)"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+              <td>
+                <KSwitch
+                  name="toggle-lesson-visibility"
+                  :checked="lesson.is_active"
+                  :value="lesson.is_active"
+                  @change="handleToggleVisibility(lesson)"
+                />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
 
       <p v-if="!lessons.length">

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -32,45 +32,45 @@
             :selectable="true"
             :emptyMessage="$tr('noUsersMatch')"
           >
-            <thead slot="thead">
-              <tr>
-                <th class="table-checkbox-header">
-                  <KCheckbox
-                    key="selectAllOnPage"
-                    :label="$tr('selectAllLabel')"
-                    :checked="selectAllCheckboxProps.checked"
-                    :disabled="selectAllCheckboxProps.disabled"
-                    @change="selectVisiblePage"
-                  />
-                </th>
-                <th class="table-header">
-                  {{ coreString('usernameLabel') }}
-                </th>
-                <th class="table-header">
-                  {{ coachString('groupsLabel') }}
-                </th>
-              </tr>
-            </thead>
+            <template #headers>
+              <th class="table-checkbox-header">
+                <KCheckbox
+                  key="selectAllOnPage"
+                  :label="$tr('selectAllLabel')"
+                  :checked="selectAllCheckboxProps.checked"
+                  :disabled="selectAllCheckboxProps.disabled"
+                  @change="selectVisiblePage"
+                />
+              </th>
+              <th class="table-header">
+                {{ coreString('usernameLabel') }}
+              </th>
+              <th class="table-header">
+                {{ coachString('groupsLabel') }}
+              </th>
+            </template>
 
-            <tbody slot="tbody">
-              <tr v-for="learner in items" :key="learner.id">
-                <td>
-                  <KCheckbox
-                    :key="`select-learner-${learner.id}`"
-                    :label="learner.name"
-                    :checked="learnerIsSelected(learner)"
-                    :disabled="learnerIsNotSelectable(learner)"
-                    @change="toggleLearner($event, learner)"
-                  />
-                </td>
-                <td class="table-data">
-                  {{ learner.username }}
-                </td>
-                <td class="table-data">
-                  {{ groupNamesForLearner(learner) }}
-                </td>
-              </tr>
-            </tbody>
+            <template #tbody>
+              <tbody>
+                <tr v-for="learner in items" :key="learner.id">
+                  <td>
+                    <KCheckbox
+                      :key="`select-learner-${learner.id}`"
+                      :label="learner.name"
+                      :checked="learnerIsSelected(learner)"
+                      :disabled="learnerIsNotSelectable(learner)"
+                      @change="toggleLearner($event, learner)"
+                    />
+                  </td>
+                  <td class="table-data">
+                    {{ learner.username }}
+                  </td>
+                  <td class="table-data">
+                    {{ groupNamesForLearner(learner) }}
+                  </td>
+                </tr>
+              </tbody>
+            </template>
           </CoreTable>
         </template>
       </PaginatedListContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -1,50 +1,50 @@
 <template>
 
   <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-    <thead slot="thead">
-      <tr>
-        <th>{{ coachString('nameLabel') }}</th>
-        <th>{{ coreString('progressLabel') }}</th>
-        <th>{{ coachString('timeSpentLabel') }}</th>
-        <th v-if="showGroupsColumn">
-          {{ coachString('groupsLabel') }}
-        </th>
-        <th>{{ coachString('lastActivityLabel') }}</th>
-      </tr>
-    </thead>
-    <transition-group slot="tbody" tag="tbody" name="list">
-      <tr v-for="entry in entries" :key="entry.id" data-test="entry">
-        <td>
-          <KLabeledIcon icon="person">
-            <KRouterLink
-              v-if="showLink(entry)"
-              :text="entry.name"
-              :to="entry.exerciseLearnerLink"
-              data-test="exercise-learner-link"
+    <template #headers>
+      <th>{{ coachString('nameLabel') }}</th>
+      <th>{{ coreString('progressLabel') }}</th>
+      <th>{{ coachString('timeSpentLabel') }}</th>
+      <th v-if="showGroupsColumn">
+        {{ coachString('groupsLabel') }}
+      </th>
+      <th>{{ coachString('lastActivityLabel') }}</th>
+    </template>
+    <template #tbody>
+      <transition-group tag="tbody" name="list">
+        <tr v-for="entry in entries" :key="entry.id" data-test="entry">
+          <td>
+            <KLabeledIcon icon="person">
+              <KRouterLink
+                v-if="showLink(entry)"
+                :text="entry.name"
+                :to="entry.exerciseLearnerLink"
+                data-test="exercise-learner-link"
+              />
+              <template v-else>
+                {{ entry.name }}
+              </template>
+            </KLabeledIcon>
+          </td>
+          <td>
+            <StatusSimple :status="entry.statusObj.status" />
+          </td>
+          <td>
+            <TimeDuration
+              :seconds="timeDuration(entry)"
             />
-            <template v-else>
-              {{ entry.name }}
-            </template>
-          </KLabeledIcon>
-        </td>
-        <td>
-          <StatusSimple :status="entry.statusObj.status" />
-        </td>
-        <td>
-          <TimeDuration
-            :seconds="timeDuration(entry)"
-          />
-        </td>
-        <td v-if="showGroupsColumn">
-          <TruncatedItemList :items="getGroupNames(entry)" />
-        </td>
-        <td>
-          <ElapsedTime
-            :date="elapsedTime(entry)"
-          />
-        </td>
-      </tr>
-    </transition-group>
+          </td>
+          <td v-if="showGroupsColumn">
+            <TruncatedItemList :items="getGroupNames(entry)" />
+          </td>
+          <td>
+            <ElapsedTime
+              :date="elapsedTime(entry)"
+            />
+          </td>
+        </tr>
+      </transition-group>
+    </template>
   </CoreTable>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -15,31 +15,31 @@
       <ReportsGroupHeader :enablePrint="true" />
       <ReportsControls @export="exportCSV" />
       <CoreTable :emptyMessage="coachString('learnerListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('nameLabel') }}</th>
-            <th>{{ coachString('avgQuizScoreLabel') }}</th>
-            <th>{{ coachString('exercisesCompletedLabel') }}</th>
-            <th>{{ coachString('resourcesViewedLabel') }}</th>
-            <th>{{ coachString('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="person">
-                <KRouterLink
-                  :text="tableRow.name"
-                  :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
-                />
-              </KLabeledIcon>
-            </td>
-            <td><Score :value="tableRow.avgScore" /></td>
-            <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
-            <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
-            <td><ElapsedTime :date="tableRow.lastActivity" /></td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coachString('avgQuizScoreLabel') }}</th>
+          <th>{{ coachString('exercisesCompletedLabel') }}</th>
+          <th>{{ coachString('resourcesViewedLabel') }}</th>
+          <th>{{ coachString('lastActivityLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="person">
+                  <KRouterLink
+                    :text="tableRow.name"
+                    :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td><Score :value="tableRow.avgScore" /></td>
+              <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
+              <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
+              <td><ElapsedTime :date="tableRow.lastActivity" /></td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -15,39 +15,39 @@
       <ReportsHeader :title="$isPrint ? $tr('printLabel', { className }) : null" />
       <ReportsControls @export="exportCSV" />
       <CoreTable :emptyMessage="coachString('groupListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('groupNameLabel') }}</th>
-            <th>{{ coreString('lessonsLabel') }}</th>
-            <th>{{ coreString('quizzesLabel') }}</th>
-            <th>{{ coreString('learnersLabel') }}</th>
-            <th>{{ coachString('avgQuizScoreLabel') }}</th>
-            <th>{{ coachString('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="group">
-                <KRouterLink
-                  :text="tableRow.name"
-                  :to="classRoute('ReportsGroupReportPage', { groupId: tableRow.id })"
-                />
-              </KLabeledIcon>
-            </td>
-            <td>
-              {{ coachString('integer', { value: tableRow.numLessons }) }}
-            </td>
-            <td>
-              {{ coachString('integer', { value: tableRow.numQuizzes }) }}
-            </td>
-            <td>
-              {{ coachString('integer', { value: tableRow.numLearners }) }}
-            </td>
-            <td><Score :value="tableRow.avgScore" /></td>
-            <td><ElapsedTime :date="tableRow.lastActivity" /></td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('groupNameLabel') }}</th>
+          <th>{{ coreString('lessonsLabel') }}</th>
+          <th>{{ coreString('quizzesLabel') }}</th>
+          <th>{{ coreString('learnersLabel') }}</th>
+          <th>{{ coachString('avgQuizScoreLabel') }}</th>
+          <th>{{ coachString('lastActivityLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="group">
+                  <KRouterLink
+                    :text="tableRow.name"
+                    :to="classRoute('ReportsGroupReportPage', { groupId: tableRow.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                {{ coachString('integer', { value: tableRow.numLessons }) }}
+              </td>
+              <td>
+                {{ coachString('integer', { value: tableRow.numQuizzes }) }}
+              </td>
+              <td>
+                {{ coachString('integer', { value: tableRow.numLearners }) }}
+              </td>
+              <td><Score :value="tableRow.avgScore" /></td>
+              <td><ElapsedTime :date="tableRow.lastActivity" /></td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -22,41 +22,41 @@
       </ReportsControls>
 
       <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('nameLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('timeSpentLabel') }}</th>
-            <th>{{ coachString('groupsLabel') }}</th>
-            <th>{{ coachString('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KRouterLink
-                v-if="showLink(tableRow.statusObj.status)"
-                :text="tableRow.name"
-                :to="link(tableRow.id)"
-              />
-              <template v-else>
-                {{ tableRow.name }}
-              </template>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration :seconds="tableRow.statusObj.time_spent" />
-            </td>
-            <td>
-              <TruncatedItemList :items="tableRow.groups" />
-            </td>
-            <td>
-              <ElapsedTime :date="tableRow.statusObj.last_activity" />
-            </td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('timeSpentLabel') }}</th>
+          <th>{{ coachString('groupsLabel') }}</th>
+          <th>{{ coachString('lastActivityLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KRouterLink
+                  v-if="showLink(tableRow.statusObj.status)"
+                  :text="tableRow.name"
+                  :to="link(tableRow.id)"
+                />
+                <template v-else>
+                  {{ tableRow.name }}
+                </template>
+              </td>
+              <td>
+                <StatusSimple :status="tableRow.statusObj.status" />
+              </td>
+              <td>
+                <TimeDuration :seconds="tableRow.statusObj.time_spent" />
+              </td>
+              <td>
+                <TruncatedItemList :items="tableRow.groups" />
+              </td>
+              <td>
+                <ElapsedTime :date="tableRow.statusObj.last_activity" />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -20,33 +20,33 @@
       </ReportsControls>
 
       <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('questionLabel') }}</th>
-            <th>{{ coachString('helpNeededLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.question_id">
-            <td>
-              <KLabeledIcon icon="person">
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.question_id)"
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.question_id">
+              <td>
+                <KLabeledIcon icon="person">
+                  <KRouterLink
+                    :text="tableRow.title"
+                    :to="questionLink(tableRow.question_id)"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <LearnerProgressRatio
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
-                :total="tableRow.total"
-                :count="tableRow.total - tableRow.correct"
-                :verbosity="1"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -45,46 +45,46 @@
       <ReportsControls @export="exportCSV" />
 
       <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('avgTimeSpentLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.node_id">
-            <td>
-              <KLabeledIcon :icon="tableRow.kind">
-                <KRouterLink
-                  v-if="tableRow.kind === 'exercise'"
-                  :text="tableRow.title"
-                  :to="classRoute(
-                    'ReportsGroupReportLessonExerciseLearnerListPage',
-                    { exerciseId: tableRow.content_id }
-                  )"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('avgTimeSpentLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.node_id">
+              <td>
+                <KLabeledIcon :icon="tableRow.kind">
+                  <KRouterLink
+                    v-if="tableRow.kind === 'exercise'"
+                    :text="tableRow.title"
+                    :to="classRoute(
+                      'ReportsGroupReportLessonExerciseLearnerListPage',
+                      { exerciseId: tableRow.content_id }
+                    )"
+                  />
+                  <KRouterLink
+                    v-else
+                    :text="tableRow.title"
+                    :to="classRoute(
+                      'ReportsGroupReportLessonResourceLearnerListPage',
+                      { resourceId: tableRow.content_id }
+                    )"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <StatusSummary
+                  :tally="tableRow.tally"
+                  :verbose="true"
                 />
-                <KRouterLink
-                  v-else
-                  :text="tableRow.title"
-                  :to="classRoute(
-                    'ReportsGroupReportLessonResourceLearnerListPage',
-                    { resourceId: tableRow.content_id }
-                  )"
-                />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSummary
-                :tally="tableRow.tally"
-                :verbose="true"
-              />
-            </td>
-            <td>
-              <TimeDuration :seconds="tableRow.avgTimeSpent" />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+              <td>
+                <TimeDuration :seconds="tableRow.avgTimeSpent" />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -56,34 +56,34 @@
       </ReportsControls>
 
       <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('nameLabel') }}</th>
-            <th>{{ coachString('statusLabel') }}</th>
-            <th>{{ coachString('timeSpentLabel') }}</th>
-            <th>{{ coachString('groupsLabel') }}</th>
-            <th>{{ coachString('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="person" :label="tableRow.name" />
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration :seconds="tableRow.statusObj.time_spent" />
-            </td>
-            <td>
-              <TruncatedItemList :items="tableRow.groups" />
-            </td>
-            <td>
-              <ElapsedTime :date="tableRow.statusObj.last_activity" />
-            </td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coachString('statusLabel') }}</th>
+          <th>{{ coachString('timeSpentLabel') }}</th>
+          <th>{{ coachString('groupsLabel') }}</th>
+          <th>{{ coachString('lastActivityLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="person" :label="tableRow.name" />
+              </td>
+              <td>
+                <StatusSimple :status="tableRow.statusObj.status" />
+              </td>
+              <td>
+                <TimeDuration :seconds="tableRow.statusObj.time_spent" />
+              </td>
+              <td>
+                <TruncatedItemList :items="tableRow.groups" />
+              </td>
+              <td>
+                <ElapsedTime :date="tableRow.statusObj.last_activity" />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -18,33 +18,33 @@
       <ReportsControls @export="exportCSV" />
 
       <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('nameLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('scoreLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="person">
-                <KRouterLink
-                  v-if="tableRow.statusObj.status !== STATUSES.notStarted"
-                  :text="tableRow.name"
-                  :to="detailLink(tableRow.id)"
-                />
-                <template v-else>
-                  {{ tableRow.name }}
-                </template>
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td><Score :value="tableRow.statusObj.score" /></td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('scoreLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="person">
+                  <KRouterLink
+                    v-if="tableRow.statusObj.status !== STATUSES.notStarted"
+                    :text="tableRow.name"
+                    :to="detailLink(tableRow.id)"
+                  />
+                  <template v-else>
+                    {{ tableRow.name }}
+                  </template>
+                </KLabeledIcon>
+              </td>
+              <td>
+                <StatusSimple :status="tableRow.statusObj.status" />
+              </td>
+              <td><Score :value="tableRow.statusObj.score" /></td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -22,33 +22,33 @@
       </ReportsControls>
 
       <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('questionLabel') }}</th>
-            <th>{{ coachString('helpNeededLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.question_id">
-            <td>
-              <KLabeledIcon icon="question">
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.question_id)"
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.question_id">
+              <td>
+                <KLabeledIcon icon="question">
+                  <KRouterLink
+                    :text="tableRow.title"
+                    :to="questionLink(tableRow.question_id)"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <LearnerProgressRatio
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
-                :total="tableRow.total"
-                :count="tableRow.total - tableRow.correct"
-                :verbosity="1"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -15,33 +15,33 @@
       <ReportsHeader :title="$isPrint ? $tr('printLabel', { className }) : null" />
       <ReportsControls @export="exportCSV" />
       <CoreTable :emptyMessage="coachString('learnerListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('nameLabel') }}</th>
-            <th>{{ coachString('groupsLabel') }}</th>
-            <th>{{ coachString('avgQuizScoreLabel') }}</th>
-            <th>{{ coachString('exercisesCompletedLabel') }}</th>
-            <th>{{ coachString('resourcesViewedLabel') }}</th>
-            <th>{{ coachString('lastActivityLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="person">
-                <KRouterLink
-                  :text="tableRow.name"
-                  :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
-                />
-              </KLabeledIcon>
-            </td>
-            <td><TruncatedItemList :items="tableRow.groups" /></td>
-            <td><Score :value="tableRow.avgScore" /></td>
-            <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
-            <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
-            <td><ElapsedTime :date="tableRow.lastActivity" /></td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('nameLabel') }}</th>
+          <th>{{ coachString('groupsLabel') }}</th>
+          <th>{{ coachString('avgQuizScoreLabel') }}</th>
+          <th>{{ coachString('exercisesCompletedLabel') }}</th>
+          <th>{{ coachString('resourcesViewedLabel') }}</th>
+          <th>{{ coachString('lastActivityLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="person">
+                  <KRouterLink
+                    :text="tableRow.name"
+                    :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td><TruncatedItemList :items="tableRow.groups" /></td>
+              <td><Score :value="tableRow.avgScore" /></td>
+              <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
+              <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
+              <td><ElapsedTime :date="tableRow.lastActivity" /></td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -55,40 +55,40 @@
       <ReportsControls @export="exportCSV" />
 
       <CoreTable :emptyMessage="emptyMessage">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('timeSpentLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.node_id">
-            <td>
-              <KLabeledIcon :icon="tableRow.kind">
-                <KRouterLink
-                  v-if="showLink(tableRow)"
-                  :text="tableRow.title"
-                  :to="classRoute(
-                    'ReportsLearnerReportLessonExercisePage',
-                    { exerciseId: tableRow.content_id }
-                  )"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('timeSpentLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.node_id">
+              <td>
+                <KLabeledIcon :icon="tableRow.kind">
+                  <KRouterLink
+                    v-if="showLink(tableRow)"
+                    :text="tableRow.title"
+                    :to="classRoute(
+                      'ReportsLearnerReportLessonExercisePage',
+                      { exerciseId: tableRow.content_id }
+                    )"
+                  />
+                  <template v-else>
+                    {{ tableRow.title }}
+                  </template>
+                </KLabeledIcon>
+              </td>
+              <td>
+                <StatusSimple :status="tableRow.statusObj.status" />
+              </td>
+              <td>
+                <TimeDuration
+                  :seconds="showTime(tableRow)"
                 />
-                <template v-else>
-                  {{ tableRow.title }}
-                </template>
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration
-                :seconds="showTime(tableRow)"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -21,55 +21,57 @@
         <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
           <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
           <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
-            <thead slot="thead">
-              <tr>
-                <th>{{ coachString('titleLabel') }}</th>
-                <th>{{ coreString('progressLabel') }}</th>
-              </tr>
-            </thead>
-            <transition-group slot="tbody" tag="tbody" name="list">
-              <tr v-for="tableRow in lessonsTable" :key="tableRow.id">
-                <td>
-                  <KLabeledIcon icon="lesson">
-                    <KRouterLink
-                      :to="classRoute('ReportsLearnerReportLessonPage', { lessonId: tableRow.id })"
-                      :text="tableRow.title"
-                    />
-                  </KLabeledIcon>
-                </td>
-                <td>
-                  <StatusSimple :status="tableRow.status" />
-                </td>
-              </tr>
-            </transition-group>
+            <template #headers>
+              <th>{{ coachString('titleLabel') }}</th>
+              <th>{{ coreString('progressLabel') }}</th>
+            </template>
+            <template #tbody>
+              <transition-group tag="tbody" name="list">
+                <tr v-for="tableRow in lessonsTable" :key="tableRow.id">
+                  <td>
+                    <KLabeledIcon icon="lesson">
+                      <KRouterLink
+                        :to="classRoute('ReportsLearnerReportLessonPage', {
+                          lessonId: tableRow.id
+                        })"
+                        :text="tableRow.title"
+                      />
+                    </KLabeledIcon>
+                  </td>
+                  <td>
+                    <StatusSimple :status="tableRow.status" />
+                  </td>
+                </tr>
+              </transition-group>
+            </template>
           </CoreTable>
         </KGridItem>
         <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
           <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
           <CoreTable :class="{ print: $isPrint }" :emptyMessage="coachString('quizListEmptyState')">
-            <thead slot="thead">
-              <tr>
-                <th>{{ coachString('titleLabel') }}</th>
-                <th>{{ coreString('progressLabel') }}</th>
-                <th>{{ coachString('scoreLabel') }}</th>
-              </tr>
-            </thead>
-            <transition-group slot="tbody" tag="tbody" name="list">
-              <tr v-for="tableRow in examsTable" :key="tableRow.id">
-                <td>
-                  <KLabeledIcon icon="quiz">
-                    <KRouterLink
-                      :to="quizLink(tableRow.id)"
-                      :text="tableRow.title"
-                    />
-                  </KLabeledIcon>
-                </td>
-                <td>
-                  <StatusSimple :status="tableRow.statusObj.status" />
-                </td>
-                <td><Score :value="tableRow.statusObj.score" /></td>
-              </tr>
-            </transition-group>
+            <template #headers>
+              <th>{{ coachString('titleLabel') }}</th>
+              <th>{{ coreString('progressLabel') }}</th>
+              <th>{{ coachString('scoreLabel') }}</th>
+            </template>
+            <template #tbody>
+              <transition-group tag="tbody" name="list">
+                <tr v-for="tableRow in examsTable" :key="tableRow.id">
+                  <td>
+                    <KLabeledIcon icon="quiz">
+                      <KRouterLink
+                        :to="quizLink(tableRow.id)"
+                        :text="tableRow.title"
+                      />
+                    </KLabeledIcon>
+                  </td>
+                  <td>
+                    <StatusSimple :status="tableRow.statusObj.status" />
+                  </td>
+                  <td><Score :value="tableRow.statusObj.score" /></td>
+                </tr>
+              </transition-group>
+            </template>
           </CoreTable>
         </KGridItem>
       </KGrid>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -21,31 +21,31 @@
         {{ coachString('overallLabel') }}
       </h2>
       <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('questionLabel') }}</th>
-            <th>{{ coachString('helpNeededLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.question_id">
-            <td>
-              <KRouterLink
-                :text="tableRow.title"
-                :to="questionLink(tableRow.question_id)"
-              />
-            </td>
-            <td>
-              <LearnerProgressRatio
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
-                :total="tableRow.total"
-                :count="tableRow.total - tableRow.correct"
-                :verbosity="1"
-              />
-            </td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.question_id">
+              <td>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.question_id)"
+                />
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
+                />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -53,31 +53,31 @@
           </h2>
 
           <CoreTable :emptyMessage="coachString('learnerListEmptyState')">
-            <thead slot="thead">
-              <tr>
-                <th>{{ coachString('nameLabel') }}</th>
-                <th>{{ coreString('progressLabel') }}</th>
-                <th>{{ coachString('groupsLabel') }}</th>
-              </tr>
-            </thead>
-            <transition-group slot="tbody" tag="tbody" name="list">
-              <tr v-for="tableRow in table" :key="tableRow.id">
-                <td>
-                  <KLabeledIcon icon="person">
-                    <KRouterLink
-                      :text="tableRow.name"
-                      :to="classRoute('ReportsLessonLearnerPage', { learnerId: tableRow.id })"
-                    />
-                  </KLabeledIcon>
-                </td>
-                <td>
-                  <StatusSimple :status="tableRow.status" />
-                </td>
-                <td>
-                  <TruncatedItemList :items="tableRow.groups" />
-                </td>
-              </tr>
-            </transition-group>
+            <template #headers>
+              <th>{{ coachString('nameLabel') }}</th>
+              <th>{{ coreString('progressLabel') }}</th>
+              <th>{{ coachString('groupsLabel') }}</th>
+            </template>
+            <template #tbody>
+              <transition-group tag="tbody" name="list">
+                <tr v-for="tableRow in table" :key="tableRow.id">
+                  <td>
+                    <KLabeledIcon icon="person">
+                      <KRouterLink
+                        :text="tableRow.name"
+                        :to="classRoute('ReportsLessonLearnerPage', { learnerId: tableRow.id })"
+                      />
+                    </KLabeledIcon>
+                  </td>
+                  <td>
+                    <StatusSimple :status="tableRow.status" />
+                  </td>
+                  <td>
+                    <TruncatedItemList :items="tableRow.groups" />
+                  </td>
+                </tr>
+              </transition-group>
+            </template>
           </CoreTable>
         </KPageContainer>
       </KGridItem>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerPage.vue
@@ -30,37 +30,37 @@
       <ReportsControls @export="exportCSV" />
 
       <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('timeSpentLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.node_id">
-            <td>
-              <KLabeledIcon :icon="tableRow.kind">
-                <KRouterLink
-                  v-if="showLink(tableRow)"
-                  :text="tableRow.title"
-                  :to="exerciseLink(tableRow.content_id)"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('timeSpentLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.node_id">
+              <td>
+                <KLabeledIcon :icon="tableRow.kind">
+                  <KRouterLink
+                    v-if="showLink(tableRow)"
+                    :text="tableRow.title"
+                    :to="exerciseLink(tableRow.content_id)"
+                  />
+                  <template v-else>
+                    {{ tableRow.title }}
+                  </template>
+                </KLabeledIcon>
+              </td>
+              <td>
+                <StatusSimple :status="tableRow.statusObj.status" />
+              </td>
+              <td>
+                <TimeDuration
+                  :seconds="showTimeDuration(tableRow)"
                 />
-                <template v-else>
-                  {{ tableRow.title }}
-                </template>
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSimple :status="tableRow.statusObj.status" />
-            </td>
-            <td>
-              <TimeDuration
-                :seconds="showTimeDuration(tableRow)"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -23,48 +23,48 @@
         -->
       </ReportsControls>
       <CoreTable :emptyMessage="emptyMessage">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('recipientsLabel') }}</th>
-            <th v-show="!$isPrint">
-              {{ $tr('visibleToLearnersLabel') }}
-            </th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="lesson">
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="classRoute('ReportsLessonReportPage', { lessonId: tableRow.id })"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('recipientsLabel') }}</th>
+          <th v-show="!$isPrint">
+            {{ $tr('visibleToLearnersLabel') }}
+          </th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="lesson">
+                  <KRouterLink
+                    :text="tableRow.title"
+                    :to="classRoute('ReportsLessonReportPage', { lessonId: tableRow.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <StatusSummary
+                  :tally="tableRow.tally"
+                  :verbose="true"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <StatusSummary
-                :tally="tableRow.tally"
-                :verbose="true"
-              />
-            </td>
-            <td>
-              <Recipients
-                :groupNames="getRecipientNamesForExam(tableRow)"
-                :hasAssignments="tableRow.assignments.length > 0"
-              />
-            </td>
-            <td v-show="!$isPrint">
-              <KSwitch
-                name="toggle-lesson-visibility"
-                :checked="tableRow.active"
-                :value="tableRow.active"
-                @change="handleToggleVisibility(tableRow)"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+              <td>
+                <Recipients
+                  :groupNames="getRecipientNamesForExam(tableRow)"
+                  :hasAssignments="tableRow.assignments.length > 0"
+                />
+              </td>
+              <td v-show="!$isPrint">
+                <KSwitch
+                  name="toggle-lesson-visibility"
+                  :checked="tableRow.active"
+                  :value="tableRow.active"
+                  @change="handleToggleVisibility(tableRow)"
+                />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
   </CoreBase>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -48,49 +48,49 @@
             />
           </HeaderTabs>
           <CoreTable :emptyMessage="emptyMessage">
-            <thead slot="thead">
-              <tr>
-                <th>{{ coachString('titleLabel') }}</th>
-                <th>{{ coreString('progressLabel') }}</th>
-                <th>{{ coachString('avgTimeSpentLabel') }}</th>
-              </tr>
-            </thead>
-            <transition-group slot="tbody" tag="tbody" name="list">
-              <tr v-for="tableRow in table" :key="tableRow.node_id">
-                <td>
-                  <KLabeledIcon :icon="tableRow.kind">
-                    <KRouterLink
-                      v-if="tableRow.kind === 'exercise' && tableRow.hasAssignments"
-                      :text="tableRow.title"
-                      :to="classRoute(
-                        'ReportsLessonExerciseLearnerListPage',
-                        { exerciseId: tableRow.content_id }
-                      )"
+            <template #headers>
+              <th>{{ coachString('titleLabel') }}</th>
+              <th>{{ coreString('progressLabel') }}</th>
+              <th>{{ coachString('avgTimeSpentLabel') }}</th>
+            </template>
+            <template #tbody>
+              <transition-group tag="tbody" name="list">
+                <tr v-for="tableRow in table" :key="tableRow.node_id">
+                  <td>
+                    <KLabeledIcon :icon="tableRow.kind">
+                      <KRouterLink
+                        v-if="tableRow.kind === 'exercise' && tableRow.hasAssignments"
+                        :text="tableRow.title"
+                        :to="classRoute(
+                          'ReportsLessonExerciseLearnerListPage',
+                          { exerciseId: tableRow.content_id }
+                        )"
+                      />
+                      <KRouterLink
+                        v-else-if="tableRow.hasAssignments"
+                        :text="tableRow.title"
+                        :to="classRoute(
+                          'ReportsLessonResourceLearnerListPage',
+                          { resourceId: tableRow.content_id }
+                        )"
+                      />
+                      <template v-else>
+                        {{ tableRow.title }}
+                      </template>
+                    </KLabeledIcon>
+                  </td>
+                  <td>
+                    <StatusSummary
+                      :tally="tableRow.tally"
+                      :verbose="true"
                     />
-                    <KRouterLink
-                      v-else-if="tableRow.hasAssignments"
-                      :text="tableRow.title"
-                      :to="classRoute(
-                        'ReportsLessonResourceLearnerListPage',
-                        { resourceId: tableRow.content_id }
-                      )"
-                    />
-                    <template v-else>
-                      {{ tableRow.title }}
-                    </template>
-                  </KLabeledIcon>
-                </td>
-                <td>
-                  <StatusSummary
-                    :tally="tableRow.tally"
-                    :verbose="true"
-                  />
-                </td>
-                <td>
-                  <TimeDuration :seconds="tableRow.avgTimeSpent" />
-                </td>
-              </tr>
-            </transition-group>
+                  </td>
+                  <td>
+                    <TimeDuration :seconds="tableRow.avgTimeSpent" />
+                  </td>
+                </tr>
+              </transition-group>
+            </template>
           </CoreTable>
         </KPageContainer>
       </KGridItem>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -2,68 +2,68 @@
 
   <ReportsQuizBaseListPage @export="exportCSV">
     <CoreTable :emptyMessage="coachString('learnerListEmptyState')">
-      <thead slot="thead">
-        <tr>
-          <th>{{ coachString('nameLabel') }}</th>
-          <th>{{ coreString('progressLabel') }}</th>
-          <th>{{ coachString('scoreLabel') }}</th>
-          <th>{{ coachString('groupsLabel') }}</th>
-        </tr>
-      </thead>
-      <transition-group slot="tbody" tag="tbody" name="list">
-        <tr v-for="tableRow in table" :key="tableRow.id">
-          <td>
-            <KLabeledIcon icon="person">
-              <KRouterLink
-                v-if="tableRow.statusObj.status !== STATUSES.notStarted"
-                :text="tableRow.name"
-                :to="classRoute('ReportsQuizLearnerPage', {
-                  learnerId: tableRow.id,
-                  questionId: 0,
-                  interactionIndex: 0
-                })"
+      <template #headers>
+        <th>{{ coachString('nameLabel') }}</th>
+        <th>{{ coreString('progressLabel') }}</th>
+        <th>{{ coachString('scoreLabel') }}</th>
+        <th>{{ coachString('groupsLabel') }}</th>
+      </template>
+      <template #tbody>
+        <transition-group tag="tbody" name="list">
+          <tr v-for="tableRow in table" :key="tableRow.id">
+            <td>
+              <KLabeledIcon icon="person">
+                <KRouterLink
+                  v-if="tableRow.statusObj.status !== STATUSES.notStarted"
+                  :text="tableRow.name"
+                  :to="classRoute('ReportsQuizLearnerPage', {
+                    learnerId: tableRow.id,
+                    questionId: 0,
+                    interactionIndex: 0
+                  })"
+                />
+                <template v-else>
+                  {{ tableRow.name }}
+                </template>
+              </KLabeledIcon>
+            </td>
+            <td v-if="tableRow.statusObj.status !== STATUSES.started">
+              <StatusSimple
+                :status="tableRow.statusObj.status"
               />
-              <template v-else>
-                {{ tableRow.name }}
-              </template>
-            </KLabeledIcon>
-          </td>
-          <td v-if="tableRow.statusObj.status !== STATUSES.started">
-            <StatusSimple
-              :status="tableRow.statusObj.status"
-            />
-            <div
-              v-if="tableRow.statusObj.status === STATUSES.completed"
-              class="small-answered-count"
-              :style="answerCountColorStyles"
-            >
-              {{
-                completedQuestionsCountLabel(tableRow.statusObj.num_answered, exam.question_count)
-              }}
-            </div>
-          </td>
-          <td v-else>
-            <KLabeledIcon>
-              <template #icon>
-                <KIcon :color="$themeTokens.progress" icon="inProgress" />
-              </template>
-              {{
-                $tr('questionsCompletedRatioLabel',
-                    { count: tableRow.statusObj.num_answered || 0, total: exam.question_count })
-              }}
-            </KLabeledIcon>
-          </td>
-          <td>
-            <Score
-              v-if="tableRow.statusObj.status === STATUSES.completed"
-              :value="tableRow.statusObj.score || 0.0"
-            />
-          </td>
-          <td>
-            <TruncatedItemList :items="tableRow.groups" />
-          </td>
-        </tr>
-      </transition-group>
+              <div
+                v-if="tableRow.statusObj.status === STATUSES.completed"
+                class="small-answered-count"
+                :style="answerCountColorStyles"
+              >
+                {{
+                  completedQuestionsCountLabel(tableRow.statusObj.num_answered, exam.question_count)
+                }}
+              </div>
+            </td>
+            <td v-else>
+              <KLabeledIcon>
+                <template #icon>
+                  <KIcon :color="$themeTokens.progress" icon="inProgress" />
+                </template>
+                {{
+                  $tr('questionsCompletedRatioLabel',
+                      { count: tableRow.statusObj.num_answered || 0, total: exam.question_count })
+                }}
+              </KLabeledIcon>
+            </td>
+            <td>
+              <Score
+                v-if="tableRow.statusObj.status === STATUSES.completed"
+                :value="tableRow.statusObj.score || 0.0"
+              />
+            </td>
+            <td>
+              <TruncatedItemList :items="tableRow.groups" />
+            </td>
+          </tr>
+        </transition-group>
+      </template>
     </CoreTable>
   </ReportsQuizBaseListPage>
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -24,75 +24,75 @@
         -->
       </ReportsControls>
       <CoreTable :emptyMessage="emptyMessage">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('titleLabel') }}</th>
-            <th style="position:relative;">
-              {{ coachString('avgScoreLabel') }}
-              <AverageScoreTooltip v-show="!$isPrint" />
-            </th>
-            <th>{{ coreString('progressLabel') }}</th>
-            <th>{{ coachString('recipientsLabel') }}</th>
-            <th v-show="!$isPrint" class="center-text">
-              {{ coachString('statusLabel') }}
-            </th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.id">
-            <td>
-              <KLabeledIcon icon="quiz">
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="classRoute('ReportsQuizLearnerListPage', { quizId: tableRow.id })"
+        <template #headers>
+          <th>{{ coachString('titleLabel') }}</th>
+          <th style="position:relative;">
+            {{ coachString('avgScoreLabel') }}
+            <AverageScoreTooltip v-show="!$isPrint" />
+          </th>
+          <th>{{ coreString('progressLabel') }}</th>
+          <th>{{ coachString('recipientsLabel') }}</th>
+          <th v-show="!$isPrint" class="center-text">
+            {{ coachString('statusLabel') }}
+          </th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="tableRow in table" :key="tableRow.id">
+              <td>
+                <KLabeledIcon icon="quiz">
+                  <KRouterLink
+                    :text="tableRow.title"
+                    :to="classRoute('ReportsQuizLearnerListPage', { quizId: tableRow.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <Score :value="tableRow.avgScore" />
+              </td>
+              <td>
+                <StatusSummary
+                  :tally="tableRow.tally"
+                  :verbose="true"
+                  :includeNotStarted="true"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <Score :value="tableRow.avgScore" />
-            </td>
-            <td>
-              <StatusSummary
-                :tally="tableRow.tally"
-                :verbose="true"
-                :includeNotStarted="true"
-              />
-            </td>
-            <td>
-              <Recipients
-                :groupNames="getRecipientNamesForExam(tableRow)"
-                :hasAssignments="tableRow.hasAssignments"
-              />
-            </td>
-            <td
-              v-show="!$isPrint"
-              class="button-col center-text core-table-button-col"
-            >
-              <!-- Open quiz button -->
-              <KButton
-                v-if="!tableRow.active && !tableRow.archive"
-                :text="coachString('openQuizLabel')"
-                appearance="flat-button"
-                class="table-left-aligned-button"
-                @click="showOpenConfirmationModal = true; modalQuizId = tableRow.id"
-              />
-              <!-- Close quiz button -->
-              <KButton
-                v-if="tableRow.active && !tableRow.archive"
-                :text="coachString('closeQuizLabel')"
-                appearance="flat-button"
-                class="table-left-aligned-button"
-                @click="showCloseConfirmationModal = true; modalQuizId = tableRow.id;"
-              />
-              <div
-                v-if="tableRow.archive"
-                class="quiz-closed-label"
+              </td>
+              <td>
+                <Recipients
+                  :groupNames="getRecipientNamesForExam(tableRow)"
+                  :hasAssignments="tableRow.hasAssignments"
+                />
+              </td>
+              <td
+                v-show="!$isPrint"
+                class="button-col center-text core-table-button-col"
               >
-                {{ coachString('quizClosedLabel') }}
-              </div>
-            </td>
-          </tr>
-        </transition-group>
+                <!-- Open quiz button -->
+                <KButton
+                  v-if="!tableRow.active && !tableRow.archive"
+                  :text="coachString('openQuizLabel')"
+                  appearance="flat-button"
+                  class="table-left-aligned-button"
+                  @click="showOpenConfirmationModal = true; modalQuizId = tableRow.id"
+                />
+                <!-- Close quiz button -->
+                <KButton
+                  v-if="tableRow.active && !tableRow.archive"
+                  :text="coachString('closeQuizLabel')"
+                  appearance="flat-button"
+                  class="table-left-aligned-button"
+                  @click="showCloseConfirmationModal = true; modalQuizId = tableRow.id;"
+                />
+                <div
+                  v-if="tableRow.archive"
+                  class="quiz-closed-label"
+                >
+                  {{ coachString('quizClosedLabel') }}
+                </div>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
       <!-- Modals for Close & Open of quiz from right-most column -->
       <KModal

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -6,34 +6,34 @@
         {{ coachString('overallLabel') }}
       </h2>
       <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <thead slot="thead">
-          <tr>
-            <th>{{ coachString('questionLabel') }}</th>
-            <th>{{ coachString('helpNeededLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="(tableRow, index) in table" :key="tableRow.question_id + index">
-            <td>
-              <span v-if="$isPrint">{{ tableRow.title }}</span>
-              <KLabeledIcon v-else icon="question">
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.question_id)"
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="(tableRow, index) in table" :key="tableRow.question_id + index">
+              <td>
+                <span v-if="$isPrint">{{ tableRow.title }}</span>
+                <KLabeledIcon v-else icon="question">
+                  <KRouterLink
+                    :text="tableRow.title"
+                    :to="questionLink(tableRow.question_id)"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
                 />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <LearnerProgressRatio
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
-                :total="tableRow.total"
-                :count="tableRow.total - tableRow.correct"
-                :verbosity="1"
-              />
-            </td>
-          </tr>
-        </transition-group>
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </div>
   </ReportsQuizBaseListPage>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceLearners.vue
@@ -1,36 +1,36 @@
 <template>
 
   <CoreTable :emptyMessage="coachString('activityListEmptyState')">
-    <thead slot="thead">
-      <tr>
-        <th>{{ coachString('nameLabel') }}</th>
-        <th>{{ coachString('statusLabel') }}</th>
-        <th>{{ coachString('timeSpentLabel') }}</th>
-        <th v-if="showGroupsColumn">
-          {{ coachString('groupsLabel') }}
-        </th>
-        <th>{{ coachString('lastActivityLabel') }}</th>
-      </tr>
-    </thead>
-    <transition-group slot="tbody" tag="tbody" name="list">
-      <tr v-for="entry in entries" :key="entry.id">
-        <td>
-          <KLabeledIcon icon="person" :label="entry.name" />
-        </td>
-        <td>
-          <StatusSimple :status="entry.statusObj.status" />
-        </td>
-        <td>
-          <TimeDuration :seconds="entry.statusObj.time_spent" />
-        </td>
-        <td v-if="showGroupsColumn">
-          <TruncatedItemList :items="getGroupNames(entry)" />
-        </td>
-        <td>
-          <ElapsedTime :date="entry.statusObj.last_activity" />
-        </td>
-      </tr>
-    </transition-group>
+    <template #headers>
+      <th>{{ coachString('nameLabel') }}</th>
+      <th>{{ coachString('statusLabel') }}</th>
+      <th>{{ coachString('timeSpentLabel') }}</th>
+      <th v-if="showGroupsColumn">
+        {{ coachString('groupsLabel') }}
+      </th>
+      <th>{{ coachString('lastActivityLabel') }}</th>
+    </template>
+    <template #tbody>
+      <transition-group tag="tbody" name="list">
+        <tr v-for="entry in entries" :key="entry.id">
+          <td>
+            <KLabeledIcon icon="person" :label="entry.name" />
+          </td>
+          <td>
+            <StatusSimple :status="entry.statusObj.status" />
+          </td>
+          <td>
+            <TimeDuration :seconds="entry.statusObj.time_spent" />
+          </td>
+          <td v-if="showGroupsColumn">
+            <TruncatedItemList :items="getGroupNames(entry)" />
+          </td>
+          <td>
+            <ElapsedTime :date="entry.statusObj.last_activity" />
+          </td>
+        </tr>
+      </transition-group>
+    </template>
   </CoreTable>
 
 </template>

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -25,38 +25,38 @@
     />
 
     <CoreTable>
-      <thead slot="thead">
-        <tr>
-          <th>{{ coreString('facilityLabel') }}</th>
-        </tr>
-      </thead>
-      <tbody slot="tbody">
-        <tr v-for="(facility, idx) in facilities" :key="idx">
-          <td>
-            <FacilityNameAndSyncStatus
-              :facility="facility"
-              :isSyncing="facilityIsSyncing(facility)"
-              :isDeleting="facilityIsDeleting(facility)"
-              :syncHasFailed="facility.syncHasFailed"
-            />
-          </td>
-          <td class="button-col">
-            <KButtonGroup>
-              <KButton
-                :text="coreString('syncAction')"
-                appearance="flat-button"
-                @click="facilityForSync = facility"
+      <template #headers>
+        <th>{{ coreString('facilityLabel') }}</th>
+      </template>
+      <template #tbody>
+        <tbody>
+          <tr v-for="(facility, idx) in facilities" :key="idx">
+            <td>
+              <FacilityNameAndSyncStatus
+                :facility="facility"
+                :isSyncing="facilityIsSyncing(facility)"
+                :isDeleting="facilityIsDeleting(facility)"
+                :syncHasFailed="facility.syncHasFailed"
               />
-              <KDropdownMenu
-                :text="coreString('optionsLabel')"
-                :options="facilityOptions(facility)"
-                appearance="flat-button"
-                @select="handleOptionSelect($event.value, facility)"
-              />
-            </KButtonGroup>
-          </td>
-        </tr>
-      </tbody>
+            </td>
+            <td class="button-col">
+              <KButtonGroup>
+                <KButton
+                  :text="coreString('syncAction')"
+                  appearance="flat-button"
+                  @click="facilityForSync = facility"
+                />
+                <KDropdownMenu
+                  :text="coreString('optionsLabel')"
+                  :options="facilityOptions(facility)"
+                  appearance="flat-button"
+                  @select="handleOptionSelect($event.value, facility)"
+                />
+              </KButtonGroup>
+            </td>
+          </tr>
+        </tbody>
+      </template>
     </CoreTable>
 
     <RemoveFacilityModal

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -3,49 +3,49 @@
   <div>
 
     <CoreTable :emptyMessage="emptyMessage">
-      <thead slot="thead">
-        <tr>
-          <th>{{ coreString('fullNameLabel') }}</th>
-          <th>{{ coreString('usernameLabel') }}</th>
-          <th v-if="hasMultipleFacilities">
-            {{ coreString('facilityLabel') }}
-          </th>
-          <th></th>
-        </tr>
-      </thead>
+      <template #headers>
+        <th>{{ coreString('fullNameLabel') }}</th>
+        <th>{{ coreString('usernameLabel') }}</th>
+        <th v-if="hasMultipleFacilities">
+          {{ coreString('facilityLabel') }}
+        </th>
+        <th></th>
+      </template>
 
-      <tbody slot="tbody">
-        <tr v-for="user in facilityUsers" :key="user.id">
-          <td>
-            <KLabeledIcon :label="fullNameLabel(user)">
-              <template #icon>
-                <PermissionsIcon
-                  v-if="Boolean(getPermissionType(user.id))"
-                  :permissionType="getPermissionType(user.id)"
-                />
-              </template>
-            </KLabeledIcon>
-          </td>
-          <td>
-            <span dir="auto" class="maxwidth">
-              {{ user.username }}
-            </span>
-          </td>
-          <td v-if="hasMultipleFacilities">
-            <span dir="auto" class="maxwidth">
-              {{ memoizedFacilityName(user.facility) }}
-            </span>
-          </td>
-          <td class="btn-col">
-            <KButton
-              appearance="flat-button"
-              :text="permissionsButtonText(user)"
-              style="margin-top: 6px;"
-              @click="goToUserPermissionsPage(user.id)"
-            />
-          </td>
-        </tr>
-      </tbody>
+      <template #tbody>
+        <tbody>
+          <tr v-for="user in facilityUsers" :key="user.id">
+            <td>
+              <KLabeledIcon :label="fullNameLabel(user)">
+                <template #icon>
+                  <PermissionsIcon
+                    v-if="Boolean(getPermissionType(user.id))"
+                    :permissionType="getPermissionType(user.id)"
+                  />
+                </template>
+              </KLabeledIcon>
+            </td>
+            <td>
+              <span dir="auto" class="maxwidth">
+                {{ user.username }}
+              </span>
+            </td>
+            <td v-if="hasMultipleFacilities">
+              <span dir="auto" class="maxwidth">
+                {{ memoizedFacilityName(user.facility) }}
+              </span>
+            </td>
+            <td class="btn-col">
+              <KButton
+                appearance="flat-button"
+                :text="permissionsButtonText(user)"
+                style="margin-top: 6px;"
+                @click="goToUserPermissionsPage(user.id)"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </template>
     </CoreTable>
 
   </div>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -13,34 +13,34 @@
       class="contents"
     >
       <CoreTable>
-        <thead slot="thead">
-          <tr>
-            <th class="core-table-checkbox-col select-all">
-              <KCheckbox
-                :label="$tr('selectAll')"
-                :checked="nodeIsChecked(annotatedTopicNode)"
-                :disabled="disableSelectAll"
-                @change="toggleSelectAll"
-              />
-            </th>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <ContentNodeRow
-            v-for="cNode in showableAnnotatedChildNodes"
-            :key="cNode.id"
-            :checked="nodeIsChecked(cNode)"
-            :disabled="disabled || disableAll || cNode.disabled ||
-              (cNode.updated_resource && !cNode.available)"
-            :indeterminate="nodeIsIndeterminate(cNode)"
-            :message="cNode.message"
-            :node="cNode"
-            :getLinkObject="topicLinkObject"
-            @changeselection="toggleSelection(cNode)"
-          />
-        </transition-group>
+        <template #headers>
+          <th class="core-table-checkbox-col select-all">
+            <KCheckbox
+              :label="$tr('selectAll')"
+              :checked="nodeIsChecked(annotatedTopicNode)"
+              :disabled="disableSelectAll"
+              @change="toggleSelectAll"
+            />
+          </th>
+          <th></th>
+          <th></th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <ContentNodeRow
+              v-for="cNode in showableAnnotatedChildNodes"
+              :key="cNode.id"
+              :checked="nodeIsChecked(cNode)"
+              :disabled="disabled || disableAll || cNode.disabled ||
+                (cNode.updated_resource && !cNode.available)"
+              :indeterminate="nodeIsIndeterminate(cNode)"
+              :message="cNode.message"
+              :node="cNode"
+              :getLinkObject="topicLinkObject"
+              @changeselection="toggleSelection(cNode)"
+            />
+          </transition-group>
+        </template>
       </CoreTable>
     </div>
 

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -3,27 +3,27 @@
   <KPageContainer>
     <h1>{{ coreString('facilitiesLabel') }} </h1>
     <CoreTable>
-      <thead slot="thead">
-        <tr>
-          <th>{{ coreString('nameLabel') }}</th>
-          <th>{{ coreString('classesLabel') }}</th>
-        </tr>
-      </thead>
-      <tbody slot="tbody">
-        <tr v-for="facility in facilities" :key="facility.id">
-          <td>
-            <KLabeledIcon icon="facility">
-              <KRouterLink
-                :text="facility.name"
-                :to="facilityLink(facility)"
-              />
-            </KLabeledIcon>
-          </td>
-          <td>
-            {{ $formatNumber(facility.num_classrooms) }}
-          </td>
-        </tr>
-      </tbody>
+      <template #headers>
+        <th>{{ coreString('nameLabel') }}</th>
+        <th>{{ coreString('classesLabel') }}</th>
+      </template>
+      <template #tbody>
+        <tbody>
+          <tr v-for="facility in facilities" :key="facility.id">
+            <td>
+              <KLabeledIcon icon="facility">
+                <KRouterLink
+                  :text="facility.name"
+                  :to="facilityLink(facility)"
+                />
+              </KLabeledIcon>
+            </td>
+            <td>
+              {{ $formatNumber(facility.num_classrooms) }}
+            </td>
+          </tr>
+        </tbody>
+      </template>
     </CoreTable>
   </KPageContainer>
 

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -12,38 +12,38 @@
     </p>
 
     <CoreTable>
-      <thead slot="thead">
-        <tr>
-          <th>{{ $tr('facility') }}</th>
-        </tr>
-      </thead>
-      <tbody slot="tbody">
-        <tr v-if="theFacility">
-          <td>
-            <FacilityNameAndSyncStatus
-              :facility="theFacility"
-              :isSyncing="isSyncing"
-              :syncHasFailed="syncHasFailed"
-            />
-          </td>
-          <td class="button-col">
-            <KButtonGroup style="margin-top: 8px; overflow: visible">
-              <KButton
-                appearance="raised-button"
-                :text="$tr('register')"
-                :disabled="Boolean(syncTaskId) || theFacility.dataset.registered"
-                @click="displayModal(Modals.REGISTER_FACILITY)"
+      <template #headers>
+        <th>{{ $tr('facility') }}</th>
+      </template>
+      <template #tbody>
+        <tbody>
+          <tr v-if="theFacility">
+            <td>
+              <FacilityNameAndSyncStatus
+                :facility="theFacility"
+                :isSyncing="isSyncing"
+                :syncHasFailed="syncHasFailed"
               />
-              <KButton
-                appearance="raised-button"
-                :text="$tr('sync')"
-                :disabled="Boolean(syncTaskId)"
-                @click="displayModal(Modals.SYNC_FACILITY)"
-              />
-            </KButtonGroup>
-          </td>
-        </tr>
-      </tbody>
+            </td>
+            <td class="button-col">
+              <KButtonGroup style="margin-top: 8px; overflow: visible">
+                <KButton
+                  appearance="raised-button"
+                  :text="$tr('register')"
+                  :disabled="Boolean(syncTaskId) || theFacility.dataset.registered"
+                  @click="displayModal(Modals.REGISTER_FACILITY)"
+                />
+                <KButton
+                  appearance="raised-button"
+                  :text="$tr('sync')"
+                  :disabled="Boolean(syncTaskId)"
+                  @click="displayModal(Modals.SYNC_FACILITY)"
+                />
+              </KButtonGroup>
+            </td>
+          </tr>
+        </tbody>
+      </template>
     </CoreTable>
 
     <PrivacyModal

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -36,59 +36,59 @@
       <caption class="visuallyhidden">
         {{ $tr('tableCaption') }}
       </caption>
-      <thead slot="thead">
-        <tr>
-          <th>{{ coreString('classNameLabel') }}</th>
-          <th>{{ coreString('coachesLabel') }}</th>
-          <th>{{ coreString('learnersLabel') }}</th>
-          <th>
-            <span class="visuallyhidden">
-              {{ $tr('actions') }}
-            </span>
-          </th>
-        </tr>
-      </thead>
-      <transition-group slot="tbody" tag="tbody" name="list">
-        <tr
-          v-for="classroom in sortedClassrooms"
-          :key="classroom.id"
-        >
-          <td>
-            <KLabeledIcon icon="classes">
-              <KRouterLink
-                :text="classroom.name"
-                :to="classEditLink(classroom.id)"
-              />
-            </KLabeledIcon>
-          </td>
-          <td>
-            <span :ref="`coachNames${classroom.id}`">
-              <template v-if="coachNames(classroom).length">
-                {{ formattedCoachNames(classroom) }}
-              </template>
-              <KEmptyPlaceholder v-else />
-            </span>
-            <KTooltip
-              v-if="formattedCoachNamesTooltip(classroom)"
-              :reference="`coachNames${classroom.id}`"
-              :refs="$refs"
-            >
-              {{ formattedCoachNamesTooltip(classroom) }}
-            </KTooltip>
-          </td>
+      <template #headers>
+        <th>{{ coreString('classNameLabel') }}</th>
+        <th>{{ coreString('coachesLabel') }}</th>
+        <th>{{ coreString('learnersLabel') }}</th>
+        <th>
+          <span class="visuallyhidden">
+            {{ $tr('actions') }}
+          </span>
+        </th>
+      </template>
+      <template #tbody>
+        <transition-group tag="tbody" name="list">
+          <tr
+            v-for="classroom in sortedClassrooms"
+            :key="classroom.id"
+          >
+            <td>
+              <KLabeledIcon icon="classes">
+                <KRouterLink
+                  :text="classroom.name"
+                  :to="classEditLink(classroom.id)"
+                />
+              </KLabeledIcon>
+            </td>
+            <td>
+              <span :ref="`coachNames${classroom.id}`">
+                <template v-if="coachNames(classroom).length">
+                  {{ formattedCoachNames(classroom) }}
+                </template>
+                <KEmptyPlaceholder v-else />
+              </span>
+              <KTooltip
+                v-if="formattedCoachNamesTooltip(classroom)"
+                :reference="`coachNames${classroom.id}`"
+                :refs="$refs"
+              >
+                {{ formattedCoachNamesTooltip(classroom) }}
+              </KTooltip>
+            </td>
 
-          <td>
-            {{ classroom.learner_count }}
-          </td>
-          <td class="core-table-button-col">
-            <KButton
-              appearance="flat-button"
-              :text="$tr('deleteClass')"
-              @click="openDeleteClassModal(classroom)"
-            />
-          </td>
-        </tr>
-      </transition-group>
+            <td>
+              {{ classroom.learner_count }}
+            </td>
+            <td class="core-table-button-col">
+              <KButton
+                appearance="flat-button"
+                :text="$tr('deleteClass')"
+                @click="openDeleteClassModal(classroom)"
+              />
+            </td>
+          </tr>
+        </transition-group>
+      </template>
     </CoreTable>
 
     <p v-if="noClassesExist">

--- a/kolibri/plugins/facility/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserTable.vue
@@ -2,121 +2,120 @@
 
   <div>
     <CoreTable>
-
-      <thead slot="thead">
-        <tr>
-          <th
-            v-if="selectable"
-            class="core-table-checkbox-col select-all"
-          >
-            <KCheckbox
-              :label="$tr('selectAllLabel')"
-              :showLabel="true"
-              :checked="allAreSelected"
-              class="overflow-label"
-              :disabled="disabled || users.length === 0"
-              @change="selectAll($event)"
-            />
-          </th>
-          <th>
-            <!-- "Full name" header visually hidden if checkbox is on -->
-            <span :class="{ visuallyhidden: selectable }">
-              {{ coreString('fullNameLabel') }}
-            </span>
-          </th>
-          <th>
-            <span class="visuallyhidden">
-              {{ $tr('role') }}
-            </span>
-          </th>
-          <th>{{ coreString('usernameLabel') }}</th>
-          <th v-if="$scopedSlots.info">
-            {{ infoDescriptor }}
-          </th>
-          <template v-if="showDemographicInfo">
-            <th>
-              <span>{{ coreString('identifierLabel') }}</span>
-              <CoreInfoIcon
-                class="tooltip"
-                :iconAriaLabel="coreString('identifierAriaLabel')"
-                :tooltipText="coreString('identifierTooltip')"
-              />
-            </th>
-            <th>
-              {{ coreString('genderLabel') }}
-            </th>
-            <th>
-              {{ coreString('birthYearLabel') }}
-            </th>
-          </template>
-          <th v-if="$scopedSlots.action" class="user-action-button">
-            <span class="visuallyhidden">
-              {{ $tr('userActionsColumnHeader') }}
-            </span>
-          </th>
-        </tr>
-      </thead>
-
-      <tbody slot="tbody">
-        <tr
-          v-for="user in users"
-          :key="user.id"
+      <template #headers>
+        <th
+          v-if="selectable"
+          class="core-table-checkbox-col select-all"
         >
-          <td v-if="selectable" class="core-table-checkbox-col">
-            <KCheckbox
-              :label="$tr('userCheckboxLabel')"
-              :showLabel="false"
-              :disabled="disabled"
-              :checked="userIsSelected(user.id)"
-              @change="selectUser(user.id, $event)"
+          <KCheckbox
+            :label="$tr('selectAllLabel')"
+            :showLabel="true"
+            :checked="allAreSelected"
+            class="overflow-label"
+            :disabled="disabled || users.length === 0"
+            @change="selectAll($event)"
+          />
+        </th>
+        <th>
+          <!-- "Full name" header visually hidden if checkbox is on -->
+          <span :class="{ visuallyhidden: selectable }">
+            {{ coreString('fullNameLabel') }}
+          </span>
+        </th>
+        <th>
+          <span class="visuallyhidden">
+            {{ $tr('role') }}
+          </span>
+        </th>
+        <th>{{ coreString('usernameLabel') }}</th>
+        <th v-if="$scopedSlots.info">
+          {{ infoDescriptor }}
+        </th>
+        <template v-if="showDemographicInfo">
+          <th>
+            <span>{{ coreString('identifierLabel') }}</span>
+            <CoreInfoIcon
+              class="tooltip"
+              :iconAriaLabel="coreString('identifierAriaLabel')"
+              :tooltipText="coreString('identifierTooltip')"
             />
-          </td>
-          <td>
-            <KLabeledIcon
-              :icon="isCoach ? 'coach' : 'person'"
-              :label="user.full_name"
-            />
-            <UserTypeDisplay
-              aria-hidden="true"
-              :userType="user.kind"
-              :omitLearner="true"
-              class="role-badge"
-              :style="{
-                color: $themeTokens.textInverted,
-                backgroundColor: $themeTokens.annotation,
-              }"
-            />
-          </td>
-          <td class="visuallyhidden">
-            {{ user.kind }}
-          </td>
-          <td>
-            <span dir="auto">
-              {{ user.username }}
-            </span>
-          </td>
-          <template v-if="showDemographicInfo">
-            <td class="id-col">
-              <span v-if="user.id_number">
-                {{ user.id_number }}
+          </th>
+          <th>
+            {{ coreString('genderLabel') }}
+          </th>
+          <th>
+            {{ coreString('birthYearLabel') }}
+          </th>
+        </template>
+        <th v-if="$scopedSlots.action" class="user-action-button">
+          <span class="visuallyhidden">
+            {{ $tr('userActionsColumnHeader') }}
+          </span>
+        </th>
+      </template>
+
+      <template #tbody>
+        <tbody>
+          <tr
+            v-for="user in users"
+            :key="user.id"
+          >
+            <td v-if="selectable" class="core-table-checkbox-col">
+              <KCheckbox
+                :label="$tr('userCheckboxLabel')"
+                :showLabel="false"
+                :disabled="disabled"
+                :checked="userIsSelected(user.id)"
+                @change="selectUser(user.id, $event)"
+              />
+            </td>
+            <td>
+              <KLabeledIcon
+                :icon="isCoach ? 'coach' : 'person'"
+                :label="user.full_name"
+              />
+              <UserTypeDisplay
+                aria-hidden="true"
+                :userType="user.kind"
+                :omitLearner="true"
+                class="role-badge"
+                :style="{
+                  color: $themeTokens.textInverted,
+                  backgroundColor: $themeTokens.annotation,
+                }"
+              />
+            </td>
+            <td class="visuallyhidden">
+              {{ user.kind }}
+            </td>
+            <td>
+              <span dir="auto">
+                {{ user.username }}
               </span>
-              <KEmptyPlaceholder v-else />
             </td>
-            <td>
-              <GenderDisplayText :gender="user.gender" />
+            <template v-if="showDemographicInfo">
+              <td class="id-col">
+                <span v-if="user.id_number">
+                  {{ user.id_number }}
+                </span>
+                <KEmptyPlaceholder v-else />
+              </td>
+              <td>
+                <GenderDisplayText :gender="user.gender" />
+              </td>
+              <td>
+                <BirthYearDisplayText :birthYear="user.birth_year" />
+              </td>
+            </template>
+            <td v-if="$scopedSlots.info">
+              <slot name="info" :user="user"></slot>
             </td>
-            <td>
-              <BirthYearDisplayText :birthYear="user.birth_year" />
+            <td v-if="$scopedSlots.action" class="core-table-button-col">
+              <slot name="action" :user="user"></slot>
             </td>
-          </template>
-          <td v-if="$scopedSlots.info">
-            <slot name="info" :user="user"></slot>
-          </td>
-          <td v-if="$scopedSlots.action" class="core-table-button-col">
-            <slot name="action" :user="user"></slot>
-          </td>
-        </tr>
-      </tbody>
+          </tr>
+        </tbody>
+      </template>
     </CoreTable>
 
     <p

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -183,7 +183,7 @@ module.exports = {
     'vue/no-deprecated-scope-attribute': ERROR,
     'vue/valid-v-bind-sync': ERROR,
     // TODO Enforcing these rules requires bigger refactor
-    // 'vue/no-deprecated-slot-scope-attribute': ERROR,
+    'vue/no-deprecated-slot-attribute': ERROR,
     'vue/no-deprecated-slot-scope-attribute': ERROR,
     'vue/valid-v-slot': ERROR,
     'vue/v-slot-style': ERROR,

--- a/packages/kolibri-tools/test/fixtures/TestComponent.vue
+++ b/packages/kolibri-tools/test/fixtures/TestComponent.vue
@@ -36,31 +36,31 @@
       </p>
 
       <CoreTable v-else>
-        <thead slot="thead">
-          <tr>
-            <th>{{ $tr('classNameLabel') }}</th>
-            <th>{{ coachString('coachesLabel') }}</th>
-            <th>{{ coachString('learnersLabel') }}</th>
-          </tr>
-        </thead>
-        <transition-group slot="tbody" tag="tbody" name="list">
-          <tr v-for="classObj in classList" :key="classObj.id">
-            <td>
-              <KLabeledIcon icon="classes">
-                <KRouterLink
-                  :text="classObj.name"
-                  :to="$router.getRoute('HomePage', { classId: classObj.id })"
-                />
-              </KLabeledIcon>
-            </td>
-            <td>
-              <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
-            </td>
-            <td>
-              {{ coachString('integer', { value: classObj.learner_count }) }}
-            </td>
-          </tr>
-        </transition-group>
+        <template #headers>
+          <th>{{ $tr('classNameLabel') }}</th>
+          <th>{{ coachString('coachesLabel') }}</th>
+          <th>{{ coachString('learnersLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="classObj in classList" :key="classObj.id">
+              <td>
+                <KLabeledIcon icon="classes">
+                  <KRouterLink
+                    :text="classObj.name"
+                    :to="$router.getRoute('HomePage', { classId: classObj.id })"
+                  />
+                </KLabeledIcon>
+              </td>
+              <td>
+                <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
+              </td>
+              <td>
+                {{ coachString('integer', { value: classObj.learner_count }) }}
+              </td>
+            </tr>
+          </transition-group>
+        </template>
       </CoreTable>
     </KPageContainer>
 


### PR DESCRIPTION
### Summary

1. Fixes `CoreTable`'s incompatibility with `v-slot` directive by 1) making copies of the `$slots.tbody` in the `render` function elements since the originals are read-only and 2) simplifying how the `thead` (now `headers`) slot is constructed in the `render` function
2. Replaces the `thead` slot with `headers` to reduce the amount of tag nesting required. `thead > tr > th's` is reduced to `template#headers > th's` (see diff)
3. Enables the 'vue/no-deprecated-slot-attribute' rule

### Reviewer guidance

Check that the pages using `CoreTable` still work and render exactly as they did before

### References

Fixes #6717 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
