### PR TITLE
Tree viewset for retrieving nested, paginated views of topic trees

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -1,5 +1,8 @@
+import isPlainObject from 'lodash/isPlainObject';
 import { Resource } from 'kolibri.lib.apiResource';
 import Store from 'kolibri.coreVue.vuex.store';
+import urls from 'kolibri.urls';
+import cloneDeep from '../cloneDeep';
 
 export default new Resource({
   name: 'contentnode',
@@ -33,5 +36,52 @@ export default new Resource({
   },
   fetchNextSteps(getParams) {
     return this.fetchDetailCollection('next_steps', Store.getters.currentUserId, getParams);
+  },
+  cache: {},
+  fetchModel({ id }) {
+    if (this.cache[id]) {
+      return Promise.resolve(this.cache[id]);
+    }
+    return this.client({ url: this.modelUrl(id) }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+  },
+  cacheData(data) {
+    if (Array.isArray(data)) {
+      for (let model of data) {
+        this.cacheData(model);
+      }
+    } else if (isPlainObject(data)) {
+      if (data[this.idKey]) {
+        this.cache[data[this.idKey]] = Object.assign(
+          this.cache[data[this.idKey]] || {},
+          cloneDeep(data)
+        );
+        if (data.children) {
+          this.cacheData(data.children);
+        }
+      } else if (data.results) {
+        for (let model of data.results) {
+          this.cacheData(model);
+        }
+      }
+    }
+  },
+  fetchCollection(params) {
+    return this.client({ url: this.collectionUrl(), params }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+  },
+  fetchTree(id, params) {
+    const url = urls['kolibri:core:contentnode_tree_detail'](id);
+    return this.client({ url, params }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+  },
+  fetchMoreTree({ id, params }) {
+    return this.fetchTree(id, params);
   },
 });

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -4,6 +4,81 @@ import Store from 'kolibri.coreVue.vuex.store';
 import urls from 'kolibri.urls';
 import cloneDeep from '../cloneDeep';
 
+/**
+ * Type definition for Language metadata
+ * @typedef {Object} Language
+ * @property {string} id - an IETF language tag
+ * @property {string} lang_code - the ISO 639‑1 language code
+ * @property {string} lang_subcode - the regional identifier
+ * @property {string} lang_name - the name of the language in that language
+ * @property {('ltr'|'rtl'|)} lang_direction - Direction of the language's script,
+ * top to bottom is not supported currently
+ */
+
+/**
+ * Type definition for AssessmentMetadata
+ * @typedef {Object} AssessmentMetadata
+ * @property {string[]} assessment_item_ids - an array of ids for assessment items
+ * @property {number} number_of_assessments - the length of assessment_item_ids
+ * @property {Object} mastery_model - object describing the mastery criterion for finishing practice
+ * @property {boolean} randomize - whether to randomize the order of assessments
+ * @property {boolean} is_manipulable - Whether this assessment can be programmatically updated
+ */
+
+/**
+ * Type definition for File
+ * @typedef {Object} File
+ * @property {string} id - id of the file object
+ * @property {string} checksum - md5 checksum of the file, used to generate the file name
+ * @property {boolean} available - whether the file is available on the server
+ * @property {number} file_size - file_size in bytes
+ * @property {string} extension - file extension, also used to generate the file name
+ * @property {string} preset - preset, the role that the file plays for this content node
+ * @property {Language|null} lang - The language of the File
+ * @property {boolean} supplementary - Whether this file is optional
+ * @property {boolean} thumbnail - Whether this file is a thumbnail
+ */
+
+/**
+ * Type definition for ContentNode metadata
+ * @typedef {Object} ContentNode
+ * @property {string} id - unique id of the ContentNode
+ * @property {string} channel_id - unique channel_id of the channel that the ContentNode is in
+ * @property {string} content_id - identifier that is common across all instances of this resource
+ * @property {string} title - A title that summarizes this ContentNode for the user
+ * @property {string} description - detailed description of the ContentNode
+ * @property {string} author - author of the ContentNode
+ * @property {string} thumbnail_url - URL for the thumbnail for this ContentNode,
+ * this may be any valid URL format including base64 encoded or blob URL
+ * @property {boolean} available - Whether the ContentNode has all necessary files for rendering
+ * @property {boolean} coach_content - Whether the ContentNode is intended only for coach users
+ * @property {Language|null} lang - The primary language of the ContentNode
+ * @property {string} license_description - The description of the license, which may be localized
+ * @property {string} license_name - The human readable name of the license, localized
+ * @property {string} license_owner - The name of the person or organization that holds copyright
+ * @property {number} num_coach_contents - Number of coach contents that are descendants of this
+ * @property {string} parent - The unique id of the parent of this ContentNode
+ * @property {number} sort_order - The order of display for this node in its channel
+ * if depth recursion was not deep enough
+ * @property {string[]} tags - Tags that apply to this content
+ * @property {boolean} is_leaf - Whether is a leaf resource or not
+ * @property {AssessmentMetadata|null} assessmentmetadata - Additional metadata for assessments
+ * @property {File[]} files - array of file objects associated with this ContentNode
+ * @property {Object[]} ancestors - array of objects with 'id' and 'title' properties
+ * @property {Children} [children] - optional pagination object with children of this ContentNode
+ */
+
+/**
+ * Type definition for children pagination object
+ * @typedef {Object} Children
+ * @property {Object} more - parameters for requesting more objects
+ * @property {string} more.id - the id of the parent of these child nodes
+ * @property {Object} more.params - the get parameters that should be used for requesting more nodes
+ * @property {number} more.params.depth - 1 or 2, how deep the nesting should be returned
+ * @property {number} more.params.lft__gt - integer value to return a lft value greater than
+ * @property {ContentNode[]} results - the array of ContentNodes for this page
+ */
+
 export default new Resource({
   name: 'contentnode',
   useContentCacheKey: true,
@@ -74,6 +149,13 @@ export default new Resource({
       return response.data;
     });
   },
+  /**
+   * A method to request paginated tree data from the backend
+   * @param {string} id - the id of the parent node for this request
+   * @param {Object} params - the GET parameters to return more results,
+   * may be both pagination and non-pagination specific parameters
+   * @return {Promise<ContentNode>} Promise that resolves with the model data
+   */
   fetchTree(id, params) {
     const url = urls['kolibri:core:contentnode_tree_detail'](id);
     return this.client({ url, params }).then(response => {
@@ -81,6 +163,14 @@ export default new Resource({
       return response.data;
     });
   },
+  /**
+   * A method to simplify requesting more items from a previously paginated response from fetchTree
+   * @param {Object} more - the 'more' property of the 'children' pagination object from a response.
+   * @param {string} more.id - the id of the parent node for this request
+   * @param {Object} more.params - the GET parameters to return more results,
+   * may be both pagination and non-pagination specific parameters
+   * @return {Promise<ContentNode>} Promise that resolves with the model data
+   */
   fetchMoreTree({ id, params }) {
     return this.fetchTree(id, params);
   },

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -115,7 +115,7 @@ export default new Resource({
   cache: {},
   fetchModel({ id }) {
     if (this.cache[id]) {
-      return Promise.resolve(this.cache[id]);
+      return Promise.resolve(cloneDeep(this.cache[id]));
     }
     return this.client({ url: this.modelUrl(id) }).then(response => {
       this.cacheData(response.data);

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -352,7 +352,9 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
 
             # We need to batch our queries for ancestors as the size of the expression tree
             # depends on the number of nodes that we are querying for.
-            ANCESTOR_BATCH_SIZE = 1000
+            # On Windows, the SQL parameter limit is 999, and an ancestors call can produce
+            # 3 parameters per node in the queryset, so this should max out the parameters at 750.
+            ANCESTOR_BATCH_SIZE = 250
 
             if len(items) > ANCESTOR_BATCH_SIZE:
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -314,9 +314,13 @@ class BaseContentNodeMixin(object):
 
         tags_map = {}
 
-        for t in models.ContentTag.objects.filter(tagged_content__in=queryset).values(
-            "tag_name",
-            "tagged_content",
+        for t in (
+            models.ContentTag.objects.filter(tagged_content__in=queryset)
+            .values(
+                "tag_name",
+                "tagged_content",
+            )
+            .order_by("tag_name")
         ):
             if t["tagged_content"] not in tags_map:
                 tags_map[t["tagged_content"]] = [t["tag_name"]]

--- a/kolibri/core/content/api_urls.py
+++ b/kolibri/core/content/api_urls.py
@@ -6,6 +6,7 @@ from .api import ChannelMetadataViewSet
 from .api import ContentNodeGranularViewset
 from .api import ContentNodeProgressViewset
 from .api import ContentNodeSearchViewset
+from .api import ContentNodeTreeViewset
 from .api import ContentNodeViewset
 from .api import FileViewset
 from .api import RemoteChannelViewSet
@@ -14,6 +15,9 @@ router = routers.SimpleRouter()
 router.register("channel", ChannelMetadataViewSet, base_name="channel")
 
 router.register(r"contentnode", ContentNodeViewset, base_name="contentnode")
+router.register(
+    r"contentnode_tree", ContentNodeTreeViewset, base_name="contentnode_tree"
+)
 router.register(
     r"contentnode_search", ContentNodeSearchViewset, base_name="contentnode_search"
 )

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -67,6 +67,10 @@ class ChannelBuilder(object):
 
         self.generate_nodes_from_root_node()
 
+    @property
+    def cache_key(self):
+        return "{}_{}".format(self.levels, self.num_children)
+
     def generate_new_tree(self):
         self.channel = self.channel_data()
         self.files = {}
@@ -83,7 +87,7 @@ class ChannelBuilder(object):
             )
 
     def load_data(self):
-        data = copy.deepcopy(self.__TREE_CACHE[self.levels])
+        data = copy.deepcopy(self.__TREE_CACHE[self.cache_key])
 
         for key in self.tree_keys:
             setattr(self, key, data[key])
@@ -94,7 +98,7 @@ class ChannelBuilder(object):
         for key in self.tree_keys:
             data[key] = getattr(self, key)
 
-        self.__TREE_CACHE[self.levels] = copy.deepcopy(data)
+        self.__TREE_CACHE[self.cache_key] = copy.deepcopy(data)
 
     def generate_nodes_from_root_node(self):
         self._django_nodes = ContentNode.objects.build_tree_nodes(self.root_node)

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -61,7 +61,6 @@ class ChannelBuilder(object):
         try:
             self.load_data()
         except KeyError:
-            print("key error {}".format(self.levels))
             self.generate_new_tree()
             self.save_data()
 
@@ -87,10 +86,18 @@ class ChannelBuilder(object):
             )
 
     def load_data(self):
-        data = copy.deepcopy(self.__TREE_CACHE[self.cache_key])
+        try:
+            data = copy.deepcopy(self.__TREE_CACHE[self.cache_key])
 
-        for key in self.tree_keys:
-            setattr(self, key, data[key])
+            for key in self.tree_keys:
+                setattr(self, key, data[key])
+        except KeyError:
+            print(
+                "No tree cache found for {} levels and {} children per level".format(
+                    self.levels, self.num_children
+                )
+            )
+            raise
 
     def save_data(self):
         data = {}

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -52,8 +52,9 @@ class ChannelBuilder(object):
         "root_node",
     )
 
-    def __init__(self, levels=3):
+    def __init__(self, levels=3, num_children=5):
         self.levels = levels
+        self.num_children = num_children
 
         self.modified = set()
 
@@ -297,7 +298,7 @@ class ChannelBuilder(object):
 
     def recurse_and_generate(self, parent_id, levels):
         children = []
-        for i in range(0, 5):
+        for i in range(0, self.num_children):
             if levels == 0:
                 node = self.generate_leaf(parent_id)
             else:

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -310,7 +310,11 @@ class ContentNodeAPITestCase(APITestCase):
                 "rght": expected.rght,
                 "tree_id": expected.tree_id,
                 "ancestors": list(expected.get_ancestors().values("id", "title")),
-                "tags": list(expected.tags.all().values_list("tag_name", flat=True)),
+                "tags": list(
+                    expected.tags.all()
+                    .order_by("tag_name")
+                    .values_list("tag_name", flat=True)
+                ),
                 "assessmentmetadata": assessmentmetadata,
                 "is_leaf": expected.kind != "topic",
                 "files": files,

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -2,10 +2,12 @@
 To run this test, type this in command line <kolibri manage test -- kolibri.core.content>
 """
 import datetime
+import unittest
 import uuid
 
 import mock
 import requests
+from django.conf import settings
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -333,6 +335,11 @@ class ContentNodeAPITestCase(APITestCase):
         self.assertEqual(len(response.data), expected_output)
         self._assert_nodes(response.data, nodes)
 
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        == "django.db.backends.postgresql",
+        "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
+    )
     def test_contentnode_list_long(self):
         # This will make > 1000 nodes which should test our ancestor batching behaviour
         builder = ChannelBuilder(num_children=10)
@@ -377,6 +384,11 @@ class ContentNodeAPITestCase(APITestCase):
         )
         self._recurse_and_assert([response.data], [root])
 
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        == "django.db.backends.postgresql",
+        "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
+    )
     def test_contentnode_tree_long(self):
         builder = ChannelBuilder(levels=2, num_children=30)
         builder.insert_into_default_db()
@@ -395,6 +407,11 @@ class ContentNodeAPITestCase(APITestCase):
         )
         self._recurse_and_assert([response.data], [root])
 
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        == "django.db.backends.postgresql",
+        "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
+    )
     def test_contentnode_tree_lft__gt(self):
         builder = ChannelBuilder(levels=2, num_children=30)
         builder.insert_into_default_db()
@@ -412,6 +429,11 @@ class ContentNodeAPITestCase(APITestCase):
             [response.data["children"]["results"][0]], [first_node], recursion_depth=1
         )
 
+    @unittest.skipIf(
+        getattr(settings, "DATABASES")["default"]["ENGINE"]
+        == "django.db.backends.postgresql",
+        "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
+    )
     def test_contentnode_tree_more(self):
         builder = ChannelBuilder(levels=2, num_children=30)
         builder.insert_into_default_db()


### PR DESCRIPTION
## Summary
* To accommodate the nested, paginated topic tree display as outlined in designs for this feature: https://github.com/learningequality/kolibri-ecosystem/issues/7 this PR creates an API endpoint that allows for subsections of a topic tree to be queried in a single request, with the parent node, the paginated children, and the paginated grand children.
* The children and the children of each child are returned as a pagination object, containing the `results` Array, and `more` which is either `null` or an object with the parameters that can be passed to the same endpoint in order to query for more results.
* This PR also updates the ContentNodeResource to allow for simple access to the tree endpoint without having to define a new resource, and with a simplified caching mechanism that works across the TreeViewset and ContentNodeViewset requests.

## References
Fixes #8108

Contributes to the solution for #7525

I did a dummy implementation using the current topics page as a PoC of using this API, an animation is seen here, but I did not commit the changes for this:
![viewmore](https://user-images.githubusercontent.com/1680573/120561729-f0b9b300-c3b9-11eb-80f6-9342811cc631.gif)


## Reviewer guidance
Does the API and its tests make sense?
Are the changes to the ContentNodeResource a good model for handling read only resources in the future?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
