### PR TITLE
Catch ValueError to catch errant JSONDecodeErrors.

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -55,6 +55,10 @@ class NetworkClient(object):
                     return response.url.rstrip("/").replace("api/public/info", "")
             except (requests.RequestException) as e:
                 logger.info("Unable to connect: {}".format(e))
+            except ValueError:
+                logger.info(
+                    "Invalid JSON returned when attempting to connect to a remote server"
+                )
 
         # we weren't able to connect to any of the URL variations, so all we can do is throw
         raise errors.NetworkLocationNotFound()


### PR DESCRIPTION
## Summary
* Somehow inputting a non-existent URL for a peer on the Android or Mac App would result in a JSON decode error in the network client
* Instead of just throwing a 500 error, handle that exception and let the requests return

## References
Fixes #7502

## Reviewer guidance
Any concerns?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
