### PR TITLE
Extract NewPasswordPage from SignInPage, and make new route

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/__test__/ActivityList.spec.js
@@ -72,8 +72,7 @@ function makeWrapper(options) {
 describe('ActivityList component', () => {
   it('on first render, calls the notification resource', async () => {
     const { fetchMock, wrapper } = makeWrapper({});
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
     expect(fetchMock).toHaveBeenCalled();
     expect(wrapper.vm.moreResults).toBe(false);
   });
@@ -84,24 +83,21 @@ describe('ActivityList component', () => {
         noActivityString: 'No activity in this classroom',
       },
     });
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
     const noActivity = wrapper.find('.notifications p');
     expect(noActivity.text()).toEqual('No activity in this classroom');
   });
 
   it('has a "show more" button if there are more pages of notifications', async () => {
     const { wrapper } = makeWrapper({ moreResults: true });
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
     const showMoreButton = wrapper.findComponent({ name: 'KButton' });
     expect(showMoreButton.exists()).toEqual(true);
   });
 
   it('does not have a "show more" button if there are no more pages of notifications', async () => {
     const { wrapper } = makeWrapper({});
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
     const showMoreButton = wrapper.findComponent({ name: 'KButton' });
     expect(showMoreButton.exists()).toEqual(false);
   });
@@ -109,8 +105,7 @@ describe('ActivityList component', () => {
   it('disables the "show more" button if any filters are activated', async () => {
     const { wrapper } = makeWrapper({});
     const showMoreButton = () => wrapper.findComponent({ name: 'KButton' });
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
     wrapper.setData({
       loading: false,
       moreResults: true,
@@ -157,8 +152,7 @@ describe('ActivityList component', () => {
       ],
     });
 
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
 
     const filters = wrapper.findComponent({ name: 'NotificationsFilter' });
     // Logic is very simple: just find the unique values in the notifications

--- a/kolibri/plugins/device/assets/src/views/__test__/RearrangeChannelsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/RearrangeChannelsPage.spec.js
@@ -16,7 +16,7 @@ async function makeWrapper() {
     store,
   });
   // Have to wait to let the channels data load
-  await wrapper.vm.$nextTick();
+  await global.flushPromises();
   return { wrapper };
 }
 
@@ -27,10 +27,7 @@ describe('RearrangeChannelsPage', () => {
       newArray: [wrapper.vm.channels[1], wrapper.vm.channels[0]],
     });
     expect(wrapper.vm.postNewOrder).toHaveBeenCalledWith(['2', '1']);
-    // Have to wait a bunch of ticks for some reason
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
+    await global.flushPromises();
   }
 
   it('loads the data on mount', async () => {

--- a/kolibri/plugins/user/assets/src/constants.js
+++ b/kolibri/plugins/user/assets/src/constants.js
@@ -5,6 +5,7 @@ export const ComponentMap = {
   PROFILE_EDIT: 'ProfileEditPage',
   AUTH_SELECT: 'AuthSelect',
   FACILITY_SELECT: 'FacilitySelect',
+  NEW_PASSWORD: 'NewPasswordPage',
 };
 
 export const pageNameToModuleMap = {

--- a/kolibri/plugins/user/assets/src/routes.js
+++ b/kolibri/plugins/user/assets/src/routes.js
@@ -9,6 +9,7 @@ import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import SignInPage from './views/SignInPage';
 import SignUpPage from './views/SignUpPage';
+import NewPasswordPage from './views/SignInPage/NewPasswordPage';
 
 router.beforeEach((to, from, next) => {
   const profileRoutes = [ComponentMap.PROFILE, ComponentMap.PROFILE_EDIT];
@@ -102,6 +103,24 @@ export default [
       } else {
         next();
       }
+    },
+  },
+  {
+    path: '/set-password',
+    component: NewPasswordPage,
+    beforeEnter(to, from, next) {
+      store.commit('CORE_SET_PAGE_LOADING', false);
+      if (!to.query.facility || !to.query.username) {
+        next({ path: '/' });
+      } else {
+        next();
+      }
+    },
+    props(route) {
+      return {
+        facilityId: route.query.facility,
+        username: route.query.username,
+      };
     },
   },
   {

--- a/kolibri/plugins/user/assets/src/views/SignInPage/NewPasswordPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/NewPasswordPage.vue
@@ -1,0 +1,132 @@
+<template>
+
+  <AuthBase>
+    <div style="text-align: left">
+      <KButton
+        appearance="basic-link"
+        style="margin-bottom: 16px;"
+        data-test="goback"
+        @click="goBack"
+      >
+        <template #icon>
+          <KIcon
+            icon="back"
+            :style="{
+              fill: $themeTokens.primary,
+              height: '1.125em',
+              width: '1.125em',
+              position: 'relative',
+              marginRight: '8px',
+              top: '2px',
+            }"
+          />{{ coreString('goBackAction') }}
+        </template>
+      </KButton>
+
+      <p>{{ $tr("needToMakeNewPasswordLabel", { user: username }) }}</p>
+
+      <PasswordTextbox
+        ref="createPassword"
+        :autofocus="true"
+        :disabled="busy"
+        :value.sync="password"
+        :isValid.sync="passwordIsValid"
+        :shouldValidate="busy"
+        @submitNewPassword="updatePassword"
+      />
+      <KButton
+        appearance="raised-button"
+        :primary="true"
+        :text="coreString('continueAction')"
+        style="width: 100%; margin: 24px auto 0; display:block;"
+        :disabled="busy"
+        data-test="submit"
+        @click="updatePassword"
+      />
+    </div>
+  </AuthBase>
+
+</template>
+
+
+<script>
+
+  import pickBy from 'lodash/pickBy';
+  import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AuthBase from '../AuthBase';
+  import { ComponentMap } from '../../constants';
+
+  export default {
+    name: 'NewPasswordPage',
+    components: {
+      AuthBase,
+      PasswordTextbox,
+    },
+    mixins: [commonCoreStrings],
+    props: {
+      username: {
+        type: String,
+        required: true,
+      },
+      facilityId: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        busy: false,
+        password: '',
+        passwordIsValid: false,
+      };
+    },
+    computed: {
+      credentials() {
+        return pickBy({
+          username: this.username,
+          password: this.password,
+          facility: this.facilityId,
+          next: this.$route.query.next,
+        });
+      },
+    },
+    methods: {
+      updatePassword() {
+        if (this.passwordIsValid) {
+          this.busy = true;
+          this.$store
+            .dispatch('kolibriSetUnspecifiedPassword', this.credentials)
+            .then(() => {
+              this.signIn();
+            })
+            .catch(() => {
+              // In case user has already set password or user does not exist,
+              // simply go back to the Sign In page.
+              this.goBack();
+            });
+        } else {
+          this.$refs.createPassword.focus();
+        }
+      },
+      signIn() {
+        this.$store.dispatch('kolibriLogin', this.credentials).catch(() => {
+          // In case of an error, we just go back to the Sign In page
+          this.goBack();
+        });
+      },
+      goBack() {
+        this.$router.push({
+          name: ComponentMap.SIGN_IN,
+        });
+      },
+    },
+    $trs: {
+      needToMakeNewPasswordLabel: 'Hi, {user}. You need to set a new password for your account.',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/user/assets/src/views/SignInPage/__test__/NewPasswordPage.spec.js
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/__test__/NewPasswordPage.spec.js
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import VueRouter from 'vue-router';
+import NewPasswordPage from '../NewPasswordPage';
+
+const loginSpy = jest.fn().mockResolvedValue();
+const updatePwSpy = jest.fn().mockResolvedValue();
+
+const store = new Vuex.Store({
+  actions: {
+    kolibriSetUnspecifiedPassword: updatePwSpy,
+    kolibriLogin: loginSpy,
+  },
+});
+
+const router = new VueRouter({
+  routes: [{ name: 'SignInPage', path: '/sign-in' }],
+});
+
+function makeWrapper() {
+  const signInSpy = jest.spyOn(NewPasswordPage.methods, 'signIn');
+  const wrapper = mount(NewPasswordPage, {
+    propsData: {
+      username: 'a',
+      facilityId: 'f',
+    },
+    store,
+    router,
+    stubs: {
+      AuthBase: {
+        template: '<div><slot></slot></div>',
+      },
+    },
+  });
+  return { wrapper, signInSpy };
+}
+
+describe('NewPasswordPage', () => {
+  afterEach(() => {
+    loginSpy.mockReset();
+    updatePwSpy.mockReset();
+  });
+
+  it('if password is not valid, clicking "continue" does nothing', async () => {
+    const { wrapper } = makeWrapper();
+    const button = wrapper.find('[data-test="submit"]');
+    button.trigger('click');
+    await global.flushPromises();
+    expect(updatePwSpy).not.toHaveBeenCalled();
+  });
+
+  it('if password is valid, clicking "continue" updates pw and signs user in', async () => {
+    const { wrapper } = makeWrapper();
+    wrapper.setData({
+      password: 'pass',
+      passwordIsValid: true,
+    });
+    const button = wrapper.find('[data-test="submit"]');
+    button.trigger('click');
+    await global.flushPromises();
+    expect(updatePwSpy.mock.calls[0][1]).toMatchObject({
+      username: 'a',
+      password: 'pass',
+      facility: 'f',
+    });
+    expect(loginSpy.mock.calls[0][1]).toMatchObject({
+      username: 'a',
+      password: 'pass',
+      facility: 'f',
+    });
+  });
+
+  it('clicking the "go back" navigates user to the Sign-In page', () => {
+    const { wrapper } = makeWrapper();
+    const button = wrapper.find('[data-test="goback"]');
+    button.trigger('click');
+    expect(wrapper.vm.$route.name).toEqual('SignInPage');
+  });
+});

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -148,56 +148,6 @@
         @userSelected="setSelectedUsername"
       />
     </div>
-
-    <!-- TODO: This can be its own separate component -->
-    <!--
-        Learner was created without a password, but now must create one.
-        This ought to be routed separately.
-      -->
-    <div v-else style="text-align: left">
-      <KButton
-        appearance="basic-link"
-        text=""
-        style="margin-bottom: 16px;"
-        @click="clearUser"
-      >
-        <template #icon>
-          <KIcon
-            icon="back"
-            :style="{
-              fill: $themeTokens.primary,
-              height: '1.125em',
-              width: '1.125em',
-              position: 'relative',
-              marginRight: '8px',
-              top: '2px',
-            }"
-          />{{ coreString('goBackAction') }}
-        </template>
-      </KButton>
-
-      <p>{{ $tr("needToMakeNewPasswordLabel", { user: username }) }}</p>
-
-      <PasswordTextbox
-        ref="createPassword"
-        :autofocus="true"
-        :disabled="busy"
-        :value.sync="createdPassword"
-        :isValid.sync="createdPasswordIsValid"
-        :shouldValidate="busy"
-        @submitNewPassword="updatePasswordAndSignIn"
-      />
-      <KButton
-        appearance="raised-button"
-        :primary="true"
-        :text="coreString('continueAction')"
-        style="width: 100%; margin: 24px auto 0; display:block;"
-        :disabled="busy"
-        @click="updatePasswordAndSignIn"
-      />
-    </div>
-    <!-- End TODO about making this its own component -->
-
   </AuthBase>
 
 </template>
@@ -210,7 +160,6 @@
   import get from 'lodash/get';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { LoginErrors } from 'kolibri.coreVue.vuex.constants';
-  import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import { validateUsername } from 'kolibri.utils.validators';
   import UiAutocompleteSuggestion from 'kolibri-design-system/lib/keen/UiAutocompleteSuggestion';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
@@ -233,7 +182,6 @@
     },
     components: {
       AuthBase,
-      PasswordTextbox,
       SignInHeading,
       UiAutocompleteSuggestion,
       UiAlert,
@@ -252,8 +200,6 @@
         usernameBlurred: false,
         passwordBlurred: false,
         formSubmitted: false,
-        createdPassword: '',
-        createdPasswordIsValid: false,
         busy: false,
         loginError: null,
         usernameSubmittedWithoutPassword: false,
@@ -375,13 +321,12 @@
       }
     },
     methods: {
-      ...mapActions(['kolibriLogin', 'kolibriSetUnspecifiedPassword']),
+      ...mapActions(['kolibriLogin']),
       clearUser() {
         // Going back to the beginning - undo what we may have
         // changed so far and clearing the errors, if any
         this.username = '';
         this.password = '';
-        this.createdPassword = '';
         // This ensures we don't get '<field> required' when going back
         // and forth
         this.usernameBlurred = false;
@@ -395,23 +340,6 @@
         // and to check if we even need a password
         // or need to change a password
         this.signIn();
-      },
-      updatePasswordAndSignIn() {
-        if (this.createdPasswordIsValid) {
-          this.busy = true;
-          this.kolibriSetUnspecifiedPassword({
-            username: this.username,
-            password: this.createdPassword,
-            facility: this.selectedFacility.id,
-          }).then(() => {
-            // Password successfully set
-            // Use this password now to sign in
-            this.password = this.createdPassword;
-            this.signIn();
-          });
-        } else {
-          this.$refs.createPassword.focus();
-        }
       },
       setSuggestionTerm(newVal) {
         if (newVal !== null && typeof newVal !== 'undefined') {
@@ -526,6 +454,10 @@
             // If we don't have a password, we submitted without a username
             if (err) {
               if (err === LoginErrors.PASSWORD_NOT_SPECIFIED) {
+                this.$router.push({
+                  name: ComponentMap.NEW_PASSWORD,
+                  query: sessionPayload,
+                });
                 // This error overrides the whole layout
                 this.loginError = err;
               } else {
@@ -550,7 +482,6 @@
       signInError: 'Incorrect username or password',
       requiredForCoachesAdmins: 'Password is required for coaches and admins',
       documentTitle: 'User Sign In',
-      needToMakeNewPasswordLabel: 'Hi, {user}. You need to set a new password for your account.',
       nextLabel: 'Next',
       changeUser: 'Change user',
       changeFacility: 'Change facility',

--- a/kolibri/plugins/user/assets/src/views/UserIndex.vue
+++ b/kolibri/plugins/user/assets/src/views/UserIndex.vue
@@ -33,6 +33,7 @@
           ComponentMap.FACILITY_SELECT,
           ComponentMap.AUTH_SELECT,
           ComponentMap.SIGN_UP,
+          ComponentMap.NEW_PASSWORD,
         ].includes(this.$route.name);
       },
       demoBannerRoute() {
@@ -40,6 +41,7 @@
           ComponentMap.SIGN_IN,
           ComponentMap.FACILITY_SELECT,
           ComponentMap.AUTH_SELECT,
+          ComponentMap.NEW_PASSWORD,
         ].includes(this.$route.name);
       },
       redirect: {

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -56,3 +56,10 @@ process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
   console.log(reason.stack);
 });
+
+// Copied from https://github.com/kentor/flush-promises/blob/f33ac564190c784019f1f689dd544187f4b77eb2/index.js
+global.flushPromises = function flushPromises() {
+  return new Promise(function(resolve) {
+    setImmediate(resolve);
+  });
+};


### PR DESCRIPTION
### Summary

1. Adds a new `NewPasswordPage`, which is assigned to a new route `/set-password`
2. Adds a test for the new component
3. In the test environment, adds a `global.flushPromises` utility, following some advice in [these docs](https://vue-test-utils.vuejs.org/guides/testing-async-components.html)
4. Refactors some tests to remove the hacky multiple calls to `nextTick`.

### Reviewer guidance

1. Does the Sign-In page still work in "learner has to update password when facility changes password requirement setting from not-required to required" flow?
2. Is the handling for edge cases good enough? e.g. when a user goes directly to a `/set-password` URL and the learner has already set their password, or the `username` query param is invalid.

### References

Closes #7321

(We should write separate issues for the other suggested refactors, since they are a little bit more complicated).

This might add some tech debt because the error states just redirect back to the sign-in page. But this is not a regression since these errors were unhandled originally. We would need some specs on how to be more informative to the user when these errors occur.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
edit