### PR TITLE
Update zip_content options to better reflect deployment needs.

### DIFF
--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -6,11 +6,8 @@
 import setWebpackPublicPath from '../utils/setWebpackPublicPath';
 import plugin_data from 'plugin_data';
 
-function generateUrl(baseUrl, { url, host, port } = {}) {
-  let urlObject = new URL(baseUrl, window.location.origin);
-  if (host) {
-    urlObject.host = host;
-  }
+function generateUrl(baseUrl, { url, origin, port } = {}) {
+  let urlObject = new URL(baseUrl, origin || window.location.origin);
   if (port) {
     urlObject.port = port;
   }
@@ -35,7 +32,7 @@ const urls = {
       throw new ReferenceError('Hashi Url is not defined');
     }
     return generateUrl(this.__hashiUrl, {
-      host: this.__zipContentHost,
+      origin: this.__zipContentOrigin,
       port: this.__zipContentPort,
     });
   },
@@ -59,7 +56,7 @@ const urls = {
       }
       return generateUrl(this.__zipContentUrl, {
         url: `${filename}/${embeddedFilePath}`,
-        host: this.__zipContentHost,
+        origin: this.__zipContentOrigin,
         port: this.__zipContentPort,
       });
     }

--- a/kolibri/core/content/templates/content/h5p.html
+++ b/kolibri/core/content/templates/content/h5p.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load zipcontent %}
 <!DOCTYPE html>
 
 <html>
@@ -14,9 +14,9 @@
             }
         </style>
 
-        <link type="text/css" rel="stylesheet" media="all" href="{% static 'assets/h5p/styles/h5p.css' %}" />
-        <link type="text/css" rel="stylesheet" media="all" href="{% static 'assets/h5p/styles/h5p-confirmation-dialog.css' %}" />
-        <link type="text/css" rel="stylesheet" media="all" href="{% static 'assets/h5p/styles/h5p-core-button.css' %}" />
+        <link type="text/css" rel="stylesheet" media="all" href="{% zc_static 'assets/h5p/styles/h5p.css' %}" />
+        <link type="text/css" rel="stylesheet" media="all" href="{% zc_static 'assets/h5p/styles/h5p-confirmation-dialog.css' %}" />
+        <link type="text/css" rel="stylesheet" media="all" href="{% zc_static 'assets/h5p/styles/h5p-core-button.css' %}" />
 
         {% for path in cssfiles %}
         <link type="text/css" rel="stylesheet" media="all" href="{{ path }}" />
@@ -80,7 +80,7 @@
 
         </script>
 
-        <script type="text/javascript" src="{% static 'assets/h5p/js/frame.bundle.js' %}" crossorigin="anonymous"></script>
+        <script type="text/javascript" src="{% zc_static 'assets/h5p/js/frame.bundle.js' %}" crossorigin="anonymous"></script>
 
         {% for path in jsfiles %}
         <script type="text/javascript" src="{{ path }}"></script>

--- a/kolibri/core/content/templates/content/hashi.html
+++ b/kolibri/core/content/templates/content/hashi.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load zipcontent %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -8,6 +8,6 @@
         <meta name="google" content="notranslate">
     </head>
     <body style="margin: 0; padding: 0;">
-        <script type="text/javascript" src="{% static hashi_file_path %}"></script>
+        <script type="text/javascript" src="{% zc_static hashi_file_path %}"></script>
     </body>
 </html>

--- a/kolibri/core/content/templatetags/zip_content_tags.py
+++ b/kolibri/core/content/templatetags/zip_content_tags.py
@@ -1,0 +1,33 @@
+"""
+Content template tags
+=====================
+
+To use
+
+.. code-block:: html
+
+    {% load webpack_tags %}
+
+    <!-- Render on-demand async inclusion tag for content renderers -->
+    {% content_renderer_assets %}
+
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django import template
+from six.moves.urllib.parse import quote
+from six.moves.urllib.parse import urljoin
+
+from kolibri.core.content.utils.paths import zip_content_static_root
+
+register = template.Library()
+
+
+@register.simple_tag
+def zc_static(path):
+    """
+    template tag to return static urls in the context of the zipcontent app
+    """
+    return urljoin(zip_content_static_root(), quote(path))

--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -99,9 +99,16 @@ class ZipContentTestCase(TestCase):
         return generate_zip_content_response(self.environ)
 
     def test_zip_file_url_reversal(self):
+        from kolibri.utils.conf import OPTIONS
+
+        path_prefix = OPTIONS["Deployment"]["ZIP_CONTENT_URL_PATH_PREFIX"]
+
+        if path_prefix != "/":
+            path_prefix = "/" + path_prefix
         file = LocalFile(id=self.hash, extension=self.extension, available=True)
         self.assertEqual(
-            file.get_storage_url(), "/zipcontent/{}/".format(self.filename)
+            file.get_storage_url(),
+            "{}zipcontent/{}/".format(path_prefix, self.filename),
         )
 
     def test_non_zip_file_url_reversal(self):
@@ -301,6 +308,11 @@ class ZipContentTestCase(TestCase):
         self.assertEqual(response.status_code, 405)
 
 
+@override_option("Deployment", "ZIP_CONTENT_URL_PATH_PREFIX", "prefix_test/")
+class UrlPrefixZipContentTestCase(ZipContentTestCase):
+    pass
+
+
 class HashiViewTestCase(TestCase):
     def setUp(self):
         self.environ = {}
@@ -359,3 +371,8 @@ class HashiViewTestCase(TestCase):
     def test_delete_not_allowed(self):
         response = self._get_hashi(REQUEST_METHOD="DELETE")
         self.assertEqual(response.status_code, 405)
+
+
+@override_option("Deployment", "ZIP_CONTENT_URL_PATH_PREFIX", "prefix_test/")
+class UrlPrefixHashiViewTestCase(HashiViewTestCase):
+    pass

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -253,8 +253,16 @@ HASHI = "hashi/"
 ZIPCONTENT = "zipcontent/"
 
 
+def zip_content_path_prefix():
+    path_prefix = conf.OPTIONS["Deployment"]["ZIP_CONTENT_URL_PATH_PREFIX"]
+
+    if path_prefix != "/":
+        path_prefix = "/" + path_prefix
+    return path_prefix
+
+
 def get_zip_content_base_path():
-    return "{}{}".format(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"], ZIPCONTENT)
+    return "{}{}".format(zip_content_path_prefix(), ZIPCONTENT)
 
 
 HASHI_FILENAME = None
@@ -277,13 +285,15 @@ def get_hashi_html_filename():
 
 
 def get_hashi_base_path():
-    return "{}{}".format(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"], HASHI)
+    return "{}{}".format(zip_content_path_prefix(), HASHI)
 
 
 def get_hashi_path():
-    return "{}{}{}".format(
-        conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"], HASHI, get_hashi_html_filename()
-    )
+    return "{}{}{}".format(zip_content_path_prefix(), HASHI, get_hashi_html_filename())
+
+
+def zip_content_static_root():
+    return urljoin(zip_content_path_prefix(), "static/")
 
 
 def get_content_storage_file_url(filename):

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -71,7 +71,7 @@ def django_response_to_wsgi(response, environ, start_response):
 
 template_engine = Engine(
     dirs=[os.path.join(os.path.dirname(__file__), "./templates/content")],
-    libraries={"staticfiles": "django.contrib.staticfiles.templatetags.staticfiles"},
+    libraries={"zipcontent": "kolibri.core.content.templatetags.zip_content_tags"},
 )
 h5p_template = template_engine.get_template("h5p.html")
 hashi_template = template_engine.get_template("hashi.html")

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -53,6 +53,14 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
             # For some reason the js_name gets escaped going into the template
             # so this was the easiest way to inject it.
         ).replace("__placeholder__", js_name)
+        zip_content_origin = OPTIONS["Deployment"]["ZIP_CONTENT_ORIGIN"]
+        if not zip_content_origin:
+            zip_content_port = str(OPTIONS["Deployment"]["ZIP_CONTENT_PORT"])
+        elif type(zip_content_origin) is int:
+            zip_content_port = str(zip_content_origin)
+            zip_content_origin = ""
+        else:
+            zip_content_port = ""
         return [
             mark_safe(
                 """<script type="text/javascript">"""
@@ -67,7 +75,7 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
             {js_name}.__contentUrl = '{content_url}';
             {js_name}.__zipContentUrl = '{zip_content_url}';
             {js_name}.__hashiUrl = '{hashi_url}';
-            {js_name}.__zipContentHost = '{zip_content_host}';
+            {js_name}.__zipContentOrigin = '{zip_content_origin}';
             {js_name}.__zipContentPort = {zip_content_port};
             </script>
             """.format(
@@ -79,8 +87,8 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
                     ),
                     zip_content_url=get_zip_content_base_path(),
                     hashi_url=get_hashi_path(),
-                    zip_content_host=OPTIONS["Deployment"]["ZIP_CONTENT_HOST"],
-                    zip_content_port=str(OPTIONS["Deployment"]["ZIP_CONTENT_PORT"]),
+                    zip_content_origin=zip_content_origin,
+                    zip_content_port=zip_content_port,
                 )
             )
         ]

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -45,7 +45,16 @@ DATA_PORTAL_SYNCING_BASE_URL
 HTTP_PORT
 RUN_MODE
 URL_PATH_PREFIX
+    Serve Kolibri from a subpath under the main domain. Used when serving multiple applications from
+    the same origin. This option is not heavily tested, but is provided for user convenience.
 LANGUAGES
+ZIP_CONTENT_URL_PATH_PREFIX
+    The zip content equivalent of URL_PATH_PREFIX - allows all zip content URLs to be prefixed with
+    a fixed path. This both changes the URL from which the endpoints are served by the alternate
+    origin server, and the URL prefix where the Kolibri frontend looks for it.
+    In the case that ZIP_CONTENT_ORIGIN is pointing to an entirely separate origin, this setting
+    can still be used to set a URL prefix that the frontend of Kolibri will look to when
+    retrieving alternate origin URLs.
 ZIP_CONTENT_ORIGIN
     When running in default operation, this will default to blank, and the Kolibri
     frontend will look for the zipcontent endpoints on the same domain as Kolibri proper
@@ -224,7 +233,7 @@ def origin_or_port(value):
             url = urlparse(value)
             if not url.scheme or not url.netloc:
                 raise VdtValueError(value)
-            value = urlunparse((url.scheme, url.netloc, url.path, "", "", ""))
+            value = urlunparse((url.scheme, url.netloc, "", "", "", ""))
     return value
 
 
@@ -408,8 +417,14 @@ base_option_spec = {
         },
         "ZIP_CONTENT_PORT": {
             "type": "port",
-            "default": 8888,
+            "default": 8765,
             "envvars": ("KOLIBRI_ZIP_CONTENT_PORT",),
+        },
+        "ZIP_CONTENT_URL_PATH_PREFIX": {
+            "type": "string",
+            "default": "/",
+            "envvars": ("KOLIBRI_ZIP_CONTENT_URL_PATH_PREFIX",),
+            "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
     },
     "Python": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -84,6 +84,7 @@ from django.utils.six import string_types
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.parse import urlunparse
 from validate import Validator
+from validate import VdtTypeError
 from validate import VdtValueError
 
 try:
@@ -216,7 +217,7 @@ def port(value):
     try:
         return validate_port_number(int(value))
     except ValueError:
-        raise VdtValueError(value)
+        raise VdtTypeError(value)
 
 
 def origin_or_port(value):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -267,7 +267,6 @@ def configure_http_server(port):
     from kolibri.deployment.default.wsgi import application
 
     whitenoise_settings = {
-        "static_root": settings.STATIC_ROOT,
         # Use 1 day as the default cache time for static assets
         "max_age": 24 * 60 * 60,
         # Add a test for any file name that contains a semantic version number

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -268,7 +268,6 @@ def configure_http_server(port):
 
     whitenoise_settings = {
         "static_root": settings.STATIC_ROOT,
-        "static_prefix": settings.STATIC_URL,
         # Use 1 day as the default cache time for static assets
         "max_age": 24 * 60 * 60,
         # Add a test for any file name that contains a semantic version number
@@ -279,7 +278,9 @@ def configure_http_server(port):
     }
 
     # Mount static files
-    application = DjangoWhiteNoise(application, **whitenoise_settings)
+    application = DjangoWhiteNoise(
+        application, static_prefix=settings.STATIC_URL, **whitenoise_settings
+    )
 
     cherrypy.tree.graft(application, "/")
 
@@ -290,14 +291,14 @@ def configure_http_server(port):
     )
 
     # Mount content files
-    CONTENT_ROOT = "/" + paths.get_content_url(
-        conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
-    ).lstrip("/")
     content_dirs = [paths.get_content_dir_path()] + paths.get_content_fallback_paths()
     dispatcher = MultiStaticDispatcher(content_dirs)
     content_handler = cherrypy.tree.mount(
         None,
-        CONTENT_ROOT,
+        "/"
+        + paths.get_content_url(conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]).lstrip(
+            "/"
+        ),
         config={"/": {"tools.caching.on": False, "request.dispatch": dispatcher}},
     )
 
@@ -322,9 +323,19 @@ def configure_http_server(port):
 
     # Mount static files
     alt_port_app = wsgi.PathInfoDispatcher(
-        {"/": get_application(), CONTENT_ROOT: content_handler}
+        {
+            "/": get_application(),
+            "/"
+            + paths.get_content_url(paths.zip_content_path_prefix()).lstrip(
+                "/"
+            ): content_handler,
+        }
     )
-    alt_port_app = DjangoWhiteNoise(alt_port_app, **whitenoise_settings)
+    alt_port_app = DjangoWhiteNoise(
+        alt_port_app,
+        static_prefix=paths.zip_content_static_root(),
+        **whitenoise_settings
+    )
 
     alt_port_server = ServerAdapter(
         cherrypy.engine,


### PR DESCRIPTION
### Summary
* Post merge review by @jamalex of #7254 showed an issue with the way that the zip content options were being used
* Specifically ZIP_CONTENT_PORT as a setting should be reserved for the port that Kolibri serves its zipcontent server on
* This PR then changes the other option to ZIP_CONTENT_ORIGIN, which can either be the port that a proxied alternate origin server is served on, or a full origin value
* This then updates the interface code between backend and frontend to either pass the port, the proxied port, or the full origin, depending on how it is configured.

### Reviewer guidance
Do the port options make sense?
Does the documentation make sense?
Does HTML5 content still serve? (I have locally confirmed that it does)

### References
Follow up from #7254 

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
