### PR TITLE
On crowdin server `$formatRelative` (and other APIs) should use the interpolated locale (and not 'ach-ug')

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -188,6 +188,17 @@ function _setUpVueIntl() {
     return $trWrapper(nameSpace, this.$options.$trs, this.$formatMessage, messageId, args);
   };
 
+  // This handles the special 'ach-ug' locale on the Crowdin translation server at
+  // https://kolibri-translate.learningequality.org/ach-ug/
+  // The Crowdin jipt.js script will inject the real language's code at this localStorage key.
+  if (currentLanguage === 'ach-ug' && localStorage.jipt_language_code_kolibri) {
+    // After making this substitution and calling Vue.setLocale, the messages injected
+    // under 'ach-ug' will be remapped to the real locale within vue-intl's methods.
+    // Thus, Vue.prototype.$formatMessage should still work as expected, while also fixing
+    // #7330 and similar issues related to the Intl API.
+    currentLanguage = localStorage.jipt_language_code_kolibri;
+  }
+
   Vue.setLocale(currentLanguage);
   if (languageGlobals.coreLanguageMessages) {
     Vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -1,5 +1,5 @@
 import has from 'lodash/has';
-import vue from 'kolibri.lib.vue';
+import Vue from 'kolibri.lib.vue';
 import logger from 'kolibri.lib.logging';
 import { languageDirections, defaultLanguage } from 'kolibri-design-system/lib/utils/i18n';
 import importIntlLocale from './intl-locale-data';
@@ -128,26 +128,26 @@ class Translator {
     return $trWrapper(
       this.nameSpace,
       this.defaultMessages,
-      vue.prototype.$formatMessage,
+      Vue.prototype.$formatMessage,
       messageId,
       args
     );
   }
   // For convenience, also proxy all vue intl translation methods on this object
   $formatDate(date, options = {}) {
-    return vue.prototype.$formatDate(date, options);
+    return Vue.prototype.$formatDate(date, options);
   }
   $formatTime(time, options = {}) {
-    return vue.prototype.$formatTime(time, options);
+    return Vue.prototype.$formatTime(time, options);
   }
   $formatRelative(date, options = {}) {
-    return vue.prototype.$formatRelative(date, options);
+    return Vue.prototype.$formatRelative(date, options);
   }
   $formatNumber(number, options = {}) {
-    return vue.prototype.$formatNumber(number, options);
+    return Vue.prototype.$formatNumber(number, options);
   }
   $formatPlural(plural, options = {}) {
-    return vue.prototype.$formatPlural(plural, options);
+    return Vue.prototype.$formatPlural(plural, options);
   }
 }
 
@@ -180,17 +180,17 @@ function _setUpVueIntl() {
    * the currentLanguage module variable which is referenced inside of here.
    **/
   const VueIntl = require('vue-intl');
-  vue.use(VueIntl, { defaultLocale });
-  vue.prototype.isRtl = languageDirection === 'rtl';
+  Vue.use(VueIntl, { defaultLocale });
+  Vue.prototype.isRtl = languageDirection === 'rtl';
 
-  vue.prototype.$tr = function $tr(messageId, args) {
+  Vue.prototype.$tr = function $tr(messageId, args) {
     const nameSpace = this.$options.name || this.$options.$trNameSpace;
     return $trWrapper(nameSpace, this.$options.$trs, this.$formatMessage, messageId, args);
   };
 
-  vue.setLocale(currentLanguage);
+  Vue.setLocale(currentLanguage);
   if (languageGlobals.coreLanguageMessages) {
-    vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);
+    Vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);
   }
   importVueIntlLocaleData().forEach(localeData => VueIntl.addLocaleData(localeData));
 


### PR DESCRIPTION
## Summary

1. Adds a guard in the i18n setup code that pulls the real language code from localStorage (on the Crowdin server) and uses that to configure VueIntl's bootstrapping.

## References

Fixes #7330 , but this is only confirmed locally. Will need to reconfirm once it is redeployed to the translation server.

## Reviewer guidance

@pcenov @radinamatic 

Per https://github.com/learningequality/kolibri/issues/7330#issuecomment-845378931, local testing might not be perfect because of some issues with the state of the localizations. Regardless, the fix for the "relative time" message on the Facility > Data page in #7330. Can be tested by taking the code or generated pex and running `kolibri start` with the translation settings:

```
kolibri start --settings=kolibri.deployment.default.settings.translation
```

For some reason, not all of the text will be localized (especially the "Generated ..." message in the screenshots), but, in my testing, the relative time localization on the Facility > Data page does look to be fixed for all of the languages supported by Kolibri.

![CleanShot 2021-05-20 at 11 34 40](https://user-images.githubusercontent.com/10248067/119040443-488ffd00-b96a-11eb-8f73-5bcb666dd7ea.png)
![CleanShot 2021-05-20 at 11 34 18](https://user-images.githubusercontent.com/10248067/119040446-49c12a00-b96a-11eb-90d2-219bae5111a2.png)
![CleanShot 2021-05-20 at 11 34 00](https://user-images.githubusercontent.com/10248067/119040447-49c12a00-b96a-11eb-8ec0-e50a890823ba.png)
![CleanShot 2021-05-20 at 11 32 10](https://user-images.githubusercontent.com/10248067/119040448-4a59c080-b96a-11eb-94d9-483fe22a8261.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
