### PR TITLE
Fix soud intervals

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -25,6 +25,7 @@ from kolibri.core.auth.management.utils import run_once
 from kolibri.core.auth.models import dataset_cache
 from kolibri.core.auth.sync_event_hook_utils import register_sync_event_handlers
 from kolibri.core.logger.utils.data import bytes_for_humans
+from kolibri.core.public.utils import schedule_new_sync
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.utils.lock import db_lock
@@ -269,6 +270,7 @@ class Command(AsyncCommand):
             self.job.save_meta()
 
         dataset_cache.deactivate()
+        schedule_new_sync(baseurl, user_id)
         logger.info("Syncing has been completed.")
 
     @contextmanager

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -82,6 +82,12 @@ class Command(AsyncCommand):
             action="store_true",
             help="do not create a facility and temporary superuser",
         )
+        parser.add_argument(
+            "--resync-interval",
+            type=int,
+            default=5,
+            help="Seconds to schedule a new sync",
+        )
         # parser.add_argument("--scope-id", type=str, default=FULL_FACILITY)
 
     def handle_async(self, *args, **options):  # noqa C901
@@ -97,6 +103,7 @@ class Command(AsyncCommand):
             no_pull,
             noninteractive,
             no_provision,
+            resync_interval,
         ) = (
             options["baseurl"],
             options["facility"],
@@ -108,6 +115,7 @@ class Command(AsyncCommand):
             options["no_pull"],
             options["noninteractive"],
             options["no_provision"],
+            options["resync_interval"],
         )
 
         PORTAL_SYNC = baseurl == DATA_PORTAL_SYNCING_BASE_URL
@@ -270,7 +278,8 @@ class Command(AsyncCommand):
             self.job.save_meta()
 
         dataset_cache.deactivate()
-        schedule_new_sync(baseurl, user_id)
+        if user_id:
+            schedule_new_sync(baseurl, user_id, resync_interval)
         logger.info("Syncing has been completed.")
 
     @contextmanager

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -85,7 +85,7 @@ class Command(AsyncCommand):
         parser.add_argument(
             "--resync-interval",
             type=int,
-            default=5,
+            default=None,
             help="Seconds to schedule a new sync",
         )
         # parser.add_argument("--scope-id", type=str, default=FULL_FACILITY)
@@ -278,7 +278,7 @@ class Command(AsyncCommand):
             self.job.save_meta()
 
         dataset_cache.deactivate()
-        if user_id:
+        if user_id and resync_interval:
             schedule_new_sync(baseurl, user_id, resync_interval)
         logger.info("Syncing has been completed.")
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -35,7 +35,7 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.models import DynamicNetworkLocation
-from kolibri.core.public.constants.user_sync_options import SYNC_INTERVAL
+from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
 from kolibri.core.public.constants.user_sync_statuses import NOT_RECENTLY_SYNCED
 from kolibri.core.public.constants.user_sync_statuses import QUEUED
 from kolibri.core.public.constants.user_sync_statuses import RECENTLY_SYNCED
@@ -212,7 +212,7 @@ def map_status(status):
     elif status["queued"]:
         return QUEUED
     elif status["last_synced"]:
-        if timezone.now() - status["last_synced"] < timedelta(minutes=SYNC_INTERVAL):
+        if timezone.now() - status["last_synced"] < timedelta(seconds=DELAYED_SYNC):
             return RECENTLY_SYNCED
         else:
             return NOT_RECENTLY_SYNCED

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -35,6 +35,11 @@ from kolibri.core.auth.models import Collection
 from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.models import DynamicNetworkLocation
+from kolibri.core.public.constants.user_sync_options import SYNC_INTERVAL
+from kolibri.core.public.constants.user_sync_statuses import NOT_RECENTLY_SYNCED
+from kolibri.core.public.constants.user_sync_statuses import QUEUED
+from kolibri.core.public.constants.user_sync_statuses import RECENTLY_SYNCED
+from kolibri.core.public.constants.user_sync_statuses import SYNCING
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.server import get_urls
 from kolibri.utils.server import installation_type
@@ -197,12 +202,6 @@ class SyncStatusFilter(FilterSet):
         fields = ["user", "member_of"]
 
 
-RECENTLY_SYNCED = "RECENTLY_SYNCED"
-SYNCING = "SYNCING"
-QUEUED = "QUEUED"
-NOT_RECENTLY_SYNCED = "NOT_RECENTLY_SYNCED"
-
-
 def map_status(status):
     """
     Summarize the current state of the sync into a constant for use by
@@ -213,9 +212,7 @@ def map_status(status):
     elif status["queued"]:
         return QUEUED
     elif status["last_synced"]:
-        # Keep this as a fixed constant for now.
-        # In future versions this may be configurable.
-        if timezone.now() - status["last_synced"] < timedelta(minutes=15):
+        if timezone.now() - status["last_synced"] < timedelta(minutes=SYNC_INTERVAL):
             return RECENTLY_SYNCED
         else:
             return NOT_RECENTLY_SYNCED

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -189,7 +189,7 @@ class SyncQueueViewSet(viewsets.ViewSet):
         return Response(queue)
 
     def check_queue(self, pk=None):
-        sync_interval = OPTIONS["SYNCING"]["SYNC_INTERVAL"]
+        sync_interval = OPTIONS["Deployment"]["SYNC_INTERVAL"]
         last_activity = timezone.now() - datetime.timedelta(minutes=5)
         current_transfers = TransferSession.objects.filter(
             active=True, last_activity_timestamp__gte=last_activity

--- a/kolibri/core/public/constants/user_sync_options.py
+++ b/kolibri/core/public/constants/user_sync_options.py
@@ -1,0 +1,6 @@
+"""
+This module contains constants representing options for SoUD sync
+"""
+from __future__ import unicode_literals
+
+SYNC_INTERVAL = 15  # recommended minutes between sync intervals

--- a/kolibri/core/public/constants/user_sync_options.py
+++ b/kolibri/core/public/constants/user_sync_options.py
@@ -3,4 +3,5 @@ This module contains constants representing options for SoUD sync
 """
 from __future__ import unicode_literals
 
-SYNC_INTERVAL = 15  # recommended minutes between sync intervals
+SYNC_INTERVAL = 5  # recommended seconds between sync intervals
+DELAYED_SYNC = 900  # seconds to mark sync as not recent

--- a/kolibri/core/public/constants/user_sync_options.py
+++ b/kolibri/core/public/constants/user_sync_options.py
@@ -3,5 +3,8 @@ This module contains constants representing options for SoUD sync
 """
 from __future__ import unicode_literals
 
-SYNC_INTERVAL = 5  # recommended seconds between sync intervals
-DELAYED_SYNC = 900  # seconds to mark sync as not recent
+SYNC_INTERVAL = 5  # client: recommended seconds between sync intervals
+DELAYED_SYNC = 900  # client: seconds to mark sync as not recent
+
+MAX_CONCURRENT_SYNCS = 1  # Server: max number of concurrent syncs allowed
+HANDSHAKING_TIME = 5  # Server: minimum time (seconds) considered as the ttl for the next sync request from an enqueued client

--- a/kolibri/core/public/constants/user_sync_statuses.py
+++ b/kolibri/core/public/constants/user_sync_statuses.py
@@ -5,5 +5,8 @@ when a SoUD request to sync
 from __future__ import unicode_literals
 
 
-SYNC = "sync"  # can begin a sync right now
-QUEUED = "queued"  # request added to the queue
+SYNC = "SYNC"  # can begin a sync right now
+RECENTLY_SYNCED = "RECENTLY_SYNCED"
+SYNCING = "SYNCING"
+QUEUED = "QUEUED"
+NOT_RECENTLY_SYNCED = "NOT_RECENTLY_SYNCED"

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -454,6 +454,13 @@ base_option_spec = {
                 Server configuration should handle ensuring that the files are properly served.
             """,
         },
+        "SYNC_INTERVAL": {
+            "type": "integer",
+            "default": 5,
+            "description": """
+                In case a SoUD connects to this server, the SoUD should use this interval to resync every user.
+            """,
+        },
     },
     "Python": {
         "PICKLE_PROTOCOL": {
@@ -472,15 +479,6 @@ base_option_spec = {
             "description": """
                 Whether to use Python multiprocessing for worker pools. If False, then it will use threading. This may be useful,
                 if running on a dedicated device with multiple cores, and a lot of asynchronous tasks get run.
-            """,
-        }
-    },
-    "SYNCING": {
-        "SYNC_INTERVAL": {
-            "type": "integer",
-            "default": 5,
-            "description": """
-                In case a SoUD connects to this server, the SoUD should use this interval to resync every user.
             """,
         }
     },

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -475,6 +475,15 @@ base_option_spec = {
             """,
         }
     },
+    "SYNCING": {
+        "SYNC_INTERVAL": {
+            "type": "integer",
+            "default": 5,
+            "description": """
+                In case a SoUD connects to this server, the SoUD should use this interval to resync every user.
+            """,
+        }
+    },
 }
 
 


### PR DESCRIPTION
## Summary
1. Ensure SOUD sync happens at regular intervals
2. Ensure sync is not scheduled by zeroconf is a sync has been previously scheduled
3. Clean failed syncinc tasks and updates UserSyncStatus to avoid staled states
4. Whenever the server accepts a sync, it will send the syncing interval so the client will use it to schedule the new syncing.

## References
Closes: #8236 
Fixes "Possible that sync jobs can get duplicated for the same server when the server is restarted" from https://www.notion.so/learningequality/Single-User-Syncing-Hack-Session-60-mins-bfb609b7d7de47b1af1e73b6446e3cbd

## Reviewer guidance

Restart several times the server or the synced server and check everything is working fine

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
