### PR TITLE
Always include --CONTEXT-- placeholder in all extracted messages

### DIFF
--- a/packages/kolibri-tools/lib/i18n/astUtils.js
+++ b/packages/kolibri-tools/lib/i18n/astUtils.js
@@ -124,14 +124,16 @@ function getObjectifiedValue(nodePropertyValue) {
   // If the value is not an object, then we'll make it into one to
   // have consistent data to work with (some will have an obj that
   // includes `context` key and value and some will have a string)
+  let message, context;
   if (nodePropertyValue.type !== 'ObjectExpression') {
-    return { message: nodePropertyValue.value };
+    message = nodePropertyValue.value;
+    context = '';
   } else {
     const contextNode = nodePropertyValue.properties.find(n => n.key.name === 'context');
     const messageNode = nodePropertyValue.properties.find(n => n.key.name === 'message');
 
-    const message = stringFromAnyLiteral(messageNode.value);
-    const context = stringFromAnyLiteral(contextNode.value);
+    message = stringFromAnyLiteral(messageNode.value);
+    context = stringFromAnyLiteral(contextNode.value);
 
     if (!message) {
       // This is mostly for dev debugging. If this happens then somethings wrong enough that
@@ -143,9 +145,8 @@ function getObjectifiedValue(nodePropertyValue) {
       );
       process.exit(1);
     }
-
-    return { message, context: `${CONTEXT_LINE}${context}` };
   }
+  return { message, context: `${CONTEXT_LINE}${context}` };
 }
 
 function getFileNameForImport(importPath, filePath) {

--- a/packages/kolibri-tools/lib/i18n/crowdin.py
+++ b/packages/kolibri-tools/lib/i18n/crowdin.py
@@ -464,7 +464,7 @@ def upload_sources(branch, project, key, login, locale_data_folder):
                 branch=branch
             ),
         )
-        _modify(UPDATE_SOURCE_URL, to_update)
+        _modify(UPDATE_SOURCE_URL, to_update, locale_data_folder)
 
     logging.info("Crowdin: source file upload succeeded!")
 


### PR DESCRIPTION
## Summary
* Restores the addition of the `--CONTEXT--` placeholder in all extracted strings.

## References
Follow up from #8224

## Reviewer guidance
Do strings with no context still have the `--CONTEXT--` placeholder in them when uploaded to crowdin?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
