### PR TITLE
Single user setup via command line

### DIFF
--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -21,6 +21,7 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_device
+from kolibri.core.device.utils import set_device_settings
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
 from kolibri.core.discovery.utils.network.errors import URLParseError
@@ -290,6 +291,7 @@ def provision_single_user_device(user_id):
     # if device has not been provisioned, set it up
     if not device_provisioned():
         provision_device(default_facility=user.facility)
+        set_device_settings(subset_of_users_device=True)
 
     DevicePermissions.objects.get_or_create(
         user=user, defaults={"is_superuser": False, "can_manage_content": True}

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -17,7 +17,7 @@ from kolibri.core.device.utils import DeviceNotProvisioned
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.public.constants.user_sync_statuses import QUEUED
 from kolibri.core.public.constants.user_sync_statuses import SYNC
-from kolibri.core.tasks.api import prepare_peer_sync_job
+from kolibri.core.tasks.api import prepare_soud_sync_job
 from kolibri.core.tasks.api import prepare_sync_task
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.main import queue
@@ -107,8 +107,8 @@ def startpeerfacilitysync(server, user_id):
         type="SYNCPEER/FULL",
     )
 
-    job_data = prepare_peer_sync_job(
-        server, facility_id, user.username, user.password, extra_metadata=extra_metadata
+    job_data = prepare_soud_sync_job(
+        server, facility_id, user_id, extra_metadata=extra_metadata
     )
 
     job_id = queue.enqueue(call_command, "sync", **job_data)
@@ -126,6 +126,7 @@ def begin_request_soud_sync(server, user):
         # this does not make sense unless this is a SoUD
         logger.warn("Only Subsets of Users Devices can do this")
         return
+    logger.info("Queuing SoUD syncing request")
     queue.enqueue(request_soud_sync, server, user)
 
 

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1248,6 +1248,18 @@ def prepare_peer_sync_job(baseurl, facility_id, username, password, **kwargs):
     return job_data
 
 
+def prepare_soud_sync_job(baseurl, facility_id, user_id, **kwargs):
+    """
+    A SoUD sync requires that the device is already "registered" with the server, so there
+    shouldn't be a need for username/password and the verification of those
+    """
+    if not ScopeDefinition.objects.filter():
+        call_command("loaddata", "scopedefinitions")
+
+    kwargs.update(user=user_id)
+    return prepare_sync_job(facility_id, baseurl=baseurl, **kwargs)
+
+
 def _remoteimport(
     channel_id,
     baseurl,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ le-utils==0.1.24
 kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.2
+morango==0.6.3
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
## Summary
@bjester's work to setup single user syncing via the command line

## Reviewer guidance
Can you setup a new instance via the command line?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
