### PR TITLE
Fix bugs when validating the number of questions in a quiz

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -327,7 +327,7 @@
         if (this.numQuestions > this.availableQuestions) {
           return this.$tr('numQuestionsExceed', {
             inputNumQuestions: this.numQuestions,
-            maxQuestionsFromSelection: this.availableQuestions,
+            maxQuestionsFromSelection: String(this.availableQuestions),
           });
         }
         return null;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -462,10 +462,8 @@
           });
       },
       continueProcess() {
-        if (this.numQuestionsInvalid) {
-          this.$refs.questionsInput.focus();
-        }
         if (this.selectionIsInvalidText) {
+          this.$refs.questionsInput.focus();
           this.showError = true;
         } else {
           this.$router.push({ name: PageNames.EXAM_CREATION_QUESTION_SELECTION });

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -324,6 +324,9 @@
         if (!Number.isInteger(this.numQuestions)) {
           return this.$tr('numQuestionsBetween');
         }
+        if (this.availableQuestions === 0) {
+          return this.$tr('noneSelected');
+        }
         if (this.numQuestions > this.availableQuestions) {
           return this.$tr('numQuestionsExceed', {
             inputNumQuestions: this.numQuestions,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -52,7 +52,7 @@
                 :invalid="Boolean(showError && numQuestIsInvalidText)"
                 :invalidText="numQuestIsInvalidText"
                 :label="$tr('numQuestions')"
-                @blur="numQuestionsBlurred = true"
+                @blur="handleNumberQuestionsBlur"
               />
             </KGridItem>
             <KGridItem
@@ -222,6 +222,10 @@
           return this.numberOfQuestions;
         },
         set(value) {
+          // If value in the input doesn't match state, update it
+          if (value !== Number(this.$refs.questionsInput.currentText)) {
+            this.$refs.questionsInput.currentText = value;
+          }
           // If it is cleared out, then set vuex state to null so it can be caught during
           // validation
           if (value === '') {
@@ -492,6 +496,15 @@
             topicId,
           },
         };
+      },
+      handleNumberQuestionsBlur() {
+        this.numQuestionsBlurred = true;
+        if (Number(this.$refs.questionsInput.currentText) < 0) {
+          this.numQuestions = 1;
+        }
+        if (Number(this.$refs.questionsInput.currentText) > this.maxQs) {
+          this.numQuestions = this.maxQs;
+        }
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary

1. Fixes #7597 by clamping the number of questions between 0 and 50 and updating Vuex and the DOM when any inputs outside of those bounds are entered.
2. Fix #7612 by coercing the input to the template message to a string, because the `{..., number}` option was missing in the message, some values were just appearing as empty string.
3. Related to the above, I added a special error message when the number of available questions was zero (e.g. if no nodes were selected yet and the user clicked continue). Even with the fix, the message would read: `'The max number of questions based on the exercises you selected is 0. Select more exercises to reach 0 questions, or lower the number of questions to 0.'` which is not possible to do.

### Reviewer guidance

verify that the two issues are fixed

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
