### PR TITLE
Kolibri stop for Windows

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -62,7 +62,7 @@ PROFILE_LOCK = os.path.join(conf.KOLIBRI_HOME, "server_profile.lock")
 PORT_CACHE = os.path.join(conf.KOLIBRI_HOME, "port_cache")
 
 # File used to send a state transition command to the server process
-PROCESS_CONTROL_FLAG = os.path.join(conf.KOLIBRI_HOME, "prcess_control.flag")
+PROCESS_CONTROL_FLAG = os.path.join(conf.KOLIBRI_HOME, "process_control.flag")
 
 # This is a special file with daemon activity. It logs ALL stderr output, some
 # might not have made it to the log file!


### PR DESCRIPTION
## Summary
* Turns the restart flag into a general purpose command flag
* Uses that as the primary means for stopping the server
* Does this as sending signals on Windows is problematic
* When we do have to resort to os.kill when the process is unresponsive, catch any SystemErrors that arise

## References
Fixes https://github.com/learningequality/kolibri/issues/7103

## Reviewer guidance
Does `kolibri stop` still work? Does it work on Windows without error?

To test:
Open two terminals in Windows
In one run `kolibri start`
Wait for it to 'go to background'
In the other run `kolibri stop`
Verify that the terminal with start, then stops!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
