### PR TITLE
Expose vue composition api through apiSpec (`kolibri.lib.vueCompositionApi`), so it is available to all SPAs

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -19,6 +19,7 @@ import responsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMi
 import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
 import scriptLoader from 'kolibri-design-system/lib/utils/scriptLoader';
 import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton'; // temp hack
+import * as vueCompositionApi from '@vue/composition-api';
 import logging from '../logging';
 import conditionalPromise from '../conditionalPromise';
 import * as apiResource from '../api-resource';
@@ -116,6 +117,7 @@ export default {
     logging,
     vue,
     vuex,
+    vueCompositionApi,
     conditionalPromise,
     apiResource,
   },

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -116,7 +116,7 @@
 
 <script>
 
-  import { computed } from '@vue/composition-api';
+  import { computed } from 'kolibri.lib.vueCompositionApi';
   import { useLocalStorage } from '@vueuse/core';
   import find from 'lodash/find';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js
@@ -4,7 +4,7 @@ import {
   onBeforeMount,
   onBeforeUnmount,
   getCurrentInstance,
-} from '@vue/composition-api';
+} from 'kolibri.lib.vueCompositionApi';
 import { get, set, useIntervalFn } from '@vueuse/core';
 import { fetchDynamicAddresses } from './api';
 

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
@@ -1,4 +1,4 @@
-import { ref, computed, onBeforeMount } from '@vue/composition-api';
+import { ref, computed, onBeforeMount } from 'kolibri.lib.vueCompositionApi';
 import { get, set, and } from '@vueuse/core';
 import { deleteAddress, fetchStaticAddresses } from './api';
 

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -74,6 +74,7 @@
 
 <script>
 
+  import { ref } from 'kolibri.lib.vueCompositionApi';
   import { mapState, mapActions } from 'vuex';
   import orderBy from 'lodash/orderBy';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
@@ -97,11 +98,16 @@
       DeleteGroupModal,
     },
     mixins: [commonCoach, commonCoreStrings],
-    data() {
+    setup() {
+      const selectedGroup = ref({
+        name: '',
+        id: '',
+      });
+
       return {
-        selectedGroup: {
-          name: '',
-          id: '',
+        selectedGroup,
+        setSelectedGroup(name, id) {
+          selectedGroup.value = { name, id };
         },
       };
     },
@@ -129,17 +135,11 @@
         this.displayModal(GroupModals.CREATE_GROUP);
       },
       openRenameGroupModal(groupName, groupId) {
-        this.selectedGroup = {
-          name: groupName,
-          id: groupId,
-        };
+        this.setSelectedGroup(groupName, groupId);
         this.displayModal(GroupModals.RENAME_GROUP);
       },
       openDeleteGroupModal(groupName, groupId) {
-        this.selectedGroup = {
-          name: groupName,
-          id: groupId,
-        };
+        this.setSelectedGroup(groupName, groupId);
         this.displayModal(GroupModals.DELETE_GROUP);
       },
       handleSuccessCreateGroup() {

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -30,6 +30,7 @@
 
 <script>
 
+  import { ref } from '@vue/composition-api';
   import omit from 'lodash/omit';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
@@ -45,6 +46,12 @@
       CoreBase,
       PostSetupModalGroup,
       DeviceTopNav,
+    },
+    setup() {
+      const foo = ref(0);
+      return {
+        foo,
+      };
     },
     computed: {
       ...mapGetters(['canManageContent', 'isSuperuser']),

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import { ref } from '@vue/composition-api';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
   import omit from 'lodash/omit';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -30,7 +30,8 @@
 
 <script>
 
-  import { ref, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
+  import { getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
+  import { useIntervalFn } from '@vueuse/core';
   import omit from 'lodash/omit';
   import { mapState, mapGetters } from 'vuex';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
@@ -48,24 +49,20 @@
       DeviceTopNav,
     },
     setup() {
-      const intervalId = ref(null);
-      const $store = getCurrentInstance().proxy.$store;
-      function refreshTaskList() {
+      const polling = useIntervalFn(() => {
         $store.dispatch('manageContent/refreshTaskList');
-      }
+      }, 1000);
+      const $store = getCurrentInstance().proxy.$store;
       function startTaskPolling() {
-        if (!intervalId.value && $store.getters.canManageContent) {
-          intervalId.value = setInterval(refreshTaskList, 1000);
+        if ($store.getters.canManageContent) {
+          polling.start();
         }
       }
       function stopTaskPolling() {
-        if (intervalId.value) {
-          intervalId.value = clearInterval(intervalId.value);
-        }
+        polling.stop();
       }
 
       return {
-        intervalId,
         stopTaskPolling,
         startTaskPolling,
       };

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/actions.js
@@ -19,18 +19,3 @@ export function createClass(store, name) {
     }
   );
 }
-
-/**
- * Do a DELETE to delete the class.
- * @param {string or Integer} id
- */
-export function deleteClass(store, id) {
-  return ClassroomResource.deleteModel({ id }).then(
-    () => {
-      store.commit('DELETE_CLASS', id);
-    },
-    error => {
-      store.dispatch('handleApiError', error, { root: true });
-    }
-  );
-}

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/index.js
@@ -1,5 +1,5 @@
 import { displayModal, SET_BUSY, SET_ERROR, SET_MODAL } from '../shared';
-import { createClass, deleteClass } from './actions';
+import { createClass } from './actions';
 
 function defaultState() {
   return {
@@ -32,7 +32,6 @@ export default {
   },
   actions: {
     createClass,
-    deleteClass,
     displayModal,
   },
 };

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -7,7 +7,7 @@
     @submit="classDelete"
     @cancel="$emit('cancel')"
   >
-    <p>{{ $tr('confirmation', { classname: classname }) }}</p>
+    <p>{{ $tr('confirmation', { classname: className }) }}</p>
     <p>{{ $tr('description') }}</p>
     <p>{{ coreString('cannotUndoActionWarning') }}</p>
   </KModal>
@@ -17,24 +17,31 @@
 
 <script>
 
+  import { readonly } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useDeleteClass from './useDeleteClass';
 
   export default {
     name: 'ClassDeleteModal',
     mixins: [commonCoreStrings],
+    setup(props) {
+      const { deleteSelectedClassModel } = useDeleteClass(props.classToDelete);
+      const { name } = props.classToDelete;
+      return {
+        className: readonly(name),
+        deleteSelectedClassModel,
+      };
+    },
     props: {
-      classname: {
-        type: String,
-        required: true,
-      },
-      classid: {
-        type: String,
+      // eslint-disable-next-line kolibri/vue-no-unused-properties
+      classToDelete: {
+        type: Object,
         required: true,
       },
     },
     methods: {
       classDelete() {
-        this.$store.dispatch('classManagement/deleteClass', this.classid).then(() => {
+        this.deleteSelectedClassModel().then(() => {
           this.$emit('success');
           this.showSnackbarNotification('classDeleted');
         });

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -82,7 +82,7 @@
               <KButton
                 appearance="flat-button"
                 :text="$tr('deleteClass')"
-                @click="openDeleteClassModal(classroom)"
+                @click="selectClassToDelete(classroom)"
               />
             </td>
           </tr>
@@ -95,10 +95,9 @@
     </p>
 
     <ClassDeleteModal
-      v-if="modalShown === Modals.DELETE_CLASS"
-      :classid="classForDeletion.id"
-      :classname="classForDeletion.name"
-      @cancel="closeModal"
+      v-if="Boolean(classToDelete)"
+      :classToDelete="classToDelete"
+      @cancel="clearClassToDelete"
       @success="handleDeleteSuccess()"
     />
     <ClassCreateModal
@@ -123,6 +122,7 @@
   import { Modals } from '../../constants';
   import ClassCreateModal from './ClassCreateModal';
   import ClassDeleteModal from './ClassDeleteModal';
+  import useDeleteClass from './useDeleteClass';
 
   export default {
     name: 'ManageClassPage',
@@ -137,8 +137,13 @@
       ClassDeleteModal,
     },
     mixins: [commonCoreStrings],
-    data() {
-      return { classForDeletion: null };
+    setup() {
+      const { classToDelete, selectClassToDelete, clearClassToDelete } = useDeleteClass();
+      return {
+        classToDelete,
+        selectClassToDelete,
+        clearClassToDelete,
+      };
     },
     computed: {
       ...mapState('classManagement', ['modalShown', 'classes']),
@@ -161,8 +166,7 @@
         this.refreshCoreFacilities();
       },
       handleDeleteSuccess() {
-        this.closeModal();
-        this.classForDeletion = null;
+        this.clearClassToDelete();
         this.refreshCoreFacilities();
       },
       refreshCoreFacilities() {
@@ -204,10 +208,6 @@
         const link = cloneDeep(this.facilityPageLinks.ClassEditPage);
         link.params.id = classId;
         return link;
-      },
-      openDeleteClassModal(classModel) {
-        this.classForDeletion = classModel;
-        this.displayModal(Modals.DELETE_CLASS);
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/useDeleteClass.js
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/useDeleteClass.js
@@ -1,0 +1,43 @@
+import { ref, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
+import { set } from '@vueuse/core';
+import { ClassroomResource } from 'kolibri.resources';
+
+// Usable that manages the state for "Delete Class" workflow
+export default function useDeleteClass(classroomProp) {
+  const $store = getCurrentInstance().proxy.$store;
+  const classToDelete = ref(null);
+
+  if (classroomProp) {
+    set(classToDelete, classroomProp);
+  }
+
+  function selectClassToDelete(selectedClassroom) {
+    set(classToDelete, selectedClassroom);
+  }
+
+  function clearClassToDelete() {
+    set(classToDelete, null);
+  }
+
+  function deleteSelectedClassModel(deleteId = classToDelete.value.id) {
+    if (!deleteId) {
+      return Promise.reject('No classId was provided');
+    }
+
+    return ClassroomResource.deleteModel({ id: deleteId }).then(
+      () => {
+        $store.commit('classManagement/DELETE_CLASS', deleteId);
+      },
+      error => {
+        $store.dispatch('handleApiError', error);
+      }
+    );
+  }
+
+  return {
+    classToDelete,
+    deleteSelectedClassModel,
+    selectClassToDelete,
+    clearClassToDelete,
+  };
+}

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -89,14 +89,14 @@
         <tr>
           <th>{{ coreString('genderLabel') }}</th>
           <td>
-            <GenderDisplayText :gender="facilityUser.gender" />
+            <GenderDisplayText :gender="currentUser.gender" />
           </td>
         </tr>
 
         <tr>
           <th>{{ coreString('birthYearLabel') }}</th>
           <td>
-            <BirthYearDisplayText :birthYear="facilityUser.birth_year" />
+            <BirthYearDisplayText :birthYear="currentUser.birth_year" />
           </td>
         </tr>
 
@@ -161,9 +161,9 @@
     mixins: [responsiveWindowMixin, commonCoreStrings],
     setup() {
       const showPasswordModal = ref(false);
-      const { facilityUser } = useCurrentUser();
+      const { currentUser } = useCurrentUser();
       return {
-        facilityUser,
+        currentUser,
         showPasswordModal,
       };
     },

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -127,6 +127,7 @@
 
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { mapState, mapGetters } from 'vuex';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
   import find from 'lodash/find';
   import pickBy from 'lodash/pickBy';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
@@ -135,11 +136,11 @@
   import PermissionsIcon from 'kolibri.coreVue.components.PermissionsIcon';
   import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
   import { PermissionTypes } from 'kolibri.coreVue.vuex.constants';
-  import { FacilityUserResource } from 'kolibri.resources';
   import GenderDisplayText from 'kolibri.coreVue.components.GenderDisplayText';
   import BirthYearDisplayText from 'kolibri.coreVue.components.BirthYearDisplayText';
   import { ComponentMap } from '../../constants';
   import ChangeUserPasswordModal from './ChangeUserPasswordModal';
+  import useCurrentUser from './useCurrentUser';
 
   export default {
     name: 'ProfilePage',
@@ -158,10 +159,12 @@
       UserTypeDisplay,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
-    data() {
+    setup() {
+      const showPasswordModal = ref(false);
+      const { facilityUser } = useCurrentUser();
       return {
-        facilityUser: {},
-        showPasswordModal: false,
+        facilityUser,
+        showPasswordModal,
       };
     },
     computed: {
@@ -215,20 +218,12 @@
     created() {
       this.$store.dispatch('fetchPoints');
     },
-    mounted() {
-      this.fetchFacilityUser();
-    },
     methods: {
       getPermissionString(permission) {
         if (permission === 'can_manage_content') {
           return this.$tr('manageContent');
         }
         return permission;
-      },
-      fetchFacilityUser() {
-        FacilityUserResource.fetchModel({ id: this.session.user_id }).then(facilityUser => {
-          this.facilityUser = { ...facilityUser };
-        });
       },
     },
     $trs: {

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/useCurrentUser.js
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/useCurrentUser.js
@@ -1,0 +1,24 @@
+import { ref, onMounted, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
+import { FacilityUserResource } from 'kolibri.resources';
+
+// A usable that returns the Facility user tied to the session
+export default function useCurrentUser() {
+  const $store = getCurrentInstance().proxy.$store;
+  const facilityUser = ref({});
+  const isLoading = ref(false);
+
+  onMounted(() => {
+    isLoading.value = true;
+    return FacilityUserResource.fetchModel({ id: $store.state.core.session.user_id }).then(
+      facilityUser => {
+        facilityUser.value = { ...facilityUser };
+        isLoading.value = false;
+      }
+    );
+  });
+
+  return {
+    facilityUser,
+    isLoading,
+  };
+}

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/useCurrentUser.js
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/useCurrentUser.js
@@ -4,21 +4,21 @@ import { FacilityUserResource } from 'kolibri.resources';
 // A usable that returns the Facility user tied to the session
 export default function useCurrentUser() {
   const $store = getCurrentInstance().proxy.$store;
-  const facilityUser = ref({});
+  const currentUser = ref({});
   const isLoading = ref(false);
 
   onMounted(() => {
     isLoading.value = true;
     return FacilityUserResource.fetchModel({ id: $store.state.core.session.user_id }).then(
-      facilityUser => {
-        facilityUser.value = { ...facilityUser };
+      userModel => {
+        currentUser.value = { ...userModel };
         isLoading.value = false;
       }
     );
   });
 
   return {
-    facilityUser,
+    currentUser,
     isLoading,
   };
 }

--- a/kolibri/plugins/user/assets/test/views/profile-page.spec.js
+++ b/kolibri/plugins/user/assets/test/views/profile-page.spec.js
@@ -1,13 +1,15 @@
+import { FacilityUserResource } from 'kolibri.resources';
 import { mount, RouterLinkStub, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import ProfilePage from '../../src/views/ProfilePage';
 import makeStore from '../makeStore';
 
+jest.mock('kolibri.resources');
+
+FacilityUserResource.fetchModel = jest.fn().mockResolvedValue({});
+
 const localVue = createLocalVue();
 localVue.use(VueRouter);
-
-ProfilePage.methods.fetchPoints = () => {};
-ProfilePage.methods.fetchFacilityUser = () => {};
 
 const router = new VueRouter();
 router.getRoute = () => {};

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -7,6 +7,7 @@ import * as AphroditeNoImportant from 'aphrodite/no-important';
 import Vue from 'vue';
 import VueMeta from 'vue-meta';
 import VueRouter from 'vue-router';
+import VueCompositionApi from '@vue/composition-api';
 import Vuex from 'vuex';
 import { i18nSetup } from 'kolibri.utils.i18n';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
@@ -35,6 +36,7 @@ Vue.use(VueRouter);
 Vue.use(VueMeta);
 Vue.use(KThemePlugin);
 Vue.use(KContentPlugin);
+Vue.use(VueCompositionApi);
 Vue.component('KSelect', KSelect);
 
 Vue.config.silent = true;


### PR DESCRIPTION
## Summary

The original PR that brought Vue Composition did not properly install the plugin for all SPAs (for reasons I don't understand). However, if it is bundled into apiSpec and exposed via `kolibri.lib.vueCompositionApi`, it works 🤷 

So this PR

1. Makes `kolibri.lib.vueCompositionApi` the primary way to import Vue Composition API into your components
2. Refactors Device, Coach, User, and Facility plugins to use the composition in a small way (to give us early warning if something goes wrong with the plugin)

## References

This issue is blocking #8137 , since the current implementation makes heavy use of the composition API.

## Reviewer guidance

Again, this refactor is a pretty straightforward mapping of Vue options -> composition functions, with a little sugar from `vueuse/core`. The app should work exactly as before.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
