### PR TITLE
Search Box Vertical Green line fixed

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -136,8 +136,7 @@
     padding: 0;
     margin: 0;
     vertical-align: middle;
-    border: 0;
-    outline: none;
+    border: 0;   
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -12,7 +12,7 @@
     >
       <label
         class="visuallyhidden"
-        for="searchfield"
+        for="searchfield"   
       >
         {{ coreString('searchLabel') }}
       </label>
@@ -25,7 +25,7 @@
         :class="$computedClass(inputPlaceHolderStyle)"
         :style="{ color: $themeTokens.text }"
         dir="auto"
-        :placeholder="coreString('searchLabel')"
+        :placeholder="coreString('searchLabel')"       
       >
 
       <div class="buttons-wrapper">
@@ -137,6 +137,7 @@
     margin: 0;
     vertical-align: middle;
     border: 0;
+    outline: none;
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -137,7 +137,6 @@
     margin: 0;
     vertical-align: middle;
     border: 0;
-    outline: none;
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -12,7 +12,7 @@
     >
       <label
         class="visuallyhidden"
-        for="searchfield"   
+        for="searchfield"
       >
         {{ coreString('searchLabel') }}
       </label>
@@ -25,7 +25,7 @@
         :class="$computedClass(inputPlaceHolderStyle)"
         :style="{ color: $themeTokens.text }"
         dir="auto"
-        :placeholder="coreString('searchLabel')"       
+        :placeholder="coreString('searchLabel')"
       >
 
       <div class="buttons-wrapper">
@@ -136,7 +136,7 @@
     padding: 0;
     margin: 0;
     vertical-align: middle;
-    border: 0;   
+    border: 0;
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -36,7 +36,7 @@
         />
         <div
           class="search-submit-button-wrapper"
-          :style="{ backgroundColor: $themeTokens.primaryDark }"
+          :style="{ backgroundColor: $themeTokens.primaryDark }"         
         >
           <KIconButton
             :icon="icon"
@@ -293,6 +293,7 @@
     margin: 0;
     vertical-align: middle;
     border: 0;
+    outline: none;
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -36,7 +36,7 @@
         />
         <div
           class="search-submit-button-wrapper"
-          :style="{ backgroundColor: $themeTokens.primaryDark }"         
+          :style="{ backgroundColor: $themeTokens.primaryDark }"
         >
           <KIconButton
             :icon="icon"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
To fix the issue line 296 was added to SearchBox.vue. See screenshot below:
![image](https://user-images.githubusercontent.com/59783720/114250474-121e9580-995b-11eb-822d-5e87c8eac8c4.png)


**Before:** Unwanted green line visible in search box.

![vertical_greenline_searchbox](https://user-images.githubusercontent.com/59783720/114250493-1fd41b00-995b-11eb-81ed-3248f3ce78ca.gif)

**After:** Green line is no longer visible.

![vertical_nogreenline_searchbox](https://user-images.githubusercontent.com/59783720/114250502-25316580-995b-11eb-9738-89166a1134a2.gif)


## References
Issue: #7990



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The only change occurs in the search box under Learn section where unwanted green line has been removed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
