### PR TITLE
Simplify i18n download paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ kolibrihome_test/
 
 # Translations
 kolibri/locale/en/
-kolibri/locale/CSV_FILES/**/*
+kolibri/locale/**/LC_MESSAGES/*.csv
 
 # Mr Developer
 .mr.developer.cfg

--- a/packages/kolibri-tools/lib/i18n/ExtractMessages.js
+++ b/packages/kolibri-tools/lib/i18n/ExtractMessages.js
@@ -12,7 +12,7 @@ function clearCsvPath(csvPath) {
   logging.info(`Removing existing messages files from ${csvPath}`);
 
   try {
-    const removedFiles = del.sync(csvPath);
+    const removedFiles = del.sync(path.join(csvPath, '*.csv'));
     logging.info(`Successfully cleared path for CSVs by removing: ${removedFiles.join('\n')}`);
   } catch (e) {
     logging.error('Failed to clear CSV path. Error message to follow...');
@@ -117,7 +117,7 @@ module.exports = function(pathInfo, ignore, localeDataFolder) {
     extractedMessages[namespace] = getAllMessagesFromFilePath(pathData.moduleFilePath, ignore);
   });
 
-  const csvPath = path.join(localeDataFolder, 'CSV_FILES', 'en');
+  const csvPath = path.join(localeDataFolder, 'en', 'LC_MESSAGES');
   // Let's just get rid of the old files to limit room for issues w/ file system
   clearCsvPath(csvPath);
 

--- a/packages/kolibri-tools/lib/i18n/crowdin.py
+++ b/packages/kolibri-tools/lib/i18n/crowdin.py
@@ -11,6 +11,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import zipfile
 
 import click
@@ -285,13 +286,6 @@ Download translations
 """
 
 
-def _wipe_translations(locale_path):
-    for file_name in os.listdir(locale_path):
-        target = os.path.join(locale_path, file_name)
-        if file_name != "en" and os.path.isdir(target):
-            shutil.rmtree(target)
-
-
 @click.command(cls=CrowdinCommand)
 @branch_argument
 @locale_data_folder_option
@@ -301,32 +295,34 @@ def download_translations(branch, project, key, login, locale_data_folder):
     """
     logging.info("Crowdin: downloading '{}'...".format(branch))
 
-    # delete previous files
-    _wipe_translations(locale_data_folder)
-
     DOWNLOAD_URL = CROWDIN_API_URL.format(
         proj=project,
         key=key,
         username=login,
         cmd="download/all.zip",
-        params="&branch={branch}&language={language}",
+        params="&branch={branch}".format(branch=branch),
     )
 
-    csv_dir_path = utils.local_locale_csv_path(locale_data_folder)
+    zip_dir = tempfile.mkdtemp()
+
+    r = requests.get(DOWNLOAD_URL)
+    r.raise_for_status()
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    z.extractall(zip_dir)
+
     for lang_object in utils.available_languages(include_in_context=True):
         code = lang_object[utils.KEY_CROWDIN_CODE]
-        url = DOWNLOAD_URL.format(language=code, branch=branch)
-        r = requests.get(url)
-        r.raise_for_status()
-        z = zipfile.ZipFile(io.BytesIO(r.content))
-        logging.info("\tExtracting {} to {}".format(code, csv_dir_path))
-        z.extractall(csv_dir_path)
-        csv_locale_dir_path = os.path.join(csv_dir_path, lang_object["crowdin_code"])
-        po_file = os.path.join(csv_locale_dir_path, "django.po")
-        if os.path.exists(po_file):
-            shutil.move(
-                po_file, utils.local_locale_path(lang_object, locale_data_folder)
-            )
+        locale_dir_path = utils.local_locale_path(lang_object, locale_data_folder)
+        logging.info("\tExtracting {} to {}".format(code, locale_dir_path))
+        MESSAGES = os.path.join(zip_dir, code)
+        if os.path.exists(MESSAGES):
+            for msg_file in os.listdir(MESSAGES):
+                shutil.move(
+                    os.path.join(MESSAGES, msg_file),
+                    os.path.join(locale_dir_path, msg_file),
+                )
+
+    shutil.rmtree(zip_dir, ignore_errors=True)
 
     logging.info("Crowdin: download succeeded!")
 
@@ -386,7 +382,7 @@ Upload source files
 
 def _source_upload_ref(file_name, locale_data_folder):
     file_pointer = open(
-        os.path.join(utils.local_locale_csv_source_path(locale_data_folder), file_name),
+        os.path.join(utils.local_locale_source_path(locale_data_folder), file_name),
         "rb",
     )
     return ("files[{0}]".format(file_name), file_pointer)
@@ -437,9 +433,7 @@ def upload_sources(branch, project, key, login, locale_data_folder):
 
     source_files = set(
         file_name
-        for file_name in os.listdir(
-            utils.local_locale_csv_source_path(locale_data_folder)
-        )
+        for file_name in os.listdir(utils.local_locale_source_path(locale_data_folder))
         if is_string_file(file_name)
     )
 

--- a/packages/kolibri-tools/lib/i18n/csvToJSON.js
+++ b/packages/kolibri-tools/lib/i18n/csvToJSON.js
@@ -30,7 +30,7 @@ module.exports = function(pathInfo, ignore, langInfo, localeDataFolder) {
     logging.info(
       `Converting CSV files to JSON for crowdin code ${crowdinCode} / Intl code ${intlCode}`
     );
-    const csvDefinitions = parseCSVDefinitions(localeDataFolder, crowdinCode);
+    const csvDefinitions = parseCSVDefinitions(localeDataFolder, intlCode);
     let messagesExist = false;
     const localeFolder = path.join(localeDataFolder, toLocale(intlCode), 'LC_MESSAGES');
     for (let name in requiredMessages) {

--- a/packages/kolibri-tools/lib/i18n/untranslatedMessages.js
+++ b/packages/kolibri-tools/lib/i18n/untranslatedMessages.js
@@ -23,7 +23,7 @@ module.exports = function(pathInfo, ignore, langInfo, localeDataFolder) {
   for (let langObject of languageInfo) {
     const crowdinCode = langObject['crowdin_code'];
     const intlCode = langObject['intl_code'];
-    const csvDefinitions = parseCSVDefinitions(localeDataFolder, crowdinCode);
+    const csvDefinitions = parseCSVDefinitions(localeDataFolder, intlCode);
     // An object for storing missing messages.
     const missingMessages = {};
     for (let name in requiredMessages) {

--- a/packages/kolibri-tools/lib/i18n/utils.js
+++ b/packages/kolibri-tools/lib/i18n/utils.js
@@ -16,7 +16,7 @@ function writeSourceToFile(filePath, fileSource) {
 
 // Compile all of the defined strings & context from the CSVs that have been downloaded
 // from Crowdin.
-function parseCSVDefinitions(dir, intlLangCode) {
+function parseCSVDefinitions(dir, intlLangCode = null) {
   if (intlLangCode) {
     intlLangCode = toLocale(intlLangCode);
   } else {

--- a/packages/kolibri-tools/lib/i18n/utils.js
+++ b/packages/kolibri-tools/lib/i18n/utils.js
@@ -16,8 +16,13 @@ function writeSourceToFile(filePath, fileSource) {
 
 // Compile all of the defined strings & context from the CSVs that have been downloaded
 // from Crowdin.
-function parseCSVDefinitions(dir, subDir = '**') {
-  return glob.sync(path.join(dir, 'CSV_FILES', subDir, '*.csv')).reduce((acc, filePath) => {
+function parseCSVDefinitions(dir, intlLangCode) {
+  if (intlLangCode) {
+    intlLangCode = toLocale(intlLangCode);
+  } else {
+    intlLangCode = '**';
+  }
+  return glob.sync(path.join(dir, intlLangCode, 'LC_MESSAGES', '*.csv')).reduce((acc, filePath) => {
     const csvFile = fs.readFileSync(filePath).toString();
 
     return [...acc, ...parseCsvSync(csvFile, { skip_empty_lines: true, columns: true })];

--- a/packages/kolibri-tools/lib/i18n/utils.py
+++ b/packages/kolibri-tools/lib/i18n/utils.py
@@ -93,20 +93,8 @@ def local_locale_path(lang_object, locale_data_folder):
 
 # Defines where we find the extracted messages
 @memoize
-def local_locale_csv_source_path(locale_data_folder):
-    csv_path = os.path.abspath(os.path.join(locale_data_folder, "CSV_FILES", "en"))
-    if not os.path.exists(csv_path):
-        os.makedirs(csv_path)
-    return csv_path
-
-
-# Defines where we'll find the downloaded CSV files from Crowdin (non english files)
-@memoize
-def local_locale_csv_path(locale_data_folder):
-    csv_path = os.path.abspath(os.path.join(locale_data_folder, "CSV_FILES"))
-    if not os.path.exists(csv_path):
-        os.makedirs(csv_path)
-    return csv_path
+def local_locale_source_path(locale_data_folder):
+    return local_locale_path({KEY_INTL_CODE: "en"}, locale_data_folder)
 
 
 def json_dump_formatted(data, file_path, file_name):


### PR DESCRIPTION
## Summary
* Removes the creation of separate crowdin language coded folders at download
* Downloads all files to a temporary directory and then immediately copies all files to the relevant Django locale dir
* Adds CSV files in the locale dir to the git ignore to prevent them being committed
* Updates all JS utilities to read from locale dirs

## References
Fixes #8245 

## Reviewer guidance
Does downloading strings and then:
a) Making message files
b) Syncing context

All work?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
