### PR TITLE
Add vacuum for morango tables in Postgresql databases

### DIFF
--- a/kolibri/core/deviceadmin/management/commands/vacuum.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuum.py
@@ -9,9 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = (
-        "Vacuum Kolibri's SQLite database to optimize it and reduce the .wal file size"
-    )
+    help = "Vacuum Kolibri's database. For Postgresql databases it vacuums only Morango tables, for SQLite databases, it optimizes it and reduces the .wal file size"
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/kolibri/core/deviceadmin/management/commands/vacuum.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuum.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Vacuum Kolibri's database. For Postgresql databases it vacuums only Morango tables, for SQLite databases, it optimizes it and reduces the .wal file size"
+    help = "Vacuum Kolibri's database. For Postgresql databases it vacuums only Morango tables, for SQLite databases, it optimizes it and reduces the .wal file size"  # noqa
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/kolibri/core/deviceadmin/management/commands/vacuum.py
+++ b/kolibri/core/deviceadmin/management/commands/vacuum.py
@@ -19,7 +19,14 @@ class Command(BaseCommand):
             default=DEFAULT_DB_ALIAS,
             help='Specifies the database to vacuum. Defaults to the "default" database.',
         )
+        parser.add_argument(
+            "--full",
+            type=bool,
+            dest="full",
+            default=False,
+            help="If set, in a Postgresql database a full vacuum will be done on the morango_recordmaxcounterbuffer and morango_buffer tables",
+        )
 
     def handle(self, *args, **options):
         database = options["database"]
-        perform_vacuum(database)
+        perform_vacuum(database, options["full"])

--- a/kolibri/core/deviceadmin/utils.py
+++ b/kolibri/core/deviceadmin/utils.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from datetime import timedelta
 
 from django import db
+from django.apps import apps
 from django.conf import settings
 
 import kolibri
@@ -205,6 +206,16 @@ def perform_vacuum(database=db.DEFAULT_DB_ALIAS):
             logger.error(new_msg)
         else:
             logger.info("Sqlite database Vacuum finished.")
+    elif connection.vendor == "postgresql":
+        morango_models = [
+            m
+            for m in apps.get_models(include_auto_created=True)
+            if "morango.models" in str(m)
+        ]
+        cursor = connection.cursor()
+        for m in morango_models:
+            cursor.execute("vacuum analyze {};".format(m._meta.db_table))
+        connection.close()
 
 
 def schedule_vacuum(job_id=None):


### PR DESCRIPTION
## Summary
Performs vacuum on morango tables if the kolibri is using a Postgresql database
It also renames current `vacuumsqlite` command to be just `vacuum`

Also, for the case of morango tables growing too much, executing
`kolibri manage vacuum --full=true`
will do a full vacuum on the `morango_recordmaxcounterbuffer` and `morango_buffer` tables

## References
Closes: #8080 

## Reviewer guidance
Installing a postgresql db and setting options.ini to be something like this 
```
[Database]
DATABASE_ENGINE=postgres
DATABASE_HOST = "127.0.0.1"
DATABASE_USER = "learningequality"
DATABASE_PASSWORD = "kolibri"
DATABASE_NAME="kolibri"
```
(replacing the options with those that match your database)

run `kolibri manage vacuum `and check that no problems appear. 
In case `psql` is available, this command `SELECT pg_size_pretty( pg_total_relation_size('morango_buffer') ); `can be used to check the size of the tables before and after performing the vacuum


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
