### PR TITLE
Move the 'manage migrate' command in the 'Getting started' doc

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -167,6 +167,16 @@ Running the Kolibri server
 
 .. _devserver:
 
+Database setup
+~~~~~~~~~~~~~~
+
+To initialize the database run the following command:
+
+.. code-block:: bash
+
+  kolibri manage migrate
+
+
 Development server
 ~~~~~~~~~~~~~~~~~~
 
@@ -359,15 +369,6 @@ Frontend dev tools
 
 To ensure a more efficient workflow, install appropriate editor plugins for Vue.js, ESLint, and stylelint.
 
-
-Database setup
-~~~~~~~~~~~~~~
-
-You can initialize the server using:
-
-.. code-block:: bash
-
-  kolibri manage migrate
 
 
 .. _workflow_intro:


### PR DESCRIPTION

### Summary
Move the `kolibri manage migrate` step from the recommended setup so it's executed by default before running the server.

### Reviewer guidance
I'm still not completely sure if _initialize database_ is the proper term...?


### References
[Conversation on Slack](https://learningequality.slack.com/archives/CB37UM23A/p1615485673008800).

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
