### PR TITLE
feat: dynamically add title on shaved text

### DIFF
--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -81,6 +81,14 @@
         shave(this.$refs.shaveEl, this.maxHeight);
         this.$nextTick(() => {
           this.textIsTruncated = Boolean(this.$el.querySelector('.js-shave'));
+          // set title attribute for shaved text but
+          // skip if a title already exists
+          if (this.textIsTruncated && !this.$refs.shaveEl.title)
+            this.$refs.shaveEl.setAttribute('title', this.text);
+          // if the text is not shaved and a title has been previously set,
+          // remove it
+          else if (!this.textIsTruncated && this.$refs.shaveEl.title)
+            this.$refs.shaveEl.removeAttribute('title');
         });
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
resolves #7557 

When a user hovers over a shaved text, the whole text is shown via the browser's tooltip. The title attribute is set only on shaved texts. If the user changes the resolution to a bigger screen and the text is no longer shaved, the title's attribute is removed.

Before Hovering:
![image](https://user-images.githubusercontent.com/45261205/112367850-1d2ec000-8ce3-11eb-8881-0b9603c14dc7.png)

After Hovering over title:
![image](https://user-images.githubusercontent.com/45261205/112367767-02f4e200-8ce3-11eb-9371-6cb46bae8a41.png)

### Reviewer guidance
1. Hover over a truncated text
2. Change the resolution in order to test the responsiveness

### References
resolves #7557 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
