### PR TITLE
Add seperate label for facility-import tasks in task manager

### DIFF
--- a/kolibri/core/assets/src/mixins/taskStrings.js
+++ b/kolibri/core/assets/src/mixins/taskStrings.js
@@ -96,13 +96,17 @@ const taskStrings = createTranslator('TaskStrings', {
   },
 
   // Import Facility Task strings
+  importFacilityTaskLabel: {
+    message: "Import '{facilityName}'",
+    context: 'Description of import-facility task',
+  },
   importSuccessStatus: {
     message: `'{facilityName}' successfully loaded to this device`,
-    context: '',
+    context: 'Message that shows after Facility is successfully imported',
   },
   importFailedStatus: {
     message: `Could not import '{facilityName}'`,
-    context: '',
+    context: 'Message that shows after Facility fails to import',
   },
 });
 

--- a/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
@@ -36,6 +36,20 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
 
   const ALL_STATUSES = Object.keys(syncStatusToDescriptionMap);
 
+  it('displays the correct header for facility-sync tasks', () => {
+    const task = makeTask('RUNNING');
+    task.type = 'SYNCPEER/FULL';
+    const displayInfo = syncFacilityTaskDisplayInfo(task);
+    expect(displayInfo.headingMsg).toEqual("Sync 'generic facility (fac1)'");
+  });
+
+  it('displays the correct header for facility-import tasks', () => {
+    const task = makeTask('RUNNING');
+    task.type = 'SYNCPEER/PULL';
+    const displayInfo = syncFacilityTaskDisplayInfo(task);
+    expect(displayInfo.headingMsg).toEqual("Import 'generic facility (fac1)'");
+  });
+
   it('display title, started by username, and device name are invariant wrt status', () => {
     const task = {
       status: null,

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -51,14 +51,23 @@ function formatNameWithId(name, id) {
   return coreString('nameWithIdInParens', { name, id: id.slice(0, 4) });
 }
 
+const PUSHPULLSTEPS = 7;
+const PULLSTEPS = 4;
+
 // Consolidates logic on how Sync-Facility Tasks should be displayed
 export function syncFacilityTaskDisplayInfo(task) {
   let statusMsg;
   let bytesTransferredMsg = '';
   let deviceNameMsg = '';
+  let headingMsg = '';
 
   const facilityName = formatNameWithId(task.facility_name, task.facility);
 
+  if (task.type === TaskTypes.SYNCPEERPULL) {
+    headingMsg = getTaskString('importFacilityTaskLabel', { facilityName });
+  } else {
+    headingMsg = getTaskString('syncFacilityTaskLabel', { facilityName });
+  }
   // Device info isn't shown on the Setup Wizard version of panel
   if (task.type === TaskTypes.SYNCDATAPORTAL) {
     deviceNameMsg = 'Kolibri Data Portal';
@@ -78,7 +87,7 @@ export function syncFacilityTaskDisplayInfo(task) {
   } else if (syncStep) {
     statusMsg = getTaskString('syncStepAndDescription', {
       step: syncStep,
-      total: task.type === TaskTypes.SYNCPEERPULL ? 4 : 7,
+      total: task.type === TaskTypes.SYNCPEERPULL ? PULLSTEPS : PUSHPULLSTEPS,
       description: statusDescription,
     });
   } else {
@@ -95,7 +104,7 @@ export function syncFacilityTaskDisplayInfo(task) {
   const canClear = task.clearable;
 
   return {
-    headingMsg: getTaskString('syncFacilityTaskLabel', { facilityName }),
+    headingMsg,
     statusMsg,
     startedByMsg: getTaskString('taskStartedByLabel', { username: task.started_by_username }),
     bytesTransferredMsg,
@@ -122,9 +131,9 @@ export function removeFacilityTaskDisplayInfo(task) {
     headingMsg: getTaskString('removeFacilityTaskLabel', { facilityName }),
     statusMsg: statusDescription,
     startedByMsg: getTaskString('taskStartedByLabel', { username: task.started_by_username }),
-    isRunning: task.status === 'RUNNING',
+    isRunning: task.status === TaskStatuses.RUNNING,
     canClear: task.clearable,
-    canCancel: !task.clearable && task.status !== 'RUNNING',
+    canCancel: !task.clearable && task.status !== TaskStatuses.RUNNING,
     canRetry: task.status === TaskStatuses.FAILED,
   };
 }


### PR DESCRIPTION
## Summary

1. Add a new label for  Facility-Import (i.e. only "pulls" and does not "push" data to peer server), to describe these tasks more accurately in the Task Manager (fixes #7370 
2. Some refactors
3. Add context to some strings

Before this would say "Sync 'Hack Session School'":

![image](https://user-images.githubusercontent.com/10248067/116913479-633e4400-abfe-11eb-8051-ac496e09ae2f.png)

## References

Fixes #7370 

## Reviewer guidance

Reviewing the unit tests should be good enough, but this can be manually tested by importing a facility from a peer server or `kolibri-beta` demo server.


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
