### PR TITLE
Add KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV - default True to options.py

### DIFF
--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -16,6 +16,7 @@ from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils import conf
 
 
 class Learn(KolibriPluginBase):
@@ -52,6 +53,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
         return {
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
+            "disableCustomChannelNav": conf.OPTIONS['LEARN']['DISABLE_CUSTOM_CHANNEL_NAV'],
         }
 
 

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -53,7 +53,9 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
         return {
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
-            "disableCustomChannelNav": conf.OPTIONS['LEARN']['DISABLE_CUSTOM_CHANNEL_NAV'],
+            "disableCustomChannelNav": conf.OPTIONS["LEARN"][
+                "DISABLE_CUSTOM_CHANNEL_NAV"
+            ],
         }
 
 

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -53,8 +53,8 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
         return {
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
-            "disableCustomChannelNav": conf.OPTIONS["LEARN"][
-                "DISABLE_CUSTOM_CHANNEL_NAV"
+            "enableCustomChannelNav": conf.OPTIONS["Learn"][
+                "KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV"
             ],
         }
 

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -21,6 +21,7 @@ from kolibri.plugins.hooks import register_hook
 class Learn(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
     translated_view_urls = "urls"
+    kolibri_options = "options"
 
 
 @register_hook

--- a/kolibri/plugins/learn/options.py
+++ b/kolibri/plugins/learn/options.py
@@ -1,9 +1,9 @@
 option_spec = {
-    "LEARN": {
-        "DISABLE_CUSTOM_CHANNEL_NAV": {
+    "Learn": {
+        "KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV": {
             "type": "boolean",
             "default": False,
-            "envvars": ("DISABLE_CUSTOM_CHANNEL_NAV",),
+            "envvars": ("KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV",),
         },
     },
 }

--- a/kolibri/plugins/learn/options.py
+++ b/kolibri/plugins/learn/options.py
@@ -1,0 +1,9 @@
+option_spec = {
+    "LEARN": {
+        "DISABLE_CUSTOM_CHANNEL_NAV": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("DISABLE_CUSTOM_CHANNEL_NAV",),
+        },
+    },
+}

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -48,6 +48,7 @@ URL_PATH_PREFIX
 LANGUAGES
 ZIP_CONTENT_HOST
 ZIP_CONTENT_PORT
+DISABLE_CUSTOM_CHANNEL_NAV
 
 [Python]
 PICKLE_PROTOCOL
@@ -366,6 +367,11 @@ base_option_spec = {
             "type": "integer",
             "default": 8888,
             "envvars": ("KOLIBRI_ZIP_CONTENT_PORT",),
+        },
+        "DISABLE_CUSTOM_CHANNEL_NAV": {
+            "type": "boolean",
+            "default": False,
+            "envvars": ("DISABLE_CUSTOM_CHANNEL_NAV",),
         },
     },
     "Python": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -48,7 +48,6 @@ URL_PATH_PREFIX
 LANGUAGES
 ZIP_CONTENT_HOST
 ZIP_CONTENT_PORT
-DISABLE_CUSTOM_CHANNEL_NAV
 
 [Python]
 PICKLE_PROTOCOL
@@ -367,11 +366,6 @@ base_option_spec = {
             "type": "integer",
             "default": 8888,
             "envvars": ("KOLIBRI_ZIP_CONTENT_PORT",),
-        },
-        "DISABLE_CUSTOM_CHANNEL_NAV": {
-            "type": "boolean",
-            "default": False,
-            "envvars": ("DISABLE_CUSTOM_CHANNEL_NAV",),
         },
     },
     "Python": {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds an option that will be picked up from the options.ini file or by env var called `DISABLE_CUSTOM_CHANNEL_NAV`.

It is not then used anywhere as (I believe) it is intended for future debugging and/or dev use during development of the new feature.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7830 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

[See that I did what is said in the well written and clear documentation that I ought to have read](https://kolibri-dev.readthedocs.io/en/develop/backend_architecture/plugins.html#creating-a-plugin)