### PR TITLE
Return learning_activities and duration from contentnode endpoints.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -227,6 +227,22 @@ def map_file(file):
     return file
 
 
+kind_activity_map = {
+    content_kinds.EXERCISE: "practice",
+    content_kinds.VIDEO: "watch",
+    content_kinds.AUDIO: "listen",
+    content_kinds.DOCUMENT: "read",
+    content_kinds.HTML5: "explore",
+}
+
+
+def infer_learning_activity(node):
+    activity = kind_activity_map.get(node["kind"])
+    if activity:
+        return [activity]
+    return []
+
+
 class BaseContentNodeMixin(object):
     """
     A base mixin for viewsets that need to return the same format of data
@@ -258,6 +274,11 @@ class BaseContentNodeMixin(object):
         "rght",
         "tree_id",
     )
+
+    field_map = {
+        "learning_activities": infer_learning_activity,
+        "duration": lambda x: None,
+    }
 
     def get_queryset(self):
         return models.ContentNode.objects.filter(available=True)
@@ -545,6 +566,10 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
                     "title": next_item.title,
                     "thumbnail": thumbnails[0]["storage_url"],
                     "is_leaf": next_item.kind != content_kinds.TOPIC,
+                    "learning_activities": infer_learning_activity(
+                        {"kind": next_item.kind}
+                    ),
+                    "duration": None,
                 }
             )
         return Response(
@@ -553,6 +578,10 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
                 "id": next_item.id,
                 "title": next_item.title,
                 "is_leaf": next_item.kind != content_kinds.TOPIC,
+                "learning_activities": infer_learning_activity(
+                    {"kind": next_item.kind}
+                ),
+                "duration": None,
             }
         )
 

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -198,6 +198,22 @@ class ContentNodeQuerysetTestCase(TestCase):
         )
 
 
+kind_activity_map = {
+    content_kinds.EXERCISE: "practice",
+    content_kinds.VIDEO: "watch",
+    content_kinds.AUDIO: "listen",
+    content_kinds.DOCUMENT: "read",
+    content_kinds.HTML5: "explore",
+}
+
+
+def infer_learning_activity(kind):
+    activity = kind_activity_map.get(kind)
+    if activity:
+        return [activity]
+    return []
+
+
 class ContentNodeAPITestCase(APITestCase):
     """
     Testcase for content API methods
@@ -298,6 +314,8 @@ class ContentNodeAPITestCase(APITestCase):
                 "coach_content": expected.coach_content,
                 "content_id": expected.content_id,
                 "description": expected.description,
+                "duration": None,
+                "learning_activities": infer_learning_activity(expected.kind),
                 "kind": expected.kind,
                 "lang": self.map_language(expected.lang),
                 "license_description": expected.license_description,


### PR DESCRIPTION
## Summary
* Returns inferred learning_activities based on content kinds
* Returns null duration value until information is available in the database

## Reviewer guidance
Does `learning_activities` return an appropriate list?
Does `duration` return null?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
