### PR TITLE
Update `TextTruncator` to handle text in Khmer, and long, unbroken strings

### DIFF
--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -78,7 +78,7 @@
       handleUpdate() {
         // TODO make "View Less" disappear when user expands window
         // and text isn't truncated any more.
-        shave(this.$refs.shaveEl, this.maxHeight);
+        shave(this.$refs.shaveEl, this.maxHeight, { spaces: false });
         this.$nextTick(() => {
           this.textIsTruncated = Boolean(this.$el.querySelector('.js-shave'));
           // set title attribute for shaved text but

--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -4,7 +4,7 @@
     <div v-if="viewAllText">
       {{ text }}
     </div>
-    <div v-else ref="shaveEl">
+    <div v-else ref="shaveEl" class="truncated">
       {{ text }}
     </div>
     <div
@@ -105,6 +105,13 @@
   .show-more {
     margin-top: 8px;
     text-align: right;
+  }
+
+  // If the text is a long single word (and not shortened by shave.js),
+  // then apply this CSS instead
+  .truncated {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -75,12 +75,25 @@
       },
     },
     methods: {
+      titleIsShaved() {
+        return Boolean(this.$el.querySelector('.js-shave'));
+      },
+      titleIsOverflowing() {
+        // This checks to see if shave.js did not work, but the text is still
+        // overflowing. This can happen if `text` prop is one long string.
+        const $shaveEl = this.$refs.shaveEl;
+        if (!$shaveEl) {
+          return false;
+        } else {
+          return $shaveEl.clientWidth < $shaveEl.scrollWidth;
+        }
+      },
       handleUpdate() {
         // TODO make "View Less" disappear when user expands window
         // and text isn't truncated any more.
         shave(this.$refs.shaveEl, this.maxHeight, { spaces: false });
         this.$nextTick(() => {
-          this.textIsTruncated = Boolean(this.$el.querySelector('.js-shave'));
+          this.textIsTruncated = this.titleIsShaved() || this.titleIsOverflowing();
           // set title attribute for shaved text but
           // skip if a title already exists
           if (this.textIsTruncated && !this.$refs.shaveEl.title)


### PR DESCRIPTION
### Summary

In `TextTruncator.vue`:


1. Adds a `{ space: false }` configuration to shave.js so that it  will shave texts before the end of a word. This helps out when the `text` prop is in a space-less language like Khmer.
1. Adds a `truncated` class which is used when shave.js does not truncate the text, which can happen if the `text` prop is a single, unbroken word (this might be a bug in shave.js, since you would think the `{space: false}` config would handle this.
2. Builds on top of #7915 , and adds a `title` attribute to the title if it ends up being truncated by the `.truncated` CSS class and not by shave.js, so there is no difference between either cases.

### Reviewer guidance

Download these channels:

KA Khmer - `f5b71417b1f657fca4d1aaecd23e4067` (Download the whole channel)

TESSA - `a9b25ac9814742c883ce1b0579448337` (Download just TESSA - Swahili)

With these channels installed, you can use the localhost URLs above to test this fix.

If other content is available on your device, see if this PR works well with those resources as well.

Use these URLS to look at the same topics in the screenshots below:

- http://localhost:8000/en/learn/#/topics/t/aeccb10df7e851f4b77be7a92681835e
- http://localhost:8000/en/learn/#/topics/t/b703155058b245b28e533f67037a2ef4

### Screenshots
(See Contributor Guidance for channels to import, otherwise these localhost URLs won't work)

**Khmer Text (Firefox) - Before**

http://localhost:8000/en/learn/#/topics/t/aeccb10df7e851f4b77be7a92681835e
![Khmer - Before](https://user-images.githubusercontent.com/10248067/112369417-665a2200-8c99-11eb-9448-b8dd04f211a6.png)


**Khmer Text - After**
![Khmer - After](https://user-images.githubusercontent.com/10248067/112369408-635f3180-8c99-11eb-8d83-b1ac10b0f49c.png)


**Long title in TESSA Swahili (Firefox) - Before**

http://localhost:8000/en/learn/#/topics/t/b703155058b245b28e533f67037a2ef4

![TESSA - Before](https://user-images.githubusercontent.com/10248067/112369432-69551280-8c99-11eb-8fe0-e9c9f2e8374c.png)

**Long title in TESSA Swahili - After**

![TESSA - After](https://user-images.githubusercontent.com/10248067/112369440-6c500300-8c99-11eb-81c6-34ad318593b8.png)

### References

Fixes #5468 
Fixes #5464

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
