### PR TITLE
Fix check_device_info

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -55,7 +55,7 @@ class NetworkClient(object):
                     info = response.json()
                     self.info = {}
                     for key in device_info_keys.get(DEVICE_INFO_VERSION, []):
-                        self.info[key] = info.get(key)
+                        self.info[key] = info.get(key) or False
                     if self.info["application"] not in ["studio", "kolibri"]:
                         raise requests.RequestException(
                             "Server is not running Kolibri or Studio"

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -9,6 +9,10 @@ from .urls import get_normalized_url_variations
 
 logger = logging.getLogger(__name__)
 
+device_info_defaults = {
+    "subset_of_users_device": False,
+}
+
 
 class NetworkClient(object):
     DEFAULT_TIMEOUT_IN_SECS = 5
@@ -55,7 +59,7 @@ class NetworkClient(object):
                     info = response.json()
                     self.info = {}
                     for key in device_info_keys.get(DEVICE_INFO_VERSION, []):
-                        self.info[key] = info.get(key) or False
+                        self.info[key] = info.get(key, device_info_defaults.get(key))
                     if self.info["application"] not in ["studio", "kolibri"]:
                         raise requests.RequestException(
                             "Server is not running Kolibri or Studio"

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -2,6 +2,7 @@ import socket
 from contextlib import closing
 
 from . import errors
+from .client import device_info_defaults
 from .client import NetworkClient
 from .urls import parse_address_into_components
 from kolibri.core.utils.cache import process_cache
@@ -10,11 +11,6 @@ from kolibri.core.utils.nothing import Nothing
 
 INVALID_DEVICE_INFO = Nothing("invalid device info")
 FAILED_TO_CONNECT = Nothing("failed to connect")
-
-
-device_info_defaults = {
-    "subset_of_users_device": False,
-}
 
 
 def check_if_port_open(base_url, timeout=1):

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -33,7 +33,9 @@ def check_device_info(base_url):
     try:
         info = NetworkClient(base_url=base_url).info
         if info["application"] in ["studio", "kolibri"]:
-            return device_info_defaults.copy().update(info)
+            complete_info = device_info_defaults.copy()
+            complete_info.update(info)
+            return complete_info
         else:
             return INVALID_DEVICE_INFO
     except (errors.NetworkClientError, errors.NetworkLocationNotFound):


### PR DESCRIPTION
## Summary
This PR fixes a couple of regressions introduced yesterday:

1. Changes introduced in `check_device_info` have created a bug because `update` function for a `dict` returns always None, not the dict itself. The function needs to return the dict
2. Changes introduced in `_attempt_connections` have created a bug returning `None` for the `subset_of_users_device` instead of `False` when the key does not exist in the discovered kolibri server.


## References

References: #8223
References: #8222 

## Reviewer guidance

Trying to provision a new kolibri installation must be able to detect and enable other servers when "Import from other facility" is used.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
