### PR TITLE
Fix "X" button on search results page going to wrong location after viewing content shortly before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ List of the most important changes for each release.
 ### Fixed
 
 * #7725 On Firefox, text in Khmer, Hindi, Marathi, and other languages did not render properly.
-* #7722, #7488 After viewing a restricted page then signing in, users were redirected to the original destination URL.
+* #7722, #7488 After viewing a restricted page, then signing in, users were not redirected back to the restricted page.
 * #7597, #7612 Quiz creation workflow did not properly validate the number of questions
 
 ([0.14.6 Github milestone](https://github.com/learningequality/kolibri/issues?q=label%3Achangelog+milestone%3A0.14.6))

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -109,7 +109,7 @@
     mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     data() {
       return {
-        lastRoute: null,
+        searchPageExitRoute: null,
         demographicInfo: null,
       };
     },
@@ -178,8 +178,9 @@
           return {
             appBarTitle: this.coreString('searchLabel'),
             immersivePage: true,
-            // Default to the Learn root page if there is no lastRoute to return to.
-            immersivePageRoute: this.lastRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
+            // Default to the Learn root page if there is no searchPageExitRoute to return to.
+            immersivePageRoute:
+              this.searchPageExitRoute || this.$router.getRoute(PageNames.TOPICS_ROOT),
             immersivePagePrimary: true,
             immersivePageIcon: 'close',
           };
@@ -275,20 +276,26 @@
     },
     watch: {
       $route: function(newRoute, oldRoute) {
-        // Return if the user is leaving or entering the Search page.
-        // This ensures we never set this.lastRoute to be any kind of
-        // SEARCH route and avoids infinite loops.
-        if (newRoute.name === 'SEARCH' || oldRoute.name === 'SEARCH') {
-          return;
+        const topicRouteNames = [
+          PageNames.TOPICS_ROOT,
+          PageNames.TOPICS_CHANNEL,
+          PageNames.TOPICS_TOPIC,
+        ];
+        // If going from topic -> search, save the topic route parameters for the
+        // exit link.
+        // But, if we go from search -> content, we do not edit `searchPageExitRoute`
+        // preserve the backwards linking from content -> search -> topic
+        if (topicRouteNames.includes(oldRoute.name) && newRoute.name === PageNames.SEARCH) {
+          this.searchPageExitRoute = {
+            name: oldRoute.name,
+            query: oldRoute.query,
+            params: oldRoute.params,
+          };
+        } else if (oldRoute.name === PageNames.SEARCH && topicRouteNames.includes(newRoute.name)) {
+          // If going from search -> topic (either by clicking "X" or clicking a topic card
+          // in the results), clear out the exit route.
+          this.searchPageExitRoute = null;
         }
-
-        // Destructure the oldRoute into an object with 3 specific properties.
-        // Setting this.lastRoute = oldRoute causes issues for some reason.
-        this.lastRoute = {
-          name: oldRoute.name,
-          query: oldRoute.query,
-          params: oldRoute.params,
-        };
       },
     },
     mounted() {


### PR DESCRIPTION
### Summary

1. Fixes #7769 by being more selective when saving `searchPageExitRoute` (previously called `lastRoute`). Now, this route is only saved when going from a topic-level page to the search page. The root cause of #7769 was that we were saving the route when going to the content page (which is never a valid exit link for the search page).
1. Edit the recent CHANGELOG entry for grammar and clarity

### Reviewer guidance

Test out exiting from the Search Results page with different variations, e.g.

**Going from different parts of the content hierarchy.** 

1. Start at Topic A -> Search "nouns" 
2. View "Intro to nouns" video 
3. Exit to Search "nouns" 
4. Exit to Topic A.

**Going from different searches.**

1. Start at Topic A 
2. Search "nouns" 
3. Search "verbs" 
4. Exit to Topic A.

**Going from search to a topic.**

1. Start at Topic A
2. Search "nouns" 
3. Click "noun topic" card in search results
4. At "noun topic" page. search "verbs"
5. Exit to "noun topic". 

That is, we do not exit to "Topic A", but return to "noun topic" as the last non-search location.

### References

Fixes #7769

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
