### PR TITLE
fix bad order of the parameters to check role permissions

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -742,7 +742,7 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
             target_user = FacilityUser.objects.get(id=scope_params.get("user_id"))
             if self == target_user:
                 return True
-            if self.has_role_for_user(target_user, role_kinds.ADMIN):
+            if self.has_role_for_user(role_kinds.ADMIN, target_user):
                 return True
             return False
         return False


### PR DESCRIPTION
## Summary

This fixes a bug in a permissions check that has been in our code base since Nov 2017.... it seems it was not important but with some sync permissions checks it's appeared now.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
