### PR TITLE
Add `/api/tasks/restarttask` endpoint

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -232,6 +232,7 @@ class BaseViewSet(viewsets.ViewSet):
         if not isinstance(request.data["task_id"], string_types):
             raise serializers.ValidationError("The 'task_id' should be a string.")
 
+        resp = {}
         for _queue in self.queues:
             try:
                 task_id = _queue.restart_job(request.data["task_id"])

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -309,7 +309,9 @@ class BaseViewSet(viewsets.ViewSet):
 
 
 class TasksViewSet(BaseViewSet):
-    queues = [queue, priority_queue]
+    @property
+    def queues(self):
+        return [queue, priority_queue]
 
     def default_permission_classes(self):
         # exclusive permission for facility management

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -221,6 +221,26 @@ class BaseViewSet(viewsets.ViewSet):
 
         return Response(task)
 
+    @decorators.action(methods=["post"], detail=False)
+    def restarttask(self, request):
+        """
+        Restart a task with its task id given in the task_id parameter.
+        """
+
+        if "task_id" not in request.data:
+            raise serializers.ValidationError("The 'task_id' field is required.")
+        if not isinstance(request.data["task_id"], string_types):
+            raise serializers.ValidationError("The 'task_id' should be a string.")
+
+        for _queue in self.queues:
+            try:
+                task_id = _queue.restart_job(request.data["task_id"])
+                break
+            except JobNotFound:
+                continue
+
+        return Response({"task_id": task_id})
+
     def destroy(self, request, pk=None):
         # unimplemented for now.
         pass

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -235,11 +235,12 @@ class BaseViewSet(viewsets.ViewSet):
         for _queue in self.queues:
             try:
                 task_id = _queue.restart_job(request.data["task_id"])
+                resp = _job_to_response(_queue.fetch_job(task_id))
                 break
             except JobNotFound:
                 continue
 
-        return Response({"task_id": task_id})
+        return Response(resp)
 
     def destroy(self, request, pk=None):
         # unimplemented for now.

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -54,6 +54,7 @@ from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import URLParseError
 from kolibri.core.logger.csv_export import CSV_EXPORT_FILENAMES
 from kolibri.core.tasks.exceptions import JobNotFound
+from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.main import facility_queue
@@ -240,6 +241,8 @@ class BaseViewSet(viewsets.ViewSet):
                 break
             except JobNotFound:
                 continue
+            except JobNotRestartable as e:
+                raise serializers.ValidationError(str(e))
 
         return Response(resp)
 

--- a/kolibri/core/tasks/exceptions.py
+++ b/kolibri/core/tasks/exceptions.py
@@ -11,3 +11,7 @@ class UserCancelledError(CancelledError):
 
 class JobNotFound(Exception):
     pass
+
+
+class JobNotRestartable(Exception):
+    pass

--- a/kolibri/core/tasks/queue.py
+++ b/kolibri/core/tasks/queue.py
@@ -66,6 +66,22 @@ class Queue(object):
         job_id = self.storage.enqueue_job(job, self.name)
         return job_id
 
+    def restart_job(self, job_id):
+        """
+        Given a job_id, restart the job for that id. A job will only be restarted if
+        in CANCELED or FAILED state.
+
+        This will create a new job with a new job_id.
+        """
+
+        old_job = self.fetch_job(job_id)
+        if old_job.state in [State.CANCELED, State.FAILED]:
+            self.clear_job(job_id)
+            job = Job(old_job)
+            return self.enqueue(job)
+        else:
+            return None
+
     def cancel(self, job_id):
         """
         Mark a job as canceling, and let the worker pick this up to initiate

--- a/kolibri/core/tasks/queue.py
+++ b/kolibri/core/tasks/queue.py
@@ -74,7 +74,6 @@ class Queue(object):
 
         This will create a new job with a new job_id.
         """
-
         old_job = self.fetch_job(job_id)
         if old_job.state in [State.CANCELED, State.FAILED]:
             self.clear_job(job_id)

--- a/kolibri/core/tasks/queue.py
+++ b/kolibri/core/tasks/queue.py
@@ -75,6 +75,7 @@ class Queue(object):
         """
 
         old_job = self.fetch_job(job_id)
+        print(old_job.state)
         if old_job.state in [State.CANCELED, State.FAILED]:
             self.clear_job(job_id)
             job = Job(old_job)

--- a/kolibri/core/tasks/queue.py
+++ b/kolibri/core/tasks/queue.py
@@ -1,3 +1,4 @@
+from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.storage import Storage
@@ -75,13 +76,14 @@ class Queue(object):
         """
 
         old_job = self.fetch_job(job_id)
-        print(old_job.state)
         if old_job.state in [State.CANCELED, State.FAILED]:
             self.clear_job(job_id)
             job = Job(old_job)
             return self.enqueue(job)
         else:
-            return None
+            raise JobNotRestartable(
+                "Cannot restart job with state={}".format(old_job.state)
+            )
 
     def cancel(self, job_id):
         """

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -118,6 +118,16 @@ class TaskAPITestCase(BaseAPITestCase):
             for i in [4, 5, 6]:
                 assert_clearable(i, True)
 
+    def test_restart_task(self, queue_mock):
+        queue_mock.restart_job.return_value = 2
+        queue_mock.restart_job.return_value = fake_job(state=State.QUEUED)
+
+        response = self.client.post(
+            reverse("kolibri:core:task-restarttask"), {"task_id": "1"}, format="json"
+        )
+
+        self.assertEqual(response.data, {})  # TODO fix response as recieved.
+
 
 class TaskAPIPermissionsTestCase(APITestCase):
     def setUp(self):

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -120,15 +120,23 @@ class TaskAPITestCase(BaseAPITestCase):
 
     def test_restart_task(self, queue_mock):
         queue_mock.restart_job.return_value = 2
-        queue_mock.restart_job.return_value = fake_job(state=State.QUEUED)
+        queue_mock.fetch_job.return_value = fake_job(state=State.QUEUED, job_id=2)
 
         response = self.client.post(
             reverse("kolibri:core:task-restarttask"), {"task_id": "1"}, format="json"
         )
 
-        self.assertEqual(
-            response.data.get("id", None), 2
-        )  # TODO fix response as recieved.
+        expected_response = {
+            "status": "QUEUED",
+            "exception": "",
+            "traceback": "",
+            "percentage": 0,
+            "id": 2,
+            "cancellable": False,
+            "clearable": False,
+        }
+
+        self.assertDictEqual(response.data, expected_response)
 
 
 class TaskAPIPermissionsTestCase(APITestCase):

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -126,7 +126,9 @@ class TaskAPITestCase(BaseAPITestCase):
             reverse("kolibri:core:task-restarttask"), {"task_id": "1"}, format="json"
         )
 
-        self.assertEqual(response.data, {})  # TODO fix response as recieved.
+        self.assertEqual(
+            response.data.get("id", None), 2
+        )  # TODO fix response as recieved.
 
 
 class TaskAPIPermissionsTestCase(APITestCase):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
Currently, the TaskAPI backend does not support restarting a task. To restart as it is now - we have to cancel/clear the task and then initiate it again. This PR adds - 
1. The backend logic to support restart for a `FAILED or CANCELLED` state task
2. Endpoint to restart a task via a `POST` request containing the `task_id` to restart.
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

### Reviewer guidance
I have added unit tests for the backend logic that is added for `queue.py` to restart a task.
I was not able to write the unit test for the API endpoint. Could someone guide me here?
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

### References
Fixes #7348 
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
