### PR TITLE
Use a different task name for automatic single user syncs.

### DIFF
--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -86,9 +86,9 @@ def get_device_info(version=DEVICE_INFO_VERSION):
     return info
 
 
-def startpeerfacilitysync(server, user_id):
+def startpeerusersync(server, user_id):
     """
-    Initiate a SYNC (PULL + PUSH) of a specific facility from another device.
+    Initiate a SYNC (PULL + PUSH) of a specific user from another device.
     """
 
     user = FacilityUser.objects.get(pk=user_id)
@@ -104,7 +104,7 @@ def startpeerfacilitysync(server, user_id):
         device_info["device_name"],
         device_info["instance_id"],
         server,
-        type="SYNCPEER/FULL",
+        type="SYNCPEER/SINGLE",
     )
 
     job_data = prepare_soud_sync_job(
@@ -187,7 +187,7 @@ def request_soud_sync(server, user=None, queue_id=None, ttl=10):
         UserSyncStatus.objects.update_or_create(user_id=user, defaults={"queued": True})
 
         if server_response["action"] == SYNC:
-            job_id = startpeerfacilitysync(server, user)
+            job_id = startpeerusersync(server, user)
             logger.info(
                 "Enqueuing a sync task for user {} in job {}".format(user, job_id)
             )


### PR DESCRIPTION
## Summary
Changes the name of the task for single user syncing tasks.
This is a quick fix to prevent this task appearing in the task list in the Device tab.

## Reviewer guidance
Does the single user syncing still run?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
