### PR TITLE
Fix regression in retrieve_list endpoint. Add regression smoketest.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1073,6 +1073,8 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         baseurl = request.GET.get("baseurl", None)
         keyword = request.GET.get("keyword", None)
         language = request.GET.get("language", None)
-        return self._make_channel_endpoint_request(
-            identifier=pk, baseurl=baseurl, keyword=keyword, language=language
+        return Response(
+            self._make_channel_endpoint_request(
+                identifier=pk, baseurl=baseurl, keyword=keyword, language=language
+            )
         )

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1539,6 +1539,14 @@ class KolibriStudioAPITestCase(APITestCase):
         self.assertEqual(response.data[0]["id"], 1)
 
     @mock_patch_decorator
+    def test_channel_retrieve_list(self):
+        response = self.client.get(
+            reverse("kolibri:core:remotechannel-retrieve-list", kwargs={"pk": 1}),
+            format="json",
+        )
+        self.assertEqual(response.data[0]["id"], 1)
+
+    @mock_patch_decorator
     def test_no_permission_non_superuser_channel_list(self):
         user = FacilityUser.objects.create(username="user", facility=self.facility)
         user.set_password(DUMMY_PASSWORD)


### PR DESCRIPTION
## Summary
Fixes regression introduced by #8039 
Adds regression test


## Reviewer guidance
Does import by token from Studio work

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
