### PR TITLE
Replace migration applied check which seems to be able to fail with try except.

### DIFF
--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -172,8 +172,12 @@ class Worker(object):
         :param job_id:
         :return:
         """
-        future = self.future_job_mapping[job_id]
-        is_future_cancelled = future.cancel()
+        try:
+            future = self.future_job_mapping[job_id]
+            is_future_cancelled = future.cancel()
+        except KeyError:
+            # In the case that the future does not even exist, say it has been cancelled.
+            is_future_cancelled = True
 
         if is_future_cancelled:  # success!
             return True


### PR DESCRIPTION
## Summary
* Our check for whether a migration has been applied seems capable of not picking this up https://github.com/learningequality/kolibri/pull/8095/checks?check_run_id=2720363235
* Replace this check with just doing a `try`/`except` for the behaviour we are trying to catch

## References
* Fixes errors seen in https://github.com/learningequality/kolibri/pull/8095 and https://github.com/learningequality/kolibri/pull/8126

## Reviewer guidance
Do tests still pass, do the changes make sense?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
