### PR TITLE
Make sure adhoc groups have a name.

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -1512,6 +1512,15 @@ class AdHocGroup(Collection):
     class Meta:
         proxy = True
 
+    @classmethod
+    def deserialize(cls, dict_model):
+        # be defensive against blank names, set to `Ad hoc` if blank
+        name = dict_model.get("name", "") or ""
+        if len(name) == 0:
+            dict_model.update(name="Ad hoc")
+
+        return super(AdHocGroup, cls).deserialize(dict_model)
+
     def save(self, *args, **kwargs):
         if not self.parent:
             raise IntegrityError(

--- a/kolibri/core/auth/upgrade.py
+++ b/kolibri/core/auth/upgrade.py
@@ -16,3 +16,12 @@ def prune_empty_adhoc_groups():
     needed. This upgrade task cleans up those empty adhoc groups.
     """
     AdHocGroup.objects.filter(membership__isnull=True).delete()
+
+
+@version_upgrade(old_version="<0.15.0")
+def named_unnamed_adhoc_groups():
+    """
+    We started making adhoc groups for every lesson and quiz, even though they were not
+    needed. This upgrade task cleans up those empty adhoc groups.
+    """
+    AdHocGroup.objects.filter(name="").update(name="Ad hoc")

--- a/kolibri/core/auth/upgrade.py
+++ b/kolibri/core/auth/upgrade.py
@@ -19,7 +19,7 @@ def prune_empty_adhoc_groups():
 
 
 @version_upgrade(old_version="<0.15.0")
-def named_unnamed_adhoc_groups():
+def name_unnamed_adhoc_groups():
     """
     We started making adhoc groups for every lesson and quiz, even though they were not
     needed. This upgrade task cleans up those empty adhoc groups.

--- a/kolibri/core/auth/utils.py
+++ b/kolibri/core/auth/utils.py
@@ -29,7 +29,7 @@ def confirm_or_exit(message):
 
 
 def create_adhoc_group_for_learners(classroom, learners):
-    adhoc_group = AdHocGroup.objects.create(name="", parent=classroom)
+    adhoc_group = AdHocGroup.objects.create(name="Ad hoc", parent=classroom)
     for learner in learners:
         Membership.objects.create(user=learner, collection=adhoc_group)
     return adhoc_group


### PR DESCRIPTION
## Summary
* Ensure all adhoc groups are created with a name
* Adds an upgrade task to add a name to all existing unnamed adhoc groups

## References
Fixes issue with adhoc groups not getting deserialized during syncs

## Reviewer guidance
I couldn't do a simple change to the default behaviour for adhocgroups to allow deserialization of empty names.

I think it might be possible by overriding the full clean method of the AdHocGroup model, but it seemed good to get this in for now, and assess if follow up was needed.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
