### PR TITLE
Options cleanup

### DIFF
--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -4,7 +4,6 @@ import time
 import uuid
 
 from kolibri.core.tasks import compat
-from kolibri.core.utils.cache import ProcessLock
 
 
 # An object on which to store data about the current job
@@ -118,6 +117,3 @@ class InfiniteLoopThread(compat.Thread):
 
     def shutdown(self):
         self.stop()
-
-
-db_task_write_lock = ProcessLock("db_task_write_lock")

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -1,12 +1,8 @@
 import logging
 
-from diskcache.recipes import RLock
 from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
-from django.core.cache.backends.base import BaseCache
 from django.utils.functional import SimpleLazyObject
-
-from kolibri.utils.conf import OPTIONS
 
 
 logger = logging.getLogger(__name__)
@@ -20,142 +16,6 @@ def __get_process_cache():
 
 
 process_cache = SimpleLazyObject(__get_process_cache)
-
-
-class ProcessLock(object):
-    def __init__(self, key, expire=None):
-        """
-        :param key: The lock key
-        :param expire: The cache key expiration in seconds (defaults to the CACHE_LOCK_TTL option if not set)
-        :type key: str
-        :type expire: int
-        """
-        self.key = key
-        self.expire = expire if expire else OPTIONS["Cache"]["CACHE_LOCK_TTL"]
-
-        self._lock_object = None
-
-    @property
-    def _lock(self):
-        if self._lock_object is None:
-            if OPTIONS["Cache"]["CACHE_BACKEND"] == "redis":
-                expire = self.expire * 1000
-                # if we're using Redis, be sure we use Redis' locking mechanism which uses
-                # `SET NX` under the hood. See redis.lock.Lock
-                # The Django RedisCache backend provide the lock method to proxy this
-                self._lock_object = process_cache.lock(
-                    self.key,
-                    timeout=expire,  # milliseconds
-                    sleep=0.01,  # seconds
-                    blocking_timeout=100,  # seconds
-                    thread_local=True,
-                )
-            else:
-                # we can't pass in the `process_cache` because it's an instance of DjangoCache
-                # and we need a DiskCache Cache instance
-                cache = process_cache.cache("locks")
-                self._lock_object = RLock(cache, self.key, expire=self.expire)
-        return self._lock_object
-
-    def acquire(self):
-        self._lock.acquire()
-
-    def release(self):
-        try:
-            self._lock.release()
-        except AssertionError:
-            logger.warning(
-                "Got an AssertionError when releasing a lock! This is likely from the lock TTL expiring."
-            )
-
-    def __enter__(self):
-        self.acquire()
-
-    def __exit__(self, *exc_info):
-        self.release()
-
-
-class NamespacedCacheProxy(BaseCache):
-    """
-    Namespaces keys and retains a record of inserted keys for easy clearing of
-    all namespaced keys in the cache
-    """
-
-    def __init__(self, cache, namespace, **params):
-        """
-        :type cache: BaseCache
-        :type namespace: str
-        """
-        params.update(KEY_PREFIX=namespace)
-        super(NamespacedCacheProxy, self).__init__(params)
-        self.cache = cache
-        self._lock = ProcessLock("namespaced_cache_{}".format(namespace))
-
-    def _get_keys(self):
-        """
-        :rtype: list
-        """
-        key = self.make_key("__KEYS__")
-        return self.cache.get(key, default=[])
-
-    def _set_keys(self, keys):
-        """
-        :type keys: list
-        """
-        key = self.make_key("__KEYS__")
-        self.cache.set(key, keys)
-
-    def add(self, key, *args, **kwargs):
-        """
-        :type key: str
-        :rtype: bool
-        """
-        with self._lock:
-            keys = self._get_keys()
-            if key not in keys:
-                keys.append(key)
-            result = self.cache.add(self.make_key(key), *args, **kwargs)
-            if result:
-                self._set_keys(keys)
-
-        return result
-
-    def get(self, key, *args, **kwargs):
-        """
-        :type key: str
-        :rtype: any
-        """
-        with self._lock:
-            return self.cache.get(self.make_key(key), *args, **kwargs)
-
-    def set(self, key, *args, **kwargs):
-        """
-        :type key: str
-        """
-        with self._lock:
-            keys = self._get_keys()
-            if key not in keys:
-                keys.append(key)
-            self.cache.set(self.make_key(key), *args, **kwargs)
-            self._set_keys(keys)
-
-    def delete(self, key, *args, **kwargs):
-        """
-        :type key: str
-        """
-        with self._lock:
-            keys = self._get_keys()
-            self.cache.delete(self.make_key(key), *args, **kwargs)
-            self._set_keys([cached_key for cached_key in keys if cached_key != key])
-
-    def clear(self):
-        """
-        Clears only the cached keys in this namespace
-        """
-        with self._lock:
-            for key in self._get_keys():
-                self.cache.delete(self.make_key(key))
-            self._set_keys([])
 
 
 class RedisSettingsHelper(object):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -54,7 +54,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
             "enableCustomChannelNav": conf.OPTIONS["Learn"][
-                "KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV"
+                "ENABLE_CUSTOM_CHANNEL_NAV"
             ],
         }
 

--- a/kolibri/plugins/learn/options.py
+++ b/kolibri/plugins/learn/options.py
@@ -1,9 +1,8 @@
 option_spec = {
     "Learn": {
-        "KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV": {
+        "ENABLE_CUSTOM_CHANNEL_NAV": {
             "type": "boolean",
             "default": False,
-            "envvars": ("KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV",),
         },
     },
 }

--- a/kolibri/plugins/learn/options.py
+++ b/kolibri/plugins/learn/options.py
@@ -3,6 +3,7 @@ option_spec = {
         "ENABLE_CUSTOM_CHANNEL_NAV": {
             "type": "boolean",
             "default": False,
+            "description": "Whether to enable custom channel navigation applications",
         },
     },
 }

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -51,7 +51,7 @@ def __initialize_options():
     # read the config file options in here so they can be accessed from a standard location
     from .options import read_options_file
 
-    return read_options_file(KOLIBRI_HOME)
+    return read_options_file()
 
 
 OPTIONS = SimpleLazyObject(__initialize_options)

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -280,10 +280,6 @@ base_option_spec = {
             "type": "string",
             "default": "localhost:6379",
         },
-        "CACHE_LOCK_TTL": {
-            "type": "integer",
-            "default": 30,
-        },
         "CACHE_REDIS_MIN_DB": {
             "type": "integer",
             "default": 0,

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -196,9 +196,9 @@ base_option_spec = {
             "options": ("memory", "redis"),
             "default": "memory",
             "description": """
-                Which backend to use for the main cache - if memory is selected, then for most cache operations,
-                an in memory, process local cache will be used, but a disk based cache will be used for some data
-                that needs to be persistent across processes. If Redis is used, it is used for all caches.
+                Which backend to use for the main cache - if 'memory' is selected, then for most cache operations,
+                an in-memory, process-local cache will be used, but a disk based cache will be used for some data
+                that needs to be persistent across processes. If 'redis' is used, it is used for all caches.
             """,
         },
         "CACHE_TIMEOUT": {
@@ -265,7 +265,7 @@ base_option_spec = {
             "type": "option",
             "options": ("sqlite", "postgres"),
             "default": "sqlite",
-            "description": "Which database backend to use, choices are sqlite or postgresql",
+            "description": "Which database backend to use, choices are 'sqlite' or 'postgresql'",
         },
         "DATABASE_NAME": {
             "type": "string",
@@ -308,9 +308,9 @@ base_option_spec = {
             "description": """
                 How long a socket should wait for data flow to resume before
                 it considers that the connection has been interrupted.
-                Increasing this may help in situations where there is high latency on a network,
-                or the bandwidth is bursty, and it is expected that data flow may be interrupted
-                but not indicative of the connection failing.
+                Increasing this may help in situations where there is high
+                latency on a network or the bandwidth is bursty, with some
+                expected data flow interruptions which may not be indicative of the connection failing.
             """,
         },
         "CHERRYPY_QUEUE_SIZE": {
@@ -353,7 +353,7 @@ base_option_spec = {
             "description": """
                 The directory that will store content files and content database files.
                 To change this in a currently active server it is recommended to use the
-                content movedirectory management command.
+                'content movedirectory' management command.
             """,
         },
         "CONTENT_FALLBACK_DIRS": {
@@ -410,31 +410,31 @@ base_option_spec = {
             "type": "language_list",
             "default": SUPPORTED_LANGUAGES,
             "description": """
-                The languages that this Kolibri should enable. The default is all the languages that Kolibri supports.
-                Can either be a single language code, or a comma separated list of language codes.
+                The user interface languages to enable on this instance of Kolibri (has no effect on languages of imported content channels).
+                The default will include all the languages Kolibri supports.
             """,
         },
         "ZIP_CONTENT_ORIGIN": {
             "type": "origin_or_port",
             "default": "",
             "description": """
-                When running in default operation, this will default to blank, and the Kolibri
-                frontend will look for the zipcontent endpoints on the same domain as Kolibri proper
-                but using ZIP_CONTENT_PORT instead of HTTP_PORT.
-                When running behind a proxy, this value should be set to the port that the zipcontent
-                endpoint is being served on, this will be substituted for the port that Kolibri proper
-                is being served on.
-                If zipcontent is being served from a completely separate domain this can be the absolute
-                origin (full protocol plus domain, e.g. 'https://myzipcontent.com/') which will then
-                be used for all zipcontent origin requests.
+                When running by default (value blank), Kolibri frontend looks for the zipcontent endpoints
+                on the same domain as Kolibri proper, but uses ZIP_CONTENT_PORT instead of HTTP_PORT.
+                When running behind a proxy, set the value to the port where zipcontent endpoint is served on,
+                and it will be substituted for the port that Kolibri proper is being served on.
+                When zipcontent is being served from a completely separate domain, you can set an
+                absolute origin (full protocol plus domain, e.g. 'https://myzipcontent.com/')
+                to be used for all zipcontent origin requests.
             """,
         },
         "ZIP_CONTENT_PORT": {
             "type": "port",
             "default": 0,
             "description": """
-                Sets the port that Kolibri will serve the alternate origin server on. This is the alternate
-                origin server equivalent of HTTP_PORT.
+                Sets the port that Kolibri will serve the alternate origin server on. This is the server that
+                is used to serve all content for the zipcontent endpoint, so as to provide safe IFrame sandboxing
+                but avoiding issues with null origins.
+                This is the alternate origin server equivalent of HTTP_PORT.
             """,
         },
         "ZIP_CONTENT_URL_PATH_PREFIX": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -244,53 +244,43 @@ base_option_spec = {
             "type": "option",
             "options": ("memory", "redis"),
             "default": "memory",
-            "envvars": ("KOLIBRI_CACHE_BACKEND",),
         },
         "CACHE_TIMEOUT": {
             "type": "integer",
             "default": 300,
-            "envvars": ("KOLIBRI_CACHE_TIMEOUT",),
         },
         "CACHE_MAX_ENTRIES": {
             "type": "integer",
             "default": 1000,
-            "envvars": ("KOLIBRI_CACHE_MAX_ENTRIES",),
         },
         "CACHE_PASSWORD": {
             "type": "string",
             "default": "",
-            "envvars": ("KOLIBRI_CACHE_PASSWORD",),
         },
         "CACHE_LOCATION": {
             "type": "string",
             "default": "localhost:6379",
-            "envvars": ("KOLIBRI_CACHE_LOCATION",),
         },
         "CACHE_LOCK_TTL": {
             "type": "integer",
             "default": 30,
-            "envvars": ("KOLIBRI_CACHE_LOCK_TTL",),
         },
         "CACHE_REDIS_MIN_DB": {
             "type": "integer",
             "default": 0,
-            "envvars": ("KOLIBRI_CACHE_REDIS_MIN_DB",),
         },
         "CACHE_REDIS_MAX_POOL_SIZE": {
             "type": "integer",
             "default": 50,  # use redis-benchmark to determine better value
-            "envvars": ("KOLIBRI_CACHE_REDIS_MAX_POOL_SIZE",),
         },
         "CACHE_REDIS_POOL_TIMEOUT": {
             "type": "integer",
             "default": 30,  # seconds
-            "envvars": ("KOLIBRI_CACHE_REDIS_POOL_TIMEOUT",),
         },
         # Optional redis settings to overwrite redis.conf
         "CACHE_REDIS_MAXMEMORY": {
             "type": "integer",
             "default": 0,
-            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY",),
         },
         "CACHE_REDIS_MAXMEMORY_POLICY": {
             "type": "option",
@@ -304,7 +294,6 @@ base_option_spec = {
                 "noeviction",
             ),
             "default": "",
-            "envvars": ("KOLIBRI_CACHE_REDIS_MAXMEMORY_POLICY",),
         },
     },
     "Database": {
@@ -312,119 +301,102 @@ base_option_spec = {
             "type": "option",
             "options": ("sqlite", "postgres"),
             "default": "sqlite",
-            "envvars": ("KOLIBRI_DATABASE_ENGINE",),
         },
-        "DATABASE_NAME": {"type": "string", "envvars": ("KOLIBRI_DATABASE_NAME",)},
+        "DATABASE_NAME": {"type": "string"},
         "DATABASE_PASSWORD": {
             "type": "string",
-            "envvars": ("KOLIBRI_DATABASE_PASSWORD",),
         },
-        "DATABASE_USER": {"type": "string", "envvars": ("KOLIBRI_DATABASE_USER",)},
-        "DATABASE_HOST": {"type": "string", "envvars": ("KOLIBRI_DATABASE_HOST",)},
-        "DATABASE_PORT": {"type": "string", "envvars": ("KOLIBRI_DATABASE_PORT",)},
+        "DATABASE_USER": {"type": "string"},
+        "DATABASE_HOST": {"type": "string"},
+        "DATABASE_PORT": {"type": "string"},
     },
     "Server": {
         "CHERRYPY_START": {
             "type": "boolean",
             "default": True,
-            "envvars": ("KOLIBRI_CHERRYPY_START",),
         },
         "CHERRYPY_THREAD_POOL": {
             "type": "integer",
             "default": calculate_thread_pool(),
-            "envvars": ("KOLIBRI_CHERRYPY_THREAD_POOL",),
         },
         "CHERRYPY_SOCKET_TIMEOUT": {
             "type": "integer",
             "default": 10,
-            "envvars": ("KOLIBRI_CHERRYPY_SOCKET_TIMEOUT",),
         },
         "CHERRYPY_QUEUE_SIZE": {
             "type": "integer",
             "default": 30,
-            "envvars": ("KOLIBRI_CHERRYPY_QUEUE_SIZE",),
         },
         "CHERRYPY_QUEUE_TIMEOUT": {
             "type": "float",
             "default": 0.1,
-            "envvars": ("KOLIBRI_CHERRYPY_QUEUE_TIMEOUT",),
         },
         "PROFILE": {
             "type": "boolean",
             "default": False,
             "envvars": ("KOLIBRI_SERVER_PROFILE",),
         },
-        "DEBUG": {"type": "boolean", "default": False, "envvars": ("KOLIBRI_DEBUG",)},
+        "DEBUG": {"type": "boolean", "default": False},
         "DEBUG_LOG_DATABASE": {
             "type": "boolean",
             "default": False,
-            "envvars": ("KOLIBRI_DEBUG_LOG_DATABASE",),
         },
     },
     "Paths": {
         "CONTENT_DIR": {
             "type": "string",
             "default": "content",
-            "envvars": ("KOLIBRI_CONTENT_DIR",),
         },
         "CONTENT_FALLBACK_DIRS": {
             "type": "path_list",
             "default": "",
-            "envvars": ("KOLIBRI_CONTENT_FALLBACK_DIRS",),
         },
     },
     "Urls": {
         "CENTRAL_CONTENT_BASE_URL": {
             "type": "string",
             "default": "https://studio.learningequality.org",
-            "envvars": (
-                "KOLIBRI_CENTRAL_CONTENT_BASE_URL",
-                "CENTRAL_CONTENT_DOWNLOAD_BASE_URL",
-            ),
+            "envvars": ("CENTRAL_CONTENT_DOWNLOAD_BASE_URL",),
         },
         "DATA_PORTAL_SYNCING_BASE_URL": {
             "type": "string",
             "default": "https://kolibridataportal.learningequality.org",
-            "envvars": ("KOLIBRI_DATA_PORTAL_SYNCING_BASE_URL",),
         },
     },
     "Deployment": {
         "HTTP_PORT": {
             "type": "port",
             "default": 8080,
-            "envvars": ("KOLIBRI_HTTP_PORT", "KOLIBRI_LISTEN_PORT"),
+            "envvars": (
+                "KOLIBRI_HTTP_PORT",
+                "KOLIBRI_LISTEN_PORT",
+            ),
         },
-        "RUN_MODE": {"type": "string", "envvars": ("KOLIBRI_RUN_MODE",)},
+        "RUN_MODE": {"type": "string"},
         "DISABLE_PING": {
             "type": "boolean",
             "default": False,
-            "envvars": ("KOLIBRI_DISABLE_PING",),
         },
         "URL_PATH_PREFIX": {
             "type": "string",
             "default": "/",
-            "envvars": ("KOLIBRI_URL_PATH_PREFIX",),
             "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
         "LANGUAGES": {
             "type": "language_list",
             "default": SUPPORTED_LANGUAGES,
-            "envvars": ("KOLIBRI_LANGUAGES",),
         },
         "ZIP_CONTENT_ORIGIN": {
             "type": "origin_or_port",
             "default": "",
-            "envvars": ("KOLIBRI_ZIP_CONTENT_ORIGIN",),
         },
         "ZIP_CONTENT_PORT": {
             "type": "port",
             "default": 0,
-            "envvars": ("KOLIBRI_ZIP_CONTENT_PORT",),
         },
         "ZIP_CONTENT_URL_PATH_PREFIX": {
             "type": "string",
             "default": "/",
-            "envvars": ("KOLIBRI_ZIP_CONTENT_URL_PATH_PREFIX",),
             "clean": lambda x: x.lstrip("/").rstrip("/") + "/",
         },
     },
@@ -432,7 +404,6 @@ base_option_spec = {
         "PICKLE_PROTOCOL": {
             "type": "integer",
             "default": 2,
-            "envvars": ("KOLIBRI_PICKLE_PROTOCOL",),
         }
     },
 }
@@ -468,7 +439,26 @@ def _get_option_spec():
     """
     Combine the default option spec with any options that are defined in plugins
     """
-    return extend_config_spec(base_option_spec)
+    option_spec = extend_config_spec(base_option_spec)
+    envvars = set()
+    for section, opts in option_spec.items():
+        for optname, attrs in opts.items():
+            opt_envvars = attrs.get("envvars", tuple())
+            default_envvar = "KOLIBRI_{}".format(optname.upper())
+            if default_envvar not in envvars:
+                envvars.add(default_envvar)
+            else:
+                logging.warn(
+                    "Duplicate environment variable for options {}".format(
+                        default_envvar
+                    )
+                )
+                default_envvar = "KOLIBRI_{}_{}".format(
+                    section.upper(), optname.upper()
+                )
+            if default_envvar not in opt_envvars:
+                attrs["envvars"] = opt_envvars + (default_envvar,)
+    return option_spec
 
 
 option_spec = SimpleLazyObject(_get_option_spec)

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -679,12 +679,12 @@ def generate_empty_options_file(ini_filename="options.ini"):
         if comments is not None:
             conf.comments[section] = comments
         comments = []
-        logging.info(section)
         for optname, attrs in opts.items():
             if not attrs.get("skip_blank", False):
                 if "description" in attrs:
                     comments.extend(attrs["description"].strip().split("\n"))
                 comments.append("{} = {}".format(optname, attrs.get("default", "")))
+                comments.append("")
     conf.final_comment = comments
 
     conf.write()

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -120,7 +120,7 @@ def check_default_options_exist():
     options_path = os.path.join(KOLIBRI_HOME, "options.ini")
     if not os.path.exists(options_path):
         try:
-            generate_empty_options_file(options_path, OPTIONS)
+            generate_empty_options_file()
         except IOError:
             logger.warning(
                 "Failed to create an options.ini file at this path: {}".format(

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -173,7 +173,7 @@ def test_kolibri_listen_port_env(monkeypatch):
         # force a reload of plugins.OPTIONS so the environment variable will be read in
         from kolibri.utils import conf
 
-        conf.OPTIONS.update(options.read_options_file(conf.KOLIBRI_HOME))
+        conf.OPTIONS.update(options.read_options_file())
 
         cli.start.callback(test_port, test_zip_port, False)
         with pytest.raises(SystemExit) as excinfo:

--- a/kolibri/utils/tests/test_cli_at_import.py
+++ b/kolibri/utils/tests/test_cli_at_import.py
@@ -36,3 +36,10 @@ def test_stop_no_db_access(create_engine_mock):
     except SystemExit:
         pass
     create_engine_mock.assert_not_called()
+
+
+@patch("kolibri.utils.options.read_options_file")
+def test_import_no_options_evaluation(read_options_mock):
+    from kolibri.utils import cli  # noqa F401
+
+    read_options_mock.assert_not_called()

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -97,6 +97,28 @@ def test_option_reading_and_precedence_rules():
         assert OPTIONS["Deployment"]["HTTP_PORT"] == _HTTP_PORT_ENV
 
 
+def test_default_envvar_generation():
+    """
+    Checks that options can be read from a dummy options.ini file, and overridden by env vars.
+    """
+    if sys.platform == "win32":
+        _CONTENT_DIR = "C:\\mycontentdir"
+    else:
+        _CONTENT_DIR = "/mycontentdir"
+
+    _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+
+    # when an env var is set, use those instead of ini file values
+    with mock.patch.dict(
+        os.environ,
+        {"KOLIBRI_CONTENT_DIR": _CONTENT_DIR},
+    ):
+        OPTIONS = options.read_options_file(
+            conf.KOLIBRI_HOME, ini_filename=tmp_ini_path
+        )
+        assert OPTIONS["Paths"]["CONTENT_DIR"] == _CONTENT_DIR
+
+
 def test_improper_settings_display_errors_and_exit(monkeypatch):
     """
     Checks that options can be read from a dummy options.ini file, and overridden by env vars.


### PR DESCRIPTION
## Summary
* Auto generates env var names for options
* Updates how we handle env var cleaning and validation to always use configobj validators
* Cleans up the now unused NamespacedCache and Lock functionality, including removing the Option it used
* In the process fixes #7682 and adds a regression test for it
* Changes the way that options are documented, and adds them as a `description` field on the config spec object
* Updates the way that we write out the empty options file to use configobj write methods
* Includes any description as part of the comments that are written out with the empty configobj
* Tweaks the name of the custom nav option in learn

## References
Fixes #5754 
Fixes #7682 

## Reviewer guidance
Check all options tests still pass.
Check that the server runs as expected.
Check that if you don't already have an options.ini file in your KOLIBRI_HOME it generates a copiously documented one!
@radinamatic if you could read the descriptions for clarity, that would be helpful - at the moment we don't have a good reason/mechanism for internationalizing them though.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
