### PR TITLE
Add a thumbnail component for new hybrid learning features

### DIFF
--- a/kolibri/core/assets/src/utils/contentNodeUtils.js
+++ b/kolibri/core/assets/src/utils/contentNodeUtils.js
@@ -1,7 +1,18 @@
 /*
- * Given a ContentNode, returns the thumbnail URL of the first file (if any) with a thumbnail
+ * Given a ContentNode, returns the thumbnail URL.
+ * A thumbnail URL is commonly saved in file objects of `files` attribute
+ * however some simplified endpoints return it only in `thumbnail` attribute.
+ * Therefore, if `thumbnail` attribute is availabe, its value is returned.
+ * If it's not available, then the first file (if any) with a thumbnail
+ * from `files` is returned.
  */
 export function getContentNodeThumbnail(contentnode) {
+  if (contentnode.thumbnail) {
+    return contentnode.thumbnail;
+  }
+  if (!contentnode.files || !contentnode.files.length) {
+    return null;
+  }
   const fileWithThumbnail = contentnode.files.find(file => file.thumbnail && file.available);
   if (fileWithThumbnail) {
     return fileWithThumbnail.storage_url;

--- a/kolibri/plugins/learn/assets/src/views/Thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/Thumbnail.vue
@@ -1,0 +1,109 @@
+<template>
+
+  <span
+    class="thumbnail"
+    :style="{ backgroundColor: $themePalette.grey.v_200 }"
+  >
+    <LearningActivityIcon
+      v-if="contentNode.is_leaf"
+      class="icon"
+      :kind="contentNode.learning_activities"
+    />
+    <KIcon
+      v-else
+      class="icon"
+      icon="topic"
+      :color="$themePalette.grey.v_500"
+    />
+
+    <!--
+      we consider thumbnails decorative - empty `alt`
+      attribute to hide it from screen readers
+    -->
+    <img
+      v-if="thumbnailUrl"
+      class="image"
+      :src="thumbnailUrl"
+      alt=""
+    >
+  </span>
+
+</template>
+
+
+<script>
+
+  import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
+  import LearningActivityIcon from './LearningActivityIcon';
+
+  /**
+   * Displays a thumbnail in 16:9 ratio. A thumbnail image with
+   * a different aspect ratio will be letterboxed to fit 16:9.
+   * If a thumbnail image is not available, a generic learning
+   * activity/multiple learning activities/topic icon will be
+   * displayed (this icon also acts as a placeholder before
+   * the image is loaded when it's available).
+   */
+  export default {
+    name: 'Thumbnail',
+    components: {
+      LearningActivityIcon,
+    },
+    props: {
+      contentNode: {
+        type: Object,
+        required: true,
+      },
+    },
+    computed: {
+      thumbnailUrl() {
+        return getContentNodeThumbnail(this.contentNode);
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  /*
+    16:9 aspect ratio with letterboxing (9 / 16 = 0.5625 = 56.25%)
+    https://www.sitepoint.com/maintain-image-aspect-ratios-responsive-web-design/
+  */
+  .thumbnail {
+    position: relative;
+    display: block;
+    height: 0;
+    padding: 56.25% 0 0;
+
+    .image {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 2;
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      margin: auto;
+    }
+
+    .icon {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 1;
+      display: block;
+      width: 25%;
+      max-width: 56px;
+      height: auto;
+      margin: auto;
+      opacity: 0.3;
+    }
+  }
+
+</style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

For my work on the completion modal  #8109, I needed to create a new thumbnail component which also draws[ from recent JB's hybrid learning work](https://github.com/learningequality/kolibri/compare/new-learn-home-page). I'll soon be preparing the rest of JB's work for merge and I will need to have this component available. Because we won't be able to merge the completion modal for some time, I've extracted the thumbnail logic from the completion modal to this separate PR.

The component displays a topic or learning activity icon when a picture is not available. Regarding the thumbnail container ratio, we decided to go with 16:9 as that's the most common ratio of thumbnails. Pictures with different ratios are letterboxed. The thumbnail adjusts its width according to its container width to allow for flexible control from parent components which is important when implementing responsive behavior across hybrid learning features.

Besides that, this PR extends the utility function for getting thumbnails from the content node to account for cases when simplified data are returned from API for a content node where the thumbnail is saved directly in the `thumbnail` attribute.

### `Thumbnail` component screenshots

| | |
| -- | -- |
| 16:9 | ![thumbnail-16:9](https://user-images.githubusercontent.com/13509191/127152689-eec1dd1d-dc0b-43bb-96ef-760ea8d7bcbc.png) |
| 4:3 | ![thumbnail-4:3](https://user-images.githubusercontent.com/13509191/127152729-ea46ebf1-f07e-421b-820a-e88dcca7c702.png) |
| 1:1 | ![thumbnail-1:1](https://user-images.githubusercontent.com/13509191/127152753-4bdb5566-34f2-486b-a7cb-92a7558275ce.png) |
| wide | ![thumbnail-wide](https://user-images.githubusercontent.com/13509191/127152800-e81b5aec-d8b4-4831-b4d1-4e5eb17cf1a9.png) |
| no thumbnail - single learning activity | ![no-thumbnail-watch](https://user-images.githubusercontent.com/13509191/127152861-9d1adaad-4cfe-44e6-b43c-e570b65388af.png) |
| no thumbnail - multiple learning activities | ![no-thumbnail-multiple_activities](https://user-images.githubusercontent.com/13509191/127152908-f8b47782-7bb8-4723-90a7-19c96ab94a58.png) |
| no thumbnail - topic | ![no-thumbnail-topic](https://user-images.githubusercontent.com/13509191/127152953-dcca62f4-9467-46c8-b507-7975d3473985.png) |

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

As for the decisions about icons colors and thumbnail container ratio, you can see [this Slack thread](https://learningequality.slack.com/archives/C023DNC5GCX/p1623699671031100).

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Since this is only a prerequisite component for work that will be reviewed in the future, I think that briefly checking code and screenshots is sufficient at this point. However, if you'd like to preview it locally on the dev server, I can provide my completion modal working branch.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
