### PR TITLE
Add utility to enable user migration

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -24,9 +24,9 @@ from django.db.models import TextField
 from django.db.models import Value
 from django.db.models.functions import Cast
 from django.http import Http404
+from django.http import HttpResponseForbidden
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import DjangoFilterBackend
@@ -40,6 +40,7 @@ from rest_framework import status
 from rest_framework import views
 from rest_framework import viewsets
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 
 from .constants import collection_kinds
 from .constants import role_kinds
@@ -546,9 +547,7 @@ class SignUpViewSet(viewsets.ViewSet):
             "username": request.data.get("username", ""),
             "full_name": request.data.get("full_name", ""),
             "password": request.data.get("password", ""),
-            "facility": request.data.get(
-                "facility", Facility.get_default_facility().id
-            ),
+            "facility": request.data.get("facility"),
             "gender": request.data.get("gender", ""),
             "birth_year": request.data.get("birth_year", ""),
         }
@@ -556,9 +555,36 @@ class SignUpViewSet(viewsets.ViewSet):
     def create(self, request):
 
         data = self.extract_request_data(request)
+        facility_id = data["facility"]
+
+        if facility_id is None:
+            facility = Facility.get_default_facility()
+            data["facility"] = facility.id
+        else:
+            try:
+                facility = Facility.objects.select_related("dataset").get(
+                    id=facility_id
+                )
+            except Facility.DoesNotExist:
+                raise ValidationError(
+                    "Facility does not exist.",
+                    code=error_constants.FACILITY_DOES_NOT_EXIST,
+                )
+
+        if not facility.dataset.learner_can_sign_up:
+            return HttpResponseForbidden("Cannot sign up to this facility")
+
         # we validate the user's input, and if valid, login as user
         serialized_user = self.serializer_class(data=data)
         if serialized_user.is_valid(raise_exception=True):
+            if (
+                data["password"] == "NOT_SPECIFIED"
+                and not facility.dataset.learner_can_login_with_no_password
+            ):
+                raise ValidationError(
+                    "No password specified and it is required",
+                    code=error_constants.PASSWORD_NOT_SPECIFIED,
+                )
             serialized_user.save()
             if data["password"] != "NOT_SPECIFIED":
                 serialized_user.instance.set_password(data["password"])
@@ -569,29 +595,6 @@ class SignUpViewSet(viewsets.ViewSet):
                 facility=data["facility"],
             )
             login(request, authenticated_user)
-            return Response(serialized_user.data, status=status.HTTP_201_CREATED)
-
-
-@method_decorator(csrf_exempt, name="dispatch")
-class PublicSignUpViewSet(SignUpViewSet):
-    """
-    Identical to the SignUpViewset except that it also allows a hashed password
-    and does not login the user.
-    This endpoint is intended to allow a FacilityUser in a different facility
-    on another device to be cloned into a facility on this device, to facilitate
-    moving a user from one facility to another.
-    """
-
-    def create(self, request):
-
-        data = self.extract_request_data(request)
-        password_hashed = request.data.get("password_hashed", False)
-        serialized_user = self.serializer_class(data=data)
-        if serialized_user.is_valid(raise_exception=True):
-            serialized_user.save()
-            if data["password"] != "NOT_SPECIFIED" and not password_hashed:
-                serialized_user.instance.set_password(data["password"])
-                serialized_user.instance.save()
             return Response(serialized_user.data, status=status.HTTP_201_CREATED)
 
 

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -933,6 +933,8 @@ class AnonSignUpTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertFalse(models.FacilityUser.objects.all())
+        self.facility.dataset.learner_can_sign_up = True
+        self.facility.dataset.save()
 
     def test_password_not_specified_password_required(self):
         self.facility.dataset.learner_can_login_with_no_password = False

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -10,7 +10,6 @@ import factory
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from rest_framework import status
-from rest_framework.test import APIClient
 from rest_framework.test import APITestCase as BaseTestCase
 
 from .. import models
@@ -926,96 +925,30 @@ class AnonSignUpTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(models.FacilityUser.objects.all())
 
-
-class PublicSignUpTestCase(APITestCase):
-    @classmethod
-    def setUpTestData(cls):
-        cls.facility = FacilityFactory.create()
-        provision_device()
-
-    def post_to_sign_up(self, data):
-        return self.client.post(
-            reverse("kolibri:core:publicsignup-list"), data=data, format="json"
-        )
-
-    def test_anon_sign_up_creates_user(self):
+    def test_no_sign_up_no_signups(self):
+        self.facility.dataset.learner_can_sign_up = False
+        self.facility.dataset.save()
         response = self.post_to_sign_up(
             {"username": "user", "password": DUMMY_PASSWORD}
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(models.FacilityUser.objects.all())
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(models.FacilityUser.objects.all())
 
-    def test_anon_sign_up_returns_user(self):
-        full_name = "Bob Lee"
+    def test_password_not_specified_password_required(self):
+        self.facility.dataset.learner_can_login_with_no_password = False
+        self.facility.dataset.save()
         response = self.post_to_sign_up(
-            {"full_name": full_name, "username": "user", "password": DUMMY_PASSWORD}
-        )
-        self.assertEqual(response.data["username"], "user")
-        self.assertEqual(response.data["full_name"], full_name)
-
-    def test_create_user_with_same_username_case_insensitive_fails(self):
-        FacilityUserFactory.create(username="bob", facility=self.facility)
-        response = self.post_to_sign_up({"username": "BOB", "password": DUMMY_PASSWORD})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(len(models.FacilityUser.objects.all()), 1)
-
-    def test_create_user_with_same_username_other_facility(self):
-        user = FacilityUserFactory.create(username="bob")
-        other_facility = models.Facility.objects.exclude(id=user.facility.id)[0]
-        response = self.post_to_sign_up(
-            {
-                "username": "bob",
-                "password": DUMMY_PASSWORD,
-                "facility": other_facility.id,
-            }
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(
-            models.FacilityUser.objects.filter(facility=self.facility.id).count(), 1
-        )
-        self.assertEqual(
-            models.FacilityUser.objects.filter(facility=other_facility.id).count(), 1
-        )
-
-    def test_create_user_for_specific_facility(self):
-        other_facility = FacilityFactory.create()
-        response = self.post_to_sign_up(
-            {
-                "username": "bob",
-                "password": DUMMY_PASSWORD,
-                "facility": other_facility.id,
-            }
-        )
-        user_id = response.data["id"]
-        self.assertEqual(
-            models.FacilityUser.objects.get(id=user_id).facility.id, other_facility.id
-        )
-        self.assertTrue(other_facility.get_members().filter(id=user_id).exists())
-
-    def test_create_bad_username_fails(self):
-        response = self.post_to_sign_up(
-            {"username": "(***)", "password": DUMMY_PASSWORD}
+            {"username": "user", "password": "NOT_SPECIFIED"}
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(models.FacilityUser.objects.all())
 
-    def test_sign_up_no_log_in_user(self):
-        session_key = self.client.session.session_key
-        self.post_to_sign_up({"username": "user", "password": DUMMY_PASSWORD})
-        self.assertEqual(session_key, self.client.session.session_key)
-
-    def test_sign_up_able_no_guest_access(self):
-        set_device_settings(allow_guest_access=False)
+    def test_password_not_specified_password_not_required(self):
+        self.facility.dataset.learner_can_login_with_no_password = True
+        self.facility.dataset.learner_can_edit_password = False
+        self.facility.dataset.save()
         response = self.post_to_sign_up(
-            {"username": "user", "password": DUMMY_PASSWORD}
-        )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(models.FacilityUser.objects.all())
-
-    def test_sign_up_able_no_CSRF(self):
-        self.client = APIClient(enforce_csrf_checks=True)
-        response = self.post_to_sign_up(
-            {"username": "user", "password": DUMMY_PASSWORD}
+            {"username": "user", "password": "NOT_SPECIFIED"}
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(models.FacilityUser.objects.all())

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -112,36 +112,170 @@ class AttemptLogFactory(factory.DjangoModelFactory):
     time_spent = factory.LazyFunction(random.random)
 
 
-class MergeUserTestCase(TestCase):
+class TeleportUserTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.facility = FacilityFactory.create()
-        for i in range(0, 5):
+        i = 1
+        user = FacilityUserFactory.create(facility=cls.facility)
+
+        sess_logs = []
+        summ_logs = []
+
+        for _ in range(3):
+            sess_logs.append(
+                ContentSessionLogFactory.create(
+                    user=user,
+                )
+            )
+
+            summ_logs.append(
+                ContentSummaryLogFactory.create(
+                    user=user,
+                )
+            )
+        ex_csessl = ContentSessionLogFactory.create(
+            user=user,
+        )
+
+        ex_csmlog = ContentSummaryLogFactory.create(
+            user=user,
+        )
+        masterylog = MasteryLogFactory.create(user=user, summarylog=ex_csmlog)
+        attemptlog = AttemptLogFactory.create(
+            user=user, masterylog=masterylog, sessionlog=ex_csessl
+        )
+        usersessionlog = UserSessionLogFactory.create(user=user)
+
+        sess_logs.append(ex_csessl)
+        summ_logs.append(ex_csmlog)
+
+        setattr(cls, "user_{}".format(str(i)), user)
+        setattr(cls, "user_{}_sess_logs".format(str(i)), sess_logs)
+        setattr(cls, "user_{}_summ_logs".format(str(i)), summ_logs)
+        setattr(cls, "user_{}_masterylog".format(str(i)), masterylog)
+        setattr(cls, "user_{}_attemptlog".format(str(i)), attemptlog)
+        setattr(cls, "user_{}_usersessionlog".format(str(i)), usersessionlog)
+
+        cls.user_1_id = cls.user_1.id
+
+        cls.user_2 = FacilityUserFactory.create(facility=cls.facility)
+
+        merge_users(cls.user_1, cls.user_2)
+
+    def test_no_user_after_merge(self):
+        self.assertFalse(FacilityUser.objects.filter(id=self.user_1_id).exists())
+
+    def test_masterylogs(self):
+        self.assertEqual(
+            log_models.MasteryLog.objects.filter(user=self.user_2).count(), 1
+        )
+        log = self.user_1_masterylog
+        self.assertTrue(
+            log_models.MasteryLog.objects.filter(
+                summarylog__progress=log.summarylog.progress,
+                user=self.user_2,
+                mastery_level=log.mastery_level,
+                summarylog__channel_id=log.summarylog.channel_id,
+                summarylog__content_id=log.summarylog.content_id,
+            ).exists()
+        )
+
+    def test_usersessionlogs(self):
+        self.assertEqual(
+            log_models.UserSessionLog.objects.filter(user=self.user_2).count(), 1
+        )
+
+    def test_attemptlogs(self):
+        self.assertEqual(
+            log_models.AttemptLog.objects.filter(user=self.user_2).count(), 1
+        )
+        log = self.user_1_attemptlog
+        self.assertTrue(
+            log_models.AttemptLog.objects.filter(
+                masterylog__summarylog__progress=log.masterylog.summarylog.progress,
+                user=self.user_2,
+                time_spent=log.time_spent,
+                masterylog__summarylog__channel_id=log.masterylog.summarylog.channel_id,
+                masterylog__summarylog__content_id=log.masterylog.summarylog.content_id,
+            ).exists()
+        )
+
+    def test_contentsessionlogs(self):
+        self.assertEqual(
+            log_models.ContentSessionLog.objects.filter(user=self.user_2).count(),
+            len(self.user_1_sess_logs),
+        )
+        for log in self.user_1_sess_logs:
+            self.assertTrue(
+                log_models.ContentSessionLog.objects.filter(
+                    progress=log.progress,
+                    user=self.user_2,
+                    content_id=log.content_id,
+                    channel_id=log.channel_id,
+                ).exists()
+            )
+
+    def test_contentsummarylogs(self):
+        self.assertEqual(
+            log_models.ContentSummaryLog.objects.filter(user=self.user_2).count(),
+            len(self.user_1_summ_logs),
+        )
+        for log in self.user_1_summ_logs:
+            self.assertTrue(
+                log_models.ContentSummaryLog.objects.filter(
+                    progress=log.progress,
+                    user=self.user_2,
+                    content_id=log.content_id,
+                    channel_id=log.channel_id,
+                ).exists()
+            )
+
+
+class MergeUsersTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        content_identifiers = [(uuid.uuid4().hex, uuid.uuid4().hex) for i in range(3)]
+        ex_identifiers = (uuid.uuid4().hex, uuid.uuid4().hex)
+        for i in range(1, 3):
             user = FacilityUserFactory.create(facility=cls.facility)
 
             sess_logs = []
             summ_logs = []
 
-            for _ in range(3):
+            for channel_id, content_id in content_identifiers:
+
                 sess_logs.append(
                     ContentSessionLogFactory.create(
                         user=user,
+                        channel_id=channel_id,
+                        content_id=content_id,
                     )
                 )
 
                 summ_logs.append(
                     ContentSummaryLogFactory.create(
                         user=user,
+                        channel_id=channel_id,
+                        content_id=content_id,
                     )
                 )
+            channel_id, content_id = ex_identifiers
             ex_csessl = ContentSessionLogFactory.create(
                 user=user,
+                channel_id=channel_id,
+                content_id=content_id,
             )
 
             ex_csmlog = ContentSummaryLogFactory.create(
                 user=user,
+                channel_id=channel_id,
+                content_id=content_id,
             )
-            masterylog = MasteryLogFactory.create(user=user, summarylog=ex_csmlog)
+            masterylog = MasteryLogFactory.create(
+                user=user, summarylog=ex_csmlog, mastery_level=1
+            )
             attemptlog = AttemptLogFactory.create(
                 user=user, masterylog=masterylog, sessionlog=ex_csessl
             )
@@ -175,9 +309,9 @@ class MergeUserTestCase(TestCase):
 
     def test_masterylogs(self):
         self.assertEqual(
-            log_models.MasteryLog.objects.filter(user=self.user_2).count(), 2
+            log_models.MasteryLog.objects.filter(user=self.user_2).count(), 1
         )
-        log = self.user_1_masterylog
+        log = self.user_2_masterylog
         self.assertTrue(
             log_models.MasteryLog.objects.filter(
                 summarylog__progress=log.summarylog.progress,
@@ -200,7 +334,7 @@ class MergeUserTestCase(TestCase):
         log = self.user_1_attemptlog
         self.assertTrue(
             log_models.AttemptLog.objects.filter(
-                masterylog__summarylog__progress=log.masterylog.summarylog.progress,
+                masterylog__summarylog__progress=self.user_2_attemptlog.masterylog.summarylog.progress,
                 user=self.user_2,
                 time_spent=log.time_spent,
                 masterylog__summarylog__channel_id=log.masterylog.summarylog.channel_id,
@@ -226,9 +360,9 @@ class MergeUserTestCase(TestCase):
     def test_contentsummarylogs(self):
         self.assertEqual(
             log_models.ContentSummaryLog.objects.filter(user=self.user_2).count(),
-            len(self.user_1_summ_logs) + len(self.user_2_summ_logs),
+            len(self.user_1_summ_logs),
         )
-        for log in self.user_1_summ_logs:
+        for log in self.user_2_summ_logs:
             self.assertTrue(
                 log_models.ContentSummaryLog.objects.filter(
                     progress=log.progress,

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -115,7 +115,6 @@ class TeleportUserTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.facility = FacilityFactory.create()
-        i = 1
         user = FacilityUserFactory.create(facility=cls.facility)
 
         sess_logs = []
@@ -149,12 +148,12 @@ class TeleportUserTestCase(TestCase):
         sess_logs.append(ex_csessl)
         summ_logs.append(ex_csmlog)
 
-        setattr(cls, "user_{}".format(str(i)), user)
-        setattr(cls, "user_{}_sess_logs".format(str(i)), sess_logs)
-        setattr(cls, "user_{}_summ_logs".format(str(i)), summ_logs)
-        setattr(cls, "user_{}_masterylog".format(str(i)), masterylog)
-        setattr(cls, "user_{}_attemptlog".format(str(i)), attemptlog)
-        setattr(cls, "user_{}_usersessionlog".format(str(i)), usersessionlog)
+        setattr(cls, "user_1", user)
+        setattr(cls, "user_1_sess_logs", sess_logs)
+        setattr(cls, "user_1_summ_logs", summ_logs)
+        setattr(cls, "user_1_masterylog", masterylog)
+        setattr(cls, "user_1_attemptlog", attemptlog)
+        setattr(cls, "user_1_usersessionlog", usersessionlog)
 
         cls.user_1_id = cls.user_1.id
 

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -2,14 +2,22 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import datetime
+import random
 import uuid
 
+import factory
 import mock
 from django.core.management.base import CommandError
 from django.test import TestCase
 
 from ..models import Facility
+from ..models import FacilityUser
 from kolibri.core.auth.management import utils
+from kolibri.core.auth.test.test_api import FacilityFactory
+from kolibri.core.auth.test.test_api import FacilityUserFactory
+from kolibri.core.auth.utils import merge_users
+from kolibri.core.logger import models as log_models
 
 
 class GetFacilityTestCase(TestCase):
@@ -50,3 +58,182 @@ class GetFacilityFailureTestCase(TestCase):
     def test_get_facility_no_facilities(self):
         with self.assertRaisesRegexp(CommandError, "no facilities"):
             utils.get_facility()
+
+
+class ContentSessionLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = log_models.ContentSessionLog
+
+    user = factory.SubFactory(FacilityUserFactory)
+    start_timestamp = datetime.datetime.now()
+    content_id = factory.LazyFunction(lambda: uuid.uuid4().hex)
+    channel_id = factory.LazyFunction(lambda: uuid.uuid4().hex)
+    progress = factory.LazyFunction(random.random)
+
+
+class ContentSummaryLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = log_models.ContentSummaryLog
+
+    user = factory.SubFactory(FacilityUserFactory)
+    start_timestamp = datetime.datetime.now()
+    content_id = factory.LazyFunction(lambda: uuid.uuid4().hex)
+    channel_id = factory.LazyFunction(lambda: uuid.uuid4().hex)
+    progress = factory.LazyFunction(random.random)
+
+
+class UserSessionLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = log_models.UserSessionLog
+
+    user = factory.SubFactory(FacilityUserFactory)
+
+
+class MasteryLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = log_models.MasteryLog
+
+    user = factory.SubFactory(FacilityUserFactory)
+    summarylog = factory.SubFactory(ContentSummaryLogFactory)
+    start_timestamp = datetime.datetime.now()
+    mastery_level = factory.LazyFunction(lambda: random.randint(1, 10))
+
+
+class AttemptLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = log_models.AttemptLog
+
+    user = factory.SubFactory(FacilityUserFactory)
+    masterylog = factory.SubFactory(MasteryLogFactory)
+    sessionlog = factory.SubFactory(ContentSessionLogFactory)
+    start_timestamp = datetime.datetime.now()
+    end_timestamp = datetime.datetime.now()
+    correct = False
+    time_spent = factory.LazyFunction(random.random)
+
+
+class MergeUserTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        for i in range(0, 5):
+            user = FacilityUserFactory.create(facility=cls.facility)
+
+            sess_logs = []
+            summ_logs = []
+
+            for _ in range(3):
+                sess_logs.append(
+                    ContentSessionLogFactory.create(
+                        user=user,
+                    )
+                )
+
+                summ_logs.append(
+                    ContentSummaryLogFactory.create(
+                        user=user,
+                    )
+                )
+            ex_csessl = ContentSessionLogFactory.create(
+                user=user,
+            )
+
+            ex_csmlog = ContentSummaryLogFactory.create(
+                user=user,
+            )
+            masterylog = MasteryLogFactory.create(user=user, summarylog=ex_csmlog)
+            attemptlog = AttemptLogFactory.create(
+                user=user, masterylog=masterylog, sessionlog=ex_csessl
+            )
+            usersessionlog = UserSessionLogFactory.create(user=user)
+
+            sess_logs.append(ex_csessl)
+            summ_logs.append(ex_csmlog)
+
+            setattr(cls, "user_{}".format(str(i)), user)
+            setattr(cls, "user_{}_sess_logs".format(str(i)), sess_logs)
+            setattr(cls, "user_{}_summ_logs".format(str(i)), summ_logs)
+            setattr(cls, "user_{}_masterylog".format(str(i)), masterylog)
+            setattr(cls, "user_{}_attemptlog".format(str(i)), attemptlog)
+            setattr(cls, "user_{}_usersessionlog".format(str(i)), usersessionlog)
+
+        cls.user_1_id = cls.user_1.id
+        cls.user_1.birth_year = "1984"
+        cls.user_1.id_number = "101"
+        cls.user_1.save()
+        cls.user_2.id_number = "13"
+        cls.user_2.save()
+        merge_users(cls.user_1, cls.user_2)
+
+    def test_no_user_after_merge(self):
+        self.assertFalse(FacilityUser.objects.filter(id=self.user_1_id).exists())
+
+    def test_user_data_after_merge(self):
+        self.user_2.refresh_from_db()
+        self.assertEqual(self.user_2.birth_year, "1984")
+        self.assertEqual(self.user_2.id_number, "13")
+
+    def test_masterylogs(self):
+        self.assertEqual(
+            log_models.MasteryLog.objects.filter(user=self.user_2).count(), 2
+        )
+        log = self.user_1_masterylog
+        self.assertTrue(
+            log_models.MasteryLog.objects.filter(
+                summarylog__progress=log.summarylog.progress,
+                user=self.user_2,
+                mastery_level=log.mastery_level,
+                summarylog__channel_id=log.summarylog.channel_id,
+                summarylog__content_id=log.summarylog.content_id,
+            ).exists()
+        )
+
+    def test_usersessionlogs(self):
+        self.assertEqual(
+            log_models.UserSessionLog.objects.filter(user=self.user_2).count(), 2
+        )
+
+    def test_attemptlogs(self):
+        self.assertEqual(
+            log_models.AttemptLog.objects.filter(user=self.user_2).count(), 2
+        )
+        log = self.user_1_attemptlog
+        self.assertTrue(
+            log_models.AttemptLog.objects.filter(
+                masterylog__summarylog__progress=log.masterylog.summarylog.progress,
+                user=self.user_2,
+                time_spent=log.time_spent,
+                masterylog__summarylog__channel_id=log.masterylog.summarylog.channel_id,
+                masterylog__summarylog__content_id=log.masterylog.summarylog.content_id,
+            ).exists()
+        )
+
+    def test_contentsessionlogs(self):
+        self.assertEqual(
+            log_models.ContentSessionLog.objects.filter(user=self.user_2).count(),
+            len(self.user_1_sess_logs) + len(self.user_2_sess_logs),
+        )
+        for log in self.user_1_sess_logs:
+            self.assertTrue(
+                log_models.ContentSessionLog.objects.filter(
+                    progress=log.progress,
+                    user=self.user_2,
+                    content_id=log.content_id,
+                    channel_id=log.channel_id,
+                ).exists()
+            )
+
+    def test_contentsummarylogs(self):
+        self.assertEqual(
+            log_models.ContentSummaryLog.objects.filter(user=self.user_2).count(),
+            len(self.user_1_summ_logs) + len(self.user_2_summ_logs),
+        )
+        for log in self.user_1_summ_logs:
+            self.assertTrue(
+                log_models.ContentSummaryLog.objects.filter(
+                    progress=log.progress,
+                    user=self.user_2,
+                    content_id=log.content_id,
+                    channel_id=log.channel_id,
+                ).exists()
+            )

--- a/kolibri/core/auth/utils.py
+++ b/kolibri/core/auth/utils.py
@@ -4,6 +4,11 @@ from django.utils.six.moves import input
 
 from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Membership
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.models import UserSessionLog
 
 
 def confirm_or_exit(message):
@@ -20,3 +25,124 @@ def create_adhoc_group_for_learners(classroom, learners):
     for learner in learners:
         Membership.objects.create(user=learner, collection=adhoc_group)
     return adhoc_group
+
+
+models_to_copy = [
+    ContentSessionLog,
+    ContentSummaryLog,
+    MasteryLog,
+    AttemptLog,
+    UserSessionLog,
+]
+
+user_fields = [
+    "gender",
+    "birth_year",
+    "id_number",
+]
+
+log_fields = {
+    ContentSessionLog: [
+        "content_id",
+        "visitor_id",
+        "channel_id",
+        "start_timestamp",
+        "end_timestamp",
+        "time_spent",
+        "progress",
+        "kind",
+        "extra_fields",
+    ],
+    ContentSummaryLog: [
+        "content_id",
+        "channel_id",
+        "start_timestamp",
+        "end_timestamp",
+        "completion_timestamp",
+        "time_spent",
+        "progress",
+        "kind",
+        "extra_fields",
+    ],
+    UserSessionLog: [
+        "channels",
+        "start_timestamp",
+        "last_interaction_timestamp",
+        "pages",
+        "device_info",
+    ],
+    MasteryLog: [
+        "mastery_criterion",
+        "start_timestamp",
+        "end_timestamp",
+        "completion_timestamp",
+        "mastery_level",
+        "complete",
+        ("summarylog_id", ContentSummaryLog),
+    ],
+    AttemptLog: [
+        "item",
+        "start_timestamp",
+        "end_timestamp",
+        "completion_timestamp",
+        "time_spent",
+        "complete",
+        "correct",
+        "hinted",
+        "answer",
+        "simple_answer",
+        "interaction_history",
+        "error",
+        ("masterylog_id", MasteryLog),
+        ("sessionlog_id", ContentSessionLog),
+    ],
+}
+
+
+def _merge_user_models(source_user, target_user):
+    for f in user_fields:
+        source_value = getattr(source_user, f, None)
+        target_value = getattr(target_user, f, None)
+        if not target_value and source_value:
+            setattr(target_user, f, source_value)
+    target_user.save()
+
+
+def merge_users(source_user, target_user):
+    """
+    Utility to merge two users. It makes no assumptions about whether
+    the users are in the same facility and does raw copies of all
+    associated user data, rather than try to do anything clever.
+    """
+    if source_user.id == target_user.id:
+        raise ValueError("Cannot merge a user with themselves")
+
+    _merge_user_models(source_user, target_user)
+
+    id_map = {}
+
+    def _merge_log_data(source_user, target_user, LogModel):
+        log_map = {}
+        id_map[LogModel] = log_map
+        for log in LogModel.objects.filter(user=source_user):
+            data = {}
+            for f in log_fields[LogModel]:
+                if isinstance(f, tuple):
+                    field_name, model = f
+                    data[field_name] = id_map[model][getattr(log, field_name)]
+                else:
+                    data[f] = getattr(log, f)
+            new_log = LogModel.objects.create(user=target_user, **data)
+            log_map[log.id] = new_log.id
+
+    _merge_log_data(source_user, target_user, ContentSessionLog)
+
+    _merge_log_data(source_user, target_user, ContentSummaryLog)
+
+    _merge_log_data(source_user, target_user, UserSessionLog)
+
+    _merge_log_data(source_user, target_user, MasteryLog)
+
+    _merge_log_data(source_user, target_user, AttemptLog)
+
+    source_user.delete()

--- a/kolibri/core/auth/utils.py
+++ b/kolibri/core/auth/utils.py
@@ -112,5 +112,3 @@ def merge_users(source_user, target_user):
     _merge_log_data(MasteryLog)
 
     _merge_log_data(AttemptLog)
-
-    source_user.delete()

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -20,7 +20,6 @@ from django.conf.urls import url
 from rest_framework import routers
 
 from ..auth.api import PublicFacilityViewSet
-from ..auth.api import PublicSignUpViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
@@ -29,7 +28,6 @@ from .api import InfoViewSet
 router = routers.SimpleRouter()
 
 router.register(r"v1/facility", PublicFacilityViewSet, base_name="publicfacility")
-router.register(r"v1/signup", PublicSignUpViewSet, base_name="publicsignup")
 router.register(r"info", InfoViewSet, base_name="info")
 
 # Add public api endpoints

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -20,6 +20,7 @@ from django.conf.urls import url
 from rest_framework import routers
 
 from ..auth.api import PublicFacilityViewSet
+from ..auth.api import PublicSignUpViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
@@ -28,6 +29,7 @@ from .api import InfoViewSet
 router = routers.SimpleRouter()
 
 router.register(r"v1/facility", PublicFacilityViewSet, base_name="publicfacility")
+router.register(r"v1/signup", PublicSignUpViewSet, base_name="publicsignup")
 router.register(r"info", InfoViewSet, base_name="info")
 
 # Add public api endpoints


### PR DESCRIPTION
## Summary
* Adds utility to merge one user into another

## References
Fixes #8061

## Reviewer guidance
Do the tests make sense?
Should we be stopping signups in the public and private viewsets when the facility doesn't allow signups?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
