### PR TITLE
Updates all content renderers with time-based progress calculation and pages visited/total available

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -636,6 +636,7 @@ export function updateExerciseProgress(store, { progressPercent }) {
  * @param {boolean} forceSave
  */
 export function updateTimeSpent(store, forceSave = false) {
+  console.log('updating time spent');
   /* Create aliases for logs */
   const summaryLog = store.getters.logging.summary;
   const sessionLog = store.getters.logging.session;

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -636,7 +636,6 @@ export function updateExerciseProgress(store, { progressPercent }) {
  * @param {boolean} forceSave
  */
 export function updateTimeSpent(store, forceSave = false) {
-  console.log('updating time spent');
   /* Create aliases for logs */
   const summaryLog = store.getters.logging.summary;
   const sessionLog = store.getters.logging.session;

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -333,6 +333,14 @@
         const seconds = (numberOfWords * 60) / WORDS_PER_MINUTE;
         return seconds;
       },
+      /* eslint-disable kolibri/vue-no-unused-properties */
+      /**
+       * @public
+       */
+      defaultDuration() {
+        return this.duration || this.expectedTimeToRead;
+      },
+      /* eslint-enable kolibri/vue-no-unused-properties */
     },
     watch: {
       sideBarOpen(newSideBar, oldSideBar) {
@@ -462,7 +470,15 @@
     },
     methods: {
       updateProgress() {
+        console.log('locations', this.locations.length, this);
         if (this.locations.length > 0) {
+          console.log(
+            'updating progress',
+            this.timeSpent,
+            this.summaryTimeSpent,
+            this.expectedTimeToRead,
+            this.summaryTimeSpent / this.expectedTimeToRead
+          );
           this.$emit('updateProgress', this.summaryTimeSpent / this.expectedTimeToRead);
         }
       },

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -708,6 +708,7 @@
         this.updateCurrentSection(location.start);
         this.currentLocation = location.start.cfi;
         this.storeVisitedPage(this.currentLocation);
+        this.updateProgress();
         this.updateContentState();
       },
       handleSliderChanged(newSliderValue) {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -151,7 +151,6 @@
   import clamp from 'lodash/clamp';
   import Lockr from 'lockr';
   import FocusLock from 'vue-focus-lock';
-  import { mapGetters } from 'vuex';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
@@ -226,7 +225,6 @@
       };
     },
     computed: {
-      ...mapGetters(['summaryTimeSpent']),
       isAtStart() {
         return get(this.rendition, 'location.atStart', false);
       },
@@ -470,16 +468,8 @@
     },
     methods: {
       updateProgress() {
-        console.log('locations', this.locations.length, this);
         if (this.locations.length > 0) {
-          console.log(
-            'updating progress',
-            this.timeSpent,
-            this.summaryTimeSpent,
-            this.expectedTimeToRead,
-            this.summaryTimeSpent / this.expectedTimeToRead
-          );
-          this.$emit('updateProgress', this.summaryTimeSpent / this.expectedTimeToRead);
+          this.$emit('updateProgress', this.durationBasedProgress);
         }
       },
       handleReadyRendition() {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -221,7 +221,7 @@
         sliderValue: 0,
         scrolled: false,
         currentLocation: null,
-        visitedPages: [],
+        visitedPages: {},
         updateContentStateInterval: null,
       };
     },
@@ -241,9 +241,9 @@
       savedVisitedPages: {
         get() {
           if (this.extraFields && this.extraFields.contentState) {
-            return this.extraFields.contentState.savedVisitedPages || [];
+            return this.extraFields.contentState.savedVisitedPages || {};
           }
-          return [];
+          return {};
         },
         set(value) {
           this.visitedPages = value;
@@ -483,15 +483,16 @@
             this.$emit('updateProgress', this.durationBasedProgress);
           } else {
             // update progress using number of pages seen out of available pages
-            this.$emit('updateProgress', this.savedVisitedPages.length / this.locations.length);
+            this.$emit(
+              'updateProgress',
+              Object.keys(this.savedVisitedPages).length / this.locations.length
+            );
           }
         }
       },
       storeVisitedPage(currentLocation) {
         let visited = this.savedVisitedPages;
-        if (!visited.includes(currentLocation)) {
-          visited.push(currentLocation);
-        }
+        visited[currentLocation] = true;
         this.savedVisitedPages = visited;
       },
       handleReadyRendition() {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -241,7 +241,7 @@
       savedVisitedPages: {
         get() {
           if (this.extraFields && this.extraFields.contentState) {
-            return this.extraFields.contentState.savedVisitedPages;
+            return this.extraFields.contentState.savedVisitedPages || [];
           }
           return [];
         },

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -476,7 +476,7 @@
       updateProgress() {
         if (this.locations.length > 0) {
           if (this.forceTimeBasedProgress) {
-            // update progress using total time user has spent on the pdf
+            // update progress using total time user has spent on the epub
             this.$emit('updateProgress', this.durationBasedProgress);
           } else {
             // update progress using number of pages seen out of available pages

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -336,7 +336,7 @@
        * @public
        */
       defaultDuration() {
-        return this.duration || this.expectedTimeToRead;
+        return this.expectedTimeToRead;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
@@ -7,32 +7,32 @@ describe('updateProgress', () => {
 
   beforeEach(() => {
     context = {
-      forceTimeBasedProgress: null,
+      forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      visitedPages: [1, 2, 3],
+      savedVisitedPages: [1, 2, 3],
       locations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     };
   });
 
-  it('should be able to calculate progress using "pages visited/total" by default', () => {
+  it('should be able to calculate progress using "pages savedVisited/total" by default', () => {
     methods.updateProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.visitedPages.length / context.locations.length
+      context.savedVisitedPages.length / context.locations.length
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
 
-  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
-    context.forceTimeBasedProgress = true;
+  it('should have option of using time-based tracking for progress calculation when forceDurationBasedProgress is true', () => {
+    context.forceDurationBasedProgress = true;
     methods.updateProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.visitedPages.length / context.locations.length
+      context.savedVisitedPages.length / context.locations.length
     );
   });
 });

--- a/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
@@ -1,0 +1,40 @@
+import EpubRendererIndex from '../src/views/EpubRendererIndex';
+
+const { methods } = EpubRendererIndex;
+
+jest.mock('kolibri.urls');
+
+describe('updateProgress', () => {
+  let context = {};
+
+  beforeEach(() => {
+    context = {
+      forceTimeBasedProgress: null,
+      $emit: jest.fn(),
+      durationBasedProgress: 0.1,
+      visitedPages: [1, 2, 3],
+      locations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+  });
+
+  it('should be able to calculate progress using "pages visited/total" by default', () => {
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toEqual(
+      context.visitedPages.length / context.locations.length
+    );
+    expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
+  });
+
+  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
+    context.forceTimeBasedProgress = true;
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+    expect(context.$emit.mock.calls[0][1]).not.toEqual(
+      context.visitedPages.length / context.locations.length
+    );
+  });
+});

--- a/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
@@ -2,8 +2,6 @@ import EpubRendererIndex from '../src/views/EpubRendererIndex';
 
 const { methods } = EpubRendererIndex;
 
-jest.mock('kolibri.urls');
-
 describe('updateProgress', () => {
   let context = {};
 

--- a/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
@@ -10,7 +10,7 @@ describe('updateProgress', () => {
       forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      savedVisitedPages: [1, 2, 3],
+      savedVisitedPages: { 1: 'true', 2: 'true', 3: 'true' },
       locations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     };
   });
@@ -20,7 +20,7 @@ describe('updateProgress', () => {
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.savedVisitedPages.length / context.locations.length
+      Object.keys(context.savedVisitedPages).length / context.locations.length
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
@@ -32,7 +32,7 @@ describe('updateProgress', () => {
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.savedVisitedPages.length / context.locations.length
+      Object.keys(context.savedVisitedPages).length / context.locations.length
     );
   });
 });

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -107,7 +107,7 @@
        * Note: the default duration historically for HTML5 Apps has been 5 min
        */
       defaultDuration() {
-        return this.duration || 300;
+        return 300;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -107,7 +107,7 @@
        * Note: the default duration historically for HTML5 Apps has been 5 min
        */
       defaultDuration() {
-        return this.duration || 300000;
+        return this.duration || 300;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/html5_viewer/assets/tests/Html5AppRendererIndex.spec.js
+++ b/kolibri/plugins/html5_viewer/assets/tests/Html5AppRendererIndex.spec.js
@@ -1,0 +1,28 @@
+import Html5AppRendererIndex from '../src/views/Html5AppRendererIndex';
+
+const { methods } = Html5AppRendererIndex;
+
+describe('recordProgress', () => {
+  let context = {};
+
+  beforeEach(() => {
+    context = {
+      $emit: jest.fn(),
+      durationBasedProgress: 0.1,
+      pollProgress: jest.fn(),
+      hashi: {
+        getProgress() {
+          return 0.1;
+        },
+      },
+    };
+  });
+
+  it('should be able to calculate progress using time-based tracking when hashiProgress is null', () => {
+    context.hashi = null;
+    methods.recordProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+  });
+});

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -28,8 +28,6 @@
         :userId="currentUserId"
         :userFullName="fullName"
         :timeSpent="summaryTimeSpent"
-        :duration="duration"
-        @defaultDuration="defaultDuration"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -23,6 +23,7 @@
         :files="content.files"
         :options="content.options"
         :available="content.available"
+        :duration="content.duration"
         :extraFields="extraFields"
         :progress="summaryProgress"
         :userId="currentUserId"
@@ -335,9 +336,9 @@
       markAsComplete() {
         this.wasIncomplete = false;
       },
-      genContentLink(id, kind) {
+      genContentLink(id, isLeaf) {
         return {
-          name: kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT,
+          name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
           params: { id },
         };
       },
@@ -373,21 +374,26 @@
     // Needs to be one less than the ScrollingHeader's z-index of 4
     z-index: 3;
   }
+
   .coach-content-label {
     margin: 8px 0;
   }
+
   .metadata {
     font-size: smaller;
   }
+
   .download-button,
   .share-button {
     display: inline-block;
     margin: 16px 16px 0 0;
   }
+
   .license-details {
     margin-bottom: 24px;
     margin-left: 16px;
   }
+
   .license-details-name {
     font-weight: bold;
   }

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -28,6 +28,8 @@
         :userId="currentUserId"
         :userFullName="fullName"
         :timeSpent="summaryTimeSpent"
+        :duration="duration"
+        @defaultDuration="defaultDuration"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateProgress="updateProgress"
@@ -335,9 +337,9 @@
       markAsComplete() {
         this.wasIncomplete = false;
       },
-      genContentLink(id, isLeaf) {
+      genContentLink(id, kind) {
         return {
-          name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
+          name: kind === ContentNodeKinds.TOPIC ? PageNames.TOPICS_TOPIC : PageNames.TOPICS_CONTENT,
           params: { id },
         };
       },
@@ -373,26 +375,21 @@
     // Needs to be one less than the ScrollingHeader's z-index of 4
     z-index: 3;
   }
-
   .coach-content-label {
     margin: 8px 0;
   }
-
   .metadata {
     font-size: smaller;
   }
-
   .download-button,
   .share-button {
     display: inline-block;
     margin: 16px 16px 0 0;
   }
-
   .license-details {
     margin-bottom: 24px;
     margin-left: 16px;
   }
-
   .license-details-name {
     font-weight: bold;
   }

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -193,7 +193,7 @@
        * @public
        */
       defaultDuration() {
-        return this.duration || this.player.duration();
+        return this.player.duration();
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
@@ -438,6 +438,11 @@
       // An alternative to recordProgress, this updates tracking based on clock-time spent on media
       updateProgress() {
         this.$emit('updateProgress', Math.min(1, this.durationBasedProgress));
+        console.log(
+          'here is the time spent and durationbasedprog',
+          this.timeSpent,
+          this.durationBasedProgress
+        );
       },
       updatePlayerSizeClass() {
         this.player.removeClass('player-medium');

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -189,7 +189,7 @@
        * @public
        */
       defaultDuration() {
-        return this.duration || this.player.duration();
+        return this.player.duration();
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -421,7 +421,7 @@
       },
       // An alternative to recordProgress, this updates tracking based on clock-time spent on media
       updateProgress() {
-        this.$emit('updateProgress', Math.min(1, this.durationBasedProgress));
+        this.$emit('updateProgress', this.durationBasedProgress);
       },
       updatePlayerSizeClass() {
         this.player.removeClass('player-medium');

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -86,11 +86,9 @@
   import MediaPlayerTranscript from './MediaPlayerTranscript';
   import CaptionsButton from './MediaPlayerCaptions/captionsButton';
   import LanguagesButton from './MediaPlayerLanguages/languagesButton';
-
   import audioIconPoster from './audio-icon-poster.svg';
 
   const GlobalLangCode = vue.locale;
-
   const componentsToRegister = {
     MimicFullscreenToggle,
     ReplayButton,
@@ -98,11 +96,9 @@
     CaptionsButton,
     LanguagesButton,
   };
-
   Object.entries(componentsToRegister).forEach(([name, component]) =>
     videojs.registerComponent(name, component)
   );
-
   export default {
     name: 'MediaPlayerIndex',
     components: { MediaPlayerFullscreen, MediaPlayerTranscript },
@@ -193,7 +189,7 @@
        * @public
        */
       defaultDuration() {
-        return this.player.duration();
+        return this.duration || this.player.duration();
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
@@ -217,7 +213,6 @@
       clearInterval(this.updateContentStateInterval);
       this.updateProgress();
       this.updateContentState();
-
       this.$emit('stopTracking');
       window.removeEventListener('resize', this.throttledResizePlayer);
       this.resetState();
@@ -228,10 +223,8 @@
         if (!this.captionLanguage) {
           return false;
         }
-
         const shortLangCode = languageIdToCode(langCode);
         const shortGlobalLangCode = languageIdToCode(this.captionLanguage);
-
         return shortLangCode === shortGlobalLangCode;
       },
       initPlayer() {
@@ -313,18 +306,15 @@
             },
           },
         };
-
         if (!this.isVideo) {
           videojsConfig.poster = this.audioPoster;
         }
-
         return videojsConfig;
       },
       handleReadyPlayer() {
         const startTime = this.savedLocation >= this.player.duration() ? 0 : this.savedLocation;
         this.player.currentTime(startTime);
         this.player.play();
-
         this.player.on('play', () => {
           this.focusOnPlayControl();
           this.setPlayState(true);
@@ -340,15 +330,12 @@
         this.player.on('volumechange', this.throttledUpdateVolume);
         this.player.on('ratechange', this.updateRate);
         this.player.on('ended', () => this.setPlayState(false));
-
         this.$watch('elementWidth', this.updatePlayerSizeClass);
         this.updatePlayerSizeClass();
         this.resizePlayer();
-
         this.useSavedSettings();
         this.loading = false;
         this.$refs.player.tabIndex = -1;
-
         this.updateContentStateInterval = setInterval(this.updateContentState, 30000);
       },
       resizePlayer() {
@@ -356,10 +343,8 @@
           this.$refs.wrapper.style.height = `100%`;
           return;
         }
-
         const aspectRatio = 16 / 9;
         const adjustedHeight = this.$refs.wrapper.clientWidth * (1 / aspectRatio);
-
         this.$refs.wrapper.style.height = `${adjustedHeight}px`;
       },
       throttledResizePlayer: throttle(function resizePlayer() {
@@ -392,7 +377,6 @@
         if (!this.forceTimeBasedProgress) {
           this.recordProgress();
         }
-
         // now, update all the timestamps to set the new time location
         // as the baseline starting point
         this.dummyTime = this.player.currentTime();
@@ -438,17 +422,11 @@
       // An alternative to recordProgress, this updates tracking based on clock-time spent on media
       updateProgress() {
         this.$emit('updateProgress', Math.min(1, this.durationBasedProgress));
-        console.log(
-          'here is the time spent and durationbasedprog',
-          this.timeSpent,
-          this.durationBasedProgress
-        );
       },
       updatePlayerSizeClass() {
         this.player.removeClass('player-medium');
         this.player.removeClass('player-small');
         this.player.removeClass('player-tiny');
-
         if (this.elementWidth < 600) {
           this.player.addClass('player-medium');
         }
@@ -519,21 +497,17 @@
   @import './videojs-style/videojs-font/css/videojs-icons.css';
   @import './videojs-style/variables';
   @import '~kolibri-design-system/lib/styles/definitions';
-
   $transcript-wrap-height: 250px;
   $transcript-wrap-fill-height: 100% * 9 / 16;
   $video-height: 100% * 9 / 16;
-
   .wrapper {
     box-sizing: content-box;
     max-width: 100%;
     max-height: $video-player-max-height;
   }
-
   .wrapper.transcript-visible.transcript-wrap {
     padding-bottom: $transcript-wrap-height;
   }
-
   .wrapper.video-loading video {
     position: absolute;
     top: 0;
@@ -541,7 +515,6 @@
     height: 100%;
     opacity: 0.1;
   }
-
   .fill-space,
   /deep/ .fill-space {
     position: relative;
@@ -549,77 +522,62 @@
     height: 100%;
     border: 1px solid transparent;
   }
-
   .loading-space,
   /deep/ .loading-space {
     box-sizing: border-box;
     padding-top: #{$video-height};
   }
-
   /deep/ .loader {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
   }
-
   .media-player-transcript {
     position: absolute;
     right: 0;
     bottom: 0;
     z-index: 0;
     box-sizing: border-box;
-
     /deep/ .fill-space {
       height: auto;
     }
-
     [dir='rtl'] & {
       right: auto;
       left: 0;
     }
   }
-
   .wrapper:not(.transcript-wrap) .media-player-transcript {
     top: 0;
     width: 33.333%;
-
     /deep/ .loading-space {
       padding-top: #{300% * 9 / 16};
     }
   }
-
   .wrapper.transcript-wrap .media-player-transcript {
     left: 0;
     height: $transcript-wrap-height;
-
     /deep/ .loading-space {
       padding-top: 90px;
     }
-
     [dir='rtl'] & {
       right: 0;
     }
   }
-
   .normalize-fullscreen,
   .mimic-fullscreen {
     border-color: transparent !important;
-
     .wrapper {
       max-height: none;
     }
-
     .wrapper.transcript-visible.transcript-wrap {
       padding-bottom: 0;
     }
-
     .wrapper.transcript-visible.transcript-wrap .media-player-transcript {
       top: 0;
       height: auto;
       margin-top: #{$video-height};
     }
-
     .wrapper.transcript-visible.transcript-wrap .video-js.vjs-fill {
       height: auto;
       padding-top: #{$video-height};
@@ -629,7 +587,6 @@
   /***** PLAYER OVERRIDES *****/
 
   /* !!rtl:begin:ignore */
-
   .transcript-visible:not(.transcript-wrap) > .video-js.vjs-fill {
     width: 66.666%;
   }
@@ -655,7 +612,6 @@
   /deep/ .custom-skin {
     $button-height-normal: 40px;
     $button-font-size-normal: 24px;
-
     @include font-family-noto;
 
     font-size: $video-player-font-size;
@@ -671,18 +627,15 @@
       height: initial;
       visibility: inherit;
       opacity: inherit;
-
       .vjs-progress-holder {
         height: 8px;
         margin-right: 16px;
         margin-left: 16px;
-
         .vjs-load-progress {
           div {
             background: $video-player-color-3;
           }
         }
-
         .vjs-play-progress {
           &::before {
             top: -5px;
@@ -703,7 +656,6 @@
     .vjs-volume-vertical {
       display: none;
     }
-
     .vjs-volume-panel-vertical {
       &:hover {
         .vjs-volume-vertical {
@@ -711,7 +663,6 @@
         }
       }
     }
-
     .vjs-volume-level {
       background-color: $video-player-font-color;
     }
@@ -735,7 +686,6 @@
         line-height: $button-height-normal;
       }
     }
-
     .vjs-big-play-button {
       position: absolute;
       top: 50%;
@@ -750,7 +700,6 @@
       border-radius: 50%;
       transform: translate(-50%, -50%);
     }
-
     .vjs-volume-panel {
       margin-left: auto;
     }
@@ -759,7 +708,6 @@
     .vjs-button-transcript img {
       max-width: 20px;
     }
-
     .vjs-transcript-visible > .vjs-tech,
     .vjs-transcript-visible > .vjs-modal-dialog,
     .vjs-transcript-visible > .vjs-text-track-display,
@@ -775,33 +723,27 @@
         padding: 8px;
         font-size: $video-player-font-size;
         background-color: $video-player-color;
-
         &:focus,
         &:hover {
           background-color: $video-player-color-3;
         }
       }
-
       li.vjs-selected {
         font-weight: bold;
         color: $video-player-font-color;
         background-color: $video-player-color-2;
-
         &:focus,
         &:hover {
           background-color: $video-player-color-3;
         }
       }
     }
-
     .vjs-menu-content {
       @include font-family-noto;
     }
-
     .vjs-volume-control {
       background-color: $video-player-color;
     }
-
     .vjs-playback-rate .vjs-menu {
       min-width: 4em;
     }
@@ -810,13 +752,11 @@
     .vjs-current-time {
       display: block;
       padding-right: 0;
-
       .vjs-current-time-display {
         font-size: $video-player-font-size;
         line-height: $button-height-normal;
       }
     }
-
     .vjs-duration {
       display: block;
       padding-left: 0;
@@ -825,7 +765,6 @@
         line-height: $button-height-normal;
       }
     }
-
     .vjs-time-divider {
       padding: 0;
       text-align: center;
@@ -858,7 +797,6 @@
     .vjs-time-divider {
       display: block;
     }
-
     .vjs-slider-bar::before {
       z-index: 0;
     }
@@ -873,7 +811,6 @@
     .vjs-control-bar {
       height: $button-height-small;
     }
-
     .vjs-button {
       .vjs-icon-placeholder {
         &::before {
@@ -881,7 +818,6 @@
         }
       }
     }
-
     .vjs-icon-replay_10,
     .vjs-icon-forward_10 {
       &::before {
@@ -901,11 +837,9 @@
       border-radius: 50%;
       transform: translate(-50%, -50%);
     }
-
     .vjs-big-play-button {
       display: none;
     }
-
     &.vjs-show-big-play-button-on-pause {
       .vjs-big-play-button {
         display: none;
@@ -938,13 +872,11 @@
         line-height: $button-height-small;
       }
     }
-
     .vjs-duration {
       .vjs-duration-display {
         line-height: $button-height-small;
       }
     }
-
     .vjs-time-divider {
       line-height: $button-height-small;
     }

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -374,9 +374,8 @@
       handleSeek() {
         // record progress before updating the times,
         // to capture any progress that happened pre-seeking
-        if (!this.forceTimeBasedProgress) {
-          this.recordProgress();
-        }
+        this.recordProgress();
+
         // now, update all the timestamps to set the new time location
         // as the baseline starting point
         this.dummyTime = this.player.currentTime();
@@ -391,16 +390,14 @@
         }
         this.dummyTime = this.player.currentTime();
         if (this.dummyTime - this.lastUpdateTime >= 5) {
-          if (!this.forceTimeBasedProgress) {
-            this.recordProgress();
-          }
+          this.recordProgress();
           this.lastUpdateTime = this.dummyTime;
         }
       },
       setPlayState(state) {
         // avoid recording progress if we're currently seeking,
         // as timers are in an intermediate state
-        if (!this.player.seeking() && !this.forceTimeBasedProgress) {
+        if (!this.player.seeking()) {
           this.recordProgress();
         }
         if (state === true) {

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -211,7 +211,6 @@
     },
     beforeDestroy() {
       clearInterval(this.updateContentStateInterval);
-      this.updateProgress();
       this.updateContentState();
       this.$emit('stopTracking');
       window.removeEventListener('resize', this.throttledResizePlayer);
@@ -323,7 +322,6 @@
           this.focusOnPlayControl();
           this.setPlayState(false);
           this.updateContentState();
-          this.updateProgress();
         });
         this.player.on('timeupdate', this.updateTime);
         this.player.on('seeking', this.handleSeek);
@@ -407,18 +405,18 @@
         }
       },
       recordProgress() {
-        this.$emit(
-          'addProgress',
-          Math.max(
-            0,
-            (this.dummyTime - this.progressStartingPoint) / Math.floor(this.player.duration())
-          )
-        );
+        if (this.forceDurationBasedProgress) {
+          this.$emit('updateProgress', this.durationBasedProgress);
+        } else {
+          this.$emit(
+            'addProgress',
+            Math.max(
+              0,
+              (this.dummyTime - this.progressStartingPoint) / Math.floor(this.player.duration())
+            )
+          );
+        }
         this.progressStartingPoint = this.dummyTime;
-      },
-      // An alternative to recordProgress, this updates tracking based on clock-time spent on media
-      updateProgress() {
-        this.$emit('updateProgress', this.durationBasedProgress);
       },
       updatePlayerSizeClass() {
         this.player.removeClass('player-medium');

--- a/kolibri/plugins/media_player/assets/tests/MediaPlayerIndex.spec.js
+++ b/kolibri/plugins/media_player/assets/tests/MediaPlayerIndex.spec.js
@@ -1,0 +1,21 @@
+import MediaPlayerIndex from '../src/views/MediaPlayerIndex';
+
+const { methods } = MediaPlayerIndex;
+
+describe('updateProgress', () => {
+  let context = {};
+
+  beforeEach(() => {
+    context = {
+      $emit: jest.fn(),
+      durationBasedProgress: 0.1,
+    };
+  });
+
+  it('should be able to calculate progress using time-based tracking by default', () => {
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+  });
+});

--- a/kolibri/plugins/media_player/assets/tests/MediaPlayerIndex.spec.js
+++ b/kolibri/plugins/media_player/assets/tests/MediaPlayerIndex.spec.js
@@ -7,13 +7,15 @@ describe('updateProgress', () => {
 
   beforeEach(() => {
     context = {
+      forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
     };
   });
 
-  it('should be able to calculate progress using time-based tracking by default', () => {
-    methods.updateProgress.call(context);
+  it('should be able to calculate progress using time-based tracking', () => {
+    context.forceDurationBasedProgress = true;
+    methods.recordProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -116,7 +116,6 @@
       currentLocation: 0,
       updateContentStateInterval: null,
       showControls: true,
-      visitedPages: [],
     }),
     computed: {
       // Returns whether or not the current device is iOS.
@@ -146,6 +145,12 @@
           return this.extraFields.contentState.savedLocation;
         }
         return 0;
+      },
+      visitedPages() {
+        if (this.extraFields && this.extraFields.contentState) {
+          return this.extraFields.contentState.visitedPages;
+        }
+        return [];
       },
       fullscreenText() {
         return this.isInFullscreen ? this.$tr('exitFullscreen') : this.$tr('enterFullscreen');
@@ -369,12 +374,12 @@
           contentState = {
             ...this.extraFields.contentState,
             savedLocation: this.currentLocation || this.savedLocation,
-            visitedPages: this.visitedPages.length,
+            visitedPages: this.visitedPages,
           };
         } else {
           contentState = {
             savedLocation: this.currentLocation || this.savedLocation,
-            visitedPages: this.visitedPages.length,
+            visitedPages: this.visitedPages,
           };
         }
         this.$emit('updateContentState', contentState);

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -154,7 +154,7 @@
        * @public
        */
       defaultDuration() {
-        return this.duration || this.targetTime;
+        return this.targetTime;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -148,7 +148,7 @@
       },
       visitedPages() {
         if (this.extraFields && this.extraFields.contentState) {
-          return this.extraFields.contentState.visitedPages;
+          return this.extraFields.contentState.visitedPages || [];
         }
         return [];
       },
@@ -285,10 +285,10 @@
           });
         }
       },
-      listVisitedPages(pageNum) {
+      listVisitedPages(currentPageNum) {
         let visited = this.visitedPages;
-        if (!visited.includes(pageNum)) {
-          visited.push(pageNum);
+        if (!visited.includes(currentPageNum)) {
+          visited.push(currentPageNum);
         }
         return visited;
       },

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -132,9 +132,6 @@
         ];
         return iDevices.includes(navigator.platform);
       },
-      targetTime() {
-        return this.totalPages * 30;
-      },
       documentLoading() {
         return this.progress < 1;
       },
@@ -166,7 +163,7 @@
        * @public
        */
       defaultDuration() {
-        return this.targetTime;
+        return this.totalPages * 30;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
@@ -254,10 +251,6 @@
         }
         this.$emit('startTracking');
         this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
-        if (this.forceDurationBasedProgress) {
-          // Automatically master after the targetTime, convert seconds -> milliseconds
-          this.timeout = setTimeout(this.updateProgress, this.targetTime * 1000);
-        }
       });
     },
     beforeDestroy() {
@@ -324,6 +317,7 @@
           // determine how many pages user has viewed/visited
           let currentPage = parseInt(this.currentLocation * this.totalPages) + 1;
           this.storeVisitedPage(currentPage);
+          this.updateProgress();
           this.updateContentState();
         }
         const startIndex = Math.floor(start) + 1;

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -116,7 +116,7 @@
       currentLocation: 0,
       updateContentStateInterval: null,
       showControls: true,
-      visitedPages: [],
+      visitedPages: {},
     }),
     computed: {
       // Returns whether or not the current device is iOS.
@@ -150,9 +150,9 @@
       savedVisitedPages: {
         get() {
           if (this.extraFields && this.extraFields.contentState) {
-            return this.extraFields.contentState.savedVisitedPages || [];
+            return this.extraFields.contentState.savedVisitedPages || {};
           }
-          return [];
+          return {};
         },
         set(value) {
           this.visitedPages = value;
@@ -293,9 +293,7 @@
       },
       storeVisitedPage(currentPageNum) {
         let visited = this.savedVisitedPages;
-        if (!visited.includes(currentPageNum)) {
-          visited.push(currentPageNum);
-        }
+        visited[currentPageNum] = true;
         this.savedVisitedPages = visited;
       },
       // handle the recycle list update event
@@ -371,7 +369,10 @@
           this.$emit('updateProgress', this.durationBasedProgress);
         } else {
           // update progress using number of pages seen out of available pages
-          this.$emit('updateProgress', this.savedVisitedPages.length / this.totalPages);
+          this.$emit(
+            'updateProgress',
+            Object.keys(this.savedVisitedPages).length / this.totalPages
+          );
         }
       },
       updateContentState() {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -21,42 +21,25 @@
           class="fullscreen-header"
           :style="{ backgroundColor: this.$themePalette.grey.v_100 }"
         >
-          <UiIconButton
+          <KIconButton
             class="button-zoom-in controls"
             aria-controls="pdf-container"
+            icon="add"
             @click="zoomIn"
-          >
-            <mat-svg
-              name="add"
-              category="content"
-            />
-          </UiIconButton>
-          <UiIconButton
+          />
+          <KIconButton
             class="button-zoom-out controls"
             aria-controls="pdf-container"
+            icon="remove"
             @click="zoomOut"
-          >
-            <mat-svg
-              name="remove"
-              category="content"
-            />
-          </UiIconButton>
+          />
           <KButton
             class="fullscreen-button"
             :primary="false"
             appearance="flat-button"
+            :icon="isInFullscreen ? 'fullscreen_exit' : 'fullscreen'"
             @click="$refs.pdfRenderer.toggleFullscreen()"
           >
-            <mat-svg
-              v-if="isInFullscreen"
-              name="fullscreen_exit"
-              category="navigation"
-            />
-            <mat-svg
-              v-else
-              name="fullscreen"
-              category="navigation"
-            />
             {{ fullscreenText }}
           </KButton>
         </div>
@@ -103,7 +86,6 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import urls from 'kolibri.urls';
-  import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton';
   import PdfPage from './PdfPage';
   // Source from which PDFJS loads its service worker, this is based on the __publicPath
   // global that is defined in the Kolibri webpack pipeline, and the additional entry in the PDF
@@ -116,7 +98,6 @@
   export default {
     name: 'PdfRendererIndex',
     components: {
-      UiIconButton,
       PdfPage,
       RecycleList,
       CoreFullscreen,
@@ -360,7 +341,6 @@
         this.$refs.recycleList.updateVisibleItems(false);
       },
       updateProgress() {
-        console.log('duration based progress in PDF renderer', this.durationBasedProgress);
         this.$emit('updateProgress', this.durationBasedProgress);
       },
       updateContentState() {
@@ -402,10 +382,7 @@
   }
   .controls {
     position: relative;
-    top: 8px;
     z-index: 0; // Hide icons with transition
-    width: 24px;
-    height: 24px;
     margin: 0 4px;
   }
   .progress-bar {

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
@@ -12,7 +12,7 @@ describe('updateProgress', () => {
       forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      savedVisitedPages: [1, 2, 3],
+      savedVisitedPages: { 1: 'true', 2: 'true', 3: 'true' },
       totalPages: 9,
     };
   });
@@ -22,7 +22,7 @@ describe('updateProgress', () => {
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.savedVisitedPages.length / context.totalPages
+      Object.keys(context.savedVisitedPages).length / context.totalPages
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
@@ -34,7 +34,7 @@ describe('updateProgress', () => {
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.savedVisitedPages.length / context.totalPages
+      Object.keys(context.savedVisitedPages).length / context.totalPages
     );
   });
 });

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
@@ -9,10 +9,10 @@ describe('updateProgress', () => {
 
   beforeEach(() => {
     context = {
-      forceTimeBasedProgress: null,
+      forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      visitedPages: [1, 2, 3],
+      savedVisitedPages: [1, 2, 3],
       totalPages: 9,
     };
   });
@@ -22,19 +22,19 @@ describe('updateProgress', () => {
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.visitedPages.length / context.totalPages
+      context.savedVisitedPages.length / context.totalPages
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
 
-  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
-    context.forceTimeBasedProgress = true;
+  it('should have option of using time-based tracking for progress calculation when forceDurationBasedProgress is true', () => {
+    context.forceDurationBasedProgress = true;
     methods.updateProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.visitedPages.length / context.totalPages
+      context.savedVisitedPages.length / context.totalPages
     );
   });
 });

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
@@ -1,0 +1,40 @@
+import PdfRendererIndex from '../src/views/PdfRendererIndex';
+
+const { methods } = PdfRendererIndex;
+
+jest.mock('kolibri.urls');
+
+describe('updateProgress', () => {
+  let context = {};
+
+  beforeEach(() => {
+    context = {
+      forceTimeBasedProgress: null,
+      $emit: jest.fn(),
+      durationBasedProgress: 0.1,
+      visitedPages: [1, 2, 3],
+      totalPages: 9,
+    };
+  });
+
+  it('should be able to calculate progress using "pages visited/total" by default', () => {
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toEqual(
+      context.visitedPages.length / context.totalPages
+    );
+    expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
+  });
+
+  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
+    context.forceTimeBasedProgress = true;
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+    expect(context.$emit.mock.calls[0][1]).not.toEqual(
+      context.visitedPages.length / context.totalPages
+    );
+  });
+});

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -101,7 +101,7 @@
       slides: [],
       currentSlideIndex: 0,
       highestViewedSlideIndex: 0,
-      visitedSlides: [],
+      visitedSlides: {},
     }),
     computed: {
       currentSlide() {
@@ -110,9 +110,9 @@
       savedVisitedSlides: {
         get() {
           if (this.extraFields && this.extraFields.contentState) {
-            return this.extraFields.contentState.savedVisitedSlides || [];
+            return this.extraFields.contentState.savedVisitedSlides || {};
           }
-          return [];
+          return {};
         },
         set(value) {
           this.visitedSlides = value;
@@ -230,9 +230,7 @@
       },
       storeVisitedSlide(currentSlideNum) {
         let visited = this.savedVisitedSlides;
-        if (!visited.includes(currentSlideNum)) {
-          visited.push(currentSlideNum);
-        }
+        visited[currentSlideNum] = true;
         this.savedVisitedSlides = visited;
       },
       setHooperListWidth() {
@@ -292,7 +290,10 @@
           this.$emit('updateProgress', this.durationBasedProgress);
         } else {
           // update progress using number of slides seen out of available slides
-          this.$emit('updateProgress', this.savedVisitedSlides.length / this.slides.length);
+          this.$emit(
+            'updateProgress',
+            Object.keys(this.savedVisitedSlides).length / this.slides.length
+          );
         }
       },
     },

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -121,6 +121,14 @@
       contentHeight: function() {
         return window.innerHeight * 0.7 + 'px';
       },
+      /* eslint-disable kolibri/vue-no-unused-properties */
+      /**
+       * @public
+       */
+      defaultDuration() {
+        return this.duration || 300000;
+      },
+      /* eslint-enable kolibri/vue-no-unused-properties */
     },
     watch: {
       defaultFile(newFile) {
@@ -134,7 +142,8 @@
         }
       },
       currentSlideIndex() {
-        if (this.currentSlideIndex + 1 === this.slides.length) {
+        console.log('in currentslideindex', this.currentSlideIndex + 1, this.slides.length);
+        if (this.currentSlideIndex + 1 <= this.slides.length) {
           this.updateProgress();
         }
       },
@@ -244,15 +253,28 @@
         this.$emit('updateContentState', this.extraFields.contentState);
       },
       updateProgress() {
-        // updateProgress adds the percent to the existing value, so only pass
+        // if the forceTimeBasedProgress is set to true, updateProgress uses time-based tracking,
+        // else updateProgress adds the percent to the existing value, so only pass
         // the percentage of progress in this session, not the full percentage.
-        const progressPercent =
-          this.highestViewedSlideIndex + 1 === this.slides.length
-            ? 1.0
-            : (this.highestViewedSlideIndex -
-                this.extraFields.contentState.highestViewedSlideIndex) /
-              this.slides.length;
-        this.$emit('updateProgress', progressPercent);
+        if (this.forceTimeBasedProgress) {
+          console.log('forcetime,', this.durationBasedProgress);
+          this.$emit('updateProgress', this.durationBasedProgress);
+        } else {
+          console.log('this.highestViewedSlideIndex', this.highestViewedSlideIndex);
+          console.log(
+            'this.extraFields.contentState.highestViewedSlideIndex',
+            this.extraFields.contentState.highestViewedSlideIndex
+          );
+          console.log('this.slides.length', this.slides.length);
+          const progressPercent =
+            this.highestViewedSlideIndex + 1 === this.slides.length
+              ? 1.0
+              : (this.highestViewedSlideIndex -
+                  this.extraFields.contentState.highestViewedSlideIndex) /
+                this.slides.length;
+          console.log('prog%', progressPercent);
+          this.$emit('updateProgress', progressPercent);
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -101,16 +101,22 @@
       slides: [],
       currentSlideIndex: 0,
       highestViewedSlideIndex: 0,
+      visitedSlides: [],
     }),
     computed: {
       currentSlide() {
         return this.slides[this.currentSlideIndex];
       },
-      visitedSlides() {
-        if (this.extraFields && this.extraFields.contentState) {
-          return this.extraFields.contentState.visitedSlides || [];
-        }
-        return [];
+      savedVisitedSlides: {
+        get() {
+          if (this.extraFields && this.extraFields.contentState) {
+            return this.extraFields.contentState.savedVisitedSlides || [];
+          }
+          return [];
+        },
+        set(value) {
+          this.visitedSlides = value;
+        },
       },
       slideshowImages: function() {
         const files = this.files;
@@ -216,18 +222,18 @@
         if (this.currentSlideIndex > this.highestViewedSlideIndex) {
           this.highestViewedSlideIndex = this.currentSlideIndex;
         }
-        this.listVisitedSlides(this.currentSlideIndex);
+        this.storeVisitedSlide(this.currentSlideIndex);
         this.updateContentState();
       },
       slideTextId(id) {
         return 'descriptive-text-' + id;
       },
-      listVisitedSlides(currentSlideNum) {
-        let visited = this.visitedSlides;
+      storeVisitedSlide(currentSlideNum) {
+        let visited = this.savedVisitedSlides;
         if (!visited.includes(currentSlideNum)) {
           visited.push(currentSlideNum);
         }
-        return visited;
+        this.savedVisitedSlides = visited;
       },
       setHooperListWidth() {
         /*
@@ -269,24 +275,24 @@
             ...this.extraFields.contentState,
             highestViewedSlideIndex: this.highestViewedSlideIndex,
             lastViewedSlideIndex: this.currentSlideIndex,
-            visitedSlides: this.visitedSlides,
+            savedVisitedSlides: this.visitedSlides || this.savedVisitedSlides,
           };
         } else {
           contentState = {
             highestViewedSlideIndex: this.highestViewedSlideIndex,
             lastViewedSlideIndex: this.currentSlideIndex,
-            visitedSlides: this.visitedSlides,
+            savedVisitedSlides: this.visitedSlides || this.savedVisitedSlides,
           };
         }
         this.$emit('updateContentState', contentState);
       },
       updateProgress() {
-        if (this.forceTimeBasedProgress) {
+        if (this.forceDurationBasedProgress) {
           // update progress using total time user has spent on the slideshow
           this.$emit('updateProgress', this.durationBasedProgress);
         } else {
           // update progress using number of slides seen out of available slides
-          this.$emit('updateProgress', this.visitedSlides.length / this.slides.length);
+          this.$emit('updateProgress', this.savedVisitedSlides.length / this.slides.length);
         }
       },
     },

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -127,7 +127,7 @@
        * Note: the default duration historically for slidshows has been 5 min
        */
       defaultDuration() {
-        return this.duration || 300;
+        return 300;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -223,6 +223,7 @@
           this.highestViewedSlideIndex = this.currentSlideIndex;
         }
         this.storeVisitedSlide(this.currentSlideIndex);
+        this.updateProgress();
         this.updateContentState();
       },
       slideTextId(id) {

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -124,9 +124,10 @@
       /* eslint-disable kolibri/vue-no-unused-properties */
       /**
        * @public
+       * Note: the default duration historically for slidshows has been 5 min
        */
       defaultDuration() {
-        return this.duration || 300000;
+        return this.duration || 300;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
     },
@@ -142,7 +143,6 @@
         }
       },
       currentSlideIndex() {
-        console.log('in currentslideindex', this.currentSlideIndex + 1, this.slides.length);
         if (this.currentSlideIndex + 1 <= this.slides.length) {
           this.updateProgress();
         }
@@ -257,22 +257,14 @@
         // else updateProgress adds the percent to the existing value, so only pass
         // the percentage of progress in this session, not the full percentage.
         if (this.forceTimeBasedProgress) {
-          console.log('forcetime,', this.durationBasedProgress);
-          this.$emit('updateProgress', this.durationBasedProgress);
+          this.$emit('updateProgress', Math.min(this.durationBasedProgress, 1));
         } else {
-          console.log('this.highestViewedSlideIndex', this.highestViewedSlideIndex);
-          console.log(
-            'this.extraFields.contentState.highestViewedSlideIndex',
-            this.extraFields.contentState.highestViewedSlideIndex
-          );
-          console.log('this.slides.length', this.slides.length);
           const progressPercent =
             this.highestViewedSlideIndex + 1 === this.slides.length
               ? 1.0
               : (this.highestViewedSlideIndex -
                   this.extraFields.contentState.highestViewedSlideIndex) /
                 this.slides.length;
-          console.log('prog%', progressPercent);
           this.$emit('updateProgress', progressPercent);
         }
       },

--- a/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
+++ b/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
@@ -1,0 +1,38 @@
+import SlideshowRendererComponent from '../src/views/SlideshowRendererComponent';
+
+const { methods } = SlideshowRendererComponent;
+
+describe('updateProgress', () => {
+  let context = {};
+
+  beforeEach(() => {
+    context = {
+      forceTimeBasedProgress: null,
+      $emit: jest.fn(),
+      durationBasedProgress: 0.1,
+      visitedSlides: [1, 2, 3],
+      slides: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+  });
+
+  it('should be able to calculate progress using "pages visited/total" by default', () => {
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toEqual(
+      context.visitedSlides.length / context.slides.length
+    );
+    expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
+  });
+
+  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
+    context.forceTimeBasedProgress = true;
+    methods.updateProgress.call(context);
+
+    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+    expect(context.$emit.mock.calls[0][1]).not.toEqual(
+      context.visitedSlides.length / context.slides.length
+    );
+  });
+});

--- a/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
+++ b/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
@@ -7,10 +7,10 @@ describe('updateProgress', () => {
 
   beforeEach(() => {
     context = {
-      forceTimeBasedProgress: null,
+      forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      visitedSlides: [1, 2, 3],
+      savedVisitedSlides: [1, 2, 3],
       slides: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     };
   });
@@ -20,19 +20,19 @@ describe('updateProgress', () => {
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.visitedSlides.length / context.slides.length
+      context.savedVisitedSlides.length / context.slides.length
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
 
-  it('should have option of using time-based tracking for progress calculation when forceTimeBasedProgress is true', () => {
-    context.forceTimeBasedProgress = true;
+  it('should have option of using time-based tracking for progress calculation when forceDurationBasedProgress is true', () => {
+    context.forceDurationBasedProgress = true;
     methods.updateProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.visitedSlides.length / context.slides.length
+      context.savedVisitedSlides.length / context.slides.length
     );
   });
 });

--- a/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
+++ b/kolibri/plugins/slideshow_viewer/assets/tests/SlideshowRendererComponent.spec.js
@@ -10,7 +10,7 @@ describe('updateProgress', () => {
       forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      savedVisitedSlides: [1, 2, 3],
+      savedVisitedSlides: { 1: 'true', 2: 'true', 3: 'true' },
       slides: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     };
   });
@@ -20,7 +20,7 @@ describe('updateProgress', () => {
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      context.savedVisitedSlides.length / context.slides.length
+      Object.keys(context.savedVisitedSlides).length / context.slides.length
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
@@ -32,7 +32,7 @@ describe('updateProgress', () => {
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      context.savedVisitedSlides.length / context.slides.length
+      Object.keys(context.savedVisitedSlides).length / context.slides.length
     );
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

1. Updated PDF, Epub, Slideshow renderers to use "pages/slides visited out of total pages/slides" for default progress calculation.
2. Gave PDF, Epub, Slideshow renderers the option to use time-based progress-tracking (via `forceTimeBasedProgress`).
3. Updated all content renderers with `defaultDuration` and `durationBasedProgress` computed props from the `KContentRenderer` mixin.
4. Added progress calculation tests for all renderers.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Resolves #7970  and resolves learningequality/kolibri-design-system#214
- Requires this additional PR to be linked to Kolibri from KDS: learningequality/kolibri-design-system#224


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### PDF, Epub, Slideshow Directions
_(for Epub and slideshows, follow the same steps, but use Epub and slideshow files instead of PDF files)._
1. Sign in as a `superadmin` and go to the learner profile (Sidenav -> Learn)
2. Click on a channel that has a PDF



**Check that progress is being correctly calculated via number of pages/slides visited out of total possible pages/slides:**
Pre-requisite:
- Open `mixin.js` in KDS
- Make sure [line 145](https://github.com/sairina/kolibri-design-system/blob/kcontentrenderer/lib/content/mixin.js#L145) reads `return this.options.force_time_based_progress || false;`
3. Open a PDF file that has not yet been opened.
4. Read through the PDF file. As you scroll through the file, make sure that:

- The blue clock icon appears within ~10-20 seconds to indicate you have started making progress. (Note that for PDFs and EPubs, you do not have to change pages for an update to be logged, but you do have to move to the next slide for an update to be logged for a slideshow.
5. Return to the channel’s index.
6. Wait another 10-20 seconds, and refresh the channel index page; make sure that the blue progress bar hasn’t moved.
7. Continue to scroll through the PDF and periodically go back to the channel’s index to see if the blue progress bar has moved according to how many pages you have viewed.
8. Once all pages/slides have been visited, the blue clock icon should change to a gold star icon



**Check that progress is being correctly calculated as time spent:**
Pre-requisite:
- Open `mixin.js` in KDS
- CHANGE [line 145](https://github.com/sairina/kolibri-design-system/blob/kcontentrenderer/lib/content/mixin.js#L145) to read `return true;`
9. Open a short (2-3 page) PDF file that has not yet been opened.
10. Read through the PDF file. As you scroll through, make sure that:
- The blue clock icon appears within ~20 seconds for the PDF; you will not have to scroll to any other pages, but you will have to for the epub and slideshow.
11. Stay on the page and wait for about 90 seconds (this should be when the 2-3 page file reaches its “target time” to indicate that the learner should have completed reading through the PDF; for the epub, it will take longer, so choose a shorter file, and for the slideshow, you’ll have to wait on the page for 5 minutes - sorry, go make yourself some tea!). Check to see that the blue clock icon has turned into a gold star icon.

### HTML5
1. Sign in as a `superadmin` and go to the learner profile (Sidenav -> Learn)
2. Click on a channel that has an HTML5app
3. Check that progress is being correctly calculated as time spent
4. Open the HTML5 app.
5. As you scroll through, make sure that:

- The blue clock icon appears within ~20 seconds.
- Stay on the page and wait for 5 minutes. 
- Check to see that the blue clock icon has turned into a gold star icon.

### Media Player

1. Sign in as a `superadmin` and go to the learner profile (Sidenav -> Learn)
2. Click on a channel that has a media file
3. Check that progress is being correctly calculated as time spent
4. Open the file.
5. As you watch or listen, make sure that:

- The blue clock icon appears within ~10 seconds.
- Stay on the page and wait until the length of the file is done (e.g. if the video is 2:05, you have to be actively watching the video for that amount of time). 
- Check to see that the blue clock icon has turned into a gold star icon.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
