### PR TITLE
Stop TextTruncator from briefly showing full text before shave.js truncates it

### DIFF
--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div :style="{ maxHeight: `${maxHeight - 16}px` }" :class="{ truncated: !shaveDone }">
     <div v-if="viewAllText">
       {{ text }}
     </div>
@@ -53,14 +53,13 @@
     data() {
       return {
         textIsTruncated: false,
+        shaveDone: false,
         viewAllText: false,
       };
     },
     computed: {
       currentDimensions() {
         return {
-          text: this.text,
-          maxHeight: this.maxHeight,
           elementWidth: this.elementWidth,
           elementHeight: this.elementHeight,
         };
@@ -88,20 +87,24 @@
           return $shaveEl.clientWidth < $shaveEl.scrollWidth;
         }
       },
+      updateTitle() {
+        // Set title attribute as full text if the visible text is truncated
+        if (this.textIsTruncated && !this.$refs.shaveEl.title) {
+          this.$refs.shaveEl.setAttribute('title', this.text);
+        } else if (!this.textIsTruncated && this.$refs.shaveEl.title) {
+          // Remove if text is fully visible after a resize
+          this.$refs.shaveEl.removeAttribute('title');
+        }
+      },
       handleUpdate() {
         // TODO make "View Less" disappear when user expands window
-        // and text isn't truncated any more.
+        // and text isn't truncated anymore.
         shave(this.$refs.shaveEl, this.maxHeight, { spaces: false });
-        this.$nextTick(() => {
+        this.$nextTick().then(() => {
           this.textIsTruncated = this.titleIsShaved() || this.titleIsOverflowing();
-          // set title attribute for shaved text but
-          // skip if a title already exists
-          if (this.textIsTruncated && !this.$refs.shaveEl.title)
-            this.$refs.shaveEl.setAttribute('title', this.text);
-          // if the text is not shaved and a title has been previously set,
-          // remove it
-          else if (!this.textIsTruncated && this.$refs.shaveEl.title)
-            this.$refs.shaveEl.removeAttribute('title');
+          this.updateTitle();
+          // Removes temporary truncated styling from main div
+          this.shaveDone = true;
         });
       },
     },

--- a/kolibri/core/assets/src/views/TextTruncator.vue
+++ b/kolibri/core/assets/src/views/TextTruncator.vue
@@ -73,6 +73,9 @@
         this.debouncedHandleUpdate();
       },
     },
+    beforeDestroy() {
+      this.debouncedHandleUpdate.cancel();
+    },
     methods: {
       titleIsShaved() {
         return Boolean(this.$el.querySelector('.js-shave'));


### PR DESCRIPTION
## Summary

1. Adds an inline style to the top-level div of TextTruncator that limits the height and hides the overflow of the untruncated `text` prop before shave.js can work on it. These styles are removed after shave.js has completed its work.
2. Cancels the debounced `updateTitle` calls during the `beforeDestroy` hook so the code isn't executed later when the component is unmounted (creating a lot of logs in the console).

Screengrabs from TE - China

**Before**

![CleanShot 2021-05-21 at 12 03 16](https://user-images.githubusercontent.com/10248067/119189463-efd76780-ba30-11eb-8895-cf0bebb77a75.gif)

**After**

There is a slight change after shave.js works, but much more subtle than before

![CleanShot 2021-05-21 at 11 34 32](https://user-images.githubusercontent.com/10248067/119189541-08e01880-ba31-11eb-8995-a549fb7bfc3a.gif)

## References

Fixes #7982 

## Reviewer guidance

Find a channel where nodes have long descriptions like Touchable Earth or CK-12. You should be able to browse the Lesson Creation workflow without seeing the issues in #7982 


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
