### PR TITLE
Reduce transform scale to prevent overflow

### DIFF
--- a/kolibri/core/assets/src/views/sortable/DragContainer.vue
+++ b/kolibri/core/assets/src/views/sortable/DragContainer.vue
@@ -121,7 +121,7 @@
       animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
     0% {
-      transform: scale3d(01.15, 01.15, 01.15);
+      transform: scale3d(1.05, 1.05, 1.05);
     }
     50% {
       transform: scale3d(0.98, 0.98, 0.98);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Reduced the keyframe `bounceIn` transform from: `transform: scale3d(1.15, 1.15, 1.15);` to `transform: scale3d(1.05, 1.05, 1.05);`

Manually tested in Chrome, Firefox, and Safari.

|Before (Note horizontal scrollbar appears at the bottom) |After|
|--|--|
|![2021-03-19 16 02 02](https://user-images.githubusercontent.com/13563002/111850074-7acea100-88cc-11eb-9544-e8dae1260430.gif)|![2021-03-19 16 01 54](https://user-images.githubusercontent.com/13563002/111850068-7609ed00-88cc-11eb-9902-bc3e58680e43.gif)|


### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Please test on multiple browsers/devices. Note: you will need to go to a lesson that has multiple resources.

1. Log in as superadmin (or as coach)
2. Go to Coach in the sidenav
3. Click on Class > Plan > Lesson
4. Attempt to reorder the lessons; check that there is no horizontal scrollbar that appears after dragging and dropping to reorder.


### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes PR #7681 


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
