### PR TITLE
fix(restarttask): client side reappearance of task upon restart

### DIFF
--- a/kolibri/core/tasks/queue.py
+++ b/kolibri/core/tasks/queue.py
@@ -72,12 +72,14 @@ class Queue(object):
         Given a job_id, restart the job for that id. A job will only be restarted if
         in CANCELED or FAILED state.
 
-        This will create a new job with a new job_id.
+        This first clears the job then creates a new job with the same job_id as
+        the cleared one.
         """
         old_job = self.fetch_job(job_id)
         if old_job.state in [State.CANCELED, State.FAILED]:
             self.clear_job(job_id)
             job = Job(old_job)
+            job.job_id = job_id
             return self.enqueue(job)
         else:
             raise JobNotRestartable(

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -119,8 +119,8 @@ class TaskAPITestCase(BaseAPITestCase):
                 assert_clearable(i, True)
 
     def test_restart_task(self, queue_mock):
-        queue_mock.restart_job.return_value = 2
-        queue_mock.fetch_job.return_value = fake_job(state=State.QUEUED, job_id=2)
+        queue_mock.restart_job.return_value = 1
+        queue_mock.fetch_job.return_value = fake_job(state=State.QUEUED, job_id=1)
 
         response = self.client.post(
             reverse("kolibri:core:task-restarttask"), {"task_id": "1"}, format="json"
@@ -131,7 +131,7 @@ class TaskAPITestCase(BaseAPITestCase):
             "exception": "",
             "traceback": "",
             "percentage": 0,
-            "id": 2,
+            "id": 1,
             "cancellable": False,
             "clearable": False,
         }

--- a/kolibri/core/tasks/test/test_job_running.py
+++ b/kolibri/core/tasks/test/test_job_running.py
@@ -328,10 +328,10 @@ class TestQueue(object):
         assert job.state == State.FAILED
 
         # Restart the function and assert the same case as above along with
-        # the new created job should have an another unique id.
+        # the new created job should have the same id.
         new_job_id = inmem_queue.restart_job(old_job_id)
 
-        assert new_job_id != old_job_id
+        assert new_job_id == old_job_id
 
         wait_for_state_change(inmem_queue, new_job_id, State.FAILED)
 
@@ -357,10 +357,10 @@ class TestQueue(object):
         job = inmem_queue.fetch_job(old_job_id)
         assert job.state == State.CANCELED
 
-        # Restart the job, check that the new created job should have a
-        # unique id.
+        # Restart the job, check that the new created job should have the
+        # same id.
         new_job_id = inmem_queue.restart_job(old_job_id)
-        assert new_job_id != old_job_id
+        assert new_job_id == old_job_id
 
         # Test the remaing cases same as above.
         wait_for_state_change(inmem_queue, new_job_id, State.RUNNING)


### PR DESCRIPTION
### Summary
The recent implementation of restart functionality had a minor client side issue where a restarted task was first disappearing and then appearing again.

This PR fixes that by keeping the `job_id` of the new job same as that of restarted job. 

### Reviewer guidance
1. Test the restarttask api.

### References

Closes https://github.com/learningequality/kolibri/issues/7929

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
