### PR TITLE
Cherry-pick #7932 and remove admin credentials from demo banner

### DIFF
--- a/kolibri/core/assets/src/views/CoreBanner.vue
+++ b/kolibri/core/assets/src/views/CoreBanner.vue
@@ -22,6 +22,7 @@
           :layout12="{ span: 3 }"
         >
           <KButton
+            ref="open_button"
             class="open-button"
             :text="$tr('openButton')"
             appearance="flat-button"
@@ -31,6 +32,7 @@
         </KGridItem>
         <KGridItem v-else class="button-grid-item">
           <KButton
+            ref="close_button"
             class="close-button"
             :text="coreString('closeAction')"
             appearance="flat-button"
@@ -57,9 +59,27 @@
         bannerClosed: false,
       };
     },
+    created() {
+      document.addEventListener('focusin', this.focusChange);
+    },
+    beforeDestroy() {
+      document.removeEventListener('focusin', this.focusChange);
+    },
     methods: {
       toggleBanner() {
         this.bannerClosed = !this.bannerClosed;
+        if (this.previouslyFocusedElement) {
+          this.previouslyFocusedElement.focus();
+        }
+      },
+      focusChange(e) {
+        // We need the element prior to the close button and more info
+        if (
+          (this.$refs.close_button && e.target != this.$refs.close_button.$el) ||
+          (this.$refs.open_button && e.target != this.$refs.open_button.$el)
+        ) {
+          this.previouslyFocusedElement = e.target;
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
+++ b/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
@@ -9,7 +9,6 @@
     <ul>
       <li>{{ $tr('demoServerL1', { user: 'learnerdemo', pass: 'pass' } ) }}</li>
       <li>{{ $tr('demoServerL2', { user: 'coachdemo', pass: 'pass' } ) }}</li>
-      <li>{{ $tr('demoServerL3', { user: 'admindemo', pass: 'pass' } ) }}</li>
     </ul>
     <p>{{ $tr('demoServerP2') }}</p>
     <p>{{ $tr('demoServerP3') }}</p>
@@ -50,7 +49,6 @@
       demoServerP1: 'Explore any of the three primary user types:',
       demoServerL1: 'Learner ({user}/{pass} or access as a guest)',
       demoServerL2: 'Coach ({user}/{pass})',
-      demoServerL3: 'Admin ({user}/{pass})',
       demoServerP2:
         'This online version of Kolibri is intended for demonstration purposes only. Users and data will be periodically deleted. The demo shows features of the latest Kolibri version, and all resources found are samples.',
       demoServerP3:


### PR DESCRIPTION
## Summary

1. Cherry-picks #7932 to 0.14.7
2. Removes admin credentials from the demo banner copy

