### PR TITLE
Restore IE11 compatibility

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -5,6 +5,6 @@
 
 > 0.1%
 last 2 versions
-ie >= 9
+ie >= 11
 ios >= 9.3
 Firefox ESR

--- a/kolibri/core/assets/src/core-app/index.js
+++ b/kolibri/core/assets/src/core-app/index.js
@@ -2,6 +2,7 @@
  * Provides the public API for the Kolibri FrontEnd core app.
  * @module Facade
  */
+import 'core-js';
 import '../styles/main.scss';
 import urls from 'kolibri.urls';
 import * as theme from 'kolibri-design-system/lib/styles/theme';

--- a/packages/kolibri-tools/babel.config.js
+++ b/packages/kolibri-tools/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
       '@babel/preset-env',
       {
         useBuiltIns: 'entry',
-        corejs: '3.10',
+        corejs: '3.13',
       },
     ],
   ],

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -129,7 +129,10 @@ module.exports = (data, { mode = 'development', hot = false } = {}) => {
         {
           test: /\.js$/,
           loader: 'babel-loader',
-          exclude: /(node_modules\/vue|dist)/,
+          exclude: {
+            test: /(node_modules\/vue|dist|core-js)/,
+            not: [/\.(esm\.js|mjs)$/],
+          },
         },
         {
           test: /\.css$/,

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -27,6 +27,7 @@
     "chokidar": "^2.0.4",
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "core-js": "3",
     "css-loader": "^0.28.7",
     "csv-parse": "^4.14.1",
     "csv-parser": "^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,6 +4294,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
+core-js@3:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.13.1.tgz#30303fabd53638892062d8b4e802cac7599e9fb7"
+  integrity sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==
+
 core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"


### PR DESCRIPTION
## Summary
* Update our babel and webpack configuration to properly transpile ES Module code, to make sure that fuse.js gets properly transpiled with babel (issue is not extant on 0.14.7 - so seems to be due to babel switch)
* Update configuration to properly polyfill with core-js 3
* Do not transpile core-js 3, as it leads to errors like this https://github.com/zloirock/core-js/issues/514

## References
Fixes #8131
Regressions caused by #7987

## Reviewer guidance
Does Kolibri work on IE11?

![Screenshot from 2021-06-01 16-57-12](https://user-images.githubusercontent.com/1680573/120404482-5004be00-c2fb-11eb-96b1-8674655eb2ef.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
