### PR TITLE
Fix unclean shutdown issue and signal handling issue

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -532,9 +532,9 @@ def start(port=0, zip_port=0, serve_http=True, background=False):
 
     # Check if there are other kolibri instances running
     # If there are, then we need to stop users from starting kolibri again.
-    _, _, _, status = _read_pid_file(PID_FILE)
+    pid, _, _, status = _read_pid_file(PID_FILE)
 
-    if status in IS_RUNNING:
+    if status in IS_RUNNING and pid_exists(pid):
         logger.error(
             "There is another Kolibri server running. "
             "Please use `kolibri stop` and try again."

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -387,6 +387,10 @@ class SignalHandler(BaseSignalHandler):
         if os.getpid() == self.process_pid:
             return super(SignalHandler, self)._handle_signal(signum, frame)
 
+    def subscribe(self):
+        super(SignalHandler, self).subscribe()
+        self.bus.subscribe("ENTER", self.ENTER)
+
     def ENTER(self):
         self.process_pid = os.getpid()
 

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -232,3 +232,30 @@ class ServerInitializationTestCase(TestCase):
             f.write("{}\n{}\n{}\n{}\n".format(1000, 8000, 8001, server.STATUS_RUNNING))
         with self.assertRaises(SystemExit):
             server.start()
+
+
+class ServerSignalHandlerTestCase(TestCase):
+    @mock.patch("kolibri.utils.server.os.getpid")
+    @mock.patch("kolibri.utils.server.BaseSignalHandler._handle_signal")
+    def test_signal_different_pid(self, handle_signal_mock, getpid_mock):
+        getpid_mock.return_value = 1235
+        signal_handler = server.SignalHandler(mock.MagicMock())
+        signal_handler.process_pid = 1234
+        signal_handler._handle_signal()
+        handle_signal_mock.assert_not_called()
+
+    @mock.patch("kolibri.utils.server.os.getpid")
+    @mock.patch("kolibri.utils.server.BaseSignalHandler._handle_signal")
+    def test_signal_same_pid(self, handle_signal_mock, getpid_mock):
+        pid = 1234
+        getpid_mock.return_value = pid
+        signal_handler = server.SignalHandler(mock.MagicMock())
+        signal_handler.process_pid = pid
+        signal_handler._handle_signal()
+        handle_signal_mock.assert_called()
+
+    def test_signal_subscribe(self):
+        bus_mock = mock.MagicMock()
+        signal_handler = server.SignalHandler(bus_mock)
+        signal_handler.subscribe()
+        bus_mock.subscribe.assert_called_with("ENTER", signal_handler.ENTER)

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -214,3 +214,21 @@ class ServerInitializationTestCase(TestCase):
         wait_for_port_mock.side_effect = OSError
         server.background_port_check("0", "0")
         logging_mock.assert_not_called()
+
+    @mock.patch("kolibri.utils.server.pid_exists")
+    @mock.patch("kolibri.utils.server.ProcessBus")
+    def test_unclean_shutdown(self, process_bus_mock, pid_exists_mock):
+        pid_exists_mock.return_value = False
+        with open(server.PID_FILE, "w") as f:
+            f.write("{}\n{}\n{}\n{}\n".format(1000, 8000, 8001, server.STATUS_RUNNING))
+        server.start()
+        process_bus_mock.assert_called()
+
+    @mock.patch("kolibri.utils.server.pid_exists")
+    @mock.patch("kolibri.utils.server.ProcessBus")
+    def test_server_running(self, process_bus_mock, pid_exists_mock):
+        pid_exists_mock.return_value = True
+        with open(server.PID_FILE, "w") as f:
+            f.write("{}\n{}\n{}\n{}\n".format(1000, 8000, 8001, server.STATUS_RUNNING))
+        with self.assertRaises(SystemExit):
+            server.start()


### PR DESCRIPTION
## Summary
* Fixes a regression caused by #8026 that prevented Kolibri from starting after an unclean shutdown
* Adds a test to confirm this fix
* Fixes a regression caused by #8026 that removed previous safeguards to prevent signal handlers from being called from worker threads
* Adds a test to confirm this fix

## References
Follow up from #8026

## Reviewer guidance
1. Run kolibri with `kolibri start`
2. In another terminal kill kolibri `killall -9 kolibri`
3. Run `kolibri start` again - confirm it starts again

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
