### PR TITLE
Deprecated options

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -40,14 +40,6 @@ default_cache = {
     "OPTIONS": {"MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"]},
 }
 
-built_files_prefix = "built_files"
-
-built_files_cache = {
-    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    # Default time out of each cache key
-    "TIMEOUT": cache_options["CACHE_TIMEOUT"],
-    "OPTIONS": {"MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"]},
-}
 
 # Setup a special cache specifically for items that are likely to be needed
 # to be shared across processes - most frequently, things that might be needed
@@ -87,16 +79,10 @@ if cache_options["CACHE_BACKEND"] == "redis":
     }
     default_cache = copy.deepcopy(base_cache)
     default_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_DB"]
-    built_files_cache = copy.deepcopy(base_cache)
-    built_files_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_DB"] + 1
-
-built_files_cache["KEY_PREFIX"] = built_files_prefix
 
 CACHES = {
     # Default cache
     "default": default_cache,
-    # Cache for builtfiles - frontend assets that only change on upgrade.
-    "built_files": built_files_cache,
 }
 
 if cache_options["CACHE_BACKEND"] != "redis":

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -86,9 +86,9 @@ if cache_options["CACHE_BACKEND"] == "redis":
         },
     }
     default_cache = copy.deepcopy(base_cache)
-    default_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_MIN_DB"]
+    default_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_DB"]
     built_files_cache = copy.deepcopy(base_cache)
-    built_files_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_MIN_DB"] + 1
+    built_files_cache["OPTIONS"]["DB"] = cache_options["CACHE_REDIS_DB"] + 1
 
 built_files_cache["KEY_PREFIX"] = built_files_prefix
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -456,16 +456,29 @@ def configure():
     pass
 
 
+def _format_env_var(envvar, value):
+    if value.get("deprecated", False) or envvar in value.get(
+        "deprecated_envvars", tuple()
+    ):
+        return click.style(
+            "{envvar} - DEPRECATED - {description}\n\n".format(
+                envvar=envvar, description=value.get("description", "")
+            ),
+            fg="yellow",
+        )
+    return "{envvar} - {description}\n\n".format(
+        envvar=envvar, description=value.get("description", "")
+    )
+
+
 def _get_env_vars():
     """
     Generator to iterate over all environment variables
     """
-    template = "{envvar} - {description}\n\n"
-
     from kolibri.utils.env import ENVIRONMENT_VARIABLES
 
     for key, value in ENVIRONMENT_VARIABLES.items():
-        yield template.format(envvar=key, description=value.get("description", ""))
+        yield _format_env_var(key, value)
 
     from kolibri.utils.options import option_spec
 
@@ -473,9 +486,7 @@ def _get_env_vars():
         for v in value.values():
             if "envvars" in v:
                 for envvar in v["envvars"]:
-                    yield template.format(
-                        envvar=envvar, description=v.get("description", "")
-                    )
+                    yield _format_env_var(envvar, v)
 
 
 @configure.command(help="List all available environment variables to configure Kolibri")

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -261,8 +261,3 @@ def update(old_version, new_version):
 
     with open(version_file(), "w") as f:
         f.write(kolibri.__version__)
-
-    from django.core.cache import caches
-
-    cache = caches["built_files"]
-    cache.clear()

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -196,7 +196,9 @@ def test_deprecated_envvars(monkeypatch):
         # deprecated envvars for otherwise valid options log warnings
         with open(tmp_ini_path, "w") as f:
             f.write("\n")
-        with mock.patch.dict(os.environ, {"KOLIBRI_LISTEN_PORT": "1234"}):
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_LISTEN_PORT": "1234", "KOLIBRI_HTTP_PORT": ""}
+        ):
             options.read_options_file(ini_filename=tmp_ini_path)
             assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 import tempfile
+from contextlib import contextmanager
 
 import mock
 import pytest
@@ -31,6 +32,7 @@ def log_logger(logger_instance, LEVEL, msg, args, **kwargs):
     logger_instance.__log(LEVEL, msg, args, **kwargs)
 
 
+@contextmanager
 def activate_log_logger(monkeypatch):
     """
     Activates logging everything to ``LOG_LOGGER`` with the monkeypatch pattern
@@ -38,6 +40,9 @@ def activate_log_logger(monkeypatch):
     """
     monkeypatch.setattr(logging.Logger, "__log", logging.Logger._log, raising=False)
     monkeypatch.setattr(logging.Logger, "_log", log_logger)
+    yield
+    # Use this to clear the list for Py2 compatibility
+    del LOG_LOGGER[:]
 
 
 def test_option_reading_and_precedence_rules():
@@ -115,67 +120,116 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
     Checks invalid options log errors and exit.
     """
 
-    activate_log_logger(monkeypatch)
+    with activate_log_logger(monkeypatch):
 
-    _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
 
-    # non-numeric arguments for an integer option in the ini file cause it to bail
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n".join(["[Deployment]", "HTTP_PORT = abba"]))
-    with mock.patch.dict(
-        os.environ, {"KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": ""}
-    ):
-        with pytest.raises(SystemExit):
-            options.read_options_file(ini_filename=tmp_ini_path)
-        assert 'value "abba" is of the wrong type' in LOG_LOGGER[-2][1]
+        # non-numeric arguments for an integer option in the ini file cause it to bail
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Deployment]", "HTTP_PORT = abba"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": ""}
+        ):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "abba" is of the wrong type' in LOG_LOGGER[-2][1]
 
-    # non-numeric arguments for an integer option in the env var cause it to bail, even when ini file is ok
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n".join(["[Deployment]", "HTTP_PORT = 1278"]))
-    with mock.patch.dict(
-        os.environ, {"KOLIBRI_HTTP_PORT": "baba", "KOLIBRI_LISTEN_PORT": ""}
-    ):
-        with pytest.raises(SystemExit):
-            options.read_options_file(ini_filename=tmp_ini_path)
-        assert 'value "baba" is of the wrong type' in LOG_LOGGER[-2][1]
+        # non-numeric arguments for an integer option in the env var cause it to bail, even when ini file is ok
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Deployment]", "HTTP_PORT = 1278"]))
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HTTP_PORT": "baba", "KOLIBRI_LISTEN_PORT": ""}
+        ):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "baba" is of the wrong type' in LOG_LOGGER[-2][1]
 
-    # invalid choice for "option" type causes it to bail
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n".join(["[Database]", "DATABASE_ENGINE = penguin"]))
-    with mock.patch.dict(os.environ, {"KOLIBRI_DATABASE_ENGINE": ""}):
-        with pytest.raises(SystemExit):
-            options.read_options_file(ini_filename=tmp_ini_path)
-        assert 'value "penguin" is unacceptable' in LOG_LOGGER[-2][1]
+        # invalid choice for "option" type causes it to bail
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Database]", "DATABASE_ENGINE = penguin"]))
+        with mock.patch.dict(os.environ, {"KOLIBRI_DATABASE_ENGINE": ""}):
+            with pytest.raises(SystemExit):
+                options.read_options_file(ini_filename=tmp_ini_path)
+            assert 'value "penguin" is unacceptable' in LOG_LOGGER[-2][1]
 
 
-def test_deprecated_values(monkeypatch):
+def test_deprecated_values_ini_file(monkeypatch):
     """
     Checks that deprecated options log warnings.
     """
 
-    activate_log_logger(monkeypatch)
+    with activate_log_logger(monkeypatch):
 
-    _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
 
-    # deprecated options in the ini file log warnings
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n".join(["[Server]", "CHERRYPY_START = false"]))
-    options.read_options_file(ini_filename=tmp_ini_path)
-    assert "deprecated" in LOG_LOGGER[-1][-1]
-
-    # deprecated options in the envvars log warnings
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n")
-    with mock.patch.dict(os.environ, {"KOLIBRI_CHERRYPY_START": "false"}):
+        # deprecated options in the ini file log warnings
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Server]", "CHERRYPY_START = false"]))
         options.read_options_file(ini_filename=tmp_ini_path)
         assert "deprecated" in LOG_LOGGER[-1][-1]
 
-    # deprecated envvars for otherwise valid options log warnings
-    with open(tmp_ini_path, "w") as f:
-        f.write("\n")
-    with mock.patch.dict(os.environ, {"KOLIBRI_LISTEN_PORT": "1234"}):
+
+def test_deprecated_values_envvars(monkeypatch):
+    """
+    Checks that deprecated options log warnings.
+    """
+
+    with activate_log_logger(monkeypatch):
+
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        # deprecated options in the envvars log warnings
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n")
+        with mock.patch.dict(os.environ, {"KOLIBRI_CHERRYPY_START": "false"}):
+            options.read_options_file(ini_filename=tmp_ini_path)
+            assert "deprecated" in LOG_LOGGER[-1][-1]
+
+
+def test_deprecated_envvars(monkeypatch):
+    """
+    Checks that deprecated options log warnings.
+    """
+
+    with activate_log_logger(monkeypatch):
+
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        # deprecated envvars for otherwise valid options log warnings
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n")
+        with mock.patch.dict(os.environ, {"KOLIBRI_LISTEN_PORT": "1234"}):
+            options.read_options_file(ini_filename=tmp_ini_path)
+            assert "deprecated" in LOG_LOGGER[-1][-1]
+
+
+def test_deprecated_aliases(monkeypatch):
+    """
+    Checks that deprecated options log warnings.
+    """
+
+    with activate_log_logger(monkeypatch):
+
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        # deprecated aliases for otherwise valid options log warnings
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n".join(["[Cache]", "CACHE_REDIS_MIN_DB = 7"]))
         options.read_options_file(ini_filename=tmp_ini_path)
         assert "deprecated" in LOG_LOGGER[-1][-1]
+
+
+def test_deprecated_aliases_envvars(monkeypatch):
+    """
+    Checks that deprecated options log warnings.
+    """
+
+    with activate_log_logger(monkeypatch):
+
+        _, tmp_ini_path = tempfile.mkstemp(prefix="options", suffix=".ini")
+        # envvars for deprecated aliases of otherwise valid options log warnings
+        with open(tmp_ini_path, "w") as f:
+            f.write("\n")
+        with mock.patch.dict(os.environ, {"KOLIBRI_CACHE_REDIS_MIN_DB": "1234"}):
+            options.read_options_file(ini_filename=tmp_ini_path)
+            assert "deprecated" in LOG_LOGGER[-1][-1]
 
 
 def test_option_writing():

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -166,7 +166,7 @@ def test_deprecated_values_ini_file(monkeypatch):
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Server]", "CHERRYPY_START = false"]))
         options.read_options_file(ini_filename=tmp_ini_path)
-        assert "deprecated" in LOG_LOGGER[-1][-1]
+        assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
 
 def test_deprecated_values_envvars(monkeypatch):
@@ -182,7 +182,7 @@ def test_deprecated_values_envvars(monkeypatch):
             f.write("\n")
         with mock.patch.dict(os.environ, {"KOLIBRI_CHERRYPY_START": "false"}):
             options.read_options_file(ini_filename=tmp_ini_path)
-            assert "deprecated" in LOG_LOGGER[-1][-1]
+            assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
 
 def test_deprecated_envvars(monkeypatch):
@@ -198,7 +198,7 @@ def test_deprecated_envvars(monkeypatch):
             f.write("\n")
         with mock.patch.dict(os.environ, {"KOLIBRI_LISTEN_PORT": "1234"}):
             options.read_options_file(ini_filename=tmp_ini_path)
-            assert "deprecated" in LOG_LOGGER[-1][-1]
+            assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
 
 def test_deprecated_aliases(monkeypatch):
@@ -213,7 +213,7 @@ def test_deprecated_aliases(monkeypatch):
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Cache]", "CACHE_REDIS_MIN_DB = 7"]))
         options.read_options_file(ini_filename=tmp_ini_path)
-        assert "deprecated" in LOG_LOGGER[-1][-1]
+        assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
 
 def test_deprecated_aliases_envvars(monkeypatch):
@@ -229,7 +229,7 @@ def test_deprecated_aliases_envvars(monkeypatch):
             f.write("\n")
         with mock.patch.dict(os.environ, {"KOLIBRI_CACHE_REDIS_MIN_DB": "1234"}):
             options.read_options_file(ini_filename=tmp_ini_path)
-            assert "deprecated" in LOG_LOGGER[-1][-1]
+            assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
 
 def test_option_writing():


### PR DESCRIPTION
## Summary
* Adds support for marking options for options.ini as deprecated
* Adds support for marking specific environment variables (either for options or generic env vars) as deprecated
* Adds support for marking a deprecated alias of an options.ini option, to allow migration of options to a new name
* Marks CHERRYPY_START as deprecated
* Marks KOLIBRI_LISTEN_PORT as a deprecated envvar
* Migrates CACHE_REDIS_MIN_DB to CACHE_REDIS_DB and marks the old option as a deprecated alias
* Updates all references to CACHE_REDIS_MIN_DB
* Updates tests for options to more precisely introspect logging
* Deletes the built files cache, removes all use of caching in reading from disk in webpack hooks, instead relying on caching of the HTML pages that use them

## References
Fixes #8058
Fixes #8129

## Reviewer guidance
I assume that the impact of not caching webpack stats files, language JSON blobs, and inlined static files should be negligible, because we cache the HTML files that use them anyway. But some double checking or challenging of this assumption would be very useful.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
