### PR TITLE
Add `clearable` property to `task` API payload

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1229,6 +1229,7 @@ def _job_to_response(job):
             "progress": [],
             "id": None,
             "cancellable": False,
+            "clearable": False,
         }
     else:
         output = {
@@ -1238,6 +1239,7 @@ def _job_to_response(job):
             "percentage": job.percentage_progress,
             "id": job.job_id,
             "cancellable": job.cancellable,
+            "clearable": job.state in [State.FAILED, State.CANCELED, State.COMPLETED],
         }
         output.update(job.extra_metadata)
         return output

--- a/kolibri/plugins/device/assets/src/constants.js
+++ b/kolibri/plugins/device/assets/src/constants.js
@@ -55,10 +55,6 @@ export const TaskStatuses = Object.freeze({
   CANCELING: 'CANCELING',
 });
 
-export function taskIsClearable(task) {
-  return task.clearable;
-}
-
 export const TransferTypes = {
   LOCALEXPORT: 'localexport',
   LOCALIMPORT: 'localimport',

--- a/kolibri/plugins/device/assets/src/constants.js
+++ b/kolibri/plugins/device/assets/src/constants.js
@@ -56,7 +56,7 @@ export const TaskStatuses = Object.freeze({
 });
 
 export function taskIsClearable(task) {
-  return [TaskStatuses.COMPLETED, TaskStatuses.CANCELED, TaskStatuses.FAILED].includes(task.status);
+  return task.clearable;
 }
 
 export const TransferTypes = {

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -1,7 +1,7 @@
 import find from 'lodash/find';
 import findLastIndex from 'lodash/findLastIndex';
 import wizard from '../wizard';
-import { TaskTypes, TaskStatuses, taskIsClearable } from '../../constants';
+import { TaskTypes, TaskStatuses } from '../../constants';
 import actions from './actions';
 
 function defaultState() {
@@ -81,7 +81,7 @@ export default {
           channel_id: channelId,
         });
         if (match) {
-          return !taskIsClearable(match);
+          return !match.clearable;
         }
         return false;
       };
@@ -92,7 +92,7 @@ export default {
           return null;
         }
         const match = find(state.taskList, { id: taskId });
-        if (match && taskIsClearable(match)) {
+        if (match && match.clearable) {
           return match.id;
         }
         return null;

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilitiesTasksPage.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilitiesTasksPage.vue
@@ -44,7 +44,6 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import HeaderWithOptions from '../HeaderWithOptions';
-  import { taskIsClearable } from '../../constants';
   import ManageTasksPage from '../ManageTasksPage';
   import BackLink from '../ManageTasksPage/BackLink';
   import FacilityTaskPanel from './FacilityTaskPanel';
@@ -72,7 +71,7 @@
     },
     computed: {
       someClearableTasks() {
-        return Boolean(this.facilityTasks.find(taskIsClearable));
+        return Boolean(this.facilityTasks.find(task => task.clearable));
       },
       emptyTasksMessage() {
         // eslint-disable-next-line kolibri/vue-no-undefined-string-uses

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
@@ -1,7 +1,7 @@
 // Mixin that can be used for a component to view and manage
 // the task queue
 import { FacilityTaskResource } from 'kolibri.resources';
-import { taskIsClearable, TaskTypes } from '../../constants';
+import { TaskTypes } from '../../constants';
 
 function isSyncTask(task) {
   return task.type === TaskTypes.SYNCDATAPORTAL || task.type === TaskTypes.SYNCPEERFULL;
@@ -82,7 +82,7 @@ export default {
   computed: {
     facilityIsSyncing() {
       return function isSyncing(facility) {
-        const syncTasks = this.facilityTasks.filter(t => isSyncTask(t) && !taskIsClearable(t));
+        const syncTasks = this.facilityTasks.filter(t => isSyncTask(t) && !t.clearable);
         return Boolean(syncTasks.find(task => taskFacilityMatch(task, facility)));
       };
     },
@@ -93,7 +93,7 @@ export default {
             task =>
               task.type === TaskTypes.DELETEFACILITY &&
               taskFacilityMatch(task, facility) &&
-              !taskIsClearable(task)
+              !task.clearable
           )
         );
       };

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -123,7 +123,7 @@
   } from 'kolibri.coreVue.componentSets.sync';
   import TasksBar from '../ManageContentPage/TasksBar';
   import HeaderWithOptions from '../HeaderWithOptions';
-  import { TaskStatuses, TaskTypes, taskIsClearable } from '../../constants';
+  import { TaskStatuses, TaskTypes } from '../../constants';
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';
@@ -187,7 +187,7 @@
             }
           } else {
             // Add tasks that aren't being watched yet
-            if (!taskIsClearable(task)) {
+            if (!task.clearable) {
               this.taskIdsToWatch.push(task.id);
             }
           }

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -115,7 +115,7 @@
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { taskIsClearable, TaskStatuses } from '../../constants';
+  import { TaskStatuses } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
 
   export default {
@@ -270,7 +270,7 @@
           channelId: this.params.channelId,
           ...sourceParams,
         }).then(task => {
-          if (taskIsClearable(task)) {
+          if (task.clearable) {
             // If the task actually just failed, re-start the task
             if (task.status === TaskStatuses.FAILED) {
               this.startDiffStatsTask({

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/TasksBar.vue
@@ -41,7 +41,6 @@
   import sumBy from 'lodash/sumBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonTaskStrings from 'kolibri.coreVue.mixins.commonTaskStrings';
-  import { taskIsClearable } from '../../constants';
 
   export default {
     name: 'TasksBar',
@@ -58,16 +57,16 @@
     },
     computed: {
       showClearCompletedButton() {
-        return some(this.tasks, taskIsClearable);
+        return some(this.tasks, task => task.clearable);
       },
       totalTasks() {
         return this.tasks.length;
       },
       clearableTasks() {
-        return this.tasks.filter(t => taskIsClearable(t));
+        return this.tasks.filter(t => t.clearable);
       },
       inProgressTasks() {
-        return this.tasks.filter(t => !taskIsClearable(t));
+        return this.tasks.filter(t => !t.clearable);
       },
       progress() {
         return (

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -93,7 +93,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
 
-  import { taskIsClearable, TaskStatuses, TaskTypes } from '../../constants';
+  import { TaskStatuses, TaskTypes } from '../../constants';
 
   const typeToTrMap = {
     [TaskTypes.REMOTECONTENTIMPORT]: 'importChannelPartial',
@@ -163,7 +163,7 @@
         return this.task.cancellable;
       },
       taskIsClearable() {
-        return taskIsClearable(this.task);
+        return this.task.clearable;
       },
       taskPercentage() {
         if (this.task.database_ready === false) {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/TaskPanel.spec.js
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/TaskPanel.spec.js
@@ -10,6 +10,7 @@ describe('TaskPanel', () => {
   const exportTask = {
     type: 'DISKCONTENTEXPORT',
     status: 'CANCELED',
+    clearable: true,
     channel_name: 'Canceled disk export channel test',
     started_by_username: 'Tester',
     file_size: 5000,

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -56,7 +56,7 @@
   import { TaskResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import { PageNames, taskIsClearable } from '../../constants';
+  import { PageNames } from '../../constants';
 
   import TaskPanel from './TaskPanel';
   import BackLink from './BackLink';
@@ -85,7 +85,7 @@
         return reverse(this.managedTasks);
       },
       showClearCompletedButton() {
-        return some(this.managedTasks, taskIsClearable);
+        return some(this.managedTasks, task => task.clearable);
       },
       homeRoute() {
         return PageNames.MANAGE_CONTENT_PAGE;

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -76,7 +76,7 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
   import TaskProgress from '../ManageContentPage/TaskProgress';
-  import { ContentWizardErrors, TaskTypes, PageNames, taskIsClearable } from '../../constants';
+  import { ContentWizardErrors, TaskTypes, PageNames } from '../../constants';
   import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
   import taskNotificationMixin from '../taskNotificationMixin';
   import { updateTreeViewTopic } from '../../modules/wizard/handlers';
@@ -174,7 +174,7 @@
         handler(val) {
           if (val) {
             this.metadataDownloadTaskId = val.id;
-            if (taskIsClearable(val)) {
+            if (val.clearable) {
               TaskResource.deleteFinishedTask(val.id);
             }
           } else {

--- a/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
@@ -6,6 +6,8 @@ import {
   SyncTaskStatuses,
 } from '../syncTaskUtils';
 
+const CLEARABLE_STATUSES = ['COMPLETED', 'CANCELED', 'FAILED'];
+
 describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
   const CANCELLABLE_STATUSES = [
     SyncTaskStatuses.SESSION_CREATION,
@@ -28,6 +30,7 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
       bytes_sent: 1000000,
       bytes_received: 500000000,
       cancellable: CANCELLABLE_STATUSES.indexOf(status) >= 0,
+      clearable: CLEARABLE_STATUSES.indexOf(status) >= 0,
     };
   }
 
@@ -134,6 +137,7 @@ describe('syncTaskUtils.removeFacilityTaskDisplayInfo', () => {
     return {
       type: 'DELETEFACILITY',
       status,
+      clearable: CLEARABLE_STATUSES.indexOf(status) >= 0,
       facility_name: 'removed facility',
       facility: 'fac123',
       started_by_username: 'removing user',

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -1,7 +1,7 @@
 import coreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 import taskStrings from 'kolibri.coreVue.mixins.commonTaskStrings';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
-import { taskIsClearable, TaskStatuses, TaskTypes } from '../constants';
+import { TaskStatuses, TaskTypes } from '../constants';
 
 export const SyncTaskStatuses = {
   SESSION_CREATION: 'SESSION_CREATION',
@@ -92,7 +92,7 @@ export function syncFacilityTaskDisplayInfo(task) {
     });
   }
 
-  const canClear = taskIsClearable(task);
+  const canClear = task.clearable;
 
   return {
     headingMsg: getTaskString('syncFacilityTaskLabel', { facilityName }),
@@ -123,8 +123,8 @@ export function removeFacilityTaskDisplayInfo(task) {
     statusMsg: statusDescription,
     startedByMsg: getTaskString('taskStartedByLabel', { username: task.started_by_username }),
     isRunning: task.status === 'RUNNING',
-    canClear: taskIsClearable(task),
-    canCancel: !taskIsClearable(task) && task.status !== 'RUNNING',
+    canClear: task.clearable,
+    canCancel: !task.clearable && task.status !== 'RUNNING',
     canRetry: task.status === TaskStatuses.FAILED,
   };
 }

--- a/kolibri/plugins/facility/assets/src/constants.js
+++ b/kolibri/plugins/facility/assets/src/constants.js
@@ -55,10 +55,6 @@ export const TaskStatuses = Object.freeze({
   CANCELING: 'CANCELING',
 });
 
-export function taskIsClearable(task) {
-  return [TaskStatuses.COMPLETED, TaskStatuses.CANCELED, TaskStatuses.FAILED].includes(task.status);
-}
-
 export const CSVGenerationStatuses = {
   NO_LOGS_CREATED: 'NOLOGSCREATED',
   GENERATING: 'GENERATING',

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -89,7 +89,7 @@
   } from 'kolibri.coreVue.componentSets.sync';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { FacilityTaskResource, FacilityResource } from 'kolibri.resources';
-  import { TaskStatuses, taskIsClearable } from '../../../constants';
+  import { TaskStatuses } from '../../../constants';
   import PrivacyModal from './PrivacyModal';
 
   const Modals = Object.freeze({
@@ -144,7 +144,7 @@
       pollSyncTask() {
         // Like facilityTaskQueue, just keep polling until component is destroyed
         FacilityTaskResource.fetchModel({ id: this.syncTaskId, force: true }).then(task => {
-          if (taskIsClearable(task)) {
+          if (task.clearable) {
             this.isSyncing = false;
             this.syncTaskId = '';
             FacilityTaskResource.deleteFinishedTask(this.syncTaskId);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Moves the concept of a task being "clearable" from the front-end via the `taskIsClearable` utility to the backend by adding a `task.clearable` property to the serialized tasks
2. Updates front-end code to directly access `task.clearable` rather than using the utility.

### Reviewer guidance

Check that task-related UIs still work correctly (e.g. facility importing/syncing, content importing, CSV uploading, etc.)

### References

Fixes #7704 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
