### PR TITLE
Lazy load config in logger

### DIFF
--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -4,8 +4,6 @@ import re
 from logging import Formatter
 from logging.handlers import TimedRotatingFileHandler
 
-from . import conf
-
 
 GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
@@ -125,6 +123,8 @@ class RequireDebugTrue(logging.Filter):
     """A copy from Django to avoid loading Django's settings stack"""
 
     def filter(self, record):
+        from . import conf
+
         return conf.OPTIONS["Server"]["DEBUG"]
 
 


### PR DESCRIPTION
### Summary

This is a simple change to `kolibri.utils.logger` which moves an import from `kolibri.utils.conf` inside the function which requires it. This allows a Kolibri desktop app like [kolibri-installer-gnome](github.com/learningequality/kolibri-installer-gnome) or [kolibri-installer-mac](github.com/learningequality/kolibri-installer-mac) to reuse Kolibri's `KolibriTimedRotatingFileHandler` without triggering an import from `kolibri.conf` (which comes with side-effects).

### Reviewer guidance

Please confirm that this change follows Kolibri's coding standards and has no unintended consequences.

### References

This is related to learningequality/kolibri-installer-gnome#19.

### Contributor Checklist

PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
