### PR TITLE
Add learning activity bar component

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -20,6 +20,8 @@
       <KIconButton
         icon="back"
         data-test="backButton"
+        :tooltip="$tr('goBack')"
+        :ariaLabel="$tr('goBack')"
         @click="onBackButtonClick"
       />
     </template>
@@ -265,6 +267,7 @@
       },
     },
     $trs: {
+      goBack: 'Go back',
       moreOptions: 'More options',
       viewLessonPlan: 'View lesson plan',
       viewTopicResources: 'View topic resources',

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -1,0 +1,309 @@
+<template>
+
+  <UiToolbar>
+    <KLabeledIcon :style="{ 'margin-top': '8px' }">
+      <template #icon>
+        <LearningActivityIcon
+          v-if="learningActivityKind"
+          data-test="learningActivityIcon"
+          :kind="learningActivityKind"
+          :shaded="true"
+        />
+      </template>
+      <TextTruncator
+        :text="resourceTitle"
+        :maxHeight="26"
+      />
+    </KLabeledIcon>
+
+    <template #icon>
+      <KIconButton
+        icon="back"
+        data-test="backButton"
+        @click="onBackButtonClick"
+      />
+    </template>
+
+    <template #actions>
+      <KIconButton
+        v-for="action in barActions"
+        :key="action.id"
+        :data-test="`bar_${action.dataTest}`"
+        :icon="action.icon"
+        :color="action.iconColor"
+        :tooltip="action.label"
+        :ariaLabel="action.label"
+        @click="onActionClick(action.event)"
+      />
+
+      <span class="menu-wrapper">
+        <KIconButton
+          v-if="menuActions.length"
+          ref="moreOptionsButton"
+          data-test="moreOptionsButton"
+          icon="optionsHorizontal"
+          :tooltip="$tr('moreOptions')"
+          :ariaLabel="$tr('moreOptions')"
+          @click="toggleMenu"
+        />
+        <CoreMenu
+          v-show="isMenuOpen"
+          ref="menu"
+          class="menu"
+          :raised="true"
+          :isOpen="isMenuOpen"
+          :containFocus="true"
+          @close="closeMenu"
+        >
+          <template #options>
+            <CoreMenuOption
+              v-for="action in menuActions"
+              :key="action.id"
+              :data-test="`menu_${action.dataTest}`"
+              :style="{ 'cursor': 'pointer' }"
+              @select="onActionClick(action.event)"
+            >
+              <KLabeledIcon>
+                <template #icon>
+                  <KIcon
+                    :icon="action.icon"
+                    :color="action.iconColor"
+                  />
+                </template>
+                <div>{{ action.label }}</div>
+              </KLabeledIcon>
+            </CoreMenuOption>
+          </template>
+        </CoreMenu>
+      </span>
+    </template>
+  </UiToolbar>
+
+</template>
+
+
+<script>
+
+  import difference from 'lodash/difference';
+  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
+  import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
+  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+  import LearningActivityIcon from './LearningActivityIcon.vue';
+
+  export default {
+    name: 'LearningActivityBar',
+    components: {
+      CoreMenu,
+      CoreMenuOption,
+      UiToolbar,
+      TextTruncator,
+      LearningActivityIcon,
+    },
+    mixins: [KResponsiveWindowMixin],
+    /**
+     * Emits the following events:
+     * - `navigateBack` on back button click
+     * - `viewResourceList` on 'View lesson plan'/'View topic resources' click
+     * - `toogleBookmark` on 'Save to bookmarks'/ 'Remove from bookmarks' click
+     * - `markComplete` on 'Mark resource as finished' click. Only when
+     *                  a resource can be marked as complete.
+     * - `viewInfo` on 'View information' click
+     */
+    props: {
+      resourceTitle: {
+        type: String,
+        required: true,
+      },
+      /**
+       * Learning activity constant
+       */
+      learningActivityKind: {
+        type: String,
+        required: true,
+        validator(value) {
+          return Object.values(LearningActivityKinds).includes(value);
+        },
+      },
+      /**
+       * Is the bar used in the context of a lesson?
+       * There are slight differences in rendering
+       * related to the context, e.g. action buttons labels.
+       */
+      isLessonContext: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      isBookmarked: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      /**
+       * Does a resource have the option to be
+       * manually marked as complete?
+       * Used to determine if a button for this action
+       * should be displayed.
+       */
+      allowMarkComplete: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+    },
+    data() {
+      return {
+        isMenuOpen: false,
+      };
+    },
+    computed: {
+      allActions() {
+        const actions = [
+          {
+            id: 'view-resource-list',
+            icon: 'resourceList',
+            label: this.isLessonContext
+              ? this.$tr('viewLessonPlan')
+              : this.$tr('viewTopicResources'),
+            event: 'viewResourceList',
+            dataTest: this.isLessonContext ? 'viewLessonPlanButton' : 'viewTopicResourcesButton',
+          },
+          {
+            id: 'bookmark',
+            icon: this.isBookmarked ? 'bookmark' : 'bookmarkEmpty',
+            label: this.isBookmarked
+              ? this.$tr('removeFromBookmarks')
+              : this.$tr('saveToBookmarks'),
+            event: 'toogleBookmark',
+            dataTest: this.isBookmarked ? 'removeBookmarkButton' : 'addBookmarkButton',
+          },
+        ];
+        if (this.allowMarkComplete) {
+          actions.push({
+            id: 'mark-complete',
+            icon: 'star',
+            iconColor: this.$themePalette.yellow.v_700,
+            label: this.$tr('markResourceAsFinished'),
+            event: 'markComplete',
+            dataTest: 'markCompleteButton',
+          });
+        }
+        actions.push({
+          id: 'view-info',
+          icon: 'info',
+          label: this.$tr('viewInformation'),
+          event: 'viewInfo',
+          dataTest: 'viewInfoButton',
+        });
+
+        return actions;
+      },
+      barActions() {
+        const actions = [];
+        if (this.windowBreakpoint >= 1) {
+          actions.push(this.allActions.find(action => action.id === 'view-resource-list'));
+        }
+        if (this.windowBreakpoint >= 2) {
+          actions.push(this.allActions.find(action => action.id === 'bookmark'));
+          // if a resource doesn’t have the option for learners to manually mark as complete,
+          // the 'More options' bar icon button changes to the 'View information' bar icon button
+          if (!this.allowMarkComplete) {
+            actions.push(this.allActions.find(action => action.id === 'view-info'));
+          }
+        }
+        return actions;
+      },
+      menuActions() {
+        return difference(this.allActions, this.barActions);
+      },
+    },
+    created() {
+      window.addEventListener('click', this.onWindowClick);
+    },
+    beforeDestroy() {
+      window.removeEventListener('click', this.onWindowClick);
+    },
+    methods: {
+      closeMenu({ focusMoreOptionsButton = true } = {}) {
+        this.isMenuOpen = false;
+        if (!focusMoreOptionsButton) {
+          return;
+        }
+        this.$nextTick(() => {
+          this.$refs.moreOptionsButton.$el.focus();
+        });
+      },
+      toggleMenu() {
+        this.isMenuOpen = !this.isMenuOpen;
+        if (!this.isMenuOpen) {
+          return;
+        }
+        this.$nextTick(() => {
+          this.$refs.menu.$el.focus();
+        });
+      },
+      onBackButtonClick() {
+        this.$emit('navigateBack');
+      },
+      onActionClick(actionEvent) {
+        this.$emit(actionEvent);
+      },
+      onWindowClick(event) {
+        if (!this.isMenuOpen) {
+          return;
+        }
+        // close menu on outside click
+        if (
+          !this.$refs.menu.$el.contains(event.target) &&
+          !this.$refs.moreOptionsButton.$el.contains(event.target)
+        ) {
+          this.closeMenu({ focusMoreOptionsButton: false });
+        }
+      },
+    },
+    $trs: {
+      moreOptions: 'More options',
+      viewLessonPlan: 'View lesson plan',
+      viewTopicResources: 'View topic resources',
+      removeFromBookmarks: 'Remove from bookmarks',
+      saveToBookmarks: 'Save to bookmarks',
+      markResourceAsFinished: 'Mark resource as finished',
+      viewInformation: 'View information',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .menu-wrapper {
+    position: relative;
+  }
+
+  .menu {
+    position: absolute;
+    top: 50%;
+    right: 10px; // right-align to the menu icon
+    min-width: 270px;
+    transform: translateY(16px);
+  }
+
+  // decrease the gap between the back navigation
+  // icon and a resource icon + title
+  /deep/ .ui-toolbar__left {
+    .ui-toolbar__nav-icon {
+      margin-right: 12px;
+    }
+  }
+
+  // increase the gap between the resource title
+  // and the action buttons on the right
+  /deep/ .ui-toolbar__right {
+    margin-left: 16px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -1,0 +1,194 @@
+import { shallowMount, mount } from '@vue/test-utils';
+
+import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+import LearningActivityBar from '../../src/views/LearningActivityBar';
+
+function makeWrapper({ propsData } = {}) {
+  return mount(LearningActivityBar, { propsData });
+}
+
+describe('LearningActivityBar', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(LearningActivityBar);
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('shows a resource title in the bar', () => {
+    const wrapper = makeWrapper({
+      propsData: { resourceTitle: 'Practice and applications of math' },
+    });
+    expect(wrapper.text()).toContain('Practice and applications of math');
+  });
+
+  it('shows the back button in the bar', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-test="backButton"]').exists()).toBeTruthy();
+  });
+
+  it('emits `navigateBack` event on the back button click', () => {
+    const wrapper = makeWrapper();
+    wrapper.find('[data-test="backButton"]').trigger('click');
+    expect(wrapper.emitted().navigateBack.length).toBe(1);
+  });
+
+  it('shows a learning activity icon in the bar', () => {
+    const wrapper = makeWrapper({
+      propsData: {
+        learningActivityKind: LearningActivityKinds.WATCH,
+      },
+    });
+    expect(wrapper.find('[data-test="learningActivityIcon"]').exists()).toBeTruthy();
+  });
+
+  // Although there are basic tests for distribution
+  // of action buttons between the bar and the menu in the following tests,
+  // their position can further change based on the window size.
+  // Purpose of these tests is rather functional. Testing all screen
+  // sizes here would result in a huge test case and it needs to be
+  // tested visually anyways. For that reason, the following tests always
+  // assume a large screen.
+  describe('on a large screen', () => {
+    describe('in the lesson context', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { isLessonContext: true } });
+      });
+
+      it("doesn't show 'View topic resources' button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_viewTopicResourcesButton']").exists()).toBeFalsy();
+      });
+
+      it("shows 'View lesson plan' button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_viewLessonPlanButton']").exists()).toBeTruthy();
+      });
+
+      it("emits `viewResourceList` event on the 'View lesson plan' button click", () => {
+        wrapper.find('[data-test="bar_viewLessonPlanButton"]').trigger('click');
+        expect(wrapper.emitted().viewResourceList.length).toBe(1);
+      });
+    });
+
+    describe('in the non-lesson context', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { isLessonContext: false } });
+      });
+
+      it("doesn't show 'View lesson plan' button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_viewLessonPlanButton']").exists()).toBeFalsy();
+      });
+
+      it("shows 'View topic resources' button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_viewTopicResourcesButton']").exists()).toBeTruthy();
+      });
+
+      it("emits `viewResourceList` event on the 'View topic resources' button click", () => {
+        wrapper.find('[data-test="bar_viewTopicResourcesButton"]').trigger('click');
+        expect(wrapper.emitted().viewResourceList.length).toBe(1);
+      });
+    });
+
+    describe('when a resource is bookmarked', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { isBookmarked: true } });
+      });
+
+      it("doesn't show the add bookmark button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_addBookmarkButton']").exists()).toBeFalsy();
+      });
+
+      it('shows the remove bookmark button in the bar', () => {
+        expect(wrapper.find("[data-test='bar_removeBookmarkButton']").exists()).toBeTruthy();
+      });
+
+      it('emits `toogleBookmark` event on the remove bookmark button click', () => {
+        wrapper.find("[data-test='bar_removeBookmarkButton']").trigger('click');
+        expect(wrapper.emitted().toogleBookmark.length).toBe(1);
+      });
+    });
+
+    describe('when a resource is not bookmarked', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { isBookmarked: false } });
+      });
+
+      it("doesn't show the remove bookmark button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_removeBookmarkButton']").exists()).toBeFalsy();
+      });
+
+      it('shows the add bookmark button in the bar', () => {
+        expect(wrapper.find("[data-test='bar_addBookmarkButton']").exists()).toBeTruthy();
+      });
+
+      it('emits `toogleBookmark` event on the add bookmark button click', () => {
+        wrapper.find("[data-test='bar_addBookmarkButton']").trigger('click');
+        expect(wrapper.emitted().toogleBookmark.length).toBe(1);
+      });
+    });
+
+    describe('if a resource can be manually marked as complete', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { allowMarkComplete: true } });
+      });
+
+      it('shows the more options button', () => {
+        expect(wrapper.find("[data-test='moreOptionsButton']").exists()).toBeTruthy();
+      });
+
+      it("shows 'Mark resource as finished' button in the menu", () => {
+        expect(wrapper.find("[data-test='bar_markCompleteButton']").exists()).toBeFalsy();
+        expect(wrapper.find("[data-test='menu_markCompleteButton']").exists()).toBeTruthy();
+      });
+
+      it("emits `markComplete` event on the 'Mark resource as finished' button click", () => {
+        wrapper.find("[data-test='menu_markCompleteButton']").vm.$emit('select');
+        expect(wrapper.emitted().markComplete.length).toBe(1);
+      });
+
+      it("shows 'View information' button in the menu", () => {
+        expect(wrapper.find("[data-test='bar_viewInfoButton']").exists()).toBeFalsy();
+        expect(wrapper.find("[data-test='menu_viewInfoButton']").exists()).toBeTruthy();
+      });
+
+      it("emits `viewInfo` event on the 'View information' menu button click", () => {
+        wrapper.find("[data-test='menu_viewInfoButton']").vm.$emit('select');
+        expect(wrapper.emitted().viewInfo.length).toBe(1);
+      });
+    });
+
+    describe("if a resource can't be manually marked as complete", () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({ propsData: { allowMarkComplete: false } });
+      });
+
+      it("doesn't show the more options button", () => {
+        expect(wrapper.find("[data-test='moreOptionsButton']").exists()).toBeFalsy();
+      });
+
+      it("doesn't show 'Mark resource as finished' button", () => {
+        expect(wrapper.find("[data-test='bar_markCompleteButton']").exists()).toBeFalsy();
+        expect(wrapper.find("[data-test='menu_markCompleteButton']").exists()).toBeFalsy();
+      });
+
+      it("shows 'View information' button in the bar", () => {
+        expect(wrapper.find("[data-test='menu_viewInfoButton']").exists()).toBeFalsy();
+        expect(wrapper.find("[data-test='bar_viewInfoButton']").exists()).toBeTruthy();
+      });
+
+      it("emits `viewInfo` event on the 'View information' bar button click", () => {
+        wrapper.find("[data-test='bar_viewInfoButton']").trigger('click');
+        expect(wrapper.emitted().viewInfo.length).toBe(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Add a new, mobile responsive, learning activity bar component.

Note that connecting the bar to the app is out of the scope of this ticket and that if you follow the testing instructions below it will appear sticky even when it's not supposed to be. It's not related to the new component itself, but rather to `CoreBase` and will need to be resolved when we start connecting new bars to pages. Also, since this PR only adds a component to our library, I didn't update any Gherkin stories at this point.

### Screenshots

Only the most important states are documented here. Please see Figma designs linked in references to compare to the full specification.

#### Bar/menu items distribution

| 320-480 | 480-600 | 600 and higher |
| ----------- | ----------- | -------------------- |
| ![320-480](https://user-images.githubusercontent.com/13509191/122390641-85074680-cf72-11eb-90aa-1872593ea6f5.png) | ![480-600](https://user-images.githubusercontent.com/13509191/122390661-89cbfa80-cf72-11eb-876d-d10b260cf853.png) | ![600-higher](https://user-images.githubusercontent.com/13509191/122390688-8fc1db80-cf72-11eb-8fda-cbb656c891af.png) |

#### Bookmarks

|    | Bookmarked resource | Not bookmarked resource |
| -- | ----------------------------- | ----------------------------------- |
| Bar | ![bookmarked-bar](https://user-images.githubusercontent.com/13509191/122390906-c566c480-cf72-11eb-8772-3dffcd748ab2.png) | ![not-bookmarked-bar](https://user-images.githubusercontent.com/13509191/122390940-cc8dd280-cf72-11eb-933a-38fa3c1ef21d.png) |
| Menu | ![bookmarked-menu](https://user-images.githubusercontent.com/13509191/122390976-d31c4a00-cf72-11eb-9c95-567a98b34d0a.png) | ![not-bookmarked-menu](https://user-images.githubusercontent.com/13509191/122390998-d9122b00-cf72-11eb-9ed7-519330e3b8f7.png) |

#### Context

|   | Lesson context | Non-lesson context |
| -- | -------------------- | -------------------------- |
| Bar | ![lesson-context-bar](https://user-images.githubusercontent.com/13509191/122391276-21314d80-cf73-11eb-8e76-9663582733c3.png) | ![non-lesson-context-bar](https://user-images.githubusercontent.com/13509191/122391306-25f60180-cf73-11eb-89e7-14ac069e9923.png) |
| Menu | ![lesson-context-menu](https://user-images.githubusercontent.com/13509191/122391330-2c847900-cf73-11eb-95b1-e65bc825537e.png) | ![non-lesson-context-menu](https://user-images.githubusercontent.com/13509191/122391349-327a5a00-cf73-11eb-8910-8957a8e7650a.png) |

#### When a resource can't be manually marked as complete

| Bar | Menu |
| ---- | -------- |
| ![cannot-be-marked-complete-bar](https://user-images.githubusercontent.com/13509191/122391599-7c634000-cf73-11eb-8470-92359609bba2.png) | ![cannot-be-marked-complete-menu](https://user-images.githubusercontent.com/13509191/122391619-808f5d80-cf73-11eb-8ea6-d971476a7c61.png) |

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- Closes #8106
- [Designs in Figma](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=387%3A26928)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I haven't found a better way to test the new bar than hacking `CoreBase` locally [as demonstrated here](https://github.com/MisRob/kolibri/commit/1e9a411e2cdc109005fed5793dbf2b3311a7a3d2) and then navigating to a resource page, for example, _"Learn"_ -> _"Channels"_ -> Select a channel and open a resource from a topic of the channel.

- [ ] Make sure to run `yarn install --check-files` to pull the latest KDS version containing learning activities icons.
- [ ] Check for different resolutions
- [ ] Check for RTL language (you can replace `/en/` by `/ar/` in the URL)
- [ ] Check accessibility - navigation in the bar, opening the menu, navigation in the menu

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md