### PR TITLE
Show resource count at channel level cards while managing lesson resources

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -38,15 +38,10 @@ function showResourceSelectionPage(store, params) {
       const ancestorCounts = {};
 
       let resourceAncestors;
-      // Don't get ancestors if at the Channels page
-      if (pageName === LessonsPageNames.SELECTION_ROOT) {
-        resourceAncestors = [];
-      } else {
-        resourceAncestors = store.state.lessonSummary.workingResources.map(
-          resource => (cache[resource.contentnode_id] || {}).ancestors || []
-        );
-      }
 
+      resourceAncestors = store.state.lessonSummary.workingResources.map(
+        resource => (cache[resource.contentnode_id] || {}).ancestors || []
+      );
       // store ancestor ids to get their descendants later
       const ancestorIds = new Set();
 


### PR DESCRIPTION

### Summary
This PR allows us to see resource count at channel level cards while managing lesson resources. It will help coaches prepare the lesson as they can easily see the channels they are working on.

![manage_resource](https://user-images.githubusercontent.com/55936040/111843039-77680380-8926-11eb-8abe-a32ec6a69847.png)


### References
Fixes #7695 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
