### PR TITLE
Use consistent "not started" icon and background color in AnswerHistory and AttemptLogList

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -21,7 +21,7 @@
           :key="index"
           class="attempt-item"
           :style="{
-            backgroundColor: isSelected(index) ? $themeTokens.textDisabled : '',
+            backgroundColor: isSelected(index) ? $themePalette.grey.v_100 : '',
           }"
         >
           <a
@@ -37,8 +37,7 @@
             <KIcon
               v-if="attemptLog.noattempt"
               class="item svg-item"
-              :style=" { fill: $themeTokens.annotation }"
-              icon="cancel"
+              icon="notStarted"
             />
             <KIcon
               v-else-if="attemptLog.correct"

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -15,7 +15,7 @@
       >
         <KIcon
           class="dot"
-          icon="dot"
+          icon="notStarted"
           :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
         />
         <div class="text">
@@ -80,7 +80,7 @@
       },
       buttonClass(index) {
         if (this.questionNumber === index) {
-          return this.$computedClass({ backgroundColor: this.$themePalette.grey.v_200 });
+          return this.$computedClass({ backgroundColor: this.$themePalette.grey.v_100 });
         }
         return this.$computedClass({
           backgroundColor: this.$themeTokens.surface,


### PR DESCRIPTION

## Summary

1. Fixes invalid `KIcon` prop on AttemptLogList (fixes #8149)
2. Changes "active" styling for list items on AnswerHistory and AttemptLogList

**AttemptLogList** at small window size (the not started icon is now visible)

![CleanShot 2021-06-21 at 17 18 39](https://user-images.githubusercontent.com/10248067/122844257-29142900-d2b6-11eb-81c0-bbd18d0dd5bb.png)

## References

Fixes #8149

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
