### PR TITLE
Implement automatic provisioning for new devices.

### DIFF
--- a/kolibri/core/device/management/commands/provisiondevice.py
+++ b/kolibri/core/device/management/commands/provisiondevice.py
@@ -4,58 +4,17 @@ import os
 import sys
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
-from django.db import transaction
 from django.utils import six
 
-from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.auth.constants.facility_presets import presets
 from kolibri.core.auth.models import Facility
-from kolibri.core.auth.models import FacilityUser
-from kolibri.core.device.utils import provision_device
+from kolibri.core.device.utils import setup_device_and_facility
+from kolibri.core.device.utils import validate_device_settings
+from kolibri.core.device.utils import validate_facility_settings
 
 logger = logging.getLogger(__name__)
-
-
-def _check_setting(name, available, msg):
-    if name not in available:
-        raise CommandError(msg.format(name))
-
-
-def check_facility_setting(name):
-    AVAILABLE_SETTINGS = [
-        "learner_can_edit_username",
-        "learner_can_edit_name",
-        "learner_can_edit_password",
-        "learner_can_sign_up",
-        "learner_can_delete_account",
-        "learner_can_login_with_no_password",
-        "show_download_button_in_learn",
-    ]
-    _check_setting(
-        name,
-        AVAILABLE_SETTINGS,
-        "'{}' is not a facility setting that can be changed by this command",
-    )
-
-
-def check_device_setting(name):
-    AVAILABLE_SETTINGS = [
-        "language_id",
-        "landing_page",
-        "allow_guest_access",
-        "allow_peer_unlisted_channel_import",
-        "allow_learner_unassigned_resource_access",
-        "name",
-        "allow_other_browsers_to_connect",
-    ]
-    _check_setting(
-        name,
-        AVAILABLE_SETTINGS,
-        "'{}' is not a device setting that can be changed by this command",
-    )
 
 
 def get_user_response(prompt, valid_answers=None, to_lower_case=True):
@@ -72,8 +31,19 @@ def get_user_response(prompt, valid_answers=None, to_lower_case=True):
 languages = dict(settings.LANGUAGES)
 
 
-def create_facility(facility_name=None, preset=None, interactive=False):
-    if facility_name is None and interactive:
+def json_file_contents(parser, arg):
+    if not os.path.exists(arg) or not os.path.isfile(arg):
+        return parser.error("The file '{}' does not exist".format(arg))
+    with open(arg, "r") as f:
+        try:
+            output = json.load(f)
+        except ValueError as e:  # Use ValueError rather than JSONDecodeError for Py2 compatibility
+            return parser.error("The file '{}' is not valid JSON:\n{}".format(arg, e))
+    return output
+
+
+def get_all_user_input(facility_name, preset, language_id, username, password):
+    if facility_name is None:
         answer = get_user_response(
             "Do you wish to create a facility? [y/n] ", ["y", "n"]
         )
@@ -83,6 +53,49 @@ def create_facility(facility_name=None, preset=None, interactive=False):
             )
         else:
             sys.exit(1)
+
+    if facility_name is not None and preset is None:
+        preset = get_user_response(
+            "Which preset do you wish to use? [{presets}]: ".format(
+                presets="/".join(presets.keys())
+            ),
+            valid_answers=presets,
+        )
+
+    if language_id is None:
+        language_id = get_user_response(
+            "Enter a default language code [{langs}]: ".format(
+                langs=",".join(languages.keys())
+            ),
+            valid_answers=languages,
+        )
+
+    if username is None:
+        username = get_user_response("Enter a username for the super user: ")
+
+    if password is None:
+        confirm = ""
+        while password != confirm:
+            password = get_user_response("Enter a password for the super user: ")
+            confirm = get_user_response("Confirm password for the super user: ")
+
+    return facility_name, preset, language_id, username, password
+
+
+def validate_options(options):
+    interactive = options["interactive"]
+    facility_name = options["facility"]
+    preset = options["preset"]
+    language_id = options["language_id"]
+    username = options["superusername"]
+    password = options["superuserpassword"]
+
+    if interactive:
+        facility_name, preset, language_id, username, password = get_all_user_input(
+            facility_name, preset, language_id, username, password
+        )
+
+    facility = None
 
     if facility_name:
         facility_query = Facility.objects.filter(name__iexact=facility_name)
@@ -94,107 +107,32 @@ def create_facility(facility_name=None, preset=None, interactive=False):
                     name=facility.name
                 )
             )
-            return facility
-        else:
-            facility = Facility.objects.create(name=facility_name)
-            logger.info(
-                "Facility with name '{name}' created.".format(name=facility.name)
-            )
-
-        if preset is None and interactive:
-            preset = get_user_response(
-                "Which preset do you wish to use? [{presets}]: ".format(
-                    presets="/".join(presets.keys())
-                ),
-                valid_answers=presets,
-            )
-
-        # Only set preset data if we have created the facility, otherwise leave previous data intact
-        if preset:
-            dataset_data = mappings[preset]
-            facility.dataset.preset = preset
-            for key, value in dataset_data.items():
-                check_facility_setting(key)
-                setattr(facility.dataset, key, value)
-            facility.dataset.save()
-            logger.info("Facility preset changed to {preset}.".format(preset=preset))
     else:
         facility = Facility.get_default_facility() or Facility.objects.first()
         if not facility:
             raise CommandError("No facility exists")
-    return facility
 
-
-def update_facility_settings(facility, new_settings):
-    # Override any settings passed in
-    for key, value in new_settings.items():
-        check_facility_setting(key)
-        setattr(facility.dataset, key, value)
-    facility.dataset.save()
-
-    if new_settings:
-        logger.info("Facility settings updated with {}".format(new_settings))
-
-
-def create_superuser(username=None, password=None, interactive=False, facility=None):
-    if username is None and interactive:
-        username = get_user_response("Enter a username for the super user: ")
-
-    if password is None and interactive:
-        confirm = ""
-        while password != confirm:
-            password = get_user_response("Enter a password for the super user: ")
-            confirm = get_user_response("Confirm password for the super user: ")
-
-    if username and password:
-        try:
-            FacilityUser.objects.create_superuser(username, password, facility=facility)
-            logger.info(
-                "Superuser created with username '{username}' in facility '{facility}'.".format(
-                    username=username, facility=facility
-                )
-            )
-        except ValidationError:
-            logger.warn(
-                "An account with username '{username}' already exists in facility '{facility}', not creating user account.".format(
-                    username=username, facility=facility
-                )
-            )
-
-
-def create_device_settings(
-    language_id=None, facility=None, interactive=False, new_settings=None
-):
-    if new_settings is None:
-        new_settings = {}
-    if language_id is None and interactive:
-        language_id = get_user_response(
-            "Enter a default language code [{langs}]: ".format(
-                langs=",".join(languages.keys())
-            ),
-            valid_answers=languages,
+    try:
+        device_settings = validate_device_settings(
+            language_id=language_id, facility=facility, **options["device_settings"]
         )
-    # Override any settings passed in
-    for key in new_settings:
-        check_device_setting(key)
+    except ValueError as e:
+        raise CommandError(str(e))
 
-    settings_to_set = dict(new_settings)
-    settings_to_set["language_id"] = language_id
-    settings_to_set["default_facility"] = facility
+    try:
+        facility_settings = validate_facility_settings(options["facility_settings"])
+    except ValueError as e:
+        raise CommandError(str(e))
 
-    provision_device(**settings_to_set)
-    logger.info("Device settings updated with {}".format(settings_to_set))
-
-
-def json_file_contents(parser, arg):
-    if not os.path.exists(arg) or not os.path.isfile(arg):
-        return parser.error("The file '{}' does not exist".format(arg))
-    with open(arg, "r") as f:
-        try:
-            output = json.load(f)
-        except json.decoder.JSONDecodeError as e:
-            return parser.error("The file '{}' is not valid JSON:\n{}".format(arg, e))
-    return output
+    return (
+        facility,
+        facility_name,
+        preset,
+        facility_settings,
+        device_settings,
+        username,
+        password,
+    )
 
 
 class Command(BaseCommand):
@@ -259,25 +197,22 @@ class Command(BaseCommand):
             "The 'provisiondevice' command is experimental, and the API and behavior will change in a future release"
         )
 
-        with transaction.atomic():
-            facility = create_facility(
-                facility_name=options["facility"],
-                preset=options["preset"],
-                interactive=options["interactive"],
-            )
+        (
+            facility,
+            facility_name,
+            preset,
+            facility_settings,
+            device_settings,
+            username,
+            password,
+        ) = validate_options(options)
 
-            update_facility_settings(facility, options["facility_settings"])
-
-            create_device_settings(
-                language_id=options["language_id"],
-                facility=facility,
-                interactive=options["interactive"],
-                new_settings=options["device_settings"],
-            )
-
-            create_superuser(
-                username=options["superusername"],
-                password=options["superuserpassword"],
-                interactive=options["interactive"],
-                facility=facility,
-            )
+        setup_device_and_facility(
+            facility,
+            facility_name,
+            preset,
+            facility_settings,
+            device_settings,
+            username,
+            password,
+        )

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -82,7 +82,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
                 validated_data["superuser"]["username"],
                 validated_data["superuser"]["password"],
                 facility=facility,
-                full_name=validated_data["superuser"]["full_name"],
+                full_name=validated_data["superuser"].get("full_name"),
             )
 
             # Create device settings

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -7,10 +7,8 @@ from kolibri.core.auth.constants.facility_presets import choices
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.serializers import FacilitySerializer
-from kolibri.core.auth.serializers import FacilityUserSerializer
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
-from kolibri.core.device.utils import create_superuser
 from kolibri.core.device.utils import provision_device
 
 
@@ -23,13 +21,10 @@ class DevicePermissionsSerializer(serializers.ModelSerializer):
         fields = ("user", "is_superuser", "can_manage_content")
 
 
-class NoFacilityFacilityUserSerializer(FacilityUserSerializer):
+class NoFacilityFacilityUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = FacilityUser
-        fields = ("id", "username", "full_name", "password", "birth_year", "gender")
-
-    def validate(self, attrs):
-        return attrs
+        fields = ("username", "full_name", "password")
 
 
 class DeviceSerializerMixin(object):
@@ -83,7 +78,12 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
             facility.dataset.save()
 
             # Create superuser
-            superuser = create_superuser(validated_data["superuser"], facility=facility)
+            superuser = FacilityUser.objects.create_superuser(
+                validated_data["superuser"]["username"],
+                validated_data["superuser"]["password"],
+                facility=facility,
+                full_name=validated_data["superuser"]["full_name"],
+            )
 
             # Create device settings
             language_id = validated_data.pop("language_id")

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -109,7 +109,7 @@ class DeviceProvisionCommandTestCase(TestCase):
 
 class DeviceProvisionFileTestCase(TestCase):
     """
-    Tests for provisiondevice command.
+    Tests for provisioning a device from a JSON file.
     """
 
     @classmethod
@@ -176,10 +176,14 @@ class DeviceProvisionFileTestCase(TestCase):
             DeviceSettings.objects.get().default_facility, default_facility
         )
 
+    def test_file_removed(self):
+        self.assertFalse(os.path.exists(self.provision_file))
+
 
 class DeviceProvisionFileUnhappyTestCase(TestCase):
     """
-    Tests for provisiondevice command.
+    Tests for provisioning a device from a JSON file.
+    To ensure that validation errors are appropriately thrown.
     """
 
     def setUp(self):

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -5,17 +5,16 @@ from __future__ import unicode_literals
 from django.core.management import call_command
 from django.test import TestCase
 
-from ..management.commands.provisiondevice import create_device_settings
-from ..management.commands.provisiondevice import create_facility
-from ..management.commands.provisiondevice import create_superuser
 from ..models import DeviceSettings
 from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.auth.constants.facility_presets import presets
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import clear_process_cache
-from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.helpers import setup_device
+from kolibri.core.device.utils import create_facility
+from kolibri.core.device.utils import provision_device
+from kolibri.core.device.utils import setup_device_and_facility
 
 
 class DeviceProvisionTestCase(TestCase):
@@ -40,28 +39,23 @@ class DeviceProvisionTestCase(TestCase):
     def test_no_facility_return_default(self):
         setup_device()
         default_facility = Facility.get_default_facility()
-        facility = create_facility(facility_name=default_facility.name)
-        self.assertEqual(default_facility, facility)
-
-    def test_create_super_user(self):
-        Facility.objects.create(name="Test")
-        provision_device()
-        create_superuser(username="test", password="test")
-        self.assertTrue(FacilityUser.objects.get(username="test").is_superuser)
+        self.assertIsNotNone(default_facility)
+        setup_device_and_facility(None, None, None, None, {}, None, None)
+        self.assertEqual(Facility.objects.all().count(), 1)
 
     def test_create_device_settings_provisioned(self):
         facility = Facility.objects.create(name="Test")
-        create_device_settings(language_id="en", facility=facility)
+        provision_device(language_id="en", default_facility=facility)
         self.assertTrue(DeviceSettings.objects.get().is_provisioned)
 
     def test_create_device_settings_language(self):
         facility = Facility.objects.create(name="Test")
-        create_device_settings(language_id="en", facility=facility)
+        provision_device(language_id="en", default_facility=facility)
         self.assertEqual(DeviceSettings.objects.get().language_id, "en")
 
     def test_create_device_settings_default_facility(self):
         facility = Facility.objects.create(name="Test")
-        create_device_settings(language_id="en", facility=facility)
+        provision_device(language_id="en", default_facility=facility)
         self.assertEqual(DeviceSettings.objects.get().default_facility, facility)
 
 

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -2,6 +2,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
+import os
+import tempfile
+
+from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -13,7 +18,9 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import setup_device
 from kolibri.core.device.utils import create_facility
+from kolibri.core.device.utils import LANDING_PAGE_LEARN
 from kolibri.core.device.utils import provision_device
+from kolibri.core.device.utils import provision_from_file
 from kolibri.core.device.utils import setup_device_and_facility
 
 
@@ -98,3 +105,131 @@ class DeviceProvisionCommandTestCase(TestCase):
         self.assertEqual(
             DeviceSettings.objects.get().default_facility, default_facility
         )
+
+
+class DeviceProvisionFileTestCase(TestCase):
+    """
+    Tests for provisiondevice command.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        clear_process_cache()
+        file_handle, file_path = tempfile.mkstemp(suffix=".json")
+        os.close(file_handle)
+        cls.provision_file = file_path
+        cls.provisioning = {
+            "facility_name": "My Facility",
+            "facility_settings": {
+                "learner_can_edit_username": False,
+                "learner_can_edit_name": False,
+                "learner_can_edit_password": False,
+                "learner_can_sign_up": False,
+                "learner_can_delete_account": False,
+                "learner_can_login_with_no_password": False,
+                "show_download_button_in_learn": False,
+            },
+            "device_settings": {
+                "language_id": "en",
+                "landing_page": LANDING_PAGE_LEARN,
+                "allow_guest_access": False,
+                "allow_peer_unlisted_channel_import": False,
+                "allow_learner_unassigned_resource_access": False,
+                "name": "My Device",
+                "allow_other_browsers_to_connect": False,
+            },
+            "superuser": {"username": "provisioned_superuser", "password": "password"},
+        }
+        json.dump(cls.provisioning, open(cls.provision_file, "w"))
+        provision_from_file(cls.provision_file)
+
+    def test_create_facility(self):
+        self.assertTrue(
+            Facility.objects.filter(name=self.provisioning["facility_name"]).exists()
+        )
+
+    def test_create_facility_set_settings(self):
+        default_facility = Facility.get_default_facility()
+        dataset_data = self.provisioning["facility_settings"]
+        for key, value in dataset_data.items():
+            self.assertEqual(getattr(default_facility.dataset, key), value)
+
+    def test_create_super_user(self):
+        self.assertTrue(
+            FacilityUser.objects.get(
+                username=self.provisioning["superuser"]["username"]
+            ).is_superuser
+        )
+
+    def test_create_device_set_settings(self):
+        device_settings = DeviceSettings.objects.get()
+        dataset_data = self.provisioning["device_settings"]
+        for key, value in dataset_data.items():
+            self.assertEqual(getattr(device_settings, key), value)
+
+    def test_create_device_settings_provisioned(self):
+        self.assertTrue(DeviceSettings.objects.get().is_provisioned)
+
+    def test_create_device_settings_default_facility(self):
+        default_facility = Facility.get_default_facility()
+        self.assertEqual(
+            DeviceSettings.objects.get().default_facility, default_facility
+        )
+
+
+class DeviceProvisionFileUnhappyTestCase(TestCase):
+    """
+    Tests for provisiondevice command.
+    """
+
+    def setUp(self):
+        file_handle, file_path = tempfile.mkstemp(suffix=".json")
+        os.close(file_handle)
+        self.provision_file = file_path
+        self.provisioning = {
+            "facility_name": "My Facility",
+            "facility_settings": {
+                "learner_can_edit_username": False,
+                "learner_can_edit_name": False,
+                "learner_can_edit_password": False,
+                "learner_can_sign_up": False,
+                "learner_can_delete_account": False,
+                "learner_can_login_with_no_password": False,
+                "show_download_button_in_learn": False,
+            },
+            "device_settings": {
+                "language_id": "en",
+                "landing_page": LANDING_PAGE_LEARN,
+                "allow_guest_access": False,
+                "allow_peer_unlisted_channel_import": False,
+                "allow_learner_unassigned_resource_access": False,
+                "name": "My Device",
+                "allow_other_browsers_to_connect": False,
+            },
+            "superuser": {"username": "provisioned_superuser", "password": "password"},
+        }
+
+    def provision(self):
+        clear_process_cache()
+        json.dump(self.provisioning, open(self.provision_file, "w"))
+        provision_from_file(self.provision_file)
+
+    def test_provisioned_raises_error(self):
+        facility = Facility.objects.create(name="Test")
+        provision_device(language_id="en", default_facility=facility)
+        with self.assertRaises(ValidationError):
+            self.provision()
+
+    def test_nofile_raises_error(self):
+        with self.assertRaises(ValidationError):
+            provision_from_file("non-existent-file.json")
+
+    def test_bad_device_settings_raises_error(self):
+        self.provisioning["device_settings"]["not_a_setting"] = False
+        with self.assertRaises(ValidationError):
+            self.provision()
+
+    def test_bad_facility_settings_raises_error(self):
+        self.provisioning["facility_settings"]["not_a_setting"] = False
+        with self.assertRaises(ValidationError):
+            self.provision()

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -258,6 +258,22 @@ def get_facility_by_name(facility_name):
     return facility
 
 
+def remove_provisioning_file(file_path):
+    try:
+        os.unlink(file_path)
+        logger.info(
+            "Removed automatic provisioning file {} after successful provisioning".format(
+                file_path
+            )
+        )
+    except (IOError, OSError):
+        logger.warn(
+            "Unable to remove provisioning file {} after successful provisioning".format(
+                file_path
+            ),
+        )
+
+
 def provision_from_file(file_path):
     """
     Expects a JSON file with the following format (example values supplied):
@@ -336,3 +352,5 @@ def provision_from_file(file_path):
         username,
         password,
     )
+
+    remove_provisioning_file(file_path)

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -3,8 +3,18 @@ Do all imports of the device settings model inside the function scope here,
 so as to allow these functions to be easily imported without worrying about
 circular imports.
 """
+import json
+import logging
+import os
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.db.utils import OperationalError
 from django.db.utils import ProgrammingError
+
+from kolibri.core.auth.constants.facility_presets import mappings
+
+logger = logging.getLogger(__name__)
 
 LANDING_PAGE_SIGN_IN = "sign-in"
 LANDING_PAGE_LEARN = "learn"
@@ -141,3 +151,219 @@ def set_app_key_on_response(response):
     from .models import DeviceAppKey
 
     response.set_cookie(APP_KEY_COOKIE_NAME, DeviceAppKey.get_app_key())
+
+
+def _check_setting(name, available, msg):
+    if name not in available:
+        raise ValueError(msg.format(name))
+
+
+def check_facility_setting(name):
+    AVAILABLE_SETTINGS = [
+        "learner_can_edit_username",
+        "learner_can_edit_name",
+        "learner_can_edit_password",
+        "learner_can_sign_up",
+        "learner_can_delete_account",
+        "learner_can_login_with_no_password",
+        "show_download_button_in_learn",
+    ]
+    _check_setting(
+        name,
+        AVAILABLE_SETTINGS,
+        "'{}' is not a facility setting that can be changed by this command",
+    )
+
+
+def check_device_setting(name):
+    AVAILABLE_SETTINGS = [
+        "language_id",
+        "landing_page",
+        "allow_guest_access",
+        "allow_peer_unlisted_channel_import",
+        "allow_learner_unassigned_resource_access",
+        "name",
+        "allow_other_browsers_to_connect",
+    ]
+    _check_setting(
+        name,
+        AVAILABLE_SETTINGS,
+        "'{}' is not a device setting that can be changed by this command",
+    )
+
+
+def validate_facility_settings(new_settings):
+    # Override any settings passed in
+    for key in new_settings:
+        check_facility_setting(key)
+    return new_settings
+
+
+def validate_device_settings(language_id=None, facility=None, **new_settings):
+    # Override any settings passed in
+    for key in new_settings:
+        check_device_setting(key)
+
+    settings_to_set = dict(new_settings)
+    if language_id is not None:
+        settings_to_set["language_id"] = language_id
+    if facility is not None:
+        settings_to_set["default_facility"] = facility
+
+    return settings_to_set
+
+
+def create_facility(facility_name=None, preset=None):
+    from kolibri.core.auth.models import Facility
+
+    facility = Facility.objects.create(name=facility_name)
+    logger.info("Facility with name '{name}' created.".format(name=facility.name))
+
+    # Only set preset data if we have created the facility, otherwise leave previous data intact
+    if preset:
+        dataset_data = mappings[preset]
+        facility.dataset.preset = preset
+        for key, value in dataset_data.items():
+            setattr(facility.dataset, key, value)
+        facility.dataset.save()
+        logger.info("Facility preset changed to {preset}.".format(preset=preset))
+    return facility
+
+
+def setup_device_and_facility(
+    facility,
+    facility_name,
+    preset,
+    facility_settings,
+    device_settings,
+    username,
+    password,
+):
+    from kolibri.core.auth.models import FacilityUser
+
+    with transaction.atomic():
+        if facility is None and facility_name is not None:
+            facility = create_facility(
+                facility_name=facility_name,
+                preset=preset,
+            )
+
+            if facility_settings:
+                for key, value in facility_settings.items():
+                    setattr(facility.dataset, key, value)
+                facility.dataset.save()
+                logger.info(
+                    "Facility settings updated with {}".format(facility_settings)
+                )
+
+        provision_device(**device_settings)
+        logger.info("Device settings updated with {}".format(device_settings))
+
+        if username and password and facility:
+            try:
+                FacilityUser.objects.create_superuser(
+                    username, password, facility=facility
+                )
+                logger.info(
+                    "Superuser created with username '{username}' in facility '{facility}'.".format(
+                        username=username, facility=facility
+                    )
+                )
+            except ValidationError:
+                logger.warn(
+                    "An account with username '{username}' already exists in facility '{facility}', not creating user account.".format(
+                        username=username, facility=facility
+                    )
+                )
+
+
+def provision_from_file(file_path):
+    """
+    Expects a JSON file with the following format (example values supplied):
+    {
+        "facility": "My Facility",
+        "preset": "formal",
+        "facility_settings": {
+            "learner_can_edit_username": true,
+            "learner_can_edit_name": true,
+            "learner_can_edit_password": true,
+            "learner_can_sign_up": true,
+            "learner_can_delete_account": true,
+            "learner_can_login_with_no_password": true,
+            "show_download_button_in_learn": true
+        },
+        "device_settings": {
+            "language_id": "en",
+            "landing_page": "homepage",
+            "allow_guest_access": true,
+            "allow_peer_unlisted_channel_import": true,
+            "allow_learner_unassigned_resource_access": true,
+            "name": "My Device",
+            "allow_other_browsers_to_connect": true
+        },
+        "username": "superuser",
+        "password": "password"
+    }
+    All fields are optional.
+    """
+    from kolibri.core.auth.models import Facility
+
+    if device_provisioned() or not os.path.exists(file_path):
+        return
+
+    try:
+        with open(file_path, "r") as f:
+            logger.info(
+                "Attempting to automatically provision device from data in {}".format(
+                    file_path
+                )
+            )
+            options = json.load(f)
+    except (IOError, ValueError) as e:
+        logging.error("Failed to load {}:\n{}".format(file_path, e))
+        return
+
+    facility_name = options.get("facility")
+
+    facility = None
+
+    if facility_name:
+        facility_query = Facility.objects.filter(name__iexact=facility_name)
+
+        if facility_query.exists():
+            facility = facility_query.get()
+            logger.warn(
+                "Facility with name '{name}' already exists, not modifying preset.".format(
+                    name=facility.name
+                )
+            )
+    else:
+        facility = Facility.get_default_facility() or Facility.objects.first()
+
+    try:
+        device_settings = validate_device_settings(**options.get("device_settings", {}))
+    except ValueError as e:
+        logging.error("Invalid device settings specified in {}.".format(file_path))
+        return
+
+    try:
+        facility_settings = validate_facility_settings(
+            options.get("facility_settings", {})
+        )
+    except ValueError as e:
+        logging.error("Invalid facility settings specified in {}.".format(file_path))
+        return
+
+    preset = options.get("preset")
+    username = options.get("username")
+    password = options.get("password")
+
+    setup_device_and_facility(
+        facility,
+        facility_name,
+        preset,
+        facility_settings,
+        device_settings,
+        username,
+        password,
+    )

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -302,7 +302,7 @@ def provision_from_file(file_path):
 
     try:
         device_settings = validate_device_settings(**options.get("device_settings", {}))
-    except ValueError as e:
+    except ValueError:
         logging.error("Invalid device settings specified in {}.".format(file_path))
         return
 
@@ -310,7 +310,7 @@ def provision_from_file(file_path):
         facility_settings = validate_facility_settings(
             options.get("facility_settings", {})
         )
-    except ValueError as e:
+    except ValueError:
         logging.error("Invalid facility settings specified in {}.".format(file_path))
         return
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -85,46 +85,6 @@ def set_device_settings(**kwargs):
         raise DeviceNotProvisioned
 
 
-def create_superuser(user_data, facility):
-    from .models import DevicePermissions
-    from kolibri.core.auth.models import FacilityUser
-    from django.core.exceptions import ValidationError
-
-    username = user_data.get("username")
-    password = user_data.get("password")
-    full_name = user_data.get("full_name")
-
-    # Code copied from FacilityUserModelManager (create_superuser method doesn't work)
-    if FacilityUser.objects.filter(
-        username__iexact=username, facility=facility
-    ).exists():
-        raise ValidationError("An account with that username already exists")
-
-    # gender and birth_year are set to "DEFERRED", since superusers do not
-    # need to provide this and are not nudged to update profile on Learn page
-    superuser = FacilityUser.objects.create(
-        full_name=full_name or username,
-        username=username,
-        password=password,
-        facility=facility,
-        gender="DEFERRED",
-        birth_year="DEFERRED",
-    )
-
-    superuser.full_clean()
-    superuser.set_password(password)
-    superuser.save()
-
-    # make the user a facility admin
-    facility.add_admin(superuser)
-
-    # make the user into a superuser on this device
-    DevicePermissions.objects.create(
-        user=superuser, is_superuser=True, can_manage_content=True
-    )
-    return superuser
-
-
 def provision_device(device_name=None, **kwargs):
     from .models import DeviceSettings
 

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -76,16 +76,19 @@ class FacilityImportViewSet(ViewSet):
         Given a username, full name and password, create a superuser attached
         to the facility that was imported
         """
-        from kolibri.core.device.utils import create_superuser
-
         # Get the imported facility (assuming its the only one at this point)
         the_facility = Facility.objects.get()
 
         try:
-            superuser = create_superuser(request.data, facility=the_facility)
+            superuser = FacilityUser.objects.create_superuser(
+                request.data.get("username"),
+                request.data.get("password"),
+                facility=the_facility,
+                full_name=request.data.get("full_name"),
+            )
             return Response({"username": superuser.username})
 
-        except (Exception,):
+        except ValidationError:
             raise ValidationError(detail="duplicate", code="duplicate_username")
 
     @decorators.action(methods=["post"], detail=False)

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -15,6 +15,7 @@ from django.core.management.base import handle_default_options
 from django.db.utils import DatabaseError
 
 import kolibri
+from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_from_file
 from kolibri.core.deviceadmin.exceptions import IncompatibleDatabase
 from kolibri.core.tasks.main import import_tasks_module_from_django_apps
@@ -162,8 +163,8 @@ def _upgrades_before_django_setup(updated, version):
 
 
 def _upgrades_after_django_setup(updated, version):
-    # On first ever run, attempt automatic provisioning
-    if not version and OPTIONS["Paths"]["AUTOMATIC_PROVISION_FILE"]:
+    # If device is not provisioned, attempt automatic provisioning
+    if not device_provisioned() and OPTIONS["Paths"]["AUTOMATIC_PROVISION_FILE"]:
         try:
             provision_from_file(OPTIONS["Paths"]["AUTOMATIC_PROVISION_FILE"])
         except ValidationError as e:

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -360,6 +360,11 @@ base_option_spec = {
             "default": "",
             "description": "Additional directories in which Kolibri will look for content files and content database files.",
         },
+        "AUTOMATIC_PROVISION_FILE": {
+            "type": "path",
+            "default": "automatic_provision.json",
+            "description": "The file that contains the automatic device provisioning data.",
+        },
     },
     "Urls": {
         "CENTRAL_CONTENT_BASE_URL": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -125,8 +125,11 @@ def path(value):
 
     if not isinstance(value, string_types):
         raise VdtValueError(repr(value))
-    # ensure all path arguments, e.g. under section "Paths", are fully resolved and expanded, relative to KOLIBRI_HOME
-    return os.path.join(KOLIBRI_HOME, os.path.expanduser(value))
+    # Allow for blank paths
+    if value:
+        # ensure all path arguments, e.g. under section "Paths", are fully resolved and expanded, relative to KOLIBRI_HOME
+        return os.path.join(KOLIBRI_HOME, os.path.expanduser(value))
+    return value
 
 
 def path_list(value):
@@ -362,7 +365,7 @@ base_option_spec = {
         },
         "AUTOMATIC_PROVISION_FILE": {
             "type": "path",
-            "default": "automatic_provision.json",
+            "default": "",
             "description": "The file that contains the automatic device provisioning data.",
         },
     },

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -13,10 +13,11 @@ from kolibri.utils import main
 
 
 @pytest.mark.django_db
+@patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value="")
 @patch("kolibri.utils.main.update")
 @patch("kolibri.core.deviceadmin.utils.dbbackup")
-def test_first_run(dbbackup, update, get_version):
+def test_first_run(dbbackup, update, get_version, upgrades_after_django_setup):
     """
     Tests that the first_run() function performs as expected
     """
@@ -32,9 +33,10 @@ def test_first_run(dbbackup, update, get_version):
 
 
 @pytest.mark.django_db
+@patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value="0.0.1")
 @patch("kolibri.utils.main.update")
-def test_update(update, get_version):
+def test_update(update, get_version, upgrades_after_django_setup):
     """
     Tests that update() function performs as expected
     """
@@ -70,10 +72,13 @@ def test_version_updated():
 
 
 @pytest.mark.django_db
+@patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value=kolibri.__version__)
 @patch("kolibri.utils.main.update")
 @patch("kolibri.core.deviceadmin.utils.dbbackup")
-def test_update_no_version_change(dbbackup, update, get_version):
+def test_update_no_version_change(
+    dbbackup, update, get_version, upgrades_after_django_setup
+):
     """
     Tests that when the version doesn't change, we are not doing things we
     shouldn't
@@ -83,11 +88,11 @@ def test_update_no_version_change(dbbackup, update, get_version):
     dbbackup.assert_not_called()
 
 
-@patch("kolibri.utils.main.provision_from_file")
+@patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main._migrate_databases")
 @patch("kolibri.utils.main.version_updated")
 def test_migrate_if_unmigrated(
-    version_updated, _migrate_databases, provision_from_file
+    version_updated, _migrate_databases, _upgrades_after_django_setup
 ):
     # No matter what, ensure that version_updated returns False
     version_updated.return_value = False

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -83,9 +83,12 @@ def test_update_no_version_change(dbbackup, update, get_version):
     dbbackup.assert_not_called()
 
 
+@patch("kolibri.utils.main.provision_from_file")
 @patch("kolibri.utils.main._migrate_databases")
 @patch("kolibri.utils.main.version_updated")
-def test_migrate_if_unmigrated(version_updated, _migrate_databases):
+def test_migrate_if_unmigrated(
+    version_updated, _migrate_databases, provision_from_file
+):
     # No matter what, ensure that version_updated returns False
     version_updated.return_value = False
     from morango.models import InstanceIDModel


### PR DESCRIPTION
## Summary
* Consolidates provisioning code
* Adds an option for the file path of an automatic provisioning file
* Creates a utility to read an automatic provisioning file and provision a device based on it
* On first upgrade, attempts to run automatic provisioning

## References
Fixes #7803
Fixes #6613

## Reviewer guidance
Does the file format make sense? Does it allow for future extensibility in ways that might cover, e.g. content configuration?

## TODO
- [ ] Add Gherkin story

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
