### PR TITLE
Align superuser ("key") icon with its label; style permissions icon with lighter color when disabled

### DIFF
--- a/kolibri/core/assets/src/views/PermissionsIcon.vue
+++ b/kolibri/core/assets/src/views/PermissionsIcon.vue
@@ -5,14 +5,14 @@
       <KIcon
         v-if="hasSuperAdminPermission"
         class="icon super-admin"
-        :style="{ fill: $themeTokens.superAdmin }"
+        :style="iconStyle"
         icon="permission"
       />
 
       <KIcon
         v-else-if="hasLimitedPermissions"
         class="icon some-permissions"
-        :style="{ fill: $themeTokens.text }"
+        :style="iconStyle"
         icon="permission"
       />
     </span>
@@ -51,6 +51,10 @@
           return [PermissionTypes.SUPERUSER, PermissionTypes.LIMITED_PERMISSIONS].includes(value);
         },
       },
+      lightIcon: {
+        type: Boolean,
+        default: false,
+      },
     },
     computed: {
       UserKinds() {
@@ -61,6 +65,17 @@
       },
       hasLimitedPermissions() {
         return this.permissionType === PermissionTypes.LIMITED_PERMISSIONS;
+      },
+      iconStyle() {
+        if (this.hasSuperAdminPermission) {
+          return {
+            fill: this.lightIcon ? this.$themePalette.amber.v_100 : this.$themeTokens.superAdmin,
+          };
+        } else {
+          return {
+            fill: this.lightIcon ? this.$themeTokens.disabled : this.$themeTokens.text,
+          };
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -47,9 +47,13 @@
           :checked="superuserChecked"
           @change="superuserChecked = $event"
         >
-          <label>
+          <label :style="superuserLabelStyle">
             <span>{{ $tr('makeSuperAdmin') }}</span>
-            <PermissionsIcon permissionType="SUPERUSER" class="permissions-icon" />
+            <PermissionsIcon
+              permissionType="SUPERUSER"
+              class="permissions-icon"
+              :lightIcon="superuserDisabled"
+            />
           </label>
         </KCheckbox>
 
@@ -155,6 +159,9 @@
           this.permissions.is_superuser === this.superuserChecked &&
           this.permissions.can_manage_content === this.devicePermissionsChecked
         );
+      },
+      superuserLabelStyle() {
+        return { color: this.superuserDisabled ? this.$themeTokens.textDisabled : '' };
       },
     },
     watch: {

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -44,11 +44,14 @@
         <KCheckbox
           class="super-admin-checkbox"
           :disabled="superuserDisabled"
-          :label="$tr('makeSuperAdmin')"
           :checked="superuserChecked"
           @change="superuserChecked = $event"
-        />
-        <PermissionsIcon permissionType="SUPERUSER" class="permissions-icon" />
+        >
+          <label>
+            <span>{{ $tr('makeSuperAdmin') }}</span>
+            <PermissionsIcon permissionType="SUPERUSER" class="permissions-icon" />
+          </label>
+        </KCheckbox>
 
         <ul
           class="checkbox-description"


### PR DESCRIPTION
### Summary

1. Modifies markup so that the "key" icon is within the label tag. Fixes #6419 
2. Gives `PermissionsIcon` a `lightIcon` prop so that the key icon will have a lighter amber hue to coordinate with the `$themeTokens.disabled` hue

### Reviewer guidance

Just take a look at the Device Permissions page in Safari and the Mac App.

**Superuser example before(top)/after**

![CleanShot 2021-03-09 at 15 36 07](https://user-images.githubusercontent.com/10248067/110553673-3550ed80-80ee-11eb-81f1-a6289119c730.png)

![CleanShot 2021-03-09 at 15 33 59](https://user-images.githubusercontent.com/10248067/110553692-3aae3800-80ee-11eb-8f3b-87a4548b6791.png)


**Learner example before/after**

![CleanShot 2021-03-09 at 15 35 58](https://user-images.githubusercontent.com/10248067/110553705-400b8280-80ee-11eb-8f6b-51f5cd7849dd.png)

![CleanShot 2021-03-09 at 15 35 35](https://user-images.githubusercontent.com/10248067/110553731-4b5eae00-80ee-11eb-9702-9a82d2197642.png)


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
Fixes #6419