### PR TITLE
Decrease min-width of username in `AppBar` when window is narrow

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -238,6 +238,12 @@
     text-overflow: ellipsis;
   }
 
+  @media (max-width: 750px) {
+    .username {
+      max-width: 50px;
+    }
+  }
+
   // Holdover from keen-ui to keep dropdown profile correctly formatted.
   /deep/ .ui-menu {
     min-width: 10.5rem;
@@ -285,6 +291,10 @@
 
   /deep/ .ui-toolbar__brand {
     min-width: inherit;
+  }
+
+  /deep/ .ui-toolbar__title {
+    margin-right: 10px;
   }
 
   .brand-logo {


### PR DESCRIPTION
### Summary
The username size was set to 200px due to which at 600px the the Learn Page top bar  become cramped so I reduced it to 50px. And there was no gap between learn title and search bar so I inserted some gap.
Note:- Now The username size is reducing only when the window width is less than 750px which was not there in previous pull request #7854 

##### Initial UI
![Screenshot from 2021-03-14 00-41-38](https://user-images.githubusercontent.com/55887726/111042177-104bda00-8462-11eb-9ff1-cacf9e19eb29.png)
##### Updated UI
![Screenshot from 2021-03-14 00-42-15](https://user-images.githubusercontent.com/55887726/111042180-1c379c00-8462-11eb-9ef6-85a9b7dbeeca.png)




### Reviewer guidance
The changes can be tested by simply going to learn page and keeping size 600px.

### References
#7670 

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md