### PR TITLE
Fix alignment of CoreTable headers on IE11

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -109,6 +109,7 @@
 
   /deep/ thead th {
     vertical-align: bottom;
+    text-align: left;
   }
 
   /deep/ tr {

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -108,8 +108,8 @@
   }
 
   /deep/ thead th {
-    vertical-align: bottom;
     text-align: left;
+    vertical-align: bottom;
   }
 
   /deep/ tr {


### PR DESCRIPTION
### Summary
fix table th alignment from center to left on IE

on IE before: 
![image](https://user-images.githubusercontent.com/18532207/111861040-25ef6100-8986-11eb-9d8a-25a38ef57d24.png)

on IE after: 
![image](https://user-images.githubusercontent.com/18532207/111860938-9f3a8400-8985-11eb-84fb-d2f608c2b037.png)

on Chrome(didn't change):
![image](https://user-images.githubusercontent.com/18532207/111860964-b7aa9e80-8985-11eb-9489-457af5ba3878.png)

### Reviewer guidance

The css of "table th" of component CoreTable has been changed.

### References

#7220 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
