### PR TITLE
Add a placeholder 0.15 upgrade notification; add reminders about the upgrade notification in release process docs

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,35 +1,51 @@
 
- .wy-table-responsive table td {
-    /* !important prevents the common CSS stylesheets from overriding
-       this as on RTD they are loaded after this stylesheet */
-    white-space: normal !important;
-    vertical-align: top !important;
- }
+.wy-table-responsive table td {
+  /* !important prevents the common CSS stylesheets from overriding
+     this as on RTD they are loaded after this stylesheet */
+  white-space: normal !important;
+  vertical-align: top !important;
+}
 
- .rst-content .section ol p, .rst-content .section ul p {
-  margin-bottom: 0px;
- }
+.wy-plain-list-disc li p:last-child,
+.rst-content .section ul li p:last-child,
+.rst-content .toctree-wrapper ul li p:last-child,
+article ul li p:last-child {
+  margin-bottom: 8px;
+}
+.wy-plain-list-disc li ul,
+.rst-content .section ul li ul,
+.rst-content .toctree-wrapper ul li ul,
+article ul li ul {
+  margin-bottom: 8px;
+}
 
- .rst-content #contents.hidden-first-item > ul:nth-of-type(1) {
-   margin-left: 0;
-   padding-left: 0;
- }
- .rst-content #contents.hidden-first-item > ul:nth-of-type(1) > li {
-   list-style: none;
-   margin-left: 0;
-   padding-left: 0;
- }
- .rst-content #contents.hidden-first-item > ul:nth-of-type(1) > li > p {
-   display: none;
- }
- .rst-content #contents.hidden-first-item ul li li {
-   list-style: disc;
- }
- .rst-content #contents.hidden-first-item ul li li li {
-   list-style: circle;
- }
+/*.rst-content .section ul li p:last-child, {
+    margin-bottom: 0;
+}
+
+.rst-content .section ol p, .rst-content .section ul p {
+margin-bottom: 0px;
+}
+.rst-content #contents.hidden-first-item > ul:nth-of-type(1) > li {
+ list-style: none;
+ margin-left: 0;
+ padding-left: 0;
+}
+.rst-content #contents.hidden-first-item > ul:nth-of-type(1) > li > p {
+ display: none;
+}
+.rst-content #contents.hidden-first-item > ul:nth-of-type(1) {
+ margin-left: 0;
+ padding-left: 0;
+}
+.rst-content #contents.hidden-first-item ul li li {
+ list-style: disc;
+}
+.rst-content #contents.hidden-first-item ul li li li {
+ list-style: circle;
+}*/
 
 /* push down the RTD banner so it's not confused with menu */
 .keep-us-sustainable {
   margin-top: 20em !important;
-} 
+}

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -239,6 +239,7 @@ See the `Perseus plugin development guide <https://github.com/learningequality/k
 
 When uploading or downloading strings, ensure that your Perseus repo is in a clean checkout state with the correct Perseus branch.
 
+.. _crowdin_upload:
 
 Extracting and uploading sources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -42,9 +42,16 @@ String chill and string freeze
   * Run ``make i18n-stats branch=<release-vN.N.x>`` to get figures on the translation work.
   * Send the stats to the i18n team, who will use them for communication with translators to measure the translation efforts needed.
 
-  Strings from the Perseus plugin also need to be revisited. They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from Crowdin such as ``kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`crowdin`.
+  **Strings from the Perseus plugin also need to be revisited.** They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from Crowdin such as ``kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`crowdin`.
 
   .. warning:: Strings exist in more places than just the Kolibri repo. Ensure we have translations for the Perseus plugin as well as other Crowdin projects such as Kolibri Server, and the Windows, Mac, Android, and GNOME Linux apps.
+
+  **Don't forget to include the new version notifications!** Before the string freeze, make sure that the messages in the `UpdateNotfication.vue component <https://github.com/learningequality/kolibri/blob/781cadfce5c56911914e613ae26b3aef36bb3333/kolibri/core/assets/src/views/UpdateNotification.vue#L85-L103>`__ have been updated for the upcoming release.
+
+  In the component's ``$trs`` options, add a new message with a key indicating the upcoming version. Provide 1-2 sentences describing the most important new features.::
+
+    upgradeMessage_0_13_0:
+      'Kolibri version 0.13.0 is available! It contains major improvements to resource management, coach tools, and much more.'
 
 
 Continuing the release process

--- a/docs/release_process.rst
+++ b/docs/release_process.rst
@@ -23,28 +23,28 @@ When a new alpha is published, *delete any older alphas* using Github's 'delete 
 
 It's common that changes have been made in the previous release that need to be propagated to the current release. For an upcoming 0.3.0 release, we would need to merge ``release-v0.2.x`` into ``develop``.
 
-During the alpha phase is all the period when we should update our Python and Javascript dependencies. In general we should avoid updating dependencies in release branches.
+The alpha phase is the period when we should update our Python and Javascript dependencies. In general, we should avoid updating dependencies in release branches.
 
 
 String chill and string freeze
 ------------------------------
 
-* **String chill**: when all new and updated user-facing strings are in ``develop``, we upload them to Crowdin and do a test translation internally. We aim to translate the strings into at least two languages at this stage, and use this opportunity to make any final updates to the English source strings.
+* **String chill**: when all new and updated user-facing strings are in ``develop``, we upload them to Crowdin (see: :ref:`crowdin_upload`) and do a test translation internally. We aim to translate the strings into at least two languages at this stage, and use this opportunity to make any final updates to the English source strings.
 
 * **String freeze**: when the internal review is finished and the user-facing strings have been signed off, the i18n team notifies external translators to begin their work. After this time, it can be highly disruptive to change English source strings because it requires communicating and coordinating with a large number of external contractors and volunteers with diverse schedules and time zones.
 
   .. note:: The in-context translation server `kolibri-translate.learningequality.org <http://kolibri-translate.learningequality.org/>`__ should always be available for translation efforts.
 
-  Each minor release (``N.N.*``) is maintained in a CrowdIn Version Branch, following the existing naming scheme ``release-vN.N.x``. The branch is automatically created when running the first ``make i18n-upload`` command. CrowdIn will automatically reuse previously translated strings in new branches.
+  Each minor release (``N.N.*``) is maintained in a Crowdin Version Branch, following the existing naming scheme ``release-vN.N.x``. The branch is automatically created when running the first ``make i18n-upload`` command. Crowdin will automatically reuse previously translated strings in new branches.
 
   The strings for the upcoming release need to be uploaded as described in :ref:`crowdin`.
 
   * Run ``make i18n-stats branch=<release-vN.N.x>`` to get figures on the translation work.
   * Send the stats to the i18n team, who will use them for communication with translators to measure the translation efforts needed.
 
-  Strings from the Perseus plugin also need to be revisited. They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from CrowdIn such as ``kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`crowdin`.
+  Strings from the Perseus plugin also need to be revisited. They are maintained in the repo `learningequality/kolibri-exercise-perseus-plugin <https://github.com/learningequality/kolibri-exercise-perseus-plugin>`__, but the source strings are generated and uploaded through the main ``kolibri`` project. The translated files from Crowdin such as ``kolibri_exercise_perseus_plugin.exercise_perseus_render_module-messages.json`` are downloaded through the ``kolibri-exercise-perseus-plugin`` project. For instructions, see :ref:`crowdin`.
 
-  .. warning:: Strings exist in more places than just the Kolibri repo. Ensure we have translations for the Perseus plugin as well as other Crowdin projects such as Kolibri Server, and the Windows, Mac, Android, and Gnome apps.
+  .. warning:: Strings exist in more places than just the Kolibri repo. Ensure we have translations for the Perseus plugin as well as other Crowdin projects such as Kolibri Server, and the Windows, Mac, Android, and GNOME Linux apps.
 
 
 Continuing the release process

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -94,8 +94,9 @@
       upgradeMessageGeneric: 'A new version of Kolibri is available.',
       upgradeMessageImportant:
         'We have released an important update with fixes to this version of Kolibri.',
-      upgradeMessage0130:
-        'Kolibri version 0.13.0 is available! It contains major improvements to resource management, coach tools, and much more.',
+      // TODO(i18n): Write a final version of this copy
+      upgradeMessage_0_15_0:
+        'Kolibri version 0.15.0 is available! It has a lot of new features!',
       upgradeDownload: 'Download it here',
       upgradeLearnAndDownload: 'Learn more and download it here',
       /* eslint-enable kolibri/vue-no-unused-translations */

--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -95,8 +95,7 @@
       upgradeMessageImportant:
         'We have released an important update with fixes to this version of Kolibri.',
       // TODO(i18n): Write a final version of this copy
-      upgradeMessage_0_15_0:
-        'Kolibri version 0.15.0 is available! It has a lot of new features!',
+      upgradeMessage_0_15_0: 'Kolibri version 0.15.0 is available! It has a lot of new features!',
       upgradeDownload: 'Download it here',
       upgradeLearnAndDownload: 'Learn more and download it here',
       /* eslint-enable kolibri/vue-no-unused-translations */


### PR DESCRIPTION
## Summary

1. Some edits to `release_process.rst`, including adding cross links to `i18n` doc, changing "CrowdIn" to "Crowdin" (to match their own branding)
2. Adds a reminder about the upgrade notification (I am working on more internal docs in Notion and on the kolibri-release-process tool)
3. Adds a _placeholder_ upgrade notification for 0.15.0 with a `TODO(i18n)` comment to remind us to finalize this once we know the full feature set.

## References

Fixes #7452 as far as the Kolibri codebase is concerned. Other documentation work is still being worked on and will be until 0.15 is released.

I would recommend writing a new issue to remind us to come up with a final version of the upgrade message _before the string freeze_.

## Reviewer guidance

1. Are the edits to the docs good? Feel free to fork, edit, and push to this branch!

