### PR TITLE
Notification generation during cleanup stage of sync

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -407,7 +407,7 @@ class Command(AsyncCommand):
 
         # allow server timeout since remotely integrating data can take a while and the request
         # could timeout. In that case, we'll assume everything is good.
-        sync_client.finalize(allow_server_timeout=True)
+        sync_client.finalize()
 
     def _update_all_progress(self, progress_fraction, progress):
         """
@@ -475,11 +475,15 @@ class Command(AsyncCommand):
             """
             :type transfer_session: morango.models.core.TransferSession
             """
-            progress = (
-                100
-                * transfer_session.records_transferred
-                / float(transfer_session.records_total)
-            )
+            try:
+                progress = (
+                    100
+                    * transfer_session.records_transferred
+                    / float(transfer_session.records_total)
+                )
+            except ZeroDivisionError:
+                progress = 100
+
             tracker.update_progress(
                 increment=math.ceil(progress - tracker.progress),
                 message=stats_msg(transfer_session),

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -12,6 +12,11 @@ INVALID_DEVICE_INFO = Nothing("invalid device info")
 FAILED_TO_CONNECT = Nothing("failed to connect")
 
 
+device_info_defaults = {
+    "subset_of_users_device": False,
+}
+
+
 def check_if_port_open(base_url, timeout=1):
     scheme, host, port, _ = parse_address_into_components(base_url)
 
@@ -28,7 +33,7 @@ def check_device_info(base_url):
     try:
         info = NetworkClient(base_url=base_url).info
         if info["application"] in ["studio", "kolibri"]:
-            return info
+            return device_info_defaults.copy().update(info)
         else:
             return INVALID_DEVICE_INFO
     except (errors.NetworkClientError, errors.NetworkLocationNotFound):

--- a/kolibri/core/notifications/api.py
+++ b/kolibri/core/notifications/api.py
@@ -64,8 +64,8 @@ def get_assignments(user, summarylog, attempt=False):
             pk__in=lesson_contentnode_map.values()
         ).in_bulk()
         for lesson_id, contentnode_id in lesson_contentnode_map.items():
-            content_node = content_nodes[contentnode_id]
-            if content_node.kind != content_kinds.EXERCISE:
+            content_node = content_nodes.get(contentnode_id, None)
+            if content_node is not None and content_node.kind != content_kinds.EXERCISE:
                 to_delete.append(lesson_id)
         for lesson_id in to_delete:
             del lesson_contentnode_map[lesson_id]

--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -17,6 +17,7 @@ import sys
 
 import pytz
 from django.conf import locale
+from morango.constants import settings as morango_settings
 from six.moves.urllib.parse import urljoin
 from tzlocal import get_localzone
 
@@ -26,6 +27,7 @@ from kolibri.plugins.utils.settings import apply_settings
 from kolibri.utils import conf
 from kolibri.utils import i18n
 from kolibri.utils.logger import get_logging_config
+
 
 try:
     isolation_level = None
@@ -358,3 +360,8 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 SESSION_COOKIE_AGE = 1200
 
 apply_settings(sys.modules[__name__])
+
+# prepend operation to generate notifications to sync cleanup
+MORANGO_CLEANUP_OPERATIONS = (
+    "kolibri.core.auth.utils:GenerateNotifications",
+) + morango_settings.MORANGO_CLEANUP_OPERATIONS

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ le-utils==0.1.24
 kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.5.5
+morango==0.6.1
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds a new Morango operation to the cleanup stage for generating notifications post-sync
- Fixes key error for certain notifications associated with `ContentNode`s that may not exist
- Fixes null-constraint issue for new device info property
- Dependency change:
```diff
diff --git a/requirements/base.txt b/requirements/base.txt
index 00695874f..f3a887763 100644
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ le-utils==0.1.24
 kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.5.5
+morango==0.6.1
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5

```

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves: https://github.com/learningequality/kolibri/issues/8188

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1) Connect to the VPN
2) Provision a fresh instance of Kolibri
2) Initiate a sync from the CLI for "Hack Session School": 
```bash
$ kolibri manage sync --baseurl "http://10.8.0.1:8080/" --username "learningequality" --password "learningequality"
```
4) Check notifications DB after sync finishes:
```bash
$ sqlite3 develop/notifications.sqlite3 
-- Loading resources from /home/bjester/.sqliterc
SQLite version 3.31.1 2020-01-27 19:55:54
Enter ".help" for usage hints.
sqlite> select count(*) from notifications_learnerprogressnotification ;
count(*)  
----------
120       
```

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [X] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
