### PR TITLE
Add explicit include_coach_content filter instead of role filter.

### DIFF
--- a/kolibri/core/analytics/measurements.py
+++ b/kolibri/core/analytics/measurements.py
@@ -121,7 +121,8 @@ def get_requests_info():
             requests.get(base_url).elapsed.total_seconds()
         )
         recommended_url = format_url(
-            "/api/content/contentnode_slim/popular/?user_kind=learner", base_url
+            "/api/content/contentnode_slim/popular/?include_coach_content=false",
+            base_url,
         )
         recommended_time = "{:.2f} s".format(
             requests.get(recommended_url).elapsed.total_seconds()

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -8,25 +8,22 @@ import { contentState } from '../coreLearn/utils';
 // User-agnostic recommendations
 function _getPopular(store) {
   return ContentNodeResource.fetchPopular({
-    user_kind: store.getters.getUserKind,
+    include_coach_content:
+      store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
   });
 }
 
 // User-specific recommendations
 function _getNextSteps(store) {
   if (store.getters.isUserLoggedIn) {
-    return ContentNodeResource.fetchNextSteps({
-      user_kind: store.getters.getUserKind,
-    });
+    return ContentNodeResource.fetchNextSteps();
   }
   return Promise.resolve([]);
 }
 
 function _getResume(store) {
   if (store.getters.isUserLoggedIn) {
-    return ContentNodeResource.fetchResume({
-      user_kind: store.getters.getUserKind,
-    });
+    return ContentNodeResource.fetchResume();
   }
   return Promise.resolve([]);
 }

--- a/kolibri/plugins/learn/assets/src/modules/search/actions.js
+++ b/kolibri/plugins/learn/assets/src/modules/search/actions.js
@@ -37,6 +37,8 @@ export function triggerSearch(
     search: searchTerm,
     kind: kindFilter,
     channel_id: channelFilter,
+    include_coach_content:
+      store.rootGetters.isAdmin || store.rootGetters.isCoach || store.rootGetters.isSuperuser,
   };
 
   return ContentNodeSearchResource.getCollection(getParams)

--- a/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsRoot/handlers.js
@@ -15,7 +15,11 @@ export function showChannels(store) {
       }
       const channelRootIds = channels.map(channel => channel.root);
       ContentNodeResource.fetchCollection({
-        getParams: { ids: channelRootIds, user_kind: store.getters.getUserKind },
+        getParams: {
+          ids: channelRootIds,
+          include_coach_content:
+            store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+        },
       }).then(channelCollection => {
         // we want them to be in the same order as the channels list
         const rootNodes = channels

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -51,7 +51,8 @@ export function showTopicsTopic(store, { id, isRoot = false }) {
       ContentNodeResource.fetchCollection({
         getParams: {
           parent: id,
-          user_kind: store.getters.getUserKind,
+          include_coach_content:
+            store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
         },
       }), // the topic's children
       store.dispatch('setChannelInfo'),


### PR DESCRIPTION
## Summary
* Adds explicit `include_coach_content` filter parameter to ContentNode endpoints
* Uses this conditionalized on whether a user is a Learner or Anonymous (False) or Coach, Admin, Superuser (True)
* Ensures this gets set for all relevant endpoints - does not add it on non-shared recommendation endpoints, next steps and resume
* Adds the filter to Search

## References
* Fixes #5467 

## Reviewer guidance
Does coach content show for all coach and higher privileged users?
Does it also show in search for them?
Is it hidden for learners and anonymous users?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
