### PR TITLE
Device info versioning

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -34,6 +34,7 @@ class NetworkClient(object):
 
     def _attempt_connections(self, urls):
         from kolibri.core.public.utils import DEVICE_INFO_VERSION
+        from kolibri.core.public.utils import device_info_keys
 
         # try each of the URLs in turn, returning the first one that succeeds
         for url in urls:
@@ -51,7 +52,10 @@ class NetworkClient(object):
                 if response.status_code == 200 and response_path.rstrip("/").endswith(
                     "/api/public/info"
                 ):
-                    self.info = response.json()
+                    info = response.json()
+                    self.info = {}
+                    for key in device_info_keys.get(DEVICE_INFO_VERSION, []):
+                        self.info[key] = info.get(key)
                     if self.info["application"] not in ["studio", "kolibri"]:
                         raise requests.RequestException(
                             "Server is not running Kolibri or Studio"

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -2,6 +2,7 @@ import logging
 
 import requests
 from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urlparse
 
 from . import errors
 from .urls import get_normalized_url_variations
@@ -32,6 +33,8 @@ class NetworkClient(object):
             )
 
     def _attempt_connections(self, urls):
+        from kolibri.core.public.utils import DEVICE_INFO_VERSION
+
         # try each of the URLs in turn, returning the first one that succeeds
         for url in urls:
             try:
@@ -41,9 +44,11 @@ class NetworkClient(object):
                     base_url=url,
                     timeout=self.timeout,
                     allow_redirects=True,
+                    params={"v": DEVICE_INFO_VERSION},
                 )
                 # check that we successfully connected, and if we were redirected that it's still the right endpoint
-                if response.status_code == 200 and response.url.rstrip("/").endswith(
+                response_path = urlparse(response.url).path
+                if response.status_code == 200 and response_path.rstrip("/").endswith(
                     "/api/public/info"
                 ):
                     self.info = response.json()

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -44,8 +44,11 @@ class InfoViewSet(viewsets.ViewSet):
 
     def list(self, request):
         """Returns metadata information about the device"""
+        # Default to version 1, as earlier versions of Kolibri
+        # will not have sent a "v" query param.
+        version = request.query_params.get("v", "1")
 
-        return Response(get_device_info())
+        return Response(get_device_info(version))
 
 
 def _get_channel_list(version, params, identifier=None):

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -98,7 +98,7 @@ class PublicAPITestCase(APITransactionTestCase):
         )
         set_channel_metadata_fields(channel2.id, public=True)
 
-    def test_info_endpoint(self):
+    def test_info_endpoint_unversioned(self):
         response = self.client.get(reverse("kolibri:core:info-list"))
         instance_model = InstanceIDModel.get_or_create_current_instance()[0]
         settings = DeviceSettings.objects.get()
@@ -107,6 +107,31 @@ class PublicAPITestCase(APITransactionTestCase):
         self.assertEqual(response.data["instance_id"], instance_model.id)
         self.assertEqual(response.data["device_name"], settings.name)
         self.assertEqual(response.data["operating_system"], platform.system())
+        self.assertIsNone(response.data.get("subset_of_users_device"))
+
+    def test_info_endpoint_v1(self):
+        response = self.client.get(reverse("kolibri:core:info-list"), data={"v": "1"})
+        instance_model = InstanceIDModel.get_or_create_current_instance()[0]
+        settings = DeviceSettings.objects.get()
+        self.assertEqual(response.data["application"], "kolibri")
+        self.assertEqual(response.data["kolibri_version"], kolibri.__version__)
+        self.assertEqual(response.data["instance_id"], instance_model.id)
+        self.assertEqual(response.data["device_name"], settings.name)
+        self.assertEqual(response.data["operating_system"], platform.system())
+        self.assertIsNone(response.data.get("subset_of_users_device"))
+
+    def test_info_endpoint_v2(self):
+        response = self.client.get(reverse("kolibri:core:info-list"), data={"v": "2"})
+        instance_model = InstanceIDModel.get_or_create_current_instance()[0]
+        settings = DeviceSettings.objects.get()
+        self.assertEqual(response.data["application"], "kolibri")
+        self.assertEqual(response.data["kolibri_version"], kolibri.__version__)
+        self.assertEqual(response.data["instance_id"], instance_model.id)
+        self.assertEqual(response.data["device_name"], settings.name)
+        self.assertEqual(response.data["operating_system"], platform.system())
+        self.assertEqual(
+            response.data["subset_of_users_device"], settings.subset_of_users_device
+        )
 
     def test_public_channel_list(self):
         response = self.client.get(get_channel_lookup_url(baseurl="/"))

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -27,7 +27,7 @@ from kolibri.core.tasks.main import scheduler
 logger = logging.getLogger(__name__)
 
 
-keys_by_version = {
+device_info_keys = {
     "1": [
         "application",
         "kolibri_version",
@@ -56,7 +56,7 @@ def get_device_info(version=DEVICE_INFO_VERSION):
     We maintain historic versions for backwards compatibility
     """
 
-    if version not in keys_by_version:
+    if version not in device_info_keys:
         version = DEVICE_INFO_VERSION
 
     instance_model = InstanceIDModel.get_or_create_current_instance()[0]
@@ -79,8 +79,8 @@ def get_device_info(version=DEVICE_INFO_VERSION):
 
     info = {}
 
-    # By this point, we have validated that the version is in keys_by_version
-    for key in keys_by_version.get(version, []):
+    # By this point, we have validated that the version is in device_info_keys
+    for key in device_info_keys.get(version, []):
         info[key] = all_info[key]
 
     return info

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -27,8 +27,37 @@ from kolibri.core.tasks.main import scheduler
 logger = logging.getLogger(__name__)
 
 
-def get_device_info():
-    """Returns metadata information about the device"""
+keys_by_version = {
+    "1": [
+        "application",
+        "kolibri_version",
+        "instance_id",
+        "device_name",
+        "operating_system",
+    ],
+    "2": [
+        "application",
+        "kolibri_version",
+        "instance_id",
+        "device_name",
+        "operating_system",
+        "subset_of_users_device",
+    ],
+}
+
+DEVICE_INFO_VERSION = "2"
+
+
+def get_device_info(version=DEVICE_INFO_VERSION):
+    """
+    Returns metadata information about the device
+    The default kwarg version should always be the latest
+    version of device info that this function supports.
+    We maintain historic versions for backwards compatibility
+    """
+
+    if version not in keys_by_version:
+        version = DEVICE_INFO_VERSION
 
     instance_model = InstanceIDModel.get_or_create_current_instance()[0]
     try:
@@ -39,7 +68,7 @@ def get_device_info():
         device_name = instance_model.hostname
         subset_of_users_device = False
 
-    info = {
+    all_info = {
         "application": "kolibri",
         "kolibri_version": kolibri.__version__,
         "instance_id": instance_model.id,
@@ -47,6 +76,13 @@ def get_device_info():
         "operating_system": platform.system(),
         "subset_of_users_device": subset_of_users_device,
     }
+
+    info = {}
+
+    # By this point, we have validated that the version is in keys_by_version
+    for key in keys_by_version.get(version, []):
+        info[key] = all_info[key]
+
     return info
 
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -6,6 +6,7 @@ import importlib
 import logging
 import signal
 import sys
+import traceback
 
 import click
 from django.core.management import execute_from_command_line
@@ -184,8 +185,8 @@ class KolibriDjangoCommand(click.Command):
     def invoke(self, ctx):
         try:
             initialize(**get_initialize_params())
-        except Exception as e:
-            raise click.ClickException(e)
+        except Exception:
+            raise click.ClickException(traceback.format_exc())
 
         # Remove parameters that are not for Django management command
         for param in initialize_params:


### PR DESCRIPTION
## Summary
* Adds versioning to device info endpoint
* Defaults to v1
* Updates code for fetching device info to send version
* Updates code for fetching device info to filter returned info recognized keys
* Adds tests for different versions of endpoint
* Fixes miscellanous CLI bug where errors would not get properly reported

## Reviewer guidance
Anything missing?

I checked the cross-version one way by changing the requested version to "1" in the Network client, then verifying that it returned `None` for `subset_of_users_device`. Have not tested the other way.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
