### PR TITLE
Remove cherrypy dependency

### DIFF
--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -42,5 +42,5 @@ jobs:
         pip install .
 
         # ensure kolibri stops within 20 seconds 10 times in a row
-        ./test/ensure_kolibri_stops_within_time.sh 20 10 8082
+        ./test/ensure_kolibri_stops_within_time.sh 20 10 8082 8083
         ./test/ensure_no_kolibris_running_on_port.sh 8082

--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -51,12 +51,14 @@ class Command(AsyncCommand):
     def handle_async(self, *args, **options):
 
         # safest not to run this command while the server is running
-        status_code, _ = server.get_urls()
-        if status_code == server.STATUS_RUNNING:
+        try:
+            server.get_status()
             logger.error(
                 "The Kolibri server is currently running. Please stop it and then re-run this command."
             )
             sys.exit(1)
+        except server.NotRunning:
+            pass
 
         # ensure the user REALLY wants to do this!
         confirm_or_exit(

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -8,6 +8,7 @@ from six.moves.urllib.parse import urljoin
 
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.utils import conf
+from kolibri.utils.server import get_zip_port
 
 
 # valid storage filenames consist of 32-char hex plus a file extension
@@ -251,6 +252,20 @@ def get_file_checksums_url(channel_id, baseurl, version="1"):
 HASHI = "hashi/"
 
 ZIPCONTENT = "zipcontent/"
+
+
+def get_zip_content_config():
+    zip_content_origin = conf.OPTIONS["Deployment"]["ZIP_CONTENT_ORIGIN"]
+    if not zip_content_origin:
+        zip_content_port = str(
+            get_zip_port() or conf.OPTIONS["Deployment"]["ZIP_CONTENT_PORT"]
+        )
+    elif type(zip_content_origin) is int:
+        zip_content_port = str(zip_content_origin)
+        zip_content_origin = ""
+    else:
+        zip_content_port = ""
+    return zip_content_origin, zip_content_port
 
 
 def zip_content_path_prefix():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -201,7 +201,11 @@ def register_zeroconf_service(port):
     if ZEROCONF_STATE["service"] is not None:
         unregister_zeroconf_service()
 
-    logger.info("Registering ourselves to zeroconf network with id '%s'..." % id)
+    logger.info(
+        "Registering ourselves to zeroconf network with id '{}' and port '{}'".format(
+            id, port
+        )
+    )
     data = device_info
     ZEROCONF_STATE["service"] = KolibriZeroconfService(id=id, port=port, data=data)
     ZEROCONF_STATE["service"].register()

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -19,6 +19,7 @@ import kolibri
 from kolibri.core.content.utils.paths import get_content_storage_url
 from kolibri.core.content.utils.paths import get_hashi_path
 from kolibri.core.content.utils.paths import get_zip_content_base_path
+from kolibri.core.content.utils.paths import get_zip_content_config
 from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.device.utils import allow_other_browsers_to_connect
 from kolibri.core.hooks import NavigationHook
@@ -53,14 +54,7 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
             # For some reason the js_name gets escaped going into the template
             # so this was the easiest way to inject it.
         ).replace("__placeholder__", js_name)
-        zip_content_origin = OPTIONS["Deployment"]["ZIP_CONTENT_ORIGIN"]
-        if not zip_content_origin:
-            zip_content_port = str(OPTIONS["Deployment"]["ZIP_CONTENT_PORT"])
-        elif type(zip_content_origin) is int:
-            zip_content_port = str(zip_content_origin)
-            zip_content_origin = ""
-        else:
-            zip_content_port = ""
+        zip_content_origin, zip_content_port = get_zip_content_config()
         return [
             mark_safe(
                 """<script type="text/javascript">"""

--- a/kolibri/core/tasks/test/test_worker.py
+++ b/kolibri/core/tasks/test/test_worker.py
@@ -40,7 +40,7 @@ class TestWorker:
         job = Job(id, 9)
         worker.storage.enqueue_job(job, QUEUE)
 
-        while job.state == State.QUEUED:
+        while job.state != State.COMPLETED:
             job = worker.storage.get_job(job.job_id)
             time.sleep(0.5)
         try:

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -49,7 +49,7 @@ def import_stringified_func(funcstring):
 class InfiniteLoopThread(compat.Thread):
     """A class that runs a given function an infinite number of times, until told to shut down."""
 
-    DEFAULT_TIMEOUT_SECONDS = 0.2
+    DEFAULT_TIMEOUT_SECONDS = 0.001
 
     def __init__(self, func, thread_name, wait_between_runs=1, *args, **kwargs):
         """

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -455,16 +455,25 @@ def main(ctx):
     help="Port on which Kolibri is being served",
 )
 @click.option(
+    "--zip-port",
+    default=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
+    type=int,
+    help="Port on which zip content server is being served",
+)
+@click.option(
     "--background/--foreground",
     default=True,
     help="Run Kolibri as a background process",
 )
-def start(port, background):
+def start(port, zip_port, background):
     """
     Start the server on given port.
     """
     server.start(
-        port=port, serve_http=OPTIONS["Server"]["CHERRYPY_START"], background=background
+        port=port,
+        zip_port=zip_port,
+        serve_http=OPTIONS["Server"]["CHERRYPY_START"],
+        background=background,
     )
 
 
@@ -530,7 +539,7 @@ def status():
     "--port",
     default=OPTIONS["Deployment"]["HTTP_PORT"],
     type=int,
-    help="Port on which to run Kolibri services",
+    help="Port on which Kolibri is running to inform services",
 )
 @click.option(
     "--background/--foreground",
@@ -544,7 +553,7 @@ def services(port, background):
 
     logger.info("Starting Kolibri background services")
 
-    server.start(port=port, serve_http=False, background=background)
+    server.start(port=port, zip_port=None, serve_http=False, background=background)
 
 
 def setup_logging(debug=False, debug_database=False):

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -224,21 +224,6 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },
-            "cherrypy.access": {
-                "handlers": ["file", "console", "file_debug"],
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
-            },
-            "cherrypy.error": {
-                "handlers": ["file", "console", "file_debug"],
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
-            },
-            "cherrypy": {
-                "handlers": ["file", "console", "file_debug"],
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
-            },
         },
     }
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -208,7 +208,7 @@ def path_list(value):
 
 
 def validate_port_number(value):
-    if 1 <= value <= 65535:
+    if 0 <= value <= 65535:
         return value
     raise VdtValueError(value)
 
@@ -418,7 +418,7 @@ base_option_spec = {
         },
         "ZIP_CONTENT_PORT": {
             "type": "port",
-            "default": 8765,
+            "default": 0,
             "envvars": ("KOLIBRI_ZIP_CONTENT_PORT",),
         },
         "ZIP_CONTENT_URL_PATH_PREFIX": {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -212,6 +212,15 @@ class KolibriServerPlugin(ServerPlugin):
     START.priority = 75
 
 
+class ZipContentServerPlugin(ServerPlugin):
+    def START(self):
+        super(ZipContentServerPlugin, self).START()
+        _, bind_port = self.httpserver.bind_addr
+        self.bus.publish("ZIP_SERVING", bind_port)
+
+    START.priority = 75
+
+
 class ServicesPlugin(SimplePlugin):
     def __init__(self, bus, port):
         self.bus = bus
@@ -444,7 +453,7 @@ def configure_http_server(port, zip_port, bus):
         zip_port,
     )
 
-    alt_port_server = ServerPlugin(
+    alt_port_server = ZipContentServerPlugin(
         bus,
         httpserver=Server(alt_port_addr, alt_application, **server_config),
         bind_addr=alt_port_addr,

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -20,7 +20,6 @@ import logging
 import os
 import signal
 import sys
-import time
 
 import six
 from django.db import connections
@@ -59,21 +58,6 @@ def _kill_pid(pid, softkill_signal_number):
             "Soft kill signal could not be sent (OSError); process may not exist?"
         )
         return
-    if pid_exists(pid):
-        logger.info("Waiting for Kolibri to finish shutting down")
-    # give some time for the process to clean itself up gracefully before we force anything
-    i = 0
-    while pid_exists(pid) and i < 60:
-        time.sleep(0.5)
-        i += 1
-    # if process didn't exit cleanly, make one last effort to kill it
-    if pid_exists(pid):
-        logger.debug(
-            "Process wth pid %s still exists after soft kill signal; attempting a SIGKILL."
-            % pid
-        )
-        os.kill(pid, signal.SIGKILL)
-        logger.debug("SIGKILL signal sent without error.")
 
 
 def _posix_kill_pid(pid):

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -166,6 +166,8 @@ def test_kolibri_listen_port_env(monkeypatch):
 
         test_port = 1234
 
+        test_zip_port = 5432
+
         os.environ["KOLIBRI_HTTP_PORT"] = str(test_port)
 
         # force a reload of plugins.OPTIONS so the environment variable will be read in
@@ -173,7 +175,7 @@ def test_kolibri_listen_port_env(monkeypatch):
 
         conf.OPTIONS.update(options.read_options_file(conf.KOLIBRI_HOME))
 
-        cli.start.callback(test_port, False)
+        cli.start.callback(test_port, test_zip_port, False)
         with pytest.raises(SystemExit) as excinfo:
             cli.stop.callback()
             assert excinfo.code == 0

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -157,7 +157,7 @@ def test_kolibri_listen_port_env(monkeypatch):
         def start_mock(port, *args, **kwargs):
             assert port == test_port
             try:
-                os.remove(server.STARTUP_LOCK)
+                os.remove(server.PID_FILE)
             except OSError:
                 pass
 
@@ -189,13 +189,13 @@ def test_kolibri_listen_port_env(monkeypatch):
         def status_starting_up():
             raise server.NotRunning(server.STATUS_STARTING_UP)
 
-        # Ensure that if a server is reported to be 'starting up', it doesn't
-        # get killed while doing that.
+        # Ensure that if a server is reported to be 'starting up', it still
+        # successfully shuts down.
         monkeypatch.setattr(server, "get_status", status_starting_up)
         with pytest.raises(SystemExit) as excinfo:
             cli.stop.callback()
             assert excinfo.code == server.STATUS_STARTING_UP
-        assert "Not stopped" in LOG_LOGGER[-1][1]
+        assert "successfully been stopped" in LOG_LOGGER[-1][1]
 
 
 @pytest.mark.django_db

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -1,45 +1,16 @@
-import os
 import sys
 import tempfile
 
-import portend
 from django.db.utils import OperationalError
 from django.test import TestCase
 from mock import patch
 
 from kolibri.utils import sanity_checks
 from kolibri.utils.sanity_checks import DatabaseNotMigrated
-from kolibri.utils.server import NotRunning
 from kolibri.utils.tests.helpers import override_option
 
 
 class SanityCheckTestCase(TestCase):
-    @patch("kolibri.utils.sanity_checks.logging.error")
-    @patch("kolibri.utils.sanity_checks.get_status", return_value={1, 2, 3})
-    def test_other_kolibri_running(self, status_mock, logging_mock):
-        with self.assertRaises(SystemExit):
-            sanity_checks.check_other_kolibri_running("8080")
-            logging_mock.assert_called()
-
-    @patch("kolibri.utils.sanity_checks.logging.error")
-    @patch("kolibri.utils.sanity_checks.portend.free")
-    @patch("kolibri.utils.sanity_checks.get_status")
-    def test_port_occupied(self, status_mock, portend_mock, logging_mock):
-        status_mock.side_effect = NotRunning("Kolibri not running")
-        portend_mock.side_effect = portend.Timeout
-        with self.assertRaises(SystemExit):
-            sanity_checks.check_port_availability("0.0.0.0", "8080")
-            logging_mock.assert_called()
-
-    @patch("kolibri.utils.sanity_checks.logging.error")
-    @patch("kolibri.utils.sanity_checks.portend.free")
-    def test_socket_activation_support(self, portend_mock, logging_mock):
-        portend_mock.side_effect = portend.Timeout
-        # LISTEN_PID environment variable would be set if using socket activation
-        with patch.dict(os.environ, {"LISTEN_PID": "1234"}):
-            sanity_checks.check_port_availability("0.0.0.0", "8080")
-            logging_mock.assert_not_called()
-
     @patch("kolibri.utils.cli.get_version", return_value="")
     @patch("kolibri.utils.sanity_checks.logging.error")
     @override_option(

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,18 +8,16 @@ colorlog==3.2.0 # pyup: <4.0.0
 configobj==5.0.6
 django-mptt==0.9.1
 requests==2.21.0
-cherrypy==13.0.1  # Temporarily pinning this until CherryPy stops depending on namespaced package, see #2971 # pyup: <13.1.0
-tempora<1.13  # derived no-upper-bounds dependency of cherrypy causing issues  # pyup: <1.13
-cheroot<6.2.0  # 6.2.0 introduced a namespaced pkg # pyup: <6.2.0
+portend==2.6
+tempora<1.13  # derived no-upper-bounds dependency of portend causing issues  # pyup: <1.13
+cheroot==8.5.2
+magicbus==4.1.2
 futures==3.1.1  # Temporarily pinning this until we can do a Python 2/3 compatible solution of newer versions # pyup: <=3.1.1
 more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
-unicodecsv==0.14.1
-metafone==0.5
 le-utils==0.1.24
 kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-clint==0.5.1
 morango==0.5.5
 tzlocal==2.1
 pytz==2020.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,6 @@ colorlog==3.2.0 # pyup: <4.0.0
 configobj==5.0.6
 django-mptt==0.9.1
 requests==2.21.0
-portend==2.6
-tempora<1.13  # derived no-upper-bounds dependency of portend causing issues  # pyup: <1.13
 cheroot==8.5.2
 magicbus==4.1.2
 futures==3.1.1  # Temporarily pinning this until we can do a Python 2/3 compatible solution of newer versions # pyup: <=3.1.1

--- a/test/ensure_kolibri_stops_within_time.sh
+++ b/test/ensure_kolibri_stops_within_time.sh
@@ -3,7 +3,7 @@
 MAX=0
 for i in $(seq 1 $2)
 do
-  kolibri start --port=$3 > /dev/null 2>&1
+  kolibri start --port=$3 --zip-port=$4 > /dev/null 2>&1
   START_TIME=$SECONDS
   kolibri stop > /dev/null 2>&1
   ELAPSED_TIME=$(($SECONDS - $START_TIME))


### PR DESCRIPTION
## Summary
* Removes cherrypy as a dependency
* Replaces it with explicit use of cheroot and magicbus
* Cleans up unused dependencies
* Passes port to zeroconf listener registration once main server has completed serving
* Has fallback for services command where it will pass in the set port once the process has started running
* Consolidates all server start code in server.py
* Uses pid file to track server status using ProcessBus life cycle hooks
* Use pid file throughout start cycle rather than separate startup lock
* Simplifies the stop procedure
* Sets default zip port to 0 to allow it to be dynamically chosen
* Creates a port cache to record previously available ports - port discovery slows startup time, so this helps to mitigate this
* Directly connect server logging to kolibri logging

## References
Depends on #8023 
Fixes #8024
Supersedes #7714
This also contributes to fixing https://github.com/learningequality/kolibri-app/issues/74 in a most general way, by allowing apps to just specify port 0, and allowing a free port to be chosen for use.

## Reviewer guidance
Kolibri should run and serve as intended.
Appropriate logging happens for all events in the server life cycle.
Start Kolibri with `--port=0` and verify that the port bound is the one reported, and that zeroconf registers that port

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
