### PR TITLE
Add topological sorting of models to ensure import order.

### DIFF
--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -35,8 +35,16 @@ from kolibri.core.content.utils.annotation import (
 from kolibri.core.content.utils.annotation import update_content_metadata
 from kolibri.core.content.utils.channel_import import ChannelImport
 from kolibri.core.content.utils.channel_import import import_channel_from_local_db
+from kolibri.core.content.utils.channel_import import topological_sort
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import load_metadata
+
+
+class UtilityTestCase(TestCase):
+    def test_topological_sort(self):
+        sorted_models = topological_sort([File, LocalFile, ContentNode])
+        self.assertGreater(sorted_models.index(File), sorted_models.index(ContentNode))
+        self.assertGreater(sorted_models.index(File), sorted_models.index(LocalFile))
 
 
 @patch("kolibri.core.content.utils.channel_import.Bridge")

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -68,6 +68,50 @@ def convert_to_sqlite_value(python_value):
         return repr(python_value)
 
 
+def _get_dependencies(content_models):
+    references = {}
+    for model in content_models:
+        meta = model._meta
+        for f in meta.concrete_fields:
+            if f.is_relation and f.many_to_one:
+                if f.related_model not in references:
+                    references[f.related_model] = set()
+                if f.related_model is not model:
+                    references[f.related_model].add(model)
+    return references
+
+
+def topological_sort(content_models):
+    """
+    Carries out a depth first search topological sort of content models to ensure we
+    import them in the correct order.
+    ref: https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
+    """
+    # First collect all non-self referential foreign key references
+    # in the set of models. We can't resolve the self-referentiality in a topological
+    # sort, so we simply ignore it.
+    references = _get_dependencies(content_models)
+
+    sorted_models = []
+    visiting = set()
+
+    def visit(n):
+        if n in sorted_models:
+            return
+        if n in visiting:
+            raise ReferenceError(n)
+        visiting.add(n)
+        for m in references.get(n, set()):
+            visit(m)
+        visiting.remove(n)
+        sorted_models.insert(0, n)
+
+    for model in content_models:
+        visit(model)
+
+    return sorted_models
+
+
 class ChannelImport(object):
     """
     The ChannelImport class has two functions:
@@ -146,6 +190,8 @@ class ChannelImport(object):
         for blacklisted_model in models_to_exclude:
             if blacklisted_model in self.content_models:
                 self.content_models.remove(blacklisted_model)
+
+        self.content_models = topological_sort(self.content_models)
 
         # Get the next available tree_id in our database
         self.available_tree_id = self.find_unique_tree_id()

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,3 +11,4 @@ pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-pythonpath==0.7.2
 sh==1.12.14
+attrs==20.3.0


### PR DESCRIPTION
## Summary
* Sorts content models during import by their foreign key dependencies to ensure we don't try to import non-existent FK references
* Adds test of utility

## References
Fixes #8140

## Reviewer guidance
Does content importing still work as expected? Does it resolve the issues on Postgres?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
