### PR TITLE
Fix deprovision cache issue

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -97,12 +97,14 @@ class DeviceSettings(models.Model):
     def save(self, *args, **kwargs):
         self.pk = 1
         self.full_clean()
-        super(DeviceSettings, self).save(*args, **kwargs)
+        out = super(DeviceSettings, self).save(*args, **kwargs)
         cache.set(DEVICE_SETTINGS_CACHE_KEY, self, 600)
+        return out
 
     def delete(self, *args, **kwargs):
-        super(DeviceSettings, self).delete(*args, **kwargs)
+        out = super(DeviceSettings, self).delete(*args, **kwargs)
         cache.delete(DEVICE_SETTINGS_CACHE_KEY)
+        return out
 
 
 CONTENT_CACHE_KEY_CACHE_KEY = "content_cache_key"

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -31,3 +31,10 @@ class DeviceSettingsTestCase(TestCase):
         DeviceSettings.objects.all().delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
+
+    def test_delete_setting_manager(self):
+        cache.clear()
+        DeviceSettings.objects.create()
+        DeviceSettings.objects.delete()
+        with self.assertRaises(DeviceSettings.DoesNotExist):
+            DeviceSettings.objects.get()

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -1,0 +1,33 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from kolibri.core.device.models import DeviceSettings
+from kolibri.core.utils.cache import process_cache as cache
+
+
+class DeviceSettingsTestCase(TestCase):
+    def test_singleton(self):
+        cache.clear()
+        DeviceSettings.objects.create()
+        with self.assertRaises(ValidationError):
+            DeviceSettings.objects.create()
+
+    def test_get_setting(self):
+        cache.clear()
+        ds = DeviceSettings.objects.create()
+        ds2 = DeviceSettings.objects.get()
+        self.assertEqual(ds, ds2)
+
+    def test_delete_setting(self):
+        cache.clear()
+        ds = DeviceSettings.objects.create()
+        ds.delete()
+        with self.assertRaises(DeviceSettings.DoesNotExist):
+            DeviceSettings.objects.get()
+
+    def test_delete_setting_queryset(self):
+        cache.clear()
+        DeviceSettings.objects.create()
+        DeviceSettings.objects.all().delete()
+        with self.assertRaises(DeviceSettings.DoesNotExist):
+            DeviceSettings.objects.get()


### PR DESCRIPTION
## Summary
* Add tests for device settings behaviours.
* Fix device settings cache persistence on deletion.

## References
Fixes issue after deprovisoining where device settings would persist in cache

## Reviewer guidance
Setup device
Deprovision
Try to set up device again

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
