### PR TITLE
Update perseus renderer for Safari compatibility

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 unicodecsv==0.14.1
 metafone==0.5
 le-utils==0.1.24
-kolibri_exercise_perseus_plugin==1.3.4
+kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1


### PR DESCRIPTION
## Summary
Removes usage of safari incompatible negative lookaheads in regex


## References
Fixes https://github.com/learningequality/kolibri/issues/8017

Diff: https://github.com/learningequality/kolibri-exercise-perseus-plugin/compare/v1.3.4...v1.3.5

## Reviewer guidance
In Safari and IE11 test this all questions in this exercise from the QA channel:
https://kolibri-beta.learningequality.org/en/learn/#/topics/c/fc3e2505ecc5441caf22b0657c651340

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
