### PR TITLE
Update layout of DeviceSettingsPage; add labels to sections; add tests

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
@@ -87,6 +87,7 @@ describe('DeviceSettingsPage', () => {
       });
     }
 
+    // These should be the inverse of the "submitting settings" tests below
     it('hydrates with the correct state when guest access is allowed', async () => {
       setMockedData(true, true);
       const { wrapper } = await makeWrapper();

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
@@ -77,7 +77,7 @@ describe('DeviceSettingsPage', () => {
   }
 
   function assertIsSelected(button, expected) {
-    // The only way to tell it's checked in the DOM is to look for "svg.checked";
+    // HACK(kds-test) The only way to tell it's checked in the DOM is to look for "svg.checked";
     expect(button.find('svg.checked').exists()).toBe(expected);
   }
 
@@ -123,7 +123,7 @@ describe('DeviceSettingsPage', () => {
       client.mockResolvedValue({
         data: {
           landing_page: 'learn',
-          // Unrealistic data, but the guest acces button should not be checked
+          // The guest access button should not be checked
           allow_guest_access: true,
         },
       });
@@ -166,7 +166,7 @@ describe('DeviceSettingsPage', () => {
       });
     });
 
-    it('if landing page is Learn page, all settings assuming a Sign-in page are false', async () => {
+    it('landing page is Learn page', async () => {
       const { wrapper } = await makeWrapper();
       const saveSpy = jest.spyOn(wrapper.vm, 'saveDeviceSettings').mockResolvedValue();
       const { learnPage, saveButton } = getButtons(wrapper);
@@ -176,7 +176,7 @@ describe('DeviceSettingsPage', () => {
       expect(saveSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           landingPage: 'learn',
-          allowGuestAccess: false,
+          allowGuestAccess: true,
           allowLearnerUnassignedResourceAccess: true,
         })
       );

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
@@ -1,0 +1,231 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import client from 'kolibri.client';
+import DeviceSettingsPage from '../index.vue';
+
+jest.mock('kolibri.client');
+jest.mock('kolibri.urls');
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+const store = new Vuex.Store({
+  state: {},
+  getters: {
+    isAppContext: () => false,
+  },
+  actions: {
+    createSnackbar() {},
+  },
+});
+
+async function makeWrapper() {
+  const wrapper = mount(DeviceSettingsPage, {
+    wrapper,
+    store,
+  });
+  // Need to wait for beforeMount to finish
+  await global.flushPromises();
+  return { wrapper };
+}
+
+function getButtons(wrapper) {
+  const radioButtons = wrapper.findAllComponents({ name: 'KRadioButton' });
+  const saveButton = wrapper.findComponent({ name: 'KButton' });
+  return {
+    learnPage: radioButtons.at(0),
+    signInPage: radioButtons.at(1),
+    allowGuestAccess: radioButtons.at(2),
+    disallowGuestAccess: radioButtons.at(3),
+    lockedContent: radioButtons.at(4),
+    saveButton,
+  };
+}
+
+describe('DeviceSettingsPage', () => {
+  afterEach(() => {
+    client.mockReset();
+  });
+
+  it('loads the data from getDeviceSettings', async () => {
+    client.mockResolvedValue({
+      data: {
+        language_id: 'en',
+        landing_page: 'sign-in',
+        allow_guest_access: false,
+        allow_learner_unassigned_resource_access: false,
+        allow_peer_unlisted_channel_import: true,
+        allow_other_browsers_to_connect: false,
+      },
+    });
+    const { wrapper } = await makeWrapper();
+    const data = wrapper.vm.$data;
+    expect(data.language).toMatchObject({ value: 'en', label: 'English' });
+    expect(data).toMatchObject({
+      landingPage: 'sign-in',
+      allowPeerUnlistedChannelImport: true,
+      allowOtherBrowsersToConnect: false,
+    });
+  });
+
+  describe('landing page section', () => {
+    function assertIsDisabled(button, expected) {
+      return expect(button.props().disabled).toBe(expected);
+    }
+
+    function assertIsSelected(button, expected) {
+      // The only way to tell it's checked in the DOM is to look for "svg.checked";
+      expect(button.find('svg.checked').exists()).toBe(expected);
+    }
+
+    function setMockedData(allowGuestAccess, allowAllAccess) {
+      client.mockResolvedValue({
+        data: {
+          landing_page: 'sign-in',
+          allow_guest_access: allowGuestAccess,
+          allow_learner_unassigned_resource_access: allowAllAccess,
+        },
+      });
+    }
+
+    it('hydrates with the correct state when guest access is allowed', async () => {
+      setMockedData(true, true);
+      const { wrapper } = await makeWrapper();
+      // The "Allow users to explore..." radio button should be checked
+      const { allowGuestAccess } = getButtons(wrapper);
+      assertIsSelected(allowGuestAccess, true);
+    });
+
+    it('hydrates with the correct state when guest access is disallowed', async () => {
+      setMockedData(false, true);
+      const { wrapper } = await makeWrapper();
+      // The "Learners must sign in..." radio button should checked
+      const { disallowGuestAccess } = getButtons(wrapper);
+      assertIsSelected(disallowGuestAccess, true);
+    });
+
+    it('hydrates with the correct state when most restricted', async () => {
+      setMockedData(false, false);
+      const { wrapper } = await makeWrapper();
+      // The "Signed in learners only see resources assigned to them" button should be checked
+      const { lockedContent } = getButtons(wrapper);
+      assertIsSelected(lockedContent, true);
+    });
+
+    // The fourth possibility with guest access but no channels tab should be impossible
+
+    it('if Learn page is the landing page, sign-in page options are disabled', async () => {
+      client.mockResolvedValue({
+        data: {
+          landing_page: 'learn',
+          // Unrealistic data, but the guest acces button should not be checked
+          allow_guest_access: true,
+        },
+      });
+      const { wrapper } = await makeWrapper();
+      const { learnPage, allowGuestAccess, disallowGuestAccess, lockedContent } = getButtons(
+        wrapper
+      );
+      // Learn page button is enabled and checked
+      assertIsDisabled(learnPage, false);
+      assertIsSelected(learnPage, true);
+
+      // Every radio button under the Sign-In page option should be disabled
+      [allowGuestAccess, disallowGuestAccess, lockedContent].forEach(button => {
+        assertIsDisabled(button, true);
+        assertIsSelected(button, false);
+      });
+    });
+  });
+
+  describe('submitting changes', () => {
+    beforeEach(() => {
+      client.mockResolvedValue({
+        data: {
+          language_id: 'en',
+          landing_page: 'sign-in',
+          allow_guest_access: false,
+          allow_learner_unassigned_resource_access: true,
+          allow_peer_unlisted_channel_import: true,
+          allow_other_browsers_to_connect: false,
+        },
+      });
+    });
+
+    async function clickRadioButton(rb) {
+      // HACK(kds-test) You need to call `vm.update(true)` method on KCheckbox to simulate a click
+      rb.vm.update(true);
+      await global.flushPromises();
+    }
+
+    it('if landing page is Learn page, all settings assuming a Sign-in page are false', async () => {
+      const { wrapper } = await makeWrapper();
+      const saveSpy = jest.spyOn(wrapper.vm, 'saveDeviceSettings').mockResolvedValue();
+      const { learnPage, saveButton } = getButtons(wrapper);
+      await clickRadioButton(learnPage);
+      saveButton.trigger('click');
+      await global.flushPromises();
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          landingPage: 'learn',
+          allowGuestAccess: false,
+          allowLearnerUnassignedResourceAccess: true,
+        })
+      );
+    });
+
+    // NOTE: See screenshot in #7247 for how radio button selection should map to settings
+    it('"Allow users to explore resources without signing in" is selected', async () => {
+      const { wrapper } = await makeWrapper();
+      const saveSpy = jest.spyOn(wrapper.vm, 'saveDeviceSettings').mockResolvedValue();
+      const { disallowGuestAccess, allowGuestAccess, saveButton } = getButtons(wrapper);
+      // Click "disallow guest access first" to temporarily change settings from initial state
+      await clickRadioButton(disallowGuestAccess);
+      await clickRadioButton(allowGuestAccess);
+      saveButton.trigger('click');
+      await global.flushPromises();
+      // Implications: Can see "explore without account" AND can see "channels" tab
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          landingPage: 'sign-in',
+          allowGuestAccess: true,
+          allowLearnerUnassignedResourceAccess: true,
+        })
+      );
+    });
+
+    it('"Learners must sign in to explore resources" is selected', async () => {
+      const { wrapper } = await makeWrapper();
+      const saveSpy = jest.spyOn(wrapper.vm, 'saveDeviceSettings').mockResolvedValue();
+      const { disallowGuestAccess, saveButton } = getButtons(wrapper);
+      await clickRadioButton(disallowGuestAccess);
+      saveButton.trigger('click');
+      await global.flushPromises();
+      // Implications: Cannot see "explore without account" AND can see "channels" tab
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          landingPage: 'sign-in',
+          allowGuestAccess: false,
+          allowLearnerUnassignedResourceAccess: true,
+        })
+      );
+    });
+
+    it('"Signed in learners only see resources assigned to them in classes" is selected', async () => {
+      const { wrapper } = await makeWrapper();
+      const saveSpy = jest.spyOn(wrapper.vm, 'saveDeviceSettings').mockResolvedValue();
+      const { lockedContent, saveButton } = getButtons(wrapper);
+      await clickRadioButton(lockedContent);
+      saveButton.trigger('click');
+      await global.flushPromises();
+      console.log(wrapper.vm.signInPageOption);
+      // Implications: Cannot see "explore without account" AND cannot see "channels" tab
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          landingPage: 'sign-in',
+          allowGuestAccess: false,
+          allowLearnerUnassignedResourceAccess: false,
+        })
+      );
+    });
+  });
+});

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -229,14 +229,10 @@
       getContentSettings() {
         // This is the inverse of 'setSignInPageOption'
         // NOTE: See screenshot in #7247 for how radio button selection should map to settings
-        if (this.landingPage === LandingPageChoices.LEARN) {
-          return {
-            allowGuestAccess: false,
-            allowLearnerUnassignedResourceAccess: true,
-          };
-        }
-
-        if (this.signInPageOption === SignInPageOptions.ALLOW_GUEST_ACCESS) {
+        if (
+          this.landingPage === LandingPageChoices.LEARN ||
+          this.signInPageOption === SignInPageOptions.ALLOW_GUEST_ACCESS
+        ) {
           return {
             allowGuestAccess: true,
             allowLearnerUnassignedResourceAccess: true,
@@ -363,6 +359,7 @@
     }
   }
 
+  // TODO replace div.fieldset with a real fieldset after styling issue is resolved
   .fieldset {
     margin: 16px 0;
   }

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -16,7 +16,7 @@
     </section>
 
     <section>
-      <fieldset>
+      <div class="fieldset">
         <KSelect
           v-model="language"
           :label="$tr('selectedLanguageLabel')"
@@ -25,9 +25,9 @@
           :floatingLabel="false"
           style="max-width: 300px"
         />
-      </fieldset>
+      </div>
 
-      <fieldset>
+      <div class="fieldset">
         <label class="fieldset-label">{{ $tr('externalDeviceSettings') }}</label>
         <KCheckbox
           :label="$tr('unlistedChannels')"
@@ -49,9 +49,9 @@
             </p>
           </span>
         </KCheckbox>
-      </fieldset>
+      </div>
 
-      <fieldset>
+      <div class="fieldset">
         <label class="fieldset-label">{{ $tr('landingPageLabel') }}</label>
         <KRadioButton
           :label="$tr('learnerAppPageChoice')"
@@ -65,7 +65,7 @@
           :currentValue="landingPage"
           @change="landingPage = landingPageChoices.SIGN_IN"
         />
-        <fieldset style="margin-left: 32px">
+        <div style="margin-left: 32px">
           <KRadioButton
             :label="$tr('allowGuestAccess')"
             value="allowGuestAccess"
@@ -87,8 +87,8 @@
             :disabled="disableAllowLearnerUnassignedResourceAccess"
             @input="signInPageOption = $event"
           />
-        </fieldset>
-      </fieldset>
+        </div>
+      </div>
     </section>
 
     <section>
@@ -317,12 +317,8 @@
     }
   }
 
-  // Resets styling from pure css
-  fieldset {
-    min-width: 0;
-    padding: 0;
-    margin: 8px 0;
-    border: 0;
+  .fieldset {
+    margin: 16px 0;
   }
 
   .fieldset-label {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -16,36 +16,43 @@
     </section>
 
     <section>
-      <KSelect
-        v-model="language"
-        :label="$tr('selectedLanguageLabel')"
-        :options="languageOptions"
-        :disabled="language.value === undefined"
-        :floatingLabel="false"
-        style="max-width: 300px"
-      />
-      <KCheckbox
-        :label="$tr('unlistedChannels')"
-        :checked="allowPeerUnlistedChannelImport"
-        @change="allowPeerUnlistedChannelImport = $event"
-      />
-      <KCheckbox
-        v-if="isAppContext"
-        :checked="allowOtherBrowsersToConnect"
-        @change="allowOtherBrowsersToConnect = $event"
-      >
-        <span> {{ $tr('allowExternalConnectionsApp') }}
-          <p
-            v-if="allowOtherBrowsersToConnect"
-            class="description"
-            :style="{ color: $themeTokens.annotation }"
-          >
-            {{ $tr('allowExternalConnectionsAppDescription') }}
-          </p>
-        </span>
-      </KCheckbox>
       <fieldset>
-        <label>{{ $tr('landingPageLabel') }}</label>
+        <KSelect
+          v-model="language"
+          :label="$tr('selectedLanguageLabel')"
+          :options="languageOptions"
+          :disabled="language.value === undefined"
+          :floatingLabel="false"
+          style="max-width: 300px"
+        />
+      </fieldset>
+
+      <fieldset>
+        <label class="fieldset-label">{{ $tr('externalDeviceSettings') }}</label>
+        <KCheckbox
+          :label="$tr('unlistedChannels')"
+          :checked="allowPeerUnlistedChannelImport"
+          @change="allowPeerUnlistedChannelImport = $event"
+        />
+        <KCheckbox
+          v-if="isAppContext"
+          :checked="allowOtherBrowsersToConnect"
+          @change="allowOtherBrowsersToConnect = $event"
+        >
+          <span> {{ $tr('allowExternalConnectionsApp') }}
+            <p
+              v-if="allowOtherBrowsersToConnect"
+              class="description"
+              :style="{ color: $themeTokens.annotation }"
+            >
+              {{ $tr('allowExternalConnectionsAppDescription') }}
+            </p>
+          </span>
+        </KCheckbox>
+      </fieldset>
+
+      <fieldset>
+        <label class="fieldset-label">{{ $tr('landingPageLabel') }}</label>
         <KRadioButton
           :label="$tr('learnerAppPageChoice')"
           :value="landingPageChoices.LEARN"
@@ -58,22 +65,32 @@
           :currentValue="landingPage"
           @change="landingPage = landingPageChoices.SIGN_IN"
         />
-        <fieldset>
-          <KCheckbox
+        <fieldset style="margin-left: 32px">
+          <KRadioButton
             :label="$tr('allowGuestAccess')"
+            value="allowGuestAccess"
+            :currentValue="signInPageOption"
             :disabled="disableAllowGuestAccess"
-            :checked="allowGuestAccess || landingPage === landingPageChoices.LEARN"
-            @change="allowGuestAccess = $event"
+            @input="signInPageOption = $event"
           />
-          <KCheckbox
+          <KRadioButton
+            :label="$tr('disallowGuestAccess')"
+            value="disallowGuestAccess"
+            :currentValue="signInPageOption"
+            :disabled="disableAllowGuestAccess"
+            @input="signInPageOption = $event"
+          />
+          <KRadioButton
             :label="$tr('lockedContent')"
+            value="lockedContent"
+            :currentValue="signInPageOption"
             :disabled="disableAllowLearnerUnassignedResourceAccess"
-            :checked="!allowLearnerUnassignedResourceAccess && landingPage !== landingPageChoices.LEARN"
-            @change="allowLearnerUnassignedResourceAccess = !$event"
+            @input="signInPageOption = $event"
           />
         </fieldset>
       </fieldset>
     </section>
+
     <section>
       <KButton
         :text="coreString('saveAction')"
@@ -131,6 +148,7 @@
         allowPeerUnlistedChannelImport: null,
         allowOtherBrowsersToConnect: null,
         landingPageChoices: LandingPageChoices,
+        signInPageOption: '',
         browserDefaultOption: {
           value: null,
           label: this.$tr('browserDefaultLanguage'),
@@ -242,7 +260,9 @@
       saveSuccessNotification: 'Settings have been updated',
       selectedLanguageLabel: 'Default language',
       facilitySettings: 'You can also configure facility settings',
-      allowGuestAccess: 'Allow users to access resources without signing in',
+      allowGuestAccess: 'Allow users to explore resources without signing in',
+      disallowGuestAccess: 'Learners must sign in to explore resources',
+      lockedContent: 'Signed in learners should only see resources assigned to them in classes',
       landingPageLabel: {
         message: 'Default landing page',
         context: 'The page that users see immediately after they log in',
@@ -253,7 +273,6 @@
         context: '\nThis refers to the page you reach when you click "Learn" in the main side nav',
       },
       unlistedChannels: 'Allow other computers on this network to import my unlisted channels',
-      lockedContent: 'Learners should only see resources assigned to them in classes',
       configureFacilitySettingsHeader: 'Configure facility settings',
       allowExternalConnectionsApp: {
         message: 'Allow others in the network to access Kolibri on this device using a browser',
@@ -265,6 +284,10 @@
           'If learners are allowed to sign in with no password on this device, enabling this may allow external devices to view the user data, which could be a potential security concern.',
         context:
           'Warns the user of the potential security risk if this setting is enabled together with users accesing without password',
+      },
+      externalDeviceSettings: {
+        message: 'External devices',
+        context: 'Label for settings controlling how Kolibri interacts with other devices',
       },
     },
   };
@@ -298,8 +321,14 @@
   fieldset {
     min-width: 0;
     padding: 0;
-    margin: 0;
+    margin: 8px 0;
     border: 0;
+  }
+
+  .fieldset-label {
+    font-size: 15px;
+    // to match label in KSelect
+    color: rgba(0, 0, 0, 0.54);
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -44,33 +44,35 @@
           </p>
         </span>
       </KCheckbox>
-      <p>
+      <fieldset>
         <label>{{ $tr('landingPageLabel') }}</label>
-        <KRadioButton
-          :label="$tr('signInPageChoice')"
-          :value="landingPageChoices.SIGN_IN"
-          :currentValue="landingPage"
-          @change="landingPage = landingPageChoices.SIGN_IN"
-        />
         <KRadioButton
           :label="$tr('learnerAppPageChoice')"
           :value="landingPageChoices.LEARN"
           :currentValue="landingPage"
           @change="landingPage = landingPageChoices.LEARN"
         />
-      </p>
-      <KCheckbox
-        :label="$tr('allowGuestAccess')"
-        :disabled="disableAllowGuestAccess"
-        :checked="allowGuestAccess || landingPage === landingPageChoices.LEARN"
-        @change="allowGuestAccess = $event"
-      />
-      <KCheckbox
-        :label="$tr('lockedContent')"
-        :disabled="disableAllowLearnerUnassignedResourceAccess"
-        :checked="!allowLearnerUnassignedResourceAccess && landingPage !== landingPageChoices.LEARN"
-        @change="allowLearnerUnassignedResourceAccess = !$event"
-      />
+        <KRadioButton
+          :label="$tr('signInPageChoice')"
+          :value="landingPageChoices.SIGN_IN"
+          :currentValue="landingPage"
+          @change="landingPage = landingPageChoices.SIGN_IN"
+        />
+        <fieldset>
+          <KCheckbox
+            :label="$tr('allowGuestAccess')"
+            :disabled="disableAllowGuestAccess"
+            :checked="allowGuestAccess || landingPage === landingPageChoices.LEARN"
+            @change="allowGuestAccess = $event"
+          />
+          <KCheckbox
+            :label="$tr('lockedContent')"
+            :disabled="disableAllowLearnerUnassignedResourceAccess"
+            :checked="!allowLearnerUnassignedResourceAccess && landingPage !== landingPageChoices.LEARN"
+            @change="allowLearnerUnassignedResourceAccess = !$event"
+          />
+        </fieldset>
+      </fieldset>
     </section>
     <section>
       <KButton
@@ -241,7 +243,10 @@
       selectedLanguageLabel: 'Default language',
       facilitySettings: 'You can also configure facility settings',
       allowGuestAccess: 'Allow users to access resources without signing in',
-      landingPageLabel: 'Landing page',
+      landingPageLabel: {
+        message: 'Default landing page',
+        context: 'The page that users see immediately after they log in',
+      },
       signInPageChoice: 'Sign-in page',
       learnerAppPageChoice: {
         message: 'Learn page',
@@ -287,6 +292,14 @@
     li {
       margin-bottom: 8px;
     }
+  }
+
+  // Resets styling from pure css
+  fieldset {
+    min-width: 0;
+    padding: 0;
+    margin: 0;
+    border: 0;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -57,13 +57,13 @@
           :label="$tr('learnerAppPageChoice')"
           :value="landingPageChoices.LEARN"
           :currentValue="landingPage"
-          @change="landingPage = landingPageChoices.LEARN"
+          @input="handleLandingPageChange"
         />
         <KRadioButton
           :label="$tr('signInPageChoice')"
           :value="landingPageChoices.SIGN_IN"
           :currentValue="landingPage"
-          @change="landingPage = landingPageChoices.SIGN_IN"
+          @input="handleLandingPageChange"
         />
         <div style="margin-left: 32px">
           <KRadioButton
@@ -71,21 +71,21 @@
             value="allowGuestAccess"
             :currentValue="signInPageOption"
             :disabled="disableAllowGuestAccess"
-            @input="signInPageOption = $event"
+            @input="handleSignInPageChange"
           />
           <KRadioButton
             :label="$tr('disallowGuestAccess')"
             value="disallowGuestAccess"
             :currentValue="signInPageOption"
             :disabled="disableAllowGuestAccess"
-            @input="signInPageOption = $event"
+            @input="handleSignInPageChange"
           />
           <KRadioButton
             :label="$tr('lockedContent')"
             value="lockedContent"
             :currentValue="signInPageOption"
             :disabled="disableAllowLearnerUnassignedResourceAccess"
-            @input="signInPageOption = $event"
+            @input="handleSignInPageChange"
           />
         </div>
       </div>
@@ -214,6 +214,15 @@
       });
     },
     methods: {
+      handleLandingPageChange(option) {
+        this.landingPage = option;
+        if (option === LandingPageChoices.LEARN) {
+          this.signInPageOption = '';
+        }
+      },
+      handleSignInPageChange(option) {
+        this.signInPageOption = option;
+      },
       getFacilitySettingsPath(facilityId = '') {
         const getUrl = urls['kolibri:kolibri.plugins.facility:facility_management'];
         if (getUrl) {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -257,6 +257,8 @@
         this.landingPage = option;
         if (option === LandingPageChoices.LEARN) {
           this.signInPageOption = '';
+        } else {
+          this.signInPageOption = SignInPageOptions.ALLOW_GUEST_ACCESS;
         }
       },
       handleSignInPageChange(option) {


### PR DESCRIPTION
## Summary

1. Updates layout of DeviceSettingsPage (#7247)
2. Adds labels for the "External devices" section and the "Default landing page" section
3. Adds tests that should cover state hydration after fetching device settings, as well as re-saving them (and does this by simulating a user clicking on the forms).

Screenshot:

![image](https://user-images.githubusercontent.com/10248067/118338983-640f8980-b4cc-11eb-94d8-66ca255b6f48.png)

Some videos:

1. [Checking that the changes are persisted + hydrated correctly](https://drive.google.com/file/d/1Wsp5QWQNtkIRwMX8s2h4ykAITqUSu3p0/view?usp=sharing)
2. [Using the form with keyboard only](https://drive.google.com/file/d/1HXNHUsbP9MP6y75X192ewHndImuKDAqP/view?usp=sharing)

## References

Fixes #7247

## Reviewer guidance

Due to #8087, it might not be able to confirm the settings have changed by using the app. Instead, you might need to go to the API explorer (http://localhost:8000/api_explorer/) and call the `devicesettings` end point.
 

[Video of me confirming this on Swagger API Explorer](https://drive.google.com/file/d/19k9AemJIOQYouo-Rkdk9iHttS2xwMLs3/view?usp=sharing)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
