### PR TITLE
Add support for multiple learning activities icon

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -4,9 +4,8 @@
     <KLabeledIcon :style="{ 'margin-top': '8px' }">
       <template #icon>
         <LearningActivityIcon
-          v-if="learningActivityKind"
           data-test="learningActivityIcon"
-          :kind="learningActivityKind"
+          :kind="learningActivities"
           :shaded="true"
         />
       </template>
@@ -120,13 +119,14 @@
         required: true,
       },
       /**
-       * Learning activity constant
+       * An array of one or more learning activities constants
        */
-      learningActivityKind: {
-        type: String,
+      learningActivities: {
+        type: Array,
         required: true,
-        validator(value) {
-          return Object.values(LearningActivities).includes(value);
+        validator(arr) {
+          const isValidLearningActivity = v => Object.values(LearningActivities).includes(v);
+          return arr.length > 0 && arr.every(isValidLearningActivity);
         },
       },
       /**

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -10,7 +10,7 @@
   import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 
   const AllActivitiesIcon = 'allActivities';
-  const LearningActivityKindToIconMap = {
+  const LearningActivityToIconMap = {
     [LearningActivities.CREATE]: 'create',
     [LearningActivities.LISTEN]: 'listen',
     [LearningActivities.REFLECT]: 'reflect',
@@ -70,7 +70,7 @@
           kind = this.kind[0];
         }
 
-        const icon = LearningActivityKindToIconMap[kind];
+        const icon = LearningActivityToIconMap[kind];
         if (this.shaded) {
           return icon + 'Shaded';
         }

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -9,6 +9,7 @@
 
   import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 
+  const AllActivitiesIcon = 'allActivities';
   const LearningActivityKindToIconMap = {
     [LearningActivities.CREATE]: 'create',
     [LearningActivities.LISTEN]: 'listen',
@@ -19,17 +20,31 @@
     [LearningActivities.EXPLORE]: 'interact',
   };
 
+  /**
+   * Displays a corresponding icon for a single learning activity
+   * or an icon for more activities if more than one learning
+   * activity is provided.
+   */
   export default {
     name: 'LearningActivityIcon',
     props: {
       /**
-       * Learning activity constant
+       * Learning activity constant(s)
+       * Can be one constant or an array of constants
        */
       kind: {
-        type: String,
+        type: [String, Array],
         required: true,
         validator(value) {
-          return Object.values(LearningActivities).includes(value);
+          const isValidLearningActivity = v => Object.values(LearningActivities).includes(v);
+
+          if (Array.isArray(value) && value.length > 0) {
+            return value.every(isValidLearningActivity);
+          } else if (typeof value === 'string') {
+            return isValidLearningActivity(value);
+          } else {
+            return false;
+          }
         },
       },
       /**
@@ -44,7 +59,18 @@
     },
     computed: {
       icon() {
-        const icon = LearningActivityKindToIconMap[this.kind];
+        // more activities
+        if (Array.isArray(this.kind) && this.kind.length > 1) {
+          return AllActivitiesIcon;
+        }
+
+        let kind = this.kind;
+        // one activity but as an array
+        if (Array.isArray(this.kind) && this.kind.length === 1) {
+          kind = this.kind[0];
+        }
+
+        const icon = LearningActivityKindToIconMap[kind];
         if (this.shaded) {
           return icon + 'Shaded';
         }

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -9,24 +9,39 @@ function makeWrapper({ propsData } = {}) {
 
 describe('LearningActivityBar', () => {
   it('smoke test', () => {
-    const wrapper = shallowMount(LearningActivityBar);
+    const wrapper = shallowMount(LearningActivityBar, {
+      propsData: {
+        learningActivities: [LearningActivities.WATCH],
+      },
+    });
     expect(wrapper.exists()).toBe(true);
   });
 
   it('shows a resource title in the bar', () => {
     const wrapper = makeWrapper({
-      propsData: { resourceTitle: 'Practice and applications of math' },
+      propsData: {
+        resourceTitle: 'Practice and applications of math',
+        learningActivities: [LearningActivities.WATCH],
+      },
     });
     expect(wrapper.text()).toContain('Practice and applications of math');
   });
 
   it('shows the back button in the bar', () => {
-    const wrapper = makeWrapper();
+    const wrapper = makeWrapper({
+      propsData: {
+        learningActivities: [LearningActivities.WATCH],
+      },
+    });
     expect(wrapper.find('[data-test="backButton"]').exists()).toBeTruthy();
   });
 
   it('emits `navigateBack` event on the back button click', () => {
-    const wrapper = makeWrapper();
+    const wrapper = makeWrapper({
+      propsData: {
+        learningActivities: [LearningActivities.WATCH],
+      },
+    });
     wrapper.find('[data-test="backButton"]').trigger('click');
     expect(wrapper.emitted().navigateBack.length).toBe(1);
   });
@@ -34,7 +49,7 @@ describe('LearningActivityBar', () => {
   it('shows a learning activity icon in the bar', () => {
     const wrapper = makeWrapper({
       propsData: {
-        learningActivityKind: LearningActivities.WATCH,
+        learningActivities: [LearningActivities.WATCH],
       },
     });
     expect(wrapper.find('[data-test="learningActivityIcon"]').exists()).toBeTruthy();
@@ -52,7 +67,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { isLessonContext: true } });
+        wrapper = makeWrapper({
+          propsData: {
+            isLessonContext: true,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it("doesn't show 'View topic resources' button in the bar", () => {
@@ -73,7 +93,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { isLessonContext: false } });
+        wrapper = makeWrapper({
+          propsData: {
+            isLessonContext: false,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it("doesn't show 'View lesson plan' button in the bar", () => {
@@ -94,7 +119,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { isBookmarked: true } });
+        wrapper = makeWrapper({
+          propsData: {
+            isBookmarked: true,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it("doesn't show the add bookmark button in the bar", () => {
@@ -115,7 +145,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { isBookmarked: false } });
+        wrapper = makeWrapper({
+          propsData: {
+            isBookmarked: false,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it("doesn't show the remove bookmark button in the bar", () => {
@@ -136,7 +171,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { allowMarkComplete: true } });
+        wrapper = makeWrapper({
+          propsData: {
+            allowMarkComplete: true,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it('shows the more options button', () => {
@@ -168,7 +208,12 @@ describe('LearningActivityBar', () => {
       let wrapper;
 
       beforeEach(() => {
-        wrapper = makeWrapper({ propsData: { allowMarkComplete: false } });
+        wrapper = makeWrapper({
+          propsData: {
+            allowMarkComplete: false,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
       });
 
       it("doesn't show the more options button", () => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I added support for `Array` type for `kind` property of `LearningActivityIcon` because backend API sends learning activities associated with a content node as an array:
```
learning_activities: ["watch"]
```
Because more learning activities can be returned, I also added logic that displays multiple activities icon

![Screenshot from 2021-07-07 15-09-38](https://user-images.githubusercontent.com/13509191/124772530-69250e00-df3c-11eb-898f-f572ddc0f1f0.png)

in case an array with more than one item is passed to `LearningActivityIcon` which reflects needs illustrated on hybrid learning designs.

I reflected these updates in `LearningActivityBar` component too. Although a correct icon will be displayed in the bar now for multiple learning activities, it's not a full implementation yet (see https://github.com/learningequality/kolibri/issues/8189).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
