### PR TITLE
Update navigateTo for non-custom HTML5 apps

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -123,6 +123,9 @@
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
       });
+      this.hashi.on('navigateto', message => {
+        this.$emit('navigateToRegularContext', message);
+      });
       this.hashi.initialize(
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData,

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -123,8 +123,8 @@
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
       });
-      this.hashi.on('navigateto', message => {
-        this.$emit('navigateToRegularContext', message);
+      this.hashi.on('navigateTo', message => {
+        this.$emit('navigateTo', message);
       });
       this.hashi.initialize(
         (this.extraFields && this.extraFields.contentState) || {},

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -193,8 +193,19 @@
               routeBase = '/topics/t';
               path = `${routeBase}/${id}`;
               router.push({ path: path }).catch(() => {});
-            } else if (contentNode) {
-              // in a custom context, launch or maintain overlay
+            } else if (contentNode && this.overlayIsOpen == false) {
+              // in a custom context, launch overlay
+              this.currentContent = contentNode;
+              this.overlayIsOpen = true;
+              context.node_id = contentNode.id;
+              context.customChannel = true;
+              const encodedContext = encodeURI(JSON.stringify(context));
+              router.replace({ query: { context: encodedContext } }).catch(() => {});
+            } else if (contentNode && this.overlayIsOpen == true) {
+              // in a custom context, within an overlay, switch the overlay
+              // content to the new content
+              this.overlayIsOpen = false;
+              console.log('new node', contentNode.title);
               this.currentContent = contentNode;
               this.overlayIsOpen = true;
               context.node_id = contentNode.id;

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -16,6 +16,7 @@
       </iframe>
       <ContentModal
         v-if="overlayIsOpen"
+        :key="currentContent.id"
         :contentNode="currentContent"
         :channelTheme="channelTheme"
         @close="overlayIsOpen = false"
@@ -36,6 +37,7 @@
   import router from 'kolibri.coreVue.router';
   import { events, MessageStatuses } from 'hashi/src/hashiBase';
   import { validateTheme } from '../../utils/themes';
+  import { PageNames } from '../../constants';
   import ContentModal from './ContentModal';
 
   function createReturnMsg({ message, data, err }) {
@@ -188,11 +190,8 @@
         let context = {};
         return ContentNodeResource.fetchModel({ id })
           .then(contentNode => {
-            let routeBase, path;
             if (contentNode && contentNode.kind === 'topic') {
-              routeBase = '/topics/t';
-              path = `${routeBase}/${id}`;
-              router.push({ path: path }).catch(() => {});
+              router.push(this.genContentLink(contentNode.id, contentNode.is_leaf));
             } else if (contentNode && this.overlayIsOpen == false) {
               // in a custom context, launch overlay
               this.currentContent = contentNode;
@@ -204,11 +203,10 @@
             } else if (contentNode && this.overlayIsOpen == true) {
               // in a custom context, within an overlay, switch the overlay
               // content to the new content
-              this.overlayIsOpen = false;
               this.currentContent = contentNode;
-              this.overlayIsOpen = true;
               context.node_id = contentNode.id;
               context.customChannel = true;
+              this.$forceUpdate();
               const encodedContext = encodeURI(JSON.stringify(context));
               router.replace({ query: { context: encodedContext } }).catch(() => {});
             }
@@ -220,6 +218,12 @@
           .then(newMsg => {
             this.hashi.mediator.sendLocalMessage(newMsg);
           });
+      },
+      genContentLink(id, isLeaf) {
+        return {
+          name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
+          params: { id },
+        };
       },
       getOrUpdateContext(message) {
         // to update context with the incoming context

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -205,7 +205,6 @@
               // in a custom context, within an overlay, switch the overlay
               // content to the new content
               this.overlayIsOpen = false;
-              console.log('new node', contentNode.title);
               this.currentContent = contentNode;
               this.overlayIsOpen = true;
               context.node_id = contentNode.id;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -34,7 +34,7 @@
         @updateProgress="updateProgress"
         @addProgress="addProgress"
         @updateContentState="updateContentState"
-        @navigateToRegularContext="navigateToRegularContext"
+        @navigateTo="navigateTo"
       />
 
       <AssessmentWrapper
@@ -337,23 +337,14 @@
       updateContentState(contentState, forceSave = true) {
         this.updateContentNodeState({ contentState, forceSave });
       },
-      navigateToRegularContext(message) {
+      navigateTo(message) {
         let id = message.nodeId;
         return ContentNodeResource.fetchModel({ id })
           .then(contentNode => {
-            let routeBase, path;
-            if (contentNode && contentNode.kind !== 'topic') {
-              routeBase = '/topics/c';
-              path = `${routeBase}/${id}`;
-              router.push({ path: path }).catch(() => {});
-            } else if (contentNode && contentNode.kind === 'topic') {
-              routeBase = '/topics/t';
-              path = `${routeBase}/${id}`;
-              router.push({ path: path }).catch(() => {});
-            }
+            router.push(this.genContentLink(contentNode.id, contentNode.is_leaf));
           })
-          .catch(err => {
-            console.log(err);
+          .catch(error => {
+            this.$store.dispatch('handleApiError', error);
           });
       },
       markAsComplete() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -34,6 +34,7 @@
         @updateProgress="updateProgress"
         @addProgress="addProgress"
         @updateContentState="updateContentState"
+        @navigateToRegularContext="navigateToRegularContext"
       />
 
       <AssessmentWrapper
@@ -148,6 +149,8 @@
 
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { ContentNodeResource } from 'kolibri.resources';
+  import router from 'kolibri.coreVue.router';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
@@ -333,6 +336,25 @@
       },
       updateContentState(contentState, forceSave = true) {
         this.updateContentNodeState({ contentState, forceSave });
+      },
+      navigateToRegularContext(message) {
+        let id = message.nodeId;
+        return ContentNodeResource.fetchModel({ id })
+          .then(contentNode => {
+            let routeBase, path;
+            if (contentNode && contentNode.kind !== 'topic') {
+              routeBase = '/topics/c';
+              path = `${routeBase}/${id}`;
+              router.push({ path: path }).catch(() => {});
+            } else if (contentNode && contentNode.kind === 'topic') {
+              routeBase = '/topics/t';
+              path = `${routeBase}/${id}`;
+              router.push({ path: path }).catch(() => {});
+            }
+          })
+          .catch(err => {
+            console.log(err);
+          });
       },
       markAsComplete() {
         this.wasIncomplete = false;

--- a/packages/hashi/src/hashiBase.js
+++ b/packages/hashi/src/hashiBase.js
@@ -10,7 +10,7 @@ export const events = {
   SEARCHRESULTREQUESTED: 'searchresultrequested',
   DATARETURNED: 'datareturned',
   KOLIBRIDATARETURNED: 'kolibridatareturned',
-  NAVIGATETO: 'navigateto',
+  NAVIGATETO: 'navigateTo',
   CONTEXT: 'context',
   THEMECHANGED: 'themechanged',
   KOLIBRIVERSIONREQUESTED: 'kolibriversionrequested',


### PR DESCRIPTION
## Summary

This PR creates a function for managing `navigateTo` events emitted from HTML5 apps but when they are used outside of a custom navigation context, such as if a user does not have access to these custom contexts but is still able to access the channel. **There is a necessary parallel PR to update and KDS to add the corresponding listener on `KContentRenderer` that is required for this to work. I will add the PR link as a comment once I create the PR.**

It also updates the `navigateTo` function for custom navigation contexts. 

Note: The title in the content overlay in the custom channel view isn't updating and thought I've spent some time trying to troubleshoot it, I can't figure out why the value isn't updating. I'm hoping it's obvious that I am just overlooking and someone will have a simple suggestion 😄 

**Custom Nav Context** 
![navigate-to-custom-context](https://user-images.githubusercontent.com/17235236/120494012-6fe2c300-c389-11eb-9dfa-f67037353fc7.gif)

**"Regular" Context**
![navigate-to-regular-channel](https://user-images.githubusercontent.com/17235236/120494017-707b5980-c389-11eb-872f-e226982a6897.gif)

…

Fixes #8098 

…

## Reviewer guidance

Before running devserver, 
`export KOLIBRI_CENTRAL_CONTENT_BASE_URL=https://hotfixes.studio.learningequality.org`
and download the test channel using token `favim-zinul`.  If you have already downloaded this channel, you will need to get the most recent changes to the channel, which now include using the `navigateTo()` hashi API function within part of the HTML5 app. 

To test outside a custom context 
1.  Navigate to Custom Nav channel
2. Open "Interlinking Content Test"
3. Click the link to the video
4. You should be redirected to a content page with video content, and the URL should update


To test with a custom context
1. To enable custom channels,  in your terminal run `export KOLIBRI_ENABLE_CUSTOM_CHANNEL_NAV=True` 
2. Restart the dev server
3. Navigate to Custom Nav channel
3. Open "Interlinking Content Test"
4. Click the link to the video
5. The modal content should be replaced with the video content

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
