### PR TITLE
fix(tasks): tasks queue is cleared on server start

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -20,7 +20,6 @@ from kolibri.core.content.utils import paths
 from kolibri.core.content.zip_wsgi import get_application
 from kolibri.core.deviceadmin.utils import schedule_vacuum
 from kolibri.core.tasks.main import initialize_workers
-from kolibri.core.tasks.main import queue
 from kolibri.core.tasks.main import scheduler
 from kolibri.utils import conf
 from kolibri.utils.android import on_android
@@ -99,10 +98,6 @@ class ServicesPlugin(SimplePlugin):
 
         # schedule the vacuum job
         schedule_vacuum()
-
-        # This is run every time the server is started to clear all the tasks
-        # in the queue
-        queue.empty()
 
         # Initialize the iceqube engine to handle queued tasks
         self.workers = initialize_workers()


### PR DESCRIPTION
### Summary
When the kolibri server starts, we were clearing the tasks queue which lead us to lose the historical information of completed, failed or cancelled tasks.

This PR fixes the issue by not letting that happen. 

### Reviewer guidance

1. Complete some tasks or cancel running tasks.
2. Restart the server.
3. See the task manager. 
4. The task list should have persisted.  

### References

Fixes https://github.com/learningequality/kolibri/issues/6255

----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
