### PR TITLE
Added validation for question_id UUID in QuestionSourceSerializer

### DIFF
--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -28,7 +28,8 @@ class NestedCollectionSerializer(ModelSerializer):
 
 class QuestionSourceSerializer(Serializer):
     exercise_id = HexUUIDField(format="hex")
-    question_id = CharField()
+    # V0 need not have question_id that is why required=False
+    question_id = HexUUIDField(format="hex", required=False)
     title = CharField()
     counter_in_exercise = IntegerField()
 

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uuid
+
 from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -217,8 +219,8 @@ class ExamAPITestCase(APITestCase):
         exam["title"] = title
         exam["question_sources"].append(
             {
-                "exercise_id": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1",
-                "question_id": "q1",
+                "exercise_id": uuid.uuid4().hex,
+                "question_id": uuid.uuid4().hex,
                 "title": "Title",
                 # missing 'counter_in_exercise'
             }
@@ -233,6 +235,20 @@ class ExamAPITestCase(APITestCase):
         exam["question_sources"].append(
             {
                 "exercise_id": "e1",
+                "question_id": uuid.uuid4().hex,
+                "title": "Title",
+                "counter_in_exercise": 1,
+            }
+        )
+        response = self.post_new_exam(exam)
+        self.assertEqual(response.status_code, 400)
+
+    def test_exam_with_invalid_question_id(self):
+        self.login_as_admin()
+        exam = self.make_basic_exam()
+        exam["question_sources"].append(
+            {
+                "exercise_id": uuid.uuid4().hex,
                 "question_id": "q1",
                 "title": "Title",
                 "counter_in_exercise": 1,
@@ -241,13 +257,26 @@ class ExamAPITestCase(APITestCase):
         response = self.post_new_exam(exam)
         self.assertEqual(response.status_code, 400)
 
+    def test_exam_with_no_question_id_succeeds(self):
+        self.login_as_admin()
+        exam = self.make_basic_exam()
+        exam["question_sources"].append(
+            {
+                "exercise_id": uuid.uuid4().hex,
+                "title": "Title",
+                "counter_in_exercise": 1,
+            }
+        )
+        response = self.post_new_exam(exam)
+        self.assertEqual(response.status_code, 201)
+
     def test_exam_with_valid_question_sources_succeeds(self):
         self.login_as_admin()
         exam = self.make_basic_exam()
         exam["question_sources"].append(
             {
-                "exercise_id": "e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1e1",
-                "question_id": "q1",
+                "exercise_id": uuid.uuid4().hex,
+                "question_id": uuid.uuid4().hex,
                 "title": "Title",
                 "counter_in_exercise": 1,
             }


### PR DESCRIPTION

### Summary

The serializer was already checking exercise_id for valid hex field, so I added the same for the question_id in the QuestionSourceSerializer and also added the test cases to validate the change made.

…

### Reviewer guidance
Test cases can be run to test the change.
kolibri manage test -- kolibri.core.exams

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

<!--
### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
-->
