### PR TITLE
Bump morango version to 0.5.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
 clint==0.5.1
-morango==0.5.5
+morango==0.5.6
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
## Summary

Updates morango dependency to version 0.5.6. Changelog:
- Add management command for garbage collection of buffer data
- Speed up instance ID calculation by skipping hostname check

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
