### PR TITLE
Delete codecov.yml (removes codecov integration)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project: off
-    patch: off
-
-comment:
-  layout: "files"


### PR DESCRIPTION
Removes the `codecov.yml`, since typically the change in coverage reports make no sense.