### PR TITLE
Python API

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from .utils import env
-from .utils.version import get_version
+from kolibri.utils import env
+from kolibri.utils.version import get_version
 
 # Setup the environment before loading anything else from the application
 env.set_env()

--- a/kolibri/core/deviceadmin/exceptions.py
+++ b/kolibri/core/deviceadmin/exceptions.py
@@ -1,0 +1,2 @@
+class IncompatibleDatabase(Exception):
+    pass

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -10,6 +10,7 @@ from django import db
 from django.conf import settings
 
 import kolibri
+from kolibri.core.deviceadmin.exceptions import IncompatibleDatabase
 from kolibri.core.tasks.main import scheduler
 from kolibri.core.utils.lock import db_lock
 from kolibri.utils.conf import KOLIBRI_HOME
@@ -30,10 +31,6 @@ KWARGS_IO_WRITE = {"mode": "w", "encoding": "utf-8"}
 if sys.version_info < (3,):
     KWARGS_IO_READ = {"mode": "rb"}
     KWARGS_IO_WRITE = {"mode": "wb"}
-
-
-class IncompatibleDatabase(Exception):
-    pass
 
 
 def default_backup_folder():

--- a/kolibri/main.py
+++ b/kolibri/main.py
@@ -1,0 +1,7 @@
+# Add imports for exporting the main entry point
+# functions for Kolibri here, so that env setup
+# has already happened by this point
+from kolibri.plugins.utils import disable_plugin  # noqa E402
+from kolibri.plugins.utils import enable_plugin  # noqa E402
+from kolibri.utils.main import initialize  # noqa E402
+from kolibri.utils.server import start  # noqa E402

--- a/kolibri/main.py
+++ b/kolibri/main.py
@@ -4,4 +4,5 @@
 from kolibri.plugins.utils import disable_plugin  # noqa E402
 from kolibri.plugins.utils import enable_plugin  # noqa E402
 from kolibri.utils.main import initialize  # noqa E402
+from kolibri.utils.server import restart  # noqa E402
 from kolibri.utils.server import start  # noqa E402

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -331,6 +331,18 @@ def services(port, background):
     server.start(port=port, zip_port=None, serve_http=False, background=background)
 
 
+@main.command(cls=KolibriCommand, help="Restart the Kolibri process")
+def restart():
+    """
+    Restarts the server if it is running
+    """
+    if server.restart():
+        logger.info("Kolibri has successfully restarted")
+        sys.exit(0)
+    logger.info("Kolibri has failed to restart - confirm that the server is running")
+    sys.exit(1)
+
+
 @main.command(
     cls=KolibriDjangoCommand,
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -1,52 +1,26 @@
-"""
-Please make note ``kolibri.utils.cli`` has  a sensitive module import order.
-
-This deliberately imports ``kolibri.__init__`` before loading additional
-``kolibri.*`` modules.
-
-TODO: Investigate and challenge/explain this load order.
-"""
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
 import importlib
 import logging
-import os
 import signal
 import sys
-from sqlite3 import DatabaseError as SQLite3DatabaseError
 
 import click
-import django
-from django.core.management import call_command
 from django.core.management import execute_from_command_line
-from django.core.management.base import handle_default_options
-from django.db.utils import DatabaseError
 
 import kolibri
-from . import sanity_checks
-from . import server
-from .debian_check import check_debian_user
-from kolibri.core.deviceadmin.utils import IncompatibleDatabase
-from kolibri.core.upgrade import matches_version
-from kolibri.core.upgrade import run_upgrades
 from kolibri.plugins import config
 from kolibri.plugins import DEFAULT_PLUGINS
-from kolibri.plugins.utils import autoremove_unavailable_plugins
-from kolibri.plugins.utils import check_plugin_config_file_location
 from kolibri.plugins.utils import disable_plugin
-from kolibri.plugins.utils import enable_new_default_plugins
 from kolibri.plugins.utils import enable_plugin
 from kolibri.plugins.utils import iterate_plugins
-from kolibri.plugins.utils import run_plugin_updates
-from kolibri.utils.conf import KOLIBRI_HOME
-from kolibri.utils.conf import LOG_ROOT
+from kolibri.utils import server
 from kolibri.utils.conf import OPTIONS
-from kolibri.utils.logger import get_base_logging_config
-from kolibri.utils.sanity_checks import check_django_stack_ready
-from kolibri.utils.sanity_checks import DatabaseInaccessible
-from kolibri.utils.sanity_checks import DatabaseNotMigrated
+from kolibri.utils.debian_check import check_debian_user
+from kolibri.utils.main import initialize
+from kolibri.utils.main import setup_logging
 
 
 logger = logging.getLogger(__name__)
@@ -58,55 +32,6 @@ logger = logging.getLogger(__name__)
 # https://github.com/learningequality/kolibri/pull/5494#discussion_r318057385
 # https://github.com/PythonCharmers/python-future/issues/22
 click.disable_unicode_literals_warning = True
-
-
-def version_file():
-    """
-    During test runtime, this path may differ because KOLIBRI_HOME is
-    regenerated
-    """
-    return os.path.join(KOLIBRI_HOME, ".data_version")
-
-
-def version_updated(kolibri_version, version_file_contents):
-    return kolibri_version != version_file_contents
-
-
-def should_back_up(kolibri_version, version_file_contents):
-    change_version = kolibri_version != version_file_contents
-    return (
-        # Only back up if there was a previous version
-        version_file_contents
-        # That version has changed
-        and change_version
-        # The previous version was not a dev version
-        and "dev" not in version_file_contents
-        # And the new version is not a dev version
-        and "dev" not in kolibri_version
-    )
-
-
-def conditional_backup(kolibri_version, version_file_contents):
-    if should_back_up(kolibri_version, version_file_contents):
-        # Non-dev version change, make a backup no matter what.
-        from kolibri.core.deviceadmin.utils import dbbackup
-
-        try:
-            backup = dbbackup(version_file_contents)
-            logger.info("Backed up database to: {path}".format(path=backup))
-        except IncompatibleDatabase:
-            logger.warning(
-                "Skipped automatic database backup, not compatible with "
-                "this DB engine."
-            )
-
-
-def get_version():
-    try:
-        version = open(version_file(), "r").read()
-        return version.strip() if version else ""
-    except IOError:
-        return ""
 
 
 def validate_module(ctx, param, value):
@@ -171,26 +96,18 @@ initialize_params = base_params + [
     skip_update_option,
 ]
 
-
-def _migrate_databases():
-    """
-    Try to migrate all active databases. This should not be called unless Django has
-    been initialized.
-    """
-    from django.conf import settings
-
-    for database in settings.DATABASES:
-        call_command("migrate", interactive=False, database=database)
-
-    # load morango fixtures needed for certificate related operations
-    call_command("loaddata", "scopedefinitions")
+initialize_kwargs = {param.name: param.default for param in initialize_params}
 
 
 def get_initialize_params():
     try:
-        return click.get_current_context().params
+        return {
+            k: v
+            for k, v in click.get_current_context().params.items()
+            if k in initialize_kwargs
+        }
     except RuntimeError:
-        return {param.name: param.default for param in initialize_params}
+        return initialize_kwargs
 
 
 class KolibriCommand(click.Command):
@@ -265,157 +182,15 @@ class KolibriDjangoCommand(click.Command):
         super(KolibriDjangoCommand, self).__init__(*args, **kwargs)
 
     def invoke(self, ctx):
-        initialize()
+        try:
+            initialize(**get_initialize_params())
+        except Exception as e:
+            raise click.ClickException(e)
 
         # Remove parameters that are not for Django management command
         for param in initialize_params:
             ctx.params.pop(param.name)
         return super(KolibriDjangoCommand, self).invoke(ctx)
-
-
-class DefaultDjangoOptions(object):
-    __slots__ = ["settings", "pythonpath"]
-
-    def __init__(self, settings, pythonpath):
-        self.settings = settings
-        self.pythonpath = pythonpath
-
-
-def _setup_django():
-    """
-    Do our django setup - separated from initialize to reduce complexity.
-    """
-    try:
-        django.setup()
-
-    except (DatabaseError, SQLite3DatabaseError) as e:
-        if "malformed" in str(e):
-            logger.error(
-                "Your database appears to be corrupted. If you encounter this,"
-                "please immediately back up all files in the .kolibri folder that"
-                "end in .sqlite3, .sqlite3-shm, .sqlite3-wal, or .log and then"
-                "contact Learning Equality. Thank you!"
-            )
-        raise
-
-
-def initialize(skip_update=False):  # noqa: max-complexity=12
-    """
-    Currently, always called before running commands. This may change in case
-    commands that conflict with this behavior show up.
-    """
-    params = get_initialize_params()
-
-    check_debian_user(params.get("no_input"))
-
-    setup_logging(
-        debug=params.get("debug"), debug_database=params.get("debug_database")
-    )
-
-    skip_update = skip_update or params["skip_update"]
-    settings = params["settings"]
-    pythonpath = params["pythonpath"]
-
-    default_options = DefaultDjangoOptions(settings, pythonpath)
-
-    handle_default_options(default_options)
-
-    # Do this here so that we can fix any issues with our configuration file before
-    # we attempt to set up django.
-    autoremove_unavailable_plugins()
-
-    # Check if there is an options.ini file exist inside the KOLIBRI_HOME folder
-    sanity_checks.check_default_options_exist()
-
-    version = get_version()
-
-    updated = version_updated(kolibri.__version__, version)
-
-    if updated:
-        check_plugin_config_file_location(version)
-        # Reset the enabled plugins to the defaults
-        # This needs to be run before dbbackup because
-        # dbbackup relies on settings.INSTALLED_APPS
-        enable_new_default_plugins()
-
-    _setup_django()
-
-    if updated and not skip_update:
-        conditional_backup(kolibri.__version__, version)
-
-        if version:
-            logger.info(
-                "Version was {old}, new version: {new}".format(
-                    old=version, new=kolibri.__version__
-                )
-            )
-        else:
-            logger.info("New install, version: {new}".format(new=kolibri.__version__))
-        update(version, kolibri.__version__)
-
-    sanity_checks.check_content_directory_exists_and_writable()
-
-    if not skip_update:
-        # Run any plugin specific updates here in case they were missed by
-        # our Kolibri version based update logic.
-        run_plugin_updates()
-
-        check_django_stack_ready()
-
-        try:
-            sanity_checks.check_database_is_migrated()
-        except DatabaseNotMigrated:
-            try:
-                _migrate_databases()
-            except Exception as e:
-                logging.error(
-                    "The database was not fully migrated. Tried to "
-                    "migrate the database and an error occurred: "
-                    "{}".format(e)
-                )
-                sys.exit(1)
-        except DatabaseInaccessible as e:
-            logging.error(
-                "Tried to check that the database was accessible "
-                "and an error occurred: {}".format(e)
-            )
-            sys.exit(1)
-
-
-def update(old_version, new_version):
-    """
-    Called whenever a version change in kolibri is detected
-
-    TODO: We should look at version numbers of external plugins, too!
-    """
-
-    logger.info("Running update routines for new version...")
-
-    try:
-        # Check if there are other kolibri instances running
-        # If there are, then we need to stop users from starting kolibri again.
-        server.get_status()
-        logger.error(
-            "There is a Kolibri server running. "
-            "Running updates now could cause a database error. "
-            "Please use `kolibri stop` and try again. "
-        )
-        sys.exit(1)
-
-    except server.NotRunning:
-        pass
-
-    _migrate_databases()
-
-    run_upgrades(old_version, new_version)
-
-    with open(version_file(), "w") as f:
-        f.write(kolibri.__version__)
-
-    from django.core.cache import caches
-
-    cache = caches["built_files"]
-    cache.clear()
 
 
 main_help = """Kolibri command-line utility
@@ -556,28 +331,6 @@ def services(port, background):
     server.start(port=port, zip_port=None, serve_http=False, background=background)
 
 
-def setup_logging(debug=False, debug_database=False):
-    """
-    Configures logging in cases where a Django environment is not supposed
-    to be configured.
-    """
-    # Sets the global DEBUG flag to be picked up in other contexts
-    # (Django settings)
-    OPTIONS["Server"]["DEBUG"] = debug
-    OPTIONS["Server"]["DEBUG_LOG_DATABASE"] = debug_database
-
-    # Would be ideal to use the upgrade logic for this, but that is currently
-    # only designed for post-Django initialization tasks. If there are more cases
-    # for pre-django initialization upgrade tasks, we can generalize the logic here
-    if matches_version(get_version(), "<0.12.4"):
-        sanity_checks.check_log_file_location()
-
-    LOGGING = get_base_logging_config(
-        LOG_ROOT, debug=debug, debug_database=debug_database
-    )
-    logging.config.dictConfig(LOGGING)
-
-
 @main.command(
     cls=KolibriDjangoCommand,
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
@@ -594,10 +347,6 @@ def manage(ctx):
 @click.pass_context
 def shell(ctx):
     execute_from_command_line(["kolibri manage", "shell"] + ctx.args)
-
-
-ENABLE = "enable"
-DISABLE = "disable"
 
 
 @main.command(cls=KolibriGroupCommand, help="Manage Kolibri plugins")

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -225,13 +225,13 @@ def main(ctx):
 @main.command(cls=KolibriDjangoCommand, help="Start the Kolibri process")
 @click.option(
     "--port",
-    default=OPTIONS["Deployment"]["HTTP_PORT"],
+    default=None,
     type=int,
     help="Port on which Kolibri is being served",
 )
 @click.option(
     "--zip-port",
-    default=OPTIONS["Deployment"]["ZIP_CONTENT_PORT"],
+    default=None,
     type=int,
     help="Port on which zip content server is being served",
 )
@@ -244,6 +244,10 @@ def start(port, zip_port, background):
     """
     Start the server on given port.
     """
+    port = OPTIONS["Deployment"]["HTTP_PORT"] if port is None else port
+    zip_port = (
+        OPTIONS["Deployment"]["ZIP_CONTENT_PORT"] if zip_port is None else zip_port
+    )
     server.start(
         port=port,
         zip_port=zip_port,
@@ -312,7 +316,7 @@ def status():
 @main.command(cls=KolibriDjangoCommand, help="Start worker processes")
 @click.option(
     "--port",
-    default=OPTIONS["Deployment"]["HTTP_PORT"],
+    default=None,
     type=int,
     help="Port on which Kolibri is running to inform services",
 )
@@ -325,6 +329,8 @@ def services(port, background):
     """
     Start the kolibri background services.
     """
+
+    port = OPTIONS["Deployment"]["HTTP_PORT"] if port is None else port
 
     logger.info("Starting Kolibri background services")
 

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -1,0 +1,265 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import os
+import sys
+from sqlite3 import DatabaseError as SQLite3DatabaseError
+
+import django
+from django.conf import settings
+from django.core.management import call_command
+from django.core.management.base import handle_default_options
+from django.db.utils import DatabaseError
+
+import kolibri
+from kolibri.core.deviceadmin.utils import IncompatibleDatabase
+from kolibri.core.upgrade import matches_version
+from kolibri.core.upgrade import run_upgrades
+from kolibri.plugins.utils import autoremove_unavailable_plugins
+from kolibri.plugins.utils import check_plugin_config_file_location
+from kolibri.plugins.utils import enable_new_default_plugins
+from kolibri.plugins.utils import run_plugin_updates
+from kolibri.utils.conf import KOLIBRI_HOME
+from kolibri.utils.conf import LOG_ROOT
+from kolibri.utils.conf import OPTIONS
+from kolibri.utils.debian_check import check_debian_user
+from kolibri.utils.logger import get_base_logging_config
+from kolibri.utils.sanity_checks import check_content_directory_exists_and_writable
+from kolibri.utils.sanity_checks import check_database_is_migrated
+from kolibri.utils.sanity_checks import check_default_options_exist
+from kolibri.utils.sanity_checks import check_django_stack_ready
+from kolibri.utils.sanity_checks import check_log_file_location
+from kolibri.utils.sanity_checks import DatabaseInaccessible
+from kolibri.utils.sanity_checks import DatabaseNotMigrated
+from kolibri.utils.server import get_status
+from kolibri.utils.server import NotRunning
+
+
+logger = logging.getLogger(__name__)
+
+
+def version_file():
+    """
+    During test runtime, this path may differ because KOLIBRI_HOME is
+    regenerated
+    """
+    return os.path.join(KOLIBRI_HOME, ".data_version")
+
+
+def version_updated(kolibri_version, version_file_contents):
+    return kolibri_version != version_file_contents
+
+
+def should_back_up(kolibri_version, version_file_contents):
+    change_version = kolibri_version != version_file_contents
+    return (
+        # Only back up if there was a previous version
+        version_file_contents
+        # That version has changed
+        and change_version
+        # The previous version was not a dev version
+        and "dev" not in version_file_contents
+        # And the new version is not a dev version
+        and "dev" not in kolibri_version
+    )
+
+
+def conditional_backup(kolibri_version, version_file_contents):
+    if should_back_up(kolibri_version, version_file_contents):
+        # Non-dev version change, make a backup no matter what.
+        from kolibri.core.deviceadmin.utils import dbbackup
+
+        try:
+            backup = dbbackup(version_file_contents)
+            logger.info("Backed up database to: {path}".format(path=backup))
+        except IncompatibleDatabase:
+            logger.warning(
+                "Skipped automatic database backup, not compatible with "
+                "this DB engine."
+            )
+
+
+def get_version():
+    try:
+        version = open(version_file(), "r").read()
+        return version.strip() if version else ""
+    except IOError:
+        return ""
+
+
+def _migrate_databases():
+    """
+    Try to migrate all active databases. This should not be called unless Django has
+    been initialized.
+    """
+    for database in settings.DATABASES:
+        call_command("migrate", interactive=False, database=database)
+
+    # load morango fixtures needed for certificate related operations
+    call_command("loaddata", "scopedefinitions")
+
+
+class DefaultDjangoOptions(object):
+    __slots__ = ["settings", "pythonpath"]
+
+    def __init__(self, settings, pythonpath):
+        self.settings = settings
+        self.pythonpath = pythonpath
+
+
+def setup_logging(debug=False, debug_database=False):
+    """
+    Configures logging in cases where a Django environment is not supposed
+    to be configured.
+    """
+    # Sets the global DEBUG flag to be picked up in other contexts
+    # (Django settings)
+    OPTIONS["Server"]["DEBUG"] = debug
+    OPTIONS["Server"]["DEBUG_LOG_DATABASE"] = debug_database
+
+    # Would be ideal to use the upgrade logic for this, but that is currently
+    # only designed for post-Django initialization tasks. If there are more cases
+    # for pre-django initialization upgrade tasks, we can generalize the logic here
+    if matches_version(get_version(), "<0.12.4"):
+        check_log_file_location()
+
+    LOGGING = get_base_logging_config(
+        LOG_ROOT, debug=debug, debug_database=debug_database
+    )
+    logging.config.dictConfig(LOGGING)
+
+
+def _setup_django():
+    """
+    Do our django setup - separated from initialize to reduce complexity.
+    """
+    try:
+        django.setup()
+
+    except (DatabaseError, SQLite3DatabaseError) as e:
+        if "malformed" in str(e):
+            logger.error(
+                "Your database appears to be corrupted. If you encounter this,"
+                "please immediately back up all files in the .kolibri folder that"
+                "end in .sqlite3, .sqlite3-shm, .sqlite3-wal, or .log and then"
+                "contact Learning Equality. Thank you!"
+            )
+        raise
+
+
+def initialize(
+    skip_update=False,
+    settings=None,
+    debug=False,
+    debug_database=False,
+    no_input=False,
+    pythonpath=None,
+):  # noqa: max-complexity=12
+    """
+    This should be called before starting the Kolibri app, it initializes Kolibri plugins
+    and sets up Django.
+    """
+    check_debian_user(no_input)
+
+    setup_logging(debug=debug, debug_database=debug_database)
+
+    default_options = DefaultDjangoOptions(settings, pythonpath)
+
+    handle_default_options(default_options)
+
+    # Do this here so that we can fix any issues with our configuration file before
+    # we attempt to set up django.
+    autoremove_unavailable_plugins()
+
+    # Check if there is an options.ini file exist inside the KOLIBRI_HOME folder
+    check_default_options_exist()
+
+    version = get_version()
+
+    updated = version_updated(kolibri.__version__, version)
+
+    if updated:
+        check_plugin_config_file_location(version)
+        # Reset the enabled plugins to the defaults
+        # This needs to be run before dbbackup because
+        # dbbackup relies on settings.INSTALLED_APPS
+        enable_new_default_plugins()
+
+    _setup_django()
+
+    if updated and not skip_update:
+        conditional_backup(kolibri.__version__, version)
+
+        if version:
+            logger.info(
+                "Version was {old}, new version: {new}".format(
+                    old=version, new=kolibri.__version__
+                )
+            )
+        else:
+            logger.info("New install, version: {new}".format(new=kolibri.__version__))
+        update(version, kolibri.__version__)
+
+    check_content_directory_exists_and_writable()
+
+    if not skip_update:
+        # Run any plugin specific updates here in case they were missed by
+        # our Kolibri version based update logic.
+        run_plugin_updates()
+
+        check_django_stack_ready()
+
+        try:
+            check_database_is_migrated()
+        except DatabaseNotMigrated:
+            try:
+                _migrate_databases()
+            except Exception as e:
+                logging.error(
+                    "The database was not fully migrated. Tried to "
+                    "migrate the database and an error occurred: "
+                    "{}".format(e)
+                )
+                raise
+        except DatabaseInaccessible as e:
+            logging.error(
+                "Tried to check that the database was accessible "
+                "and an error occurred: {}".format(e)
+            )
+            raise
+
+
+def update(old_version, new_version):
+    """
+    Called whenever a version change in kolibri is detected
+    """
+
+    logger.info("Running update routines for new version...")
+
+    try:
+        # Check if there are other kolibri instances running
+        # If there are, then we need to stop users from starting kolibri again.
+        get_status()
+        logger.error(
+            "There is a Kolibri server running. "
+            "Running updates now could cause a database error. "
+            "Please use `kolibri stop` and try again. "
+        )
+        sys.exit(1)
+
+    except NotRunning:
+        pass
+
+    _migrate_databases()
+
+    run_upgrades(old_version, new_version)
+
+    with open(version_file(), "w") as f:
+        f.write(kolibri.__version__)
+
+    from django.core.cache import caches
+
+    cache = caches["built_files"]
+    cache.clear()

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -14,7 +14,7 @@ from django.core.management.base import handle_default_options
 from django.db.utils import DatabaseError
 
 import kolibri
-from kolibri.core.deviceadmin.utils import IncompatibleDatabase
+from kolibri.core.deviceadmin.exceptions import IncompatibleDatabase
 from kolibri.core.upgrade import matches_version
 from kolibri.core.upgrade import run_upgrades
 from kolibri.plugins.utils import autoremove_unavailable_plugins

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -26,9 +26,6 @@ import kolibri
 from .system import become_daemon
 from .system import kill_pid
 from .system import pid_exists
-from kolibri.core.tasks.main import initialize_workers
-from kolibri.core.tasks.main import scheduler
-from kolibri.deployment.default.cache import recreate_diskcache
 from kolibri.utils import conf
 from kolibri.utils.android import on_android
 
@@ -242,9 +239,14 @@ class ServicesPlugin(SimplePlugin):
         self.bus.subscribe("SERVING", self.SERVING)
 
     def ENTER(self):
+        from kolibri.deployment.default.cache import recreate_diskcache
+
         recreate_diskcache()
 
     def START(self):
+        from kolibri.core.tasks.main import initialize_workers
+        from kolibri.core.tasks.main import scheduler
+
         # schedule the pingback job if not already scheduled
         if SCH_PING_JOB_ID not in scheduler:
             from kolibri.core.analytics.utils import schedule_ping
@@ -272,6 +274,8 @@ class ServicesPlugin(SimplePlugin):
         register_zeroconf_service(port=port or self.port)
 
     def STOP(self):
+        from kolibri.core.tasks.main import scheduler
+
         scheduler.shutdown_scheduler()
         if self.workers is not None:
             for worker in self.workers:

--- a/kolibri/utils/tests/test_cli_at_import.py
+++ b/kolibri/utils/tests/test_cli_at_import.py
@@ -38,8 +38,8 @@ def test_stop_no_db_access(create_engine_mock):
     create_engine_mock.assert_not_called()
 
 
-@patch("kolibri.utils.options.read_options_file")
-def test_import_no_options_evaluation(read_options_mock):
+@patch("kolibri.utils.conf.OPTIONS")
+def test_import_no_options_evaluation(options_mock):
     from kolibri.utils import cli  # noqa F401
 
-    read_options_mock.assert_not_called()
+    options_mock.__getitem__.assert_not_called()

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -1,0 +1,98 @@
+"""
+Tests for `kolibri.utils.main` module.
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import pytest
+from django.db.utils import OperationalError
+from mock import patch
+
+import kolibri
+from kolibri.utils import main
+
+
+@pytest.mark.django_db
+@patch("kolibri.utils.main.get_version", return_value="")
+@patch("kolibri.utils.main.update")
+@patch("kolibri.core.deviceadmin.utils.dbbackup")
+def test_first_run(dbbackup, update, get_version):
+    """
+    Tests that the first_run() function performs as expected
+    """
+
+    main.initialize()
+    update.assert_called_once()
+    dbbackup.assert_not_called()
+
+    # Check that it got called for each default plugin
+    from kolibri import plugins
+
+    assert set(plugins.config["INSTALLED_PLUGINS"]) == set(plugins.DEFAULT_PLUGINS)
+
+
+@pytest.mark.django_db
+@patch("kolibri.utils.main.get_version", return_value="0.0.1")
+@patch("kolibri.utils.main.update")
+def test_update(update, get_version):
+    """
+    Tests that update() function performs as expected
+    """
+    main.initialize()
+    update.assert_called_once()
+
+
+@pytest.mark.django_db
+@patch("kolibri.utils.main.get_version", return_value="0.0.1")
+def test_update_exits_if_running(get_version):
+    """
+    Tests that update() function performs as expected
+    """
+    with patch("kolibri.utils.main.get_status"):
+        try:
+            main.initialize()
+            pytest.fail("Update did not exit when Kolibri was already running")
+        except SystemExit:
+            pass
+
+
+@pytest.mark.django_db
+def test_version_updated():
+    """
+    Tests our db backup logic: version_updated gets any change, backup gets only non-dev changes
+    """
+    assert main.version_updated("0.10.0", "0.10.1")
+    assert not main.version_updated("0.10.0", "0.10.0")
+    assert not main.should_back_up("0.10.0-dev0", "")
+    assert not main.should_back_up("0.10.0-dev0", "0.10.0")
+    assert not main.should_back_up("0.10.0", "0.10.0-dev0")
+    assert not main.should_back_up("0.10.0-dev0", "0.10.0-dev0")
+
+
+@pytest.mark.django_db
+@patch("kolibri.utils.main.get_version", return_value=kolibri.__version__)
+@patch("kolibri.utils.main.update")
+@patch("kolibri.core.deviceadmin.utils.dbbackup")
+def test_update_no_version_change(dbbackup, update, get_version):
+    """
+    Tests that when the version doesn't change, we are not doing things we
+    shouldn't
+    """
+    main.initialize()
+    update.assert_not_called()
+    dbbackup.assert_not_called()
+
+
+@patch("kolibri.utils.main._migrate_databases")
+@patch("kolibri.utils.main.version_updated")
+def test_migrate_if_unmigrated(version_updated, _migrate_databases):
+    # No matter what, ensure that version_updated returns False
+    version_updated.return_value = False
+    from morango.models import InstanceIDModel
+
+    with patch.object(
+        InstanceIDModel, "get_or_create_current_instance"
+    ) as get_or_create_current_instance:
+        get_or_create_current_instance.side_effect = OperationalError("Test")
+        main.initialize()
+        _migrate_databases.assert_called_once()

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -11,12 +11,11 @@ from kolibri.utils.tests.helpers import override_option
 
 
 class SanityCheckTestCase(TestCase):
-    @patch("kolibri.utils.cli.get_version", return_value="")
     @patch("kolibri.utils.sanity_checks.logging.error")
     @override_option(
         "Paths", "CONTENT_DIR", "Z:\\NOTREAL" if sys.platform == "win32" else "/dir_dne"
     )
-    def test_content_dir_dne(self, logging_mock, get_version):
+    def test_content_dir_dne(self, logging_mock):
         with self.assertRaises(SystemExit):
             sanity_checks.check_content_directory_exists_and_writable()
             logging_mock.assert_called()
@@ -29,7 +28,6 @@ class SanityCheckTestCase(TestCase):
             sanity_checks.check_content_directory_exists_and_writable()
             logging_mock.assert_called()
 
-    @patch("kolibri.utils.cli.get_version", return_value="")
     @patch("kolibri.utils.sanity_checks.shutil.move")
     @patch(
         "kolibri.utils.sanity_checks.os.path.exists",
@@ -39,7 +37,7 @@ class SanityCheckTestCase(TestCase):
         # that make the difference to the assert count below.
         side_effect=[True, False, True, False],
     )
-    def test_old_log_file_exists(self, path_exists_mock, move_mock, get_version):
+    def test_old_log_file_exists(self, path_exists_mock, move_mock):
         sanity_checks.check_log_file_location()
         # Check if the number of calls to shutil.move equals to the number of times
         # os.path.exists returns True


### PR DESCRIPTION
## Summary
* Consolidates non-CLI code in `kolibri.utils.main`
* Exposes core CLI methods as a Python API
* Adds a restart CLI function and API method

## References
Fixes #6197 

## Reviewer guidance
Test:
```
from kolibri.main import initialize
from kolibri.main import start
from kolibri.main import restart
from kolibri.main import enable_plugin
from kolibri.main import disable_plugin
```

Should we add anything else?
Is this the right place to expose these?


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
