### PR TITLE
Prevent iterable changing size during iteration.

### DIFF
--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -41,7 +41,9 @@ class Worker(object):
 
     def shutdown_workers(self, wait=True):
         # First cancel all running jobs
-        job_ids = self.future_job_mapping.keys()
+        # Coerce to a list, as otherwise the iterable can change size
+        # during iteration, as jobs are cancelled and removed from the mapping
+        job_ids = list(self.future_job_mapping.keys())
         for job_id in job_ids:
             logger.info("Canceling job id {}.".format(job_id))
             self.cancel(job_id)


### PR DESCRIPTION
## Summary
* An occasional intermittent test failure can happen when jobs get removed from the future jobs mapping while being iterated over to cancel
* This coerces the keys to a list before iterating to ensure that it does not change size during iteration

## Reviewer guidance
Do all tests still pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
