### PR TITLE
Add ZIM documents to filePresetStrings

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -20,6 +20,7 @@ const filePresetStrings = {
   exercise: 'Exercise ({fileSize})',
   html5_zip: 'HTML5 Zip ({fileSize})',
   epub: 'ePub Document ({fileSize})',
+  zim: 'ZIM Document ({fileSize})',
   slideshow_manifest: 'Slideshow ({fileSize})',
   slideshow_image: 'Slideshow image ({fileSize})',
 };


### PR DESCRIPTION
## Summary

This change adds a string related to ZIM files to `filePresetStrings.js`. The rest of this is being added in learningequality/le-utils#89.

## Reviewer guidance

Please let me know if I have missed anything. The goal here is to support Zim files for the purpose of a Kolibri ZIM file plugin at https://github.com/endlessm/kolibri-zim-plugin/.
