### PR TITLE
Fix broken links in dev docs

### DIFF
--- a/docs/backend_architecture/content/implementation.rst
+++ b/docs/backend_architecture/content/implementation.rst
@@ -65,7 +65,7 @@ ContentNode
 ``ContentNode`` is implemented as a Django model that inherits from two abstract classes, MPTTModel and ContentDatabaseModel.
 
 
- * `django-mptt's MPTTModel <http://django-mptt.github.io/django-mptt/overview.html/>`__ allows for efficient traversal and querying of the ContentNode tree.
+ * `django-mptt's MPTTModel <https://django-mptt.readthedocs.io/en/latest/overview.html>`__ allows for efficient traversal and querying of the ContentNode tree.
  * ``ContentDatabaseModel`` is used as a marker so that the content_db_router knows to query against the content database only if the model inherits from ContentDatabaseModel.
 
 The tree structure is established by the ``parent`` field that is a foreign key pointing to another ContentNode object. You can also create a symmetric relationship using the ``related`` field, or an asymmetric field using the ``is_prerequisite`` field.

--- a/docs/backend_architecture/uap/implementation.rst
+++ b/docs/backend_architecture/uap/implementation.rst
@@ -5,7 +5,7 @@ Collections
 -----------
 
 A ``Collection`` is implemented as a Django model that inherits from
-`django-mptt's MPTTModel <http://django-mptt.github.io/django-mptt/>`__, which
+`django-mptt's MPTTModel <https://django-mptt.readthedocs.io/en/latest/index.html>`__, which
 allows for efficient traversal and querying of the collection hierarchy. For
 convenience, the specific types of collections -- ``Facility``, ``Classroom``,
 and ``LearnerGroup`` -- are implemented as _proxy models of the main

--- a/docs/frontend_architecture/core.rst
+++ b/docs/frontend_architecture/core.rst
@@ -21,7 +21,7 @@ And **many** others. The complete specification for commonly shared modules can 
   import Vue from 'kolibri.lib.vue';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
 
-Adding additional globally-available objects is relatively straightforward due to the `plugin and webpack build system </pipeline/frontend_build_pipeline>`__.
+Adding additional globally-available objects is relatively straightforward due to the :doc:`plugin and webpack build system <frontend_build_pipeline>`.
 
 To expose something in the core app, add the module to the object in ``apiSpec.js``, scoping it to the appropriate property for better organization - e.g.:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -76,7 +76,7 @@ Python virtual environment
 
 You should use a Python virtual environment to isolate the dependencies of your Python projects from each other and to avoid corrupting your system's Python installation.
 
-There are many ways to set up Python virtual environments: You can use `Pipenv <https://pipenv.readthedocs.io/en/latest/>`__ as shown in the instructions below; you can also use `Virtualenv <https://virtualenv.pypa.io/en/stable/userguide/>`__, `Python 3 venv <https://docs.python.org/3/library/venv.html>`__, `Poetry <https://poetry.eustace.io>`__ etc.
+There are many ways to set up Python virtual environments: You can use `Pipenv <https://pipenv.readthedocs.io/en/latest/>`__ as shown in the instructions below; you can also use `Virtualenv <https://virtualenv.pypa.io/en/latest/>`__, `Python 3 venv <https://docs.python.org/3/library/venv.html>`__, `Poetry <https://poetry.eustace.io>`__ etc.
 
 .. note::
   Most virtual environments will require special setup for non-Bash shells such as Fish and ZSH.
@@ -116,8 +116,12 @@ Environment variables can be set in many ways, including:
 
 There are two environment variables you should plan to set:
 
-* ``KOLIBRI_RUN_MODE`` (required): This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_, and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. (There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing gherkin stories.)
-* ``KOLIBRI_HOME`` (optional): This variable determines where Kolibri will store its content and databases. It is useful to set if you want to have multiple versions of Kolibri running simultaneously.
+* ``KOLIBRI_RUN_MODE`` (required)
+  
+  This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.
+* ``KOLIBRI_HOME`` (optional)
+  
+  This variable determines where Kolibri will store its content and databases. It is useful to set if you want to have multiple versions of Kolibri running simultaneously.
 
 
 Install Python dependencies

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -117,10 +117,10 @@ Environment variables can be set in many ways, including:
 There are two environment variables you should plan to set:
 
 * ``KOLIBRI_RUN_MODE`` (required)
-  
+
   This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.
 * ``KOLIBRI_HOME`` (optional)
-  
+
   This variable determines where Kolibri will store its content and databases. It is useful to set if you want to have multiple versions of Kolibri running simultaneously.
 
 

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -87,7 +87,7 @@ Then messages are available from the ``$tr`` method on the translator object:
 ICU message syntax
 ~~~~~~~~~~~~~~~~~~
 
-All frontend translations can be parameterized using `ICU message syntax <https://formatjs.io/guides/message-syntax/>`__. Additional documentation is `available on crowdin <https://support.crowdin.com/icu-message-syntax/>`__.
+All frontend translations can be parameterized using `ICU message syntax <https://formatjs.io/docs/core-concepts/icu-syntax>`__. Additional documentation is `available on crowdin <https://support.crowdin.com/icu-message-syntax/>`__.
 
 This syntax can be used to do things like inject variables, pluralize words, and localize numbers.
 

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -3,7 +3,7 @@
 Release process
 ===============
 
-We maintain a set of `release process automation scripts <https://github.com/learningequality/kolibri-release-process/>`__ which automatically create internal next actions in `Notion <https://www.notion.so/learningequality/>`__. The processes there have separate sets of actions for:
+We maintain a set of `release process automation scripts <https://github.com/learningequality/kolibri-release-process/>`__ (private repo) which automatically create internal next actions in `Notion <https://www.notion.so/learningequality/>`__. The processes there have separate sets of actions for:
 
 * finals, beta, and release candidates
 * major versus patch releases

--- a/docs/stack.rst
+++ b/docs/stack.rst
@@ -54,7 +54,7 @@ Preparation of client-side resources involves:
 - Generating source maps
 - Providing mechanisms for decoupled "Kolibri plugins" to interact with each other and asynchronously load dependencies
 
-The *Makefile* contains the top-level commands for building Python distributions, in particular `wheel files <https://pythonwheels.com/>`__ (``make dist``) and `pex files <https://pex.readthedocs.io/en/stable/>`__ (``make pex``).
+The *Makefile* contains the top-level commands for building Python distributions, in particular `wheel files <https://pythonwheels.com/>`__ (``make dist``) and `pex files <https://pex.readthedocs.io/en/latest/>`__ (``make pex``).
 
 The builds are automated using `buildkite <https://buildkite.com/learningequality>`__, whose top-level configuration lives in the Kolibri repo. Other platform distributions such as `Windows <https://github.com/learningequality/kolibri-installer-windows>`__, `Debian <https://github.com/learningequality/kolibri-installer-debian>`__, and `Android <https://github.com/learningequality/kolibri-installer-android/issues>`__ are built from the wheel files and maintained in their own repositories.
 


### PR DESCRIPTION

### Summary

* https://pex.readthedocs.io/en/stable/ ✔️ 
* https://kolibri-dev.readthedocs.io/pipeline/frontend_build_pipeline ✔️ 
* https://kolibri-dev.readthedocs.io/en/develop/build_system/Pipeline_vocab_illustrated.png 🚫 - Will need to be targeted to `develop`?
* https://formatjs.io/docs/icu-syntax/ ✔️ 
* https://github.com/learningequality/kolibri-release-process/ - Added `(private repo)`
* https://github.com/learningequality/nutritionfacts/ - Added `(private repo)`
* https://virtualenv.pypa.io/en/stable/userguide/ ✔️ 
* http://django-mptt.github.io/django-mptt/ ✔️ 
* http://django-mptt.github.io/django-mptt/overview.html/ ✔️ 

### Reviewer guidance
Build dev docs and check if the links are corrected properly.

### References
Fixes #7807 

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
