### PR TITLE
Fixed the outline error in searchbar and On video player (hovering)

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -293,6 +293,7 @@
     margin: 0;
     vertical-align: middle;
     border: 0;
+    outline: none;
 
     // removes the IE clear button
     &::-ms-clear {

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -699,6 +699,12 @@
         &::before {
           font-size: $button-font-size-normal;
           line-height: $button-height-normal;
+           &:hover {
+            outline: none;
+        }
+        }
+        &:hover {
+          outline: none;
         }
       }
     }

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -699,12 +699,6 @@
         &::before {
           font-size: $button-font-size-normal;
           line-height: $button-height-normal;
-           &:hover {
-            outline: none;
-        }
-        }
-        &:hover {
-          outline: none;
         }
       }
     }

--- a/kolibri/plugins/media_player/assets/src/views/videojs-style/video-js.min.css
+++ b/kolibri/plugins/media_player/assets/src/views/videojs-style/video-js.min.css
@@ -237,6 +237,7 @@
   font-family: VideoJS;
   font-style: normal;
   font-weight: 400;
+  outline: none;
 }
 .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder::before,
 .vjs-icon-cancel::before {

--- a/~/.bash_profile
+++ b/~/.bash_profile
@@ -1,0 +1,1 @@
+export KOLIBRI_RUN_MODE="dev"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
 I have fixed the issues of outline which was appearing on some components like searchbar, on video player while hovering.
![simplescreenrecorder-2021-04-10_13 56 34](https://user-images.githubusercontent.com/40101776/114263716-d809ce00-9a04-11eb-933d-1283fbd4b847.gif)
![image](https://user-images.githubusercontent.com/40101776/114263920-ae04db80-9a05-11eb-9bc5-463434cc5a1b.png)


## References
<!--

-->

Issue: #7974

## Reviewer guidance
<!--


-->
 Just need to ensure the changes are visible. The components which are needed to be checked are searchbox and video player Play/Pause button.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
