### PR TITLE
Implement swipe-to-open/close gestures for Side Navigation

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -8,6 +8,9 @@
 
     <div v-if="blockDoubleClicks" class="click-mask"></div>
 
+    <!-- Invisible div on the very edge that enables the swipe-to-open-menu gesture -->
+    <div v-if="windowIsSmall" ref="swipeZone" class="swipe-zone"></div>
+
     <ScrollingHeader
       :scrollPosition="scrollPosition"
       :alwaysVisible="fixedAppBar"
@@ -125,6 +128,8 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
+  import { useSwipe } from '@vueuse/core';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import AppBar from 'kolibri.coreVue.components.AppBar';
   import SideNav from 'kolibri.coreVue.components.SideNav';
@@ -196,6 +201,19 @@
       LanguageSwitcherModal,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
+    setup() {
+      const swipeZone = ref(null);
+      const navShown = ref(false);
+      const { isSwiping } = useSwipe(swipeZone, {
+        onSwipeEnd: (e, direction) => {
+          if (direction === 'RIGHT' && !navShown.value) {
+            navShown.value = true;
+          }
+        },
+      });
+
+      return { swipeZone, navShown, isSwiping };
+    },
     props: {
       appBarTitle: {
         type: String,
@@ -288,7 +306,6 @@
     },
     data() {
       return {
-        navShown: false,
         scrollPosition: 0,
         unwatchScrollHeight: undefined,
         notificationModalShown: true,
@@ -587,6 +604,16 @@
     font-size: large;
     font-weight: bold;
     line-height: 2em;
+  }
+
+  .swipe-zone {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 5;
+    width: 10px;
+    opacity: 0;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -204,7 +204,7 @@
     setup() {
       const swipeZone = ref(null);
       const navShown = ref(false);
-      const { isSwiping } = useSwipe(swipeZone, {
+      useSwipe(swipeZone, {
         onSwipeEnd: (e, direction) => {
           if (direction === 'RIGHT' && !navShown.value) {
             navShown.value = true;
@@ -212,7 +212,7 @@
         },
       });
 
-      return { swipeZone, navShown, isSwiping };
+      return { swipeZone, navShown };
     },
     props: {
       appBarTitle: {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -9,6 +9,7 @@
     <transition name="side-nav">
       <div
         v-show="navShown"
+        ref="sideNavInside"
         class="side-nav"
         :style="{
           width: `${width}px`,
@@ -130,6 +131,8 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
+  import { useSwipe } from '@vueuse/core';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
@@ -163,6 +166,19 @@
       PrivacyInfoModal,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin, responsiveElementMixin, navComponentsMixin],
+    setup(props, { emit }) {
+      const sideNavInside = ref(null);
+      useSwipe(sideNavInside, {
+        threshold: 100,
+        onSwipeEnd: (e, direction) => {
+          if (direction === 'LEFT') {
+            emit('toggleSideNav');
+          }
+        },
+      });
+
+      return { sideNavInside };
+    },
     props: {
       navShown: {
         type: Boolean,


### PR DESCRIPTION
## Summary

1. Uses https://vueuse.org/core/useswipe/#useswipe to listen to TouchEvents (so this should only work on touch screens, and not with mice) and open/close the SideNav when swiping right/left.

*Screenshot from iOS simulator*

(this can also be reproduced using Chrome mobile device simulator)
![CleanShot 2021-06-22 at 11 19 50](https://user-images.githubusercontent.com/10248067/122979928-f6693f80-d34c-11eb-88dc-b7a6206dadad.gif)


## References

Fixes #6899 

## Reviewer guidance

The options for `useSwipe`, like the threshold, as well as the size of the "swipe zone" for opening the menu may need to be tuned. Do you have any suggestions?

I also made a decision not to place a guard around the swipe-left-to-close gesture for large devices. This means that something like a MS Surface user could use the gesture.

Also, this does not account for RTL languages (might need have a follow up issue). The `isRTL` prop should be accessible using https://v3.vuejs.org/api/composition-api.html#getcurrentinstance within the `setup()` function like this

```
const isRTL = getCurrentInstance().proxy.isRtl
```

In an RTL layout, the swipe directions need to be reversed, and the swipe zone on CoreBase needs to be moved to the right edge of the screen.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
