### PR TITLE
Catch Database locked errors during dynamic location registration

### DIFF
--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import socket
+import time
 
 from django.core.exceptions import ValidationError
 from django.db import connection
+from django.db.utils import OperationalError
 from six import integer_types
 from six import string_types
 from zeroconf import get_all_addresses
@@ -168,43 +170,55 @@ class KolibriZeroconfListener(object):
 
         if not is_self:
 
-            try:
+            logger.info(
+                "Kolibri instance '%s' joined zeroconf network; service info: %s"
+                % (id, self.instances[id])
+            )
 
-                DynamicNetworkLocation.objects.update_or_create(
-                    dict(base_url=base_url, **device_info), id=id
-                )
+            db_locked = self.store_service(id, base_url, device_info)
 
-                logger.info(
-                    "Kolibri instance '%s' joined zeroconf network; service info: %s"
-                    % (id, self.instances[id])
-                )
+            if get_device_setting(
+                "subset_of_users_device", False
+            ) and not device_info.get("subset_of_users_device", False):
+                server = base_url[:-1]  # removes ending slash
+                for user in FacilityUser.objects.all().values("id"):
+                    begin_request_soud_sync(server=server, user=user["id"])
 
-            except ValidationError:
-                import traceback
+            attempts = 0
+            while db_locked and attempts < 5:
+                db_locked = self.store_service(id, base_url, device_info)
+                attempts += 1
+                time.sleep(0.1)
 
-                logger.warn(
+    def store_service(self, id, base_url, device_info):
+        db_locked = False
+        try:
+
+            DynamicNetworkLocation.objects.update_or_create(
+                dict(base_url=base_url, **device_info), id=id
+            )
+
+        except ValidationError:
+            import traceback
+
+            logger.warn(
+                """
+                    A new Kolibri instance '%s' was seen on the zeroconf network,
+                    but we had trouble getting the information we needed about it.
+                    Service info:
+                    %s
+                    The following exception was raised:
+                    %s
                     """
-                        A new Kolibri instance '%s' was seen on the zeroconf network,
-                        but we had trouble getting the information we needed about it.
-                        Service info:
-                        %s
-                        The following exception was raised:
-                        %s
-                        """
-                    % (id, self.instances[id], traceback.format_exc(limit=1))
-                )
-            finally:
-                connection.close()
-
-            if (
-                "subset_of_users_device" in device_info
-            ):  # discards previous versions of Kolibri
-                if get_device_setting(
-                    "subset_of_users_device", False
-                ) and not device_info.get("subset_of_users_device", False):
-                    server = base_url[:-1]  # removes ending slash
-                    for user in FacilityUser.objects.all().values("id"):
-                        begin_request_soud_sync(server=server, user=user["id"])
+                % (id, self.instances[id], traceback.format_exc(limit=1))
+            )
+        except OperationalError as e:
+            if "database is locked" not in str(e):
+                raise
+            db_locked = True
+        finally:
+            connection.close()
+        return db_locked
 
     def remove_service(self, zeroconf, type, name):
         id = _id_from_name(name)


### PR DESCRIPTION
## Summary
* Presumably because of the large number of devices appearing on zeroconf, and it happening at startup when other threads (like the Vacuum task) are all trying to write to the DB, we saw database locked errors when starting the server
* This catches these errors and attempts to retry 5 times

## References
Fixes #8237

## Reviewer guidance
Does registration still happen as expected?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
