### PR TITLE
Properly filter classrooms by role.

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -436,7 +436,10 @@ class ClassroomFilter(FilterSet):
         if value == role_kinds.COACH:
             roles = roles.filter(kind=value)
 
-        return queryset.filter(id__in=roles.values("collection_id"))
+        return queryset.filter(
+            Q(id__in=roles.values("collection_id"))
+            | Q(parent_id__in=roles.values("collection_id"))
+        )
 
     class Meta:
         model = Classroom

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -425,6 +425,9 @@ class ClassroomFilter(FilterSet):
         if requesting_user.is_superuser:
             return queryset
 
+        if requesting_user.is_anonymous():
+            return queryset.none()
+
         # filter queryset by admin role and coach role
         roles = requesting_user.roles.exclude(kind=role_kinds.ASSIGNABLE_COACH)
 

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -296,6 +296,17 @@ class ClassroomAPITestCase(APITestCase):
         }
         self.assertDictEqual(response.data, expected)
 
+    def test_classroom_facility_coach_role_for_filter(self):
+        coach = FacilityUserFactory.create(facility=self.facility)
+        self.facility.add_coach(coach)
+        response = self.client.get(
+            reverse("kolibri:core:classroom-list"),
+            data={"role": "coach"},
+            format="json",
+        )
+        # Should return all classrooms
+        self.assertEqual(len(response.data), len(self.classrooms))
+
     def test_cannot_create_classroom_same_name(self):
         classroom_name = self.classrooms[0].name
         response = self.client.post(


### PR DESCRIPTION
## Summary
* Follow up to #7928 
* PR failed to properly refactor the `filter_by_role` method of the ClassroomFilter
* Only filtered properly if people had roles directly for the classroom, and not for the the facility parent
* Fixes this issue and adds a regression test

## References
Fixes #8053 

## Reviewer guidance
* Create a classroom
* Add a leaner to the classroom
* Create a facility coach user
* Login as the facility coach user
* Go to Coach
* Confirm that the newly created class appears, either as an option, or as the default if it is the only classroom

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
