### PR TITLE
Reset Facility settings based on `facilty.dataset.preset` value

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -168,7 +168,7 @@ class FacilityDatasetViewSet(ValuesViewset):
             queryset = queryset.filter(collection__id=facility_id)
         return queryset
 
-    @decorators.action(methods=["patch"], detail=True)
+    @decorators.action(methods=["post"], detail=True)
     def resetsettings(self, request, pk):
         try:
             dataset = FacilityDataset.objects.get(pk=pk)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -14,6 +14,7 @@ from django.contrib.auth import logout
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Func
 from django.db.models import OuterRef
@@ -32,6 +33,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from django_filters.rest_framework import ModelChoiceFilter
 from morango.models import TransferSession
+from rest_framework import decorators
 from rest_framework import filters
 from rest_framework import permissions
 from rest_framework import status
@@ -165,6 +167,18 @@ class FacilityDatasetViewSet(ValuesViewset):
         if facility_id is not None:
             queryset = queryset.filter(collection__id=facility_id)
         return queryset
+
+    @decorators.action(methods=["patch"], detail=True)
+    def resetsettings(self, request, pk):
+        try:
+            dataset = FacilityDataset.objects.get(pk=pk)
+            if not request.user.can_update(dataset):
+                raise PermissionDenied("You cannot reset this facility's settings")
+            dataset.reset_to_default_settings()
+            data = FacilityDatasetSerializer(dataset).data
+            return Response(data)
+        except FacilityDataset.DoesNotExist:
+            raise Http404("Facility does not exist")
 
 
 class FacilityUserFilter(FilterSet):

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -164,8 +164,14 @@ class FacilityDataset(FacilityDataSyncableModel):
             tree_id=self.get_root_certificate().tree_id
         ).exclude(_private_key=None)
 
-    def reset_to_default_settings(self):
-        pass
+    def reset_to_default_settings(self, preset=None):
+        from kolibri.core.auth.constants.facility_presets import mappings
+
+        # use the current preset if it is not passed in
+        dataset_data = mappings[preset or self.preset]
+        for key, value in dataset_data.items():
+            setattr(self, key, value)
+        self.save()
 
 
 class AbstractFacilityDataModel(FacilityDataSyncableModel):

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -164,6 +164,9 @@ class FacilityDataset(FacilityDataSyncableModel):
             tree_id=self.get_root_certificate().tree_id
         ).exclude(_private_key=None)
 
+    def reset_to_default_settings(self):
+        pass
+
 
 class AbstractFacilityDataModel(FacilityDataSyncableModel):
     """

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
 
 from kolibri.core.auth.constants.facility_presets import choices
-from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.serializers import FacilitySerializer
@@ -74,10 +73,8 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
         with transaction.atomic():
             facility = Facility.objects.create(**validated_data.pop("facility"))
             preset = validated_data.pop("preset")
-            dataset_data = mappings[preset]
             facility.dataset.preset = preset
-            for key, value in dataset_data.items():
-                setattr(facility.dataset, key, value)
+            facility.dataset.reset_to_default_settings(preset)
             # overwrite the settings in dataset_data with validated_data.settings
             custom_settings = validated_data.pop("settings")
             for key, value in custom_settings.items():

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -1,4 +1,6 @@
 import { FacilityDatasetResource, FacilityResource } from 'kolibri.resources';
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
 
 export function saveFacilityName(store, payload) {
   return FacilityResource.saveModel({
@@ -36,14 +38,19 @@ export function saveFacilityConfig(store) {
 }
 
 export function resetFacilityConfig(store) {
-  store.commit('CONFIG_PAGE_MODIFY_ALL_SETTINGS', {
-    learner_can_edit_username: true,
-    learner_can_edit_name: true,
-    learner_can_edit_password: true,
-    learner_can_sign_up: true,
-    learner_can_delete_account: true,
-    learner_can_login_with_no_password: false,
-    show_download_button_in_learn: false,
+  const { facilityDatasetId } = store.state;
+  return client({
+    url: urls['kolibri:core:facilitydataset-resetsettings'](facilityDatasetId),
+    method: 'POST',
+  }).then(({ data }) => {
+    store.commit('CONFIG_PAGE_MODIFY_ALL_SETTINGS', {
+      learner_can_edit_username: data.learner_can_edit_username,
+      learner_can_edit_name: data.learner_can_edit_name,
+      learner_can_edit_password: data.learner_can_edit_password,
+      learner_can_sign_up: data.learner_can_sign_up,
+      learner_can_delete_account: data.learner_can_delete_account,
+      learner_can_login_with_no_password: data.learner_can_login_with_no_password,
+      show_download_button_in_learn: data.show_download_button_in_learn,
+    });
   });
-  return saveFacilityConfig(store);
 }

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -1,7 +1,13 @@
 import { FacilityResource, FacilityDatasetResource } from 'kolibri.resources';
+import client from 'kolibri.client';
 import { showFacilityConfigPage } from '../../src/modules/facilityConfig/handlers';
 import { jestMockResource } from 'testUtils'; // eslint-disable-line
 import makeStore from '../makeStore';
+
+jest.mock('kolibri.client', () => jest.fn());
+jest.mock('kolibri.urls', () => ({
+  'kolibri:core:facilitydataset-resetsettings': () => {},
+}));
 
 const FacilityStub = jestMockResource(FacilityResource);
 const DatasetStub = jestMockResource(FacilityDatasetResource);
@@ -156,18 +162,18 @@ describe('facility config page actions', () => {
     });
 
     it('resetFacilityConfig action dispatches resets settings and makes a save request', () => {
-      const saveStub = DatasetStub.__getModelSaveReturns('ok default');
+      const expected = {
+        learner_can_edit_username: true,
+        learner_can_edit_name: false,
+        learner_can_edit_password: true,
+        learner_can_sign_up: false,
+        learner_can_delete_account: true,
+        learner_can_login_with_no_password: false,
+        show_download_button_in_learn: true,
+      };
+      client.mockResolvedValue({ data: expected });
       return store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
-        expect(saveStub).toHaveBeenCalled();
-        expect(store.state.facilityConfig.settings).toEqual({
-          learner_can_edit_username: true,
-          learner_can_edit_name: true,
-          learner_can_edit_password: true,
-          learner_can_sign_up: true,
-          learner_can_delete_account: true,
-          learner_can_login_with_no_password: false,
-          show_download_button_in_learn: false,
-        });
+        expect(store.state.facilityConfig.settings).toEqual(expected);
       });
     });
   });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

1. Adds a new endpoint `/api/auth/facilitydataset/<dataset_id>/resetsettings` that the client can POST to. The backend will reset to the settings based on `dataset.preset`, then return the new settings, which are used to update the client.
2. To implement this update logic, this adds a `reset_to_default_settings` on the `FacilityDataset` model.
3. Update the `/provisiondevice` endpoint to take advantage of the `reset_to_default_settings` method.
4. Add tests for new endpoint, and update front-end tests for new behavior.

### Reviewer guidance

1. Does the setup wizard still work properly for different presets?
2. Does the "reset settings" function work properly and reflect the facility preset after setup?
3. Because I can't use the `permissions_classes` from the parent class for the new endpoint using `@decorators.action`, are the permissions used there good enough?

### References

Fixes #7334

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
