### PR TITLE
Add step to import Kolibri QA channel to the 'Getting Started' doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,6 +217,15 @@ html_show_copyright = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = "kolibri-dev"
 
+# Add replacement codes
+rst_prolog = """
+.. role:: raw-html(raw)
+     :format: html
+
+.. |br| replace:: :raw-html:`<br /><br />`
+
+
+"""
 
 # -- I18N ----------------------------------------------------------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -370,6 +370,12 @@ Frontend dev tools
 To ensure a more efficient workflow, install appropriate editor plugins for Vue.js, ESLint, and stylelint.
 
 
+Import channels and resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+
+
 
 .. _workflow_intro:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -120,7 +120,7 @@ There are two environment variables you should plan to set:
 
   This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.
   |br|
-  For example you could add this line at the end of your ``~/.bash_profile`` file:
+  For example, you could add this line at the end of your ``~/.bash_profile`` file:
 
   .. code-block:: bash
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -118,7 +118,7 @@ There are two environment variables you should plan to set:
 
 * ``KOLIBRI_RUN_MODE`` is **required**.
 
-  This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.  
+  This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.
   |br|
   For example you could add this line at the end of your ``~/.bash_profile`` file:
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -116,10 +116,18 @@ Environment variables can be set in many ways, including:
 
 There are two environment variables you should plan to set:
 
-* ``KOLIBRI_RUN_MODE`` (required)
+* ``KOLIBRI_RUN_MODE`` is **required**.
 
-  This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.
-* ``KOLIBRI_HOME`` (optional)
+  This variable is sent to our `pingback server <https://github.com/learningequality/nutritionfacts>`_ (private repo), and you must set it to something besides an empty string. This allows us to filter development work out of our usage statistics. There are also some `special testing behaviors <https://github.com/learningequality/nutritionfacts/blob/b150ec9fd80cd0f02c087956fd5f16b2592f94d4/nutritionfacts/views.py#L125-L179>`_ that can be triggered for special strings, as described elsewhere in the developer docs and integration testing Gherkin scenarios.  
+  |br|
+  For example you could add this line at the end of your ``~/.bash_profile`` file:
+
+  .. code-block:: bash
+
+    export KOLIBRI_RUN_MODE="dev"
+
+
+* ``KOLIBRI_HOME`` is optional.
 
   This variable determines where Kolibri will store its content and databases. It is useful to set if you want to have multiple versions of Kolibri running simultaneously.
 
@@ -373,7 +381,7 @@ To ensure a more efficient workflow, install appropriate editor plugins for Vue.
 Import channels and resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
+Once you have the server running, proceed to import some channels and resources. To quickly import all available and supported Kolibri resource types, use the token ``nakav-mafak`` for the `Kolibri QA channel <https://kolibri-beta.learningequality.org/en/learn/#/topics/95a52b386f2c485cb97dd60901674a98>`__ (~350MB).
 
 
 


### PR DESCRIPTION

### Summary
Plus some more explicit instructions on how to set `KOLIBRI_RUN_MODE` env var, and a handy replacement to insert line breaks.

### Reviewer guidance

Read to check if all makes sense.

### References
Various conversations on Slack.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
