### PR TITLE
Customize `ContentUnavailablePage` for different roles and change its URL

### DIFF
--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -79,7 +79,7 @@ export default [
   },
   {
     name: PageNames.CONTENT_UNAVAILABLE,
-    path: '/content-unavailable',
+    path: '/resources-unavailable',
     handler: () => {
       store.commit('SET_PAGE_NAME', PageNames.CONTENT_UNAVAILABLE);
       store.commit('CORE_SET_PAGE_LOADING', false);

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -5,7 +5,9 @@
     <p>
       <KExternalLink v-if="deviceContentUrl" :text="$tr('adminLink')" :href="deviceContentUrl" />
     </p>
-    <p>{{ $tr('learnerText') }}</p>
+    <p v-if="showLearnerText">
+      {{ $tr('learnerText') }}
+    </p>
   </div>
 
 </template>
@@ -24,7 +26,7 @@
       };
     },
     computed: {
-      ...mapGetters(['canManageContent']),
+      ...mapGetters(['canManageContent', 'isLearner']),
       deviceContentUrl() {
         const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
         if (deviceContentUrl && this.canManageContent) {
@@ -33,10 +35,13 @@
 
         return '';
       },
+      showLearnerText() {
+        return this.isLearner && !this.canManageContent;
+      },
     },
     $trs: {
       header: 'No resources available',
-      adminLink: 'As an administrator you can import channels',
+      adminLink: 'As an administrator, you can import channels',
       learnerText: 'Please ask your coach or administrator for assistance',
       documentTitle: {
         message: 'Resource unavailable',


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

This pull request incorporates following changes:
- Show `learnerText` message only if the user has the Learner role (and does not have the "can manage content role").
- Fix punctuation in the import channels link text for admin.
- Change URL of the `ContentUnavailablePage` from `content-unavailable` to `resources-unavailable`.

http://localhost:8000/en/learn/#/resources-unavailable when viewed from admin account

![resource-unavailable-admin](https://user-images.githubusercontent.com/55936040/110968863-0badf580-837e-11eb-96fa-10bc740450da.png)


http://localhost:8000/en/learn/#/resources-unavailable when viewed from learner account

![resource-unavailable-learner](https://user-images.githubusercontent.com/55936040/110968902-14063080-837e-11eb-87ba-19ccf9f0836e.png)


### References
Fixes #7694 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
