### PR TITLE
Credential handling for password-less learner certificate generation 

### DIFF
--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -3,7 +3,11 @@ Implements custom auth backends as described in the Django docs, for our custom 
 The appropriate classes should be listed in the AUTHENTICATION_BACKENDS. Note that authentication
 backends are checked in the order they're listed.
 """
+from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+
+
+FACILITY_CREDENTIAL_NAME = "facility"
 
 
 class FacilityUserBackend(object):
@@ -11,18 +15,21 @@ class FacilityUserBackend(object):
     A class that implements authentication for FacilityUsers.
     """
 
-    def authenticate(self, username=None, password=None, facility=None):
+    def authenticate(self, request, username=None, password=None, **kwargs):
         """
         Authenticates the user if the credentials correspond to a FacilityUser for the specified Facility.
 
         :param username: a string
         :param password: a string
-        :param facility: a Facility
+        :param kwargs: a dict of additional credentials (see `keyword`s)
+        :keyword facility: a Facility object or facility ID
         :return: A FacilityUser instance if successful, or None if authentication failed.
         """
+        facility = kwargs.get(FACILITY_CREDENTIAL_NAME, None)
         users = FacilityUser.objects.filter(username__iexact=username)
         if facility:
-            users = users.filter(facility=facility)
+            facility_id = facility.pk if isinstance(facility, Facility) else facility
+            users = users.filter(facility_id=facility_id)
         for user in users:
             if user.check_password(password):
                 return user

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -3,11 +3,10 @@ Implements custom auth backends as described in the Django docs, for our custom 
 The appropriate classes should be listed in the AUTHENTICATION_BACKENDS. Note that authentication
 backends are checked in the order they're listed.
 """
-from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 
 
-FACILITY_CREDENTIAL_NAME = "facility"
+FACILITY_CREDENTIAL_KEY = "facility"
 
 
 class FacilityUserBackend(object):
@@ -26,11 +25,10 @@ class FacilityUserBackend(object):
         :keyword facility: a Facility object or facility ID
         :return: A FacilityUser instance if successful, or None if authentication failed.
         """
-        facility = kwargs.get(FACILITY_CREDENTIAL_NAME, None)
         users = FacilityUser.objects.filter(username__iexact=username)
+        facility = kwargs.get(FACILITY_CREDENTIAL_KEY, None)
         if facility:
-            facility_id = facility.pk if isinstance(facility, Facility) else facility
-            users = users.filter(facility_id=facility_id)
+            users = users.filter(facility=facility)
         for user in users:
             if user.check_password(password):
                 return user

--- a/kolibri/core/auth/backends.py
+++ b/kolibri/core/auth/backends.py
@@ -19,6 +19,7 @@ class FacilityUserBackend(object):
         """
         Authenticates the user if the credentials correspond to a FacilityUser for the specified Facility.
 
+        :param request: The request is a required positional argument in newer versions of Django
         :param username: a string
         :param password: a string
         :param kwargs: a dict of additional credentials (see `keyword`s)

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -154,6 +154,7 @@ class Command(AsyncCommand):
                 dataset_id,
                 network_connection,
                 user_id=user_id,
+                facility_id=facility_id,
                 noninteractive=noninteractive,
             )
 
@@ -212,6 +213,7 @@ class Command(AsyncCommand):
                 password,
                 dataset_id,
                 network_connection,
+                facility_id=facility_id,
                 noninteractive=noninteractive,
             )
 

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -15,6 +15,7 @@ from morango.models import Certificate
 from morango.models import ScopeDefinition
 from six.moves.urllib.parse import urljoin
 
+from kolibri.core.auth.backends import FACILITY_CREDENTIAL_NAME
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -227,11 +228,16 @@ def get_client_and_server_certs(
                 username = input("Please enter username: ")
                 password = getpass.getpass("Please enter password: ")
 
+        # add facility so `FacilityUserBackend` can validate
+        userargs = {
+            FacilityUser.USERNAME_FIELD: username,
+            FACILITY_CREDENTIAL_NAME: dataset_id,
+        }
         client_cert = nc.certificate_signing_request(
             server_cert,
             client_scope,
             csr_scope_params,
-            userargs=username,
+            userargs=userargs,
             password=password,
         )
     else:

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -15,7 +15,7 @@ from morango.models import Certificate
 from morango.models import ScopeDefinition
 from six.moves.urllib.parse import urljoin
 
-from kolibri.core.auth.backends import FACILITY_CREDENTIAL_NAME
+from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -162,7 +162,13 @@ def get_baseurl(baseurl):
 
 
 def get_client_and_server_certs(
-    username, password, dataset_id, nc, user_id=None, noninteractive=False
+    username,
+    password,
+    dataset_id,
+    nc,
+    user_id=None,
+    facility_id=None,
+    noninteractive=False,
 ):
 
     # get any full-facility certificates we have for the facility
@@ -228,11 +234,13 @@ def get_client_and_server_certs(
                 username = input("Please enter username: ")
                 password = getpass.getpass("Please enter password: ")
 
-        # add facility so `FacilityUserBackend` can validate
-        userargs = {
-            FacilityUser.USERNAME_FIELD: username,
-            FACILITY_CREDENTIAL_NAME: dataset_id,
-        }
+        userargs = username
+        if user_id:
+            # add facility so `FacilityUserBackend` can validate
+            userargs = {
+                FacilityUser.USERNAME_FIELD: username,
+                FACILITY_CREDENTIAL_KEY: facility_id,
+            }
         client_cert = nc.certificate_signing_request(
             server_cert,
             client_scope,

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -171,7 +171,7 @@ class FacilityDataset(FacilityDataSyncableModel):
         if self.learner_can_login_with_no_password and self.learner_can_edit_password:
             raise IncompatibleDeviceSettingError(
                 "Device Settings [learner_can_login_with_no_password={}] & [learner_can_edit_password={}] "
-                "values incompatible togeather.".format(
+                "values incompatible together.".format(
                     self.learner_can_login_with_no_password,
                     self.learner_can_edit_password,
                 )

--- a/kolibri/core/auth/test/test_backend.py
+++ b/kolibri/core/auth/test/test_backend.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 from django.test import TestCase
 
 from ..backends import FacilityUserBackend
@@ -16,30 +17,46 @@ class FacilityUserBackendTestCase(TestCase):
         cls.user = FacilityUser(username="Mike", facility=cls.facility)
         cls.user.set_password("foo")
         cls.user.save()
+        cls.request = mock.Mock()
 
     def test_facility_user_authenticated(self):
         self.assertEqual(
             self.user,
             FacilityUserBackend().authenticate(
-                username="Mike", password="foo", facility=self.facility
+                self.request, username="Mike", password="foo", facility=self.facility
+            ),
+        )
+
+    def test_facility_user_authenticated__facility_id(self):
+        self.assertEqual(
+            self.user,
+            FacilityUserBackend().authenticate(
+                self.request, username="Mike", password="foo", facility=self.facility.pk
             ),
         )
 
     def test_facility_user_authentication_does_not_require_facility(self):
         self.assertEqual(
             self.user,
-            FacilityUserBackend().authenticate(username="Mike", password="foo"),
+            FacilityUserBackend().authenticate(
+                self.request, username="Mike", password="foo"
+            ),
         )
 
     def test_device_owner_not_authenticated(self):
         self.assertIsNone(
-            FacilityUserBackend().authenticate(username="Chuck", password="foobar")
+            FacilityUserBackend().authenticate(
+                self.request, username="Chuck", password="foobar"
+            )
         )
 
     def test_incorrect_password_does_not_authenticate(self):
         self.assertIsNone(
             FacilityUserBackend().authenticate(
-                username="Mike", password="blahblah", facility=self.facility
+                self.request,
+                username="Mike",
+                password="blahblah",
+                facility=self.facility,
             )
         )
 
@@ -52,7 +69,11 @@ class FacilityUserBackendTestCase(TestCase):
         )
 
     def test_authenticate_nonexistent_user_returns_none(self):
-        self.assertIsNone(FacilityUserBackend().authenticate("foo", "bar"))
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(self.request, "foo", "bar")
+        )
 
     def test_authenticate_with_wrong_password_returns_none(self):
-        self.assertIsNone(FacilityUserBackend().authenticate("Mike", "goo"))
+        self.assertIsNone(
+            FacilityUserBackend().authenticate(self.request, "Mike", "goo")
+        )

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -52,7 +52,7 @@ class NetworkLocationAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["base_url"], "https://kolibrihappyurl.qqq/")
+        self.assertEqual(response.data["base_url"], "https://kolibrihappyurl.qqq")
 
     def test_creating_good_address_with_one_url_timing_out(self):
         self.login(self.superuser)
@@ -63,7 +63,7 @@ class NetworkLocationAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data["base_url"], "http://timeoutonport80url.qqq:8080/"
+            response.data["base_url"], "http://timeoutonport80url.qqq:8080"
         )
 
     def test_creating_bad_address(self):

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -144,7 +144,7 @@ class TestURLParsing(TestCase):
 class TestNetworkClientConnections(TestCase):
     def test_successful_connection_to_kolibri_address(self):
         nc = NetworkClient(address="kolibrihappyurl.qqq")
-        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq/")
+        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq")
 
     def test_unsuccessful_connection_to_unavailable_address(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
@@ -156,11 +156,11 @@ class TestNetworkClientConnections(TestCase):
 
     def test_successful_connection_to_address_with_port80_timeout(self):
         nc = NetworkClient(address="timeoutonport80url.qqq")
-        self.assertEqual(nc.base_url, "http://timeoutonport80url.qqq:8080/")
+        self.assertEqual(nc.base_url, "http://timeoutonport80url.qqq:8080")
 
     def test_successful_connection_to_kolibri_base_url(self):
         nc = NetworkClient(base_url="https://kolibrihappyurl.qqq/")
-        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq/")
+        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq")
 
     def test_unsuccessful_connection_to_unavailable_base_url(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
@@ -172,4 +172,4 @@ class TestNetworkClientConnections(TestCase):
 
     def test_unsuccessful_connection_to_base_url_with_timeout(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
-            NetworkClient(base_url="http://timeoutonport80url.qqq/")
+            NetworkClient(base_url="http://timeoutonport80url.qqq")

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -3,7 +3,6 @@ import logging
 import requests
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlparse
-from six.moves.urllib.parse import urlunparse
 
 from . import errors
 from .urls import get_normalized_url_variations
@@ -68,8 +67,7 @@ class NetworkClient(object):
                         )
                     logger.info("Success! We connected to: {}".format(response.url))
 
-                    # return (scheme, netloc) of url
-                    return urlunparse(parsed_url[:2])
+                    return "{}://{}".format(parsed_url.scheme, parsed_url.netloc)
             except (requests.RequestException) as e:
                 logger.info("Unable to connect: {}".format(e))
             except ValueError:

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -3,6 +3,7 @@ import logging
 import requests
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlunparse
 
 from . import errors
 from .urls import get_normalized_url_variations
@@ -51,9 +52,10 @@ class NetworkClient(object):
                     allow_redirects=True,
                     params={"v": DEVICE_INFO_VERSION},
                 )
-                # check that we successfully connected, and if we were redirected that it's still the right endpoint
-                response_path = urlparse(response.url).path
-                if response.status_code == 200 and response_path.rstrip("/").endswith(
+                # check that we successfully connected, and if we were redirected that it's still
+                # the right endpoint
+                parsed_url = urlparse(response.url)
+                if response.status_code == 200 and parsed_url.path.rstrip("/").endswith(
                     "/api/public/info"
                 ):
                     info = response.json()
@@ -65,7 +67,9 @@ class NetworkClient(object):
                             "Server is not running Kolibri or Studio"
                         )
                     logger.info("Success! We connected to: {}".format(response.url))
-                    return response.url.rstrip("/").replace("api/public/info", "")
+
+                    # return (scheme, netloc) of url
+                    return urlunparse(parsed_url[:2])
             except (requests.RequestException) as e:
                 logger.info("Unable to connect: {}".format(e))
             except ValueError:

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1248,6 +1248,7 @@ def prepare_peer_sync_job(baseurl, facility_id, username, password, **kwargs):
             dataset_id,
             network_connection,
             user_id=user_id,
+            facility_id=facility_id,
             noninteractive=True,
         )
     except (CommandError, HTTPError) as e:

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -1008,7 +1008,13 @@ class FacilityTaskHelperTestCase(TestCase):
         )
 
         get_client_and_server_certs.assert_called_with(
-            "tester", "mypassword", dataset_id, network_connection, noninteractive=True
+            "tester",
+            "mypassword",
+            dataset_id,
+            network_connection,
+            user_id=None,
+            facility_id=123,
+            noninteractive=True,
         )
 
     def test_validate_peer_sync_job__no_baseurl(self):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes URL issue when initiating a sync with remote server
- Fixes certificate authentication of learner for facility that does not require learners to use passwords
- Updates sync preparation function to pass through `user` sync command argument to certificate authentication (@jredrejo)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
See issues tracked in [Notion](https://www.notion.so/learningequality/Single-User-Syncing-Hack-Session-60-mins-bfb609b7d7de47b1af1e73b6446e3cbd)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- The server side does not require the learner password-less authentication handling updates for that scenario to be fixed
- A new Morango integration test ensures Morango passes through the `facility` credential argument to Kolibri's auth backend:
```bash
$ INTEGRATION_TEST=1 pytest -k "test_learner_password" kolibri/core/auth/test/test_morango_integration.py
```

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
