### PR TITLE
Don't modify lessons when content is deleted.

### DIFF
--- a/kolibri/core/content/signals.py
+++ b/kolibri/core/content/signals.py
@@ -4,7 +4,6 @@ from django.dispatch import receiver
 
 from .models import ChannelMetadata
 from .models import ContentNode
-from kolibri.core.lessons.models import Lesson
 from kolibri.core.notifications.models import LearnerProgressNotification
 
 
@@ -26,17 +25,3 @@ def reorder_channels_upon_deletion(sender, instance=None, *args, **kwargs):
         ChannelMetadata.objects.filter(order__gt=instance.order).update(
             order=F("order") - 1
         )
-
-
-@receiver(pre_delete, sender=ChannelMetadata)
-def update_lesson_resources_before_delete(sender, instance=None, *args, **kwargs):
-    # Update the resources array of all lessons to ensure they don't have
-    # any deleted content
-    lessons = Lesson.objects.filter(resources__contains=instance.id)
-    for lesson in lessons:
-        updated_resources = [
-            r for r in lesson.resources if r["channel_id"] != instance.id
-        ]
-        if len(updated_resources) < len(lesson.resources):
-            lesson.resources = updated_resources
-            lesson.save()


### PR DESCRIPTION
## Summary
* Cleans up a residual handler for modifying lessons if content is deleted
* Probably wasn't doing anything as we mostly don't use Django ORM to delete content nodes
* Remove for safety and code cleanup

## Reviewer guidance
Tests still pass?
I think this was not deleted because of oversight rather than intention.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
