### PR TITLE
Handle ValueError from tzlocal.get_localzone

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -251,7 +251,7 @@ LANGUAGE_CODE = (
 
 try:
     TIME_ZONE = get_localzone().zone
-except pytz.UnknownTimeZoneError:
+except (pytz.UnknownTimeZoneError, ValueError):
     # Do not fail at this point because a timezone was not
     # detected.
     TIME_ZONE = pytz.utc.zone


### PR DESCRIPTION
### Summary

This changes some code which determines the local time zone so it will _also_ handle an exception raised by tzlocal's `get_localzone` function.

### References

Closes #7760

### Contributor Checklist

PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
