### PR TITLE
Error properly on startup

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -277,17 +277,14 @@ class ServicesPlugin(SimplePlugin):
         register_zeroconf_service(port=port or self.port)
 
     def STOP(self):
-        from kolibri.core.tasks.main import scheduler
-
-        scheduler.shutdown_scheduler()
-        if self.workers is not None:
-            for worker in self.workers:
-                worker.shutdown()
         from kolibri.core.discovery.utils.network.search import (
             unregister_zeroconf_service,
         )
 
         unregister_zeroconf_service()
+        from kolibri.core.tasks.main import scheduler
+
+        scheduler.shutdown_scheduler()
 
         if self.workers is not None:
             for worker in self.workers:

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -324,7 +324,7 @@ class PIDPlugin(SimplePlugin):
             handler.priority = 10
             self.bus.subscribe(bus_status, handler)
 
-    def set_pid_file(self, status):
+    def set_pid_file(self, status, *args):
         """
         Writes a PID file in the format Kolibri parses
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -383,9 +383,9 @@ class SignalHandler(BaseSignalHandler):
 
         self.handlers.update(
             {
-                "SIGINT": self.handle_SIGTERM,
-                "CTRL_C_EVENT": self.handle_SIGTERM,
-                "CTRL_BREAK_EVENT": self.handle_SIGTERM,
+                "SIGINT": self.handle_SIGINT,
+                "CTRL_C_EVENT": self.handle_SIGINT,
+                "CTRL_BREAK_EVENT": self.handle_SIGINT,
             }
         )
 
@@ -401,6 +401,11 @@ class SignalHandler(BaseSignalHandler):
 
     def ENTER(self):
         self.process_pid = os.getpid()
+
+    def handle_SIGINT(self):
+        """Transition to the EXITED state."""
+        self.bus.log("Keyboard interrupt caught. Exiting.")
+        self.bus.transition("EXITED")
 
 
 class ProcessControlPlugin(Monitor):

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -178,9 +178,8 @@ class TestServerServices(object):
 
             # Do we shutdown workers correctly?
             for mock_worker in services_plugin.workers:
-                assert mock_worker.shutdown.call_count == 2
+                assert mock_worker.shutdown.call_count == 1
                 assert mock_worker.mock_calls == [
-                    mock.call.shutdown(),
                     mock.call.shutdown(wait=True),
                 ]
 


### PR DESCRIPTION
## Summary
* Resolves a regression caused by #8026 whereby errors occurring during plugin life cycle events would then cause an error in their handling.
* Does this by letting the handler function take arbitrary *args, to match the signature of the magicbus error state handlers: https://github.com/cherrypy/magicbus/blob/main/magicbus/process.py#L101
* Simplifies service shutdown by only makes the call to shutdown the worker threads once, and makes it blocking
* Adds a handle_SIGINT method to give different logging when a SIGINT signal is called versus SIGTERM

## References
Fixes #8119 

## Reviewer guidance
Make sure Kolibri starts up properly and then reacts properly to CTRL-C, or throwing any error during a call to register the zero conf service, or start one of the worker threads.

Noting that I have observed recently that a command prompt will display and then further logging text will happen after the CTRL-C - I am at a loss to work out how to prevent this, as the way that magicbus handles signal handlers is the way that every StackOverflow post recommends to try to handle this, so I am at a loss as to how to resolve it.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
