### PR TITLE
Change exit link for Select Content Page after being taken there as part of channel upgrade flow

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -115,7 +115,7 @@
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { TaskStatuses } from '../../constants';
+  import { TaskStatuses, PageNames } from '../../constants';
   import { fetchOrTriggerChannelDiffStatsTask, fetchChannelAtSource } from './api';
 
   export default {
@@ -232,14 +232,19 @@
                 const match = tasks.find(task => task.id === taskId) || {};
                 if (match && match.database_ready) {
                   stopWatching();
-                  this.$router.push(this.$router.getRoute('SELECT_CONTENT'));
+                  this.$router.push({
+                    ...this.$router.getRoute(PageNames.SELECT_CONTENT),
+                    query: {
+                      last: PageNames.MANAGE_CONTENT_PAGE,
+                    },
+                  });
                 } else if (match.status === TaskStatuses.FAILED) {
                   stopWatching();
-                  this.$router.push(this.$router.getRoute('MANAGE_TASKS'));
+                  this.$router.push(this.$router.getRoute(PageNames.MANAGE_TASKS));
                 }
               });
             } else {
-              this.$router.push(this.$router.getRoute('MANAGE_TASKS'));
+              this.$router.push(this.$router.getRoute(PageNames.MANAGE_TASKS));
             }
           })
           .catch(error => {


### PR DESCRIPTION
### Summary

Previously, after upgrading a channel that has new resources, the user would be redirected to the Select Content Page, but the "immersive toolbar route" on the top-left would take one the Available Channels Page.

This patch changes the immersive toolbar route to the Manage Content Page, instead, as a reasonable reset point.

Flow Before:

1. Start at Manage Content Page
1. Click "Manage" next to a channel
2. Click "Upgrade" channel on the next page
3. Confirm the upgrade
4. You are taken to the select content page for the channel
5. Click the "X" on the upper-left corner
6. You are taken to the Available Channels Page

Flow After is the same except

6. You are taken to the Manage content page (i.e. step 1)

### Reviewer guidance

This is a hassle to actually test because of the requirement to publish new versions of channels on studio. The simplest thing to do would be to simply go to the URL in the updated redirection code and see that it goes to the right place.

e.g. the URL would be something like

https://localhost:8000/en/device/#/content/channels/40010d1071724fc4a45c3df2504519b6?last=MANAGE_CONTENT_PAGE

### References

Fixes #7397

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
