### PR TITLE
In password-update sign-in flow, block user if password and its confirmation do not match

### DIFF
--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -183,7 +183,7 @@
         :autofocus="true"
         :disabled="busy"
         :value.sync="createdPassword"
-        :isValid.sync="createdPasswordConfirmation"
+        :isValid.sync="createdPasswordIsValid"
         :shouldValidate="busy"
         @submitNewPassword="updatePasswordAndSignIn"
       />
@@ -252,7 +252,7 @@
         passwordBlurred: false,
         formSubmitted: false,
         createdPassword: '',
-        createdPasswordConfirmation: '',
+        createdPasswordIsValid: false,
         busy: false,
         loginError: null,
         usernameSubmittedWithoutPassword: false,
@@ -378,7 +378,6 @@
         this.username = '';
         this.password = '';
         this.createdPassword = '';
-        this.createdPasswordConfirmation = '';
         // This ensures we don't get '<field> required' when going back
         // and forth
         this.usernameBlurred = false;
@@ -394,18 +393,21 @@
         this.signIn();
       },
       updatePasswordAndSignIn() {
-        this.busy = true;
-        const payload = {
-          username: this.username,
-          password: this.createdPassword,
-          facility: this.selectedFacility.id,
-        };
-        this.kolibriSetUnspecifiedPassword(payload).then(() => {
-          // Password successfully set
-          // Use this password now to sign in
-          this.password = this.createdPassword;
-          this.signIn();
-        });
+        if (this.createdPasswordIsValid) {
+          this.busy = true;
+          this.kolibriSetUnspecifiedPassword({
+            username: this.username,
+            password: this.createdPassword,
+            facility: this.selectedFacility.id,
+          }).then(() => {
+            // Password successfully set
+            // Use this password now to sign in
+            this.password = this.createdPassword;
+            this.signIn();
+          });
+        } else {
+          this.$refs.createPassword.focus();
+        }
       },
       setSuggestionTerm(newVal) {
         if (newVal !== null && typeof newVal !== 'undefined') {


### PR DESCRIPTION

### Summary

Fixes #7810

Here's a gif of the password validation at work, which is similar to the user creation workflow:

![CleanShot 2021-02-24 at 17 17 16](https://user-images.githubusercontent.com/10248067/109088720-d25e6000-76c4-11eb-8b11-0f5f478bfc7b.gif)


### Reviewer guidance

This needs to be set up as described in #7810. Basically

1. When facility settings do not require passwords, create a learner as an admin
2. Change facility settings to require passwords
3. Try to login as the learner from step 1

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
