### PR TITLE
Initiate auto-syncing from zeroconf

### DIFF
--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -1,3 +1,4 @@
+import datetime
 import gzip
 import io
 import json
@@ -183,7 +184,10 @@ class SyncQueueViewSet(viewsets.ViewSet):
         return Response(queue)
 
     def check_queue(self, pk=None):
-        current_transfers = TransferSession.objects.filter(active=True).count()
+        last_activity = datetime.datetime.now() - datetime.timedelta(minutes=5)
+        current_transfers = TransferSession.objects.filter(
+            active=True, last_activity_timestamp__gte=last_activity
+        ).count()
         if current_transfers < MAX_CONCURRENT_SYNCS:
             allow_sync = True
             data = {"action": SYNC}


### PR DESCRIPTION
## Summary

For a device that has a subset of users, when a new device joins the network, that is not a subset of users device, attempt to initiate an automatic sync with that device.


## References
Closes: #8157



## Reviewer guidance
All the api handshake seems to work fine, tested between three devices: 
1. A previous version of  kolibri
2. A kolibri server that's not a SoUD 
3. A kolibri server that's a SoUD and has some users synced from the previous server

After starting 1, 2, 3 and stopping 2 the algorithm increases the timeouts to request , what is correct.
After starting 2 again, the algorithm waits to have a permission to request, respecting the order in the queue


![2021-06-21_12-18](https://user-images.githubusercontent.com/1008178/122747678-a4141a00-d28b-11eb-8239-063cfcb52206.png)


However, I have watched the queue in server 2 is always keeping one `TransferSession` active, so this seems to be a never-to-sync situation. The session marked below never ends:
![image](https://user-images.githubusercontent.com/1008178/122747858-d4f44f00-d28b-11eb-8e26-a531cbe523d1.png)

As we changed the `MAX_CONCURRENT_SYNCS` [variable to be 1](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/public/api.py#L33), syncing is never going to happen while one session  is stalled

To avoid this problem, and following @bjester adviced, the server is not giving permission to sync if there has not been any syncing activity in the last five minutes. After that changed (in a commit in this PR) syncing is triggered automatically by zeroconf and it seems to work fine between these two servers (having server 3 two `FacilityUsers`):
![image](https://user-images.githubusercontent.com/1008178/122809942-0b9f8900-d2cf-11eb-85f7-0c92ef518bdd.png)




## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
