### PR TITLE
Attempt to restore the build

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -103,6 +103,7 @@ def run_pip_install(
             "--cache-dir",
             cache_path,
             "--only-binary=:all:",
+            "--no-deps",
             "{}=={}".format(name, pk_version),
         ]
     )
@@ -274,7 +275,8 @@ def parse_requirements(args):
                 parse_pypi_and_piwheels(
                     char_list[0].strip(), char_list[1].strip(), cache_path
                 )
-            else:
+            # Ignore comments
+            elif not line.startswith("#"):
                 sys.exit(
                     "\nName format in cext.txt is incorrect. Should be 'packageName==packageVersion'.\n"
                 )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,3 +34,4 @@ ifcfg==0.21
 Click==7.0
 ua-parser==0.10.0
 whitenoise==4.1.4
+idna==2.8

--- a/requirements/cext.txt
+++ b/requirements/cext.txt
@@ -1,1 +1,8 @@
+# If libraries in here have dependencies
+# they must be explicitly listed in here if
+# they have architecture requirements, or
+# in other files toe ensure they are properly
+# installed - as these dependencies are installed
+# without their dependencies.
 cryptography==2.3
+cffi==1.14.4

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -2,3 +2,4 @@
 # ones that don't need to be shipped in one version per
 # arch/OS/pyVesion
 pyOpenSSL==18.0.0
+asn1crypto==1.4.0

--- a/test/test_cext.py
+++ b/test/test_cext.py
@@ -11,11 +11,31 @@ def test_cryptography_path():
         import cryptography
 
         # If this is 'n' and we can import cryptography, there is a problem
-        assert os.environ.get("TOX_ENV") != "nocext"
-        if os.environ.get("TOX_ENV") == "cext":
+        assert os.environ.get("GITHUB_JOB") != "nocext"
+        if os.environ.get("GITHUB_JOB") == "cext":
             assert "dist/cext" in cryptography.__file__
     except ImportError:
-        # This variable is defined in .travis.yml and the intention is to fail
+        # This variable is defined by Github Actions and the intention is to fail
         # loudly when were unsuccessful when importing cryptography
-        if os.environ.get("TOX_ENV") == "cext":
-            raise AssertionError("Expected c extesions")
+        if os.environ.get("GITHUB_JOB") == "cext":
+            raise AssertionError("Expected c extensions")
+
+
+def test_cryptography_runs():
+    """
+    Checks that an imported version of cryptography is actually from the
+    dist/cext folder. We can allow other versions, but for now, we want tests
+    to fail until we identify the right way to do this.
+    """
+    if os.environ.get("GITHUB_JOB") == "cext":
+        try:
+            from cryptography.hazmat.primitives.asymmetric import rsa
+            from cryptography.hazmat.backends import default_backend
+
+            crypto_backend = default_backend()
+            rsa.generate_private_key(
+                public_exponent=65537, key_size=2048, backend=crypto_backend
+            )
+
+        except Exception:
+            raise AssertionError("Cryptography could not run.")


### PR DESCRIPTION
### Summary
* Install c extensions with no dependencies to prevent conflicts.
* Explicitly list dependencies in either cext, cext_noarch, or base.

…

### Reviewer guidance
Does it build? Do cext tests pass?

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
