### PR TITLE
Custom channels fullscreen modal

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -3,9 +3,8 @@
   <CoreFullscreen
     ref="html5Renderer"
     class="html5-renderer"
-    :style="{ height: contentRendererHeight, width: iframeWidth }"
   >
-    <div class="iframe-container" :style="containerStyle">
+    <div class="iframe-container">
       <iframe
         ref="iframe"
         class="iframe"
@@ -38,10 +37,6 @@
   import { events, MessageStatuses } from 'hashi/src/hashiBase';
   import { validateTheme } from '../../utils/themes';
   import ContentModal from './ContentModal';
-
-  const defaultContentHeight = '500px';
-  const frameTopbarHeight = '37px';
-  const pxStringAdd = (x, y) => parseInt(x, 10) + parseInt(y, 10) + 'px';
 
   function createReturnMsg({ message, data, err }) {
     // Infer status from data or err
@@ -84,18 +79,6 @@
       },
       rooturl() {
         return urls.hashi();
-      },
-      iframeHeight() {
-        return defaultContentHeight;
-      },
-      iframeWidth() {
-        return 'auto';
-      },
-      contentRendererHeight() {
-        return pxStringAdd(this.iframeHeight, frameTopbarHeight);
-      },
-      containerStyle() {
-        return { height: this.iframeHeight };
       },
     },
     mounted() {
@@ -267,23 +250,15 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .fullscreen-header {
-    text-align: right;
-  }
-
-  .fs-icon {
-    position: relative;
-    top: 8px;
-    width: 24px;
-    height: 24px;
-  }
-
   .html5-renderer {
     position: relative;
     text-align: center;
   }
 
   .iframe {
+    position: fixed;
+    top: 64px;
+    left: 0;
     width: 100%;
     height: 100%;
   }

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -125,6 +125,7 @@
       ...mapState('topicsTree', {
         topicsTreeContent: 'content',
         topicsTreeChannel: 'channel',
+        topicsTreeTopic: 'topic',
       }),
       ...mapState('examReportViewer', ['exam']),
       ...mapState(['pageName']),
@@ -141,6 +142,13 @@
           pageNameToComponentMap[PageNames.TOPICS_TOPIC],
           pageNameToComponentMap[PageNames.TOPICS_CHANNEL],
         ].includes(this.currentPage);
+      },
+      currentChannelIsCustom() {
+        return (
+          this.topicsTreeTopic &&
+          this.topicsTreeTopic.options &&
+          this.topicsTreeTopic.options.modality === 'CUSTOM_NAVIGATION'
+        );
       },
       immersivePageProps() {
         if (this.pageName === ClassesPageNames.EXAM_VIEWER) {
@@ -185,7 +193,14 @@
             immersivePageIcon: 'close',
           };
         }
-
+        if (this.pageName === PageNames.TOPICS_CHANNEL && this.currentChannelIsCustom) {
+          return {
+            immersivePage: true,
+            immersivePageRoute: this.$router.getRoute(PageNames.TOPICS_ROOT),
+            immersivePagePrimary: false,
+            immersivePageIcon: 'close',
+          };
+        }
         if (this.pageName === PageNames.TOPICS_CONTENT) {
           let immersivePageRoute = {};
           let appBarTitle;
@@ -220,7 +235,7 @@
             appBarTitle,
             immersivePage: true,
             immersivePageRoute,
-            immersivePagePrimary: true,
+            immersivePagePrimary: false,
             immersivePageIcon: 'close',
           };
         }

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -195,10 +195,11 @@
         }
         if (this.pageName === PageNames.TOPICS_CHANNEL && this.currentChannelIsCustom) {
           return {
+            appBarTitle: this.topicsTreeChannel.title || '',
             immersivePage: true,
             immersivePageRoute: this.$router.getRoute(PageNames.TOPICS_ROOT),
             immersivePagePrimary: false,
-            immersivePageIcon: 'close',
+            immersivePageIcon: 'back',
           };
         }
         if (this.pageName === PageNames.TOPICS_CONTENT) {

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -144,6 +144,12 @@ export default class Kolibri extends BaseShim {
        * @return {Promise} - a Promise that resolves when the theme has been applied
        */
       themeRenderer(options) {
+        // options = {
+        //   appBarColor: 'red',
+        //   textColor: 'green',
+        //   backdropColor: 'purple',
+        //   backgroundColor: null,
+        // };
         return self.mediator.sendMessageAwaitReply({
           event: events.THEMECHANGED,
           data: options,

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -144,12 +144,6 @@ export default class Kolibri extends BaseShim {
        * @return {Promise} - a Promise that resolves when the theme has been applied
        */
       themeRenderer(options) {
-        // options = {
-        //   appBarColor: 'red',
-        //   textColor: 'green',
-        //   backdropColor: 'purple',
-        //   backgroundColor: null,
-        // };
         return self.mediator.sendMessageAwaitReply({
           event: events.THEMECHANGED,
           data: options,


### PR DESCRIPTION
## Summary
This PR implements a full screen modal view for the custom channel renderer. 

![fullscreen-custom-renderer](https://user-images.githubusercontent.com/17235236/117728300-446c1e80-b1b7-11eb-841d-37cf6c58b5fb.gif)

…

## Reviewer guidance

Manual QA by navigating into the custom channel and also into "regular" channels to test and ensure this is working both for custom channels and that no odd regressions have been caused by the implementation.

Note: I have caused an issue with the render overlay, which now does not cover the header bar. I think the backdrop should cover it completely when the overlay is open, but I am not sure how to fix it. Any thoughts of what to change would be appreciated, and I can update the PR.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
