### PR TITLE
Add content serving on alternate origin.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -297,7 +297,7 @@ def configure_http_server(port):
     ).lstrip("/")
     content_dirs = [paths.get_content_dir_path()] + paths.get_content_fallback_paths()
     dispatcher = MultiStaticDispatcher(content_dirs)
-    cherrypy.tree.mount(
+    content_handler = cherrypy.tree.mount(
         None,
         CONTENT_ROOT,
         config={"/": {"tools.caching.on": False, "request.dispatch": dispatcher}},
@@ -323,7 +323,10 @@ def configure_http_server(port):
     )
 
     # Mount static files
-    alt_port_app = DjangoWhiteNoise(get_application(), **whitenoise_settings)
+    alt_port_app = wsgi.PathInfoDispatcher(
+        {"/": get_application(), CONTENT_ROOT: content_handler}
+    )
+    alt_port_app = DjangoWhiteNoise(alt_port_app, **whitenoise_settings)
 
     alt_port_server = ServerAdapter(
         cherrypy.engine,


### PR DESCRIPTION
### Summary
* Reapply changes in custom-channels branch to develop
* Adds content serving to alternate origin server

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
