### PR TITLE
When managing lesson resources, do not show "Saving..." notification unless the resources were changed

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -20,6 +20,7 @@
         <KGridItem :layout12="{ span: 4 }">
           <KSwitch
             name="toggle-lesson-visibility"
+            label=""
             :checked="lesson[activeKey]"
             :value="lesson[activeKey]"
             @change="handleToggleVisibility"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -80,6 +80,7 @@
         >
           <KSwitch
             name="toggle-quiz-visibility"
+            label=""
             style="display:inline;"
             :checked="exam.active"
             :value="exam.active"

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import LessonResourceSelectionPage from '../index.vue';
+import makeStore from '../../../../../test/makeStore';
+
+const router = new VueRouter({
+  routes: [],
+})
+
+router.getRoute = name => ({ name });
+
+function makeWrapper() {
+  const wrapper = mount(LessonResourceSelectionPage, {
+    store: makeStore(),
+    router,
+  });
+  return { wrapper };
+}
+
+describe('LessonResourceSelectionPage', () => {
+  it('mounts', () => {
+    const { wrapper } = makeWrapper();
+  });
+});

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
@@ -5,10 +5,13 @@ import makeStore from '../../../../../test/makeStore';
 
 const router = new VueRouter({
   routes: [
+    { name: 'SUMMARY', path: '/summary' },
     { name: 'SELECT_RESOURCES', path: '/' },
     { name: 'SELECTION_ROOT', path: '/select' },
     { name: 'SELECTION', path: '/select/:topicId' },
     { name: 'SELECTION_SEARCH', path: '/search/:searchTerm' },
+    { name: 'ReportsLessonReportPage', path: '/reportslessonreportpage' },
+    { name: 'ReportsLessonLearnerListPage', path: '/reportslessonlearnerlistpage' },
   ],
 });
 
@@ -19,6 +22,7 @@ const slotDiv = {
 };
 
 const store = makeStore();
+store.state.toolbarRoute = { name: 'SUMMARY' };
 
 function makeWrapper() {
   const wrapper = mount(LessonResourceSelectionPage, {
@@ -53,16 +57,18 @@ describe('LessonResourceSelectionPage', () => {
 
     it('the filters are visible and have correct model values', () => {
       const filters = wrapper.findComponent({ name: 'LessonsSearchFilters' });
-      expect(filters.exists()).toBe(true);
       expect(filters.props().value).toEqual(filterValues);
+      expect(filters.props().searchTerm).toEqual('painting');
     });
 
-    it('button on BottomAppBar has the correct label and link', () => {
+    it('button on BottomAppBar has the correct label and link', async () => {
       const button = wrapper
         .findComponent({ name: 'BottomAppBar' })
         .findComponent({ name: 'KRouterLink' });
 
       expect(button.props().text).toEqual('Exit search');
+
+      // If last_id is in URL, link back to the topic page
       expect(button.props().to).toEqual({
         name: 'SELECTION',
         params: {
@@ -73,6 +79,55 @@ describe('LessonResourceSelectionPage', () => {
           ...filterValues,
         },
       });
+
+      // If there is no last_id in query params, link to SELECTION_ROOT
+      const noLastIdQuery = { ...filterValues };
+      await router.replace({ query: noLastIdQuery });
+      expect(button.props().to).toEqual({
+        name: 'SELECTION_ROOT',
+        params: {},
+        query: {
+          ...filterValues,
+        },
+      });
+    });
+  });
+
+  describe('in browse mode', () => {
+    let wrapper;
+
+    beforeAll(() => {
+      store.state.pageName = 'SELECTION';
+      router.replace({
+        name: 'SELECTION',
+        params: { topicId: 'topic_id' },
+      });
+      wrapper = makeWrapper().wrapper;
+    });
+
+    it('the breadcrumbs are visible and have the correct links', () => {
+      const breadcrumbs = wrapper.findComponent({ name: 'ResourceSelectionBreadcrumbs' });
+      expect(breadcrumbs.exists()).toBe(true);
+      expect(breadcrumbs.props().channelsLink.name).toEqual('SELECTION_ROOT');
+    });
+
+    it('the bottom bar has the correct label and link if coming from reports page', async () => {
+      const button = wrapper
+        .findComponent({ name: 'BottomAppBar' })
+        .findComponent({ name: 'KRouterLink' });
+
+      expect(button.props().text).toEqual('Close');
+
+      const exitRoute = () => button.props().to.name;
+      // Exit link goes to Lesson Summary page by default
+      expect(exitRoute()).toEqual('SUMMARY');
+
+      // Exit link goes to report page if that's in the URL
+      await router.replace({ query: { last: 'ReportsLessonReportPage' } });
+      expect(exitRoute()).toEqual('ReportsLessonReportPage');
+
+      await router.replace({ query: { last: 'ReportsLessonLearnerListPage' } });
+      expect(exitRoute()).toEqual('ReportsLessonLearnerListPage');
     });
   });
 });

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/__test__/LessonResourceSelectionPage.spec.js
@@ -4,21 +4,75 @@ import LessonResourceSelectionPage from '../index.vue';
 import makeStore from '../../../../../test/makeStore';
 
 const router = new VueRouter({
-  routes: [],
-})
+  routes: [
+    { name: 'SELECT_RESOURCES', path: '/' },
+    { name: 'SELECTION_ROOT', path: '/select' },
+    { name: 'SELECTION', path: '/select/:topicId' },
+    { name: 'SELECTION_SEARCH', path: '/search/:searchTerm' },
+  ],
+});
 
-router.getRoute = name => ({ name });
+router.getRoute = (name, params, query) => ({ name, params, query });
+
+const slotDiv = {
+  template: '<div><slot></slot></div>',
+};
+
+const store = makeStore();
 
 function makeWrapper() {
   const wrapper = mount(LessonResourceSelectionPage, {
-    store: makeStore(),
+    store,
     router,
+    stubs: {
+      CoreBase: slotDiv,
+    },
   });
   return { wrapper };
 }
 
 describe('LessonResourceSelectionPage', () => {
-  it('mounts', () => {
-    const { wrapper } = makeWrapper();
+  describe('in search mode', () => {
+    let wrapper;
+
+    const filterValues = {
+      channel: 'channel',
+      kind: 'kind',
+      role: 'role',
+    };
+
+    beforeAll(() => {
+      store.state.pageName = 'SELECTION_SEARCH';
+      router.replace({
+        name: 'SELECTION_SEARCH',
+        params: { searchTerm: 'painting' },
+        query: { last_id: 'last_topic_id', ...filterValues },
+      });
+      wrapper = makeWrapper().wrapper;
+    });
+
+    it('the filters are visible and have correct model values', () => {
+      const filters = wrapper.findComponent({ name: 'LessonsSearchFilters' });
+      expect(filters.exists()).toBe(true);
+      expect(filters.props().value).toEqual(filterValues);
+    });
+
+    it('button on BottomAppBar has the correct label and link', () => {
+      const button = wrapper
+        .findComponent({ name: 'BottomAppBar' })
+        .findComponent({ name: 'KRouterLink' });
+
+      expect(button.props().text).toEqual('Exit search');
+      expect(button.props().to).toEqual({
+        name: 'SELECTION',
+        params: {
+          topicId: 'last_topic_id',
+        },
+        // query.last_id should be deleted
+        query: {
+          ...filterValues,
+        },
+      });
+    });
   });
 });

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -220,7 +220,9 @@
       exitButtonRoute() {
         const lastId = this.$route.query.last_id;
         if (this.inSearchMode && lastId) {
-          return this.topicListingLink({ ...this.routerParams, topicId: lastId });
+          const queryCopy = {...this.$route.query};
+          delete queryCopy.last_id;
+          return this.$router.getRoute(LessonsPageNames.SELECTION, { topicId: lastId }, queryCopy);
         } else if (this.inSearchMode) {
           return this.selectionRootLink({ ...this.routerParams });
         } else if (this.$route.query.last === 'ReportsLessonReportPage') {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -421,9 +421,8 @@
       },
     },
     $trs: {
-      // TODO: Handle singular/plural
       selectionInformation:
-        '{count, number, integer} of {total, number, integer} resources selected',
+        '{count, number, integer} of {total, number, integer} {total, plural, one {resource} other {resources}} selected',
       totalResourcesSelected:
         '{total, number, integer} {total, plural, one {resource} other {resources}} in this lesson',
       documentTitle: `Manage resources in '{lessonName}'`,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -220,7 +220,7 @@
       exitButtonRoute() {
         const lastId = this.$route.query.last_id;
         if (this.inSearchMode && lastId) {
-          const queryCopy = {...this.$route.query};
+          const queryCopy = { ...this.$route.query };
           delete queryCopy.last_id;
           return this.$router.getRoute(LessonsPageNames.SELECTION, { topicId: lastId }, queryCopy);
         } else if (this.inSearchMode) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -120,6 +120,7 @@
         },
         isExiting: false,
         moreResultsState: null,
+        resourcesChanged: false,
       };
     },
     computed: {
@@ -255,29 +256,38 @@
     beforeRouteLeave(to, from, next) {
       // Block the UI and show a notification in case last save takes too long
       this.isExiting = true;
-      const isSamePage = samePageCheckGenerator(this.$store);
-      setTimeout(() => {
-        if (isSamePage()) {
-          this.createSnackbar(this.$tr('saveBeforeExitSnackbarText'));
-        }
-      }, 500);
 
-      // Cancel any debounced calls
-      this.debouncedSaveResources.cancel();
-      this.saveLessonResources({
-        lessonId: this.lessonId,
-        resources: [...this.workingResources],
-      })
-        .then(() => {
-          this.clearSnackbar();
-          this.isExiting = false;
-          next();
+      // If the working resources array hasn't changed at least once,
+      // just exit without autosaving
+      if (!this.resourcesChanged) {
+        next();
+        this.isExiting = false;
+      } else {
+        this.resourcesChanged = true;
+        const isSamePage = samePageCheckGenerator(this.$store);
+        setTimeout(() => {
+          if (isSamePage()) {
+            this.createSnackbar(this.$tr('saveBeforeExitSnackbarText'));
+          }
+        }, 500);
+
+        // Cancel any debounced calls
+        this.debouncedSaveResources.cancel();
+        this.saveLessonResources({
+          lessonId: this.lessonId,
+          resources: [...this.workingResources],
         })
-        .catch(() => {
-          this.showResourcesChangedError();
-          this.isExiting = false;
-          next(false);
-        });
+          .then(() => {
+            this.clearSnackbar();
+            this.isExiting = false;
+            next();
+          })
+          .catch(() => {
+            this.showResourcesChangedError();
+            this.isExiting = false;
+            next(false);
+          });
+      }
     },
     methods: {
       ...mapActions(['createSnackbar', 'clearSnackbar']),
@@ -291,6 +301,7 @@
         if (difference === 0) {
           return;
         }
+        this.resourcesChanged = true;
         if (difference > 0) {
           this.showSnackbarNotification('resourcesAddedWithCount', { count: difference });
         } else {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -49,7 +49,7 @@
         type: String,
         required: true,
         validator: function(value) {
-          return ['COPY', 'DELETE'].includes(value.toUpperCase());
+          return ['', 'COPY', 'DELETE'].includes(value.toUpperCase());
         },
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -66,6 +66,7 @@
               <td>
                 <KSwitch
                   name="toggle-lesson-visibility"
+                  label=""
                   :checked="lesson.is_active"
                   :value="lesson.is_active"
                   @change="handleToggleVisibility(lesson)"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -56,6 +56,7 @@
               <td v-show="!$isPrint">
                 <KSwitch
                   name="toggle-lesson-visibility"
+                  label=""
                   :checked="tableRow.active"
                   :value="tableRow.active"
                   @change="handleToggleVisibility(tableRow)"


### PR DESCRIPTION
### Summary

Fixes #7477 by adding a `resourcesChanged` flag inside of `LessonResourceSelectionPage/index.vue`. It is only when `resourcesChange = true`, that will automatically save the lesson, and show the "Saving your changes..." notification if that request takes a long time.

Previously, this notification and PATCH request would be shown even if _no changes_ were made to the lesson.

Other misc changes:

1. Adds some basic tests for `LessonResourceSelectionPage`
2. Fixes some prop validation errors
3. Adds a pluralized message (resolves a `TODO` comment)

### Reviewer guidance

The original issue is easier replicate locally if you throttle your network to a slower setting like "slow 3G". When the network is slower, you will see the "Saving your changes..." notification nearly every time you click to a new topic. After applying this PR, you will not see the notification anymore.

Because the relevant code is in the `beforeRouteLeave` hook, you will only see the notification bug when going from the list of channels (the `SELECTION_ROOT` route) to a subtopic (`SELECTION`), or when exiting back to the lesson summary (where you can reorder resources, rename the lesson, etc). 

Similarly, if you are at a `SELECTION` route, you will only see the notification bug  if going to the lesson summary or back to `SELECTION_ROOT`. You will not see it going from topic-to-topic (that only invokes the `beforeRouteUpdate` hook.

Confirm that lesson resources are still automatically saved as they are added/removed.

In both screen-captures, I go from `SELECTION_ROOT` to `SELECTION`, then exit back to the lesson summary.

**Before (with slow 3g setting)**

![CleanShot 2021-03-22 at 19 04 13](https://user-images.githubusercontent.com/10248067/112082108-043ad900-8b42-11eb-9f06-fa9216557d66.gif)

**After**

![CleanShot 2021-03-22 at 19 07 18](https://user-images.githubusercontent.com/10248067/112082111-069d3300-8b42-11eb-84e5-dabff8676606.gif)

### References

Fixes #7477

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
