### PR TITLE
Github Actions for building WHL and PEX files

### DIFF
--- a/.github/workflows/build_pex.yml
+++ b/.github/workflows/build_pex.yml
@@ -1,0 +1,46 @@
+name: Build PEX file
+
+on:
+  workflow_call:
+    inputs:
+      whl-file-name:
+        required: true
+        type: string
+    outputs:
+      pex-file-name:
+        description: "PEX file name"
+        value: ${{ jobs.build_pex.outputs.pex-file-name }}
+
+jobs:
+  build_pex:
+    name: Build PEX
+    runs-on: ubuntu-latest
+    outputs:
+      pex-file-name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install Python build dependencies
+      run: pip install -r requirements/build.txt
+    - uses: actions/download-artifact@v2
+      with:
+        name: ${{ inputs.whl-file-name }}
+        path: dist
+    - name: Build PEX
+      run: make pex
+    - name: Get PEX filename
+      id: get-pex-filename
+      run: echo "::set-output name=pex-file-name::$(ls dist | grep .pex | cat)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
+        path: dist/${{ steps.get-pex-filename.outputs.pex-file-name }}

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -42,12 +42,20 @@ jobs:
       run: |
         yarn --frozen-lockfile
         npm rebuild node-sass
-    - uses: actions/cache@v2
+    - name: Cache Python dependencies
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: Cache C extensions
+      uses: actions/cache@v2
+      with:
+        path: cext_cache
+        key: ${{ runner.os }}-cext-${{ hashFiles('requirements/cext*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-cext-
     - name: Install Python build dependencies
       run: pip install -r requirements/build.txt
     - name: Build Kolibri

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -1,0 +1,68 @@
+name: Build WHL file
+
+on:
+  workflow_call:
+    outputs:
+      whl-file-name:
+        description: "WHL file name"
+        value: ${{ jobs.build_whl.outputs.whl-file-name }}
+      tar-file-name:
+        description: "TAR file name"
+        value: ${{ jobs.build_whl.outputs.tar-file-name }}
+
+jobs:
+  build_whl:
+    name: Build WHL
+    runs-on: ubuntu-latest
+    outputs:
+      whl-file-name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
+      tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt-get -y -qq update
+        sudo apt-get install -y gettext
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '16.x'
+    - name: Cache Node.js modules
+      uses: actions/cache@v2
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+    - name: Install Javascript dependencies
+      run: |
+        yarn --frozen-lockfile
+        npm rebuild node-sass
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install Python build dependencies
+      run: pip install -r requirements/build.txt
+    - name: Build Kolibri
+      run: make dist
+    - name: Get WHL filename
+      id: get-whl-filename
+      run: echo "::set-output name=whl-file-name::$(ls dist | grep .whl | cat)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
+        path: dist/${{ steps.get-whl-filename.outputs.whl-file-name }}
+    - name: Get TAR filename
+      id: get-tar-filename
+      run: echo "::set-output name=tar-file-name::$(ls dist | grep .tar | cat)"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
+        path: dist/${{ steps.get-tar-filename.outputs.tar-file-name }}

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -12,3 +12,10 @@ jobs:
     uses: ./.github/workflows/build_pex.yml
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
+  dmg:
+    name: Build DMG file
+    needs: whl
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@develop
+    with:
+      whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
+      ref: develop

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -1,0 +1,8 @@
+name: Kolibri Build Assets for Pull Request
+
+on: pull_request
+
+jobs:
+  whl:
+    name: Build WHL file
+    uses: ./.github/workflows/build_whl.yml

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -6,3 +6,9 @@ jobs:
   whl:
     name: Build WHL file
     uses: ./.github/workflows/build_whl.yml
+  pex:
+    name: Build PEX file
+    needs: whl
+    uses: ./.github/workflows/build_pex.yml
+    with:
+      whl-file-name: ${{ needs.whl.outputs.whl-file-name }}


### PR DESCRIPTION
## Summary
* Creates a reusable workflow for building the Kolibri WHL file and TAR ball that uploads them both to workflow artifacts and outputs the file names
* Creates a reusable workflow for building the Kolibri PEX file given the name of WHL file that can be downloaded from workflow artifacts
* Creates a workflow that chains the two workflows together in order to build the WHL file, then the PEX file - does so on PR and Push to branch.
* Adds caching for C extensions installation to remove about 40 seconds from the WHL build time.

## References
Fixes #9016 
Fixes #9015 

## Reviewer guidance


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201862306297808