### PR TITLE
After deleting all resources of a topic, allow the topic to be re-importable

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -559,7 +559,10 @@ def recurse_annotation_up_tree(channel_id):
                 ContentNodeTable.c.kind == content_kinds.TOPIC,
             )
         )
-        .values(available=False)
+        .values(
+            available=False,
+            on_device_resources=0,
+        )
     )
 
     # Expression to capture all available child nodes of a contentnode


### PR DESCRIPTION
## Summary
This pull request makes a topic re-importable after all its resources (not the topic itself) are deleted.

## References
Fixes #8015 

## Reviewer guidance

1. For a channel, delete all the contents of a topic (but not the entire topic itself).
2. Wait for the deletion task to finish.
3. Go back to the channel and click on the `Import more` button.
4. The deleted topic should be now flagged as importable.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
