### PR TITLE
Add kolibri.searchContent method to hashi; add error handling to CustomContentRenderer

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -120,6 +120,9 @@
       this.hashi.on(events.SEARCHRESULTREQUESTED, message => {
         this.fetchSearchResult.call(this, message);
       });
+      this.hashi.on(events.KOLIBRIVERSIONREQUESTED, message => {
+        this.sendKolibriVersion.call(this, message);
+      });
     },
     methods: {
       // helper functions for fetching data from kolibri
@@ -248,6 +251,10 @@
         delete themeCopy.message_id;
         this.channelTheme = validateTheme(themeCopy);
         const newMsg = createReturnMsg({ message, data: {} });
+        return this.hashi.mediator.sendMessage(newMsg);
+      },
+      sendKolibriVersion(message) {
+        const newMsg = createReturnMsg({ message, data: __version });
         return this.hashi.mediator.sendMessage(newMsg);
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -91,13 +91,13 @@
         this.fetchContentCollection(message);
       });
       this.hashi.on('modelrequested', message => {
-        this.fetchContentModel(message).bind(this);
+        this.fetchContentModel.call(this, message);
       });
       this.hashi.on('navigateto', message => {
-        this.navigateTo(message).bind(this);
+        this.navigateTo.call(this, message);
       });
       this.hashi.on('context', message => {
-        this.getOrUpdateContext(message).bind(this);
+        this.getOrUpdateContext.call(this, message);
       });
       this.hashi.on('themechanged', theme => {
         delete theme.message_id;

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -102,22 +102,22 @@
       this.hashi = new Hashi({ iframe: this.$refs.iframe, now });
       const zipFile = this.topic.files.find(f => f.extension === 'zip');
       this.hashi.initialize({}, {}, zipFile.storage_url, zipFile.checksum);
-      this.hashi.on('collectionrequested', message => {
+      this.hashi.on(events.COLLECTIONREQUESTED, message => {
         this.fetchContentCollection(message);
       });
-      this.hashi.on('modelrequested', message => {
+      this.hashi.on(events.MODELREQUESTED, message => {
         this.fetchContentModel.call(this, message);
       });
-      this.hashi.on('navigateto', message => {
+      this.hashi.on(events.NAVIGATETO, message => {
         this.navigateTo.call(this, message);
       });
-      this.hashi.on('context', message => {
+      this.hashi.on(events.CONTEXT, message => {
         this.getOrUpdateContext.call(this, message);
       });
-      this.hashi.on('themechanged', message => {
+      this.hashi.on(events.THEMECHANGED, message => {
         this.updateTheme.call(this, message);
       });
-      this.hashi.on('searchresultrequested', message => {
+      this.hashi.on(events.SEARCHRESULTREQUESTED, message => {
         this.fetchSearchResult.call(this, message);
       });
     },

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -103,6 +103,9 @@
         delete theme.message_id;
         this.channelTheme = validateTheme(theme);
       });
+      this.hashi.on('searchresultrequested', message => {
+        this.fetchSearchResult.call(this, message);
+      });
     },
     methods: {
       // helper functions for fetching data from kolibri
@@ -141,6 +144,14 @@
             event: events.KOLIBRIDATARETURNED,
             data: message,
           });
+        });
+      },
+
+      fetchSearchResult(message) {
+        this.hashi.mediator.sendMessage({
+          nameSpace: 'hashi',
+          event: events.KOLIBRIDATARETURNED,
+          data: { ...message, status: 'success', type: 'response' },
         });
       },
 

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -36,7 +36,7 @@
   import { now } from 'kolibri.utils.serverClock';
   import { ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
   import router from 'kolibri.coreVue.router';
-  import { events } from 'hashi/src/hashiBase';
+  import { events, MessageStatuses } from 'hashi/src/hashiBase';
   import { validateTheme } from '../../utils/themes';
   import ContentModal from './ContentModal';
 
@@ -118,7 +118,7 @@
           getParams.parent = this.topic.id;
         }
         ContentNodeResource.fetchCollection({ getParams }).then(contentNodes => {
-          message.status = contentNodes ? 'success' : 'failure';
+          message.status = contentNodes ? MessageStatuses.SUCCESS : MessageStatuses.FAILURE;
           let response = {};
           response.page = message.options.page ? message.options.page : 1;
           response.pageSize = message.options.pageSize ? message.options.pageSize : 50;
@@ -136,7 +136,7 @@
       fetchContentModel(message) {
         let id = message.id;
         ContentNodeResource.fetchModel({ id }).then(contentNode => {
-          message.status = contentNode ? 'success' : 'failure';
+          message.status = contentNode ? MessageStatuses.SUCCESS : MessageStatuses.FAILURE;
           message.data = contentNode;
           message.type = 'response';
           this.hashi.mediator.sendMessage({
@@ -176,12 +176,12 @@
         searchPromise
           .then(response => {
             newMessage.data.data = response;
-            newMessage.data.status = 'success';
+            newMessage.data.status = MessageStatuses.SUCCESS;
             this.hashi.mediator.sendMessage(newMessage);
           })
           .catch(err => {
             newMessage.data.data = err;
-            newMessage.data.status = 'failure';
+            newMessage.data.status = MessageStatuses.FAILURE;
             this.hashi.mediator.sendMessage(newMessage);
           });
       },

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -114,9 +114,8 @@
       this.hashi.on('context', message => {
         this.getOrUpdateContext.call(this, message);
       });
-      this.hashi.on('themechanged', theme => {
-        delete theme.message_id;
-        this.channelTheme = validateTheme(theme);
+      this.hashi.on('themechanged', message => {
+        this.updateTheme.call(this, message);
       });
       this.hashi.on('searchresultrequested', message => {
         this.fetchSearchResult.call(this, message);
@@ -243,6 +242,13 @@
 
         const newMsg = createReturnMsg({ message, data: {} });
         this.hashi.mediator.sendLocalMessage(newMsg);
+      },
+      updateTheme(message) {
+        const themeCopy = { ...message };
+        delete themeCopy.message_id;
+        this.channelTheme = validateTheme(themeCopy);
+        const newMsg = createReturnMsg({ message, data: {} });
+        return this.hashi.mediator.sendMessage(newMsg);
       },
     },
   };

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -13,12 +13,14 @@ export const events = {
   NAVIGATETO: 'navigateto',
   CONTEXT: 'context',
   THEMECHANGED: 'themechanged',
+  KOLIBRIVERSIONREQUESTED: 'kolibriversionrequested',
 };
 
 export const DataTypes = {
   MODEL: 'Model',
   SEARCHRESULT: 'SearchResult',
   COLLECTION: 'Collection',
+  KOLIBRIVERSION: 'KolibriVersion',
 };
 
 export const MessageStatuses = {

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -21,4 +21,9 @@ export const DataTypes = {
   COLLECTION: 'Collection',
 };
 
+export const MessageStatuses = {
+  FAILURE: 'failure',
+  SUCCESS: 'success',
+};
+
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -7,11 +7,18 @@ export const events = {
   DATAREQUESTED: 'datarequested',
   COLLECTIONREQUESTED: 'collectionrequested',
   MODELREQUESTED: 'modelrequested',
+  SEARCHRESULTREQUESTED: 'searchresultrequested',
   DATARETURNED: 'datareturned',
   KOLIBRIDATARETURNED: 'kolibridatareturned',
   NAVIGATETO: 'navigateto',
   CONTEXT: 'context',
   THEMECHANGED: 'themechanged',
+};
+
+export const DataTypes = {
+  MODEL: 'Model',
+  SEARCHRESULT: 'SearchResult',
+  COLLECTION: 'Collection',
 };
 
 export const nameSpace = 'hashi';

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -199,11 +199,15 @@ export default class Kolibri extends BaseShim {
       }
 
       /*
-       * Getter to return the current version of Kolibri and hence the API available.
-       * @return {string} - A version string
+       * Method to return the current version of Kolibri and hence the API available.
+       * @return {Promise<string>} - A version string
        */
-      get version() {
-        return '';
+      getVersion() {
+        return self.mediator.sendMessageAwaitReply({
+          event: events.DATAREQUESTED,
+          data: { dataType: DataTypes.KOLIBRIVERSION },
+          nameSpace,
+        });
       }
     }
 

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -4,7 +4,7 @@
  */
 import BaseShim from './baseShim';
 import Mediator from './mediator';
-import { events, nameSpace } from './hashiBase';
+import { events, nameSpace, DataTypes } from './hashiBase';
 
 /**
  * Type definition for Language metadata
@@ -99,7 +99,7 @@ export default class Kolibri extends BaseShim {
       getContentByFilter(options) {
         return self.mediator.sendMessageAwaitReply({
           event: events.DATAREQUESTED,
-          data: { options, dataType: 'Collection' },
+          data: { options, dataType: DataTypes.COLLECTION },
           nameSpace,
         });
       }
@@ -112,7 +112,7 @@ export default class Kolibri extends BaseShim {
       getContentById(id) {
         return self.mediator.sendMessageAwaitReply({
           event: events.DATAREQUESTED,
-          data: { id, dataType: 'Model' },
+          data: { id, dataType: DataTypes.MODEL },
           nameSpace,
         });
       }
@@ -126,7 +126,13 @@ export default class Kolibri extends BaseShim {
        * @param {number} [options.pageSize=50] - the page size for pagination
        * @return {Promise<PageResult>} - a Promise that resolves to an array of ContentNodes
        */
-      searchContent() {}
+      searchContent(options) {
+        return self.mediator.sendMessageAwaitReply({
+          event: events.DATAREQUESTED,
+          data: { options, dataType: DataTypes.SEARCHRESULT },
+          nameSpace,
+        });
+      }
 
       /*
        * Method to set a default theme for any content rendering initiated by this app

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -84,7 +84,7 @@ export default class MainClient {
       }
     });
 
-    this.on(this.events.KOLIBRIDATARETURNED, message => {
+    this.on(this.events.DATARETURNED, message => {
       this.mediator.sendMessage({ nameSpace, event: events.DATARETURNED, data: message });
     });
 

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -2,7 +2,7 @@ import Mediator from './mediator';
 import LocalStorage from './localStorage';
 import Cookie from './cookie';
 import SCORM from './SCORM';
-import { events, nameSpace } from './hashiBase';
+import { events, nameSpace, DataTypes } from './hashiBase';
 import Kolibri from './kolibri';
 
 /*
@@ -66,16 +66,19 @@ export default class MainClient {
     // They each fetch data from the kolibri database and return it to
     // the iframe
     this.on(this.events.DATAREQUESTED, message => {
-      if (message.dataType === 'Collection') {
+      let event;
+      if (message.dataType === DataTypes.COLLECTION) {
+        event = events.COLLECTIONREQUESTED;
+      } else if (message.dataType === DataTypes.MODEL) {
+        event = events.MODELREQUESTED;
+      } else if (message.dataType === DataTypes.SEARCHRESULT) {
+        event = events.SEARCHRESULTREQUESTED;
+      }
+
+      if (event) {
         this.mediator.sendLocalMessage({
           nameSpace,
-          event: events.COLLECTIONREQUESTED,
-          data: message,
-        });
-      } else if (message.dataType === 'Model') {
-        this.mediator.sendLocalMessage({
-          nameSpace,
-          event: events.MODELREQUESTED,
+          event,
           data: message,
         });
       }

--- a/packages/hashi/src/mainClient.js
+++ b/packages/hashi/src/mainClient.js
@@ -73,6 +73,8 @@ export default class MainClient {
         event = events.MODELREQUESTED;
       } else if (message.dataType === DataTypes.SEARCHRESULT) {
         event = events.SEARCHRESULTREQUESTED;
+      } else if (message.dataType === DataTypes.KOLIBRIVERSION) {
+        event = events.KOLIBRIVERSIONREQUESTED;
       }
 
       if (event) {

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -1,4 +1,9 @@
 import uuidv4 from 'uuid/v4';
+import { events } from './hashiBase';
+
+function isUndefined(x) {
+  return typeof x === 'undefined';
+}
 
 /*
  * This class manages all message listening and sending from the postMessage
@@ -14,10 +19,10 @@ class Mediator {
     this.__messageHandlers = {};
   }
 
-  handleMessage(ev) {
-    const { nameSpace, event, data } = ev.data;
+  handleMessage(message) {
+    const { nameSpace, event, data } = message.data;
     // nameSpace and event should be defined, otherwise, it's not our message!
-    if (typeof nameSpace === 'undefined' || typeof event === 'undefined') {
+    if (isUndefined(nameSpace) || isUndefined(event)) {
       return;
     }
     if (this.__messageHandlers[nameSpace] && this.__messageHandlers[nameSpace][event]) {
@@ -35,21 +40,11 @@ class Mediator {
   }
 
   sendLocalMessage({ event, data, nameSpace } = {}) {
-    const message = {
-      event,
-      data,
-      nameSpace,
-    };
-    this.local.postMessage(message, '*');
+    this.local.postMessage({ event, data, nameSpace }, '*');
   }
 
   sendMessage({ event, data, nameSpace }) {
-    const message = {
-      event,
-      data,
-      nameSpace,
-    };
-    this.remote.postMessage(message, '*');
+    this.remote.postMessage({ event, data, nameSpace }, '*');
   }
 
   // a function to manage messages for kolibri.js,
@@ -71,7 +66,7 @@ class Mediator {
           try {
             self.removeMessageHandler({
               nameSpace,
-              event: 'datareturned',
+              event: events.DATARETURNED,
               callback: handler,
             });
           } catch (e) {
@@ -82,7 +77,7 @@ class Mediator {
       }
       this.registerMessageHandler({
         nameSpace,
-        event: 'datareturned',
+        event: events.DATARETURNED,
         callback: handler,
       });
       data.message_id = msgId;
@@ -91,11 +86,7 @@ class Mediator {
   }
 
   registerMessageHandler({ event, nameSpace, callback } = {}) {
-    if (
-      typeof callback !== 'function' ||
-      typeof event === 'undefined' ||
-      typeof nameSpace === 'undefined'
-    ) {
+    if (typeof callback !== 'function' || isUndefined(event) || isUndefined(nameSpace)) {
       return;
     }
     if (!this.__messageHandlers[nameSpace]) {

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -1,5 +1,5 @@
 import uuidv4 from 'uuid/v4';
-import { events } from './hashiBase';
+import { events, MessageStatuses } from './hashiBase';
 
 function isUndefined(x) {
   return typeof x === 'undefined';
@@ -55,9 +55,9 @@ class Mediator {
       let self = this;
       function handler(message) {
         if (message.message_id === msgId && message.type === 'response') {
-          if (message.status == 'success') {
+          if (message.status == MessageStatuses.SUCCESS) {
             resolve(message.data);
-          } else if (message.status === 'failure' && message.err) {
+          } else if (message.status === MessageStatuses.FAILURE && message.err) {
             reject(message.err);
           } else {
             // Otherwise something unspecified happened

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -75,6 +75,7 @@ class Mediator {
               callback: handler,
             });
           } catch (e) {
+            // eslint-disable-next-line no-console
             console.log(e);
           }
         }

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -165,4 +165,39 @@ describe('the kolibri hashi shim', () => {
       });
     });
   });
+
+  describe('searchContent method', () => {
+    beforeEach(function() {
+      mockMessage = {
+        data: {},
+        event: 'context',
+        nameSpace: 'hashi',
+      };
+      mockMediatorPromise = jest
+        .spyOn(kolibri.mediator, 'sendMessageAwaitReply')
+        .mockResolvedValue(response);
+    });
+
+    afterEach(() => {
+      mockMediatorPromise.mockReset();
+    });
+
+    it('should be called with the correct event, data, and namespace', async () => {
+      const options = {
+        keyword: 'sewing',
+        under: 'self',
+        page: 1,
+        pageSize: 25,
+      };
+      await kolibri.shim.searchContent(options);
+      expect(mockMediatorPromise).toHaveBeenCalledWith({
+        event: 'datarequested',
+        data: {
+          options,
+          dataType: 'SearchResult',
+        },
+        nameSpace: 'hashi',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

1. Adds `kolibri.searchContent` to hashi
2. Adds error handling to `CustomContentRenderer`, sending messages with an `err` field back to the iFrame side if something fails on the Kolibri side
3. Adds `createReturnMsg` utility to `CustomContentRenderer` to format messages sent back to iframe. Now, instead of overwriting the message received from the `iframe`, it creates a new one, but reuses the `message_id` (which is necessary to let the iframe know the message has a response).
4. Renames `KOLIBRIDATARETURNED` event to just `DATARETURNED` on the Kolibri side to match the expected event name in the mediator.
5. Adds `kolibri.getVersion`, which retrieves the version number async from Kolibri (this was done to avoid having to use webpack's define plugin to hardcode it into the hashi codebase).

## References

Fixes #7835

## Reviewer guidance

You can test out searchContent by switching the execution context from "top" to "localhost:8000" in Chrome dev tools. Try running an expression like

```
kolibri.searchContent({ keyword: 'song' }).then(x => { console.log(x) })
```

And you should see the results logged out.

For the other refactors, just make sure that my decision to delete the data from the original message does not break any functionality. For instance, before the message sent back from kolibri to the iframe would include parameters sent from the iframe.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
