### PR TITLE
Clear failed facility import tasks when restarting Setup Wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -22,7 +22,7 @@ export const FacilityImportResource = new Resource({
 export const SetupTasksResource = new Resource({
   name: 'tasks',
   namespace: 'kolibri.plugins.setup_wizard',
-  // Use SetupTasksResoure.fetchCollection to get tasks
+  // Use SetupTasksResource.fetchCollection to get tasks
   canceltask(task_id) {
     return this.postListEndpoint('canceltask', { task_id });
   },

--- a/kolibri/plugins/setup_wizard/assets/src/app.js
+++ b/kolibri/plugins/setup_wizard/assets/src/app.js
@@ -8,6 +8,7 @@ import KolibriApp from 'kolibri_app';
 
 const logging = logger.getLogger(__filename);
 
+class SetupWizardModule extends KolibriApp {
   get RootVue() {
     return RootVue;
   }
@@ -29,4 +30,4 @@ const logging = logger.getLogger(__filename);
   }
 }
 
-export default new OnboardingApp();
+export default new SetupWizardModule();

--- a/kolibri/plugins/setup_wizard/assets/src/app.js
+++ b/kolibri/plugins/setup_wizard/assets/src/app.js
@@ -1,10 +1,13 @@
 import heartbeat from 'kolibri.heartbeat';
+import logger from 'kolibri.lib.logging';
 import RootVue from './views/SetupWizardIndex';
 import pluginModule from './modules/pluginModule';
 import routes from './routes';
+import { SetupTasksResource } from './api';
 import KolibriApp from 'kolibri_app';
 
-class OnboardingApp extends KolibriApp {
+const logging = logger.getLogger(__filename);
+
   get RootVue() {
     return RootVue;
   }
@@ -16,6 +19,8 @@ class OnboardingApp extends KolibriApp {
   }
   ready() {
     return super.ready().then(() => {
+      logging.info('Clearning facility tasks created in previous sessions...');
+      SetupTasksResource.cleartasks();
       // Fix for https://github.com/learningequality/kolibri/issues/3852
       // Don't call beat because it may cause a save in the session endpoint
       // while the device provisioning is in progress

--- a/kolibri/plugins/setup_wizard/assets/src/app.js
+++ b/kolibri/plugins/setup_wizard/assets/src/app.js
@@ -20,7 +20,7 @@ class SetupWizardModule extends KolibriApp {
   }
   ready() {
     return super.ready().then(() => {
-      logging.info('Clearning facility tasks created in previous sessions...');
+      logging.info('Clearing facility tasks created in previous sessions...');
       SetupTasksResource.cleartasks();
       // Fix for https://github.com/learningequality/kolibri/issues/3852
       // Don't call beat because it may cause a save in the session endpoint

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -124,6 +124,7 @@
         return SetupTasksResource.cleartasks();
       },
       handleClickContinue() {
+        this.isPolling = false;
         this.clearTasks();
         this.$emit('click_next');
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -9,7 +9,6 @@
       @cancel="cancelTask"
     />
     <template #buttons>
-      <!-- This span is to make sure slot contents get rendered -->
       <KButton
         v-if="loadingTask.status === 'COMPLETED'"
         primary

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -65,6 +65,7 @@
     data() {
       return {
         loadingTask: {},
+        isPolling: false,
       };
     },
     computed: {
@@ -76,6 +77,7 @@
       },
     },
     beforeMount() {
+      this.isPolling = true;
       this.pollTask();
     },
     methods: {
@@ -86,9 +88,11 @@
             facility_name: this.facilityName,
           };
         });
-        setTimeout(() => {
-          this.pollTask();
-        }, 2000);
+        if (this.isPolling) {
+          setTimeout(() => {
+            this.pollTask();
+          }, 2000);
+        }
       },
       retryImport() {
         this.clearTasks()
@@ -109,6 +113,7 @@
         return SetupTasksResource.canceltask(this.loadingTask.id);
       },
       startOver() {
+        this.isPolling = false;
         this.clearTasks().then(() => {
           this.$router.replace('/');
         });

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -114,8 +114,11 @@
       startOver() {
         this.isPolling = false;
         this.clearTasks().then(() => {
-          this.$router.replace('/');
+          this.goToRootUrl();
         });
+      },
+      goToRootUrl() {
+        this.$router.replace('/');
       },
       clearTasks() {
         return SetupTasksResource.cleartasks();

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -17,16 +17,18 @@
         @click="handleClickContinue"
       />
       <template v-else-if="loadingTask.status === 'FAILED'">
-        <KButton
-          primary
-          :text="coreString('retryAction')"
-          @click="retryImport"
-        />
-        <KButton
-          :text="coreString('startOverAction')"
-          appearance="flat-button"
-          @click="startOver"
-        />
+        <KButtonGroup>
+          <KButton
+            primary
+            :text="coreString('retryAction')"
+            @click="retryImport"
+          />
+          <KButton
+            :text="coreString('startOverAction')"
+            appearance="flat-button"
+            @click="startOver"
+          />
+        </KButtonGroup>
       </template>
       <span v-else></span>
     </template>
@@ -107,7 +109,9 @@
         return SetupTasksResource.canceltask(this.loadingTask.id);
       },
       startOver() {
-        this.$router.replace('/');
+        this.clearTasks().then(() => {
+          this.$router.replace('/');
+        });
       },
       clearTasks() {
         return SetupTasksResource.cleartasks();

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
@@ -64,6 +64,7 @@ describe('LoadingTaskPage', () => {
     continueButton.trigger('click');
     expect(continueSpy).toBeCalled();
     expect(wrapper.emitted().click_next).toBeTruthy();
+    expect(wrapper.vm.isPolling).toBe(false);
   });
 
   it('when task fails, the "retry" button is available', async () => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import LoadingTaskPage from '../LoadingTaskPage';
+import { SetupTasksResource } from '../../../api';
+
+jest.mock('../../../api', () => ({
+  SetupTasksResource: {
+    canceltask: jest.fn(),
+    cleartasks: jest.fn(),
+    fetchCollection: jest.fn(),
+  },
+}));
+
+function makeWrapper() {
+  afterEach(() => {
+    SetupTasksResource.canceltask.mockReset();
+    SetupTasksResource.cleartasks.mockReset();
+    SetupTasksResource.fetchCollection.mockReset();
+  });
+
+  const wrapper = mount(LoadingTaskPage, {
+    propsData: {
+      facility: {
+        name: 'Kolibri School',
+      },
+    },
+  });
+  return { wrapper };
+}
+
+describe('LoadingTaskPage', () => {
+  it('loads the first task in the queue and starts polling', async () => {
+    SetupTasksResource.fetchCollection.mockResolvedValue([{ status: 'RUNNING' }]);
+    const { wrapper } = makeWrapper();
+    await global.flushPromises();
+    const taskPanel = wrapper.findComponent({ name: 'FacilityTaskPanel' });
+    expect(taskPanel.exists()).toBe(true);
+    expect(wrapper.vm.isPolling).toBe(true);
+  });
+});

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/__test__/LoadingTaskPage.spec.js
@@ -10,17 +10,21 @@ jest.mock('../../../api', () => ({
   },
 }));
 
-function makeWrapper() {
-  afterEach(() => {
-    SetupTasksResource.canceltask.mockReset();
-    SetupTasksResource.cleartasks.mockReset();
-    SetupTasksResource.fetchCollection.mockReset();
-  });
+const cancelTaskMock = SetupTasksResource.canceltask;
+const clearTasksMock = SetupTasksResource.cleartasks;
+const fetchCollectionMock = SetupTasksResource.fetchCollection;
 
+function makeWrapper() {
   const wrapper = mount(LoadingTaskPage, {
     propsData: {
       facility: {
+        id: '4494060ae9b746af80200faa848eb23d',
         name: 'Kolibri School',
+        username: 'username',
+        password: 'password',
+      },
+      device: {
+        baseurl: 'http://localhost:8000',
       },
     },
   });
@@ -28,12 +32,99 @@ function makeWrapper() {
 }
 
 describe('LoadingTaskPage', () => {
+  beforeEach(() => {
+    clearTasksMock.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    cancelTaskMock.mockReset();
+    clearTasksMock.mockReset();
+    fetchCollectionMock.mockReset();
+  });
+
   it('loads the first task in the queue and starts polling', async () => {
-    SetupTasksResource.fetchCollection.mockResolvedValue([{ status: 'RUNNING' }]);
+    fetchCollectionMock.mockResolvedValue([{ status: 'RUNNING' }]);
     const { wrapper } = makeWrapper();
     await global.flushPromises();
     const taskPanel = wrapper.findComponent({ name: 'FacilityTaskPanel' });
     expect(taskPanel.exists()).toBe(true);
     expect(wrapper.vm.isPolling).toBe(true);
+    expect(wrapper.find('h1').text()).toEqual("Loading 'Kolibri School'");
+  });
+
+  it('when tasks succeeds, the "continue" button is available', async () => {
+    fetchCollectionMock.mockResolvedValue([{ status: 'COMPLETED' }]);
+    const { wrapper } = makeWrapper();
+    const continueSpy = jest.spyOn(wrapper.vm, 'handleClickContinue');
+    await global.flushPromises();
+    const buttons = wrapper.findAllComponents({ name: 'KButton' });
+    expect(buttons).toHaveLength(1);
+    const continueButton = buttons.at(0);
+    expect(continueButton.props('text')).toEqual('Continue');
+    continueButton.trigger('click');
+    expect(continueSpy).toBeCalled();
+    expect(wrapper.emitted().click_next).toBeTruthy();
+  });
+
+  it('when task fails, the "retry" button is available', async () => {
+    fetchCollectionMock.mockResolvedValue([{ status: 'FAILED' }]);
+    const { wrapper } = makeWrapper();
+    const retrySpy = jest.spyOn(wrapper.vm, 'retryImport');
+
+    // Mocking the proxied method instead of the whole mixin module
+    const startImportSpy = jest.spyOn(wrapper.vm, 'startPeerImportTask').mockResolvedValue();
+
+    await global.flushPromises();
+    const buttons = wrapper.findAllComponents({ name: 'KButton' });
+    expect(buttons).toHaveLength(2);
+    const retryButton = buttons.at(0);
+    expect(retryButton.props().text).toEqual('Retry');
+
+    retryButton.trigger('click');
+    await global.flushPromises();
+
+    expect(retrySpy).toBeCalledTimes(1);
+    expect(clearTasksMock).toBeCalledTimes(1);
+    expect(startImportSpy).toBeCalledTimes(1);
+    expect(startImportSpy).toBeCalledWith({
+      facility: '4494060ae9b746af80200faa848eb23d',
+      facility_name: 'Kolibri School',
+      username: 'username',
+      password: 'password',
+      baseurl: 'http://localhost:8000',
+    });
+  });
+
+  it('when task fails, the "start over" button is available', async () => {
+    fetchCollectionMock.mockResolvedValue([{ status: 'FAILED' }]);
+    const { wrapper } = makeWrapper();
+    const startOverSpy = jest.spyOn(wrapper.vm, 'startOver');
+
+    // Mocking the method because the router can't be mocked
+    const goToRootSpy = jest.spyOn(wrapper.vm, 'goToRootUrl').mockResolvedValue();
+
+    await global.flushPromises();
+    const buttons = wrapper.findAllComponents({ name: 'KButton' });
+    expect(buttons).toHaveLength(2);
+    const startOverButton = buttons.at(1);
+    expect(startOverButton.props().text).toEqual('Start over');
+
+    startOverButton.trigger('click');
+    await global.flushPromises();
+
+    expect(startOverSpy).toBeCalledTimes(1);
+    expect(clearTasksMock).toBeCalledTimes(1);
+    expect(goToRootSpy).toBeCalledTimes(1);
+    expect(wrapper.vm.isPolling).toBe(false);
+  });
+
+  it('a cancel request is made when "cancel" is clicked', async () => {
+    fetchCollectionMock.mockResolvedValue([{ status: 'RUNNING' }]);
+    const { wrapper } = makeWrapper();
+    await global.flushPromises();
+    const taskPanel = wrapper.findComponent({ name: 'FacilityTaskPanel' });
+    // Simulating a 'cancel' event rather than clicking the cancel button within
+    taskPanel.vm.$emit('cancel');
+    expect(cancelTaskMock).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Summary

1. In `LoadingTaskPage`, I add a call to the `cleartasks` endpoint when the "Start Over" button is clicked. This should ensure that the tasks queue is cleared when the user is returned to the beginning of the setup wizard.
2. In `kolibri/plugins/setup_wizard/assets/src/app.js`, I make the same call to the `cleartasks` endpoint when the user (re)starts the Kolibri server. This should ensure that the tasks queue is cleared if the user stops the server with Ctrl-C _before_ clicking "Start Over".
3. Adds tests for the core behavior in `LoadingTaskPage`
4. Fixes a bug where the polling would never be turned off after leaving the `LoadingTaskPage`
5. Adds a missing `KButtonGroup` wrapper

### Reviewer guidance

[See this video](https://drive.google.com/file/d/1egsr_ZGXXENkATZ3AJAfXPw2J-Qkiu2A/view?usp=sharing) on how to use the setup wizard. Try to see if you can cause a problem where the setup wizard gets stuck like in #7693. (Direct message me for credentials you can use at timestamp `0:33` of the video)


In the video, I import facilities from kolibri-beta.learningequality.org. The three current facilities have these useful properties:

* Demo Facility has _a lot_ of data, so you can cancel an import task and start over
* ZukVillage is small and, at the moment, facility import tasks always succed
* Hack Session School _always_ fails to import in my testing.

To get to the Setup Wizard, your server must be "unprovisioned" (otherwise you will just see the Login Page when you start the server). 

The easiest way to "deprovision" a device is to delete (or move) your existing `KOLIBRI_HOME` folder to another location, then run `kolibri manage migrate`, then run the devserver.  

### References

Fixes #7693 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [ x If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
