### PR TITLE
Fix backdrop not being shown while searching resources on mobile

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
@@ -76,9 +76,11 @@
       openDropdownSearchBox() {
         this.searchBoxIsOpen = true;
         this.focusOnSearchBox();
+        window.document.documentElement.style['overflow'] = 'hidden';
       },
       closeDropdownSearchBox() {
         this.searchBoxIsOpen = false;
+        window.document.documentElement.style['overflow'] = 'visible';
       },
       toggleDropdownSearchBox() {
         if (this.searchBoxIsOpen) {
@@ -124,11 +126,12 @@
 
   .search-box-dropdown-backdrop {
     position: fixed;
-    top: 111px;
+    top: 116px;
     right: 0;
     bottom: 0;
     left: 0;
     z-index: 4;
+    height: 90vh;
     background-color: rgba(0, 0, 0, 0.7);
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/ActionBarSearchBox.vue
@@ -80,7 +80,7 @@
       },
       closeDropdownSearchBox() {
         this.searchBoxIsOpen = false;
-        window.document.documentElement.style['overflow'] = 'visible';
+        window.document.documentElement.style['overflow'] = '';
       },
       toggleDropdownSearchBox() {
         if (this.searchBoxIsOpen) {
@@ -126,12 +126,12 @@
 
   .search-box-dropdown-backdrop {
     position: fixed;
-    top: 116px;
+    top: 117px; // 66px (search bar) + 55px (dropdown)
     right: 0;
     bottom: 0;
     left: 0;
     z-index: 4;
-    height: 90vh;
+    height: 100vh;
     background-color: rgba(0, 0, 0, 0.7);
   }
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The search bar backdrop in ActionSearchBox was not visible. We just have to test which height would have been perfect. Earlier, the backdrop was acting as zero-height div element.

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Issue: #8007
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I have tested for all the available screen sizes using the chrome dev-tools and I am also providing the screenshots.

## Screenshots
![WhatsApp Image 2021-05-10 at 4 19 01 PM (1)](https://user-images.githubusercontent.com/40101776/117648857-62805180-b1ac-11eb-8329-cfdb81518fb7.jpeg)
![WhatsApp Image 2021-05-10 at 4 19 01 PM (2)](https://user-images.githubusercontent.com/40101776/117648868-66ac6f00-b1ac-11eb-8674-1d9c2758ebc8.jpeg)
![WhatsApp Image 2021-05-10 at 4 19 01 PM](https://user-images.githubusercontent.com/40101776/117648881-6b712300-b1ac-11eb-83b4-6af75309bfc7.jpeg)


…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
