### PR TITLE
updated FacilityUsernameViewSet to check for exisiting user

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -259,9 +259,6 @@ class FacilityUserViewSet(ValuesViewset):
         self.set_password_if_needed(instance, serializer)
 
 
-
-
-
 class FacilityUsernameViewSet(ValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
     filter_fields = ("facility",)
@@ -275,7 +272,7 @@ class FacilityUsernameViewSet(ValuesViewset):
         user_name = self.request.query_params.get("search")
         user = FacilityUser.objects.get(username=user_name)
         if user is not None:
-            return FacilityUser.objects.filter(username=userName)
+            return FacilityUser.objects.filter(username=user_ame)
         if valid_app_key_on_request(self.request):
             # Special case for app context to return usernames for
             # the list display

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -277,8 +277,9 @@ class FacilityUsernameViewSet(ValuesViewset):
             user_name = self.request.query_params.get("search")
             try:
                 user = FacilityUser.objects.get(username=user_name)
-                return FacilityUser.objects.filter(username=user_name)
-            except user.DoesNotExist:
+                if user is not None:
+                    return FacilityUser.objects.filter(username=user_name)
+            except FacilityUser.DoesNotExist:
                 return FacilityUser.objects.filter(
                     dataset__learner_can_login_with_no_password=True, roles=None
                 ).filter(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -269,18 +269,22 @@ class FacilityUsernameViewSet(ValuesViewset):
     values = ("username",)
 
     def get_queryset(self):
-        user_name = self.request.query_params.get("search")
-
-        try:
-            user = FacilityUser.objects.get(username=user_name)
-            return FacilityUser.objects.filter(username=user_name)
-        except:
-            return FacilityUser.objects.filter(
-                dataset__learner_can_login_with_no_password=True, roles=None
-            ).filter(
-                Q(devicepermissions__is_superuser=False) 
-                | Q(devicepermissions__isnull=True)
-            )
+        if valid_app_key_on_request(self.request):
+            # Special case for app context to return usernames for
+            # the list display
+            return FacilityUser.objects.all()
+        else:
+            user_name = self.request.query_params.get("search")
+            try:
+                user = FacilityUser.objects.get(username=user_name)
+                return FacilityUser.objects.filter(username=user_name)
+            except:
+                return FacilityUser.objects.filter(
+                    dataset__learner_can_login_with_no_password=True, roles=None
+                ).filter(
+                    Q(devicepermissions__is_superuser=False)
+                    | Q(devicepermissions__isnull=True)
+                )
 
 
 class MembershipFilter(FilterSet):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -278,7 +278,7 @@ class FacilityUsernameViewSet(ValuesViewset):
             try:
                 user = FacilityUser.objects.get(username=user_name)
                 return FacilityUser.objects.filter(username=user_name)
-            except:
+            except user.DoesNotExist:
                 return FacilityUser.objects.filter(
                     dataset__learner_can_login_with_no_password=True, roles=None
                 ).filter(

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -259,16 +259,23 @@ class FacilityUserViewSet(ValuesViewset):
         self.set_password_if_needed(instance, serializer)
 
 
+
+
+
 class FacilityUsernameViewSet(ValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
-    filter_fields = ("facility",)
-    search_fields = ("^username",)
+    filter_fields = ("facility",'username')
+    search_fields = ["username",]
 
     read_only = True
 
     values = ("username",)
 
     def get_queryset(self):
+        userName = self.request.query_params.get('search')
+        user = FacilityUser.objects.get(username=userName)
+        if user is not None:
+            return FacilityUser.objects.filter(username=userName)
         if valid_app_key_on_request(self.request):
             # Special case for app context to return usernames for
             # the list display

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -264,16 +264,16 @@ class FacilityUserViewSet(ValuesViewset):
 
 class FacilityUsernameViewSet(ValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
-    filter_fields = ("facility",'username')
-    search_fields = ["username",]
+    filter_fields = ("facility",)
+    search_fields = ("^username",)
 
     read_only = True
 
     values = ("username",)
 
     def get_queryset(self):
-        userName = self.request.query_params.get('search')
-        user = FacilityUser.objects.get(username=userName)
+        user_name = self.request.query_params.get('search')
+        user = FacilityUser.objects.get(username=user_name)
         if user is not None:
             return FacilityUser.objects.filter(username=userName)
         if valid_app_key_on_request(self.request):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -278,9 +278,10 @@ class FacilityUsernameViewSet(ValuesViewset):
             return FacilityUser.objects.filter(
                 dataset__learner_can_login_with_no_password=True, roles=None
             ).filter(
-                Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True)
+                Q(devicepermissions__is_superuser=False) 
+                | Q(devicepermissions__isnull=True)
             )
-            
+
 
 class MembershipFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -272,7 +272,7 @@ class FacilityUsernameViewSet(ValuesViewset):
         user_name = self.request.query_params.get("search")
         user = FacilityUser.objects.get(username=user_name)
         if user is not None:
-            return FacilityUser.objects.filter(username=user_ame)
+            return FacilityUser.objects.filter(username=user_name)
         if valid_app_key_on_request(self.request):
             # Special case for app context to return usernames for
             # the list display

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -272,7 +272,7 @@ class FacilityUsernameViewSet(ValuesViewset):
     values = ("username",)
 
     def get_queryset(self):
-        user_name = self.request.query_params.get('search')
+        user_name = self.request.query_params.get("search")
         user = FacilityUser.objects.get(username=user_name)
         if user is not None:
             return FacilityUser.objects.filter(username=userName)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -270,19 +270,17 @@ class FacilityUsernameViewSet(ValuesViewset):
 
     def get_queryset(self):
         user_name = self.request.query_params.get("search")
-        user = FacilityUser.objects.get(username=user_name)
-        if user is not None:
-            return FacilityUser.objects.filter(username=user_name)
-        if valid_app_key_on_request(self.request):
-            # Special case for app context to return usernames for
-            # the list display
-            return FacilityUser.objects.all()
-        return FacilityUser.objects.filter(
-            dataset__learner_can_login_with_no_password=True, roles=None
-        ).filter(
-            Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True)
-        )
 
+        try:
+            user = FacilityUser.objects.get(username=user_name)
+            return FacilityUser.objects.filter(username=user_name)
+        except:
+            return FacilityUser.objects.filter(
+                dataset__learner_can_login_with_no_password=True, roles=None
+            ).filter(
+                Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True)
+            )
+            
 
 class MembershipFilter(FilterSet):
     user_ids = CharFilter(method="filter_user_ids")


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Create Account - Existing username error isn't displayed as expected
Updated the get_queryset method


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

On testing on the local server, on status 200 it is now warning for existing user before going to step 2.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
![Peek 2021-03-13 18-05](https://user-images.githubusercontent.com/60326725/111030179-e2956f80-8426-11eb-910e-4d080360564a.gif)
