### PR TITLE
Ensure mp3 type is audio/mpeg in media player

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -57,7 +57,7 @@
           <source
             :key="audio.storage_url"
             :src="audio.storage_url"
-            :type="`audio/${audio.extension}`"
+            :type="audioSourceType(audio.extension)"
           >
         </template>
       </audio>
@@ -153,6 +153,18 @@
         return this.supplementaryFiles.filter(file =>
           trackFileExtensions.some(ext => ext === file.extension)
         );
+      },
+      audioSourceType() {
+        return function(extension) {
+          switch (extension) {
+            case 'mp3':
+              // the correct type for mp3
+              return 'audio/mpeg';
+            default:
+              // generally speaking, this should work for others
+              return `audio/${extension}`;
+          }
+        };
       },
       isVideo() {
         return this.videoSources.length;


### PR DESCRIPTION
### Summary
Ensures that we're passing the correct audio type for `.mp3` files as it's type should be `audio/mpeg`.

### Reviewer guidance
1. Import audio content from channel `nakav-mafak`
2. Verify that audio files play correctly in supported browsers

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Found during investigating: https://github.com/learningequality/kolibri/issues/7395

----

### Contributor Checklist

PR process:

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

Testing:

- [X] Contributor has fully tested the PR manually

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
