### PR TITLE
Don't use KResponsiveElementMixin in all ContentCards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupCarousel.vue
@@ -72,11 +72,6 @@
   import { validateLinkObject } from 'kolibri.utils.validators';
   import ContentCard from './ContentCard';
 
-  if (!ContentCard.mixins) {
-    ContentCard.mixins = [];
-  }
-  ContentCard.mixins.push(responsiveElementMixin); //including because carousel breaks without it
-
   const contentCardWidth = 210;
   const gutterWidth = 20;
   const horizontalShadowOffset = 12;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Remove a piece of code that pushes `KResponsiveElementMixin` into `ContentCard` in `<script>` part above `export default`
of `ContentCardGroupCarousel`.

Due to how files are bundled, the removed piece of code is evaluated on the application start, no matter whether `ContentCardGroupCarousel` is mounted or no. Consequently, `KResponsiveElementMixin` is unintentionally used in all `ContentCards` in the whole app, not only in `ContentCardGroupCarousel` itself. This means unnecessary performance losses whenever `ContentCard` is used on a page because `KResponsiveElementMixin`s `ResizeSensor` causes render tree layouts/reflows.

Regarding the intended usage for `ContentCard`s that are children of `ContentCardGroupCarousel`, `elementWidth` and `elementHeight` provided by `KResponsiveElementMixin` are not used in `ContentCard` at all, and I haven't noticed any problems with the carousel during testing after removing this code. Removed logic, including the warning in a comment, is quite old. I assume that it might be obsolete.

The carousel recording for various screen sizes taken after the update:

![carousel](https://user-images.githubusercontent.com/13509191/119976967-20327f00-bfb8-11eb-8883-feff36acd7b8.gif)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Related #7525

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check possible regressions of `ContentCardGroupCarousel`.

Currently, it is used in the following places:

1. _Learn_ -> _Recommended_ -> there are three carousels, one for each of the following sections: _Most Popular_, _Next Steps_, _Resume_

![carousel-recommended](https://user-images.githubusercontent.com/13509191/119976683-c336c900-bfb7-11eb-907c-1e7bf9f3e6c8.png)

2. _Learn_ -> _Channels_ -> Open a resource -> there are two carousels, one for each of the following sections:  _Next resource_, _Recommended_

![carousel-resource](https://user-images.githubusercontent.com/13509191/119976876-08f39180-bfb8-11eb-96ca-465fb138fac6.png)

Depending on your test data, it's possible that not all carousels will be visible. I took screenshots above after tweaking the code a bit to display carousels all the time so I could test properly all places.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
