### PR TITLE
Watch for changes to the `channels` prop when unlisted channels are added to the list of importable channels in Vuex

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -42,8 +42,6 @@ jobs:
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       run: tox -e py${{ matrix.python-version }}
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
   postgres:
     name: Python postgres unit tests
     needs: pre_job
@@ -85,5 +83,3 @@ jobs:
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       run: tox -e postgres
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -39,5 +39,3 @@ jobs:
         npm rebuild node-sass
     - name: Run tests
       run: yarn run coverage
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/FilteredChannelListContainer.vue
@@ -136,6 +136,16 @@
         return '';
       },
     },
+    watch: {
+      channels(newVal, oldVal) {
+        if (newVal.length !== oldVal.length) {
+          // HACK: Whenever `this.channels` is updated with an unlisted channel, update
+          // `this.channelsCopy`. In `this.filteredItems`, we still cannot directly
+          // pull from `this.channels` because of #6989
+          this.channelsCopy = [...newVal];
+        }
+      },
+    },
     beforeMount() {
       this.languageFilter = { ...this.allLanguagesOption };
     },


### PR DESCRIPTION
### Summary

Fixes a regression from https://github.com/learningequality/kolibri/pull/7269, where the following scenario fails:

```
Given you are in 'Device > Select resources for import'
And you click "Select entire channels instead"
And you click "Import with token"
And you enter 95a52b386f2c485cb97dd60901674a98 (kolibri qa, unlisted channel) in the input
And you click "Continue"
Then you see "Kolibri QA Channel" at the top of the list
```

This was caused because, to fix 7269, we had to decouple `FilteredChannelListContainer` from Vuex. However, when you add an unlisted channel via the scenario above, the unlisted channel gets added to Vuex but _was not_ added to `FilteredChannelListContainer`'s `filteredItems` computed prop at the same time.

### Reviewer guidance

@pcenov, could you QA this PR?

Confirm that the scenario above works now. You will see that this defect exists on https://kolibri-beta.learningequality.org.

### References


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
