### PR TITLE
Point develop at most recent KDS

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -18,7 +18,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#cfcfc2548584dcdf48426d9379fccb8f56dd6c54",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -18,7 +18,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -17,7 +17,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#cfcfc2548584dcdf48426d9379fccb8f56dd6c54",
+    "kolibri-design-system": "github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -17,7 +17,7 @@
     "frame-throttle": "^3.0.0",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-design-system": "github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f",
     "lockr": "0.8.4",
     "lodash": "^4.17.4",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7971,9 +7971,9 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#cfcfc2548584dcdf48426d9379fccb8f56dd6c54":
+"kolibri-design-system@github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f":
   version "0.2.2-beta-2"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/cfcfc2548584dcdf48426d9379fccb8f56dd6c54"
+  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/65ee3a69a2ab072ea92e034d95118687678b4f5f"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7971,9 +7971,9 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-"kolibri-design-system@github:learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f":
+"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f":
   version "0.2.2-beta-2"
-  resolved "https://codeload.github.com/learningequality/kolibri-design-system/tar.gz/65ee3a69a2ab072ea92e034d95118687678b4f5f"
+  resolved "git://github.com/learningequality/kolibri-design-system#65ee3a69a2ab072ea92e034d95118687678b4f5f"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary

Point Kolibri `develop` to the latest `HEAD` of KDS

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Points to https://github.com/learningequality/kolibri-design-system/commit/65ee3a69a2ab072ea92e034d95118687678b4f5f

KDS updates since the last time:

![changelog](https://user-images.githubusercontent.com/13509191/126772786-58e02db6-9060-408b-a2ac-a3587604369e.png)

No updates are required on Kolibri side.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Run `yarn install`
- You can check for regressions

I don't think there are any risky areas. Regarding updates of existing KDS icons, I already checked that no updates are needed for Kolibri https://github.com/learningequality/kolibri-design-system/pull/251#issuecomment-878964231

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
