### PR TITLE
Update progress using summary spent_time, not session

### DIFF
--- a/kolibri/core/assets/src/state/modules/logging.js
+++ b/kolibri/core/assets/src/state/modules/logging.js
@@ -17,6 +17,9 @@ export default {
     sessionTimeSpent(state) {
       return state.session.time_spent;
     },
+    summaryTimeSpent(state) {
+      return state.summary.time_spent;
+    },
   },
   mutations: {
     SET_LOGGING_SUMMARY_STATE(state, summaryState) {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -452,7 +452,7 @@
     },
     beforeDestroy() {
       this.updateContentState();
-      this.updateProgress();
+      this.addProgress();
       this.$emit('stopTracking');
       window.removeEventListener('mousedown', this.handleMouseDown, { passive: true });
       clearInterval(this.updateContentStateInterval);
@@ -461,9 +461,9 @@
       delete global.ePub;
     },
     methods: {
-      updateProgress() {
+      addProgress() {
         if (this.locations.length > 0) {
-          this.$emit('updateProgress', this.sessionTimeSpent / this.expectedTimeToRead);
+          this.$emit('addProgress', this.sessionTimeSpent / this.expectedTimeToRead);
         }
       },
       handleReadyRendition() {
@@ -480,7 +480,7 @@
         this.book.locations.generate(LOCATIONS_INTERVAL).then(locations => {
           this.locations = locations;
           this.$emit('startTracking');
-          this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
+          this.updateContentStateInterval = setInterval(this.addProgress, 30000);
 
           // Update current location, .currentLocation() can return Promise or value
           Promise.resolve()

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -226,7 +226,7 @@
       };
     },
     computed: {
-      ...mapGetters(['sessionTimeSpent']),
+      ...mapGetters(['summaryTimeSpent']),
       isAtStart() {
         return get(this.rendition, 'location.atStart', false);
       },
@@ -452,7 +452,7 @@
     },
     beforeDestroy() {
       this.updateContentState();
-      this.addProgress();
+      this.updateProgress();
       this.$emit('stopTracking');
       window.removeEventListener('mousedown', this.handleMouseDown, { passive: true });
       clearInterval(this.updateContentStateInterval);
@@ -461,9 +461,9 @@
       delete global.ePub;
     },
     methods: {
-      addProgress() {
+      updateProgress() {
         if (this.locations.length > 0) {
-          this.$emit('addProgress', this.sessionTimeSpent / this.expectedTimeToRead);
+          this.$emit('updateProgress', this.summaryTimeSpent / this.expectedTimeToRead);
         }
       },
       handleReadyRendition() {
@@ -480,7 +480,7 @@
         this.book.locations.generate(LOCATIONS_INTERVAL).then(locations => {
           this.locations = locations;
           this.$emit('startTracking');
-          this.updateContentStateInterval = setInterval(this.addProgress, 30000);
+          this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
 
           // Update current location, .currentLocation() can return Promise or value
           Promise.resolve()

--- a/kolibri/plugins/h5p_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/h5p_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -35,6 +35,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import { now } from 'kolibri.utils.serverClock';
   import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
@@ -53,6 +54,7 @@
       };
     },
     computed: {
+      ...mapGetters(['summaryTimeSpent']),
       name() {
         return nameSpace;
       },
@@ -67,7 +69,6 @@
       });
       this.hashi.initialize((this.extraFields && this.extraFields.contentState) || {});
       this.$emit('startTracking');
-      this.startTime = now();
       this.pollProgress();
     },
     beforeDestroy() {
@@ -78,8 +79,8 @@
     },
     methods: {
       recordProgress() {
-        const totalTime = now() - this.startTime;
-        this.$emit('addProgress', Math.max(0, totalTime / 300000));
+        const totalTime = this.summaryTimeSpent * 1000;
+        this.$emit('updateProgress', Math.max(0, totalTime / 300000));
         this.pollProgress();
       },
       pollProgress() {

--- a/kolibri/plugins/h5p_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/h5p_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -79,7 +79,7 @@
     methods: {
       recordProgress() {
         const totalTime = now() - this.startTime;
-        this.$emit('updateProgress', Math.max(0, totalTime / 300000));
+        this.$emit('addProgress', Math.max(0, totalTime / 300000));
         this.pollProgress();
       },
       pollProgress() {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -48,6 +48,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import { now } from 'kolibri.utils.serverClock';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import Hashi from 'hashi';
@@ -73,6 +74,7 @@
       };
     },
     computed: {
+      ...mapGetters(['summaryTimeSpent']),
       name() {
         return nameSpace;
       },
@@ -135,7 +137,6 @@
         this.userData
       );
       this.$emit('startTracking');
-      this.startTime = now();
       this.pollProgress();
     },
     beforeDestroy() {
@@ -146,10 +147,10 @@
     },
     methods: {
       recordProgress() {
-        const totalTime = now() - this.startTime;
+        const totalTime = this.summaryTimeSpent * 1000;
         const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
         this.$emit(
-          'addProgress',
+          'updateProgress',
           hashiProgress === null ? Math.max(0, totalTime / 300000) : hashiProgress
         );
         this.pollProgress();

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -149,7 +149,7 @@
         const totalTime = now() - this.startTime;
         const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
         this.$emit(
-          'updateProgress',
+          'addProgress',
           hashiProgress === null ? Math.max(0, totalTime / 300000) : hashiProgress
         );
         this.pollProgress();

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -142,7 +142,7 @@
       showControls: true,
     }),
     computed: {
-      ...mapGetters(['sessionTimeSpent']),
+      ...mapGetters(['summaryTimeSpent']),
       // Returns whether or not the current device is iOS.
       // Probably not perfect, but worked in testing.
       iOS() {
@@ -261,13 +261,13 @@
           this.progress = 1;
         }
         this.$emit('startTracking');
-        this.updateContentStateInterval = setInterval(this.addProgress, 30000);
+        this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
         // Automatically master after the targetTime, convert seconds -> milliseconds
-        this.timeout = setTimeout(this.addProgress, this.targetTime * 1000);
+        this.timeout = setTimeout(this.updateProgress, this.targetTime * 1000);
       });
     },
     beforeDestroy() {
-      this.addProgress();
+      this.updateProgress();
       this.updateContentState();
 
       if (this.timeout) {
@@ -365,8 +365,8 @@
       forceUpdateRecycleList() {
         this.$refs.recycleList.updateVisibleItems(false);
       },
-      addProgress() {
-        this.$emit('addProgress', this.sessionTimeSpent / this.targetTime);
+      updateProgress() {
+        this.$emit('updateProgress', this.summaryTimeSpent / this.targetTime);
       },
       updateContentState() {
         let contentState;

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -261,13 +261,13 @@
           this.progress = 1;
         }
         this.$emit('startTracking');
-        this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
+        this.updateContentStateInterval = setInterval(this.addProgress, 30000);
         // Automatically master after the targetTime, convert seconds -> milliseconds
-        this.timeout = setTimeout(this.updateProgress, this.targetTime * 1000);
+        this.timeout = setTimeout(this.addProgress, this.targetTime * 1000);
       });
     },
     beforeDestroy() {
-      this.updateProgress();
+      this.addProgress();
       this.updateContentState();
 
       if (this.timeout) {
@@ -365,8 +365,8 @@
       forceUpdateRecycleList() {
         this.$refs.recycleList.updateVisibleItems(false);
       },
-      updateProgress() {
-        this.$emit('updateProgress', this.sessionTimeSpent / this.targetTime);
+      addProgress() {
+        this.$emit('addProgress', this.sessionTimeSpent / this.targetTime);
       },
       updateContentState() {
         let contentState;

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -135,7 +135,7 @@
       },
       currentSlideIndex() {
         if (this.currentSlideIndex + 1 === this.slides.length) {
-          this.addProgress();
+          this.updateProgress();
         }
       },
     },
@@ -158,7 +158,7 @@
       }
     },
     beforeDestroy() {
-      this.addProgress();
+      this.updateProgress();
       this.updateContentState();
       this.$emit('stopTracking');
     },
@@ -243,8 +243,8 @@
         this.extraFields.contentState.lastViewedSlideIndex = this.currentSlideIndex;
         this.$emit('updateContentState', this.extraFields.contentState);
       },
-      addProgress() {
-        // addProgress adds the percent to the existing value, so only pass
+      updateProgress() {
+        // updateProgress adds the percent to the existing value, so only pass
         // the percentage of progress in this session, not the full percentage.
         const progressPercent =
           this.highestViewedSlideIndex + 1 === this.slides.length
@@ -252,7 +252,7 @@
             : (this.highestViewedSlideIndex -
                 this.extraFields.contentState.highestViewedSlideIndex) /
               this.slides.length;
-        this.$emit('addProgress', progressPercent);
+        this.$emit('updateProgress', progressPercent);
       },
     },
     $trs: {

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -135,7 +135,7 @@
       },
       currentSlideIndex() {
         if (this.currentSlideIndex + 1 === this.slides.length) {
-          this.updateProgress();
+          this.addProgress();
         }
       },
     },
@@ -158,7 +158,7 @@
       }
     },
     beforeDestroy() {
-      this.updateProgress();
+      this.addProgress();
       this.updateContentState();
       this.$emit('stopTracking');
     },
@@ -243,8 +243,8 @@
         this.extraFields.contentState.lastViewedSlideIndex = this.currentSlideIndex;
         this.$emit('updateContentState', this.extraFields.contentState);
       },
-      updateProgress() {
-        // updateProgress adds the percent to the existing value, so only pass
+      addProgress() {
+        // addProgress adds the percent to the existing value, so only pass
         // the percentage of progress in this session, not the full percentage.
         const progressPercent =
           this.highestViewedSlideIndex + 1 === this.slides.length
@@ -252,7 +252,7 @@
             : (this.highestViewedSlideIndex -
                 this.extraFields.contentState.highestViewedSlideIndex) /
               this.slides.length;
-        this.$emit('updateProgress', progressPercent);
+        this.$emit('addProgress', progressPercent);
       },
     },
     $trs: {


### PR DESCRIPTION
### Summary

Users are complaining because spending long time (more than 50 minutes in some cases) in some resources they don't get it marked as completed. The reason was the user spends the time entering in the resource in different moments.

This PR changes the criteria to update the summary log in several renderers.
Renderers that use time as a completion criteria were restarting the completion percentage everytime the user goes back to the resource. 

Users should see its summary progress percentage increase when continuing reading/viewing a previous resource, so the completion is ended in the right completion time. 


### Reviewer guidance
In any channel enter into a pdf, epub or  html5 app.
Check that exiting/entering several times in the resource does not avoid it to be completed.

### References

Closes: #7764 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
