### PR TITLE
Add conditional polling interval for learner sync status

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -197,10 +197,6 @@
       window.addEventListener('click', this.handleWindowClick);
       this.$kolibriBranding = branding;
     },
-    mounted() {
-      this.isUserLoggedIn ? (this.isPolling = true) : null;
-      this.pollUserSyncStatusTask(this.userId);
-    },
     beforeDestroy() {
       window.removeEventListener('click', this.handleWindowClick);
       this.isPolling = false;
@@ -234,7 +230,11 @@
         if (this.userMenuDropdownIsOpen) {
           this.$nextTick(() => {
             this.$refs.userMenuDropdown.$el.focus();
+            this.isPolling = true;
+            this.pollUserSyncStatusTask(this.userId);
           });
+        } else if (!this.userMenuDropdownIsOpen) {
+          this.isPolling = false;
         }
         return event;
       },
@@ -245,11 +245,13 @@
           this.userMenuDropdownIsOpen
         ) {
           this.userMenuDropdownIsOpen = false;
+          this.isPolling = false;
         }
         return event;
       },
       handleCoreMenuClose() {
         this.userMenuDropdownIsOpen = false;
+        this.isPolling = false;
         if (this.$refs.userMenuButton) {
           this.$refs.userMenuButton.$el.focus();
         }
@@ -257,6 +259,7 @@
       handleChangeLanguage() {
         this.$emit('showLanguageModal');
         this.userMenuDropdownIsOpen = false;
+        this.isPolling = false;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -211,12 +211,22 @@
         this.fetchUserSyncStatus({ user: this.userId }).then(syncData => {
           if (syncData && syncData[0]) {
             this.userSyncStatus = syncData[0];
+            this.setPollingInterval(this.userSyncStatus.status);
           }
         });
         if (this.isPolling) {
           setTimeout(() => {
             this.pollUserSyncStatusTask();
           }, this.pollingInterval);
+        }
+      },
+      setPollingInterval(status) {
+        if (status === SyncStatus.QUEUED) {
+          // check more frequently for updates if the user is waiting to sync,
+          // so that the sync isn't missed
+          this.pollingInterval = 1000;
+        } else {
+          this.pollingInterval = 10000;
         }
       },
       handleUserMenuButtonClick(event) {


### PR DESCRIPTION
Adds a check to see if a learner is in the queue. If so, updates the polling interval for checking the sync status to every 1 second.