### PR TITLE
Learning activities constants naming

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -29,7 +29,7 @@ export const ContentNodeKinds = {
   SLIDESHOW: 'slideshow',
 };
 
-export const LearningActivityKinds = {
+export const LearningActivities = {
   CREATE: 'create',
   LISTEN: 'listen',
   REFLECT: 'reflect',

--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -30,14 +30,14 @@ export const ContentNodeKinds = {
 };
 
 export const LearningActivityKinds = {
-  CREATE: 'CREATE',
-  LISTEN: 'LISTEN',
-  REFLECT: 'REFLECT',
-  PRACTICE: 'PRACTICE',
-  READ: 'READ',
-  WATCH: 'WATCH',
-  EXPLORE: 'EXPLORE',
-  TOPIC: 'TOPIC',
+  CREATE: 'create',
+  LISTEN: 'listen',
+  REFLECT: 'reflect',
+  PRACTICE: 'practice',
+  READ: 'read',
+  WATCH: 'watch',
+  EXPLORE: 'explore',
+  TOPIC: 'topic',
 };
 
 // used internally on the client as a hack to allow content-icons to display users

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -92,7 +92,7 @@
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
-  import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+  import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
   import LearningActivityIcon from './LearningActivityIcon.vue';
 
   export default {
@@ -126,7 +126,7 @@
         type: String,
         required: true,
         validator(value) {
-          return Object.values(LearningActivityKinds).includes(value);
+          return Object.values(LearningActivities).includes(value);
         },
       },
       /**

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -7,16 +7,16 @@
 
 <script>
 
-  import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+  import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 
   const LearningActivityKindToIconMap = {
-    [LearningActivityKinds.CREATE]: 'create',
-    [LearningActivityKinds.LISTEN]: 'listen',
-    [LearningActivityKinds.REFLECT]: 'reflect',
-    [LearningActivityKinds.PRACTICE]: 'practice',
-    [LearningActivityKinds.READ]: 'read',
-    [LearningActivityKinds.WATCH]: 'watch',
-    [LearningActivityKinds.EXPLORE]: 'interact',
+    [LearningActivities.CREATE]: 'create',
+    [LearningActivities.LISTEN]: 'listen',
+    [LearningActivities.REFLECT]: 'reflect',
+    [LearningActivities.PRACTICE]: 'practice',
+    [LearningActivities.READ]: 'read',
+    [LearningActivities.WATCH]: 'watch',
+    [LearningActivities.EXPLORE]: 'interact',
   };
 
   export default {
@@ -29,7 +29,7 @@
         type: String,
         required: true,
         validator(value) {
-          return Object.values(LearningActivityKinds).includes(value);
+          return Object.values(LearningActivities).includes(value);
         },
       },
       /**

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -1,6 +1,6 @@
 import { shallowMount, mount } from '@vue/test-utils';
 
-import { LearningActivityKinds } from 'kolibri.coreVue.vuex.constants';
+import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import LearningActivityBar from '../../src/views/LearningActivityBar';
 
 function makeWrapper({ propsData } = {}) {
@@ -34,7 +34,7 @@ describe('LearningActivityBar', () => {
   it('shows a learning activity icon in the bar', () => {
     const wrapper = makeWrapper({
       propsData: {
-        learningActivityKind: LearningActivityKinds.WATCH,
+        learningActivityKind: LearningActivities.WATCH,
       },
     });
     expect(wrapper.find('[data-test="learningActivityIcon"]').exists()).toBeTruthy();


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary

- Update frontend learning activities constants to lower case (a follow-up to https://github.com/learningequality/kolibri/pull/8177 where backend constants have been defined)
- Rename `LearningActivityKinds` to `LearningActivities` on @rtibbles suggestion https://github.com/learningequality/kolibri/pull/8177#discussion_r660631496


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
