### PR TITLE
Upgrade perseus to 1.3.4

### DIFF
--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -40,7 +40,7 @@ const urls = {
   },
   storageUrl(fileId, extension, embeddedFilePath = '') {
     const filename = `${fileId}.${extension}`;
-    if (['perseus', 'zip', 'h5p'].includes(extension)) {
+    if (['zip', 'h5p'].includes(extension)) {
       return this['kolibri:core:zipcontent'](filename, embeddedFilePath);
     }
     return generateUrl(this.__contentUrl, `${filename[0]}/${filename[1]}/${filename}`);

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -13,8 +13,7 @@ from kolibri.utils import conf
 VALID_STORAGE_FILENAME = re.compile(r"[0-9a-f]{32}(-data)?\.[0-9a-z]+")
 
 # set of file extensions that should be considered zip files and allow access to internal files
-POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".perseus", ".zip", ".h5p"])
-# TODO: add ".epub" and ".epub3" if epub-equivalent of ZipContentView implemented
+POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".zip", ".h5p"])
 
 
 def _maybe_makedirs(path):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.24
-kolibri_exercise_perseus_plugin==1.3.3
+kolibri_exercise_perseus_plugin==1.3.4
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1


### PR DESCRIPTION
### Summary
* Upgrades Perseus to v1.3.4
* Stops serving Perseus files from the zipcontent endpoint

### Reviewer guidance
Do perseus exercises still render as expected?

### References
Fixes #7837

Diff: https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v1.3.3...v1.3.4

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
