### PR TITLE
Add Python 3.8 to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     cmdclass={"install_scripts": gen_windows_batch_files},


### PR DESCRIPTION
Adds 3.8 to setup.py to match `tox` config and make it available on pypi for python 3.8 users.