### PR TITLE
Infer dataset change

### DIFF
--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -108,7 +108,7 @@ class FacilityDatasetTestCase(TestCase):
             self.lesson.cached_related_dataset_lookup("created_by"),
         )
         self.assertEqual(self.exam.infer_dataset(), self.facility.dataset.id)
-   
+
     def test_dataset_incompatible_setting(self):
         with self.assertRaises(IncompatibleDeviceSettingError):
             FacilityDataset.objects.create(

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -9,6 +9,8 @@ from ..models import Facility
 from ..models import FacilityDataset
 from ..models import FacilityUser
 from ..models import LearnerGroup
+from kolibri.core.exams.models import Exam
+from kolibri.core.lessons.models import Lesson
 
 
 class FacilityDatasetTestCase(TestCase):
@@ -18,6 +20,15 @@ class FacilityDatasetTestCase(TestCase):
         cls.facility_2 = Facility.objects.create()
         cls.classroom = Classroom.objects.create(parent=cls.facility)
         cls.learner_group = LearnerGroup.objects.create(parent=cls.classroom)
+        cls.user = FacilityUser.objects.create(
+            username="user", password="password", facility=cls.facility
+        )
+        cls.exam = Exam.objects.create(
+            title="", question_count=1, collection=cls.facility, creator=cls.user
+        )
+        cls.lesson = Lesson.objects.create(
+            created_by=cls.user, title="lesson", collection=cls.facility
+        )
 
     def setUp(self):
         self.facility_user = FacilityUser.objects.create(
@@ -71,3 +82,28 @@ class FacilityDatasetTestCase(TestCase):
         )
         new_dataset = FacilityDataset.objects.create()
         self.assertEqual(str(new_dataset), "FacilityDataset (no associated Facility)")
+
+    def test_exam_lesson_dataset(self):
+        self.assertTrue(self.facility.dataset is not None)
+        self.assertEqual(self.exam.infer_dataset(), self.lesson.infer_dataset())
+
+        # Check current implementation of infer_dataset on Lesson and Exam
+        self.assertEqual(
+            self.exam.infer_dataset(),
+            self.exam.cached_related_dataset_lookup("collection"),
+        )
+        self.assertEqual(
+            self.lesson.infer_dataset(),
+            self.lesson.cached_related_dataset_lookup("collection"),
+        )
+
+        # Check if the current implementation is equivalent to the previous implementation
+        self.assertEqual(
+            self.exam.infer_dataset(),
+            self.exam.cached_related_dataset_lookup("creator"),
+        )
+        self.assertEqual(
+            self.lesson.infer_dataset(),
+            self.lesson.cached_related_dataset_lookup("created_by"),
+        )
+        self.assertEqual(self.exam.infer_dataset(), self.facility.dataset.id)

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -141,7 +141,7 @@ class Exam(AbstractFacilityDataModel):
     data_model_version = models.SmallIntegerField(default=2)
 
     def infer_dataset(self, *args, **kwargs):
-        return self.cached_related_dataset_lookup("creator")
+        return self.cached_related_dataset_lookup("collection")
 
     def calculate_partition(self):
         return self.dataset_id

--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -75,7 +75,7 @@ class Lesson(AbstractFacilityDataModel):
     morango_model_name = "lesson"
 
     def infer_dataset(self, *args, **kwargs):
-        return self.cached_related_dataset_lookup("created_by")
+        return self.cached_related_dataset_lookup("collection")
 
     def calculate_partition(self):
         return self.dataset_id


### PR DESCRIPTION
### Summary
Changed infet_dataset from Exam and Lesson from created_by to collection

…

### References
Fixes https://github.com/learningequality/kolibri/issues/7859

…

----

### Contributor Checklist


PR process:

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
