### PR TITLE
ContentNodeViewset: Add content tags

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -356,11 +356,25 @@ class ContentNodeViewset(ValuesViewset):
                 "id", "title", "lft", "rght", "tree_id"
             )
 
+            tags = {}
+
+            for t in models.ContentTag.objects.filter(
+                tagged_content__in=queryset
+            ).values(
+                "tag_name",
+                "tagged_content",
+            ):
+                if t["tagged_content"] not in tags:
+                    tags[t["tagged_content"]] = [t["tag_name"]]
+                else:
+                    tags[t["tagged_content"]].append(t["tag_name"])
+
             for item in items:
                 item["assessmentmetadata"] = assessmentmetadata.get(item["id"])
                 item["files"] = list(
                     map(lambda x: map_file(x, item), files.get(item["id"], []))
                 )
+                item["tags"] = tags.get(item["id"], [])
 
                 lft = item.pop("lft")
                 rght = item.pop("rght")

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -801,6 +801,19 @@ class ContentNodeAPITestCase(APITestCase):
         for i in range(len(children)):
             self.assertEqual(response.data[i]["title"], children[i].title)
 
+    def test_contentnode_tags(self):
+        expected = {
+            "root": ["tag_1", "tag_2", "tag_3"],
+            "c1": ["tag_1"],
+            "c2": ["tag_2"],
+        }
+        for title, tags in expected.items():
+            node = content.ContentNode.objects.get(title=title)
+            response = self.client.get(
+                reverse("kolibri:core:contentnode-detail", kwargs={"pk": node.id})
+            )
+            self.assertEqual(set(response.data["tags"]), set(tags))
+
     def test_channelmetadata_list(self):
         response = self.client.get(reverse("kolibri:core:channel-list", kwargs={}))
         self.assertEqual(response.data[0]["name"], "testing")


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

### Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Expose the tags to the frontent through the REST API.

### Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Add some tags to content using Kolibri Studio.
- Update the channel.
- Confirm that tags are passed to the frontend. For instance by adding a `{{ content.tags }}` to the `ContentPage.vue` component in the Learn plugin.

### References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
