### PR TITLE
Fix closing animation on `sideNav`

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -109,12 +109,14 @@
       </div>
     </transition>
 
-    <div
-      v-show="navShown"
-      class="side-nav-backdrop"
-      @click="toggleNav"
-    >
-    </div>
+    <transition name="side-nav-backdrop">
+      <div
+        v-show="navShown"
+        class="side-nav-backdrop"
+        @click="toggleNav"
+      >
+      </div>
+    </transition>
 
     <PrivacyInfoModal
       v-if="privacyModalVisible"
@@ -370,7 +372,30 @@
     height: 100%;
     background: rgba(0, 0, 0, 0.7);
     background-attachment: fixed;
-    transition: opacity 0.3s ease;
+  }
+
+  .side-nav-backdrop-enter {
+    opacity: 0;
+  }
+
+  .side-nav-backdrop-enter-to {
+    opacity: 1;
+  }
+
+  .side-nav-backdrop-enter-active {
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  .side-nav-backdrop-leave {
+    opacity: 1;
+  }
+
+  .side-nav-backdrop-leave-to {
+    opacity: 0;
+  }
+
+  .side-nav-backdrop-leave-active {
+    transition: opacity 0.2s ease-in-out;
   }
 
   /* keen menu */

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -1,7 +1,6 @@
 <template>
 
   <div
-    v-show="navShown"
     ref="sideNav"
     class="side-nav-wrapper"
     tabindex="0"


### PR DESCRIPTION

### Summary

This fixes the closing animation on `sideNav`. Earlier, closing the `sideNav` caused it to disappear immediately.

![sidebar](https://user-images.githubusercontent.com/55936040/110917103-8ad00900-833f-11eb-9db8-18514ab5edee.gif)

### References

This pull request is a fix for #7700 


### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
