### PR TITLE
Don't try to initialize H5P when it is does not exist.

### DIFF
--- a/packages/hashi/src/H5P/H5PInterface.js
+++ b/packages/hashi/src/H5P/H5PInterface.js
@@ -37,7 +37,7 @@ export default class H5P extends BaseShim {
    * to configure itself.
    */
   iframeInitialize(contentWindow) {
-    this.H5PRunner.shimH5PIntegration(contentWindow);
+    this.H5PRunner && this.H5PRunner.shimH5PIntegration(contentWindow);
   }
 
   loaded() {


### PR DESCRIPTION
## Summary
Fixes attempt to unconditionally initialize H5P regardless of the context

## References
Follow up from #7989 

## Reviewer guidance
Load any non-H5P HTML5 app
Confirm that it does not log `'Shimming storage APIs failed, data will not persist'` to the console

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
