### PR TITLE
Pin attrs for Py34 compatibility.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,3 +10,4 @@ pytest-cov==2.5.1
 pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-pythonpath==0.7.2
+attrs==20.3.0


### PR DESCRIPTION
## Summary
* Upgrading to attrs on or after 1.21.0 breaks Py34 compatiblity
* Pins to before that to ensure Py34 tests still run.

## References
Same error happened in le utils: https://github.com/learningequality/le-utils/pull/87/commits/a8e9d41dbb230693c9f5d7a98923017dd43db40f

## Reviewer guidance
Do tests pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
