### PR TITLE
Add '@vue/composition-api' plugin; refactor SelectAddressForm with `setup()`; implement #7345

### DIFF
--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -15,6 +15,7 @@ import Vue from 'vue';
 import VueMeta from 'vue-meta';
 import VueRouter from 'vue-router';
 import Vuex from 'vuex';
+import VueCompositionApi from '@vue/composition-api';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import heartbeat from 'kolibri.heartbeat';
 import KContentPlugin from 'kolibri-design-system/lib/content/KContentPlugin';
@@ -74,6 +75,7 @@ Vue.use(Vuex);
 Vue.use(VueRouter);
 Vue.use(VueMeta);
 Vue.use(KThemePlugin);
+Vue.use(VueCompositionApi);
 
 Vue.use(KContentPlugin, {
   languageDirection,

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -3,6 +3,7 @@ import forEach from 'lodash/forEach';
 import router from 'kolibri.coreVue.router';
 import logger from 'kolibri.lib.logging';
 import Vue from 'kolibri.lib.vue';
+import VueCompositionApi from '@vue/composition-api';
 import store from 'kolibri.coreVue.vuex.store';
 import heartbeat from 'kolibri.heartbeat';
 import KolibriModule from 'kolibri_module';
@@ -54,6 +55,7 @@ export default class KolibriApp extends KolibriModule {
   }
 
   ready() {
+    Vue.use(VueCompositionApi);
     // VueRouter instance needs to be defined to use vuex-router-sync
     if (!router._vueRouter) {
       router.initRouter();

--- a/kolibri/core/assets/src/kolibri_app.js
+++ b/kolibri/core/assets/src/kolibri_app.js
@@ -3,7 +3,6 @@ import forEach from 'lodash/forEach';
 import router from 'kolibri.coreVue.router';
 import logger from 'kolibri.lib.logging';
 import Vue from 'kolibri.lib.vue';
-import VueCompositionApi from '@vue/composition-api';
 import store from 'kolibri.coreVue.vuex.store';
 import heartbeat from 'kolibri.heartbeat';
 import KolibriModule from 'kolibri_module';
@@ -55,7 +54,6 @@ export default class KolibriApp extends KolibriModule {
   }
 
   ready() {
-    Vue.use(VueCompositionApi);
     // VueRouter instance needs to be defined to use vuex-router-sync
     if (!router._vueRouter) {
       router.initRouter();

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -247,7 +247,9 @@
         this.availableAddressIds = addrs
           .filter(address => address.available)
           .map(address => address.id);
-        this.resetSelectedAddress();
+        if (!this.selectedAddressId) {
+          this.resetSelectedAddress();
+        }
       },
     },
     mounted() {

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -9,7 +9,7 @@
     @cancel="$emit('cancel')"
   >
     <template>
-      <p v-if="initialFetchingComplete && !addresses.length">
+      <p v-if="initialFetchingComplete && !combinedAddresses.length">
         {{ $tr('noAddressText') }}
       </p>
       <UiAlert
@@ -148,7 +148,7 @@
         fetchingAddresses,
       } = useSavedAddresses(props, context);
 
-      const addresses = computed(() => {
+      const combinedAddresses = computed(() => {
         return [...savedAddresses.value, ...discoveredAddresses.value];
       });
 
@@ -156,8 +156,10 @@
         return savedAddressesInitiallyFetched.value && discoveredAddressesInitiallyFetched.value;
       });
 
+      const storageAddressId = useLocalStorage('kolibri-lastSelectedNetworkLocationId', '');
+
       return {
-        addresses,
+        combinedAddresses,
         initialFetchingComplete,
         discoveredAddresses,
         discoveringPeers,
@@ -243,7 +245,7 @@
       },
     },
     watch: {
-      addresses(addrs) {
+      combinedAddresses(addrs) {
         this.availableAddressIds = addrs
           .filter(address => address.available)
           .map(address => address.id);
@@ -271,7 +273,7 @@
       },
       handleSubmit() {
         if (this.selectedAddressId) {
-          const match = find(this.addresses, { id: this.selectedAddressId });
+          const match = find(this.combinedAddresses, { id: this.selectedAddressId });
           match.isDynamic = Boolean(find(this.discoveredAddresses, { id: this.selectedAddressId }));
           this.$emit('submit', match);
         }

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -117,6 +117,7 @@
 <script>
 
   import { computed } from '@vue/composition-api';
+  import { useLocalStorage } from '@vueuse/core';
   import find from 'lodash/find';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -172,6 +173,7 @@
         requestsFailed,
         deletingAddress,
         fetchingAddresses,
+        storageAddressId,
       };
     },
     props: {
@@ -245,10 +247,16 @@
       },
     },
     watch: {
+      selectedAddressId(newVal) {
+        this.storageAddressId = newVal;
+      },
       combinedAddresses(addrs) {
         this.availableAddressIds = addrs
           .filter(address => address.available)
           .map(address => address.id);
+        if (!this.availableAddressIds.includes(this.selectedAddressId)) {
+          this.selectedAddressId = '';
+        }
         if (!this.selectedAddressId) {
           this.resetSelectedAddress();
         }
@@ -264,9 +272,9 @@
     methods: {
       resetSelectedAddress() {
         if (this.availableAddressIds.length !== 0) {
-          const selectedId = this.selectedId ? this.selectedId : this.selectedAddressId;
+          const selectedId = this.selectedId || this.storageAddressId || this.selectedAddressId;
           this.selectedAddressId =
-            this.availableAddressIds.find(id => selectedId === id) || this.availableAddressIds[0];
+            this.availableAddressIds.find(id => id === selectedId) || this.availableAddressIds[0];
         } else {
           this.selectedAddressId = '';
         }

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -243,8 +243,8 @@
       },
     },
     watch: {
-      addresses(addresses) {
-        this.availableAddressIds = addresses
+      addresses(addrs) {
+        this.availableAddressIds = addrs
           .filter(address => address.available)
           .map(address => address.id);
         this.resetSelectedAddress();

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
@@ -70,5 +70,6 @@ export default function useDynamicAddresses(props) {
     addresses,
     discoveringPeers,
     discoveryFailed,
+    discoveredAddressesInitiallyFetched,
   };
 }

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
@@ -1,0 +1,74 @@
+import {
+  ref,
+  computed,
+  onBeforeMount,
+  onBeforeUnmount,
+  getCurrentInstance,
+} from '@vue/composition-api';
+import { fetchDynamicAddresses } from './api';
+
+const Stages = Object.freeze({
+  PEER_DISCOVERY_STARTED: 'PEER_DISCOVERY_STARTED',
+  PEER_DISCOVERY_SUCCESSFUL: 'PEER_DISCOVERY_SUCCESSFUL',
+  PEER_DISCOVERY_FAILED: 'PEER_DISCOVERY_FAILED',
+});
+
+export default function useDynamicAddresses(props) {
+  const { fetchAddressArgs, discoverySpinnerTime } = props;
+  const addresses = ref([]);
+  const stage = ref('');
+  const intervalId = ref('');
+  const discoveredAddressesInitiallyFetched = ref(false);
+  const $parent = getCurrentInstance().proxy.$parent;
+
+  function parentEmit(event, ...args) {
+    $parent.$emit(event, ...args);
+  }
+
+  function discoverPeers() {
+    parentEmit('started_peer_discovery');
+    stage.value = Stages.PEER_DISCOVERY_STARTED;
+    return fetchDynamicAddresses(fetchAddressArgs)
+      .then(devices => {
+        addresses.value = devices;
+        parentEmit('finished_peer_discovery');
+        setTimeout(() => {
+          stage.value = Stages.PEER_DISCOVERY_SUCCESSFUL;
+        }, discoverySpinnerTime);
+        discoveredAddressesInitiallyFetched.value = true;
+      })
+      .catch(() => {
+        parentEmit('peer_discovery_failed');
+        stage.value = Stages.PEER_DISCOVERY_FAILED;
+      });
+  }
+
+  // Start polling
+  onBeforeMount(() => {
+    discoverPeers();
+    if (!intervalId.value) {
+      intervalId.value = setInterval(discoverPeers, 5000);
+    }
+  });
+
+  // Stop polling
+  onBeforeUnmount(() => {
+    if (intervalId.value) {
+      intervalId.value = clearInterval(intervalId.value);
+    }
+  });
+
+  const discoveringPeers = computed(() => {
+    return stage.value === Stages.PEER_DISCOVERY_STARTED;
+  });
+
+  const discoveryFailed = computed(() => {
+    return stage.value === Stages.PEER_DISCOVERY_FAILED;
+  });
+
+  return {
+    addresses,
+    discoveringPeers,
+    discoveryFailed,
+  };
+}

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
@@ -16,19 +16,17 @@ export default function useSavedAddresses(props, context) {
   const stage = ref('');
   const savedAddressesInitiallyFetched = ref(false);
 
-  function updateStage(newStage) {
-    set(stage, newStage);
-  }
+  const setStage = newStage => set(stage, newStage);
 
   function removeSavedAddress(id) {
-    updateStage(Stages.DELETING_ADDRESS);
+    setStage(Stages.DELETING_ADDRESS);
     return deleteAddress(id)
       .then(() => {
         set(
           addresses,
           get(addresses).filter(a => a.id !== id)
         );
-        updateStage(Stages.DELETING_SUCCESSFUL);
+        setStage(Stages.DELETING_SUCCESSFUL);
         context.emit('removed_address');
       })
       .catch(() => {
@@ -47,16 +45,16 @@ export default function useSavedAddresses(props, context) {
   });
 
   function refreshSavedAddressList() {
-    updateStage(Stages.FETCHING_ADDRESSES);
+    setStage(Stages.FETCHING_ADDRESSES);
     set(addresses, []);
     return fetchStaticAddresses(get(fetchAddressArgs))
       .then(addrs => {
         set(addresses, [...addrs]);
-        updateStage(Stages.FETCHING_SUCCESSFUL);
+        setStage(Stages.FETCHING_SUCCESSFUL);
         set(savedAddressesInitiallyFetched, true);
       })
       .catch(() => {
-        updateStage(Stages.FETCHING_FAILED);
+        setStage(Stages.FETCHING_FAILED);
       });
   }
 

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
@@ -43,7 +43,7 @@ export default function useSavedAddresses(props, context) {
     addresses.value = [];
     return fetchStaticAddresses(fetchAddressArgs.value)
       .then(addrs => {
-        addresses.value = addrs;
+        addresses.value = [...addrs];
         stage.value = Stages.FETCHING_SUCCESSFUL;
         savedAddressesInitiallyFetched.value = true;
       })

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
@@ -1,0 +1,90 @@
+import { ref, computed, onBeforeMount } from '@vue/composition-api';
+import { deleteAddress, fetchStaticAddresses } from './api';
+
+const Stages = Object.freeze({
+  FETCHING_ADDRESSES: 'FETCHING_ADDRESSES',
+  FETCHING_SUCCESSFUL: 'FETCHING_SUCCESSFUL',
+  FETCHING_FAILED: 'FETCHING_FAILED',
+  DELETING_ADDRESS: 'DELETING_ADDRESS',
+  DELETING_SUCCESSFUL: 'DELETING_SUCCESSFUL',
+  DELETING_FAILED: 'DELETING_FAILED',
+});
+
+export default function useSavedAddresses(props, context) {
+  const addresses = ref([]);
+  const stage = ref('');
+  const savedAddressesInitiallyFetched = ref(false);
+
+  function removeSavedAddress(id) {
+    stage.value = Stages.DELETING_ADDRESS;
+    return deleteAddress(id)
+      .then(() => {
+        addresses.value = addresses.value.filter(a => a.id !== id);
+        stage.value = Stages.DELETING_SUCCESSFUL;
+        context.emit('removed_address');
+      })
+      .catch(() => {
+        stage.value = Stages.DELETING_FAILED;
+      });
+  }
+
+  const fetchAddressArgs = computed(() => {
+    if (props.filterByChannelId) {
+      return { channelId: props.filterByChannelId };
+    } else if (props.filterByFacilityId) {
+      return { facilityId: props.filterByFacilityId };
+    } else {
+      return {};
+    }
+  });
+
+  function refreshSavedAddressList() {
+    stage.value = Stages.FETCHING_ADDRESSES;
+    addresses.value = [];
+    return fetchStaticAddresses(fetchAddressArgs.value)
+      .then(addrs => {
+        addresses.value = addrs;
+        stage.value = Stages.FETCHING_SUCCESSFUL;
+        savedAddressesInitiallyFetched.value = true;
+      })
+      .catch(() => {
+        stage.value = Stages.FETCHING_FAILED;
+      });
+  }
+
+  const fetchingAddresses = computed(() => {
+    return stage.value === Stages.FETCHING_ADDRESSES;
+  });
+
+  const fetchingFailed = computed(() => {
+    return stage.value === Stages.FETCHING_FAILED;
+  });
+
+  const deletingAddress = computed(() => {
+    return stage.value === Stages.DELETING_ADDRESS;
+  });
+
+  const deletingFailed = computed(() => {
+    return stage.value === Stages.DELETING_FAILED;
+  });
+
+  onBeforeMount(() => {
+    refreshSavedAddressList();
+  });
+
+  const requestsFailed = computed(() => {
+    return fetchingFailed.value && deletingFailed.value;
+  });
+
+  return {
+    addresses,
+    removeSavedAddress,
+    refreshSavedAddressList,
+    fetchingAddresses,
+    fetchingFailed,
+    deletingAddress,
+    deletingFailed,
+    requestsFailed,
+    savedAddressesInitiallyFetched,
+  };
+}

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "dependencies": {
     "@shopify/draggable": "^1.0.0-beta.8",
+    "@vue/composition-api": "^1.0.0-rc.9",
     "axios": "^0.19.2",
     "clipboard": "^2.0.1",
     "core-js": "^3.2.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@shopify/draggable": "^1.0.0-beta.8",
     "@vue/composition-api": "^1.0.0-rc.9",
+    "@vueuse/core": "^4.11.1",
     "axios": "^0.19.2",
     "clipboard": "^2.0.1",
     "core-js": "^3.2.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "dependencies": {
     "@shopify/draggable": "^1.0.0-beta.8",
-    "@vue/composition-api": "^1.0.0-rc.9",
+    "@vue/composition-api": "^1.0.0-rc.11",
     "@vueuse/core": "^4.11.1",
     "axios": "^0.19.2",
     "clipboard": "^2.0.1",

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
       files: ['**/__mocks__/*.*'],
       env: {
         jest: true,
-      }
+      },
     },
     {
       files: ['*.int.js'],
@@ -159,6 +159,7 @@ module.exports = {
           'extends',
           'mixins',
           'inheritAttrs',
+          'setup',
           'model',
           ['props', 'propsData'],
           'data',

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
     },
   },
   rules: {
+    'no-shadow': ERROR,
     'comma-style': ERROR,
     'max-len': [
       ERROR,

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -66,7 +66,6 @@ module.exports = {
     },
   },
   rules: {
-    'no-shadow': ERROR,
     'comma-style': ERROR,
     'max-len': [
       ERROR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,6 +1644,21 @@
     lodash "^4.17.15"
     pretty "^2.0.0"
 
+"@vueuse/core@^4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-4.11.1.tgz#1ab79284dffe8934420a1a40491333cd0591ecd2"
+  integrity sha512-69PdXDVLqZgmjFLbhqN+3Yp/29BRjKtk83UoeVv6csPIPB0DG7SFfsmZbnuSouEetgHXyFSKzty7+4S8GwEyWA==
+  dependencies:
+    "@vueuse/shared" "4.11.1"
+    vue-demi "*"
+
+"@vueuse/shared@4.11.1":
+  version "4.11.1"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-4.11.1.tgz#c8f5735839659bf0a03655bdf70ab337b8f0d452"
+  integrity sha512-9ye1Y6AwjAsbbPSVoWvOVFbObPcEe5ZFV2eU560+Ii+LGhvP8NhH+lyReuuhTzjVL8kEYR6mWRCRqK3rQc7dag==
+  dependencies:
+    vue-demi "*"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -14570,6 +14585,11 @@ vue-compiler@^4.2.0:
     postcss-plugin-composition "^0.1.1"
     source-map "^0.6.1"
     vue-template-es2015-compiler "^1.6.0"
+
+vue-demi@*:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.9.0.tgz#b30da61450079d60a132d7aaf9e86d1949e8445e"
+  integrity sha512-f8vVUpC726YXv99fF/3zHaw5CUYbP5H/DVWBN+pncXM8P2Uz88kkffwj9yD7MukuVzPICDHNrgS3VC2ursaP7g==
 
 vue-eslint-parser@^7.3.0:
   version "7.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1628,6 +1628,13 @@
   optionalDependencies:
     prettier "^1.18.2"
 
+"@vue/composition-api@^1.0.0-rc.9":
+  version "1.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.9.tgz#ddfcaa13040add84edab918573dfc999b5f03cf3"
+  integrity sha512-U//BqmGRVaPyZbYsPfRlmCKnnFkhRzUBu7cjrWn4PSwQ5Oh+M0KcYIHlupUd+Qmd8KwaiYiuUpJLncl3wFsrdg==
+  dependencies:
+    tslib "^2.2.0"
+
 "@vue/test-utils@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
@@ -14028,6 +14035,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
## Summary

1. Adds `@vue/composition-api@1.0.0-rc9` (seems fine to me and the final should be out sometime in Q3), so we can finally use it and take advantage of its benefits.
2. Adds `vueuse`, which is a large library of utility functions that work with the Vue composition api. 
2. Factors out all the network location code out of `SelectAddressForm` into two "usables": `useDynamicAddresses` and `useSavedAdddresses`, and moving the object exposed from the usables into `SelectAddressForm`'s `setup` function. Why is this cool? Because now all the code related to the two types of addresses can live in their own module, instead of being interlaced in lots of different parts of the Vue component. There are opportunities for cleaning up the API from the usables; I just wanted to do a direct 1-to-1 translation from Vue option -> usable without too much extra refactoring. This is also an opportunity to increase the test coverage of this code without having to worry about the extra complexities of unit testing the Component they live in.
3. Fixes a bug where if you add an address, then select a different address right after, then the radio button for the added address will be selected after the polling for the dynamic addresses.
4. Implements #7345 by using https://vueuse.org/core/usestorage/#usage, which lets you create a reactive proxy to a local storage value.
5. ~turns on the ESLint 'no-shadow' rule (which can cause a lot of confusion when you don't see it 😠 )~ Had to revert it bc there's a lot of this in the codebase (needs followup issue)

**Video of unreported bug that was fixed:**

![CleanShot 2021-05-26 at 11 10 10](https://user-images.githubusercontent.com/10248067/119720519-e9753100-be1e-11eb-9272-8df70ee17219.gif)


## References

Fixes #7345, and hopefully makes it easier to "fix" #7785 (which seems to be an issue with how static addresses are being filtered within `useSavedAddresses`)

## Reviewer guidance

1. Does the UI work
2. Review the code carefully. Within `setup` and inside the usable's implementation, notice how I need to access `ref.value`, but outside of these functions (e.g. inside the template or `options.computed`, I don't need to do that (since _those_ variables are now reactive proxies). Are there any places in the code where I overlook those caveats?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
Use Vue Composition API plugin