### PR TITLE
Add more verbose logging for request errors.

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -1,3 +1,4 @@
+import store from 'kolibri.coreVue.vuex.store';
 import logger from 'kolibri.lib.logging';
 import find from 'lodash/find';
 import matches from 'lodash/matches';
@@ -86,7 +87,7 @@ export class Model {
                 this.promises.splice(this.promises.indexOf(promise), 1);
               },
               response => {
-                logging.error('An error occurred', response);
+                this.resource.logError(response);
                 reject(response);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -164,7 +165,7 @@ export class Model {
                 this.promises.splice(this.promises.indexOf(promise), 1);
               },
               response => {
-                logging.error('An error occurred', response);
+                this.resource.logError(response);
                 reject(response);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -214,7 +215,7 @@ export class Model {
                 this.promises.splice(this.promises.indexOf(promise), 1);
               },
               response => {
-                logging.error('An error occurred', response);
+                this.resource.logError(response);
                 reject(response);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -340,7 +341,7 @@ export class Collection {
                 this.promises.splice(this.promises.indexOf(promise), 1);
               },
               response => {
-                logging.error('An error occurred', response);
+                this.resource.logError(response);
                 reject(response);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -399,7 +400,7 @@ export class Collection {
               this.promises.splice(this.promises.indexOf(promise), 1);
             },
             response => {
-              logging.error('An error occurred', response);
+              this.resource.logError(response);
               reject(response);
               // Clean up the reference to this promise
               this.promises.splice(this.promises.indexOf(promise), 1);
@@ -450,7 +451,7 @@ export class Collection {
                 this.promises.splice(this.promises.indexOf(promise), 1);
               },
               response => {
-                logging.error('An error occurred', response);
+                this.resource.logError(response);
                 reject(response);
                 // Clean up the reference to this promise
                 this.promises.splice(this.promises.indexOf(promise), 1);
@@ -987,5 +988,39 @@ export class Resource {
       options.cacheBust = false;
     }
     return client(options);
+  }
+
+  logError(err) {
+    /* eslint-disable no-console */
+    console.group(
+      `%cRequest error: ${err.response.statusText}, ${
+        err.response.status
+      } for ${err.config.method.toUpperCase()} to ${err.config.url}`,
+      'color: red'
+    );
+    console.log(`Error occured for ${this.name} resource on page ${window.location.href}`);
+    if (store.state.route) {
+      console.log(
+        `Vue router fullPath is ${store.state.route.fullPath} with route name ${store.state.route.name}`
+      );
+      if (Object.keys(store.state.route.params).length) {
+        console.log('Vue router params', store.state.route.params);
+      }
+    }
+    if (Object.keys(err.config.params).length) {
+      console.log('Params:', err.config.params);
+    }
+    if (err.config.data) {
+      try {
+        const data = JSON.parse(err.config.data);
+        console.log('Data:', data);
+      } catch (e) {} // eslint-disable-line no-empty
+    }
+    if (err.config.headers) {
+      console.log('Headers:', err.config.headers);
+    }
+    console.trace('Traceback for request');
+    console.groupEnd();
+    /* eslint-enable */
   }
 }

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -1,4 +1,3 @@
-import store from 'kolibri.coreVue.vuex.store';
 import logger from 'kolibri.lib.logging';
 import find from 'lodash/find';
 import matches from 'lodash/matches';
@@ -991,33 +990,53 @@ export class Resource {
   }
 
   logError(err) {
+    const store = require('kolibri.coreVue.vuex.store').default;
     /* eslint-disable no-console */
-    console.group(
+    console.groupCollapsed(
       `%cRequest error: ${err.response.statusText}, ${
         err.response.status
-      } for ${err.config.method.toUpperCase()} to ${err.config.url}`,
+      } for ${err.config.method.toUpperCase()} to ${err.config.url} - open for more info`,
       'color: red'
     );
     console.log(`Error occured for ${this.name} resource on page ${window.location.href}`);
     if (store.state.route) {
-      console.log(
-        `Vue router fullPath is ${store.state.route.fullPath} with route name ${store.state.route.name}`
-      );
+      console.group('Vue Router');
+      console.log(`fullPath: ${store.state.route.fullPath}`);
+      console.log(`Route name: ${store.state.route.name}`);
       if (Object.keys(store.state.route.params).length) {
-        console.log('Vue router params', store.state.route.params);
+        console.group('Vue router params');
+        for (let [k, v] of Object.entries(store.state.route.params)) {
+          console.log(`${k}: ${v}`);
+        }
+        console.groupEnd();
       }
+      console.groupEnd();
     }
     if (Object.keys(err.config.params).length) {
-      console.log('Params:', err.config.params);
+      console.group('Query parameters');
+      for (let [k, v] of Object.entries(err.config.params)) {
+        console.log(`${k}: ${v}`);
+      }
+      console.groupEnd();
     }
     if (err.config.data) {
       try {
         const data = JSON.parse(err.config.data);
-        console.log('Data:', data);
+        if (Object.keys(data).length) {
+          console.group('Data');
+          for (let [k, v] of Object.entries(data)) {
+            console.log(`${k}: ${v}`);
+          }
+          console.groupEnd();
+        }
       } catch (e) {} // eslint-disable-line no-empty
     }
-    if (err.config.headers) {
-      console.log('Headers:', err.config.headers);
+    if (Object.keys(err.config.headers).length) {
+      console.group('Headers');
+      for (let [k, v] of Object.entries(err.config.headers)) {
+        console.log(`${k}: ${v}`);
+      }
+      console.groupEnd();
     }
     console.trace('Traceback for request');
     console.groupEnd();

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -332,7 +332,7 @@ export class Collection {
                   this.new = false;
                 } else {
                   // It's all gone a bit Pete Tong.
-                  logging.error('Data appears to be malformed', response.data);
+                  this.resource.logError(response);
                   reject(response);
                 }
                 resolve(this.data);

--- a/kolibri/core/assets/test/api-resource.spec.js
+++ b/kolibri/core/assets/test/api-resource.spec.js
@@ -152,6 +152,7 @@ describe('Collection', function() {
         resource._client = fn;
       },
     });
+    resource.logError = jest.fn();
     params = {};
     data = [{ test: 'test', id: 'testing' }];
     collection = new Resources.Collection(params, data, resource);
@@ -231,7 +232,7 @@ describe('Collection', function() {
     });
   });
   describe('fetch method', function() {
-    let setSpy, clearCacheSpy, client, logstub;
+    let setSpy, clearCacheSpy, client;
     describe('if called when Collection.synced = true and force is false', function() {
       it('should return current data immediately', function(done) {
         collection.synced = true;
@@ -397,10 +398,6 @@ describe('Collection', function() {
             response = {};
             client = jest.fn().mockResolvedValue(response);
             resource.client = client;
-            logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
-          });
-          afterEach(function() {
-            logstub.mockRestore();
           });
           it('should call the client once', function(done) {
             collection.synced = false;
@@ -409,10 +406,10 @@ describe('Collection', function() {
               done();
             });
           });
-          it('should call logging.error once', function(done) {
+          it('should call resource.logError once', function(done) {
             collection.synced = false;
             collection.fetch().catch(() => {
-              expect(logstub).toHaveBeenCalledTimes(1);
+              expect(resource.logError).toHaveBeenCalledTimes(1);
               done();
             });
           });
@@ -423,15 +420,11 @@ describe('Collection', function() {
           response = 'Error';
           client = jest.fn().mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           collection.synced = false;
           collection.fetch().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -487,7 +480,7 @@ describe('Collection', function() {
     });
   });
   describe('save method', function() {
-    let setSpy, client, logstub;
+    let setSpy, client;
     describe('if called when Collection.new = false', function() {
       it('should reject the promise', async function() {
         collection.new = false;
@@ -547,10 +540,6 @@ describe('Collection', function() {
             response = {};
             client = jest.fn().mockResolvedValue(response);
             resource.client = client;
-            logstub = jest.spyOn(Resources.logging, 'debug').mockImplementation(() => {});
-          });
-          afterEach(function() {
-            logstub.mockRestore();
           });
           it('should call the client once', async function() {
             collection.synced = false;
@@ -560,7 +549,7 @@ describe('Collection', function() {
           it('should call logging.debug once', async function() {
             collection.synced = false;
             await collection.save();
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
           });
         });
       });
@@ -569,15 +558,11 @@ describe('Collection', function() {
           response = 'Error';
           client = jest.fn().mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           collection.synced = false;
           collection.save().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -621,7 +606,7 @@ describe('Collection', function() {
     });
   });
   describe('delete method', function() {
-    let client, logstub;
+    let client;
     describe('if called when Collection has no getParams', function() {
       it('should reject the promise', function(done) {
         collection.getParams = {};
@@ -695,15 +680,11 @@ describe('Collection', function() {
           client = jest.fn();
           client.mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           collection.synced = false;
           collection.delete().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -806,7 +787,7 @@ describe('Collection', function() {
 });
 
 describe('Model', function() {
-  let resource, model, data, payload, client, logstub, setSpy;
+  let resource, model, data, payload, client, setSpy;
   beforeEach(function() {
     resource = {
       modelUrl: () => 'modelUrl',
@@ -814,6 +795,7 @@ describe('Model', function() {
       idKey: 'id',
       client: () => Promise.resolve({ data: {} }),
       removeModel: () => {},
+      logError: jest.fn(),
     };
     data = { test: 'test', id: 'testing' };
     model = new Resources.Model(data, {}, resource);
@@ -881,7 +863,7 @@ describe('Model', function() {
     });
   });
   describe('fetch method', function() {
-    let response, client, setSpy, logstub;
+    let response, client, setSpy;
     describe('if called when Model.synced = true and force is false', function() {
       it('should return current data immediately', async function() {
         model.synced = true;
@@ -947,15 +929,11 @@ describe('Model', function() {
           client = jest.fn();
           client.mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           model.synced = false;
           model.fetch().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -1146,15 +1124,11 @@ describe('Model', function() {
           client = jest.fn();
           client.mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           model.synced = false;
           model.save().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });
@@ -1298,14 +1272,10 @@ describe('Model', function() {
           client = jest.fn();
           client.mockRejectedValue(response);
           resource.client = client;
-          logstub = jest.spyOn(Resources.logging, 'error').mockImplementation(() => {});
         });
-        afterEach(function() {
-          logstub.mockRestore();
-        });
-        it('should call logging.error once', function(done) {
+        it('should call resource.logError once', function(done) {
           model.delete().catch(() => {
-            expect(logstub).toHaveBeenCalledTimes(1);
+            expect(resource.logError).toHaveBeenCalledTimes(1);
             done();
           });
         });


### PR DESCRIPTION
## Summary
* Provide more verbose error logging in the API Resource layer.
* Provide the status text, status code, URL and HTTP Verb used
* Provide the namespaced URL name of the endpoint
* Provide the full href of the page it occurred on
* Provide the fullPath of the Vue Router route
* Provide the route name
* Provide any params to the Vue Router route
* Provide the JSON parsed data if used
* Provide the GET params if used
* Provide the request headers
* Provide a traceback of the call

## References
Fixes https://github.com/learningequality/kolibri/issues/7268

## Reviewer guidance
Referencing the resource class name would require adding additional information to the instantiation, it is not available through introspection.

Main question - is this now too verbose? Should the groups be collapsed?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
