### PR TITLE
Increasing scrolling room for question lists in `MultiPaneLayout`

### DIFF
--- a/kolibri/core/assets/src/views/MultiPaneLayout.vue
+++ b/kolibri/core/assets/src/views/MultiPaneLayout.vue
@@ -52,29 +52,16 @@
     name: 'MultiPaneLayout',
     mixins: [responsiveWindowMixin, responsiveElementMixin],
     computed: {
-      maxHeight() {
-        const APP_BAR_HEIGHT = this.windowIsSmall ? 56 : 64;
-        const PADDING = this.windowIsSmall ? 16 : 32;
-        const MARGIN = 16;
-        let maxHeight = this.windowHeight - APP_BAR_HEIGHT - PADDING * 2 - MARGIN;
-        if (this.$refs.header) {
-          maxHeight = maxHeight - this.$refs.header.clientHeight;
-        }
-        if (this.$refs.footer) {
-          maxHeight = maxHeight - this.$refs.footer.clientHeight;
-        }
-        return maxHeight;
-      },
       styles() {
         return {
           header: {
             borderBottomColor: this.$themeTokens.textDisabled,
           },
           aside: {
-            maxHeight: `${this.maxHeight}px`,
+            maxHeight: `${this.windowHeight}px`,
           },
           main: {
-            maxHeight: this.$slots.aside ? `${this.maxHeight}px` : '',
+            maxHeight: this.$slots.aside ? `${this.windowHeight}px` : '',
           },
           footer: {
             borderTopColor: this.$themeTokens.textDisabled,
@@ -101,6 +88,12 @@
     padding: 16px;
     border-bottom-style: solid;
     border-bottom-width: 1px;
+  }
+
+  .main,
+  .aside {
+    height: 100%;
+    overflow-y: auto;
   }
 
   .aside {

--- a/kolibri/core/assets/src/views/MultiPaneLayout.vue
+++ b/kolibri/core/assets/src/views/MultiPaneLayout.vue
@@ -103,11 +103,6 @@
     border-bottom-width: 1px;
   }
 
-  .aside,
-  .main {
-    overflow-y: auto;
-  }
-
   .aside {
     display: inline-block;
     width: 33%;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -5,8 +5,8 @@
       <div>
         <KGrid>
           <KGridItem
-            :layout8="{ span: 4 }"
-            :layout12="{ span: 6 }"
+            :layout8="{ span: 6 }"
+            :layout12="{ span: 9 }"
           >
             <h1>
               <KLabeledIcon :icon="content.kind" :label="content.title" />
@@ -14,8 +14,8 @@
           </KGridItem>
           <KGridItem
             :layout="{ alignment: 'right' }"
-            :layout8="{ span: 4 }"
-            :layout12="{ span: 6 }"
+            :layout8="{ span: 2 }"
+            :layout12="{ span: 3 }"
           >
             <template v-if="displaySelectOptions">
               <template v-if="isSelected">

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -16,7 +16,6 @@
         :questions="preview.questions"
         :displaySelectOptions="true"
         :completionData="preview.completionData"
-        :style="{ 'padding-bottom': '32px' }"
         @addResource="handleAddResource"
         @removeResource="handleRemoveResource"
       />

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanQuizPreviewPage.vue
@@ -16,6 +16,7 @@
         :questions="preview.questions"
         :displaySelectOptions="true"
         :completionData="preview.completionData"
+        :style="{ 'padding-bottom': '32px' }"
         @addResource="handleAddResource"
         @removeResource="handleRemoveResource"
       />


### PR DESCRIPTION
## Summary

Removed the `maxHeight` calculations for the `MultiPaneLayout` container because the original issue (#6945) is partially caused by the header of this component being non-responsive, and thus, when the window height is reduced, the header continues to take up the same amount of space in the visible window (also seen in #6900), which causes the remaining portions (the `aside` and `main` parts) of the component to shrink dramatically to fit. Removing the calculation allows for the bottom portion to be fully visible on page scroll.

Because this component is used in several places, changes are also documented below. There is also tech debt in this component, and that has been filed as a separate issue.

### `LessonContentPreviewPage` (The main issue)
NOTE: The reason this particular component has major problems with the `MultiPaneLayout` is because of all of the information in the `header`. Other components tend not to have such an obvious issue.

|Before|After|
|--|--|
|![2021-06-07 16 20 23](https://user-images.githubusercontent.com/13563002/121099237-51773000-c7ac-11eb-8712-7ab71ede3ffc.gif)|![2021-06-07 16 19 01](https://user-images.githubusercontent.com/13563002/121099198-3d333300-c7ac-11eb-90bf-0152d53cd643.gif)

### `ExamReport`
|Before|After|
|--|--|
|![2021-06-07 16 15 45](https://user-images.githubusercontent.com/13563002/121098880-aa929400-c7ab-11eb-8dca-bb653389faef.gif)|![2021-06-07 16 16 51](https://user-images.githubusercontent.com/13563002/121098962-d4e45180-c7ab-11eb-8882-d6dd8d1543d4.gif)|

### `LearnerExercisesReport`
|Before|After|
|--|--|
|![2021-06-07 16 12 39](https://user-images.githubusercontent.com/13563002/121098684-3bb53b00-c7ab-11eb-8357-582e3be62227.gif)|![2021-06-07 16 11 59](https://user-images.githubusercontent.com/13563002/121098629-20e2c680-c7ab-11eb-850c-2c24f4f743fa.gif)|

### `QuestionLearnersReport`
|Before|After|
|--|--|
|![2021-06-07 16 05 42](https://user-images.githubusercontent.com/13563002/121098238-458a6e80-c7aa-11eb-93f2-ae96f1d950fd.gif)|![2021-06-07 16 03 30](https://user-images.githubusercontent.com/13563002/121098064-f0e6f380-c7a9-11eb-8484-675333a6283b.gif)|


## References

- Addresses #6945
- Connected issues: #6900 and #8141


## Reviewer guidance

### To see the original issue, `LessonContentPreviewPage`
1. Log in as Coach
2. Click on "Plan" >"Quizzes" > "New quiz"
3. Make a new quiz, and while previewing it to choose questions, change the size of the window. You should still be able to see all the questions in the question list, by scrolling through the page scroll.

### `ExamReport`
1. Sign in as learner
2. Click on Quizzes
3. Click on a quiz that you have completed to see a report

### `LearnerExerciseReport`
1. Log in as coach
2. Click on Reports > Lessons (click on a lesson) > Report (click on a lesson) > Report (click on a learner's name)
3. View the `LearnerExerciseReport` 

### `QuestionLearnersReport`
1. Login as coach
2. Click on Reports > Lessons (click on a lesson) > Difficult questions (click on a question)
3. View the individual question, which will be the component, `QuestionLearnersReport`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
