### PR TITLE
Use `whitenoise` to pre-compress static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ SQLITE_MAX_VARIABLE_NUMBER.cache
 
 # static c extensions cache folder
 cext_cache
+
+# ignore gzipped files
+*.gz

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test-all:
 assets:
 	yarn install
 	yarn run build
+	yarn run compress
 
 coverage:
 	coverage run --source kolibri setup.py test

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -271,7 +271,15 @@ def configure_http_server(port):
     if not getattr(settings, "DEVELOPER_MODE", False):
         # Mount static files
         application = WhiteNoise(
-            application, root=settings.STATIC_ROOT, prefix=settings.STATIC_URL
+            application,
+            root=settings.STATIC_ROOT,
+            prefix=settings.STATIC_URL,
+            # Use 1 day as the default cache time for static assets
+            max_age=24 * 60 * 60,
+            # Add a test for any file name that contains a semantic version number
+            # or a 32 digit number (assumed to be a file hash)
+            # these files will be cached indefinitely
+            immutable_file_test=r"((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)|[a-f0-9]{32})",
         )
 
     cherrypy.tree.graft(application, "/")

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build-kolibri-tools": "yarn workspace kolibri-tools run build-kolibri-tools",
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
-    "hashi-build": "yarn workspace hashi run build"
+    "hashi-build": "yarn workspace hashi run build",
+    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{js,css,svg,map,eot,woff,ttf,woff2}'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
     "hashi-build": "yarn workspace hashi run build",
-    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{js,css,svg,map,eot,woff,ttf,woff2}'"
+    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{js,css,ico,svg,map,eot,woff,ttf,woff2}'"
   },
   "repository": {
     "type": "git",

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -349,6 +349,26 @@ program
     require('jest-cli/build/cli').run();
   });
 
+// Test
+program
+  .command('compress')
+  .arguments('[files...]', 'List of custom file globs or file names to compress')
+  .allowUnknownOption()
+  .action(function(files) {
+    if (!files.length) {
+      program.help();
+    } else {
+      const glob = require('glob');
+      const compressFile = require('./compress');
+      Promise.all(
+        files.map(file => {
+          const matches = glob.sync(file);
+          return Promise.all(matches.map(compressFile));
+        })
+      );
+    }
+  });
+
 // Check engines, then process args
 const engines = require(path.resolve(__dirname, '../../../package.json')).engines;
 checkVersion(engines, (err, results) => {

--- a/packages/kolibri-tools/lib/compress.js
+++ b/packages/kolibri-tools/lib/compress.js
@@ -1,0 +1,27 @@
+const { constants, createGzip } = require('zlib');
+const { pipeline } = require('stream');
+const { createReadStream, createWriteStream } = require('fs');
+const logger = require('./logging');
+
+const logging = logger.getLogger('Kolibri Compressor');
+
+function compressFile(input) {
+  return new Promise(resolve => {
+    const gzip = createGzip({
+      level: constants.Z_BEST_COMPRESSION,
+    });
+    const source = createReadStream(input);
+    const destination = createWriteStream(input + '.gz');
+    pipeline(source, gzip, destination, err => {
+      if (err) {
+        logging.error('An error occurred compressing file: ', input);
+        logging.error(err);
+      } else {
+        logging.info('Successfully compressed: ', input);
+      }
+      resolve();
+    });
+  });
+}
+
+module.exports = compressFile;

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -154,7 +154,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
           test: /\.(png|jpe?g|gif|svg)$/,
           use: {
             loader: 'url-loader',
-            options: { limit: 10000, name: '[name].[ext]?[hash]' },
+            options: { limit: 10000, name: '[name]-[contenthash].[ext]' },
           },
         },
         // Use url loader to load font files.
@@ -162,7 +162,7 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
           test: /\.(eot|woff|ttf|woff2)$/,
           use: {
             loader: 'url-loader',
-            options: { name: '[name].[ext]?[hash]' },
+            options: { name: '[name]-[contenthash].[ext]' },
           },
         },
       ],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,3 +33,4 @@ zeroconf-py2compat==0.19.10
 ifcfg==0.21
 Click==7.0
 ua-parser==0.10.0
+whitenoise==4.1.4


### PR DESCRIPTION
### Summary
* Uses whitenoise to serve precompressed static files when available
* Adds a kolibri-tools utility to precompress static files
* Adds a build step to compress all files in static folders

### Reviewer guidance
Does Kolibri still run properly?
Do static assets serve properly and with gzip encoding?

### References
Fixes #7791 

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
