### PR TITLE
Use a double tap strategy to ensure against zombies

### DIFF
--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["kolibri/**.py", "requirements/base.txt"]'
+          paths: '["kolibri/**/*.py", "requirements/base.txt"]'
   zombies:
     name: No zombies
     needs: pre_job
@@ -44,3 +44,4 @@ jobs:
         # ensure kolibri stops within 20 seconds 10 times in a row
         ./test/ensure_kolibri_stops_within_time.sh 20 10 8082 8083
         ./test/ensure_no_kolibris_running_on_port.sh 8082
+        ./test/ensure_no_kolibris_running_on_port.sh 8083

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -463,24 +463,24 @@ def stop():
 
     with open(PROCESS_CONTROL_FLAG, "w") as f:
         f.write(STOP)
-    if not wait_for_status(STATUS_STOPPED, timeout=30):
+    wait_for_status(STATUS_STOPPED, timeout=10)
+    if pid_exists(pid):
+        logger.debug("Process wth pid %s still exists; attempting a SIGKILL." % pid)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except SystemError as e:
+            logger.debug(
+                "Received an error while trying to kill the Kolibri process: %s" % e
+            )
+    starttime = time.time()
+    while time.time() - starttime <= 10:
         if pid_exists(pid):
-            logger.debug("Process wth pid %s still exists; attempting a SIGKILL." % pid)
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except SystemError as e:
-                logger.debug(
-                    "Received an error while trying to kill the Kolibri process: %s" % e
-                )
-        starttime = time.time()
-        while time.time() - starttime <= 10:
-            if pid_exists(pid):
-                time.sleep(0.1)
-            else:
-                break
-        if pid_exists(pid):
-            logging.error("Kolibri process has failed to shutdown")
-            return STATUS_UNCLEAN_SHUTDOWN
+            time.sleep(0.1)
+        else:
+            break
+    if pid_exists(pid):
+        logging.error("Kolibri process has failed to shutdown")
+        return STATUS_UNCLEAN_SHUTDOWN
     return STATUS_STOPPED
 
 


### PR DESCRIPTION
## Summary
* Make kolibri stop more aggressive to ensure shutdown.
* Instead of only checking for existence of the PID if the status fails to change, wait for the status change and then ensure that the pid stops existing

## Reviewer guidance
* Do the no zombie tests pass reliably on Github and locally?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
