### PR TITLE
Fix Windows installer to correctly detect running Kolibri

### DIFF
--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.2
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.3
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.1
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.2
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.3
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.4
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,7 +1,7 @@
 KOLIBRI_VERSION
 
 # Set the default version of the Windows Installer
-KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.0-beta3
+KOLIBRI_WINDOWS_INSTALLER_VERSION=v1.4.1
 
 # Make sure we don't record these docker runs in pingbacks
 KOLIBRI_RUN_MODE="docker"


### PR DESCRIPTION
## Summary
This integrates a fix for the Windows installer, so that the installer gets the correct port information from `server.pid` when putting together a running Kolibri instance's base URL.

## References
- https://github.com/learningequality/kolibri-installer-windows/pull/188

## Reviewer guidance
- @radinamatic knows how to test this! 


## Testing checklist

- [ ] Contributor has fully tested the PR manually

## PR process

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
