### PR TITLE
Learn Page top bar become cramped

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -229,7 +229,7 @@
   }
 
   .username {
-    max-width: 200px;
+    max-width: 50px;
     // overflow-x hidden seems to affect overflow-y also, so include a fixed height
     height: 16px;
     // overflow: hidden on both x and y so that the -y doesn't show scroll buttons
@@ -285,6 +285,10 @@
 
   /deep/ .ui-toolbar__brand {
     min-width: inherit;
+  }
+
+  /deep/ .ui-toolbar__title {
+    margin-right: 10px;
   }
 
   .brand-logo {


### PR DESCRIPTION


### Summary
The username size was set to 200px due to which at 600px the the Learn Page top bar  become cramped so I reduced it to 50px. And there was no gap between learn title and searchbar so I inserted some gap.
##### Initial UI
![Screenshot from 2021-03-14 00-41-38](https://user-images.githubusercontent.com/55887726/111042177-104bda00-8462-11eb-9ff1-cacf9e19eb29.png)
##### Updated UI
![Screenshot from 2021-03-14 00-42-15](https://user-images.githubusercontent.com/55887726/111042180-1c379c00-8462-11eb-9ef6-85a9b7dbeeca.png)




### Reviewer guidance
The changes can be tested by simply going to learn page and keeping size 600px.

### References
#7670 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
