### PR TITLE
Remove db_lock from non-django ops

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -25,8 +25,7 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
 
     if node_ids or exclude_node_ids:
         # If we have been passed node ids do not do a full deletion pass
-        with db_lock():
-            set_content_invisible(channel.id, node_ids, exclude_node_ids)
+        set_content_invisible(channel.id, node_ids, exclude_node_ids)
         # If everything has been made invisible, delete all the metadata
         delete_all_metadata = not channel.root.available
 

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -52,8 +52,7 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
         # seems to cause the Django ORM interactions in the former to roll back
         # Not quite sure what is causing it, but presumably due to transaction
         # scopes.
-        with db_lock():
-            reannotate_all_channels()
+        reannotate_all_channels()
 
     if delete_all_metadata:
         logger.info("Deleting all channel metadata")

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -12,7 +12,6 @@ from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.errors import KolibriUpgradeError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
-from kolibri.core.utils.lock import db_lock
 from kolibri.utils import conf
 
 logger = logging.getLogger(__name__)
@@ -169,12 +168,10 @@ class Command(AsyncCommand):
                         .exclude(kind=content_kinds.TOPIC)
                         .values_list("id", flat=True)
                     )
-                    with db_lock():
-                        import_ran = import_channel_by_id(channel_id, self.is_cancelled)
+                    import_ran = import_channel_by_id(channel_id, self.is_cancelled)
                     if node_ids and import_ran:
                         # annotate default channel db based on previously annotated leaf nodes
-                        with db_lock():
-                            update_content_metadata(channel_id, node_ids=node_ids)
+                        update_content_metadata(channel_id, node_ids=node_ids)
                     if import_ran:
                         # Clear any previously set channel availability stats for this channel
                         clear_channel_stats(channel_id)

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -18,7 +18,6 @@ from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.content.utils.upgrade import get_import_data_for_update
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
-from kolibri.core.utils.lock import db_lock
 from kolibri.utils import conf
 
 # constants to specify the transfer method to be used
@@ -375,14 +374,13 @@ class Command(AsyncCommand):
                                 self.exception = e
                                 break
 
-            with db_lock():
-                annotation.set_content_visibility(
-                    channel_id,
-                    file_checksums_to_annotate,
-                    node_ids=node_ids,
-                    exclude_node_ids=exclude_node_ids,
-                    public=public,
-                )
+            annotation.set_content_visibility(
+                channel_id,
+                file_checksums_to_annotate,
+                node_ids=node_ids,
+                exclude_node_ids=exclude_node_ids,
+                public=public,
+            )
 
             resources_after_transfer = (
                 ContentNode.objects.filter(channel_id=channel_id, available=True)

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -28,6 +28,7 @@ from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.sqlalchemybridge import filter_by_checksums
 from kolibri.core.device.models import ContentCacheKey
+from kolibri.core.utils.lock import db_lock
 
 logger = logging.getLogger(__name__)
 
@@ -704,15 +705,16 @@ def set_content_invisible(channel_id, node_ids, exclude_node_ids):
 
 
 def set_channel_metadata_fields(channel_id, public=None):
-    channel = ChannelMetadata.objects.get(id=channel_id)
-    calculate_published_size(channel)
-    calculate_total_resource_count(channel)
-    calculate_included_languages(channel)
-    calculate_next_order(channel)
+    with db_lock():
+        channel = ChannelMetadata.objects.get(id=channel_id)
+        calculate_published_size(channel)
+        calculate_total_resource_count(channel)
+        calculate_included_languages(channel)
+        calculate_next_order(channel)
 
-    if public is not None:
-        channel.public = public
-        channel.save()
+        if public is not None:
+            channel.public = public
+            channel.save()
 
 
 def files_for_nodes(nodes):

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -99,7 +99,7 @@ def get_engine(connection_string):
     if connection_string.startswith("sqlite"):
         # Set timeout to 60s, as with most of our content import write operations
         # it is more important to complete, than to do so quickly.
-        engine_kwargs["connect_args"] = {"check_same_thread": False, "timeout": 60}
+        engine_kwargs["connect_args"] = {"check_same_thread": False, "timeout": 5 * 60}
         engine_kwargs["poolclass"] = NullPool
     else:
         engine_kwargs["pool_pre_ping"] = True


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Removes the `db_lock` for import operations that use the SQLAlchemy connection instead of Django's

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/8012

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Manual testing:

* Import a channel from studio
* Delete content
* Sync

Code review:

In the code, look for any database functions that use the SQLAlchemy bridge (can tell because `sqlalchemy.Bridge` will be somewhere in the call stack. These functions should not be with a lock.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
