### PR TITLE
Update values viewset implementation and pagination

### DIFF
--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -1,13 +1,19 @@
 import uuid
 
 import requests
+from django.db.models import Q
 from django.http import Http404
 from rest_framework import viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.filters import OrderingFilter
+from rest_framework.generics import get_object_or_404
+from rest_framework.mixins import CreateModelMixin as BaseCreateModelMixin
+from rest_framework.mixins import DestroyModelMixin
+from rest_framework.mixins import UpdateModelMixin as BaseUpdateModelMixin
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 from rest_framework.serializers import UUIDField
+from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_201_CREATED
 from six.moves.urllib.parse import urljoin
 
@@ -42,7 +48,77 @@ class KolibriDataPortalViewSet(viewsets.ViewSet):
         return Response(data, status=response.status_code)
 
 
-class ValuesViewset(viewsets.ModelViewSet):
+class ValuesViewsetOrderingFilter(OrderingFilter):
+    def get_default_valid_fields(self, queryset, view, context={}):
+        """
+        The original implementation of this makes the assumption that the DRF serializer for the class
+        encodes all the serialization behaviour for the viewset:
+        https://github.com/encode/django-rest-framework/blob/version-3.12.2/rest_framework/filters.py#L208
+
+        With the ValuesViewset, this is no longer the case so here we do an equivalent mapping from the values
+        defined by the values viewset, with consideration for the mapped fields.
+
+        Importantly, we filter out values that have not yet been annotated on the queryset, so if an annotated
+        value is requried for ordering, it should be defined in the get_queryset method of the viewset, and not
+        the annotate_queryset method, which is executed after filtering.
+        """
+        default_fields = set()
+        # All the fields that we have field maps defined for - this only allows for simple mapped fields
+        # where the field is essentially a rename, as we have no good way of doing ordering on a field that
+        # that is doing more complex function based mapping.
+        mapped_fields = {v: k for k, v in view.field_map.items() if isinstance(v, str)}
+        # All the fields of the model
+        model_fields = {f.name for f in queryset.model._meta.get_fields()}
+        # Loop through every value in the view's values tuple
+        for field in view.values:
+            # If the value is for a foreign key lookup, we split it here to make sure that the first relation key
+            # exists on the model - it's unlikely this would ever not be the case, as otherwise the viewset would
+            # be returning 500s.
+            fk_ref = field.split("__")[0]
+            # Check either if the field is a model field, a currently annotated annotation, or
+            # is a foreign key lookup on an FK on this model.
+            if (
+                field in model_fields
+                or field in queryset.query.annotations
+                or fk_ref in model_fields
+            ):
+                # If the field is a mapped field, we store the field name as returned to the client
+                # not the actual internal field - this will later be mapped when we come to do the ordering.
+                if field in mapped_fields:
+                    default_fields.add((mapped_fields[field], mapped_fields[field]))
+                else:
+                    default_fields.add((field, field))
+
+        return default_fields
+
+    def remove_invalid_fields(self, queryset, fields, view, request):
+        """
+        Modified from https://github.com/encode/django-rest-framework/blob/version-3.12.2/rest_framework/filters.py#L259
+        to do filtering based on valuesviewset setup
+        """
+        # We filter the mapped fields to ones that do simple string mappings here, any functional maps are excluded.
+        mapped_fields = {k: v for k, v in view.field_map.items() if isinstance(v, str)}
+        valid_fields = [
+            item[0]
+            for item in self.get_valid_fields(queryset, view, {"request": request})
+        ]
+        ordering = []
+        for term in fields:
+            if term.lstrip("-") in valid_fields:
+                if term.lstrip("-") in mapped_fields:
+                    # In the case that the ordering field is a mapped field on the values viewset
+                    # we substitute the serialized name of the field for the database name.
+                    prefix = "-" if term[0] == "-" else ""
+                    new_term = prefix + mapped_fields[term.lstrip("-")]
+                    ordering.append(new_term)
+                else:
+                    ordering.append(term)
+        if len(ordering) > 1:
+            raise ValidationError("Can only define a single ordering field")
+        return ordering
+
+
+class ReadOnlyValuesViewset(viewsets.ReadOnlyModelViewSet):
     """
     A viewset that uses a values call to get all model/queryset data in
     a single database query, rather than delegating serialization to a
@@ -53,13 +129,13 @@ class ValuesViewset(viewsets.ModelViewSet):
     values = None
     # A map of target_key, source_key where target_key is the final target_key that will be set
     # and source_key is the key on the object retrieved from the values call.
+    # Alternatively, the source_key can be a callable that will be passed the object and return
+    # the value for the target_key. This callable can also pop unwanted values from the obj
+    # to remove unneeded keys from the object as a side effect.
     field_map = {}
 
-    # Create a read only property rather than creating separate viewsets
-    read_only = False
-
     def __init__(self, *args, **kwargs):
-        viewset = super(ValuesViewset, self).__init__(*args, **kwargs)
+        viewset = super(ReadOnlyValuesViewset, self).__init__(*args, **kwargs)
         if not isinstance(self.values, tuple):
             raise TypeError("values must be defined as a tuple")
         self._values = tuple(self.values)
@@ -68,16 +144,115 @@ class ValuesViewset(viewsets.ModelViewSet):
         self._field_map = self.field_map.copy()
         return viewset
 
+    @classmethod
+    def id_attr(cls):
+        if cls.serializer_class is not None and hasattr(
+            cls.serializer_class, "id_attr"
+        ):
+            return cls.serializer_class.id_attr()
+        return None
+
+    @classmethod
+    def values_from_key(cls, key):
+        """
+        Method to return an iterable that can be used as arguments for dict
+        to return the values from key.
+        Key is either a string, in which case the key is a singular value
+        or a list, in which case the key is a combined value.
+        """
+        id_attr = cls.id_attr()
+
+        if id_attr:
+            if isinstance(id_attr, str):
+                # Singular value
+                # Just return the single id_attr and the original key
+                return [(id_attr, key)]
+            else:
+                # Multiple values in the key, zip together the id_attr and the key
+                # to create key, value pairs for a dict
+                # Order in the key matters, and must match the "update_lookup_field"
+                # property of the serializer.
+                return [(attr, value) for attr, value in zip(id_attr, key)]
+        return []
+
+    @classmethod
+    def filter_queryset_from_keys(cls, queryset, keys):
+        """
+        Method to filter a queryset based on keys.
+        """
+        id_attr = cls.id_attr()
+
+        if id_attr:
+            if isinstance(id_attr, str):
+                # In the case of single valued keys, this is just an __in lookup
+                return queryset.filter(**{"{}__in".format(id_attr): keys})
+            else:
+                # If id_attr is multivalued we need to do an ORed lookup for each
+                # set of values represented by a key.
+                # This is probably not as performant as the simple __in query
+                # improvements welcome!
+                query = Q()
+                for key in keys:
+                    query |= Q(**{attr: value for attr, value in zip(id_attr, key)})
+                return queryset.filter(query)
+        return queryset.none()
+
     def get_serializer_class(self):
         if self.serializer_class is not None:
             return self.serializer_class
         # Hack to prevent the renderer logic from breaking completely.
         return Serializer
 
-    def annotate_queryset(self, queryset):
+    def get_queryset(self):
+        queryset = super(ReadOnlyValuesViewset, self).get_queryset()
+        if hasattr(queryset.model, "filter_view_queryset"):
+            return queryset.model.filter_view_queryset(queryset, self.request.user)
         return queryset
 
-    def prefetch_queryset(self, queryset):
+    def get_edit_queryset(self):
+        """
+        Return a filtered copy of the queryset to only the objects
+        that a user is able to edit, rather than view.
+        """
+        queryset = super(ReadOnlyValuesViewset, self).get_queryset()
+        if hasattr(queryset.model, "filter_edit_queryset"):
+            return queryset.model.filter_edit_queryset(queryset, self.request.user)
+        return self.get_queryset()
+
+    def _get_lookup_filter(self):
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+
+        assert lookup_url_kwarg in self.kwargs, (
+            "Expected view %s to be called with a URL keyword argument "
+            'named "%s". Fix your URL conf, or set the `.lookup_field` '
+            "attribute on the view correctly."
+            % (self.__class__.__name__, lookup_url_kwarg)
+        )
+
+        return {self.lookup_field: self.kwargs[lookup_url_kwarg]}
+
+    def _get_object_from_queryset(self, queryset):
+        """
+        Returns the object the view is displaying.
+        We override this to remove the DRF default behaviour
+        of filtering the queryset.
+        (rtibbles) There doesn't seem to be a use case for
+        querying a detail endpoint and also filtering by query
+        parameters that might result in a 404.
+        """
+        # Perform the lookup filtering.
+        filter_kwargs = self._get_lookup_filter()
+        obj = get_object_or_404(queryset, **filter_kwargs)
+
+        # May raise a permission denied
+        self.check_object_permissions(self.request, obj)
+
+        return obj
+
+    def get_object(self):
+        return self._get_object_from_queryset(self.get_queryset())
+
+    def annotate_queryset(self, queryset):
         return queryset
 
     def _map_fields(self, item):
@@ -93,56 +268,68 @@ class ValuesViewset(viewsets.ModelViewSet):
     def consolidate(self, items, queryset):
         return items
 
-    def _serialize_queryset(self, queryset):
+    def _cast_queryset_to_values(self, queryset):
         queryset = self.annotate_queryset(queryset)
         return queryset.values(*self._values)
 
     def serialize(self, queryset):
-        return self.consolidate(
-            list(map(self._map_fields, self._serialize_queryset(queryset) or [])),
-            queryset,
-        )
+        return self.consolidate(list(map(self._map_fields, queryset or [])), queryset)
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.prefetch_queryset(self.get_queryset()))
+        queryset = self.filter_queryset(self.get_queryset())
 
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            return self.get_paginated_response(self.serialize(page))
+        page_queryset = self.paginate_queryset(queryset)
+
+        if page_queryset is not None:
+            queryset = page_queryset
+
+        queryset = self._cast_queryset_to_values(queryset)
+
+        if page_queryset is not None:
+            return self.get_paginated_response(self.serialize(queryset))
 
         return Response(self.serialize(queryset))
 
-    def serialize_object(self, pk):
-        queryset = self.filter_queryset(self.prefetch_queryset(self.get_queryset()))
+    def serialize_object(self, **filter_kwargs):
+        queryset = self.get_queryset()
         try:
-            return self.serialize(queryset.filter(pk=pk))[0]
+            filter_kwargs = filter_kwargs or self._get_lookup_filter()
+            return self.serialize(
+                self._cast_queryset_to_values(queryset.filter(**filter_kwargs))
+            )[0]
         except IndexError:
             raise Http404(
                 "No %s matches the given query." % queryset.model._meta.object_name
             )
 
-    def retrieve(self, request, pk, *args, **kwargs):
-        return Response(self.serialize_object(pk))
+    def retrieve(self, request, *args, **kwargs):
+        return Response(self.serialize_object())
 
+
+class CreateModelMixin(BaseCreateModelMixin):
     def create(self, request, *args, **kwargs):
-        if self.read_only:
-            raise MethodNotAllowed
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
         instance = serializer.instance
-        return Response(self.serialize_object(instance.id), status=HTTP_201_CREATED)
+        return Response(self.serialize_object(pk=instance.pk), status=HTTP_201_CREATED)
 
+
+class UpdateModelMixin(BaseUpdateModelMixin):
     def update(self, request, *args, **kwargs):
-        if self.read_only:
-            raise MethodNotAllowed
         partial = kwargs.pop("partial", False)
-        instance = self.get_object()
+        instance = self.get_edit_object()
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
 
-        return Response(self.serialize_object(instance.id))
+        return Response(self.serialize_object())
+
+
+class ValuesViewset(
+    ReadOnlyValuesViewset, CreateModelMixin, UpdateModelMixin, DestroyModelMixin
+):
+    pass
 
 
 class HexUUIDField(UUIDField):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -59,6 +59,7 @@ from .serializers import MembershipSerializer
 from .serializers import PublicFacilitySerializer
 from .serializers import RoleSerializer
 from kolibri.core import error_constants
+from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.api import ValuesViewset
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import allow_other_browsers_to_connect
@@ -283,12 +284,10 @@ class ExistingUsernameView(views.APIView):
             return Response({"username_exists": False}, status=status.HTTP_200_OK)
 
 
-class FacilityUsernameViewSet(ValuesViewset):
+class FacilityUsernameViewSet(ReadOnlyValuesViewset):
     filter_backends = (DjangoFilterBackend, filters.SearchFilter)
     filter_fields = ("facility",)
     search_fields = ("^username",)
-
-    read_only = True
 
     values = ("username",)
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -25,14 +25,13 @@ from django_filters.rest_framework import UUIDFilter
 from le_utils.constants import content_kinds
 from le_utils.constants import languages
 from rest_framework import mixins
-from rest_framework import pagination
 from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.decorators import list_route
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 
-from kolibri.core.api import ValuesViewset
+from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.middleware import session_exempt
 from kolibri.core.content import models
 from kolibri.core.content import serializers
@@ -60,6 +59,7 @@ from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.query import SQSum
+from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 
 
 logger = logging.getLogger(__name__)
@@ -199,7 +199,7 @@ class ContentNodeFilter(IdFilter):
         return queryset.filter(coach_content=False)
 
 
-class OptionalPageNumberPagination(pagination.PageNumberPagination):
+class OptionalPageNumberPagination(ValuesViewsetPageNumberPagination):
     """
     Pagination class that allows for page number-style pagination, when requested.
     To activate, the `page_size` argument must be set. For example, to request the first 20 records:
@@ -246,7 +246,7 @@ def map_file(file):
 
 
 @method_decorator(cache_forever, name="dispatch")
-class ContentNodeViewset(ValuesViewset):
+class ContentNodeViewset(ReadOnlyValuesViewset):
     filter_backends = (DjangoFilterBackend,)
     filter_class = ContentNodeFilter
     pagination_class = OptionalPageNumberPagination
@@ -280,8 +280,6 @@ class ContentNodeViewset(ValuesViewset):
     )
 
     field_map = {"lang": map_lang}
-
-    read_only = True
 
     def consolidate(self, items, queryset):
         output = []
@@ -907,7 +905,7 @@ def mean(data):
     return mean
 
 
-class ContentNodeProgressViewset(ValuesViewset):
+class ContentNodeProgressViewset(ReadOnlyValuesViewset):
     filter_backends = (DjangoFilterBackend,)
     filter_class = ContentNodeProgressFilter
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -521,9 +521,8 @@ class ContentNodeViewset(ReadOnlyValuesViewset):
         pk = kwargs.get("pk", None)
         node = get_object_or_404(queryset, pk=pk)
         queryset = self.filter_queryset(self.get_queryset())
-        queryset = self.prefetch_queryset(
-            queryset
-            & node.get_siblings(include_self=False).exclude(kind=content_kinds.TOPIC)
+        queryset = queryset & node.get_siblings(include_self=False).exclude(
+            kind=content_kinds.TOPIC
         )
         return Response(self.serialize(queryset))
 
@@ -541,7 +540,7 @@ class ContentNodeViewset(ReadOnlyValuesViewset):
         """
         user = request.user
         user_id = kwargs.get("pk", None)
-        queryset = self.prefetch_queryset(self.get_queryset())
+        queryset = self.get_queryset()
         # if user is anonymous, don't return any nodes
         # if person requesting is not the data they are requesting for, also return no nodes
         if not user.is_facility_user or user.id != user_id:
@@ -600,7 +599,7 @@ class ContentNodeViewset(ReadOnlyValuesViewset):
         if cache.get(cache_key) is not None:
             return Response(cache.get(cache_key))
 
-        queryset = self.filter_queryset(self.prefetch_queryset(self.get_queryset()))
+        queryset = self.filter_queryset(self.get_queryset())
 
         if ContentSessionLog.objects.count() < 50:
             # return 25 random content nodes if not enough session logs
@@ -654,7 +653,7 @@ class ContentNodeViewset(ReadOnlyValuesViewset):
         """
         user = request.user
         user_id = kwargs.get("pk", None)
-        queryset = self.prefetch_queryset(self.get_queryset())
+        queryset = self.get_queryset()
         # if user is anonymous, don't return any nodes
         # if person requesting is not the data they are requesting for, also return no nodes
         if not user.is_facility_user or user.id != user_id:

--- a/kolibri/core/utils/pagination.py
+++ b/kolibri/core/utils/pagination.py
@@ -1,0 +1,132 @@
+import hashlib
+
+from django.core.cache import cache
+from django.core.exceptions import EmptyResultSet
+from django.core.paginator import InvalidPage
+from django.core.paginator import Page
+from django.core.paginator import Paginator
+from django.db.models import QuerySet
+from django.utils.functional import cached_property
+from rest_framework.pagination import NotFound
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class ValuesPage(Page):
+    def __init__(self, object_list, number, paginator):
+        self.queryset = object_list
+        self.object_list = object_list
+        self.number = number
+        self.paginator = paginator
+
+
+class ValuesViewsetPaginator(Paginator):
+    def __init__(self, object_list, *args, **kwargs):
+        if not isinstance(object_list, QuerySet):
+            raise TypeError(
+                "ValuesViewsetPaginator is only intended for use with Querysets"
+            )
+        self.queryset = object_list
+        object_list = object_list.values_list("pk", flat=True).distinct()
+        return super(ValuesViewsetPaginator, self).__init__(
+            object_list, *args, **kwargs
+        )
+
+    def _get_page(self, object_list, *args, **kwargs):
+        pks = list(object_list)
+        return ValuesPage(self.queryset.filter(pk__in=pks), *args, **kwargs)
+
+
+class CachedValuesViewsetPaginator(ValuesViewsetPaginator):
+    @cached_property
+    def count(self):
+        """
+        The count is implemented with this 'double cache' so as to cache the empty results
+        as well. Because the cache key is dependent on the query string, and that cannot be
+        generated in the instance that the query_string produces an EmptyResultSet exception.
+        """
+        try:
+            query_string = str(self.object_list.query).encode("utf8")
+            cache_key = "query-count:" + hashlib.md5(query_string).hexdigest()
+            value = cache.get(cache_key)
+            if value is None:
+                value = super(CachedValuesViewsetPaginator, self).count
+                cache.set(cache_key, value, 300)  # save the count for 5 minutes
+        except EmptyResultSet:
+            # If the query is an empty result set, then this error will be raised by
+            # Django - this happens, for example when doing a pk__in=[] query
+            # In this case, we know the value is just 0!
+            value = 0
+        return value
+
+
+class ValuesViewsetPageNumberPagination(PageNumberPagination):
+    django_paginator_class = ValuesViewsetPaginator
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Paginate a queryset if required, either returning a
+        the queryset of a page object so that it can be further annotated for serialization,
+        or `None` if pagination is not configured for this view.
+        This is vendored and modified from:
+        https://github.com/encode/django-rest-framework/blob/master/rest_framework/pagination.py#L191
+        """
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        paginator = self.django_paginator_class(queryset, page_size)
+        page_number = request.query_params.get(self.page_query_param, 1)
+
+        try:
+            self.page = paginator.page(page_number)
+        except InvalidPage as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=str(exc)
+            )
+            raise NotFound(msg)
+
+        if paginator.num_pages > 1 and self.template is not None:
+            # The browsable API should display pagination controls.
+            self.display_page_controls = True
+
+        self.request = request
+        # This is the only difference between the original function and this implementation
+        # here, instead of returning the page coerced to a list, we explicitly return the queryset
+        # of the page, so that we can do further annotations on it - otherwise, once it is coerced
+        # to a list, the DB read has already occurred.
+        return self.page.queryset
+
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "page": self.page.number,
+                "count": self.page.paginator.count,
+                "total_pages": self.page.paginator.num_pages,
+                "results": data,
+            }
+        )
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "example": 123,
+                },
+                "results": schema,
+                "page": {
+                    "type": "integer",
+                    "example": 123,
+                },
+                "total_pages": {
+                    "type": "integer",
+                    "example": 123,
+                },
+            },
+        }
+
+
+class CachedListPagination(ValuesViewsetPageNumberPagination):
+    django_paginator_class = CachedValuesViewsetPaginator

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -224,7 +224,7 @@ class ClassroomNotificationsViewset(ValuesViewset):
         are requesting notifications in the last five minutes
         """
         try:
-            queryset = self.filter_queryset(self.prefetch_queryset(self.get_queryset()))
+            queryset = self.filter_queryset(self.get_queryset())
         except (OperationalError, DatabaseError):
             repair_sqlite_db(connections["notifications_db"])
 

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -5,7 +5,7 @@ from django.db.models import Subquery
 from django.db.models import Sum
 from rest_framework.permissions import IsAuthenticated
 
-from kolibri.core.api import ValuesViewset
+from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.models import Classroom
 from kolibri.core.exams.models import Exam
@@ -15,7 +15,7 @@ from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
 
 
-class LearnerClassroomViewset(ValuesViewset):
+class LearnerClassroomViewset(ReadOnlyValuesViewset):
     """
     Returns all Classrooms for which the requesting User is a member,
     along with all associated assignments.
@@ -23,8 +23,6 @@ class LearnerClassroomViewset(ValuesViewset):
 
     filter_backends = (KolibriAuthPermissionsFilter,)
     permission_classes = (IsAuthenticated,)
-
-    read_only = True
 
     values = ("id", "name")
 
@@ -158,15 +156,13 @@ def _map_lesson_classroom(item):
     }
 
 
-class LearnerLessonViewset(ValuesViewset):
+class LearnerLessonViewset(ReadOnlyValuesViewset):
     """
     Special Viewset for Learners to view Lessons to which they are assigned.
     The core Lesson Viewset is locked down to Admin users only.
     """
 
     permission_classes = (IsAuthenticated,)
-
-    read_only = True
 
     values = (
         "id",


### PR DESCRIPTION
## Summary
* Ports ValuesViewset implementation from Studio
* Updates all read_only flagged ValuesViewsets to use ReadOnlyValuesViewset
* Tweaks ValuesViewset implementation to pass the queryset prior to the `values` call to consolidate
* Imports the ValuesViewset pagination implementation from Studio and uses it in place of current pagination uses (which upon investigation seemed not to be working)

## References
Fixes #8067

## Reviewer guidance
Do all API tests pass?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
