### PR TITLE
Make `window.kolibri` object available to Hashi iframe context

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -1,14 +1,6 @@
 <template>
 
   <div>
-    <KContentRenderer
-      class="content-renderer"
-      :kind="content.kind"
-      :lang="content.lang"
-      :files="content.files"
-      :options="content.options"
-      :available="content.available"
-    />
     <div class="header">
 
       <KGrid>
@@ -127,9 +119,6 @@
       },
       getTagline() {
         return this.topicOrChannel['tagline'] || this.topicOrChannel['description'] || null;
-      },
-      content() {
-        return this.topicOrChannel;
       },
       calculateProgress() {
         // calculate progress across all topics

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -1,7 +1,14 @@
 <template>
 
   <div>
-
+    <KContentRenderer
+      class="content-renderer"
+      :kind="content.kind"
+      :lang="content.lang"
+      :files="content.files"
+      :options="content.options"
+      :available="content.available"
+    />
     <div class="header">
 
       <KGrid>
@@ -73,7 +80,6 @@
       :contents="contents"
       :genContentLink="genContentLink"
     />
-
   </div>
 
 </template>
@@ -121,6 +127,9 @@
       },
       getTagline() {
         return this.topicOrChannel['tagline'] || this.topicOrChannel['description'] || null;
+      },
+      content() {
+        return this.topicOrChannel;
       },
       calculateProgress() {
         // calculate progress across all topics

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div>
+
     <div class="header">
 
       <KGrid>
@@ -72,6 +73,7 @@
       :contents="contents"
       :genContentLink="genContentLink"
     />
+
   </div>
 
 </template>

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -6,6 +6,8 @@ export const events = {
   USERDATAUPDATE: 'userdataupdate',
   DATAREQUESTED: 'datarequested',
   DATARETURNED: 'datareturned',
+  NAVIGATETO: 'navigateto',
+  CONTEXT: 'context',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -4,6 +4,8 @@ export const events = {
   IFRAMEREADY: 'iframeready',
   STATEUPDATE: 'stateupdate',
   USERDATAUPDATE: 'userdataupdate',
+  DATAREQUESTED: 'datarequested',
+  DATARETURNED: 'datareturned',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -45,6 +45,7 @@ export default class SandboxEnvironment {
       // initalized the local environment.
       callback: this.createIframe,
     });
+
     // Set up a listener for a ready check event.
     this.mediator.registerMessageHandler({
       nameSpace,

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -3,6 +3,7 @@ import LocalStorage from './localStorage';
 import SessionStorage from './sessionStorage';
 import Cookie from './cookie';
 import SCORM from './SCORM';
+import Kolibri from './kolibri';
 import patchIndexedDB from './patchIndexedDB';
 import { events, nameSpace } from './hashiBase';
 
@@ -24,6 +25,8 @@ export default class SandboxEnvironment {
     this.sessionStorage = new SessionStorage(this.mediator);
 
     this.cookie = new Cookie(this.mediator);
+
+    this.kolibri = new Kolibri(this.mediator);
 
     this.SCORM = new SCORM(this.mediator);
 
@@ -66,6 +69,7 @@ export default class SandboxEnvironment {
         this.localStorage.iframeInitialize(this.iframe.contentWindow);
         this.sessionStorage.iframeInitialize(this.iframe.contentWindow);
         this.cookie.iframeInitialize(this.iframe.contentWindow);
+        this.kolibri.iframeInitialize(this.iframe.contentWindow);
         patchIndexedDB(this.contentNamespace, this.iframe.contentWindow);
       } catch (e) {
         console.log('Shimming storage APIs failed, data will not persist'); // eslint-disable-line no-console

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -45,7 +45,6 @@ export default class SandboxEnvironment {
       // initalized the local environment.
       callback: this.createIframe,
     });
-
     // Set up a listener for a ready check event.
     this.mediator.registerMessageHandler({
       nameSpace,

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -181,6 +181,7 @@ export default class Kolibri extends BaseShim {
       getContext() {
         return self.mediator.sendMessageAwaitReply({
           event: events.CONTEXT,
+          data: {},
           nameSpace,
         });
       }

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -102,6 +102,8 @@ export default class Kolibri extends BaseShim {
 
     // const nameSpace = self.nameSpace;
 
+    // const nameSpace = self.nameSpace;
+
     class Shim {
       /*
        * Method to query contentnodes from Kolibri and return

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -79,14 +79,6 @@ export default class Kolibri extends BaseShim {
     this.data = {};
     this.nameSpace = 'kolibri';
     this.mediator = new Mediator(window.parent);
-    this.__setData = this.__setData.bind(this);
-    this.on(this.events.STATEUPDATE, this.__setData);
-  }
-
-  __setData(data) {
-    if (data) {
-      this.__data = data;
-    }
   }
 
   iframeInitialize(contentWindow) {
@@ -100,13 +92,13 @@ export default class Kolibri extends BaseShim {
   __setShimInterface() {
     const self = this;
 
-    var lang = {
-      id: 'en-gb',
-      lang_code: 'en',
-      lang_subcode: 'gb',
-      lang_name: 'Proper English innit?',
-      lang_direction: 'ltr',
-    };
+    // var lang = {
+    //   id: 'en-gb',
+    //   lang_code: 'en',
+    //   lang_subcode: 'gb',
+    //   lang_name: 'Proper English innit?',
+    //   lang_direction: 'ltr',
+    // };
 
     // const nameSpace = self.nameSpace;
 
@@ -121,47 +113,25 @@ export default class Kolibri extends BaseShim {
        * @param {number} [options.pageSize=50] - the page size for pagination
        * @return {Promise<PageResult>} - a Promise that resolves to an array of ContentNodes
        */
-      getContentByFilter() {
-        return Promise.resolve({
-          page: 1,
-          pageSize: 50,
-          results: [
-            {
-              id: '0afc7cf1be865f4c8f5bc844255a7cef',
-              channel_id: 'a1a62374546e47509b6979a9322e7598',
-              content_id: 'cc5c6829685d439385920f39db9bed65',
-              title: 'Test Node 1',
-              description: 'Just a test',
-              author: 'Me',
-              thumbnail_url:
-                'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIj8+CjwhLS0gR2VuZXJhdGVkIGJ5IFNWR28gLS0+Cjxzdmcgd2lkdGg9IjIyMCIgaGVpZ2h0PSIyMjAiCiAgICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMjI2LDI1NSwyMjIpIiAvPgo8cmVjdCB4PSIzNiIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjEwOCIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTQ0IiB5PSIwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDIyNiwyNTUsMjIyKSIgLz4KPHJlY3QgeD0iMCIgeT0iMzYiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjM2IiB5PSIzNiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxMDgiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxNDQiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIwIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjM2IiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjcyIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMTQ4LDIzMiw1NikiIC8+CjxyZWN0IHg9IjEwOCIgeT0iNzIiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDE0OCwyMzIsNTYpIiAvPgo8cmVjdCB4PSIxNDQiIHk9IjcyIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMTgwIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjAiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMzYiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTA4IiB5PSIxMDgiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjE0NCIgeT0iMTA4IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMCIgeT0iMTQ0IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMzYiIHk9IjE0NCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMjI2LDI1NSwyMjIpIiAvPgo8cmVjdCB4PSI3MiIgeT0iMTQ0IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxMDgiIHk9IjE0NCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTQ0IiB5PSIxNDQiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDIyNiwyNTUsMjIyKSIgLz4KPHJlY3QgeD0iMTgwIiB5PSIxNDQiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDY3LDE5MSwxMzQpIiAvPgo8cmVjdCB4PSIwIiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjM2IiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDY3LDE5MSwxMzQpIiAvPgo8cmVjdCB4PSI3MiIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYigyMjYsMjU1LDIyMikiIC8+CjxyZWN0IHg9IjEwOCIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYigyMjYsMjU1LDIyMikiIC8+CjxyZWN0IHg9IjE0NCIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMTgwIiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+Cjwvc3ZnPgo=',
-              available: true,
-              coach_content: false,
-              lang: lang,
-              license_description: null,
-              license_name: 'CC-BY',
-              license_owner: 'Me',
-              num_coach_contents: 0,
-              parent: '862381f7848346b1bd3fdea86042d1e0',
-              sort_order: 1,
-            },
-          ],
+      getContentByFilter(options) {
+        return self.mediator.sendMessageAwaitReply({
+          event: events.DATAREQUESTED,
+          data: { options },
+          nameSpace,
         });
       }
       /*
-       * Method to query a single contentnodes from Kolibri and return
+       * Method to query a single contentnode from Kolibri and return
        * a metadata object
        * @param {string} id - id of the ContentNode
        * @return {Promise<ContentNode>} - a Promise that resolves to a ContentNode
        */
       getContentById(id) {
-        return self.mediator
-          .sendMessageAwaitReply({
-            event: events.DATAREQUESTED,
-            data: { id },
-            nameSpace,
-          })
-          .then(res => console.log('response', res));
+        return self.mediator.sendMessageAwaitReply({
+          event: events.DATAREQUESTED,
+          data: { id },
+          nameSpace,
+        });
       }
       /*
        * Method to search for contentnodes on Kolibri and return
@@ -195,8 +165,14 @@ export default class Kolibri extends BaseShim {
        * if node_id is missing from the context, it will be automatically filled in by this method
        * @return {Promise} - a Promise that resolves when the navigation has completed
        */
-      navigateTo() {
-        console.log(this.getContentById('0afc7cf1be865f4c8f5bc844255a7cef'));
+      navigateTo(nodeId, context) {
+        return self.mediator
+          .sendMessageAwaitReply({
+            event: events.NAVIGATETO,
+            data: { nodeId, context },
+            nameSpace,
+          })
+          .then(res => console.log(res));
       }
 
       /*
@@ -204,14 +180,25 @@ export default class Kolibri extends BaseShim {
        * @param {NavigationContext} context - context describing the state update
        * @return {Promise} - a Promise that resolves when the context has been updated
        */
-      updateContext() {}
+      updateContext(context) {
+        return self.mediator.sendMessageAwaitReply({
+          event: events.CONTEXT,
+          data: { context },
+          nameSpace,
+        });
+      }
 
       /*
        * Method to request the current context state
        * @return {Promise<NavigationContext>} - a Promise that resolves
        * when the context has been updated
        */
-      getContext() {}
+      getContext() {
+        return self.mediator.sendMessageAwaitReply({
+          event: events.CONTEXT,
+          nameSpace,
+        });
+      }
     }
     this.shim = new Shim();
     return this.shim;

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -3,6 +3,10 @@
  * that the HTML5 app is embedded within
  */
 import BaseShim from './baseShim';
+import Mediator from './mediator';
+import { events, nameSpace } from './hashiBase';
+// import BaseStorage from './baseStorage';
+
 // import KolibriData from './kolibriData';
 
 /**
@@ -74,21 +78,27 @@ export default class Kolibri extends BaseShim {
     super(mediator);
     this.data = {};
     this.nameSpace = 'kolibri';
-    // this.__setData = this.__setData.bind(this);
-    // this.on(this.events.STATEUPDATE, this.__setData);
+    this.mediator = new Mediator(window.parent);
+    this.__setData = this.__setData.bind(this);
+    this.on(this.events.STATEUPDATE, this.__setData);
+  }
+
+  __setData(data) {
+    if (data) {
+      this.__data = data;
+    }
   }
 
   iframeInitialize(contentWindow) {
     this.__setShimInterface();
     Object.defineProperty(contentWindow, this.nameSpace, {
       value: this.shim,
-      writable: true,
+      configurable: true,
     });
-    console.log(contentWindow.kolibri.getContentByFilter());
   }
 
   __setShimInterface() {
-    // const self = this;
+    const self = this;
 
     var lang = {
       id: 'en-gb',
@@ -97,6 +107,8 @@ export default class Kolibri extends BaseShim {
       lang_name: 'Proper English innit?',
       lang_direction: 'ltr',
     };
+
+    // const nameSpace = self.nameSpace;
 
     class Shim {
       /*
@@ -115,7 +127,7 @@ export default class Kolibri extends BaseShim {
           pageSize: 50,
           results: [
             {
-              id: '3fe4c0d834c54646889854bfc2d41c30',
+              id: '0afc7cf1be865f4c8f5bc844255a7cef',
               channel_id: 'a1a62374546e47509b6979a9322e7598',
               content_id: 'cc5c6829685d439385920f39db9bed65',
               title: 'Test Node 1',
@@ -142,7 +154,15 @@ export default class Kolibri extends BaseShim {
        * @param {string} id - id of the ContentNode
        * @return {Promise<ContentNode>} - a Promise that resolves to a ContentNode
        */
-      getContentById() {}
+      getContentById(id) {
+        return self.mediator
+          .sendMessageAwaitReply({
+            event: events.DATAREQUESTED,
+            data: { id },
+            nameSpace,
+          })
+          .then(res => console.log('response', res));
+      }
       /*
        * Method to search for contentnodes on Kolibri and return
        * an array of matching metadata
@@ -176,7 +196,7 @@ export default class Kolibri extends BaseShim {
        * @return {Promise} - a Promise that resolves when the navigation has completed
        */
       navigateTo() {
-        window.alert('Navigating to node_id');
+        console.log(this.getContentById('0afc7cf1be865f4c8f5bc844255a7cef'));
       }
 
       /*

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -1,0 +1,199 @@
+/**
+ * This class offers an API interface for interacting directly with the Kolibri app
+ * that the HTML5 app is embedded within
+ */
+import BaseShim from './baseShim';
+// import KolibriData from './kolibriData';
+
+/**
+ * Type definition for Language metadata
+ * @typedef {Object} Language
+ * @property {string} id - an IETF language tag
+ * @property {string} lang_code - the ISO 639‑1 language code
+ * @property {string} lang_subcode - the regional identifier
+ * @property {string} lang_name - the name of the language in that language
+ * @property {('ltr'|'rtl'|)} lang_direction - Direction of the language's script,
+ * top to bottom is not supported currently
+ */
+
+/**
+ * Type definition for ContentNode metadata
+ * @typedef {Object} ContentNode
+ * @property {string} id - unique id of the ContentNode
+ * @property {string} channel_id - unique channel_id of the channel that the ContentNode is in
+ * @property {string} content_id - identifier that is common across all instances of this resource
+ * @property {string} title - A title that summarizes this ContentNode for the user
+ * @property {string} description - detailed description of the ContentNode
+ * @property {string} author - author of the ContentNode
+ * @property {string} thumbnail_url - URL for the thumbnail for this ContentNode,
+ * this may be any valid URL format including base64 encoded or blob URL
+ * @property {boolean} available - Whether the ContentNode has all necessary files for rendering
+ * @property {boolean} coach_content - Whether the ContentNode is intended only for coach users
+ * @property {Language} lang - The primary language of the ContentNode
+ * @property {string} license_description - The description of the license, which may be localized
+ * @property {string} license_name - The human readable name of the license, localized
+ * @property {string} license_owner - The name of the person or organization that holds copyright
+ * @property {number} num_coach_contents - Number of coach contents that are descendants of this
+ * @property {string} parent - The unique id of the parent of this ContentNode
+ * @property {number} sort_order - The order of display for this node in its channel
+ * if depth recursion was not deep enough
+ */
+
+/**
+ * Type definition for pagination object
+ * @typedef {Object} PageResult
+ * @property {number} page - the page that this pagination object represents
+ * @property {number} pageSize - the page size for this pagination object
+ * @property {ContentNode[]} results - the array of ContentNodes for this page
+ */
+
+/**
+ * Type definition for Theme options
+ * properties TBD
+ * @typedef {Object} Theme
+ */
+
+// function encodeContext(context) {
+//   return encodeURI(Object.entries(context).map(([k, v]) => `${k}:${v}`));
+// }
+
+/**
+ * Type definition for NavigationContext
+ * This can have arbitrary properties as defined
+ * by the navigating app that it uses to resume its state
+ * Should be able to be encoded down to <1600 characters using
+ * an encoding function something like 'encode context' above
+ * @typedef {Object} NavigationContext
+ * @property {string} node_id - The current node_id that is being displayed,
+ * custom apps should handle this as it may be used to
+ * generate links externally to jump to this state
+ */
+
+export default class Kolibri extends BaseShim {
+  constructor(mediator) {
+    super(mediator);
+    this.data = {};
+    this.nameSpace = 'kolibri';
+    // this.__setData = this.__setData.bind(this);
+    // this.on(this.events.STATEUPDATE, this.__setData);
+  }
+
+  iframeInitialize(contentWindow) {
+    this.__setShimInterface();
+    Object.defineProperty(contentWindow, this.nameSpace, {
+      value: this.shim,
+      writable: true,
+    });
+    console.log(contentWindow.kolibri.getContentByFilter());
+  }
+
+  __setShimInterface() {
+    // const self = this;
+
+    var lang = {
+      id: 'en-gb',
+      lang_code: 'en',
+      lang_subcode: 'gb',
+      lang_name: 'Proper English innit?',
+      lang_direction: 'ltr',
+    };
+
+    class Shim {
+      /*
+       * Method to query contentnodes from Kolibri and return
+       * an array of matching metadata
+       * @param {Object} options - The different options to filter by
+       * @param {string=} options.parent - id of the parent node to filter by, or 'self'
+       * @param {string[]} options.ids - an array of ids to filter by
+       * @param {number} [options.page=1] - which page to return from the result set
+       * @param {number} [options.pageSize=50] - the page size for pagination
+       * @return {Promise<PageResult>} - a Promise that resolves to an array of ContentNodes
+       */
+      getContentByFilter() {
+        return Promise.resolve({
+          page: 1,
+          pageSize: 50,
+          results: [
+            {
+              id: '3fe4c0d834c54646889854bfc2d41c30',
+              channel_id: 'a1a62374546e47509b6979a9322e7598',
+              content_id: 'cc5c6829685d439385920f39db9bed65',
+              title: 'Test Node 1',
+              description: 'Just a test',
+              author: 'Me',
+              thumbnail_url:
+                'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIj8+CjwhLS0gR2VuZXJhdGVkIGJ5IFNWR28gLS0+Cjxzdmcgd2lkdGg9IjIyMCIgaGVpZ2h0PSIyMjAiCiAgICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICAgIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMjI2LDI1NSwyMjIpIiAvPgo8cmVjdCB4PSIzNiIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjEwOCIgeT0iMCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTQ0IiB5PSIwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDIyNiwyNTUsMjIyKSIgLz4KPHJlY3QgeD0iMCIgeT0iMzYiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjM2IiB5PSIzNiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxMDgiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxNDQiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjM2IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIwIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjM2IiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjcyIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMTQ4LDIzMiw1NikiIC8+CjxyZWN0IHg9IjEwOCIgeT0iNzIiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDE0OCwyMzIsNTYpIiAvPgo8cmVjdCB4PSIxNDQiIHk9IjcyIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMTgwIiB5PSI3MiIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoNjcsMTkxLDEzNCkiIC8+CjxyZWN0IHg9IjAiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMzYiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iNzIiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTA4IiB5PSIxMDgiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjE0NCIgeT0iMTA4IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxODAiIHk9IjEwOCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMCIgeT0iMTQ0IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMzYiIHk9IjE0NCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoMjI2LDI1NSwyMjIpIiAvPgo8cmVjdCB4PSI3MiIgeT0iMTQ0IiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig5MywyMTQsNzUpIiAvPgo8cmVjdCB4PSIxMDgiIHk9IjE0NCIgd2lkdGg9IjM2IiBoZWlnaHQ9IjM2IiBzdHlsZT0iZmlsbDpyZ2IoOTMsMjE0LDc1KSIgLz4KPHJlY3QgeD0iMTQ0IiB5PSIxNDQiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDIyNiwyNTUsMjIyKSIgLz4KPHJlY3QgeD0iMTgwIiB5PSIxNDQiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDY3LDE5MSwxMzQpIiAvPgo8cmVjdCB4PSIwIiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+CjxyZWN0IHg9IjM2IiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDY3LDE5MSwxMzQpIiAvPgo8cmVjdCB4PSI3MiIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYigyMjYsMjU1LDIyMikiIC8+CjxyZWN0IHg9IjEwOCIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYigyMjYsMjU1LDIyMikiIC8+CjxyZWN0IHg9IjE0NCIgeT0iMTgwIiB3aWR0aD0iMzYiIGhlaWdodD0iMzYiIHN0eWxlPSJmaWxsOnJnYig2NywxOTEsMTM0KSIgLz4KPHJlY3QgeD0iMTgwIiB5PSIxODAiIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiIgc3R5bGU9ImZpbGw6cmdiKDkzLDIxNCw3NSkiIC8+Cjwvc3ZnPgo=',
+              available: true,
+              coach_content: false,
+              lang: lang,
+              license_description: null,
+              license_name: 'CC-BY',
+              license_owner: 'Me',
+              num_coach_contents: 0,
+              parent: '862381f7848346b1bd3fdea86042d1e0',
+              sort_order: 1,
+            },
+          ],
+        });
+      }
+      /*
+       * Method to query a single contentnodes from Kolibri and return
+       * a metadata object
+       * @param {string} id - id of the ContentNode
+       * @return {Promise<ContentNode>} - a Promise that resolves to a ContentNode
+       */
+      getContentById() {}
+      /*
+       * Method to search for contentnodes on Kolibri and return
+       * an array of matching metadata
+       * @param {Object} options - The different options to search by
+       * @param {string=} options.keyword - search term for key word search
+       * @param {string=} options.under - id of topic to search under, or 'self'
+       * @param {number} [options.page=1] - which page to return from the result set
+       * @param {number} [options.pageSize=50] - the page size for pagination
+       * @return {Promise<PageResult>} - a Promise that resolves to an array of ContentNodes
+       */
+      searchContent() {}
+
+      /*
+       * Method to set a default theme for any content rendering initiated by this app
+       * @param {Theme} options - The different options for custom themeing
+       * @return {Promise} - a Promise that resolves when the theme has been applied
+       */
+      themeRenderer() {}
+
+      /*
+       * Method to allow navigation to or rendering of a specific node
+       * has optional parameter context that can update the URL for a custom context.
+       * When this is called for a resource node in the custom navigation context
+       * this will launch a renderer overlay to maintain the current state, and update the
+       * query parameters for the URL of the custom context to indicate the change
+       * If called for a topic in a custom context or outside of a custom context
+       * this will simply prompt navigation to that node in Kolibri.
+       * @param {string} nodeId - id of the parent node to navigate to
+       * @param {NavigationContext=} context - optional context describing the state update
+       * if node_id is missing from the context, it will be automatically filled in by this method
+       * @return {Promise} - a Promise that resolves when the navigation has completed
+       */
+      navigateTo() {
+        window.alert('Navigating to node_id');
+      }
+
+      /*
+       * Method to allow updating of stored state in the URL
+       * @param {NavigationContext} context - context describing the state update
+       * @return {Promise} - a Promise that resolves when the context has been updated
+       */
+      updateContext() {}
+
+      /*
+       * Method to request the current context state
+       * @return {Promise<NavigationContext>} - a Promise that resolves
+       * when the context has been updated
+       */
+      getContext() {}
+    }
+    this.shim = new Shim();
+    return this.shim;
+  }
+}

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -74,7 +74,6 @@ export default class Kolibri extends BaseShim {
     super(mediator);
     this.data = {};
     this.nameSpace = 'kolibri';
-    // const hashi = new Hashi();
     this.mediator = new Mediator(window.parent);
   }
 
@@ -97,8 +96,7 @@ export default class Kolibri extends BaseShim {
     const options = message.options;
     const getParams = pick(options, ['ids', 'page', 'pageSize', 'parent']);
     if (options.parent && options.parent == 'self') {
-      // there must be a better way to do this...
-      getParams.parent = window.location.hash.split('/').pop();
+      // to be refactored and handled in dependency injection
     }
     ContentNodeResource.fetchCollection({ getParams }).then(contentNodes => {
       contentNodes ? (message.status = 'success') : (message.status = 'failure');
@@ -145,7 +143,7 @@ export default class Kolibri extends BaseShim {
       } else if (contentNode && !message.context) {
         routeBase = '/topics/c';
         router.push({ path: path }).catch(() => {});
-      } else if (!message.context) {
+      } else if (contentNode && message.context) {
         // if there is custom context, launch overlay
         message.context.node_id = id;
         routeBase = '/topics/c';

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -3,6 +3,7 @@ import LocalStorage from './localStorage';
 import Cookie from './cookie';
 import SCORM from './SCORM';
 import { events, nameSpace } from './hashiBase';
+import Kolibri from './kolibri';
 
 /*
  * This is the main entry point for interacting with the Hashi library.
@@ -22,6 +23,7 @@ export default class MainClient {
       cookie: new Cookie(this.mediator),
       SCORM: new SCORM(this.mediator),
     };
+    this.kolibri = new Kolibri(this.mediator);
     this.now = now;
     this.ready = false;
     this.contentNamespace = null;

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -1,3 +1,5 @@
+import { ContentNodeResource } from 'kolibri.resources';
+import router from 'kolibri.coreVue.router';
 import Mediator from './mediator';
 import LocalStorage from './localStorage';
 import Cookie from './cookie';
@@ -29,6 +31,14 @@ export default class MainClient {
     this.contentNamespace = null;
     this.startUrl = null;
     this.__setData = this.__setData.bind(this);
+
+    // this.mediator.registerMessageHandler({
+    //   nameSpace,
+    //   event: events.GETCONTENT,
+    //   callback: () => {
+    //     // this.mediator.sendMessage({ nameSpace, event: events.REQUESTINGDATA, data: true });
+    //   },
+    // });
   }
   initialize(contentState, userData, startUrl, contentNamespace) {
     /*
@@ -61,6 +71,27 @@ export default class MainClient {
       });
     });
     this.mediator.sendMessage({ nameSpace, event: events.READYCHECK, data: true });
+
+    this.on(this.events.DATAREQUESTED, message => {
+      let id = message.id;
+      let status;
+      ContentNodeResource.fetchModel({ id }).then(contentNode => {
+        if (contentNode) {
+          status = 'success';
+        } else {
+          status = 'failure';
+        }
+        message.status = status;
+        message.data = contentNode;
+        message.type = 'response';
+        this.mediator.sendMessage({
+          nameSpace,
+          event: events.DATARETURNED,
+          data: message,
+        });
+        router.push({ query: { context: 'newContext' } }).catch(() => {});
+      });
+    });
   }
 
   updateData({ contentState, userData }) {

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -1,4 +1,3 @@
-// import router from 'kolibri.coreVue.router';
 import Mediator from './mediator';
 import LocalStorage from './localStorage';
 import Cookie from './cookie';
@@ -63,11 +62,12 @@ export default class MainClient {
     });
     this.mediator.sendMessage({ nameSpace, event: events.READYCHECK, data: true });
 
+    // This group of functions and events is for the custom channels work
+    // They each fetch data from the kolibri database and return it to
+    // the iframe
     this.on(this.events.DATAREQUESTED, message => {
-      // console.log('data requested');
       if (message.dataType === 'Collection') {
         this.__fetchContentCollection = this.kolibri.__fetchContentCollection;
-        // console.log(this);
         this.__fetchContentCollection(message);
       } else if (message.dataType === 'Model') {
         this.__fetchContentModel = this.kolibri.__fetchContentModel;
@@ -128,10 +128,6 @@ export default class MainClient {
         this.mediator.sendLocalMessage({ nameSpace, event: events.STATEUPDATE, data: this.data });
       });
     });
-  }
-
-  __setDependencies() {
-    console.log(this.hashi);
   }
 
   get data() {

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -79,15 +79,11 @@ class Mediator {
         event: 'datareturned',
         callback: handler,
       });
-      // window.addEventListener('datareturn', this.handler);
       data.message_id = msgId;
       this.sendMessage({ event, data, nameSpace });
     });
   }
 
-  helloworld() {
-    console.log('in the new hello world');
-  }
   registerMessageHandler({ event, nameSpace, callback } = {}) {
     if (
       typeof callback !== 'function' ||

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -59,6 +59,11 @@ class Mediator {
       const msgId = uuidv4();
       function handler(message) {
         if (message.message_id === msgId && message.type === 'response') {
+          this.removeMessageHandler({
+            nameSpace,
+            event: 'datareturned',
+            callback: handler,
+          });
           if (message.status === 'success') {
             console.log(message.data);
             return resolve(message.data);
@@ -68,11 +73,6 @@ class Mediator {
           // Otherwise something unspecified happened
           return reject();
         }
-        this.removeMessageHandler({
-          nameSpace,
-          event: 'datareturned',
-          callback: handler,
-        });
       }
       this.registerMessageHandler({
         nameSpace,

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -55,7 +55,6 @@ class Mediator {
   // a function to manage messages for kolibri.js,
   // when most messages require a response, to minimize redundancy
   sendMessageAwaitReply({ event, data, nameSpace }) {
-    console.log('incoming data', { event, data, nameSpace });
     return new Promise((resolve, reject) => {
       const msgId = uuidv4();
       function handler(message) {

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -1,3 +1,5 @@
+import uuidv4 from 'uuid/v4';
+
 /*
  * This class manages all message listening and sending from the postMessage
  * layer. All interfaces that need to message via the postMessage layer should
@@ -50,6 +52,38 @@ class Mediator {
     this.remote.postMessage(message, '*');
   }
 
+  // a function to manage messages for kolibri.js,
+  // when most messages require a response, to minimize redundancy
+  sendMessageAwaitReply({ event, data, nameSpace }) {
+    console.log('incoming data', { event, data, nameSpace });
+    return new Promise((resolve, reject) => {
+      const msgId = uuidv4();
+      function handler(message) {
+        if (message.message_id === msgId && message.type === 'response') {
+          if (message.status === 'success') {
+            console.log(message.data);
+            return resolve(message.data);
+          } else if (message.status === 'failure' && message.err) {
+            return reject(message.err);
+          }
+          // Otherwise something unspecified happened
+          return reject();
+        }
+      }
+      this.registerMessageHandler({
+        nameSpace,
+        event: 'datareturned',
+        callback: handler,
+      });
+      // window.addEventListener('datareturn', this.handler);
+      data.message_id = msgId;
+      this.sendMessage({ event, data, nameSpace });
+    });
+  }
+
+  helloworld() {
+    console.log('in the new hello world');
+  }
   registerMessageHandler({ event, nameSpace, callback } = {}) {
     if (
       typeof callback !== 'function' ||

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -68,6 +68,11 @@ class Mediator {
           // Otherwise something unspecified happened
           return reject();
         }
+        this.removeMessageHandler({
+          nameSpace,
+          event: 'datareturned',
+          callback: handler,
+        });
       }
       this.registerMessageHandler({
         nameSpace,

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -5,7 +5,7 @@ import Kolibri from '../src/kolibri';
 describe('the kolibri hashi shim', () => {
   let kolibri;
   let mediator;
-
+  let response;
   beforeEach(() => {
     mediator = new Mediator(window);
     kolibri = new Kolibri(mediator);
@@ -25,41 +25,35 @@ describe('the kolibri hashi shim', () => {
   });
 
   describe('getContentById method', () => {
-    let response, client;
     beforeEach(function() {
-      response = { data: [{ testing: 'testing' }] };
-      client = jest.fn().mockResolvedValue(response);
-      kolibri.shim.client = client;
+      response = { node: { id: 'abc123' } };
+      kolibri.shim.getContentById = jest.fn().mockResolvedValue(response);
     });
     it('should be called once', () => {
       kolibri.shim.getContentById().then(() => {
-        expect(client).toHaveBeenCalledTimes(1);
+        expect(kolibri.shim.getContentById).toHaveBeenCalledTimes(1);
       });
     });
     it('should return a promise that resolves to a ContentNode object', () => {
-      expect(kolibri.shim.getContentById()).toBeInstanceOf(Promise);
-      kolibri.shim.getContentById().then(() => {
-        expect(client).toBeInstanceOf(Object);
+      return kolibri.shim.getContentById().then(data => {
+        expect(data).toEqual(response);
       });
     });
   });
 
   describe('getContentByFilter method', () => {
-    let response, client;
     beforeEach(function() {
       response = [{ 1: [{ node: 'abc' }] }, { 2: [{ node: '123' }] }];
-      client = jest.fn().mockResolvedValue(response);
-      kolibri.shim.client = client;
+      kolibri.shim.getContentByFilter = jest.fn().mockResolvedValue(response);
     });
     it('should be called once', () => {
       kolibri.shim.getContentByFilter().then(() => {
-        expect(client).toHaveBeenCalledTimes(1);
+        expect(kolibri.shim.getContentByFilter).toHaveBeenCalledTimes(1);
       });
     });
     it('should return a promise that resolves to an array of metadata objects', () => {
-      expect(kolibri.shim.getContentByFilter()).toBeInstanceOf(Promise);
-      kolibri.shim.getContentByFilter().then(() => {
-        expect(client).toBeInstanceOf(Array);
+      return kolibri.shim.getContentByFilter().then(data => {
+        expect(data).toEqual(response);
       });
     });
   });
@@ -77,21 +71,18 @@ describe('the kolibri hashi shim', () => {
   });
 
   describe('getContext method', () => {
-    let response, client;
     beforeEach(function() {
       response = { node_id: 'abc', context: { test: 'test' } };
-      client = jest.fn().mockResolvedValue(response);
-      kolibri.shim.client = client;
+      kolibri.shim.getContext = jest.fn().mockResolvedValue(response);
     });
     it('should be called once', () => {
       kolibri.shim.getContext().then(() => {
-        expect(client).toHaveBeenCalledTimes(1);
+        expect(kolibri.shim.getContext).toHaveBeenCalledTimes(1);
       });
     });
     it('should return a promise that resolves to a context Object', () => {
-      expect(kolibri.shim.getContext()).toBeInstanceOf(Promise);
-      kolibri.shim.getContext().then(() => {
-        expect(client).toBeInstanceOf(Object);
+      kolibri.shim.getContext().then(data => {
+        expect(data).toEqual(response);
       });
     });
   });

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -1,0 +1,72 @@
+// import flatMap from 'lodash/flatMap';
+import Mediator from '../src/mediator';
+import Kolibri from '../src/kolibri';
+
+describe('the kolibri hashi shim', () => {
+  let kolibri;
+  let mediator;
+
+  beforeEach(() => {
+    mediator = new Mediator(window);
+    kolibri = new Kolibri(mediator);
+    kolibri.__setShimInterface();
+  });
+  describe('__setShimInterface method', () => {
+    it('should set kolibri shim property', () => {
+      expect(kolibri.shim).not.toBeUndefined();
+    });
+  });
+  describe('iframeInitialize method', () => {
+    it('should set a "kolibri" property on object', () => {
+      const obj = {};
+      kolibri.iframeInitialize(obj);
+      expect(obj.kolibri).toEqual(kolibri.shim);
+    });
+  });
+
+  describe('getContentById method', () => {
+    let response, client;
+    beforeEach(function() {
+      response = { data: [{ testing: 'testing' }] };
+      client = jest.fn().mockResolvedValue(response);
+      kolibri.shim.client = client;
+    });
+    it('should be called once', () => {
+      kolibri.shim.getContentById().then(() => {
+        expect(client).toHaveBeenCalledTimes(1);
+      });
+    });
+    it('should return a promise that resolves to a ContentNode object', () => {
+      expect(kolibri.shim.getContentById()).toBeInstanceOf(Promise);
+      kolibri.shim.getContentById().then(() => {
+        expect(client).toBeInstanceOf(Object);
+      });
+    });
+  });
+
+  describe('getContentByFilter method', () => {
+    let response, client;
+    beforeEach(function() {
+      response = [{ 1: [{ node: 'abc' }] }, { 2: [{ node: '123' }] }];
+      client = jest.fn().mockResolvedValue(response);
+      kolibri.shim.client = client;
+    });
+    it('should be called once', () => {
+      kolibri.shim.getContentByFilter().then(() => {
+        expect(client).toHaveBeenCalledTimes(1);
+      });
+    });
+    it('should return a promise that resolves to aan array of metadata objects', () => {
+      expect(kolibri.shim.getContentByFilter()).toBeInstanceOf(Promise);
+      kolibri.shim.getContentByFilter().then(() => {
+        expect(client).toBeInstanceOf(Array);
+      });
+    });
+  });
+
+  describe('navigateTo method', () => {
+    it('should return a promise', () => {
+      expect(kolibri.shim.navigateTo()).toBeInstanceOf(Promise);
+    });
+  });
+});

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -56,7 +56,7 @@ describe('the kolibri hashi shim', () => {
         expect(client).toHaveBeenCalledTimes(1);
       });
     });
-    it('should return a promise that resolves to aan array of metadata objects', () => {
+    it('should return a promise that resolves to an array of metadata objects', () => {
       expect(kolibri.shim.getContentByFilter()).toBeInstanceOf(Promise);
       kolibri.shim.getContentByFilter().then(() => {
         expect(client).toBeInstanceOf(Array);
@@ -67,6 +67,32 @@ describe('the kolibri hashi shim', () => {
   describe('navigateTo method', () => {
     it('should return a promise', () => {
       expect(kolibri.shim.navigateTo()).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe('updateContext method', () => {
+    it('should return a promise', () => {
+      expect(kolibri.shim.updateContext()).toBeInstanceOf(Promise);
+    });
+  });
+
+  describe('getContext method', () => {
+    let response, client;
+    beforeEach(function() {
+      response = { node_id: 'abc', context: { test: 'test' } };
+      client = jest.fn().mockResolvedValue(response);
+      kolibri.shim.client = client;
+    });
+    it('should be called once', () => {
+      kolibri.shim.getContext().then(() => {
+        expect(client).toHaveBeenCalledTimes(1);
+      });
+    });
+    it('should return a promise that resolves to a context Object', () => {
+      expect(kolibri.shim.getContext()).toBeInstanceOf(Promise);
+      kolibri.shim.getContext().then(() => {
+        expect(client).toBeInstanceOf(Object);
+      });
     });
   });
 });

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -3,9 +3,7 @@ import Mediator from '../src/mediator';
 import Kolibri from '../src/kolibri';
 
 describe('the kolibri hashi shim', () => {
-  let kolibri;
-  let mediator;
-  let response;
+  let kolibri, mediator;
   beforeEach(() => {
     mediator = new Mediator(window);
     kolibri = new Kolibri(mediator);
@@ -24,35 +22,80 @@ describe('the kolibri hashi shim', () => {
     });
   });
 
+  // methods
+  let response, id, mockMessage, mockMediatorPromise;
+
   describe('getContentById method', () => {
+    id = 'abc123';
+    mockMessage = {
+      data: { dataType: 'Model', id: 'abc123' },
+      event: 'datarequested',
+      nameSpace: 'hashi',
+    };
+    response = { node: { id: 'abc123' } };
     beforeEach(function() {
-      response = { node: { id: 'abc123' } };
-      kolibri.shim.getContentById = jest.fn().mockResolvedValue(response);
+      mockMediatorPromise = jest
+        .spyOn(kolibri.mediator, 'sendMessageAwaitReply')
+        .mockResolvedValue(response);
     });
     it('should be called once', () => {
-      kolibri.shim.getContentById().then(() => {
-        expect(kolibri.shim.getContentById).toHaveBeenCalledTimes(1);
-      });
+      kolibri.shim.getContentById(id);
+      expect(mockMediatorPromise).toHaveBeenCalled();
+    });
+    it('should be called with the correct event, data, and namespace', () => {
+      kolibri.shim.getContentById(id);
+      expect(mockMediatorPromise).toHaveBeenCalledWith(mockMessage);
     });
     it('should return a promise that resolves to a ContentNode object', () => {
-      return kolibri.shim.getContentById().then(data => {
+      return kolibri.shim.getContentById(id).then(data => {
         expect(data).toEqual(response);
       });
     });
   });
 
   describe('getContentByFilter method', () => {
+    let options = { page: 1, pageSize: 50, parent: 'self' };
+    response = { page: 1, pageSize: 50, results: [{ id: 'abc123' }, { id: 'def456' }] };
     beforeEach(function() {
-      response = [{ 1: [{ node: 'abc' }] }, { 2: [{ node: '123' }] }];
-      kolibri.shim.getContentByFilter = jest.fn().mockResolvedValue(response);
+      mockMessage = {
+        data: { dataType: 'Collection', options: options },
+        event: 'datarequested',
+        nameSpace: 'hashi',
+      };
+      mockMediatorPromise = jest
+        .spyOn(kolibri.mediator, 'sendMessageAwaitReply')
+        .mockResolvedValue(response);
     });
     it('should be called once', () => {
-      kolibri.shim.getContentByFilter().then(() => {
-        expect(kolibri.shim.getContentByFilter).toHaveBeenCalledTimes(1);
+      kolibri.shim.getContentByFilter(options);
+      expect(mockMediatorPromise).toHaveBeenCalled();
+    });
+    it('should be called with the correct event, data, and namespace', () => {
+      kolibri.shim.getContentByFilter(options);
+      expect(mockMediatorPromise).toHaveBeenCalledWith(mockMessage);
+    });
+    it('should return a promise that resolves to pagination object that contains an array of metadata objects', () => {
+      return kolibri.shim.getContentByFilter().then(data => {
+        expect(data).toEqual(response);
       });
     });
-    it('should return a promise that resolves to an array of metadata objects', () => {
-      return kolibri.shim.getContentByFilter().then(data => {
+  });
+
+  describe('getContentById method', () => {
+    response = { node: { id: 'abc123' } };
+    id = 'abc123';
+    beforeEach(function() {
+      mockMessage = {
+        data: { dataType: 'Model', id: 'abc123' },
+        event: 'datarequested',
+        nameSpace: 'hashi',
+      };
+      mockMediatorPromise = jest
+        .spyOn(kolibri.mediator, 'sendMessageAwaitReply')
+        .mockResolvedValue(response);
+    });
+    it('should return a promise that resolves to a ContentNode object', () => {
+      return kolibri.shim.getContentById(id).then(data => {
         expect(data).toEqual(response);
       });
     });
@@ -71,17 +114,27 @@ describe('the kolibri hashi shim', () => {
   });
 
   describe('getContext method', () => {
+    response = { node_id: 'abc', context: { test: 'test' } };
     beforeEach(function() {
-      response = { node_id: 'abc', context: { test: 'test' } };
-      kolibri.shim.getContext = jest.fn().mockResolvedValue(response);
+      mockMessage = {
+        data: {},
+        event: 'context',
+        nameSpace: 'hashi',
+      };
+      mockMediatorPromise = jest
+        .spyOn(kolibri.mediator, 'sendMessageAwaitReply')
+        .mockResolvedValue(response);
     });
     it('should be called once', () => {
-      kolibri.shim.getContext().then(() => {
-        expect(kolibri.shim.getContext).toHaveBeenCalledTimes(1);
-      });
+      kolibri.shim.getContext();
+      expect(mockMediatorPromise).toHaveBeenCalled();
     });
-    it('should return a promise that resolves to a context Object', () => {
-      kolibri.shim.getContext().then(data => {
+    it('should be called with the correct event, data, and namespace', () => {
+      kolibri.shim.getContext();
+      expect(mockMediatorPromise).toHaveBeenCalledWith(mockMessage);
+    });
+    it('should return a promise that resolves to pagination object that contains an array of metadata objects', () => {
+      return kolibri.shim.getContext().then(data => {
         expect(data).toEqual(response);
       });
     });


### PR DESCRIPTION
This is very much a draft/WIP PR that is working to establish the foundation for a kolibri object and the core MVP functions. 

Some functions are fully working, some are WIP with elements of pseudo code, as I need a more well-thought-out strategy for doing manual QA in some places. The new data-fetching code in `mainClient.js` should most likely be relocated to another file - maybe a `handlers.js`, or within the custom channels vue file which is not yet finished (TBD). 

I am also not sure if `__navigateTo()` is doing _enough_, and if it's not, what exactly needs to be adjusted/added.