### PR TITLE
Update KDS dependency and update all KRouterLink components

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -15,7 +15,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.1",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.x",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -19,12 +19,11 @@
           <tbody>
             <tr v-for="facility in facilities" :key="facility.id">
               <td>
-                <KLabeledIcon icon="facility">
-                  <KRouterLink
-                    :text="facility.name"
-                    :to="coachClassListPageLink(facility)"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="facility.name"
+                  :to="coachClassListPageLink(facility)"
+                  icon="facility"
+                />
               </td>
               <td>
                 {{ $formatNumber(facility.num_classrooms) }}

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -46,12 +46,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="classObj in classList" :key="classObj.id">
               <td>
-                <KLabeledIcon icon="classes">
-                  <KRouterLink
-                    :text="classObj.name"
-                    :to="$router.getRoute('HomePage', { classId: classObj.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="classObj.name"
+                  :to="$router.getRoute('HomePage', { classId: classObj.id })"
+                  icon="classes"
+                />
               </td>
               <td>
                 <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -48,13 +48,12 @@
               :key="exam.id"
             >
               <td>
-                <KLabeledIcon icon="quiz">
-                  <KRouterLink
-                    :to="$router.getRoute('QuizSummaryPage', { quizId: exam.id })"
-                    appearance="basic-link"
-                    :text="exam.title"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :to="$router.getRoute('QuizSummaryPage', { quizId: exam.id })"
+                  appearance="basic-link"
+                  :text="exam.title"
+                  icon="quiz"
+                />
               </td>
 
               <td>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -2,12 +2,11 @@
 
   <tr>
     <td>
-      <KLabeledIcon icon="group">
-        <KRouterLink
-          :text="group.name"
-          :to="$router.getRoute('GroupMembersPage', { groupId: group.id })"
-        />
-      </KLabeledIcon>
+      <KRouterLink
+        :text="group.name"
+        :to="$router.getRoute('GroupMembersPage', { groupId: group.id })"
+        icon="group"
+      />
     </td>
     <td>
       {{ group.users.length }}

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -49,12 +49,11 @@
               :key="lesson.id"
             >
               <td>
-                <KLabeledIcon icon="lesson">
-                  <KRouterLink
-                    :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
-                    :text="lesson.title"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
+                  :text="lesson.title"
+                  icon="lesson"
+                />
               </td>
               <td>{{ coachString('numberOfResources', { value: lesson.resources.length }) }}</td>
               <td>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsExerciseLearners.vue
@@ -14,17 +14,16 @@
       <transition-group tag="tbody" name="list">
         <tr v-for="entry in entries" :key="entry.id" data-test="entry">
           <td>
-            <KLabeledIcon icon="person">
-              <KRouterLink
-                v-if="showLink(entry)"
-                :text="entry.name"
-                :to="entry.exerciseLearnerLink"
-                data-test="exercise-learner-link"
-              />
-              <template v-else>
-                {{ entry.name }}
-              </template>
-            </KLabeledIcon>
+            <KRouterLink
+              v-if="showLink(entry)"
+              :text="entry.name"
+              :to="entry.exerciseLearnerLink"
+              data-test="exercise-learner-link"
+              icon="person"
+            />
+            <template v-else>
+              {{ entry.name }}
+            </template>
           </td>
           <td>
             <StatusSimple :status="entry.statusObj.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -26,12 +26,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="person">
-                  <KRouterLink
-                    :text="tableRow.name"
-                    :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.name"
+                  :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
+                  icon="person"
+                />
               </td>
               <td><Score :value="tableRow.avgScore" /></td>
               <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -27,12 +27,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="group">
-                  <KRouterLink
-                    :text="tableRow.name"
-                    :to="classRoute('ReportsGroupReportPage', { groupId: tableRow.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.name"
+                  :to="classRoute('ReportsGroupReportPage', { groupId: tableRow.id })"
+                  icon="group"
+                />
               </td>
               <td>
                 {{ coachString('integer', { value: tableRow.numLessons }) }}

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -28,12 +28,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.question_id">
               <td>
-                <KLabeledIcon icon="person">
-                  <KRouterLink
-                    :text="tableRow.title"
-                    :to="questionLink(tableRow.question_id)"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.question_id)"
+                  icon="person"
+                />
               </td>
               <td>
                 <LearnerProgressRatio

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -54,24 +54,24 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.node_id">
               <td>
-                <KLabeledIcon :icon="tableRow.kind">
-                  <KRouterLink
-                    v-if="tableRow.kind === 'exercise'"
-                    :text="tableRow.title"
-                    :to="classRoute(
-                      'ReportsGroupReportLessonExerciseLearnerListPage',
-                      { exerciseId: tableRow.content_id }
-                    )"
-                  />
-                  <KRouterLink
-                    v-else
-                    :text="tableRow.title"
-                    :to="classRoute(
-                      'ReportsGroupReportLessonResourceLearnerListPage',
-                      { resourceId: tableRow.content_id }
-                    )"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  v-if="tableRow.kind === 'exercise'"
+                  :text="tableRow.title"
+                  :to="classRoute(
+                    'ReportsGroupReportLessonExerciseLearnerListPage',
+                    { exerciseId: tableRow.content_id }
+                  )"
+                  :icon="tableRow.kind"
+                />
+                <KRouterLink
+                  v-else
+                  :text="tableRow.title"
+                  :to="classRoute(
+                    'ReportsGroupReportLessonResourceLearnerListPage',
+                    { resourceId: tableRow.content_id }
+                  )"
+                  :icon="tableRow.kind"
+                />
               </td>
               <td>
                 <StatusSummary

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
@@ -20,12 +20,11 @@
           <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
           <ul class="list">
             <li v-for="lesson in lessonsList" :key="lesson.id">
-              <KLabeledIcon icon="lesson">
-                <KRouterLink
-                  :to="classRoute('ReportsGroupReportLessonPage', { lessonId: lesson.id })"
-                  :text="lesson.title"
-                />
-              </KLabeledIcon>
+              <KRouterLink
+                :to="classRoute('ReportsGroupReportLessonPage', { lessonId: lesson.id })"
+                :text="lesson.title"
+                icon="lesson"
+              />
             </li>
           </ul>
           <p v-if="lessonsList.length === 0">
@@ -36,12 +35,11 @@
           <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
           <ul class="list">
             <li v-for="exam in examsList" :key="exam.id">
-              <KLabeledIcon icon="quiz">
-                <KRouterLink
-                  :to="classRoute('ReportsGroupReportQuizLearnerListPage', { quizId: exam.id })"
-                  :text="exam.title"
-                />
-              </KLabeledIcon>
+              <KRouterLink
+                :to="classRoute('ReportsGroupReportQuizLearnerListPage', { quizId: exam.id })"
+                :text="exam.title"
+                icon="quiz"
+              />
             </li>
           </ul>
           <p v-if="examsList.length === 0">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -27,16 +27,15 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="person">
-                  <KRouterLink
-                    v-if="tableRow.statusObj.status !== STATUSES.notStarted"
-                    :text="tableRow.name"
-                    :to="detailLink(tableRow.id)"
-                  />
-                  <template v-else>
-                    {{ tableRow.name }}
-                  </template>
-                </KLabeledIcon>
+                <KRouterLink
+                  v-if="tableRow.statusObj.status !== STATUSES.notStarted"
+                  :text="tableRow.name"
+                  :to="detailLink(tableRow.id)"
+                  icon="person"
+                />
+                <template v-else>
+                  {{ tableRow.name }}
+                </template>
               </td>
               <td>
                 <StatusSimple :status="tableRow.statusObj.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -30,12 +30,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.question_id">
               <td>
-                <KLabeledIcon icon="question">
-                  <KRouterLink
-                    :text="tableRow.title"
-                    :to="questionLink(tableRow.question_id)"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.question_id)"
+                  icon="question"
+                />
               </td>
               <td>
                 <LearnerProgressRatio

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -27,12 +27,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="person">
-                  <KRouterLink
-                    :text="tableRow.name"
-                    :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.name"
+                  :to="classRoute('ReportsLearnerReportPage', { learnerId: tableRow.id })"
+                  icon="person"
+                />
               </td>
               <td><TruncatedItemList :items="tableRow.groups" /></td>
               <td><Score :value="tableRow.avgScore" /></td>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -29,14 +29,13 @@
               <transition-group tag="tbody" name="list">
                 <tr v-for="tableRow in lessonsTable" :key="tableRow.id">
                   <td>
-                    <KLabeledIcon icon="lesson">
-                      <KRouterLink
-                        :to="classRoute('ReportsLearnerReportLessonPage', {
-                          lessonId: tableRow.id
-                        })"
-                        :text="tableRow.title"
-                      />
-                    </KLabeledIcon>
+                    <KRouterLink
+                      :to="classRoute('ReportsLearnerReportLessonPage', {
+                        lessonId: tableRow.id
+                      })"
+                      :text="tableRow.title"
+                      icon="lesson"
+                    />
                   </td>
                   <td>
                     <StatusSimple :status="tableRow.status" />
@@ -58,12 +57,11 @@
               <transition-group tag="tbody" name="list">
                 <tr v-for="tableRow in examsTable" :key="tableRow.id">
                   <td>
-                    <KLabeledIcon icon="quiz">
-                      <KRouterLink
-                        :to="quizLink(tableRow.id)"
-                        :text="tableRow.title"
-                      />
-                    </KLabeledIcon>
+                    <KRouterLink
+                      :to="quizLink(tableRow.id)"
+                      :text="tableRow.title"
+                      icon="quiz"
+                    />
                   </td>
                   <td>
                     <StatusSimple :status="tableRow.statusObj.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -62,12 +62,11 @@
               <transition-group tag="tbody" name="list">
                 <tr v-for="tableRow in table" :key="tableRow.id">
                   <td>
-                    <KLabeledIcon icon="person">
-                      <KRouterLink
-                        :text="tableRow.name"
-                        :to="classRoute('ReportsLessonLearnerPage', { learnerId: tableRow.id })"
-                      />
-                    </KLabeledIcon>
+                    <KRouterLink
+                      :text="tableRow.name"
+                      :to="classRoute('ReportsLessonLearnerPage', { learnerId: tableRow.id })"
+                      icon="person"
+                    />
                   </td>
                   <td>
                     <StatusSimple :status="tableRow.status" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -35,12 +35,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="lesson">
-                  <KRouterLink
-                    :text="tableRow.title"
-                    :to="classRoute('ReportsLessonReportPage', { lessonId: tableRow.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="classRoute('ReportsLessonReportPage', { lessonId: tableRow.id })"
+                  icon="lesson"
+                />
               </td>
               <td>
                 <StatusSummary

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -40,12 +40,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="tableRow in table" :key="tableRow.id">
               <td>
-                <KLabeledIcon icon="quiz">
-                  <KRouterLink
-                    :text="tableRow.title"
-                    :to="classRoute('ReportsQuizLearnerListPage', { quizId: tableRow.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="classRoute('ReportsQuizLearnerListPage', { quizId: tableRow.id })"
+                  icon="quiz"
+                />
               </td>
               <td>
                 <Score :value="tableRow.avgScore" />

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -15,12 +15,11 @@
             <tr v-for="(tableRow, index) in table" :key="tableRow.question_id + index">
               <td>
                 <span v-if="$isPrint">{{ tableRow.title }}</span>
-                <KLabeledIcon v-else icon="question">
-                  <KRouterLink
-                    :text="tableRow.title"
-                    :to="questionLink(tableRow.question_id)"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.question_id)"
+                  icon="question"
+                />
               </td>
               <td>
                 <LearnerProgressRatio

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -14,10 +14,8 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
-              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
-            </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
-            <!----></a></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"> <span class="link-text">learner1</span>
+            <!----></span></span> <span class="icon-after"><!----></span></span></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #ffc107;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Completed
@@ -32,10 +30,8 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
-              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
-            </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
-            <!----></a></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"> <span class="link-text">learner2</span>
+            <!----></span></span> <span class="icon-after"><!----></span></span></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #03a9f4;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Started
@@ -70,10 +66,8 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
-              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
-            </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
-            <!----></a></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"> <span class="link-text">learner1</span>
+            <!----></span></span> <span class="icon-after"><!----></span></span></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #ffc107;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Completed
@@ -92,10 +86,8 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
-              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
-            </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
-            <!----></a></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"> <span class="link-text">learner2</span>
+            <!----></span></span> <span class="icon-after"><!----></span></span></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #03a9f4;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Started

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -14,8 +14,10 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner1</span>
-          <!----></span></span> <span class="icon-after"><!----></span></span></a></span></span> <span class="icon-after"><!----></span></span></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
+            </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
+            <!----></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #ffc107;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Completed
@@ -30,8 +32,10 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner2</span>
-          <!----></span></span> <span class="icon-after"><!----></span></span></a></span></span> <span class="icon-after"><!----></span></span></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
+            </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
+            <!----></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #03a9f4;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Started
@@ -66,8 +70,10 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner1</span>
-          <!----></span></span> <span class="icon-after"><!----></span></span></a></span></span> <span class="icon-after"><!----></span></span></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
+            </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
+            <!----></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #ffc107;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Completed
@@ -86,8 +92,10 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><span class="labeled-icon-wrapper"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #212121; top: 2px;"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning"><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><span class="labeled-icon-wrapper"><span class="icon"><!----></span> <span class="label" style="max-width: 100%;"><span dir="auto" class="debug-warning"><!----> <span class="link-text">learner2</span>
-          <!----></span></span> <span class="icon-after"><!----></span></span></a></span></span> <span class="icon-after"><!----></span></span></td>
+        <td><a dir="auto" class="KRouterLink-noKey-0_qhgpwa link" data-test="exercise-learner-link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;">
+              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
+            </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
+            <!----></a></td>
         <td>
           <div><span class="labeled-icon-wrapper" nowrap="nowrap"><span class="icon"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #03a9f4;"><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path><path d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"></path></svg></span> <span class="label" style="margin-left: 1.975em; max-width: calc(100% - 1.975em);"><span dir="auto" class="debug-warning">
     Started

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -11,12 +11,11 @@
         <tbody>
           <tr v-for="facility in facilities" :key="facility.id">
             <td>
-              <KLabeledIcon icon="facility">
-                <KRouterLink
-                  :text="facility.name"
-                  :to="facilityLink(facility)"
-                />
-              </KLabeledIcon>
+              <KRouterLink
+                :text="facility.name"
+                :to="facilityLink(facility)"
+                icon="facility"
+              />
             </td>
             <td>
               {{ $formatNumber(facility.num_classrooms) }}

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -53,12 +53,11 @@
             :key="classroom.id"
           >
             <td>
-              <KLabeledIcon icon="classes">
-                <KRouterLink
-                  :text="classroom.name"
-                  :to="classEditLink(classroom.id)"
-                />
-              </KLabeledIcon>
+              <KRouterLink
+                :text="classroom.name"
+                :to="classEditLink(classroom.id)"
+                icon="classes"
+              />
             </td>
             <td>
               <span :ref="`coachNames${classroom.id}`">

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -17,7 +17,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:nucleogenesis/kolibri-design-system-1#big-keen-ui-vendoring",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#v0.2.x",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-tools/test/fixtures/TestComponent.vue
+++ b/packages/kolibri-tools/test/fixtures/TestComponent.vue
@@ -45,12 +45,11 @@
           <transition-group tag="tbody" name="list">
             <tr v-for="classObj in classList" :key="classObj.id">
               <td>
-                <KLabeledIcon icon="classes">
-                  <KRouterLink
-                    :text="classObj.name"
-                    :to="$router.getRoute('HomePage', { classId: classObj.id })"
-                  />
-                </KLabeledIcon>
+                <KRouterLink
+                  :text="classObj.name"
+                  :to="$router.getRoute('HomePage', { classId: classObj.id })"
+                  icon="classes"
+                />
               </td>
               <td>
                 <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8594,24 +8594,6 @@ knuth-shuffle-seeded@^1.0.6:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
 
-"kolibri-design-system@github:nucleogenesis/kolibri-design-system-1#big-keen-ui-vendoring":
-  version "0.2.0"
-  resolved "https://codeload.github.com/nucleogenesis/kolibri-design-system-1/tar.gz/3548f0cb4870da41bc7e466190500d8f3d98e45b"
-  dependencies:
-    "@babel/core" "^7.9.6"
-    "@babel/preset-env" "^7.9.6"
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "^3.0.21"
-    css-element-queries "^1.2.0"
-    fuzzysearch "^1.0.3"
-    keen-ui "^1.3.0"
-    lodash "^4.17.15"
-    material-design-icons "^3.0.1"
-    popper.js "^1.14.6"
-    purecss "^0.6.2"
-    svgo "^1.3.2"
-    tippy.js "^4.2.1"
-
 last-call-webpack-plugin@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz#9742df0e10e3cf46e5c0381c2de90d3a7a2d7555"
@@ -13556,7 +13538,7 @@ svgo@^0.7.0, svgo@^0.7.2:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-svgo@^1.0.0, svgo@^1.3.2:
+svgo@^1.0.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"
   integrity sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,11 +1012,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@mdi/svg@^5.3.45":
-  version "5.3.45"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-5.3.45.tgz#27456a94ffa16b71c0a6581b584f24ed9d4f6b2e"
-  integrity sha512-MHUZBDSRDG6uWcRlQs4nALliPRT8u4gg5E+knk7FuFBUb3NjFgjT0PjdnTyEN0f3mwVLzLvggs7v7G/NVO+gaw==
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -8585,23 +8580,18 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.1":
-  version "0.2.1"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/d8d8e88f5d644f04dac948fc9a1ab0296afbe09a"
+"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.x":
+  version "0.2.2-beta4"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/4a2ae39872817e189c35db1de975c9c49b5b03fa"
   dependencies:
-    "@babel/core" "^7.9.6"
-    "@babel/preset-env" "^7.9.6"
-    "@mdi/svg" "^5.3.45"
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"
-    material-design-icons "^3.0.1"
     popper.js "^1.14.6"
     purecss "^0.6.2"
-    svgo "^1.3.2"
     tippy.js "^4.2.1"
 
 "kolibri-design-system@github:nucleogenesis/kolibri-design-system-1#big-keen-ui-vendoring":


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Changes were made to the `KRouterLink` component to standardize the use of props, including:
- `icon` (color now matches the link text)
- `iconAfter` (color now matches the link text)
- `default`

|Before|After|
|--|--|
|![Screen Shot 2021-02-26 at 1 44 08 PM](https://user-images.githubusercontent.com/13563002/109358732-11adbd80-7839-11eb-85f7-3ffd97ed1dfa.png)|![Screen Shot 2021-02-26 at 1 43 32 PM](https://user-images.githubusercontent.com/13563002/109358701-08245580-7839-11eb-8495-1a4f9947509d.png)|

As a result, the use of `KRouterLink` to achieve this look is:

Code before:
```
<KLabeledIcon icon="lesson">
    <KRouterLink
        :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
        :text="lesson.title"
    />
</KLabeledIcon>
```
Code after:
```
<KRouterLink
    :to="lessonSummaryLink({ lessonId: lesson.id, classId })"
    :text="lesson.title"
    icon="lesson"
/>
```
|

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Please look through the code for places that use `KRouterLink` to make sure that all instances of `KRouterLink` have been updated appropriately - particularly when used in conjunction with an icon.

There are still three places that are still using `KLabeledIcon` in conjunction with `KRouterLink`:
- ReportsLearnerReportLessonPage.vue
- ReportsLessonLearnerPage.vue
- ReportsLessonReportPage.vue

Essentially, in a table, these are instances when the icon sits next to the link, and some UI changes do occur.
![Screen Shot 2021-02-26 at 12 34 42 PM](https://user-images.githubusercontent.com/13563002/109360455-1e7fe080-783c-11eb-82d4-8427457ffac9.png)

…

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

The `yarn.lock` has been changed:
```
diff --git a/yarn.lock b/yarn.lock
index f56d55354..bbeffa3af 100644
--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,11 +1012,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@mdi/svg@^5.3.45":
-  version "5.3.45"
-  resolved "https://registry.yarnpkg.com/@mdi/svg/-/svg-5.3.45.tgz#27456a94ffa16b71c0a6581b584f24ed9d4f6b2e"
-  integrity sha512-MHUZBDSRDG6uWcRlQs4nALliPRT8u4gg5E+knk7FuFBUb3NjFgjT0PjdnTyEN0f3mwVLzLvggs7v7G/NVO+gaw==
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -8585,23 +8580,18 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.1":
-  version "0.2.1"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/d8d8e88f5d644f04dac948fc9a1ab0296afbe09a"
+"kolibri-design-system@github:learningequality/kolibri-design-system#v0.2.x":
+  version "0.2.2-beta4"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/4a2ae39872817e189c35db1de975c9c49b5b03fa"
   dependencies:
-    "@babel/core" "^7.9.6"
-    "@babel/preset-env" "^7.9.6"
-    "@mdi/svg" "^5.3.45"
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"
-    material-design-icons "^3.0.1"
     popper.js "^1.14.6"
     purecss "^0.6.2"
-    svgo "^1.3.2"
     tippy.js "^4.2.1"
 ```

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
