### PR TITLE
Prevent KeyErrors when pickling jobs

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -153,7 +153,7 @@ class Job(object):
             "func",
             "result",
         ]
-        return {key: self.__dict__[key] for key in keys}
+        return {key: self.__dict__[key] for key in keys if key in self.__dict__}
 
     def __init__(self, func, *args, **kwargs):
         """

--- a/kolibri/core/tasks/upgrade.py
+++ b/kolibri/core/tasks/upgrade.py
@@ -3,17 +3,20 @@ A file to contain specific logic to handle version upgrades in Kolibri.
 """
 import logging
 
-from kolibri.core.tasks.main import queue
+from kolibri.core.tasks.main import job_storage
 from kolibri.core.upgrade import version_upgrade
 
 logger = logging.getLogger(__name__)
 
 
-# The schema of iceqube DBs changed between these versions
-@version_upgrade(old_version="<0.13.0")
+# The schema of iceqube DBs changed between version 0.12 and 0.13.
+# We have coopted this upgrade to just drop all the data in the job storage
+# table from before 0.15, as from 0.15 onwards, we persist jobs in the
+# database, rather than clearing at every startup.
+@version_upgrade(old_version="<0.15.0")
 def drop_old_iceqube_tables():
     """
     Rather than write a migration for the iceqube database, it is simpler to just drop the tables
     and let iceqube reinitialize the tables from scratch.
     """
-    queue.storage.recreate_tables()
+    job_storage.recreate_tables()


### PR DESCRIPTION
## Summary
* Adds a defensive check against KeyErrors when attempting to pickle job objects
* Updates the upgrade step from 0.13 to clear all job storage tables, to happen for everything before 0.15, when jobs are now persisted between runs

## Reviewer guidance
Does this prevent weird errors when the scheduler attempts to queue a task (such as the pingback or vacuum tasks)?

Does this clear old jobs from before 0.15?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
