### PR TITLE
Update language about delete tasks

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -4,6 +4,7 @@ import notificationStrings from './notificationStrings';
 export const coreStrings = createTranslator('CommonCoreStrings', {
   // actions
   cancelAction: 'Cancel',
+  cannotUndoActionWarning: 'This action cannot be undone',
   clearAction: {
     message: 'Clear',
     context:

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
@@ -8,7 +8,7 @@
     @cancel="$emit('cancel')"
   >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
-    <p>{{ $tr('noUndo') }}</p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
   </KModal>
 
 </template>
@@ -43,7 +43,6 @@
     $trs: {
       deleteLearnerGroup: 'Delete group',
       areYouSure: "Are you sure you want to delete '{ groupName }'?",
-      noUndo: 'This action cannot be undone',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/DeleteGroupModal.vue
@@ -8,6 +8,7 @@
     @cancel="$emit('cancel')"
   >
     <p>{{ $tr('areYouSure', { groupName: groupName }) }}</p>
+    <p>{{ $tr('noUndo') }}</p>
   </KModal>
 
 </template>
@@ -42,6 +43,7 @@
     $trs: {
       deleteLearnerGroup: 'Delete group',
       areYouSure: "Are you sure you want to delete '{ groupName }'?",
+      noUndo: 'This action cannot be undone',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -15,7 +15,7 @@
       v-if="currentAction === AssignmentActions.DELETE"
       :modalTitle="$tr('deleteLessonTitle')"
       :modalDescription="$tr('deleteLessonConfirmation', { title: currentLesson.title })"
-      :noUndo="$tr('noUndo')"
+      :cannotUndoActionWarning="coreString('cannotUndoActionWarning')"
       @submit="handleSubmitDelete"
       @cancel="closeModal"
     />
@@ -129,7 +129,6 @@
       assignmentQuestion: 'Assign lesson to',
       deleteLessonTitle: 'Delete lesson',
       deleteLessonConfirmation: "Are you sure you want to delete '{ title }'?",
-      noUndo: 'This action cannot be undone',
       copyOfLesson: 'Copy of { lessonTitle }',
       uniqueTitleError: `A lesson titled '{title}' already exists in '{className}'`,
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -127,7 +127,8 @@
       copyLessonTitle: 'Copy lesson to',
       assignmentQuestion: 'Assign lesson to',
       deleteLessonTitle: 'Delete lesson',
-      deleteLessonConfirmation: "Are you sure you want to delete '{ title }'?",
+      deleteLessonConfirmation:
+        "Are you sure you want to delete '{ title }'? This action cannot be undone",
       copyOfLesson: 'Copy of { lessonTitle }',
       uniqueTitleError: `A lesson titled '{title}' already exists in '{className}'`,
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -15,6 +15,7 @@
       v-if="currentAction === AssignmentActions.DELETE"
       :modalTitle="$tr('deleteLessonTitle')"
       :modalDescription="$tr('deleteLessonConfirmation', { title: currentLesson.title })"
+      :noUndo="$tr('noUndo')"
       @submit="handleSubmitDelete"
       @cancel="closeModal"
     />
@@ -127,8 +128,8 @@
       copyLessonTitle: 'Copy lesson to',
       assignmentQuestion: 'Assign lesson to',
       deleteLessonTitle: 'Delete lesson',
-      deleteLessonConfirmation:
-        "Are you sure you want to delete '{ title }'? This action cannot be undone",
+      deleteLessonConfirmation: "Are you sure you want to delete '{ title }'?",
+      noUndo: 'This action cannot be undone',
       copyOfLesson: 'Copy of { lessonTitle }',
       uniqueTitleError: `A lesson titled '{title}' already exists in '{className}'`,
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
@@ -16,6 +16,7 @@
       :modalTitle="$tr('deleteExamTitle')"
       :modalDescription="$tr('deleteExamDescription', { title: quiz.title })"
       :modalConfirmation="$tr('deleteExamConfirmation')"
+      :noUndo="$tr('noUndo')"
       @submit="$emit('submit_delete')"
       @cancel="$emit('cancel')"
     />
@@ -65,8 +66,8 @@
       copyExamTitle: 'Copy quiz to',
       assignmentQuestion: 'Assign quiz to',
       deleteExamTitle: 'Delete quiz',
-      deleteExamDescription:
-        "Are you sure you want to delete '{ title }'? This action cannot be undone",
+      deleteExamDescription: "Are you sure you want to delete '{ title }'?",
+      noUndo: ' This action cannot be undone',
       deleteExamConfirmation: 'All learner progress on this quiz will be lost.',
       copyOfExam: 'Copy of { examTitle }',
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
@@ -16,7 +16,7 @@
       :modalTitle="$tr('deleteExamTitle')"
       :modalDescription="$tr('deleteExamDescription', { title: quiz.title })"
       :modalConfirmation="$tr('deleteExamConfirmation')"
-      :noUndo="$tr('noUndo')"
+      :cannotUndoActionWarning="coreString('cannotUndoActionWarning')"
       @submit="$emit('submit_delete')"
       @cancel="$emit('cancel')"
     />
@@ -28,6 +28,7 @@
 <script>
 
   import { mapState } from 'vuex';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AssignmentCopyModal from '../assignments/AssignmentCopyModal';
   import AssignmentDeleteModal from '../assignments/AssignmentDeleteModal';
 
@@ -37,6 +38,7 @@
       AssignmentCopyModal,
       AssignmentDeleteModal,
     },
+    mixins: [commonCoreStrings],
     props: {
       // Passed-through quiz object from parent
       quiz: {
@@ -67,7 +69,6 @@
       assignmentQuestion: 'Assign quiz to',
       deleteExamTitle: 'Delete quiz',
       deleteExamDescription: "Are you sure you want to delete '{ title }'?",
-      noUndo: ' This action cannot be undone',
       deleteExamConfirmation: 'All learner progress on this quiz will be lost.',
       copyOfExam: 'Copy of { examTitle }',
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/ManageExamModals.vue
@@ -65,7 +65,8 @@
       copyExamTitle: 'Copy quiz to',
       assignmentQuestion: 'Assign quiz to',
       deleteExamTitle: 'Delete quiz',
-      deleteExamDescription: "Are you sure you want to delete '{ title }'?",
+      deleteExamDescription:
+        "Are you sure you want to delete '{ title }'? This action cannot be undone",
       deleteExamConfirmation: 'All learner progress on this quiz will be lost.',
       copyOfExam: 'Copy of { examTitle }',
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
@@ -11,6 +11,9 @@
     <p v-if="modalConfirmation">
       {{ modalConfirmation }}
     </p>
+    <p v-if="noUndo">
+      {{ noUndo }}
+    </p>
   </KModal>
 
 </template>
@@ -34,6 +37,10 @@
         required: true,
       },
       modalConfirmation: {
+        type: String,
+        default: null,
+      },
+      noUndo: {
         type: String,
         default: null,
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDeleteModal.vue
@@ -11,8 +11,8 @@
     <p v-if="modalConfirmation">
       {{ modalConfirmation }}
     </p>
-    <p v-if="noUndo">
-      {{ noUndo }}
+    <p v-if="cannotUndoActionWarning">
+      {{ cannotUndoActionWarning }}
     </p>
   </KModal>
 
@@ -40,7 +40,7 @@
         type: String,
         default: null,
       },
-      noUndo: {
+      cannotUndoActionWarning: {
         type: String,
         default: null,
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
@@ -16,6 +16,7 @@
     <p v-else>
       {{ $tr('confirmationQuestionMultipleChannels') }}
     </p>
+    <p>{{ $tr('noCancellation') }}</p>
   </KModal>
 
 </template>
@@ -56,6 +57,7 @@
         message: 'Are you sure you want to delete these channels from your device?',
         context: '\nA confirmation that appears when a user tries to delete multiple channels',
       },
+      noCancellation: 'This action cannot be cancelled',
       titleSingleChannel: 'Delete channel',
       titleMultipleChannels: 'Delete channels',
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
@@ -16,7 +16,7 @@
     <p v-else>
       {{ $tr('confirmationQuestionMultipleChannels') }}
     </p>
-    <p>{{ $tr('noCancellation') }}</p>
+    <p>{{ $tr('noUndo') }}</p>
   </KModal>
 
 </template>
@@ -57,7 +57,7 @@
         message: 'Are you sure you want to delete these channels from your device?',
         context: '\nA confirmation that appears when a user tries to delete multiple channels',
       },
-      noCancellation: 'This action cannot be cancelled',
+      noUndo: 'This action cannot be undone',
       titleSingleChannel: 'Delete channel',
       titleMultipleChannels: 'Delete channels',
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteChannelModal.vue
@@ -16,7 +16,7 @@
     <p v-else>
       {{ $tr('confirmationQuestionMultipleChannels') }}
     </p>
-    <p>{{ $tr('noUndo') }}</p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
   </KModal>
 
 </template>
@@ -57,7 +57,6 @@
         message: 'Are you sure you want to delete these channels from your device?',
         context: '\nA confirmation that appears when a user tries to delete multiple channels',
       },
-      noUndo: 'This action cannot be undone',
       titleSingleChannel: 'Delete channel',
       titleMultipleChannels: 'Delete channels',
     },

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
@@ -10,10 +10,12 @@
     <div>
       <template v-if="numberOfResources === 1">
         <p>{{ $tr('confirmationQuestionOneResource') }}</p>
+        <p>{{ $tr('noCancellation') }}</p>
         <p>{{ $tr('deleteEverywhereExplanationOneResource') }}</p>
       </template>
       <template v-else>
         <p>{{ $tr('confirmationQuestionMultipleResources') }}</p>
+        <p>{{ $tr('noCancellation') }}</p>
         <p>{{ $tr('deleteEverywhereExplanationMultipleResources') }}</p>
       </template>
       <KCheckbox
@@ -59,6 +61,7 @@
         'Are you sure you want to delete this resource from your device?',
       confirmationQuestionMultipleResources:
         'Are you sure you want to delete these resources from your device?',
+      noCancellation: 'This action cannot be cancelled',
       deleteEverywhereLabel: {
         message: 'Also delete any copies found in other locations and channels',
         context:

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
@@ -10,12 +10,10 @@
     <div>
       <template v-if="numberOfResources === 1">
         <p>{{ $tr('confirmationQuestionOneResource') }}</p>
-        <p>{{ $tr('noCancellation') }}</p>
         <p>{{ $tr('deleteEverywhereExplanationOneResource') }}</p>
       </template>
       <template v-else>
         <p>{{ $tr('confirmationQuestionMultipleResources') }}</p>
-        <p>{{ $tr('noCancellation') }}</p>
         <p>{{ $tr('deleteEverywhereExplanationMultipleResources') }}</p>
       </template>
       <KCheckbox
@@ -23,6 +21,7 @@
         :label="$tr('deleteEverywhereLabel')"
         @change="deleteEverywhere = $event"
       />
+      <p>{{ $tr('noUndo') }}</p>
     </div>
   </KModal>
 
@@ -61,7 +60,7 @@
         'Are you sure you want to delete this resource from your device?',
       confirmationQuestionMultipleResources:
         'Are you sure you want to delete these resources from your device?',
-      noCancellation: 'This action cannot be cancelled',
+      noUndo: 'This action cannot be undone',
       deleteEverywhereLabel: {
         message: 'Also delete any copies found in other locations and channels',
         context:

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/DeleteResourcesModal.vue
@@ -21,7 +21,7 @@
         :label="$tr('deleteEverywhereLabel')"
         @change="deleteEverywhere = $event"
       />
-      <p>{{ $tr('noUndo') }}</p>
+      <p>{{ coreString('cannotUndoActionWarning') }}</p>
     </div>
   </KModal>
 
@@ -60,7 +60,6 @@
         'Are you sure you want to delete this resource from your device?',
       confirmationQuestionMultipleResources:
         'Are you sure you want to delete these resources from your device?',
-      noUndo: 'This action cannot be undone',
       deleteEverywhereLabel: {
         message: 'Also delete any copies found in other locations and channels',
         context:

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -9,6 +9,7 @@
   >
     <p>{{ $tr('confirmation', { classname: classname }) }}</p>
     <p>{{ $tr('description') }}</p>
+    <p>{{ $tr('noUndo') }}</p>
   </KModal>
 
 </template>
@@ -41,7 +42,8 @@
     },
     $trs: {
       modalTitle: 'Delete class',
-      confirmation: "Are you sure you want to delete '{ classname }'? This action cannot be undone",
+      confirmation: "Are you sure you want to delete '{ classname }'?",
+      noUndo: ' This action cannot be undone',
       description:
         "Enrolled users will be removed from the class but remain accessible from the 'Users' tab.",
     },

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -9,7 +9,7 @@
   >
     <p>{{ $tr('confirmation', { classname: classname }) }}</p>
     <p>{{ $tr('description') }}</p>
-    <p>{{ $tr('noUndo') }}</p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
   </KModal>
 
 </template>
@@ -43,7 +43,6 @@
     $trs: {
       modalTitle: 'Delete class',
       confirmation: "Are you sure you want to delete '{ classname }'?",
-      noUndo: ' This action cannot be undone',
       description:
         "Enrolled users will be removed from the class but remain accessible from the 'Users' tab.",
     },

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -41,7 +41,7 @@
     },
     $trs: {
       modalTitle: 'Delete class',
-      confirmation: "Are you sure you want to delete '{ classname }'?",
+      confirmation: "Are you sure you want to delete '{ classname }'? This action cannot be undone",
       description:
         "Enrolled users will be removed from the class but remain accessible from the 'Users' tab.",
     },

--- a/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
@@ -9,6 +9,7 @@
     @cancel="$emit('cancel')"
   >
     <p>{{ $tr('confirmation', { username: username }) }}</p>
+    <p>{{ $tr('noUndo') }}</p>
     <p>{{ $tr('warning', { username: username }) }}</p>
   </KModal>
 
@@ -55,6 +56,7 @@
     $trs: {
       deleteUser: 'Delete user',
       confirmation: "Are you sure you want to delete the user '{ username }'?",
+      noUndo: 'This action cannot be undone',
       warning: 'All data and logs for this user will be lost.',
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
@@ -9,8 +9,8 @@
     @cancel="$emit('cancel')"
   >
     <p>{{ $tr('confirmation', { username: username }) }}</p>
-    <p>{{ $tr('noUndo') }}</p>
     <p>{{ $tr('warning', { username: username }) }}</p>
+    <p>{{ $tr('noUndo') }}</p>
   </KModal>
 
 </template>

--- a/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
@@ -10,7 +10,7 @@
   >
     <p>{{ $tr('confirmation', { username: username }) }}</p>
     <p>{{ $tr('warning', { username: username }) }}</p>
-    <p>{{ $tr('noUndo') }}</p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
   </KModal>
 
 </template>
@@ -56,7 +56,6 @@
     $trs: {
       deleteUser: 'Delete user',
       confirmation: "Are you sure you want to delete the user '{ username }'?",
-      noUndo: 'This action cannot be undone',
       warning: 'All data and logs for this user will be lost.',
     },
   };


### PR DESCRIPTION
## Summary

This PR updates the modals for deletion tasks to include a warning that tasks cannot be cancelled or undone, as applicable. 
Fixes #6727 

Example of before/after from one of the modals

Before: 
<img width="940" alt="Screen Shot 2021-05-07 at 12 44 43 PM" src="https://user-images.githubusercontent.com/17235236/117482178-01e5e000-af32-11eb-8369-7719759a8007.png">


After: 
<img width="874" alt="Screen Shot 2021-05-07 at 12 43 07 PM" src="https://user-images.githubusercontent.com/17235236/117482133-f397c400-af31-11eb-993d-c219e1a1cca2.png">


## Reviewer guidance

You can confirm the new strings do not have any typos :) and manually QA by checking the modals that pop up when deleting: 
- Channel(s)
- Resource(s)
- Group
- Lesson
- Exam
- Class
- User

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
