### PR TITLE
Add content serving to alternate origin server

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -319,7 +319,9 @@ def configure_http_server(port):
         conf.OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
     )
 
-    alt_port_app = wsgi.PathInfoDispatcher({"/": get_application(), CONTENT_ROOT: content_handler})
+    alt_port_app = wsgi.PathInfoDispatcher(
+        {"/": get_application(), CONTENT_ROOT: content_handler}
+    )
 
     alt_port_server = ServerAdapter(
         cherrypy.engine,


### PR DESCRIPTION
## Summary
* Serves content on the alternate origin to allow HTML5 apps to load and serve content

## References

* Prerequisite for efficiently displaying thumbnails in custom navigation apps.

## Reviewer guidance
* Do tests still pass, does everything run?
* Can you access a content url on the alternate origin (default port: 8888)

----

## Testing checklist

- [X] Contributor has fully tested the PR manually


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
