### PR TITLE
Use transaction lock.

### DIFF
--- a/kolibri/core/utils/lock.py
+++ b/kolibri/core/utils/lock.py
@@ -24,12 +24,7 @@ class PostgresLock(object):
         self.key = key
 
     def execute(self):
-        query = "SELECT pg_advisory_lock({key}) AS lock;".format(key=self.key)
-        with connection.cursor() as c:
-            c.execute(query)
-
-    def revert(self):
-        query = "SELECT pg_advisory_unlock({key}) AS lock;".format(key=self.key)
+        query = "SELECT pg_advisory_xact_lock({key}) AS lock;".format(key=self.key)
         with connection.cursor() as c:
             c.execute(query)
 


### PR DESCRIPTION
## Summary
Fixes issue raised in post-merge review of https://github.com/learningequality/kolibri/pull/8004#discussion_r614220041
Uses transaction level advisory lock rather than session level

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
