### PR TITLE
Upgrade custom nav

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -979,7 +979,7 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         # map the channel list into the format the Kolibri client-side expects
         channels = list(map(self._studio_response_to_kolibri_response, resp.json()))
 
-        return Response(channels)
+        return channels
 
     @staticmethod
     def _get_lang_native_name(code):
@@ -1038,9 +1038,10 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         baseurl = request.GET.get("baseurl", None)
         keyword = request.GET.get("keyword", None)
         language = request.GET.get("language", None)
-        return self._make_channel_endpoint_request(
+        channels = self._make_channel_endpoint_request(
             baseurl=baseurl, keyword=keyword, language=language
         )
+        return Response(channels)
 
     def retrieve(self, request, pk=None):
         """
@@ -1049,9 +1050,12 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         baseurl = request.GET.get("baseurl", None)
         keyword = request.GET.get("keyword", None)
         language = request.GET.get("language", None)
-        return self._make_channel_endpoint_request(
+        channels = self._make_channel_endpoint_request(
             identifier=pk, baseurl=baseurl, keyword=keyword, language=language
         )
+        if not channels:
+            raise Http404
+        return Response(channels[0])
 
     @list_route(methods=["get"])
     def kolibri_studio_status(self, request, **kwargs):

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1556,7 +1556,7 @@ class KolibriStudioAPITestCase(APITestCase):
             reverse("kolibri:core:remotechannel-detail", kwargs={"pk": "abc"}),
             format="json",
         )
-        self.assertEqual(response.data[0]["name"], "studio")
+        self.assertEqual(response.data["name"], "studio")
 
     @mock_patch_decorator
     def test_channel_info_cache(self):

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -604,12 +604,11 @@ def get_import_data_for_update(
         i += batch_size
         updated_ids_slice = updated_resource_ids[i : i + batch_size]
 
-    # Get all nodes that are marked as available but have missing supplementary files.
+    # Get all nodes that are marked as available but have missing files.
     # This will ensure that we update thumbnails, and other files.
     queried_file_objects.extend(
         LocalFile.objects.filter(
             available=False,
-            files__supplementary=True,
             files__contentnode__in=ContentNode.objects.filter(
                 available=True, channel_id=channel_id
             ),

--- a/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
@@ -1,6 +1,6 @@
 import differenceBy from 'lodash/differenceBy';
 import find from 'lodash/find';
-import { getRemoteChannelByToken } from '../utils';
+import { getRemoteChannelByToken, getRemoteChannelBundleByToken } from '../utils';
 
 /**
  * HACK: Makes a request to Kolibri Studio to get info on unlisted channels, then appends
@@ -18,7 +18,7 @@ export function getAllRemoteChannels(store, publicChannels) {
   );
   const promises = installedUnlistedChannels.map(installedChannel =>
     getRemoteChannelByToken(installedChannel.id)
-      .then(([channel]) =>
+      .then(channel =>
         Promise.resolve({
           ...channel,
           ...installedChannel,
@@ -47,7 +47,6 @@ export function getAllDriveChannels(store, drive) {
     };
   });
 }
-
 export function fetchUnlistedChannelInfo(store, channelId) {
-  return getRemoteChannelByToken(channelId).then(channels => Array(channels));
+  return getRemoteChannelBundleByToken(channelId).then(channels => Array(channels));
 }

--- a/kolibri/plugins/device/assets/src/modules/wizard/apiPeerImport.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/apiPeerImport.js
@@ -58,8 +58,8 @@ export function getTransferredChannelOnPeerServer(store, { addressId, channelId 
             },
             force: true,
           })
-            .then(channels => {
-              resolve({ ...channels[0] });
+            .then(channel => {
+              resolve(channel);
             })
             .catch(() => {
               // Only appears if channel with channelId is not on the device. Will still load

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -196,8 +196,8 @@ export function showSelectContentPage(store, params) {
         // Force fetching because using cached version switches
         // between returning an array and returning an object
         .then(
-          channels => {
-            resolve({ ...channels[0] });
+          channel => {
+            resolve(channel);
           },
           error => {
             if (error.response.status === 404) {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
@@ -9,7 +9,7 @@ import { getDeviceInfo } from '../../../modules/deviceInfo/handlers';
 export function fetchPageData(channelId) {
   const studioChannelPromise = RemoteChannelResource.fetchModel({ id: channelId, force: true })
     .then(channel => {
-      this.studioChannel = { ...channel[0] };
+      this.studioChannel = channel;
     })
     .catch(() => {
       // Fail silently in case server is offline

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
@@ -33,7 +33,7 @@ function getChannelOnPeer(addressId, channelId) {
           baseurl: location.base_url,
         },
         force: true,
-      }).then(([channel]) => {
+      }).then(channel => {
         return {
           ...channel,
           baseurl: location.base_url,
@@ -49,7 +49,7 @@ function getChannelOnStudio(channelId) {
   return RemoteChannelResource.fetchModel({
     id: channelId,
   })
-    .then(([channel]) => {
+    .then(channel => {
       return {
         ...channel,
         baseurl: kolibriStudioUrl,


### PR DESCRIPTION
## Summary
* Allow upgrade of custom nav items
* Slight refactor of Remote Channel viewset and Remote Channel Resource to return a single item on Model fetch.

## Reviewer guidance
Can you upgrade to a newer version of a custom nav channel?

I tested this by upgrading, and then confirming that the new zip file was marked as available in my DB and also that it was my content storage folder.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
