### PR TITLE
FacilityUser performance speed up for non-admin users

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -34,6 +34,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models.query import F
+from django.db.models.query import Q
 from django.db.utils import IntegrityError
 from django.utils.encoding import python_2_unicode_compatible
 from morango.models import Certificate
@@ -649,6 +650,26 @@ def validate_birth_year(value):
         raise ValidationError(error)
 
 
+class FacilityUserRoleBasedPermissionsForCoach(RoleBasedPermissions):
+    def readable_by_user_filter(self, user, queryset):
+        if user.is_anonymous():
+            return queryset.none()
+        roles = user.roles.filter(kind__in=self.can_be_read_by)
+
+        if not roles:
+            return queryset.none()
+
+        filter = Q()
+
+        for role in roles:
+            filter |= Q(
+                Q(memberships__collection_id=role.collection_id)
+                | Q(facility_id=role.collection_id)
+            )
+
+        return queryset.filter(filter)
+
+
 @python_2_unicode_compatible
 class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
     """
@@ -664,7 +685,7 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
     # FacilityUser can be read and written by a facility admin
     admin = IsAdminForOwnFacility()
     # FacilityUser can be read by admin or coach, and updated by admin, but not created/deleted by non-facility admin
-    role = RoleBasedPermissions(
+    role = FacilityUserRoleBasedPermissionsForCoach(
         target_field=".",
         can_be_created_by=(),  # we can't check creation permissions by role, as user doesn't exist yet
         can_be_read_by=(role_kinds.ADMIN, role_kinds.COACH),

--- a/kolibri/core/auth/test/test_roles_and_membership.py
+++ b/kolibri/core/auth/test/test_roles_and_membership.py
@@ -115,7 +115,9 @@ class ExplicitMembershipTestCase(TestCase):
         self.assertTrue(self.admin.can_read(self.learner))
 
     def test_learner_is_in_list_of_readable_objects(self):
-        self.assertIn(
+        # This should not be present as we are no longer supporting classroom membership
+        # solely by virtue of being a member of a group in that class.
+        self.assertNotIn(
             self.learner, self.admin.filter_readable(FacilityUser.objects.all())
         )
 


### PR DESCRIPTION
### Summary
* For coach users requesting lists of classroom or group users, because they are not facility admins, end up using the HierarchyRelationsFilter in the permissions filtering of their requests
* This filter seems to suffer from extreme performance issues when the number of collections is ~100 or more.
* Specifically we have seen significant performance issues with ~50+ classrooms and ~50+ learner groups
* This PR removes hierarchy relations filtering from facility user permissions
* Instead it only queries direct membership in collections
* This means that a learner being a member of a Learner Group but not a Classroom will no longer mean they are readable by a classroom coach
* However, we do not currently allow this kind of assignment through the UI - as follow up, we should enforce these assumptions, and also completely remove HierarchyRelationsFilter from the code base to prevent future performance issues.

### Reviewer guidance
* Create ~50 classrooms with learner groups in
* Check difference in performance for a fetch as a coach user when loading the Groups tab of the Plan page
* Check that the tests are only changed to prevent learner group membership from granting classroom membership

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
