### PR TITLE
Do not delete `?next` query param when redirected from AuthMessage to SignInPage

### DIFF
--- a/kolibri/plugins/user/assets/src/routes.js
+++ b/kolibri/plugins/user/assets/src/routes.js
@@ -59,7 +59,7 @@ export default [
           const route = {
             ...router.getRoute(ComponentMap.FACILITY_SELECT),
             params: { whereToNext },
-            query: query,
+            query,
           };
           next(route);
         } else {

--- a/kolibri/plugins/user/assets/src/routes.js
+++ b/kolibri/plugins/user/assets/src/routes.js
@@ -52,9 +52,14 @@ export default [
         if (store.getters.facilities.length > 1 && !store.state.facilityId) {
           // Go to FacilitySelect with whereToNext => SignUpPage
           const whereToNext = router.getRoute(ComponentMap.SIGN_IN);
+          let query = {};
+          if (to.query.next) {
+            query = { next: to.query.next };
+          }
           const route = {
             ...router.getRoute(ComponentMap.FACILITY_SELECT),
             params: { whereToNext },
+            query: query,
           };
           next(route);
         } else {

--- a/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
@@ -106,10 +106,14 @@
     },
     methods: {
       setFacility(facilityId) {
+        let whereToNext = { ...this.whereToNext };
+        if (this.$route.query.next) {
+          whereToNext.query.next = this.$route.query.next;
+        }
         // Save the selected facility, get its config, then move along to next route
         this.$store.dispatch('setFacilityId', { facilityId }).then(() => {
           this.$store.dispatch('getFacilityConfig', facilityId).then(() => {
-            this.$router.push(this.whereToNext);
+            this.$router.push(whereToNext);
           });
         });
       },

--- a/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
+++ b/kolibri/plugins/user/assets/src/views/FacilitySelect.vue
@@ -106,7 +106,7 @@
     },
     methods: {
       setFacility(facilityId) {
-        let whereToNext = { ...this.whereToNext };
+        const whereToNext = { ...this.whereToNext };
         if (this.$route.query.next) {
           whereToNext.query.next = this.$route.query.next;
         }

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -211,7 +211,11 @@
       backToFacilitySelectionRoute() {
         const facilityRoute = this.$router.getRoute(ComponentMap.FACILITY_SELECT);
         const whereToNext = this.$router.getRoute(ComponentMap.SIGN_IN);
-        return { ...facilityRoute, params: { whereToNext } };
+        let query = {};
+        if (this.nextParam) {
+          query = { next: this.nextParam };
+        }
+        return { ...facilityRoute, params: { whereToNext }, query: query };
       },
       showPasswordForm() {
         return (

--- a/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/SignInPage/index.vue
@@ -215,7 +215,7 @@
         if (this.nextParam) {
           query = { next: this.nextParam };
         }
-        return { ...facilityRoute, params: { whereToNext }, query: query };
+        return { ...facilityRoute, params: { whereToNext }, query };
       },
       showPasswordForm() {
         return (


### PR DESCRIPTION
Passed the param next to the route whereToNext

…

Step 1: Open the link in incognito mode.
Go to https://kolibri-beta.learningequality.org/en/coach/#/0ca0280c91ccb9a880d922914226557f/plan/lessons/a7666d7f39eb34f13965ffa2e443bdee 

or 

http://127.0.0.1:8000/en/coach/#/cf75dbe3de5a09a2fc9e45702cd6a84e/plan/lessons/0a41af5b21df81371f45d8f05596b3a3

Step 2: Open use the same link to and open it in normal mode.
and you will see something like 

http://127.0.0.1:8000/en/user/#/signin?next=http%3A%2F%2F127.0.0.1%3A8000%2Fen%2Fcoach%2F%23%2Fcf75dbe3de5a09a2fc9e45702cd6a84e%2Fplan%2Flessons%2F0a41af5b21df81371f45d8f05596b3a3

where `?next` param is preserved.

Step 3: Pick a facility, sign-in, etc. and it will redirect you to the STEP 1's resource.


…

### References
FIx for #7896
…

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

<!--
### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
-->