### PR TITLE
Fix sign-in link to redirect to original Learn-page URL when attempting to view restricted content as a guest

### DIFF
--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -83,8 +83,14 @@
           // In practice, this will only happen on select Learn pages.
           return '/';
         } else {
-          const currentURL = window.encodeURIComponent(window.location.href);
-          return `${this.userPluginUrl()}#/signin?next=${currentURL}`;
+          let next;
+          // If the current URL has a ?next param, use that instead of the current URL
+          if (this.$route.query.next) {
+            next = this.$route.query.next;
+          } else {
+            next = window.encodeURIComponent(window.location.href);
+          }
+          return `${this.userPluginUrl()}#/signin?next=${next}`;
         }
       },
     },

--- a/kolibri/core/assets/test/views/auth-message.spec.js
+++ b/kolibri/core/assets/test/views/auth-message.spec.js
@@ -1,9 +1,17 @@
 import urls from 'kolibri.urls';
 import Vuex from 'vuex';
-import { shallowMount } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import AuthMessage from '../../src/views/AuthMessage';
 
 jest.mock('urls', () => ({}));
+
+const localVue = createLocalVue();
+
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+const router = new VueRouter();
 
 function makeWrapper(options) {
   const store = new Vuex.Store({
@@ -13,7 +21,7 @@ function makeWrapper(options) {
       },
     },
   });
-  return shallowMount(AuthMessage, { store, ...options });
+  return shallowMount(AuthMessage, { store, localVue, router, ...options });
 }
 
 // prettier-ignore
@@ -76,7 +84,7 @@ describe('auth message component', () => {
     const wrapper = makeWrapper();
     const link = wrapper.find('kexternallink-stub');
     expect(link.attributes()).toMatchObject({
-      href: 'http://localhost:8000/en/user/#/signin?next=http%3A%2F%2Fkolibri.time%2F',
+      href: 'http://localhost:8000/en/user/#/signin?next=http%3A%2F%2Fkolibri.time%2F%23%2F',
       text: 'Sign in to Kolibri',
     });
     delete urls['kolibri:kolibri.plugins.user:user'];

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -28,7 +28,14 @@ class LearnModule extends KolibriApp {
         !this.store.state.allowGuestAccess &&
         !this.store.getters.isUserLoggedIn
       ) {
-        router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
+        // Pass the ?next param on to AuthMessage
+        const currentURL = window.encodeURIComponent(window.location.href);
+        router.replace({
+          name: PageNames.CONTENT_UNAVAILABLE,
+          query: {
+            next: currentURL,
+          },
+        });
       } else {
         next();
       }


### PR DESCRIPTION
### Summary

Updates logic in the Learn SPA's `beforeEach` hook that annotates the `content-unavailable` URL with a `next` param that the sign-in page will use to redirect to the intended page after authentication.

<img width="742" alt="CleanShot 2021-01-12 at 14 43 49@2x" src="https://user-images.githubusercontent.com/10248067/104383564-e23f2d80-54e4-11eb-964a-c73f3e250d47.png">

example Content-unavailable link with `next` param

http://localhost:8000/en/learn/#/content-unavailable?next=http%253A%252F%252Flocalhost%253A8000%252Fen%252Flearn%252F%2523%252Ftopics%252F000409f81dbe5d1ba67101cb9fed4530

Example sign-in link (the next param is the `/topics/` URL instead of the `content-unavailable` URL it was previously)

http://localhost:8000/en/user/#/signin?next=http%3A%2F%2Flocalhost%3A8000%2Fen%2Flearn%2F%23%2Ftopics%2F000409f81dbe5d1ba67101cb9fed4530


### Reviewer guidance

1. On Device settings, disable guest access to content.
2. In a different guest session, try to access any URL on the learn page
3. You will see an AuthMessage page
4. Follow the "sign-in" link, and log in. 
5. You will be taken to the original page in step 2


### References

Fixes #7722 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
