### PR TITLE
Ensure progress_fraction is propagated through resource api

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
@@ -1,4 +1,6 @@
-import { ContentNodeResource } from 'kolibri.resources';
+import { ContentNodeProgressResource, ContentNodeResource } from 'kolibri.resources';
+import chunk from 'lodash/chunk';
+import merge from 'lodash/merge';
 import { PageNames } from '../../constants';
 import { _collectionState } from '../coreLearn/utils';
 
@@ -30,9 +32,37 @@ export function showChannels(store) {
             }
           })
           .filter(Boolean);
-        store.commit('topicsRoot/SET_STATE', { rootNodes });
-        store.commit('CORE_SET_PAGE_LOADING', false);
-        store.commit('CORE_SET_ERROR', null);
+
+        // We will create an array that will either be empty when there is no user logged in,
+        // or it will contain Promises returned by `fetchCollection`.
+        // In either case we will pass the `progressPromises` array to Promise.all() and chain
+        // a finally() to handle updating the store in any case
+        const userIsLoggedIn = store.getters.isUserLoggedIn;
+        const progressPromises = !userIsLoggedIn
+          ? [] // The user is not logged in - so we don't need to fetch anything
+          : chunk(rootNodes, 30).map(chunkOfNodes => {
+              // Chunking these to avoid too complex a query.
+              const ids = chunkOfNodes.map(n => n.id);
+              return ContentNodeProgressResource.fetchCollection({
+                getParams: { ids },
+              }).then(progressResponse => {
+                // We're going to merge this into rootNodes and we want the key to be progress from
+                // here on
+                progressResponse.forEach(o => {
+                  o.progress = o.progress_fraction;
+                  delete o.progress_fraction;
+                });
+                // Merges the progressResponse object into rootNodes (mutating rootNodes)
+                merge(rootNodes, progressResponse);
+              });
+            });
+
+        // Whether we've updated the rootNodes with progress or not, we need to updat the store
+        Promise.all(progressPromises).finally(() => {
+          store.commit('topicsRoot/SET_STATE', { rootNodes });
+          store.commit('CORE_SET_PAGE_LOADING', false);
+          store.commit('CORE_SET_ERROR', null);
+        });
       });
     },
     error => {

--- a/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
@@ -1,6 +1,7 @@
 import { ContentNodeProgressResource, ContentNodeResource } from 'kolibri.resources';
 import chunk from 'lodash/chunk';
 import merge from 'lodash/merge';
+import find from 'lodash/find';
 import { PageNames } from '../../constants';
 import { _collectionState } from '../coreLearn/utils';
 
@@ -46,14 +47,11 @@ export function showChannels(store) {
               return ContentNodeProgressResource.fetchCollection({
                 getParams: { ids },
               }).then(progressResponse => {
-                // We're going to merge this into rootNodes and we want the key to be progress from
-                // here on
                 progressResponse.forEach(o => {
-                  o.progress = o.progress_fraction;
-                  delete o.progress_fraction;
+                  // Set the value of progress in the matching node in rootNodes with the
+                  // response object's progress_fraction value
+                  find(rootNodes, n => n.id == o.id).progress = o.progress_fraction;
                 });
-                // Merges the progressResponse object into rootNodes (mutating rootNodes)
-                merge(rootNodes, progressResponse);
               });
             });
 

--- a/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
@@ -1,6 +1,5 @@
 import { ContentNodeProgressResource, ContentNodeResource } from 'kolibri.resources';
 import chunk from 'lodash/chunk';
-import merge from 'lodash/merge';
 import find from 'lodash/find';
 import { PageNames } from '../../constants';
 import { _collectionState } from '../coreLearn/utils';


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In the Learn topicsRoot module's handler `showChannels` - I added some logic to gather the progress for the channels and merge the values into the store so that the display logic that is already in place for the ChannelCard to display the "In progress" icon has the `progress` value it is expecting on each Channel's node.

This won't happen if the user is not logged in - we skip the calls to `ContentNodeProgressResource.fetchCollection` in this case.

I lodash.chunk()ed the calls to that resource to avoid too complex queries, per @rtibbles notes about a similar bit of logic in `RecommendedSubpage.vue`.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #6112 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Check as a user who has progress
- Change to another logged in user who has different progress (see that it is different)
- Log out and view as guest - make sure you don't see any progress on the frontend and that you see no calls to `/api/content/contentnodeprogress`.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
