### PR TITLE
Add windows and macos python 3.6 unit test runners; make filesystem operations safer on Windows

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -83,3 +83,52 @@ jobs:
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       run: tox -e postgres
+  macos:
+    name: Python unit tests on Mac OS
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: tox env cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
+        key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
+    - name: Test with tox
+      run: tox -e py${{ matrix.python-version }}
+  windows:
+    name: Python unit tests on Windows Server
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Test with tox
+      run: tox -e py${{ matrix.python-version }}

--- a/kolibri/conftest.py
+++ b/kolibri/conftest.py
@@ -15,4 +15,8 @@ def global_fixture():
         os.mkdir(os.path.join(TEMP_KOLIBRI_HOME, "content"))
     yield  # wait until the test ended
     if os.path.exists(TEMP_KOLIBRI_HOME):
-        shutil.rmtree(TEMP_KOLIBRI_HOME)
+        try:
+            shutil.rmtree(TEMP_KOLIBRI_HOME)
+        except OSError:
+            # Don't fail a test just because we failed to cleanup
+            pass

--- a/kolibri/core/auth/test/test_user_import.py
+++ b/kolibri/core/auth/test/test_user_import.py
@@ -142,6 +142,7 @@ class DeviceNotSetup(TestCase):
         csvfile, csvpath = tempfile.mkstemp(suffix="csv")
         with self.assertRaisesRegexp(CommandError, "No default facility exists"):
             call_command("importusers", csvpath)
+        os.close(csvfile)
         os.remove(csvpath)
 
 
@@ -160,6 +161,7 @@ class UserImportCommandTestCase(TestCase):
 
     def tearDown(self):
         FacilityUser.objects.exclude(username=self.superuser.username).delete()
+        os.close(self.csvfile)
         os.remove(self.csvpath)
 
     def importFromRows(self, *args):

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -79,7 +79,8 @@ class ImportChannelTestCase(TestCase):
         start_progress_mock,
         import_channel_mock,
     ):
-        local_path = tempfile.mkstemp()[1]
+        fd, local_path = tempfile.mkstemp()
+        os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
         FileDownloadMock.return_value.__iter__.side_effect = TransferCanceled()
@@ -116,8 +117,10 @@ class ImportChannelTestCase(TestCase):
         start_progress_mock,
         import_channel_mock,
     ):
-        local_dest_path = tempfile.mkstemp()[1]
-        local_src_path = tempfile.mkstemp()[1]
+        fd1, local_dest_path = tempfile.mkstemp()
+        fd2, local_src_path = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         local_path_mock.side_effect = [local_dest_path, local_src_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
         call_command("importchannel", "disk", self.the_channel_id, tempfile.mkdtemp())
@@ -214,7 +217,8 @@ class ImportChannelTestCase(TestCase):
         start_progress_mock,
         import_channel_mock,
     ):
-        local_path = tempfile.mkstemp()[1]
+        fd, local_path = tempfile.mkstemp()
+        os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
         FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
@@ -295,7 +299,8 @@ class ImportContentTestCase(TestCase):
         channel_list_status_mock,
     ):
         # If transfer is cancelled during transfer of first file
-        local_path = tempfile.mkstemp()[1]
+        fd, local_path = tempfile.mkstemp()
+        os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
         # Mock this __iter__ so that the filetransfer can be looped over
@@ -345,8 +350,10 @@ class ImportContentTestCase(TestCase):
         channel_list_status_mock,
     ):
         # If transfer is cancelled after transfer of first file
-        local_path_1 = tempfile.mkstemp()[1]
-        local_path_2 = tempfile.mkstemp()[1]
+        fd1, local_path_1 = tempfile.mkstemp()
+        fd2, local_path_2 = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         with open(local_path_1, "w") as f:
             f.write("a")
         local_path_mock.side_effect = [local_path_1, local_path_2]
@@ -410,8 +417,10 @@ class ImportContentTestCase(TestCase):
         channel_list_status_mock,
     ):
         # Local version of test above
-        local_dest_path = tempfile.mkstemp()[1]
-        local_src_path = tempfile.mkstemp()[1]
+        fd1, local_dest_path = tempfile.mkstemp()
+        fd2, local_src_path = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         local_path_mock.side_effect = [local_dest_path, local_src_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
         get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
@@ -480,9 +489,12 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        local_dest_path_1 = tempfile.mkstemp()[1]
-        local_dest_path_2 = tempfile.mkstemp()[1]
-        local_dest_path_3 = tempfile.mkstemp()[1]
+        fd1, local_dest_path_1 = tempfile.mkstemp()
+        fd2, local_dest_path_2 = tempfile.mkstemp()
+        fd3, local_dest_path_3 = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
+        os.close(fd3)
         path_mock.side_effect = [
             local_dest_path_1,
             local_dest_path_2,
@@ -654,7 +666,8 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        dest_path = tempfile.mkstemp()[1]
+        fd, dest_path = tempfile.mkstemp()
+        os.close(fd)
         path_mock.side_effect = [dest_path, "/test/dne"]
         LocalFile.objects.filter(
             files__contentnode__channel_id=self.the_channel_id
@@ -678,7 +691,8 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        dest_path = tempfile.mkstemp()[1]
+        fd, dest_path = tempfile.mkstemp()
+        os.close(fd)
         path_mock.side_effect = [dest_path, "/test/dne"]
         getsize_mock.side_effect = ["1", OSError("Permission denied")]
         get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
@@ -711,8 +725,10 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        local_src_path = tempfile.mkstemp()[1]
-        local_dest_path = tempfile.mkstemp()[1]
+        fd1, local_dest_path = tempfile.mkstemp()
+        fd2, local_src_path = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         LocalFile.objects.filter(
             files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
         ).update(file_size=1)
@@ -770,7 +786,8 @@ class ImportContentTestCase(TestCase):
         with open(local_src_path, "w") as f:
             f.write("This is just a test")
         expected_file_size = 10000
-        local_dest_path = tempfile.mkstemp()[1]
+        fd, local_dest_path = tempfile.mkstemp()
+        os.close(fd)
         os.remove(local_dest_path)
         # Delete all but one file associated with ContentNode to reduce need for mocking
         files = ContentNode.objects.get(
@@ -829,8 +846,10 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        dest_path_1 = tempfile.mkstemp()[1]
-        dest_path_2 = tempfile.mkstemp()[1]
+        fd1, dest_path_1 = tempfile.mkstemp()
+        fd2, dest_path_2 = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         path_mock.side_effect = [dest_path_1, dest_path_2]
         LocalFile.objects.filter(pk="6bdfea4a01830fdd4a585181c0b8068c").update(
             file_size=2201062
@@ -883,8 +902,10 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        dest_path_1 = tempfile.mkstemp()[1]
-        dest_path_2 = tempfile.mkstemp()[1]
+        fd1, dest_path_1 = tempfile.mkstemp()
+        fd2, dest_path_2 = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         path_mock.side_effect = [dest_path_1, dest_path_2]
         LocalFile.objects.filter(pk="6bdfea4a01830fdd4a585181c0b8068c").update(
             file_size=2201062
@@ -989,8 +1010,10 @@ class ExportChannelTestCase(TestCase):
         start_progress_mock,
     ):
         # Make sure we clean up a database file that is canceled during export
-        local_dest_path = tempfile.mkstemp()[1]
-        local_src_path = tempfile.mkstemp()[1]
+        fd1, local_dest_path = tempfile.mkstemp()
+        fd2, local_src_path = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
         call_command("exportchannel", self.the_channel_id, local_dest_path)
@@ -1055,8 +1078,10 @@ class ExportContentTestCase(TestCase):
         get_import_export_mock,
     ):
         # Make sure we cancel during transfer
-        local_dest_path = tempfile.mkstemp()[1]
-        local_src_path = tempfile.mkstemp()[1]
+        fd1, local_dest_path = tempfile.mkstemp()
+        fd2, local_src_path = tempfile.mkstemp()
+        os.close(fd1)
+        os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
         get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)

--- a/kolibri/core/content/test/test_movedirectory.py
+++ b/kolibri/core/content/test/test_movedirectory.py
@@ -1,8 +1,18 @@
+import os
+
 from django.core.management import call_command
 from django.test import TestCase
 from mock import patch
 
 from kolibri.utils.conf import OPTIONS
+
+success_path = os.path.join("/", "test", "success")
+
+no_content_path = os.path.join("/", "test", "content_exists_no")
+
+yes_content_path = os.path.join("/", "test", "content_exists_yes")
+
+random_content_path = os.path.join("/", "test", "content_exists_random")
 
 
 @patch("kolibri.core.content.management.commands.content.update_options_file")
@@ -15,16 +25,16 @@ class ContentMoveDirectoryTestCase(TestCase):
     def _path_exists_side_effect(*args):
         if args[0] == OPTIONS["Paths"]["CONTENT_DIR"]:
             return True
-        elif args[0].startswith("/test/success"):
+        elif args[0].startswith(success_path):
             return False
         return True
 
     def _listdir_side_effect(*args):
-        if args[0] == OPTIONS["Paths"]["CONTENT_DIR"] + "/databases":
+        if args[0] == os.path.join(OPTIONS["Paths"]["CONTENT_DIR"], "databases"):
             return ["test.sqlite3"]
-        elif args[0] == OPTIONS["Paths"]["CONTENT_DIR"] + "/storage":
+        elif args[0] == os.path.join(OPTIONS["Paths"]["CONTENT_DIR"], "storage"):
             return ["test.mp3"]
-        elif args[0] == "/test/content_exists_no/databases":
+        elif args[0] == os.path.join(no_content_path, "databases"):
             return ["exists.sqlite3"]
         return []
 
@@ -73,7 +83,7 @@ class ContentMoveDirectoryTestCase(TestCase):
         remove_mock,
         update_mock,
     ):
-        destination = "/test/content_exists_no"
+        destination = no_content_path
         call_command("content", "movedirectory", destination)
         self.assertEqual(copyfile_mock.call_count, 2)
         self.assertEqual(remove_mock.call_count, 2)
@@ -98,7 +108,7 @@ class ContentMoveDirectoryTestCase(TestCase):
         copy_mock,
         update_mock,
     ):
-        destination = "/test/content_exists_yes"
+        destination = yes_content_path
         call_command("content", "movedirectory", destination)
         copy_mock.assert_called()
         self.assertEqual(remove_mock.call_count, 4)
@@ -149,7 +159,7 @@ class ContentMoveDirectoryTestCase(TestCase):
         remove_mock,
         update_mock,
     ):
-        destination = "/test/success"
+        destination = success_path
         call_command("content", "movedirectory", destination)
         remove_mock.assert_called()
         mkdir_mock.assert_called()

--- a/kolibri/core/content/test/test_movedirectory.py
+++ b/kolibri/core/content/test/test_movedirectory.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -6,13 +7,15 @@ from mock import patch
 
 from kolibri.utils.conf import OPTIONS
 
-success_path = os.path.join("/", "test", "success")
+path_prefix = "C:\\" if sys.platform == "win32" else "/"
 
-no_content_path = os.path.join("/", "test", "content_exists_no")
+success_path = os.path.join(path_prefix, "test", "success")
 
-yes_content_path = os.path.join("/", "test", "content_exists_yes")
+no_content_path = os.path.join(path_prefix, "test", "content_exists_no")
 
-random_content_path = os.path.join("/", "test", "content_exists_random")
+yes_content_path = os.path.join(path_prefix, "test", "content_exists_yes")
+
+random_content_path = os.path.join(path_prefix, "test", "content_exists_random")
 
 
 @patch("kolibri.core.content.management.commands.content.update_options_file")
@@ -25,7 +28,7 @@ class ContentMoveDirectoryTestCase(TestCase):
     def _path_exists_side_effect(*args):
         if args[0] == OPTIONS["Paths"]["CONTENT_DIR"]:
             return True
-        elif success_path in args[0]:
+        elif args[0].startswith(success_path):
             return False
         return True
 

--- a/kolibri/core/content/test/test_movedirectory.py
+++ b/kolibri/core/content/test/test_movedirectory.py
@@ -25,7 +25,7 @@ class ContentMoveDirectoryTestCase(TestCase):
     def _path_exists_side_effect(*args):
         if args[0] == OPTIONS["Paths"]["CONTENT_DIR"]:
             return True
-        elif args[0].startswith(success_path):
+        elif success_path in args[0]:
             return False
         return True
 

--- a/kolibri/core/discovery/utils/filesystem/windows.py
+++ b/kolibri/core/discovery/utils/filesystem/windows.py
@@ -84,18 +84,21 @@ def _wmic_output():
         tempfile.gettempdir(), "kolibri_disks-{}.txt".format(uuid.uuid4())
     )
 
-    # pipe output from the WMIC command to the temp file
-    csv_path = os.path.join(
-        os.environ["WINDIR"], "System32", "wbem", "en-us", "csv.xsl"
-    )
-    # Use different WMIC commands, depending on whether the csv_path exists.
-    if os.path.exists(csv_path):
-        cmd = 'wmic logicaldisk list full /format:"{}" > "{}"'.format(
-            csv_path, OUTPUT_PATH
+    # fallback when en-us directory does not exist
+    cmd = 'wmic logicaldisk list full /format:csv > "{}"'.format(OUTPUT_PATH)
+    try:
+        # pipe output from the WMIC command to the temp file
+        csv_path = os.path.join(
+            os.environ["WINDIR"], "System32", "wbem", "en-us", "csv.xsl"
         )
-    else:
-        # fallback when en-us directory does not exist
-        cmd = 'wmic logicaldisk list full /format:csv > "{}"'.format(OUTPUT_PATH)
+        # If csv_path exists, use a different WMIC command.
+        if os.path.exists(csv_path):
+            cmd = 'wmic logicaldisk list full /format:"{}" > "{}"'.format(
+                csv_path, OUTPUT_PATH
+            )
+    except KeyError:
+        # If WINDIR is undefined on env
+        pass
     returnCode = os.system(cmd)
     if returnCode:
         raise Exception("Could not run command '{}'".format(cmd))

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -154,7 +154,7 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
     if sys.version_info[0] < 3:
         csv_file = io.open(filepath, "wb")
     else:
-        csv_file = io.open(filepath, "w", newline="")
+        csv_file = io.open(filepath, "w", newline="", encoding="utf-8")
 
     with csv_file as f:
         writer = csv.DictWriter(f, header_labels)

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests that ensure the correct items are returned from api calls.
 Also tests whether the users with permissions can create logs.
@@ -556,6 +557,32 @@ class ContentSummaryLogCSVExportTestCase(APITestCase):
             self.assertEqual(len(results[0]), len(row))
         self.assertEqual(len(results[1:]), expected_count)
 
+    def test_csv_download_unicode_username(self):
+        user = FacilityUserFactory.create(
+            facility=self.facility, username="كوليبري", full_name="كوليبري"
+        )
+        for _ in range(3):
+            ContentSummaryLogFactory.create(
+                user=user,
+                content_id=uuid.uuid4().hex,
+                channel_id="6199dde695db4ee4ab392222d5af1e5c",
+            )
+
+        expected_count = ContentSummaryLog.objects.count()
+        _, filepath = tempfile.mkstemp(suffix=".csv")
+        call_command(
+            "exportlogs", log_type="summary", output_file=filepath, overwrite=True
+        )
+        if sys.version_info[0] < 3:
+            csv_file = open(filepath, "rb")
+        else:
+            csv_file = open(filepath, "r", newline="")
+        with csv_file as f:
+            results = list(csv.reader(f))
+        for row in results[1:]:
+            self.assertEqual(len(results[0]), len(row))
+        self.assertEqual(len(results[1:]), expected_count)
+
 
 class ContentSessionLogCSVExportTestCase(APITestCase):
 
@@ -598,6 +625,32 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
         expected_count = ContentSessionLog.objects.count()
         ContentNode.objects.all().delete()
         ChannelMetadata.objects.all().delete()
+        _, filepath = tempfile.mkstemp(suffix=".csv")
+        call_command(
+            "exportlogs", log_type="session", output_file=filepath, overwrite=True
+        )
+        if sys.version_info[0] < 3:
+            csv_file = open(filepath, "rb")
+        else:
+            csv_file = open(filepath, "r", newline="")
+        with csv_file as f:
+            results = list(csv.reader(f))
+        for row in results[1:]:
+            self.assertEqual(len(results[0]), len(row))
+        self.assertEqual(len(results[1:]), expected_count)
+
+    def test_csv_download_unicode_username(self):
+        user = FacilityUserFactory.create(
+            facility=self.facility, username="كوليبري", full_name="كوليبري"
+        )
+        for _ in range(3):
+            ContentSessionLogFactory.create(
+                user=user,
+                content_id=uuid.uuid4().hex,
+                channel_id="6199dde695db4ee4ab392222d5af1e5c",
+            )
+
+        expected_count = ContentSessionLog.objects.count()
         _, filepath = tempfile.mkstemp(suffix=".csv")
         call_command(
             "exportlogs", log_type="session", output_file=filepath, overwrite=True

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -3,7 +3,7 @@ import ntpath
 import os
 import shutil
 from functools import partial
-from tempfile import NamedTemporaryFile
+from tempfile import mkstemp
 
 import requests
 from django.apps.registry import AppRegistryNotReady
@@ -643,9 +643,8 @@ class TasksViewSet(BaseViewSet):
             # Django uses InMemoryUploadedFile for files less than 2.5Mb
             # and TemporaryUploadedFile for bigger files:
             if type(upload.file) == InMemoryUploadedFile:
-                with NamedTemporaryFile(
-                    dir=temp_dir, suffix=".upload", delete=False
-                ) as dest:
+                _, filepath = mkstemp(dir=temp_dir, suffix=".upload")
+                with open(filepath, "w+b") as dest:
                     filepath = dest.name
                     for chunk in upload.file.chunks():
                         dest.write(chunk)

--- a/kolibri/core/tasks/test/test_job_running.py
+++ b/kolibri/core/tasks/test/test_job_running.py
@@ -48,7 +48,10 @@ def inmem_queue():
     yield c
     e.shutdown()
     os.close(fd)
-    os.remove(filepath)
+    try:
+        os.remove(filepath)
+    except OSError:
+        pass
 
 
 @pytest.fixture

--- a/kolibri/core/tasks/test/test_scheduler.py
+++ b/kolibri/core/tasks/test/test_scheduler.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 import tempfile
 
 import pytest
@@ -14,14 +15,16 @@ from kolibri.utils.time_utils import naive_utc_datetime
 
 @pytest.fixture
 def queue():
-    with tempfile.NamedTemporaryFile() as f:
-        connection = create_engine(
-            "sqlite:///{path}".format(path=f.name),
-            connect_args={"check_same_thread": False},
-            poolclass=NullPool,
-        )
-        q = Queue("pytest", connection)
-        yield q
+    fd, filepath = tempfile.mkstemp()
+    connection = create_engine(
+        "sqlite:///{path}".format(path=filepath),
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    q = Queue("pytest", connection)
+    yield q
+    os.close(fd)
+    os.remove(filepath)
 
 
 @pytest.fixture

--- a/kolibri/core/tasks/test/test_storage.py
+++ b/kolibri/core/tasks/test/test_storage.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -15,15 +16,17 @@ QUEUE = "pytest"
 
 @pytest.fixture
 def defaultbackend():
-    with tempfile.NamedTemporaryFile() as f:
-        connection = create_engine(
-            "sqlite:///{path}".format(path=f.name),
-            connect_args={"check_same_thread": False},
-            poolclass=NullPool,
-        )
-        b = Storage(connection)
-        yield b
-        b.clear()
+    fd, filepath = tempfile.mkstemp()
+    connection = create_engine(
+        "sqlite:///{path}".format(path=filepath),
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    b = Storage(connection)
+    yield b
+    b.clear()
+    os.close(fd)
+    os.remove(filepath)
 
 
 @pytest.fixture

--- a/kolibri/core/tasks/test/test_worker.py
+++ b/kolibri/core/tasks/test/test_worker.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import time
 
@@ -16,15 +17,19 @@ QUEUE = "pytest"
 
 @pytest.fixture
 def worker():
-    with tempfile.NamedTemporaryFile() as f:
-        connection = create_engine(
-            "sqlite:///{path}".format(path=f.name),
-            connect_args={"check_same_thread": False},
-            poolclass=NullPool,
-        )
-        b = Worker(QUEUE, connection)
-        yield b
-        b.shutdown()
+    _, filepath = tempfile.mkstemp()
+    connection = create_engine(
+        "sqlite:///{path}".format(path=filepath),
+        connect_args={"check_same_thread": False},
+        poolclass=NullPool,
+    )
+    b = Worker(QUEUE, connection)
+    yield b
+    b.shutdown()
+    try:
+        os.remove(filepath)
+    except OSError:
+        pass
 
 
 class TestWorker:

--- a/kolibri/core/webpack/test/base.py
+++ b/kolibri/core/webpack/test/base.py
@@ -34,7 +34,8 @@ class HookMixin(object):
 
     @property
     def _stats_file(self):
-        self.TEST_STATS_FILE = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+        _, filename = tempfile.mkstemp()
+        self.TEST_STATS_FILE = open(filename, mode="w+")
         self.TEST_STATS_FILE_DATA = copy.deepcopy(TEST_STATS_FILE_DATA)
         self.TEST_STATS_FILE_DATA["chunks"][self.unique_id] = self.TEST_STATS_FILE_DATA[
             "chunks"

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -210,11 +210,13 @@ def test_path_expansion():
 
     _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
 
-    with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": "/absolute"}):
+    absolute_path = "C:\\absolute" if sys.platform == "win32" else "/absolute"
+
+    with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": absolute_path}):
         OPTIONS = options.read_options_file(
             KOLIBRI_HOME_TEMP, ini_filename=tmp_ini_path
         )
-        assert OPTIONS["Paths"]["CONTENT_DIR"] == "/absolute"
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == absolute_path
 
     with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": "relative"}):
         OPTIONS = options.read_options_file(
@@ -224,10 +226,10 @@ def test_path_expansion():
             KOLIBRI_HOME_TEMP, "relative"
         )
 
-    with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": "~/homeiswherethecatis"}):
+    user_path = os.path.join("~", "homeiswherethecatis")
+
+    with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": user_path}):
         OPTIONS = options.read_options_file(
             KOLIBRI_HOME_TEMP, ini_filename=tmp_ini_path
         )
-        assert OPTIONS["Paths"]["CONTENT_DIR"] == os.path.expanduser(
-            "~/homeiswherethecatis"
-        )
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == os.path.expanduser(user_path)

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import sys
 import tempfile
 
 import mock
@@ -44,7 +45,10 @@ def test_option_reading_and_precedence_rules():
     """
     Checks that options can be read from a dummy options.ini file, and overridden by env vars.
     """
-    _CONTENT_DIR = "/mycontentdir"
+    if sys.platform == "win32":
+        _CONTENT_DIR = "C:\\mycontentdir"
+    else:
+        _CONTENT_DIR = "/mycontentdir"
     _HTTP_PORT_INI = 7007
     _HTTP_PORT_ENV = 9009
 
@@ -135,8 +139,12 @@ def test_option_writing():
     """
     Checks that options can be written to a dummy options.ini file, validated, and then read back.
     """
-    _OLD_CONTENT_DIR = "/mycontentdir"
-    _NEW_CONTENT_DIR = "/goodnessme"
+    if sys.platform == "win32":
+        _OLD_CONTENT_DIR = "C:\\mycontentdir"
+        _NEW_CONTENT_DIR = "C:\\goodnessme"
+    else:
+        _OLD_CONTENT_DIR = "/mycontentdir"
+        _NEW_CONTENT_DIR = "/goodnessme"
     _HTTP_PORT_GOOD = 7007
     _HTTP_PORT_BAD = "abba"
 

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tempfile
 
 import portend
@@ -41,7 +42,9 @@ class SanityCheckTestCase(TestCase):
 
     @patch("kolibri.utils.cli.get_version", return_value="")
     @patch("kolibri.utils.sanity_checks.logging.error")
-    @override_option("Paths", "CONTENT_DIR", "/dir_dne")
+    @override_option(
+        "Paths", "CONTENT_DIR", "Z:\\NOTREAL" if sys.platform == "win32" else "/dir_dne"
+    )
     def test_content_dir_dne(self, logging_mock, get_version):
         with self.assertRaises(SystemExit):
             sanity_checks.check_content_directory_exists_and_writable()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,3 @@ pytest-cov==2.5.1
 pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-pythonpath==0.7.2
-sh==1.12.14


### PR DESCRIPTION
### Summary
Adds windows and macos to unit tests, running only on Python 3.6
Removes use of `NamedTemporaryFile` as all our usages required opening the file by reference to the filepath which is not supported on Windows (see https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile). Instead uses mkstemp which is safer.

### Reviewer guidance
Do tests pass?
Does caching function correctly on new platforms?

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
