### PR TITLE
Long channel names truncated in two UI components

### DIFF
--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -296,4 +296,8 @@
     opacity: 0;
   }
 
+  /deep/ .breadcrumbs-crumb-text {
+    max-width: 750px;
+  }
+
 </style>

--- a/kolibri/plugins/learn/assets/src/views/Breadcrumbs.vue
+++ b/kolibri/plugins/learn/assets/src/views/Breadcrumbs.vue
@@ -114,4 +114,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  /deep/ .breadcrumb-visible-item-last .breadcrumbs-crumb-text {
+    max-width: 750px;
+  }
+
+</style>


### PR DESCRIPTION


### Summary
Removed the issue by increasing the breadcrumb max-width.


#### 1.

#### Initial UI

![Screenshot from 2021-03-15 17-50-00](https://user-images.githubusercontent.com/55887726/111156026-4650a180-85bb-11eb-9fe2-f7429f199a65.png)

#### Final UI

![Screenshot from 2021-03-15 17-52-33](https://user-images.githubusercontent.com/55887726/111156036-481a6500-85bb-11eb-9667-5b09050ea52d.png)


#### 2.

#### Initial UI

![Screenshot from 2021-03-15 17-46-05](https://user-images.githubusercontent.com/55887726/111156015-42248400-85bb-11eb-996c-8975750e0db5.png)

#### Final UI

![Screenshot from 2021-03-15 18-12-17](https://user-images.githubusercontent.com/55887726/111156044-49e42880-85bb-11eb-8235-82fef791df65.png)



### Reviewer guidance

…

### References

#6918 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
