### PR TITLE
Fix non localized numerals

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span v-if="isSpecified && birthYear">
-    {{ birthYear }}
+    {{ $formatDate(birthYear, { year: 'numeric' }) }}
   </span>
   <KEmptyPlaceholder v-else />
 

--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -38,15 +38,6 @@
   // or the year of the server date
   const firstYear = Math.max(Number(__copyrightYear), getYear(now()));
 
-  function makeYearOptions(max, min) {
-    return range(max, min, -1).map(n => ({
-      label: String(n),
-      value: String(n),
-    }));
-  }
-
-  const yearOptions = makeYearOptions(firstYear, 1900);
-
   export default {
     name: 'BirthYearSelect',
     components: {
@@ -59,6 +50,11 @@
         default: null,
       },
     },
+    data() {
+      return {
+        yearOptions: this.makeYearOptions(firstYear, 1900),
+      };
+    },
     computed: {
       selected() {
         return this.options.find(o => o.value === this.value) || {};
@@ -68,7 +64,7 @@
         // fill in the gaps just in case a user was given a later date, e.g. via CSV
         let extraYears = [];
         if (Number(this.value) > firstYear) {
-          extraYears = makeYearOptions(Number(this.value), firstYear - 1);
+          extraYears = this.makeYearOptions(Number(this.value), firstYear - 1);
         }
         return [
           {
@@ -76,7 +72,7 @@
             label: this.coreString('birthYearNotSpecified'),
           },
           ...extraYears,
-          ...yearOptions,
+          ...this.yearOptions,
         ];
       },
       tooltipPlacement() {
@@ -84,6 +80,16 @@
           return 'left';
         }
         return 'bottom';
+      },
+    },
+    methods: {
+      makeYearOptions(max, min) {
+        return range(max, min, -1).map(n => {
+          return {
+            label: this.$formatDate(String(n), { year: 'numeric' }),
+            value: String(n),
+          };
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -56,7 +56,7 @@
                 <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
               </td>
               <td>
-                {{ coachString('integer', { value: classObj.learner_count }) }}
+                {{ $formatNumber(classObj.learner_count) }}
               </td>
             </tr>
           </transition-group>

--- a/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/StatusElapsedTime.vue
@@ -53,7 +53,7 @@
 
         // Seconds
         if (this.timeDifference < MINUTE) {
-          const strParams = { seconds: this.toSeconds(this.timeDifference) };
+          const strParams = { seconds: this.$formatNumber(this.toSeconds(this.timeDifference)) };
           switch (this.actionType) {
             case 'created':
               return this.$tr('createdSecondsAgo', strParams);
@@ -67,7 +67,7 @@
         }
         // Minutes
         if (this.timeDifference < HOUR) {
-          const strParams = { minutes: this.toMinutes(this.timeDifference) };
+          const strParams = { minutes: this.$formatNumber(this.toMinutes(this.timeDifference)) };
           switch (this.actionType) {
             case 'created':
               return this.$tr('createdMinutesAgo', strParams);
@@ -81,7 +81,7 @@
         }
         // Hours
         if (this.timeDifference < DAY) {
-          const strParams = { hours: this.toHours(this.timeDifference) };
+          const strParams = { hours: this.$formatNumber(this.toHours(this.timeDifference)) };
           switch (this.actionType) {
             case 'created':
               return this.$tr('createdHoursAgo', strParams);
@@ -94,7 +94,7 @@
           }
         }
         // else, Days
-        const strParams = { days: this.toDays(this.timeDifference) };
+        const strParams = { days: this.$formatNumber(this.toDays(this.timeDifference)) };
         switch (this.actionType) {
           case 'created':
             return this.$tr('createdDaysAgo', strParams);

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -96,7 +96,6 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   viewByGroupsLabel: 'View by groups',
 
   // formatted values
-  integer: '{value, number, integer}',
   nthExerciseName: '{name} ({number, number, integer})',
   numberOfLearners: '{value, number, integer} {value, plural, one {learner} other {learners}}',
   numberOfQuestions: '{value, number, integer} {value, plural, one {question} other {questions}}',

--- a/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressCount.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/status/LearnerProgressCount.vue
@@ -53,7 +53,7 @@
       },
       text() {
         if (!this.verbosityNumber) {
-          return this.coachString('integer', { value: this.count });
+          return this.$formatNumber(this.count);
         }
         return this.strings.$tr(this.shorten('count', this.verbosityNumber), { count: this.count });
       },

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -32,7 +32,7 @@
           />
         </template>
         <template #value>
-          {{ coachString('integer', { value: learnerNames.length }) }}
+          {{ $formatNumber(learnerNames.length) }}
         </template>
       </HeaderTableRow>
     </HeaderTable>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/GroupRow.vue
@@ -9,7 +9,7 @@
       />
     </td>
     <td>
-      {{ group.users.length }}
+      {{ this.$formatNumber(group.users.length) }}
     </td>
     <td class="core-table-button-col">
       <KDropdownMenu

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -33,8 +33,8 @@
                 />
               </td>
               <td><Score :value="tableRow.avgScore" /></td>
-              <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
-              <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
+              <td>{{ $formatNumber(tableRow.exercises) }}</td>
+              <td>{{ $formatNumber(tableRow.resources) }}</td>
               <td><ElapsedTime :date="tableRow.lastActivity" /></td>
             </tr>
           </transition-group>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -34,13 +34,13 @@
                 />
               </td>
               <td>
-                {{ coachString('integer', { value: tableRow.numLessons }) }}
+                {{ $formatNumber(tableRow.numLessons) }}
               </td>
               <td>
-                {{ coachString('integer', { value: tableRow.numQuizzes }) }}
+                {{ $formatNumber(tableRow.numQuizzes) }}
               </td>
               <td>
-                {{ coachString('integer', { value: tableRow.numLearners }) }}
+                {{ $formatNumber(tableRow.numLearners) }}
               </td>
               <td><Score :value="tableRow.avgScore" /></td>
               <td><ElapsedTime :date="tableRow.lastActivity" /></td>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -40,7 +40,7 @@
           {{ coachString('exercisesCompletedLabel') }}
         </template>
         <template #value>
-          {{ coachString('integer', { value: exercisesCompleted }) }}
+          {{ $formatNumber(exercisesCompleted) }}
         </template>
       </HeaderTableRow>
       <HeaderTableRow>
@@ -48,7 +48,7 @@
           {{ coachString('resourcesViewedLabel') }}
         </template>
         <template #value>
-          {{ coachString('integer', { value: resourcesViewed }) }}
+          {{ $formatNumber(resourcesViewed) }}
         </template>
       </HeaderTableRow>
     </HeaderTable>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -35,8 +35,8 @@
               </td>
               <td><TruncatedItemList :items="tableRow.groups" /></td>
               <td><Score :value="tableRow.avgScore" /></td>
-              <td>{{ coachString('integer', { value: tableRow.exercises }) }}</td>
-              <td>{{ coachString('integer', { value: tableRow.resources }) }}</td>
+              <td>{{ $formatNumber(tableRow.exercises) }}</td>
+              <td>{{ $formatNumber(tableRow.resources) }}</td>
               <td><ElapsedTime :date="tableRow.lastActivity" /></td>
             </tr>
           </transition-group>

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -79,7 +79,7 @@
       },
     },
     $trs: {
-      versionNumber: 'Version {v}',
+      versionNumber: 'Version {v, number, integer}',
       defaultDescription: '(No description)',
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -76,7 +76,7 @@
             </td>
 
             <td>
-              {{ classroom.learner_count }}
+              {{ $formatNumber(classroom.learner_count) }}
             </td>
             <td class="core-table-button-col">
               <KButton

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -91,7 +91,7 @@
       },
     },
     $trs: {
-      question: 'Question { num }',
+      question: 'Question { num, number, integer}',
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -343,7 +343,7 @@
       unanswered:
         'You have {numLeft, number} {numLeft, plural, one {question} other {questions}} unanswered',
       noItemId: 'This question has an error, please move on to the next question',
-      question: 'Question { num } of { total }',
+      question: 'Question {num, number, integer} of {total, number, integer}',
     },
   };
 

--- a/packages/kolibri-tools/test/fixtures/TestComponent.vue
+++ b/packages/kolibri-tools/test/fixtures/TestComponent.vue
@@ -55,7 +55,7 @@
                 <TruncatedItemList :items="classObj.coaches.map(c => c.full_name)" />
               </td>
               <td>
-                {{ coachString('integer', { value: classObj.learner_count }) }}
+                {{ $formatNumber(classObj.learner_count) }}
               </td>
             </tr>
           </transition-group>


### PR DESCRIPTION
### Summary
Non translated numerals have been fixed in the below occurrences:
- Exam question counter in list 
- Exam question counter in title
- Exam answer counter
- Channel's version
- User's Birth year on profile page and other places
- Time elapsed on `StatusElapsedTime` componenent
- Total learners in group (used by coach)

_Note: numeral formatting on kolibri design system componenets such as `KTextBox` couldn't be fixed since that is a design system's issue_



### Reviewer guidance
The reviewer can visit the below pages
- User profile
- Device channels
- Exam (as a learner)
- As a coach, plan a class and browse the groups


### References
This PR resolves #7696 .


----

### Contributor Checklist


PR process:

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

Testing:

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

### Reviewer Checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
