### PR TITLE
Bump morango to fix removal of assert statements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ le-utils==0.1.24
 kolibri_exercise_perseus_plugin==1.3.5
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.3
+morango==0.6.4
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
 commands =
     sh -c 'kolibri manage makemigrations --check'
     # Run the actual tests
-    py.test {posargs:--cov=kolibri --cov-report= --cov-append --color=no}
+    python -O -m pytest {posargs:--cov=kolibri --cov-report= --cov-append --color=no}
     # Fail if the log is longer than 200 lines (something erroring or very noisy got added)
     sh -c "if [ `cat {env:KOLIBRI_HOME}/logs/kolibri.txt | wc -l` -gt 200 ] ; then echo 'Log too long' && echo '' && tail -n 20 {env:KOLIBRI_HOME}/logs/kolibri.txt && exit 1 ; fi"
 
@@ -51,5 +51,5 @@ deps =
     -r{toxinidir}/requirements/cext.txt
     -r{toxinidir}/requirements/postgres.txt
 commands =
-    py.test {posargs:--cov=kolibri --color=no}
+    python -O -m pytest {posargs:--cov=kolibri --color=no}
     # rm -rf {env:KOLIBRI_HOME}


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Bumps morango to [v0.6.4](https://github.com/learningequality/morango/releases/tag/v0.6.4)
- Updates tox to run pytest with `python -O`

## References
https://github.com/learningequality/morango/pull/131

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
