### PR TITLE
Add env var to disable file based logging

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -449,3 +449,35 @@ def list():
             + " " * (max_len - len(plugin) + 4)
             + ("ENABLED" if plugin in config.ACTIVE_PLUGINS else "DISABLED")
         )
+
+
+@main.command(cls=KolibriGroupCommand, help="Configure Kolibri and enabled plugins")
+def configure():
+    pass
+
+
+def _get_env_vars():
+    """
+    Generator to iterate over all environment variables
+    """
+    template = "{envvar} - {description}\n\n"
+
+    from kolibri.utils.env import ENVIRONMENT_VARIABLES
+
+    for key, value in ENVIRONMENT_VARIABLES.items():
+        yield template.format(envvar=key, description=value.get("description", ""))
+
+    from kolibri.utils.options import option_spec
+
+    for value in option_spec.values():
+        for v in value.values():
+            if "envvars" in v:
+                for envvar in v["envvars"]:
+                    yield template.format(
+                        envvar=envvar, description=v.get("description", "")
+                    )
+
+
+@configure.command(help="List all available environment variables to configure Kolibri")
+def list_env():
+    click.echo_via_pager(_get_env_vars())

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -7,6 +7,39 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
 
 
+def settings_module():
+    from .build_config.default_settings import settings_path
+
+    return settings_path
+
+
+# Enumerate all the environment variables that are used in Kolibri, and describe
+# their usage. Optionally provide a default value as a callback function, to set as
+# a default if the environment variable is not set.
+ENVIRONMENT_VARIABLES = {
+    "DJANGO_SETTINGS_MODULE": {
+        "default": settings_module,
+        "description": "The Django settings module to use.",
+    },
+    "KOLIBRI_HOME": {
+        "default": lambda: os.path.join(os.path.expanduser("~"), ".kolibri"),
+        "description": "The base directory for the Kolibri installation.",
+    },
+    "KOLIBRI_NO_FILE_BASED_LOGGING": {
+        "description": "Disable file-based logging.",
+    },
+    "KOLIBRI_APK_VERSION_NAME": {
+        "description": "Version name for the Kolibri APK (Android Installer)",
+    },
+    "LISTEN_PID": {
+        "description": """
+            The PID of the process to listen for signals from -
+            used to detect whether running under socket activation under Debian.
+        """,
+    },
+}
+
+
 def prepend_cext_path(dist_path):
     """
     Calculate the directory of C extensions and add it to sys.path if exists.
@@ -71,10 +104,7 @@ def set_env():
             )
         ]
 
-    from .build_config.default_settings import settings_path
-
     # Set default env
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_path)
-    os.environ.setdefault(
-        "KOLIBRI_HOME", os.path.join(os.path.expanduser("~"), ".kolibri")
-    )
+    for key, value in ENVIRONMENT_VARIABLES.items():
+        if "default" in value:
+            os.environ.setdefault(key, value["default"]())

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -1,7 +1,5 @@
 import logging
 import os
-import re
-from logging import Formatter
 from logging.handlers import TimedRotatingFileHandler
 
 from . import conf
@@ -96,22 +94,6 @@ class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
         return result
 
 
-class KolibriLogFileFormatter(Formatter):
-    """
-    A custom Formatter to change the format string of Cherrypy logging messages.
-    """
-
-    def format(self, record):
-        if "cherrypy" in record.name:
-            # Remove the timestamp from Cherrypy logging so that the message only contains one timestamp.
-            record.msg = re.sub(r"\[[^)]*\]\s", "", record.msg)
-            # Change the format string for Cherrypy logging messages from %module(_cplogging) to %name.
-            record.module = record.name
-
-        message = super(KolibriLogFileFormatter, self).format(record)
-        return message
-
-
 class FalseFilter(logging.Filter):
     """
     A filter that ignores everything, useful to create log config
@@ -157,10 +139,6 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
             "simple": {"format": "%(levelname)s %(message)s"},
             "simple_date": {"format": "%(levelname)s %(asctime)s %(name)s %(message)s"},
-            "simple_date_file": {
-                "()": "kolibri.utils.logger.KolibriLogFileFormatter",
-                "format": "%(levelname)s %(asctime)s %(name)s %(message)s",
-            },
             "color": {
                 "()": "colorlog.ColoredFormatter",
                 "format": "%(log_color)s%(levelname)-8s %(message)s",
@@ -184,7 +162,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "filters": [],
                 "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
                 "filename": os.path.join(LOG_ROOT, "kolibri.txt"),
-                "formatter": "simple_date_file",
+                "formatter": "simple_date",
                 "when": "midnight",
                 "backupCount": 30,
             },

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -10,6 +10,8 @@ from . import conf
 GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
 
+NO_FILE_BASED_LOGGING = os.environ.get("KOLIBRI_NO_FILE_BASED_LOGGING", False)
+
 
 class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
     """
@@ -137,6 +139,10 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     configuration.
     """
 
+    DEFAULT_HANDLERS = (
+        ["console"] if NO_FILE_BASED_LOGGING else ["file", "console", "file_debug"]
+    )
+
     # This is the general level
     DEFAULT_LEVEL = "INFO" if not debug else "DEBUG"
     DATABASE_LEVEL = "INFO" if not debug_database else "DEBUG"
@@ -192,7 +198,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
         },
         "loggers": {
             "kolibri": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },
@@ -200,27 +206,27 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             # We should introduce custom debug log levels or log
             # targets, i.e. --debug-level=high
             "kolibri.core.tasks.worker": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": "INFO",
                 "propagate": False,
             },
             "morango": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },
             "django": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },
             "django.db.backends": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": DATABASE_LEVEL,
                 "propagate": False,
             },
             "django.request": {
-                "handlers": ["file", "console", "file_debug"],
+                "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },


### PR DESCRIPTION
## Summary
* Adds an environment variable which prevents file based logging
* Cleans up unused cherrypy log formatter
* Consolidates configuration environment variables into `env.py`
* Adds a CLI command to page through all available configuration environment variables with descriptions

## References
Fixes #7979

## Reviewer guidance
Run kolibri with and without `KOLIBRI_NO_FILE_BASED_LOGGING` env var set, see that with it set, nothing is written to logs.

![Screenshot from 2021-07-13 13-00-13](https://user-images.githubusercontent.com/1680573/125517164-65e688bf-2ed3-420f-93e4-5d9a37880c01.png)



----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
