### PR TITLE
Lock used ports to prevent their being picked up by the port cache.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -588,12 +588,13 @@ def _read_pid_file(filename):
     Reads a pid file and returns the contents. PID files have 1 or 2 lines;
      - first line is always the pid
      - second line is the port the server is listening on.
-     - third line is the status of the server process
+     - third line is the port the alternate origin server is listening on
+     - fourth line is the status of the server process
 
     :param filename: Path of PID to read
-    :return: (pid, port, status): with the PID in the file and the port number
-                          if it exists. If the port number doesn't exist, then
-                          port is None.
+    :return: (pid, port, zip_port, status): with the PID in the file, the port numbers
+                          if they exist. If the port number doesn't exist, then
+                          port is None. Lastly, the status code is returned.
     """
     if not os.path.isfile(PID_FILE):
         return None, None, None, STATUS_STOPPED


### PR DESCRIPTION
## Summary
* The port caching machinery introduced in #8026 had a significant bug where it would not take into account ports that were already occupied by currently running servers.
* This fixes that by pre-emptively registering any ports being used for servers with the port cache before WSGI servers are initialized.

## References
Fixes #8056

…

## Reviewer guidance
Set `8000` as the first value of the `port_cache` file in KOLIBRI_HOME dir.
Run `yarn run python-devserver` and confirm no errors occur

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
