### PR TITLE
Remove `_blank` in favor of `openInNewTab` in KExternalLink.

### DIFF
--- a/kolibri/core/assets/src/views/PrivacyInfoModal.vue
+++ b/kolibri/core/assets/src/views/PrivacyInfoModal.vue
@@ -38,7 +38,7 @@
         <KExternalLink
           text="https://learningequality.org"
           href="https://learningequality.org"
-          target="_blank"
+          openInNewTab="true"
         />
       </p>
       <p>{{ $tr('kolibriAboutP2') }}</p>

--- a/kolibri/core/assets/src/views/PrivacyInfoModal.vue
+++ b/kolibri/core/assets/src/views/PrivacyInfoModal.vue
@@ -38,7 +38,7 @@
         <KExternalLink
           text="https://learningequality.org"
           href="https://learningequality.org"
-          openInNewTab="true"
+          :openInNewTab="true"
         />
       </p>
       <p>{{ $tr('kolibriAboutP2') }}</p>

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -12,7 +12,7 @@
         v-if="linkUrl"
         :href="linkUrl"
         :text="linkText || linkUrl"
-        openInNewTab="true"
+        :openInNewTab="true"
       />
     </p>
     <p v-if="!isSuperuser">

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -12,7 +12,7 @@
         v-if="linkUrl"
         :href="linkUrl"
         :text="linkText || linkUrl"
-        target="_blank"
+        openInNewTab="true"
       />
     </p>
     <p v-if="!isSuperuser">

--- a/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
+++ b/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
@@ -18,14 +18,14 @@
         <KExternalLink
           href="https://learningequality.org/documentation/"
           :text="$tr('demoServerA1')"
-          target="_blank"
+          openInNewTab="true"
         />
       </li>
       <li>
         <KExternalLink
           href="https://learningequality.org/download/"
           :text="$tr('demoServerA2')"
-          target="_blank"
+          openInNewTab="true"
         />
       </li>
     </ul>

--- a/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
+++ b/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
@@ -18,14 +18,14 @@
         <KExternalLink
           href="https://learningequality.org/documentation/"
           :text="$tr('demoServerA1')"
-          openInNewTab="true"
+          :openInNewTab="true"
         />
       </li>
       <li>
         <KExternalLink
           href="https://learningequality.org/download/"
           :text="$tr('demoServerA2')"
-          openInNewTab="true"
+          :openInNewTab="true"
         />
       </li>
     </ul>

--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -14,7 +14,7 @@
             :text="url"
             :href="url"
             :primary="true"
-            target="_blank"
+            openInNewTab="true"
             appearance="basic-link"
           />
         </td>

--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -14,7 +14,7 @@
             :text="url"
             :href="url"
             :primary="true"
-            openInNewTab="true"
+            :openInNewTab="true"
             appearance="basic-link"
           />
         </td>

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -63,7 +63,7 @@
                 :text="$tr('poweredByKolibri')"
                 :primary="true"
                 href="https://learningequality.org/r/powered_by_kolibri"
-                target="_blank"
+                openInNewTab="true"
                 appearance="basic-link"
               />
             </p>
@@ -137,7 +137,7 @@
           text="https://learningequality.org/kolibri"
           :primary="true"
           href="https://learningequality.org/r/powered_by_kolibri"
-          target="_blank"
+          openInNewTab="true"
           appearance="basic-link"
         />
       </p>

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -63,7 +63,7 @@
                 :text="$tr('poweredByKolibri')"
                 :primary="true"
                 href="https://learningequality.org/r/powered_by_kolibri"
-                openInNewTab="true"
+                :openInNewTab="true"
                 appearance="basic-link"
               />
             </p>
@@ -137,7 +137,7 @@
           text="https://learningequality.org/kolibri"
           :primary="true"
           href="https://learningequality.org/r/powered_by_kolibri"
-          openInNewTab="true"
+          :openInNewTab="true"
           appearance="basic-link"
         />
       </p>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR removes `target="_blank"` in `KExternalLink` to make use of the `openInNewTab` prop of `KExternalLink`.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The external links (as in the Privacy modal) should appear with an iconographic representation of the "new tab" behavior.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7712.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
