### PR TITLE
Open CSV file with utf-8 encoding in Py3.

### DIFF
--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -154,7 +154,7 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
     if sys.version_info[0] < 3:
         csv_file = io.open(filepath, "wb")
     else:
-        csv_file = io.open(filepath, "w", newline="")
+        csv_file = io.open(filepath, "w", newline="", encoding="utf-8")
 
     with csv_file as f:
         writer = csv.DictWriter(f, header_labels)


### PR DESCRIPTION
### Summary
* We do not open files CSV files for writing with unicode encoding on Python 3
* This causes writing unicode to CSV files fail on Windows
* This fixes that.

### Reviewer Guidance
* Install on Windows
* Create user with unicode username and full name
* Login with user, interact with some content
* Log back in as admin or super admin and attempt to export session logs
* Verify that session logs export

### References
Cherry-picked commit from https://github.com/learningequality/kolibri/pull/7899/commits/c088d08b3e6c4a0f4194a17062457cbd7ae34816 that is part of https://github.com/learningequality/kolibri/pull/7899 that has the full test and fix for this as well as Windows tests.

Fixes #7946

----

### Contributor Checklist


PR process:

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
