### PR TITLE
Redirect to the Learn page after updating profile (when prompted by notification)

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -311,7 +311,7 @@
       },
       handleSubmitUpdateYourProfileModal() {
         if (this.userPluginUrl) {
-          const url = `${this.userPluginUrl()}#/profile/edit`;
+          const url = `${this.userPluginUrl()}#/profile/edit?next_page=learn`;
           const redirect = () => {
             window.location.href = url;
           };

--- a/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfileEditPage.vue
@@ -47,7 +47,7 @@
           :disabled="formDisabled"
           appearance="raised-button"
           :primary="false"
-          @click="$router.push($router.getRoute(ComponentMap.PROFILE))"
+          @click="handleCancel"
         />
       </KButtonGroup>
     </form>
@@ -61,6 +61,7 @@
   import every from 'lodash/every';
   import pickBy from 'lodash/pickBy';
   import { mapGetters } from 'vuex';
+  import urls from 'kolibri.urls';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import GenderSelect from 'kolibri.coreVue.components.GenderSelect';
@@ -98,7 +99,6 @@
         formSubmitted: false,
         status: '',
         userCopy: {},
-        ComponentMap,
       };
     },
     computed: {
@@ -123,6 +123,9 @@
       },
       formIsValid() {
         return every([this.fullNameValid, this.usernameValid]);
+      },
+      isReferredFromLearnPage() {
+        return this.$route.query.next_page === 'learn';
       },
     },
     mounted() {
@@ -152,6 +155,13 @@
           }
         );
       },
+      handleCancel() {
+        if (this.isReferredFromLearnPage) {
+          this.navigateToLearnPage();
+        } else {
+          this.$router.push(this.$router.getRoute(ComponentMap.PROFILE));
+        }
+      },
       handleSubmit() {
         this.formSubmitted = true;
         if (this.formIsValid) {
@@ -162,8 +172,12 @@
             })
             .then(() => {
               this.showSnackbarNotification('changesSaved');
-              const nextRoute = this.$router.getRoute(ComponentMap.PROFILE);
-              this.$router.push(nextRoute);
+              if (this.isReferredFromLearnPage) {
+                this.navigateToLearnPage();
+              } else {
+                const nextRoute = this.$router.getRoute(ComponentMap.PROFILE);
+                this.$router.push(nextRoute);
+              }
             })
             .catch(error => {
               this.status = 'FAILURE';
@@ -186,6 +200,9 @@
             this.$refs.usernameTextbox.focus();
           }
         });
+      },
+      navigateToLearnPage() {
+        window.location.href = urls['kolibri:kolibri.plugins.learn:learn']();
       },
     },
     $trs: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

Fixes #7362 by updating `ProfileEditPage.vue` to redirect back to the `/learn` URL when the user has updated their profile (when prompted by the "Update your profile" notification). See gherkin story:

https://github.com/learningequality/kolibri/blob/64f1439972b7d6994bfe37dbd81fa46298834449/integration_testing/features/learner/learner-profile-update-notification.feature#L22-L31

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
