### PR TITLE
Add endpoint to check for duplicate username and use it to check for existing username while creating an account

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -259,6 +259,32 @@ class FacilityUserViewSet(ValuesViewset):
         self.set_password_if_needed(instance, serializer)
 
 
+class ExistingUsernameView(views.APIView):
+    def get(self, request):
+        username = request.GET.get("username")
+        facility_id = request.GET.get("facility")
+
+        if not username or not facility_id:
+            return Response(
+                "Must specify username, and facility",
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            Facility.objects.get(id=facility_id)
+        except (ValueError, ObjectDoesNotExist):
+            return Response(
+                "Facility not found",
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            FacilityUser.objects.get(username__iexact=username, facility=facility_id)
+            return Response({"username_exists": True}, status=status.HTTP_200_OK)
+        except ObjectDoesNotExist:
+            return Response({"username_exists": False}, status=status.HTTP_200_OK)
+
+
 class FacilityUsernameViewSet(ValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
     filter_fields = ("facility",)

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from rest_framework import routers
 
 from .api import ClassroomViewSet
+from .api import ExistingUsernameView
 from .api import FacilityDatasetViewSet
 from .api import FacilityUsernameViewSet
 from .api import FacilityUserViewSet
@@ -42,6 +43,11 @@ urlpatterns = (
             r"^setnonspecifiedpassword$",
             SetNonSpecifiedPasswordView.as_view(),
             name="setnonspecifiedpassword",
-        )
+        ),
+        url(
+            r"^usernameexists",
+            ExistingUsernameView.as_view(),
+            name="usernameexists",
+        ),
     ]
 )

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -45,7 +45,7 @@ urlpatterns = (
             name="setnonspecifiedpassword",
         ),
         url(
-            r"^usernameexists",
+            r"^usernameexists$",
             ExistingUsernameView.as_view(),
             name="usernameexists",
         ),

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1159,3 +1159,40 @@ class GroupMembership(APITestCase):
             url, {"user": self.user.id, "collection": self.classroom2.id}, format="json"
         )
         self.assertEqual(response.status_code, 201)
+
+
+class DuplicateUsernameTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        cls.user = FacilityUserFactory.create(facility=cls.facility, username="user")
+        cls.url = reverse("kolibri:core:usernameexists")
+        provision_device()
+
+    def test_check_duplicate_username_with_unique_username(self):
+        response = self.client.get(
+            self.url,
+            {"username": "new_user", "facility": self.facility.id},
+            format="json",
+        )
+        expected = {"username_exists": False}
+        self.assertDictEqual(response.data, expected)
+
+    def test_check_duplicate_username_with_existing_username(self):
+        response = self.client.get(
+            self.url,
+            {"username": self.user.username, "facility": self.facility.id},
+            format="json",
+        )
+        expected = {"username_exists": True}
+        self.assertDictEqual(response.data, expected)
+
+    def test_check_duplicate_username_with_existing_username_other_facility(self):
+        other_facility = FacilityFactory.create()
+        response = self.client.get(
+            self.url,
+            {"username": self.user.username, "facility": other_facility.id},
+            format="json",
+        )
+        expected = {"username_exists": False}
+        self.assertDictEqual(response.data, expected)

--- a/kolibri/plugins/user/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user/assets/src/views/SignUpPage.vue
@@ -110,8 +110,6 @@
 
   import { mapGetters } from 'vuex';
   import every from 'lodash/every';
-  import find from 'lodash/find';
-  import { FacilityUsernameResource } from 'kolibri.resources';
   import { DemographicConstants, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import GenderSelect from 'kolibri.coreVue.components.GenderSelect';
   import BirthYearSelect from 'kolibri.coreVue.components.BirthYearSelect';
@@ -122,6 +120,8 @@
   import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import urls from 'kolibri.urls';
+  import client from 'kolibri.client';
   import { ComponentMap } from '../constants';
   import { SignUpResource } from '../apiResource';
   import LanguageSwitcherFooter from './LanguageSwitcherFooter';
@@ -196,24 +196,17 @@
         if (!username) {
           return Promise.resolve();
         }
-        // NOTE: the superuser will not be returned in this search.
-        // TODO: create an specialized endpoint that only checks to see if a username
-        // already exists in a facility
-        return FacilityUsernameResource.fetchCollection({
-          getParams: {
+        return client({
+          url: urls['kolibri:core:usernameexists'](),
+          method: 'GET',
+          params: {
             facility: this.selectedFacility.id,
-            search: username,
+            username: username,
           },
-          force: true,
-        })
-          .then(results => {
-            if (find(results, { username })) {
-              this.caughtErrors.push(ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS);
-            }
-          })
-          .catch(() => {
-            // Silently handle search errors, idk
-          });
+        }).then(response => {
+          if (response.data.username_exists)
+            this.caughtErrors.push(ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS);
+        });
       },
       handleSubmit() {
         if (this.atFirstStep) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary

This pull request incorporates the following changes:
* Add endpoint to check for duplicate username
* Use the above endpoint to check for existing username while creating an account

### Reviewer guidance

To review the changes:

1. Click Create an account button on the login page
2. On Step 1 page fill the Full name, Username and password field as for Username field use the same input as the one with the already existing account.
3. Click Continue button
4. "Username already exists" error message will appear on the screen.

### References

Fixes #7591 

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
