### PR TITLE
Ensure imported content is immediately accessible

### DIFF
--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -1,6 +1,9 @@
 """
 Helper functions for use across the user/auth/permission-related tests.
 """
+from django.core.cache import caches
+from django.core.cache.backends.base import InvalidCacheBackendError
+
 from ..models import Classroom
 from ..models import Facility
 from ..models import FacilityDataset
@@ -11,6 +14,14 @@ from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import provision_device  # noqa
 
 DUMMY_PASSWORD = "password"
+
+
+def clear_process_cache():
+    try:
+        process_cache = caches["process_cache"]
+        process_cache.clear()
+    except InvalidCacheBackendError:
+        pass
 
 
 def create_superuser(facility, username="superuser"):

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -3,7 +3,6 @@ import time
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.cache import cache
 from django.db import models
 from morango.models import UUIDField
 
@@ -11,6 +10,7 @@ from .utils import LANDING_PAGE_LEARN
 from .utils import LANDING_PAGE_SIGN_IN
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.utils.cache import process_cache as cache
 from kolibri.plugins.app.utils import interface
 
 device_permissions_fields = ["is_superuser", "can_manage_content"]

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -19,6 +19,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Role
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
@@ -30,6 +31,8 @@ DUMMY_PASSWORD = "password"
 
 
 class DeviceProvisionTestCase(APITestCase):
+    def setUp(self):
+        clear_process_cache()
 
     superuser_data = {"username": "superuser", "password": "password"}
     facility_data = {"name": "Wilson Elementary"}

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -13,6 +13,7 @@ from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.auth.constants.facility_presets import presets
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.helpers import setup_device
 
@@ -21,6 +22,9 @@ class DeviceProvisionTestCase(TestCase):
     """
     Tests for functions used in provisiondevice command.
     """
+
+    def setUp(self):
+        clear_process_cache()
 
     def test_create_facility(self):
         create_facility(facility_name="test")

--- a/kolibri/core/device/test/test_locale_middleware.py
+++ b/kolibri/core/device/test/test_locale_middleware.py
@@ -11,6 +11,7 @@ from django.utils import translation
 from django.utils._os import upath
 from mock import patch
 
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.tests.helpers import override_option
 
@@ -51,10 +52,12 @@ class URLTestCaseBase(TestCase):
     def setUp(self):
         # Make sure the cache is empty before we are doing our tests.
         clear_url_caches()
+        clear_process_cache()
 
     def tearDown(self):
         # Make sure we will leave an empty cache for other testcases.
         clear_url_caches()
+        clear_process_cache()
 
 
 class URLPrefixTestsBase(object):

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -10,6 +10,7 @@ from rest_framework.test import APITestCase
 from rest_framework.test import APITransactionTestCase
 
 from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import DUMMY_PASSWORD
@@ -20,6 +21,9 @@ from kolibri.deployment.default.urls import urlpatterns
 
 
 class BeforeDeviceProvisionTests(APITestCase):
+    def setUp(self):
+        clear_process_cache()
+
     def test_redirect_to_setup_wizard(self):
         response = self.client.get(reverse("kolibri:core:root_redirect"))
         self.assertEqual(response.status_code, 302)

--- a/kolibri/plugins/setup_wizard/test/test_api.py
+++ b/kolibri/plugins/setup_wizard/test/test_api.py
@@ -5,12 +5,14 @@ from __future__ import unicode_literals
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_dummy_facility_data
 from kolibri.core.auth.test.helpers import provision_device
 
 
 class GetFacilityAdminsTest(APITestCase):
     def setUp(self):
+        clear_process_cache()
         create_dummy_facility_data(classroom_count=1)
 
     def _make_request(self):
@@ -35,6 +37,8 @@ class GetFacilityAdminsTest(APITestCase):
 
 class GrantSuperuserPermissionsTest(APITestCase):
     def setUp(self):
+        clear_process_cache()
+
         facility_data = create_dummy_facility_data(classroom_count=1)
         self.admin = facility_data["facility_admin"]
         self.admin.set_password("password")


### PR DESCRIPTION
### Summary
This fixes an issue where newly imported content wasn't showing up immediately.  @rtibbles suggested this change, and it worked.  In his own words:

> The reason being that the cache key cache is being updated in the async task, which runs in a different process to the server, and so they don't use a shared cache in the default configuration

### Reviewer guidance
- Import some content
- Make sure it shows up on the "Learn -> Channels" page

### References
Fixes https://github.com/learningequality/kolibri/issues/7765

PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label

Testing:

- [x] Contributor has fully tested the PR manually

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
