### PR TITLE
Fixes multiple issues in `IndividualLearnerSelector`

### DIFF
--- a/kolibri/core/assets/src/views/PaginatedListContainer.vue
+++ b/kolibri/core/assets/src/views/PaginatedListContainer.vue
@@ -118,11 +118,14 @@
       },
     },
     watch: {
-      numFilteredItems: {
-        handler() {
-          this.currentPage = 1;
-          this.$emit('pageChanged', 1);
+      visibleFilteredItems: {
+        handler(newVal) {
+          this.$emit('pageChanged', {
+            page: this.currentPage,
+            items: newVal,
+          });
         },
+        immediate: true,
       },
     },
     methods: {
@@ -130,7 +133,6 @@
         // Clamp the newPage number between the bounds if browser doesn't correctly
         // disable buttons (see #6454 issue with old versions of MS Edge)
         this.currentPage = clamp(this.currentPage + change, 1, this.totalPages);
-        this.$emit('pageChanged', this.currentPage);
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentCopyModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentCopyModal.vue
@@ -2,6 +2,7 @@
 
   <KModal
     :title="modalTitle"
+    size="large"
     v-bind="modalTexts"
     @submit="handleSubmit"
     @cancel="$emit('cancel')"

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -24,7 +24,7 @@
         :items="allLearners"
         :filterPlaceholder="$tr('searchPlaceholder')"
         :itemsPerPage="itemsPerPage"
-        @pageChanged="pageNum => currentPage = pageNum"
+        @pageChanged="currentPageLearners = $event.items"
       >
         <template #default="{ items }">
           <CoreTable
@@ -131,8 +131,7 @@
     },
     data() {
       return {
-        currentPage: 1,
-        searchText: '',
+        currentPageLearners: [],
         fetchingOutside: false,
         learnersFromOtherClass: null,
         groupMapFromOtherClass: null,
@@ -163,13 +162,6 @@
       },
       currentGroupMap() {
         return this.groupMapFromOtherClass || this.groupMap;
-      },
-      currentPageLearners() {
-        const baseIndex = (this.currentPage - 1) * this.itemsPerPage;
-        return this.filterLearners(this.allLearners, this.searchText).slice(
-          baseIndex,
-          baseIndex + this.itemsPerPage
-        );
       },
       learnerIdsFromSelectedGroups() {
         // If a learner is part of a Learner Group that has already been selected

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -88,6 +88,7 @@
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import flatMap from 'lodash/flatMap';
+  import forEach from 'lodash/forEach';
   import countBy from 'lodash/countBy';
   import every from 'lodash/every';
   import ClassSummaryResource from '../../../apiResources/classSummary';
@@ -243,9 +244,12 @@
         return this.learnerIsInSelectedGroup(id) || this.disabled;
       },
       groupNamesForLearner({ id }) {
-        const groupNames = this.groups
-          .filter(group => group.member_ids.includes(id))
-          .map(group => group.name);
+        const groupNames = [];
+        forEach(this.currentGroupMap, group => {
+          if (group.member_ids.includes(id)) {
+            groupNames.push(group.name);
+          }
+        });
         return formatList(groupNames);
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -94,7 +94,6 @@
   import commonCoachStrings from '../../common';
 
   const DEFAULT_ITEMS_PER_PAGE = 50;
-  const SHORT_ITEMS_PER_PAGE = 5;
 
   export default {
     name: 'IndividualLearnerSelector',
@@ -185,7 +184,7 @@
         };
       },
       itemsPerPage() {
-        return this.targetClassId ? SHORT_ITEMS_PER_PAGE : DEFAULT_ITEMS_PER_PAGE;
+        return DEFAULT_ITEMS_PER_PAGE;
       },
     },
     methods: {


### PR DESCRIPTION
### Summary

Fixes multiple issues in the `IndividualLearnerSelector`

1. Fixes regression from #7735 by emitting the "page" of current items from the child `PaginatedListContainer` back to the parent `IndividualLearnerSelector` (previously, the `ILS` component would derive it in the `currentPageLearners` computed prop based on the list of users, the current page, and the page size). Fixes #7819
2. Make the `AssignmentCopyModal` larger to accommodate the  `IndividualLearnerSelector`'s larger size
3. Makes the default page size 50 in all situations. Before, it would be as small as 5 in some cases. Fixes #6224
4. When copying an assignment, compiles group names for learners (to display in the group column) from the destination class rather than the source class. Fixes #7652

### Reviewer guidance

Confirm that these patches fix the three issues referenced.

### References

Fixes #7819 
Fixes #6244
Fixes #7652

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
