### PR TITLE
Fix timeout error while installing yarn dependencies in Docker

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -36,4 +36,4 @@ RUN cd /kolibri \
     && pip install -r requirements/dev.txt \
     && pip install -r requirements/build.txt \
     && pip install -r requirements/test.txt \
-    && yarn install
+    && yarn install --network-timeout 100000


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Error
`There appears to be trouble with your network connection. Retrying...`


### Summary
This happens when your network is too slow or the package being installed is too large, and Yarn just assumes it's a network problem.

…

### FIX
Increasing Yarn network timeout fixes the issue

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
