### PR TITLE
Add test and fix for byte encoded unicode text as a value for info.

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import socket
 import threading
 
@@ -14,6 +15,7 @@ from ..utils.network.search import initialize_zeroconf_listener
 from ..utils.network.search import KolibriZeroconfService
 from ..utils.network.search import LOCAL_DOMAIN
 from ..utils.network.search import NonUniqueNameException
+from ..utils.network.search import parse_device_info
 from ..utils.network.search import register_zeroconf_service
 from ..utils.network.search import SERVICE_TYPE
 from ..utils.network.search import unregister_zeroconf_service
@@ -118,6 +120,16 @@ class TestNetworkSearch(TransactionTestCase):
         assert ZEROCONF_STATE["listener"] is None
         initialize_zeroconf_listener()
         assert ZEROCONF_STATE["listener"] is not None
+
+    def test_call_parse_device_info_value_bytes(self, *mocks):
+        info_mock = mock.MagicMock()
+        info_mock.properties = MOCK_PROPERTIES.copy()
+        info_mock.properties[b"operating_system"] = '"كوليبري"'.encode("utf-8")
+        try:
+            device_info = parse_device_info(info_mock)
+        except TypeError:
+            self.fail("Failed to parse info with bytes values")
+        self.assertEqual(device_info["operating_system"], "كوليبري")
 
     def test_register_zeroconf_service(self, mock_db, get_device_mock):
         assert len(get_peer_instances()) == 0

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -101,6 +101,15 @@ class KolibriZeroconfService(object):
             self.unregister()
 
 
+def parse_device_info(info):
+    obj = {}
+    for key, val in info.properties.items():
+        if isinstance(val, bytes):
+            val = val.decode("utf-8")
+        obj[bytes.decode(key)] = json.loads(val)
+    return obj
+
+
 class KolibriZeroconfListener(object):
 
     instances = {}
@@ -133,9 +142,7 @@ class KolibriZeroconfListener(object):
             "self": is_self,
         }
 
-        device_info = {
-            bytes.decode(key): json.loads(val) for (key, val) in info.properties.items()
-        }
+        device_info = parse_device_info(info)
 
         instance.update(device_info)
         self.instances[id] = instance


### PR DESCRIPTION
## Summary
* Isolates and then fixes https://github.com/learningequality/kolibri/issues/6615
* This was caused by an issue specific to Python 3.4 and 3.5 whereby json.loads does not accept `bytes` objects
* Newer Python 3 versions do, and it was not an issue on Python 2.

## References
Fixes https://github.com/learningequality/kolibri/issues/6615

## Reviewer guidance
Does it catch the error and pass the test on Python 3.4 and 3.5?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
