### PR TITLE
Cleanup errors from ContentNodeResource changes

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -3,6 +3,7 @@ import { Resource } from 'kolibri.lib.apiResource';
 import Store from 'kolibri.coreVue.vuex.store';
 import urls from 'kolibri.urls';
 import cloneDeep from '../cloneDeep';
+import ConditionalPromise from '../conditionalPromise';
 
 /**
  * Type definition for Language metadata
@@ -115,12 +116,14 @@ export default new Resource({
   cache: {},
   fetchModel({ id }) {
     if (this.cache[id]) {
-      return Promise.resolve(cloneDeep(this.cache[id]));
+      return ConditionalPromise.resolve(cloneDeep(this.cache[id]));
     }
-    return this.client({ url: this.modelUrl(id) }).then(response => {
+    const promise = new ConditionalPromise();
+    promise._promise = this.client({ url: this.modelUrl(id) }).then(response => {
       this.cacheData(response.data);
       return response.data;
     });
+    return promise;
   },
   cacheData(data) {
     if (Array.isArray(data)) {
@@ -143,11 +146,13 @@ export default new Resource({
       }
     }
   },
-  fetchCollection(params) {
-    return this.client({ url: this.collectionUrl(), params }).then(response => {
+  fetchCollection({ getParams: params }) {
+    const promise = new ConditionalPromise();
+    promise._promise = this.client({ url: this.collectionUrl(), params }).then(response => {
       this.cacheData(response.data);
       return response.data;
     });
+    return promise;
   },
   /**
    * A method to request paginated tree data from the backend


### PR DESCRIPTION
## Summary
* Properly receive parameters for fetchCollection method.
* Return conditional promises for async methods.

## References
Follow up from #8138

## Reviewer guidance
Can a quiz be loaded for a learner?
Do topic trees properly load just the children of the parent, and not everything?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
