### PR TITLE
Stop installing dev dependencies during build.

### DIFF
--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -34,7 +34,6 @@ WORKDIR /kolibri
 # Python dependencies
 COPY requirements/ requirements/
 RUN echo '--- Installing Python dependencies' && \
-    pip install -r requirements/dev.txt && \
     pip install -r requirements/build.txt
 
 # Set yarn cache folder for easy binding during runtime


### PR DESCRIPTION
### Summary
* [PR Build on 0.14](https://buildkite.com/learningequality/kolibri-python-package/builds/2513#_) would not finish, and seemed to be an issue with a newer version of a dev dependency that was not Python 2.7 compatible
* I then wondered why we needed to install dev dependencies in the build at all
* So, I tried it locally and it did not seem to be needed
* This PR is the result, and may be needed for builds to complete on 0.14 :/

### Reviewer guidance
Any other reason my PR build might be breaking?

…

### References
If the build breakage is wider than just my PR https://github.com/learningequality/kolibri/pull/7947 this may be needed for release of 0.14.7.

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
