### PR TITLE
Sync notifications updates

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -188,19 +188,7 @@
       },
       mapSyncStatusOptionToLearner() {
         if (this.userSyncStatus) {
-          if (this.userSyncStatus.active) {
-            return SyncStatus.SYNCING;
-          } else if (this.userSyncStatus.queued) {
-            return SyncStatus.QUEUED;
-          } else if (this.userSyncStatus.last_synced) {
-            const currentDateTime = new Date();
-            const timeDifference = currentDateTime - this.userSyncStatus.last_synced;
-            if (timeDifference < 5184000000) {
-              return SyncStatus.RECENTLY_SYNCED;
-            } else {
-              return SyncStatus.NOT_RECENTLY_SYNCED;
-            }
-          }
+          return this.userSyncStatus.status;
         }
         return SyncStatus.NOT_CONNECTED;
       },

--- a/kolibri/core/assets/src/views/SyncStatusDisplay.vue
+++ b/kolibri/core/assets/src/views/SyncStatusDisplay.vue
@@ -45,6 +45,7 @@
           [SyncStatus.QUEUED]: this.$tr('queued'),
           [SyncStatus.SYNCING]: this.$tr('syncing'),
           [SyncStatus.UNABLE_TO_SYNC]: this.$tr('unableToSync'),
+          [SyncStatus.NOT_RECENTLY_SYNCED]: this.$tr('notRecentlySynced'),
           [SyncStatus.UNABLE_OR_NOT_SYNCED]: this.$tr('unableOrNotSynced'),
           [SyncStatus.NOT_CONNECTED]: this.$tr('notConnected'),
         };
@@ -72,6 +73,7 @@
       syncing: 'Syncing...',
       queued: 'Waiting to sync...',
       unableToSync: 'Unable to sync',
+      notRecentlySynced: 'Not recently synced',
       unableOrNotSynced: 'Not recently synced or unable to sync',
       notConnected: 'Not connected to server',
     },

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -213,7 +213,9 @@ def map_status(status):
     elif status["queued"]:
         return QUEUED
     elif status["last_synced"]:
-        if timezone.now() - status["last_synced"] < timedelta(hours=1):
+        # Keep this as a fixed constant for now.
+        # In future versions this may be configurable.
+        if timezone.now() - status["last_synced"] < timedelta(minutes=15):
             return RECENTLY_SYNCED
         else:
             return NOT_RECENTLY_SYNCED

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -10,7 +10,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from django_filters.rest_framework import ModelChoiceFilter
 from morango.models import InstanceIDModel
-from morango.models import SyncSession
+from morango.models import TransferSession
 from rest_framework import mixins
 from rest_framework import status
 from rest_framework import views
@@ -217,10 +217,10 @@ class UserSyncStatusViewSet(ReadOnlyValuesViewset):
             last_synced=Max("sync_session__last_activity_timestamp")
         )
 
-        sync_sessions = SyncSession.objects.filter(
-            id=OuterRef("sync_session__pk"), active=True
+        active_transfer_sessions = TransferSession.objects.filter(
+            sync_session=OuterRef("sync_session"), active=True
         )
 
-        queryset = queryset.annotate(active=Exists(sync_sessions))
+        queryset = queryset.annotate(active=Exists(active_transfer_sessions))
 
         return queryset

--- a/kolibri/core/device/kolibri_plugin.py
+++ b/kolibri/core/device/kolibri_plugin.py
@@ -3,7 +3,7 @@ from kolibri.plugins.hooks import register_hook
 
 
 @register_hook
-class SingleUserExamSyncHook(FacilityDataSyncHook):
+class UserSyncStatusHook(FacilityDataSyncHook):
     def pre_transfer(
         self,
         dataset_id,
@@ -12,7 +12,7 @@ class SingleUserExamSyncHook(FacilityDataSyncHook):
         single_user_id,
         context,
     ):
-        # if we're about to send data to a single-user device, prep the syncable exam assignments
+        # if we're about to do a single user sync, update UserSyncStatus accordingly
         if context.sync_session and single_user_id is not None:
             from kolibri.core.device.models import UserSyncStatus
 

--- a/kolibri/core/device/kolibri_plugin.py
+++ b/kolibri/core/device/kolibri_plugin.py
@@ -1,0 +1,22 @@
+from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.plugins.hooks import register_hook
+
+
+@register_hook
+class SingleUserExamSyncHook(FacilityDataSyncHook):
+    def pre_transfer(
+        self,
+        dataset_id,
+        local_is_single_user,
+        remote_is_single_user,
+        single_user_id,
+        context,
+    ):
+        # if we're about to send data to a single-user device, prep the syncable exam assignments
+        if context.sync_session and single_user_id is not None:
+            from kolibri.core.device.models import UserSyncStatus
+
+            UserSyncStatus.objects.update_or_create(
+                user_id=single_user_id,
+                defaults={"queued": False, "sync_session": context.sync_session},
+            )

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -264,7 +264,8 @@ class SyncQueueViewSet(viewsets.ViewSet):
             data["id"] = element.id
         else:
             SyncQueue.objects.filter(id=pk).delete()
-        UserSyncStatus.objects.update_or_create(
-            user=element.user, defaults={"queued": not allow_sync}
-        )
+        if element is not None:
+            UserSyncStatus.objects.update_or_create(
+                user=element.user, defaults={"queued": not allow_sync}
+            )
         return Response(data)

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -62,7 +62,7 @@
               </td>
               <td>
                 <ElapsedTime
-                  :date="mapLastSyncedTimeToLearner(entry)"
+                  :date="mapLastSyncedTimeToLearner(learner.id)"
                 />
               </td>
             </tr>

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -61,9 +61,9 @@
                 />
               </td>
               <td>
-                <span dir="auto">
-                  {{ $tr('lastSyncedTime', { time: mapLastSynctedTimeToLearner(learner.id) }) }}
-                </span>
+                <ElapsedTime
+                  :date="mapLastSyncedTimeToLearner(entry)"
+                />
               </td>
             </tr>
           </tbody>
@@ -79,6 +79,7 @@
 
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
+  import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
   import { mapState, mapActions } from 'vuex';
@@ -95,6 +96,7 @@
     components: {
       CoreBase,
       CoreTable,
+      ElapsedTime,
       SyncStatusDisplay,
       SyncStatusDescription,
     },
@@ -102,7 +104,7 @@
     data: function() {
       return {
         displayTroubleshootModal: false,
-        classSyncStatusList: [],
+        classSyncStatusList: {},
         // poll every 10 seconds
         pollingInterval: 10000,
       };
@@ -139,55 +141,27 @@
     },
     methods: {
       ...mapActions(['fetchUserSyncStatus']),
-      mapLastSynctedTimeToLearner(learnerId) {
-        let learnerSyncData;
-        if (this.classSyncStatusList) {
-          learnerSyncData = this.classSyncStatusList.filter(entry => {
-            entry.user_id == learnerId;
-          });
-        }
+      mapLastSyncedTimeToLearner(learnerId) {
+        const learnerSyncData = this.classSyncStatusList[learnerId];
         if (learnerSyncData) {
-          learnerSyncData.last_synced = new Date(new Date().valueOf() - 1000);
-          if (learnerSyncData.last_synced) {
-            const currentDateTime = new Date();
-            const timeDifference = currentDateTime - learnerSyncData.last_synced;
-            if (timeDifference < 5184000000) {
-              const diffMins = Math.round(timeDifference / 60).toString();
-              return diffMins.toString();
-            }
-          }
-          return '--';
+          return learnerSyncData.last_synced;
         }
-        return '--';
+        return null;
       },
       mapSyncStatusOptionToLearner(learnerId) {
-        let learnerSyncData;
-        if (this.classSyncStatusList) {
-          learnerSyncData = this.classSyncStatusList.filter(entry => {
-            return entry.user_id == learnerId;
-          });
-          learnerSyncData = learnerSyncData[learnerSyncData.length - 1];
-        }
+        const learnerSyncData = this.classSyncStatusList[learnerId];
         if (learnerSyncData) {
-          if (learnerSyncData.active) {
-            return SyncStatus.SYNCING;
-          } else if (learnerSyncData.queued) {
-            return SyncStatus.QUEUED;
-          } else if (learnerSyncData.last_synced) {
-            const currentDateTime = new Date();
-            const timeDifference = currentDateTime - learnerSyncData.last_synced;
-            if (timeDifference < 5184000000) {
-              return SyncStatus.RECENTLY_SYNCED;
-            } else {
-              return SyncStatus.NOT_RECENTLY_SYNCED;
-            }
-          }
+          return learnerSyncData.status;
         }
         return SyncStatus.NOT_CONNECTED;
       },
       pollClassListSyncStatuses() {
-        this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(status => {
-          this.classSyncStatusList = status;
+        this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
+          const statuses = {};
+          for (let status of data) {
+            statuses[status.user] = status;
+          }
+          this.classSyncStatusList = statuses;
         });
         if (this.isPolling) {
           setTimeout(() => {
@@ -200,7 +174,6 @@
       pageHeader: "Learners in '{className}'",
       deviceStatus: 'Device status',
       lastSyncedStatus: 'Last synced',
-      lastSyncedTime: 'Last synced {time} minutes ago',
       howToTroubleshootModalHeader: 'Information about sync statuses',
       close: 'Close',
     },


### PR DESCRIPTION
## Summary
* Create or update UserSyncStatus for non-SoUD devices when a user's request to sync is queued
* Create or update UserSyncStatus for non-SoUD devices when a user's request to sync is initiated
* Create or update UserSyncStatus in the pre-transfer of a sync, to log the SyncSession and flag that it is no longer queued
* Update UserSyncStatus endpoint to compute status on the backend rather than the frontend
* Remove unused fields from endpoint
* For SoUD devices if there are no non-SoUD devices to sync with return no data to flag as 'not connected'
* Add missing string for not recently synced status
* Use `ElapsedTime` component to reuse existing component, and to be closer to spec

## References
Follow up to #8202 

## Reviewer guidance
Does the backend now properly report sync status?

Does the frontend properly render all states?

The previous 'recently synced' time was 60 days - this has been reduced to 1 day in this implementation, but maybe still needs updating.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
