### PR TITLE
Make dataset_id caching thread local and only used in sync to avoid locks.

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -108,6 +108,7 @@ class Command(AsyncCommand):
             call_command("loaddata", "scopedefinitions")
 
         dataset_cache.clear()
+        dataset_cache.activate()
 
         # try to connect to server
         controller = MorangoProfileController(PROFILE_FACILITY_DATA)
@@ -204,6 +205,7 @@ class Command(AsyncCommand):
             self.job.extra_metadata.update(sync_state=State.COMPLETED)
             self.job.save_meta()
 
+        dataset_cache.deactivate()
         logger.info("Syncing has been completed.")
 
     @contextmanager

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -23,13 +23,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
+from threading import local
 
 import six
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.models import UserManager
 from django.core import validators
-from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -75,11 +75,37 @@ from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import set_device_settings
 from kolibri.core.errors import KolibriValidationError
 from kolibri.core.fields import DateTimeTzField
-from kolibri.core.utils.cache import NamespacedCacheProxy
 from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
-dataset_cache = NamespacedCacheProxy(cache, "dataset")
+
+
+class DatasetCache(local):
+    def __init__(self):
+        self.deactivate()
+
+    def activate(self):
+        self._active = True
+
+    def deactivate(self):
+        self._active = False
+        self.clear()
+
+    def clear(self):
+        self._cache = {}
+
+    def get(self, key):
+        if self._active:
+            return self._cache.get(key)
+        return None
+
+    def set(self, key, dataset_id):
+        if self._active:
+            self._cache[key] = dataset_id
+        return None
+
+
+dataset_cache = DatasetCache()
 
 
 def _has_permissions_class(obj):
@@ -203,7 +229,7 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
                 dataset_id = getattr(self, related_obj_name).dataset_id
             except ObjectDoesNotExist as e:
                 raise ValidationError(e)
-            dataset_cache.set(key, dataset_id, 60 * 10)
+            dataset_cache.set(key, dataset_id)
         return dataset_id
 
     def calculate_source_id(self):


### PR DESCRIPTION
## Summary
* Prevents uncleared locks for cache operations by removing the use of locks
* Creates a thread local object for caching dataset_ids only when activated
* Activates and deactivates the object during sync

## References
Fixes #7908
Fixes #7463

## Reviewer guidance
I tested this by adding some logging statements to the kolibri/core/auth/models.py `AbstractFacilityDataModel` `cached_related_dataset_lookup` to log when a cached value was found and when one was not found.

During a very simple sync, first datasets were looked up twice without being found in the cache, but then multiple subsequent lookups were found in the cache object.

During repeated logins via the interface, no cached values were used, implying that the activation and deactivation is working as intended.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
