### PR TITLE
Enforce server-consistent settings

### DIFF
--- a/kolibri/core/auth/errors.py
+++ b/kolibri/core/auth/errors.py
@@ -27,3 +27,7 @@ class UserIsMemberOnlyIndirectlyThroughHierarchyError(KolibriError):
 
 class InvalidHierarchyRelationsArgument(KolibriError):
     pass
+
+
+class IncompatibleDeviceSetting(KolibriError):
+    pass

--- a/kolibri/core/auth/errors.py
+++ b/kolibri/core/auth/errors.py
@@ -29,5 +29,5 @@ class InvalidHierarchyRelationsArgument(KolibriError):
     pass
 
 
-class IncompatibleDeviceSetting(KolibriError):
+class IncompatibleDeviceSettingError(KolibriError):
     pass

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -139,11 +139,7 @@ class FacilityDataset(FacilityDataSyncableModel):
             return "FacilityDataset (no associated Facility)"
 
     def save(self, *args, **kwargs):
-        try:
-            self.ensure_compatibility()
-        except IncompatibleDeviceSettingError as e:
-            raise IncompatibleDeviceSettingError(str(e))
-
+        self.ensure_compatibility()
         super(FacilityDataset, self).save(*args, **kwargs)
 
     def ensure_compatibility(self, *args, **kwargs):

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -48,7 +48,7 @@ from .constants import facility_presets
 from .constants import morango_sync
 from .constants import role_kinds
 from .constants import user_kinds
-from .errors import IncompatibleDeviceSetting
+from .errors import IncompatibleDeviceSettingError
 from .errors import InvalidRoleKind
 from .errors import UserDoesNotHaveRoleError
 from .errors import UserHasRoleOnlyIndirectlyThroughHierarchyError
@@ -141,15 +141,16 @@ class FacilityDataset(FacilityDataSyncableModel):
     def save(self, *args, **kwargs):
         try:
             self.ensure_compatibility()
-        except IncompatibleDeviceSetting as e:
-            raise IntegrityError(str(e))
+        except IncompatibleDeviceSettingError as e:
+            raise IncompatibleDeviceSettingError(str(e))
 
         super(FacilityDataset, self).save(*args, **kwargs)
 
     def ensure_compatibility(self, *args, **kwargs):
         if self.learner_can_login_with_no_password and self.learner_can_edit_password:
-            raise IncompatibleDeviceSetting(
-                "Device Settings [learner_can_login_with_no_password={}] & [learner_can_edit_password={}] values incompatible.".format(
+            raise IncompatibleDeviceSettingError(
+                "Device Settings [learner_can_login_with_no_password={}] & [learner_can_edit_password={}] "
+                "values incompatible togeather.".format(
                     self.learner_can_login_with_no_password,
                     self.learner_can_edit_password,
                 )

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 
+from .errors import IncompatibleDeviceSettingError
 from .models import Classroom
 from .models import Facility
 from .models import FacilityDataset
@@ -84,20 +85,11 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
             "preset",
         )
 
-    def validate(self, attrs):
-        learner_can_edit_password = attrs.get("learner_can_edit_password")
-        learner_can_login_with_no_password = attrs.get(
-            "learner_can_login_with_no_password"
-        )
-        if learner_can_login_with_no_password and learner_can_edit_password:
-            raise serializers.ValidationError(
-                "Device Settings [learner_can_login_with_no_password={}] & [learner_can_edit_password={}] values incompatible.".format(
-                    learner_can_login_with_no_password,
-                    learner_can_edit_password,
-                )
-            )
-        else:
-            return attrs
+    def save(self, **kwargs):
+        try:
+            return super(FacilityDatasetSerializer, self).save(**kwargs)
+        except IncompatibleDeviceSettingError as e:
+            raise serializers.ValidationError(str(e))
 
 
 class FacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -84,6 +84,21 @@ class FacilityDatasetSerializer(serializers.ModelSerializer):
             "preset",
         )
 
+    def validate(self, attrs):
+        learner_can_edit_password = attrs.get("learner_can_edit_password")
+        learner_can_login_with_no_password = attrs.get(
+            "learner_can_login_with_no_password"
+        )
+        if learner_can_login_with_no_password and learner_can_edit_password:
+            raise serializers.ValidationError(
+                "Device Settings [learner_can_login_with_no_password={}] & [learner_can_edit_password={}] values incompatible.".format(
+                    learner_can_login_with_no_password,
+                    learner_can_edit_password,
+                )
+            )
+        else:
+            return attrs
+
 
 class FacilitySerializer(serializers.ModelSerializer):
     class Meta:

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -987,6 +987,21 @@ class FacilityDatasetAPITestCase(APITestCase):
             response = post_resetsettings()
             self.assertDictContainsSubset(mappings[setting], response.data)
 
+    def test_validation_for_incompatible_settings(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.patch(
+            reverse(
+                "kolibri:core:facilitydataset-detail",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            {
+                "learner_can_login_with_no_password": "true",
+                "learner_can_edit_password": "true",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
 
 class MembershipCascadeDeletion(APITestCase):
     @classmethod

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -987,7 +987,7 @@ class FacilityDatasetAPITestCase(APITestCase):
             response = post_resetsettings()
             self.assertDictContainsSubset(mappings[setting], response.data)
 
-    def test_validation_for_incompatible_settings(self):
+    def test_for_incompatible_settings_together(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.patch(
             reverse(
@@ -997,6 +997,49 @@ class FacilityDatasetAPITestCase(APITestCase):
             {
                 "learner_can_login_with_no_password": "true",
                 "learner_can_edit_password": "true",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_for_incompatible_settings_sequentially(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.patch(
+            reverse(
+                "kolibri:core:facilitydataset-detail",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            {
+                "learner_can_edit_password": "true",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.patch(
+            reverse(
+                "kolibri:core:facilitydataset-detail",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            {
+                "learner_can_login_with_no_password": "true",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_for_incompatible_settings_only_one(self):
+        # Test case handles the case when only `learner_can_login_with_no_password`
+        # is set to true in the patch request while `learner_can_edit_password`
+        # already being true due to it's default value
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.patch(
+            reverse(
+                "kolibri:core:facilitydataset-detail",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            {
+                "learner_can_login_with_no_password": "true",
             },
             format="json",
         )

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -71,3 +71,9 @@ class FacilityDatasetTestCase(TestCase):
         )
         new_dataset = FacilityDataset.objects.create()
         self.assertEqual(str(new_dataset), "FacilityDataset (no associated Facility)")
+
+    def test_dataset_incompatible_setting(self):
+        with self.assertRaises(IntegrityError):
+            FacilityDataset.objects.create(
+                learner_can_edit_password=True, learner_can_login_with_no_password=True
+            )

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -4,6 +4,7 @@ Tests related specifically to the FacilityDataset model.
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
+from ..errors import IncompatibleDeviceSettingError
 from ..models import Classroom
 from ..models import Facility
 from ..models import FacilityDataset
@@ -73,7 +74,7 @@ class FacilityDatasetTestCase(TestCase):
         self.assertEqual(str(new_dataset), "FacilityDataset (no associated Facility)")
 
     def test_dataset_incompatible_setting(self):
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(IncompatibleDeviceSettingError):
             FacilityDataset.objects.create(
                 learner_can_edit_password=True, learner_can_login_with_no_password=True
             )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Added a function for validating consistency in FacilityDataset model. Learners cannot have the following setting - 
```
learner_can_login_with_no_password: true
learner_can_edit_password: true
```
This has been implemented from the client side already. This PR brings the consistency to server side logic


### Reviewer guidance
A unit test has been added in `test_datasets.py` to test the case of both these values being set to `True`.
A database `IntegrityError` would be raised if this case is reached.

### References
Resolves the example in #7281
There could be more inconsistencies yet to be identified.   

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
