### PR TITLE
First pass at MVP single-user syncing backend

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -70,7 +70,7 @@ class Command(AsyncCommand):
             help="password of superuser or facility admin on server we are syncing with",
         )
         parser.add_argument(
-            "--user-id",
+            "--user",
             type=str,
             help="for single-user syncing, the user ID of the account to be synced",
         )
@@ -100,7 +100,7 @@ class Command(AsyncCommand):
             options["chunk_size"],
             options["username"],
             options["password"],
-            options["user_id"],
+            options["user"],
             options["no_push"],
             options["no_pull"],
             options["noninteractive"],

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import math
+import re
 from contextlib import contextmanager
 
 from django.core.management import call_command
@@ -14,6 +15,8 @@ from ..utils import create_superuser_and_provision_device
 from ..utils import get_baseurl
 from ..utils import get_client_and_server_certs
 from ..utils import get_dataset_id
+from ..utils import get_single_user_sync_filter
+from ..utils import provision_single_user_device
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.constants.morango_sync import State
@@ -59,12 +62,17 @@ class Command(AsyncCommand):
         parser.add_argument(
             "--username",
             type=str,
-            help="username of superuser on server we are syncing with",
+            help="username of superuser or facility admin on server we are syncing with",
         )
         parser.add_argument(
             "--password",
             type=str,
-            help="password of superuser on server we are syncing with",
+            help="password of superuser or facility admin on server we are syncing with",
+        )
+        parser.add_argument(
+            "--user-id",
+            type=str,
+            help="for single-user syncing, the user ID of the account to be synced",
         )
         parser.add_argument(
             "--no-provision",
@@ -81,6 +89,7 @@ class Command(AsyncCommand):
             chunk_size,
             username,
             password,
+            user_id,
             no_push,
             no_pull,
             noninteractive,
@@ -91,6 +100,7 @@ class Command(AsyncCommand):
             options["chunk_size"],
             options["username"],
             options["password"],
+            options["user_id"],
             options["no_push"],
             options["no_pull"],
             options["noninteractive"],
@@ -122,7 +132,36 @@ class Command(AsyncCommand):
                 "Device can not sync with itself. Please recheck base URL and try again."
             )
 
-        if PORTAL_SYNC:  # do portal sync setup
+        if user_id:  # it's a single-user sync
+
+            if not facility_id:
+                raise CommandError(
+                    "Facility ID must be specified in order to do single-user syncing"
+                )
+            if not re.match("[a-f0-9]{32}", user_id):
+                raise CommandError("User ID must be a 32-character UUID (no dashes)")
+
+            dataset_id = get_dataset_id(
+                baseurl, identifier=facility_id, noninteractive=True
+            )
+
+            client_cert, server_cert, username = get_client_and_server_certs(
+                username,
+                password,
+                dataset_id,
+                network_connection,
+                user_id=user_id,
+                noninteractive=noninteractive,
+            )
+
+            scopes = [client_cert.scope_definition_id, server_cert.scope_definition_id]
+
+            if len(set(scopes)) != 2:
+                raise CommandError(
+                    "To do a single-user sync, one device must have a single-user certificate, and the other a full-facility certificate."
+                )
+
+        elif PORTAL_SYNC:  # do portal sync setup
             facility = get_facility(
                 facility_id=facility_id, noninteractive=noninteractive
             )
@@ -181,16 +220,34 @@ class Command(AsyncCommand):
         try:
             # pull from server
             if not no_pull:
-                self._handle_pull(sync_session_client, noninteractive, dataset_id)
+                self._handle_pull(
+                    sync_session_client,
+                    noninteractive,
+                    dataset_id,
+                    client_cert,
+                    server_cert,
+                    user_id=user_id,
+                )
             # and push our own data to server
             if not no_push:
-                self._handle_push(sync_session_client, noninteractive, dataset_id)
+                self._handle_push(
+                    sync_session_client,
+                    noninteractive,
+                    dataset_id,
+                    client_cert,
+                    server_cert,
+                    user_id=user_id,
+                )
 
             if not no_provision:
                 with self._lock():
-                    create_superuser_and_provision_device(
-                        username, dataset_id, noninteractive=noninteractive
-                    )
+                    if user_id:
+                        provision_single_user_device(user_id)
+                    else:
+                        create_superuser_and_provision_device(
+                            username, dataset_id, noninteractive=noninteractive
+                        )
+
         except UserCancelledError:
             if self.job:
                 self.job.extra_metadata.update(sync_state=State.CANCELLED)
@@ -224,7 +281,15 @@ class Command(AsyncCommand):
         if self.is_cancelled() and (not self.job or self.job.cancellable):
             raise UserCancelledError()
 
-    def _handle_pull(self, sync_session_client, noninteractive, dataset_id):
+    def _handle_pull(
+        self,
+        sync_session_client,
+        noninteractive,
+        dataset_id,
+        client_cert,
+        server_cert,
+        user_id,
+    ):
         """
         :type sync_session_client: morango.sync.syncsession.SyncSessionClient
         :type noninteractive: bool
@@ -259,12 +324,32 @@ class Command(AsyncCommand):
             "Completed pull transfer session",
         )
 
-        sync_client.initialize(Filter(dataset_id))
+        if not user_id:
+            # full-facility sync
+            sync_client.initialize(Filter(dataset_id))
+        else:
+            # single-user sync
+            client_is_single_user = (
+                client_cert.scope_definition_id == ScopeDefinitions.SINGLE_USER
+            )
+            filt = get_single_user_sync_filter(
+                dataset_id, user_id, is_read=client_is_single_user
+            )
+            sync_client.initialize(Filter(filt))
+
         sync_client.run()
         with self._lock():
             sync_client.finalize()
 
-    def _handle_push(self, sync_session_client, noninteractive, dataset_id):
+    def _handle_push(
+        self,
+        sync_session_client,
+        noninteractive,
+        dataset_id,
+        client_cert,
+        server_cert,
+        user_id,
+    ):
         """
         :type sync_session_client: morango.sync.syncsession.SyncSessionClient
         :type noninteractive: bool
@@ -299,7 +384,18 @@ class Command(AsyncCommand):
         )
 
         with self._lock():
-            sync_client.initialize(Filter(dataset_id))
+            if not user_id:
+                # full-facility sync
+                sync_client.initialize(Filter(dataset_id))
+            else:
+                # single-user sync
+                client_is_single_user = (
+                    client_cert.scope_definition_id == ScopeDefinitions.SINGLE_USER
+                )
+                filt = get_single_user_sync_filter(
+                    dataset_id, user_id, is_read=not client_is_single_user
+                )
+                sync_client.initialize(Filter(filt))
 
         sync_client.run()
 

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -55,25 +55,25 @@ class KolibriServer(object):
             env=self.env,
         )
 
-    def create_model(self, model_name, **kwargs):
+    def create_model(self, model, **kwargs):
         kwarg_text = ",".join(
             '{key}=\\"{value}\\"'.format(key=key, value=value)
             for key, value in kwargs.items()
         )
         self.pipe_shell(
-            "from kolibri.core.auth.models import {model_name}; {model_name}.objects.create({})".format(
-                kwarg_text, model_name=model_name
+            "from {module_path} import {model_name}; {model_name}.objects.create({})".format(
+                kwarg_text, module_path=model.__module__, model_name=model.__name__
             )
         )
 
-    def delete_model(self, model_name, **kwargs):
+    def delete_model(self, model, **kwargs):
         kwarg_text = ",".join(
             '{key}=\\"{value}\\"'.format(key=key, value=value)
             for key, value in kwargs.items()
         )
         self.pipe_shell(
-            "from kolibri.core.auth.models import {model_name}; obj = {model_name}.objects.get({}); obj.delete()".format(
-                kwarg_text, model_name=model_name
+            "from {module_path} import {model_name}; obj = {model_name}.objects.get({}); obj.delete()".format(
+                kwarg_text, module_path=model.__module__, model_name=model.__name__
             )
         )
 
@@ -96,6 +96,7 @@ class KolibriServer(object):
 
     def kill(self):
         try:
+            subprocess.call("kolibri stop", env=self.env, shell=True)
             self._instance.kill()
             shutil.rmtree(self.env["KOLIBRI_HOME"])
         except OSError:

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -2,18 +2,14 @@
 Tests related specifically to integration with Morango.
 """
 import os
-import sys
 import unittest
 import uuid
 
-import requests
 from django.test import TestCase
 from morango.models import InstanceIDModel
 from morango.models import Store
 from morango.models import syncable_models
 from morango.sync.controller import MorangoProfileController
-from rest_framework import status
-from six.moves.urllib.parse import urljoin
 
 from ..constants.morango_sync import PROFILE_FACILITY_DATA
 from ..models import Classroom
@@ -62,13 +58,17 @@ class DateTimeTZFieldTestCase(TestCase):
             self.fail(e.message)
 
 
-@unittest.skipIf(sys.platform.startswith("win"), "can't run on Windows")
 @unittest.skipIf(
-    not os.environ.get("TRAVIS_TAG"), "This test will only be run during tagged builds."
+    not os.environ.get("INTEGRATION_TEST"),
+    "This test will only be run during integration testing.",
 )
 class EcosystemTestCase(TestCase):
-    def _data(self, *args, **kwargs):
-        return kwargs
+    """
+    Where possible this test case uses the using kwarg with the db alias in order
+    to save models to the write DB. Unfortunately, because of an internal issue with
+    MPTT, this will sometimes fail for MPTT models.
+    TODO: defer this to the server class as an implementation detail.
+    """
 
     def _create_objects(self, server):
         fac = Facility.objects.using(server.db_alias).first()
@@ -80,52 +80,18 @@ class EcosystemTestCase(TestCase):
             username=uuid.uuid4().hex[:30], password=DUMMY_PASSWORD, facility=fac
         )
         learner.save(using=server.db_alias)
-        class_resp = self.request_server(
-            server, "classroom", data=self._data(parent=fac.id, name=uuid.uuid4().hex)
-        )
-        lg_resp = self.request_server(
-            server,
-            "learnergroup",
-            data=self._data(parent=class_resp.json()["id"], name=uuid.uuid4().hex),
-        )
-        self.request_server(
-            server,
-            "membership",
-            data=self._data(user=learner.id, collection=class_resp.json()["id"]),
-        )
-        self.request_server(
-            server,
-            "membership",
-            data=self._data(user=learner.id, collection=lg_resp.json()["id"]),
-        )
-        self.request_server(
-            server,
-            "role",
-            data=self._data(collection=fac.id, user=admin.id, kind="admin"),
-        )
 
-    def request_server(
-        self, server, endpoint, method="POST", lookup=None, data={}, params={}
-    ):
-        """
-
-        :param server: kolibri instance we are querying
-        :param endpoint: constant representing which kolibri endpoint we are querying
-        :param method: HTTP verb/method for request
-        :param lookup: the pk value for the specific object we are querying
-        :param data: dict that will be form-encoded in request
-        :param params: dict to be sent as part of URL's query string
-        :return: ``Response`` object from request
-        """
-
-        # build up url and send request
-        if lookup:
-            lookup = lookup + "/"
-        url = urljoin(urljoin(server.baseurl, "api/auth/" + endpoint + "/"), lookup)
-        auth = ("superuser", "password")
-        resp = requests.request(method, url, json=data, params=params, auth=auth)
-        resp.raise_for_status()
-        return resp
+        name = uuid.uuid4().hex
+        server.create_model("Classroom", parent_id=fac.id, name=name)
+        class_id = Classroom.objects.using(server.db_alias).get(name=name).id
+        name = uuid.uuid4().hex
+        server.create_model("LearnerGroup", parent_id=class_id, name=name)
+        lg_id = LearnerGroup.objects.using(server.db_alias).get(name=name).id
+        server.create_model("Membership", user_id=learner.id, collection_id=class_id)
+        server.create_model("Membership", user_id=learner.id, collection_id=lg_id)
+        server.create_model(
+            "Role", collection_id=fac.id, user_id=admin.id, kind="admin"
+        )
 
     def assertServerQuerysetEqual(self, s1, s2, dataset_id):
         models = syncable_models.get_models(PROFILE_FACILITY_DATA)
@@ -166,12 +132,26 @@ class EcosystemTestCase(TestCase):
         s2_alias = servers[2].db_alias
         s2_url = servers[2].baseurl
         servers[0].manage("loaddata", "content_test")
-        servers[0].manage("generateuserdata", no_onboarding=True, num_content_items=1)
+        servers[0].manage(
+            "generateuserdata", "--no-onboarding", "--num-content-items", "1"
+        )
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         servers[2].manage(
-            "sync", baseurl=s1_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s1_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
 
         # assert that all kolibri instances start off equal
@@ -189,7 +169,13 @@ class EcosystemTestCase(TestCase):
             facility=Facility.objects.using(s0_alias).first(),
         ).save(using=s0_alias)
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         self.assertTrue(
             FacilityUser.objects.using(s1_alias).filter(username="user").exists()
@@ -198,15 +184,19 @@ class EcosystemTestCase(TestCase):
         # missing foreign key lookup should be handled gracefully (https://github.com/learningequality/kolibri/pull/5734)
         user = FacilityUser.objects.using(s1_alias).get(username="user")
         fac = Facility.objects.using(s1_alias).get()
-        self.request_server(
-            servers[1],
-            "role",
-            data=self._data(collection=fac.id, user=user.id, kind="admin"),
+        servers[1].create_model(
+            "Role", collection_id=fac.id, user_id=user.id, kind="admin"
         )
-        self.request_server(servers[0], "facilityuser", method="DELETE", lookup=user.id)
+        servers[0].delete_model("FacilityUser", id=user.id)
         # role object that is synced will try to do FK lookup on deleted user
         servers[0].manage(
-            "sync", baseurl=s1_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s1_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
 
         # create user with same username on two servers and check they both exist
@@ -221,7 +211,13 @@ class EcosystemTestCase(TestCase):
             facility=Facility.objects.using(s1_alias).first(),
         ).save(using=s1_alias)
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         self.assertEqual(
             FacilityUser.objects.using(s0_alias).filter(username="copycat").count(), 2
@@ -231,30 +227,38 @@ class EcosystemTestCase(TestCase):
         )
 
         # Add a classroom
-        self.request_server(
-            servers[0],
-            "classroom",
-            data=self._data(
-                name="classroom", parent=Facility.objects.using(s0_alias).first().id
-            ),
+        servers[0].create_model(
+            "Classroom",
+            name="classroom",
+            parent_id=Facility.objects.using(s0_alias).first().id,
         )
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         self.assertTrue(
             Classroom.objects.using(s1_alias).filter(name="classroom").exists()
         )
 
         # Add a learnergroup
-        self.request_server(
-            servers[0],
-            "learnergroup",
-            data=self._data(
-                name="learnergroup", parent=Classroom.objects.using(s0_alias).first().id
-            ),
+        servers[0].create_model(
+            "LearnerGroup",
+            name="learnergroup",
+            parent_id=Classroom.objects.using(s0_alias).first().id,
         )
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         self.assertTrue(
             LearnerGroup.objects.using(s1_alias).filter(name="learnergroup").exists()
@@ -263,29 +267,35 @@ class EcosystemTestCase(TestCase):
         # assert conflicting serialized data is appended after same role is created on different device
         fac = Facility.objects.using(s1_alias).get()
         alk_user = FacilityUser.objects.using(s0_alias).get(username="Antemblowind")
-        self.request_server(
-            servers[1],
-            "role",
-            data=self._data(collection=fac.id, user=alk_user.id, kind="admin"),
+        servers[1].create_model(
+            "Role", collection_id=fac.id, user_id=alk_user.id, kind="admin"
         )
-        self.request_server(
-            servers[0],
-            "role",
-            data=self._data(collection=fac.id, user=alk_user.id, kind="admin"),
+        servers[0].create_model(
+            "Role", collection_id=fac.id, user_id=alk_user.id, kind="admin"
         )
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         role = Role.objects.using(s1_alias).get(user=alk_user)
         admin_role = Store.objects.using(s1_alias).get(id=role.id)
         self.assertTrue(admin_role.conflicting_serialized_data)
 
         # assert deleted object is propagated
-        self.request_server(
-            servers[0], "facilityuser", method="DELETE", lookup=alk_user.id
-        )
+        servers[0].delete_model("FacilityUser", id=alk_user.id)
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         self.assertFalse(
             FacilityUser.objects.using(s1_alias)
@@ -297,13 +307,22 @@ class EcosystemTestCase(TestCase):
         # # role deletion and re-creation
         # Change roles for users
         alto_user = FacilityUser.objects.using(s1_alias).get(username="Altobjews1977")
-        resp = self.request_server(
-            servers[1],
-            "role",
-            data=self._data(collection=fac.id, user=alto_user.id, kind="admin"),
+        servers[1].create_model(
+            "Role", collection_id=fac.id, user_id=alto_user.id, kind="admin"
+        )
+        role_id = (
+            Role.objects.using(s1_alias)
+            .get(collection_id=fac.id, user_id=alto_user.id)
+            .id
         )
         servers[1].manage(
-            "sync", baseurl=s2_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s2_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
 
         self.assertEqual(
@@ -315,54 +334,62 @@ class EcosystemTestCase(TestCase):
             "admin",
         )
         # delete admin role and sync
-        self.request_server(
-            servers[2], "role", method="DELETE", lookup=resp.json()["id"]
-        )
+        servers[2].delete_model("Role", id=role_id)
         servers[1].manage(
-            "sync", baseurl=s2_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s2_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
         # create admin role and sync
-        resp = self.request_server(
-            servers[1],
-            "role",
-            data=self._data(collection=fac.id, user=alto_user.id, kind="admin"),
+        servers[1].create_model(
+            "Role", collection_id=fac.id, user_id=alto_user.id, kind="admin"
+        )
+        role_id = (
+            Role.objects.using(s1_alias).get(collection=fac.id, user=alto_user.id).id
         )
         servers[1].manage(
-            "sync", baseurl=s2_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s2_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
 
-        self.assertFalse(
-            Store.objects.using(s2_alias).get(id=resp.json()["id"]).deleted
-        )
+        self.assertFalse(Store.objects.using(s2_alias).get(id=role_id).deleted)
 
-        # Change password for a user, check if you can log in on other device
-        self.request_server(
-            servers[1],
-            "facilityuser",
-            method="PATCH",
-            lookup=alto_user.id,
-            data=self._data(password="syncing"),
-        )
+        # Change password for a user, check is changed on other device
+        server1_fu = FacilityUser.objects.using(s1_alias).get(id=alto_user.id)
+        server1_fu.set_password("syncing")
+        server1_fu.save(using=s1_alias)
         servers[1].manage(
-            "sync", baseurl=s0_url, username="superuser", password="password"
+            "sync",
+            "--baseurl",
+            s0_url,
+            "--username",
+            "superuser",
+            "--password",
+            "password",
         )
-        resp = self.request_server(
-            servers[0],
-            "session",
-            data=self._data(
-                username=alto_user.username, password="syncing", facility=fac.id
-            ),
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        server0_fu = FacilityUser.objects.using(s0_alias).get(id=alto_user.id)
+        self.assertTrue(server0_fu.check_password("syncing"))
 
         # sync in a circle node twice to ensure full consistency
         for i in range(2):
             for j in range(servers_len):
                 servers[j].manage(
                     "sync",
-                    baseurl=servers[(j + 1) % servers_len].baseurl,
-                    username="superuser",
-                    password="password",
+                    "--baseurl",
+                    servers[(j + 1) % servers_len].baseurl,
+                    "--username",
+                    "superuser",
+                    "--password",
+                    "password",
                 )
 
         # assert that the data of specific models match up
@@ -378,13 +405,16 @@ class EcosystemTestCase(TestCase):
         servers_len = len(servers)
 
         # consistent state for all servers
-        servers[0].manage("generateuserdata", no_onboarding=True)
+        servers[0].manage("generateuserdata", "--no-onboarding")
         for i in range(servers_len - 1):
             servers[i + 1].manage(
                 "sync",
-                baseurl=servers[0].baseurl,
-                username="superuser",
-                password="password",
+                "--baseurl",
+                servers[0].baseurl,
+                "--username",
+                "superuser",
+                "--password",
+                "password",
             )
 
         # randomly create objects on two servers and sync with each other
@@ -396,9 +426,12 @@ class EcosystemTestCase(TestCase):
 
             servers[2].manage(
                 "sync",
-                baseurl=servers[4].baseurl,
-                username="superuser",
-                password="password",
+                "--baseurl",
+                servers[4].baseurl,
+                "--username",
+                "superuser",
+                "--password",
+                "password",
             )
 
         # sync in a circle node twice to ensure full consistency
@@ -406,9 +439,12 @@ class EcosystemTestCase(TestCase):
             for j in range(servers_len):
                 servers[j].manage(
                     "sync",
-                    baseurl=servers[(j + 1) % servers_len].baseurl,
-                    username="superuser",
-                    password="password",
+                    "--baseurl",
+                    servers[(j + 1) % servers_len].baseurl,
+                    "--username",
+                    "superuser",
+                    "--password",
+                    "password",
                 )
 
         # assert that the data of specific models match up

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -489,7 +489,7 @@ class EcosystemTestCase(TestCase):
             "password",
             "--facility",
             facility_id,
-            "--user-id",
+            "--user",
             learner1.id,
         )
         # Test that we can single user sync with learner creds
@@ -503,7 +503,7 @@ class EcosystemTestCase(TestCase):
             "syncing",
             "--facility",
             facility_id,
-            "--user-id",
+            "--user",
             learner2.id,
         )
 
@@ -568,7 +568,7 @@ class EcosystemTestCase(TestCase):
             s0_url,
             "--facility",
             facility_id,
-            "--user-id",
+            "--user",
             learner1.id,
         )
         # Test that we can single user sync with learner creds
@@ -578,7 +578,7 @@ class EcosystemTestCase(TestCase):
             s0_url,
             "--facility",
             facility_id,
-            "--user-id",
+            "--user",
             learner2.id,
         )
 


### PR DESCRIPTION
## Summary

First pass at #7858, adding the `--user-id` parameter to the `sync` management command, to initiate single-user syncing.

Some fun facts:
- No changes were needed to Morango, or to the "server side" of Kolibri. Just some modifications to the `sync` command itself and to its supporting utils functions. This means that the current code is actually backwards-compatible with older versions of Kolibri running as the "server".
- Given the top-level partition they're under, Lessons, Exams, and their Assignments are not in fact currently included in a single-user sync. So we'll be building a side-channel syncing method for that instead, which was our fallback. That does mean that when syncing against older Kolibri versions, to a single-user device, these models won't be included. For that reason, we may not actually want to allow it to be back-compatible, to avoid confusion.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Closes #7858.

## Reviewer guidance

I tested this by creating two Kolibri data directories, one to act as the server, the other as the client:

```
export KOLIBRI_HOME=~/.singleusersyncserver
yarn run python-devserver
# and then used the UI to provision it, and add a user
```

```
export KOLIBRI_HOME=~/.singleusersyncclient
# the following values are based on the facility ID and user ID from the other server
kolibri manage sync --user-id=71f1b6a9c53e79f379bd96a6464a3025 --facility=d1cf3dfad3c01583100467336d7b3693 --baseurl=http://127.0.0.1:8000
# when it asks for credentials, you can put in either the superuser or the learner account that were created
```

@rtibbles is working on updating/fixing the automated syncing tests to cover this.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
