### PR TITLE
In Facility task cards, only quote the facility name and not the ID fragment

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -93,7 +93,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   invalidCredentialsError: 'Incorrect username or password',
 
   // Formatting
-  nameWithIdInParens: '{name} ({id})',
+  nameWithIdInParens: `'{name}' ({id})`,
   quotedPhrase: `'{phrase}'`,
   dashSeparatedPair: '{item1} - {item2}',
   dashSeparatedTriple: '{item1} - {item2} - {item3}',

--- a/kolibri/core/assets/src/mixins/taskStrings.js
+++ b/kolibri/core/assets/src/mixins/taskStrings.js
@@ -69,7 +69,7 @@ const taskStrings = createTranslator('TaskStrings', {
     context: 'Sync task status',
   },
   syncFacilityTaskLabel: {
-    message: "Sync '{facilityName}'",
+    message: 'Sync {facilityName}',
     context: 'Description of sync-facility task',
   },
   syncStepAndDescription: {
@@ -87,7 +87,7 @@ const taskStrings = createTranslator('TaskStrings', {
     context: 'Remove facility task status',
   },
   removeFacilityTaskLabel: {
-    message: "Remove '{facilityName}'",
+    message: 'Remove {facilityName}',
     context: 'Description of a remove-facility task',
   },
   removeFacilitySuccessStatus: {
@@ -97,7 +97,7 @@ const taskStrings = createTranslator('TaskStrings', {
 
   // Import Facility Task strings
   importFacilityTaskLabel: {
-    message: "Import '{facilityName}'",
+    message: 'Import {facilityName}',
     context: 'Description of import-facility task',
   },
   importSuccessStatus: {

--- a/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/syncTaskUtils.spec.js
@@ -40,14 +40,14 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
     const task = makeTask('RUNNING');
     task.type = 'SYNCPEER/FULL';
     const displayInfo = syncFacilityTaskDisplayInfo(task);
-    expect(displayInfo.headingMsg).toEqual("Sync 'generic facility (fac1)'");
+    expect(displayInfo.headingMsg).toEqual("Sync 'generic facility' (fac1)");
   });
 
   it('displays the correct header for facility-import tasks', () => {
     const task = makeTask('RUNNING');
     task.type = 'SYNCPEER/PULL';
     const displayInfo = syncFacilityTaskDisplayInfo(task);
-    expect(displayInfo.headingMsg).toEqual("Import 'generic facility (fac1)'");
+    expect(displayInfo.headingMsg).toEqual("Import 'generic facility' (fac1)");
   });
 
   it('display title, started by username, and device name are invariant wrt status', () => {
@@ -63,9 +63,9 @@ describe('syncTaskUtils.syncFacilityTaskDisplayInfo', () => {
     ALL_STATUSES.forEach(status => {
       task.status = status;
       expect(syncFacilityTaskDisplayInfo(task)).toMatchObject({
-        headingMsg: "Sync 'invariant facility (fac1)'",
+        headingMsg: "Sync 'invariant facility' (fac1)",
         startedByMsg: "Started by 'invariant user'",
-        deviceNameMsg: "'invariant device (dev1)'",
+        deviceNameMsg: "'invariant device' (dev1)",
       });
     });
   });
@@ -164,7 +164,7 @@ describe('syncTaskUtils.removeFacilityTaskDisplayInfo', () => {
     ALL_STATUSES.forEach(status => {
       const task = makeTask(status);
       expect(removeFacilityTaskDisplayInfo(task)).toMatchObject({
-        headingMsg: "Remove 'removed facility (fac1)'",
+        headingMsg: "Remove 'removed facility' (fac1)",
         startedByMsg: "Started by 'removing user'",
       });
     });

--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -72,9 +72,7 @@ export function syncFacilityTaskDisplayInfo(task) {
   if (task.type === TaskTypes.SYNCDATAPORTAL) {
     deviceNameMsg = 'Kolibri Data Portal';
   } else if (task.device_name) {
-    deviceNameMsg = coreString('quotedPhrase', {
-      phrase: formatNameWithId(task.device_name, task.device_id),
-    });
+    deviceNameMsg = formatNameWithId(task.device_name, task.device_id);
   }
   const syncStep = syncTaskStatusToStepMap[task.sync_state];
   const statusDescription =


### PR DESCRIPTION


## Summary

Fixes #7123

## References

## Reviewer guidance

The tests should confirm the new behavior, but this can be manually confirmed by importing/syncing/deleting a facility in the app.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
