### PR TITLE
Simplify file URL generation.

### DIFF
--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -48,27 +48,21 @@ const urls = {
     }
     return generateUrl(this.__mediaUrl, { url });
   },
-  storageUrl(fileId, extension, embeddedFilePath = '') {
+  zipContentUrl(fileId, extension, embeddedFilePath = '') {
     const filename = `${fileId}.${extension}`;
-    if (['zip', 'h5p'].includes(extension)) {
-      if (!this.__zipContentUrl) {
-        throw new ReferenceError('Zipcontent Url is not defined');
-      }
-      return generateUrl(this.__zipContentUrl, {
-        url: `${filename}/${embeddedFilePath}`,
-        origin: this.__zipContentOrigin,
-        port: this.__zipContentPort,
-      });
-    }
-    if (!this.__contentUrl) {
+    if (!this.__zipContentUrl) {
       throw new ReferenceError('Zipcontent Url is not defined');
     }
-    return generateUrl(this.__contentUrl, { url: `${filename[0]}/${filename[1]}/${filename}` });
+    return generateUrl(this.__zipContentUrl, {
+      url: `${filename}/${embeddedFilePath}`,
+      origin: this.__zipContentOrigin,
+      port: this.__zipContentPort,
+    });
   },
-  downloadUrl(fileId, extension) {
+  storageUrl(fileId, extension) {
     const filename = `${fileId}.${extension}`;
     if (!this.__contentUrl) {
-      throw new ReferenceError('Content Url is not defined');
+      throw new ReferenceError('Zipcontent Url is not defined');
     }
     return generateUrl(this.__contentUrl, { url: `${filename[0]}/${filename[1]}/${filename}` });
   },

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -11,7 +11,6 @@
 
 <script>
 
-  import urls from 'kolibri.urls';
   import { getFilePresetString } from './filePresetStrings';
 
   export default {
@@ -32,7 +31,7 @@
           const label = getFilePresetString(file);
           return {
             label,
-            url: urls.downloadUrl(file.checksum, file.extension),
+            url: file.storage_url,
             fileName: this.$tr('downloadFilename', {
               resourceTitle: this.nodeTitle,
               fileExtension: file.extension,

--- a/kolibri/core/content/test/test_paths.py
+++ b/kolibri/core/content/test/test_paths.py
@@ -3,14 +3,29 @@ import hashlib
 from django.test import TestCase
 
 from kolibri.core.content.models import LocalFile
+from kolibri.utils.tests.helpers import override_option
 
 
 class LocalFilePathsTest(TestCase):
     def test_file_url_reversal(self):
+        from kolibri.utils.conf import OPTIONS
+
+        path_prefix = OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+
+        if path_prefix != "/":
+            path_prefix = "/" + path_prefix
+
         self.hash = hashlib.md5("DUMMYDATA".encode()).hexdigest()
         file = LocalFile(id=self.hash, extension="otherextension", available=True)
         filename = file.get_filename()
         self.assertEqual(
             file.get_storage_url(),
-            "/content/storage/{}/{}/{}".format(filename[0], filename[1], filename),
+            "{}content/storage/{}/{}/{}".format(
+                path_prefix, filename[0], filename[1], filename
+            ),
         )
+
+
+@override_option("Deployment", "URL_PATH_PREFIX", "prefix_test/")
+class PrefixedLocalFilesPathsTest(LocalFilePathsTest):
+    pass

--- a/kolibri/core/content/test/test_paths.py
+++ b/kolibri/core/content/test/test_paths.py
@@ -1,0 +1,16 @@
+import hashlib
+
+from django.test import TestCase
+
+from kolibri.core.content.models import LocalFile
+
+
+class LocalFilePathsTest(TestCase):
+    def test_file_url_reversal(self):
+        self.hash = hashlib.md5("DUMMYDATA".encode()).hexdigest()
+        file = LocalFile(id=self.hash, extension="otherextension", available=True)
+        filename = file.get_filename()
+        self.assertEqual(
+            file.get_storage_url(),
+            "/content/storage/{}/{}/{}".format(filename[0], filename[1], filename),
+        )

--- a/kolibri/core/content/test/test_zipcontent.py
+++ b/kolibri/core/content/test/test_zipcontent.py
@@ -8,7 +8,6 @@ from django.test import override_settings
 from django.test import TestCase
 from django.utils.http import http_date
 
-from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.paths import get_content_storage_file_path
 from kolibri.core.content.zip_wsgi import generate_zip_content_response
 from kolibri.core.content.zip_wsgi import INITIALIZE_HASHI_FROM_IFRAME
@@ -91,27 +90,6 @@ class ZipContentTestCase(TestCase):
         self.environ["PATH_INFO"] = base_url + file_name
         self.environ.update(kwargs)
         return generate_zip_content_response(self.environ)
-
-    def test_zip_file_url_reversal(self):
-        from kolibri.utils.conf import OPTIONS
-
-        path_prefix = OPTIONS["Deployment"]["ZIP_CONTENT_URL_PATH_PREFIX"]
-
-        if path_prefix != "/":
-            path_prefix = "/" + path_prefix
-        file = LocalFile(id=self.hash, extension=self.extension, available=True)
-        self.assertEqual(
-            file.get_storage_url(),
-            "{}content/zipcontent/{}/".format(path_prefix, self.filename),
-        )
-
-    def test_non_zip_file_url_reversal(self):
-        file = LocalFile(id=self.hash, extension="otherextension", available=True)
-        filename = file.get_filename()
-        self.assertEqual(
-            file.get_storage_url(),
-            "/content/storage/{}/{}/{}".format(filename[0], filename[1], filename),
-        )
 
     def test_zip_file_internal_file_access(self):
         # test reading the data from file #1 inside the zip

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -14,9 +14,6 @@ from kolibri.utils.server import get_zip_port
 # valid storage filenames consist of 32-char hex plus a file extension
 VALID_STORAGE_FILENAME = re.compile(r"[0-9a-f]{32}(-data)?\.[0-9a-z]+")
 
-# set of file extensions that should be considered zip files and allow access to internal files
-POSSIBLE_ZIPPED_FILE_EXTENSIONS = set([".zip"])
-
 
 def _maybe_makedirs(path):
     if not os.path.isdir(path):
@@ -49,7 +46,15 @@ def get_local_content_storage_file_url(obj):
     The same url will also be exposed by the file serializer.
     """
     if get_attribute(obj, "available"):
-        return get_content_storage_file_url(filename=get_content_file_name(obj))
+        filename = get_content_file_name(obj)
+        return "/{}{}/{}/{}".format(
+            get_content_storage_url(
+                conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
+            ).lstrip("/"),
+            filename[0],
+            filename[1],
+            filename,
+        )
     else:
         return None
 
@@ -305,23 +310,3 @@ def zip_content_static_root():
 
 def get_hashi_path():
     return "{}{}{}".format(zip_content_static_root(), HASHI, get_hashi_html_filename())
-
-
-def get_content_storage_file_url(filename):
-    """
-    Return the URL at which the specified file can be accessed. For regular files, this is a link to the static
-    file itself, under "/content/storage/". For "zip" files, this points to a dynamically generated view that
-    allows the client-side to index into the files within the zip.
-    """
-    ext = os.path.splitext(filename)[1]
-    if ext in POSSIBLE_ZIPPED_FILE_EXTENSIONS:
-        return "{}{}/".format(get_zip_content_base_path(), filename)
-    else:
-        return "/{}{}/{}/{}".format(
-            get_content_storage_url(
-                conf.OPTIONS["Deployment"]["URL_PATH_PREFIX"]
-            ).lstrip("/"),
-            filename[0],
-            filename[1],
-            filename,
-        )

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -157,7 +157,9 @@
       this.hashi.initialize(
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData,
-        this.defaultFile.storage_url,
+        this.defaultFile.extension === 'zip'
+          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension)
+          : this.defaultFile.storage_url,
         this.defaultFile.checksum
       );
       this.$emit('startTracking');


### PR DESCRIPTION
## Summary
* The zipcontent URL is now a special case, so this simplifies the generation of file URLs to always be the same, regardless of file type
* The current storage_url was not being used by the HTML5 rendering any more, so there is no need for this behaviour

## References
Cleanup from #7989 and #8005
Prep work for #8070

## Reviewer guidance
Does content still load?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
