### PR TITLE
Fix for routing issue while exiting search in quiz creation

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -124,7 +124,7 @@
           appearance="raised-button"
           :text="$tr('exitSearchButtonLabel')"
           primary
-          :to="toolbarRoute"
+          :to="topicRoute"
         />
       </BottomAppBar>
       <BottomAppBar v-else>
@@ -203,6 +203,18 @@
         'searchResults',
         'ancestors',
       ]),
+      topicRoute() {
+        if (this.$route.query.last_id) {
+          return {
+            name: PageNames.EXAM_CREATION_TOPIC,
+            params: {
+              topicId: this.$route.query.last_id,
+            },
+          };
+        } else {
+          return this.toolbarRoute;
+        }
+      },
       pageName() {
         return this.$route.name;
       },


### PR DESCRIPTION
### Summary
Changed the route config for the "Exit Search" button such that it uses the last_id ( if present in the query params ) to route to a more recent route.


![quiz_route_fix_demo](https://user-images.githubusercontent.com/24357568/111531778-5d1e0200-873b-11eb-8c74-3c260cc23506.gif)

…

### References
 *  Fix for the issue - https://github.com/learningequality/kolibri/issues/7744

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
