### PR TITLE
fix(docs): deprecate runserver, instead use python-devserver

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -228,7 +228,7 @@ In the first terminal you can start the django development server with this comm
 
 .. code-block:: bash
 
-  kolibri manage --debug runserver --settings=kolibri.deployment.default.settings.dev "0.0.0.0:8000"
+  yarn run python-devserver
 
 In the second terminal, you can start the webpack build process for frontend assets in 'watch' mode – meaning they will be automatically rebuilt if you modify them – with this command:
 
@@ -242,8 +242,10 @@ If you need to make the development server available through the LAN, you need t
 
   # first build the assets
   yarn run build
+  # collects the static files into KOLIBRI_HOME/static allowing them to be served by cherrypy
+  kolibri manage collectstatic
   # now, run the Django devserver
-  kolibri manage --debug runserver -- 0.0.0.0:8000
+  yarn run python-devserver
 
 Now you can simply use your server's IP from another device in the local network through the port 8000, for example ``http://192.168.1.38:8000/``.
 
@@ -263,6 +265,8 @@ In production, content is served through CherryPy. Static assets must be pre-bui
 
   # first build the assets
   yarn run build
+  # collects the static files into KOLIBRI_HOME/static allowing them to be served by cherrypy
+  kolibri manage collectstatic
   # now, run the Django production server
   kolibri start
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -242,8 +242,6 @@ If you need to make the development server available through the LAN, you need t
 
   # first build the assets
   yarn run build
-  # collects the static files into KOLIBRI_HOME/static allowing them to be served by cherrypy
-  kolibri manage collectstatic
   # now, run the Django devserver
   yarn run python-devserver
 
@@ -265,8 +263,6 @@ In production, content is served through CherryPy. Static assets must be pre-bui
 
   # first build the assets
   yarn run build
-  # collects the static files into KOLIBRI_HOME/static allowing them to be served by cherrypy
-  kolibri manage collectstatic
   # now, run the Django production server
   kolibri start
 


### PR DESCRIPTION
### Summary

[Based on my discussion with @rtibbles](https://learningequality.slack.com/archives/C01QW21F8F6/p1616609623111100?thread_ts=1616571699.106100&cid=C01QW21F8F6), I was advised to use the `python-devserver` command instead of `kolibri manage runserver` when on develop branch because `python-devserver` command starts the kolibri services which are needed for kolibri to work. Also, I was told to run `kolibri manage collectstatic` after building the assets (`yarn run build`) to make them available for serving by cherrypy.

This PR updates the getting started section of the developer documentation to reflect the above.

### Reviewer guidance
1. [Build & update the documentation locally](https://kolibri-dev.readthedocs.io/en/latest/getting_started.html#updating-documentation). 
1. Visit the getting started page of the built version to see the latest changes.

### References
Might be somewhat related to https://github.com/learningequality/kolibri/issues/7384.

### Contributor Checklist

PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
