### PR TITLE
Fix issue with "in progress" icon being displayed in guest mode and update icon display logic in ProgressIcon.vue

### DIFF
--- a/kolibri/core/assets/src/views/ProgressIcon.vue
+++ b/kolibri/core/assets/src/views/ProgressIcon.vue
@@ -58,7 +58,8 @@
     },
     computed: {
       isInProgress() {
-        return this.progress !== null && this.progress >= 0 && this.progress < 1;
+        // this logic is updated to be consistent with the logic in CardThumbnail
+        return this.progress !== null && this.progress > 0 && this.progress < 1;
       },
       isCompleted() {
         return this.progress >= 1;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -1,10 +1,11 @@
 <template>
 
   <KPageContainer>
-
+    <!-- isUserLoggedIn is used here to check if user is logged in or not.-->
+    <!-- If in guest mode, do not show progress icon at all-->
     <PageHeader
       :title="content.title"
-      :progress="progress"
+      :progress="isUserLoggedIn ? progress : null"
       dir="auto"
       :contentType="content.kind"
     />


### PR DESCRIPTION
### Summary

1. Fix the issue where "in progress" icon will be displayed in guest mode.

**Before**
![before_1](https://user-images.githubusercontent.com/32107618/104643369-2eaf7800-5661-11eb-8f29-5128d90c12e6.png)

**After**
![after_1](https://user-images.githubusercontent.com/32107618/104643396-3a9b3a00-5661-11eb-9a2d-65aa6d3b4446.png)

2. The logic controlling when the icon is displayed in `ProgressIcon` is updated to be the same as the logic in `CardThumbnail`. 

This changes the behavior for signed-in user when a resource is first clicked on. Before this change when a signed-in user views a non-video resource for the first time, the in-progress icon **will be display already**. Now the in-progress icon will be displayed **after second visit**. For video resource, the icon will appear after a few seconds.

### Reviewer guidance

**Test steps for item 1**
1. Use Kolibri as a guest
2. Go to some resource
3. The icon should not be displayed in guest mode 

**Test steps for item 2**
1. Logged on to Kolibri 
2. Go to a non video resource which has not been view before (with no "in progress" icon)
3. The icon should not be displayed. Navigate away from this page.
4. Now navigate back to the same resource. The icon should now be displayed.
5. Go to a video resource which has not been view before (with no "in progress" icon)
6. The icon should not be displayed.
7. Click to play the video. The icon should appear after a few seconds.

### References

#7719 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
