### PR TITLE
Remove double negation in query

### DIFF
--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -269,9 +269,14 @@ class LocalFileQueryset(models.QuerySet, FilterByUUIDQuerysetMixin):
         return self.filter(files__isnull=True).delete()
 
     def get_unused_files(self):
-        return self.filter(
+        ids = LocalFile.objects.filter(
             Q(files__contentnode__available=False) | Q(files__isnull=True)
-        ).filter(available=True)
+        )
+        return (
+            self.filter(id__in=ids)
+            .exclude(files__contentnode__available=True)
+            .filter(available=True)
+        )
 
 
 @python_2_unicode_compatible

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -270,7 +270,7 @@ class LocalFileQueryset(models.QuerySet, FilterByUUIDQuerysetMixin):
 
     def get_unused_files(self):
         return self.filter(
-            ~Q(files__contentnode__available=True) | Q(files__isnull=True)
+            Q(files__contentnode__available=False) | Q(files__isnull=True)
         ).filter(available=True)
 
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,3 +11,4 @@ pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-pythonpath==0.7.2
 sh==1.12.14
+attrs==20.3.0


### PR DESCRIPTION
## Summary
Executing the get_unused_files function is problematic in databases with many records, making it unusable when the database times out as it's happening in UNW servers.
This change remove a double negation in a query improving the performance .
Measuring it in the Mexico UNW server it passes from timeout to be executed in Time: 2068.917 ms (00:02.069)


## References
Closes: #8155

```
Explain SELECT "content_localfile"."id",
       "content_localfile"."extension",
       "content_localfile"."available",
       "content_localfile"."file_size"
FROM "content_localfile"
LEFT OUTER JOIN "content_file" ON ("content_localfile"."id" = "content_file"."local_file_id")
WHERE ((NOT ("content_localfile"."id" IN
               (SELECT U1."local_file_id" AS Col1
                FROM "content_file" U1
                INNER JOIN "content_contentnode" U2 ON (U1."contentnode_id" = U2."id")
                WHERE U2."available" =TRUE))
        OR "content_file"."id" IS NULL)
       AND "content_localfile"."available" = TRUE)


 Merge Left Join  (cost=29.99..477901437.97 rows=42855 width=42)
   Merge Cond: ((content_localfile.id)::text = (content_file.local_file_id)::text)
   Filter: ((NOT (SubPlan 1)) OR (content_file.id IS NULL))
   ->  Index Scan using content_localfile_pkey on content_localfile  (cost=0.41..1056.17 rows=31650 width=42)
         Filter: available
   ->  Index Scan using content_file_local_file_id_9780c2ab on content_file  (cost=0.42..3464.65 rows=85751 width=49)
   SubPlan 1
     ->  Materialize  (cost=29.16..10970.53 rows=84033 width=33)
           ->  Merge Join  (cost=29.16..9893.37 rows=84033 width=33)
                 Merge Cond: (u2.id = u1.contentnode_id)
                 ->  Index Scan using content_contentnode_pkey on content_contentnode u2  (cost=0.29..5561.79 rows=51595 width=16)
                       Filter: available
                 ->  Index Scan using content_file_contentnode_id_d4089e6e on content_file u1  (cost=0.42..3147.88 rows=85751 width=49)
```
versus
```
        explain        SELECT "content_localfile"."id",
       "content_localfile"."extension",
       "content_localfile"."available",
       "content_localfile"."file_size"
FROM "content_localfile"
WHERE ("content_localfile"."id" IN
         (SELECT U0."id" AS Col1
          FROM "content_localfile" U0
          LEFT OUTER JOIN "content_file" U1 ON (U0."id" = U1."local_file_id")
          LEFT OUTER JOIN "content_contentnode" U2 ON (U1."contentnode_id" = U2."id")
          WHERE (U2."available" = FALSE
                 OR U1."id" IS NULL))
       AND NOT ("content_localfile"."id" IN
                  (SELECT U1."local_file_id" AS Col1
                   FROM "content_file" U1
                   INNER JOIN "content_contentnode" U2 ON (U1."contentnode_id" = U2."id")
                   WHERE U2."available" = TRUE))
       AND "content_localfile"."available" = TRUE)

                                                                          QUERY PLAN                                                                           
---------------------------------------------------------------------------------------------------------------------------------------------------------------
Nested Loop  (cost=11075.56..9793357.85 rows=864 width=42) (actual time=1301.533..2431.096 rows=2 loops=1)
   ->  HashAggregate  (cost=11045.57..11062.85 rows=1728 width=33) (actual time=119.545..119.926 rows=774 loops=1)
         Group Key: (u0.id)::text
         ->  Hash Left Join  (cost=6439.65..11041.25 rows=1728 width=33) (actual time=54.456..119.150 rows=841 loops=1)
               Hash Cond: (u1.contentnode_id = u2.id)
               Filter: ((NOT u2.available) OR (u1.id IS NULL))
               Rows Removed by Filter: 85385
               ->  Hash Right Join  (cost=1042.54..4458.12 rows=86256 width=65) (actual time=11.846..60.164 rows=86226 loops=1)
                     Hash Cond: ((u1.local_file_id)::text = (u0.id)::text)
                     ->  Seq Scan on content_file u1  (cost=0.00..2229.56 rows=86256 width=65) (actual time=0.014..16.750 rows=86226 loops=1)
                     ->  Hash  (cost=633.35..633.35 rows=32735 width=33) (actual time=11.627..11.628 rows=31693 loops=1)
                           Buckets: 32768  Batches: 1  Memory Usage: 2268kB
                           ->  Seq Scan on content_localfile u0  (cost=0.00..633.35 rows=32735 width=33) (actual time=0.013..4.844 rows=31693 loops=1)
               ->  Hash  (cost=4729.27..4729.27 rows=53427 width=17) (actual time=31.455..31.455 rows=52904 loops=1)
                     Buckets: 65536  Batches: 1  Memory Usage: 3044kB
                     ->  Seq Scan on content_contentnode u2  (cost=0.00..4729.27 rows=53427 width=17) (actual time=0.007..22.051 rows=52904 loops=1)
   ->  Index Scan using content_localfile_id_a2a9e67d_like on content_localfile  (cost=30.00..5661.04 rows=1 width=42) (actual time=2.985..2.986 rows=0 loops=774)
         Index Cond: ((id)::text = (u0.id)::text)
         Filter: (available AND (NOT (SubPlan 1)))
         Rows Removed by Filter: 1
         SubPlan 1
           ->  Materialize  (cost=29.59..11080.27 rows=84529 width=33) (actual time=0.020..7.690 rows=48061 loops=190)
                 ->  Merge Join  (cost=29.59..9996.63 rows=84529 width=33) (actual time=0.024..122.061 rows=85385 loops=1)
                       Merge Cond: (u2_1.id = u1_1.contentnode_id)
                       ->  Index Scan using content_contentnode_pkey on content_contentnode u2_1  (cost=0.29..5640.55 rows=52357 width=16) (actual time=0.011..52.332 rows=51857 loops=1)
                             Filter: available
                             Rows Removed by Filter: 1047
                       ->  Index Scan using content_file_contentnode_id_d4089e6e on content_file u1_1  (cost=0.42..3164.26 rows=86256 width=49) (actual time=0.010..49.322 rows=86226 loops=1)
 Planning time: 1.150 ms
 Execution time: 2435.905 ms
(30 rows)

```


## Reviewer guidance

Check not side effects happen deleting undesired files when executing `LocalFile.objects.delete_unused_files()`


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
