### PR TITLE
Add learning activities constants and learning activity icon component

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -29,6 +29,17 @@ export const ContentNodeKinds = {
   SLIDESHOW: 'slideshow',
 };
 
+export const LearningActivityKinds = {
+  CREATE: 'CREATE',
+  LISTEN: 'LISTEN',
+  REFLECT: 'REFLECT',
+  PRACTICE: 'PRACTICE',
+  READ: 'READ',
+  WATCH: 'WATCH',
+  EXPLORE: 'EXPLORE',
+  TOPIC: 'TOPIC',
+};
+
 // used internally on the client as a hack to allow content-icons to display users
 export const USER = 'user';
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -1,0 +1,56 @@
+<template>
+
+  <KIcon :icon="icon" />
+
+</template>
+
+
+<script>
+
+  import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+
+  const LearningActivityKindToIconMap = {
+    [LearningActivityKinds.CREATE]: 'create',
+    [LearningActivityKinds.LISTEN]: 'listen',
+    [LearningActivityKinds.REFLECT]: 'reflect',
+    [LearningActivityKinds.PRACTICE]: 'practice',
+    [LearningActivityKinds.READ]: 'read',
+    [LearningActivityKinds.WATCH]: 'watch',
+    [LearningActivityKinds.EXPLORE]: 'interact',
+  };
+
+  export default {
+    name: 'LearningActivityIcon',
+    props: {
+      /**
+       * Learning activity constant
+       */
+      kind: {
+        type: String,
+        required: true,
+        validator(value) {
+          return Object.values(LearningActivityKinds).includes(value);
+        },
+      },
+      /**
+       * Icon is solid by default.
+       * Set to `true` to make it shaded.
+       */
+      shaded: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+    },
+    computed: {
+      icon() {
+        const icon = LearningActivityKindToIconMap[this.kind];
+        if (this.shaded) {
+          return icon + 'Shaded';
+        }
+        return icon + 'Solid';
+      },
+    },
+  };
+
+</script>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I extracted some parts of #8151 that more devs use when implementing hybrid learning features, namely learning activity constants and a component for a learning activity icon. The component only contains some basic functionality that I needed for #8151 but is already placed into `src/views/` to be shared across the whole learn plugin and can be extended as needed. I also added an option to switch between shaded and solid style. It can be used on its own or as part of `KLabeledIcon` ([example](https://github.com/learningequality/kolibri/pull/8151/files#diff-acab644da93f15633de6bae4d5b1b3fe36ef427a8641ea305eb12e9aeb50b759R6)).

I checked that the icon component renders all activities as expected in the bar I've been working on:

| Activity | Solid | Shaded |
| --------- | ------- | ---------- |
| create | ![create-solid](https://user-images.githubusercontent.com/13509191/122051626-1943a300-cde5-11eb-9333-cd1a2a084379.png) | ![create-shaded](https://user-images.githubusercontent.com/13509191/122051648-1fd21a80-cde5-11eb-8f5d-6a94283753dd.png) |
| explore | ![explore-solid](https://user-images.githubusercontent.com/13509191/122051684-29f41900-cde5-11eb-9e3b-7cd2ddb95264.png) | ![explore-shaded](https://user-images.githubusercontent.com/13509191/122051701-2eb8cd00-cde5-11eb-95f9-bd0ca8585460.png) |
| listen | ![listen-solid](https://user-images.githubusercontent.com/13509191/122051720-35dfdb00-cde5-11eb-936a-bc23cfeae6ab.png) | ![listen-shaded](https://user-images.githubusercontent.com/13509191/122051744-3b3d2580-cde5-11eb-83bc-6af3603aa14b.png) |
| practice | ![practice-solid](https://user-images.githubusercontent.com/13509191/122051936-6f184b00-cde5-11eb-8b9e-719744f468de.png) | ![practice-shaded](https://user-images.githubusercontent.com/13509191/122051959-73446880-cde5-11eb-93c3-95184c25ca73.png) |
| read | ![read-solid](https://user-images.githubusercontent.com/13509191/122051983-7b040d00-cde5-11eb-90c2-a48587bf3941.png) | ![read-shaded](https://user-images.githubusercontent.com/13509191/122052005-81928480-cde5-11eb-80f4-e1e6ae396779.png) |
| reflect | ![reflect-solid](https://user-images.githubusercontent.com/13509191/122052036-88b99280-cde5-11eb-84fd-1fdb9012baa2.png) | ![reflect-shaded](https://user-images.githubusercontent.com/13509191/122052056-8d7e4680-cde5-11eb-83eb-ff9e6925e7bc.png) |
| watch | ![watch-solid](https://user-images.githubusercontent.com/13509191/122052082-966f1800-cde5-11eb-8356-47490ebfec73.png) | ![watch-shaded](https://user-images.githubusercontent.com/13509191/122052100-9a9b3580-cde5-11eb-9e2b-93a65a03dc0f.png) |

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
