### PR TITLE
Fixes dynamic file discovery and serving on windows.

### DIFF
--- a/kolibri/utils/tests/test_kolibri_whitenoise.py
+++ b/kolibri/utils/tests/test_kolibri_whitenoise.py
@@ -10,7 +10,7 @@ from kolibri.utils.kolibri_whitenoise import FileFinder
 def test_file_finder():
     tempdir1 = tempfile.mkdtemp()
     tempdir2 = tempfile.mkdtemp()
-    prefix = "test"
+    prefix = "/test"
     tempdir1tempfile, tempdir1tempfilepath = tempfile.mkstemp(dir=tempdir1)
     tempdir2tempfile, tempdir2tempfilepath = tempfile.mkstemp(dir=tempdir2)
     tempdir1tempfilename = os.path.basename(tempdir1tempfilepath)
@@ -30,14 +30,14 @@ def test_file_finder():
 def test_dynamic_whitenoise():
     tempdir11 = tempfile.mkdtemp()
     tempdir12 = tempfile.mkdtemp()
-    prefix1 = "test"
+    prefix1 = "/test"
     tempdir11tempfile, tempdir11tempfilepath = tempfile.mkstemp(dir=tempdir11)
     tempdir12tempfile, tempdir12tempfilepath = tempfile.mkstemp(dir=tempdir12)
     tempdir11tempfilename = os.path.basename(tempdir11tempfilepath)
     tempdir12tempfilename = os.path.basename(tempdir12tempfilepath)
     tempdir21 = tempfile.mkdtemp()
     tempdir22 = tempfile.mkdtemp()
-    prefix2 = "notatest"
+    prefix2 = "/notatest"
     tempdir21tempfile, tempdir21tempfilepath = tempfile.mkstemp(dir=tempdir21)
     tempdir22tempfile, tempdir22tempfilepath = tempfile.mkstemp(dir=tempdir22)
     tempdir21tempfilename = os.path.basename(tempdir21tempfilepath)


### PR DESCRIPTION
## Summary
* Changes to how we serve dynamically discovered files (like content, and static files that are not precached) led to a regression where files would not be discovered on Windows
* Tests intended to cover this failed to do so, because they did not include `/` in the prefix for the files, as all of our production prefixes do (as they are intended to be root URLs)
* This PR fixes these issues by updating the File Finder class used to directly handle URLs

## References
Fixes #8161

## Reviewer guidance
* Do content files get properly served from a Windows server?
* Do hashi static files for an HTML5 app get properly served from a Windows server?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
