### PR TITLE
Display relevant text message when user selects a single resource while managing a channel

### DIFF
--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/treeViewUtils.js
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/treeViewUtils.js
@@ -17,6 +17,7 @@ const translator = createTranslator('TreeViewRowMessages', {
   someResourcesOnDevice: 'Some resources on this device',
   allResourcesSelected: 'All resources selected',
   allResourcesOnDevice: 'All resources on this device',
+  resourceSelected: 'Resource selected',
 });
 
 export const CheckboxTypes = {
@@ -46,7 +47,9 @@ function partiallySelectedNode(node) {
 function fullySelectedNode(node) {
   return {
     ...node,
-    message: translator.$tr('allResourcesSelected'),
+    message: node.is_leaf
+      ? translator.$tr('resourceSelected')
+      : translator.$tr('allResourcesSelected'),
     disabled: false,
     checkboxType: CheckboxTypes.CHECKED,
   };


### PR DESCRIPTION
### Summary
Fixes #7626 by displaying "Resource selected" message in place on "All resources selected" message when user selects a single resource while managing a channel.

Before:
![resource_selection_before](https://user-images.githubusercontent.com/55936040/112215797-cb385c80-8c46-11eb-84dd-ddb2e59be840.png)

After:
![resource_selection_after](https://user-images.githubusercontent.com/55936040/112215829-d55a5b00-8c46-11eb-81fe-4276e782f2eb.png)



### References
Fixes #7626 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
