### PR TITLE
Add method to detect if network has changed and reinitialize zeroconf

### DIFF
--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -25,7 +25,12 @@ LOCAL_DOMAIN = "kolibri.local"
 TRUE = "TRUE"
 FALSE = "FALSE"
 
-ZEROCONF_STATE = {"zeroconf": None, "listener": None, "service": None}
+ZEROCONF_STATE = {
+    "zeroconf": None,
+    "listener": None,
+    "service": None,
+    "addresses": None,
+}
 
 
 def _id_from_name(name):
@@ -254,6 +259,22 @@ def initialize_zeroconf_listener():
     ZEROCONF_STATE["zeroconf"].add_service_listener(
         SERVICE_TYPE, ZEROCONF_STATE["listener"]
     )
+    ZEROCONF_STATE["addresses"] = set(get_all_addresses())
+
+
+def reinitialize_zeroconf_if_network_has_changed():
+    if ZEROCONF_STATE["addresses"] == set(get_all_addresses()):
+        return
+    if ZEROCONF_STATE["listener"] is None:
+        initialize_zeroconf_listener()
+        return
+    if ZEROCONF_STATE["zeroconf"] is not None:
+        ZEROCONF_STATE["zeroconf"].close()
+    ZEROCONF_STATE["zeroconf"] = Zeroconf()
+    ZEROCONF_STATE["zeroconf"].add_service_listener(
+        SERVICE_TYPE, ZEROCONF_STATE["listener"]
+    )
+    ZEROCONF_STATE["addresses"] = set(get_all_addresses())
 
 
 def get_peer_instances():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -111,7 +111,8 @@ class KolibriZeroconfService(object):
             logging.error("Service is not registered!")
             return
 
-        ZEROCONF_STATE["zeroconf"].unregister_service(self.info)
+        if self.info.name.lower() in ZEROCONF_STATE["zeroconf"].services:
+            ZEROCONF_STATE["zeroconf"].unregister_service(self.info)
 
         self.info = None
 
@@ -268,6 +269,9 @@ def reinitialize_zeroconf_if_network_has_changed():
     if ZEROCONF_STATE["listener"] is None:
         initialize_zeroconf_listener()
         return
+    logger.info(
+        "New addresses detected since zeroconf was initialized, re-initializing now"
+    )
     if ZEROCONF_STATE["zeroconf"] is not None:
         ZEROCONF_STATE["zeroconf"].close()
     ZEROCONF_STATE["zeroconf"] = Zeroconf()
@@ -275,6 +279,7 @@ def reinitialize_zeroconf_if_network_has_changed():
         SERVICE_TYPE, ZEROCONF_STATE["listener"]
     )
     ZEROCONF_STATE["addresses"] = set(get_all_addresses())
+    logger.info("Zeroconf has reinitialized")
 
 
 def get_peer_instances():


### PR DESCRIPTION
## Summary

We identified that zeroconf doesn't pick up when a new network connection is established, so it doesn't become discoverable on networks that it wasn't connected to at the time Kolibri started up.

This PR adds a method for detecting when the set of bound IP addresses on the system has changed, and reinitializing the zeroconf internals to ensure they're attached to each of those IPs.

Note: no code has been added to actually _call_ this new method. We may want to spawn a thread that calls it every minute (as it should be very lightweight most of the time, since it's checking the list of bound IPs against its cached copy and only doing something if it changes). We'll need to ensure it happens in the same process, as the zeroconf state is process-local (in global vars inside `kolibri.core.discovery.utils.network.search`), so we may not want to use iceqube.

## Reviewer guidance

To test:
- Have Kolibri running on another machine on the network
- On the test machine, disconnect from the network (e.g. disable wifi)
- Start `kolibri shell`, and run `from kolibri.core.discovery.utils.network.search import *; register_zeroconf_service(999)`
- Run `[p["device_name"] for p in get_peer_instances()]`, and you should only see your own machine name
- Reconnect to the network
- Run `[p["device_name"] for p in get_peer_instances()]` again several times, waiting in between, and you should still only see your own machine name
- Run `reinitialize_zeroconf_if_network_has_changed()`
- Start trying `[p["device_name"] for p in get_peer_instances()]` again. After a short time, it should start showing the name of the other device on your network in the list as well.

Hopefully sorts out #8227

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
