### PR TITLE
Single worker pool for tasks

### DIFF
--- a/kolibri/core/tasks/decorators.py
+++ b/kolibri/core/tasks/decorators.py
@@ -4,8 +4,8 @@ from functools import partial
 from kolibri.core.tasks.job import JobRegistry
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import RegisteredJob
+from kolibri.core.tasks.queue import DEFAULT_QUEUE
 from kolibri.core.tasks.utils import stringify_func
-
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 def register_task(
     func=None,
     job_id=None,
+    queue=DEFAULT_QUEUE,
     validator=None,
     priority=Priority.REGULAR,
     cancellable=False,
@@ -26,6 +27,7 @@ def register_task(
         return partial(
             register_task,
             job_id=job_id,
+            queue=queue,
             validator=validator,
             priority=priority,
             cancellable=cancellable,
@@ -36,6 +38,7 @@ def register_task(
     registered_job = RegisteredJob(
         func,
         job_id=job_id,
+        queue=queue,
         validator=validator,
         priority=priority,
         cancellable=cancellable,

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -6,7 +6,6 @@ import uuid
 from django.db import connection as django_connection
 
 from kolibri.core.tasks.exceptions import UserCancelledError
-from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.utils import current_state_tracker
 from kolibri.core.tasks.utils import import_stringified_func
 from kolibri.core.tasks.utils import stringify_func
@@ -316,6 +315,8 @@ class RegisteredJob(object):
 
         :return: enqueued job's id.
         """
+        from kolibri.core.tasks.main import job_storage
+
         job_obj = self._ready_job(*args, **kwargs)
         return job_storage.enqueue_job(job_obj, self.queue, self.priority)
 

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -6,6 +6,7 @@ import uuid
 from django.db import connection as django_connection
 
 from kolibri.core.tasks.exceptions import UserCancelledError
+from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.utils import current_state_tracker
 from kolibri.core.tasks.utils import import_stringified_func
 from kolibri.core.tasks.utils import stringify_func
@@ -85,6 +86,10 @@ class Priority(object):
 
     REGULAR = "REGULAR"
     HIGH = "HIGH"
+
+    # PriorityOrder is for ordering all the priority levels in their
+    # descending order of priority. Used for fetching the next queued job.
+    PriorityOrder = [HIGH, REGULAR]
 
 
 def execute_job(job_id, db_type, db_url):
@@ -277,27 +282,33 @@ class RegisteredJob(object):
     def __init__(
         self,
         func,
-        validator=None,
-        priority=Priority.REGULAR,
-        permission_classes=[],
-        **kwargs
+        validator,
+        priority,
+        permission_classes,
+        queue,
+        job_id,
+        cancellable,
+        track_progress,
     ):
         if validator is not None and not callable(validator):
             raise TypeError("Can't assign validator of type {}".format(type(validator)))
-        elif priority.upper() not in [Priority.REGULAR, Priority.HIGH]:
-            raise ValueError("priority must be one of 'regular' or 'high'.")
+        elif priority.upper() not in Priority.PriorityOrder:
+            raise ValueError("priority must be one of 'regular' or 'high' (string).")
         elif not isinstance(permission_classes, list):
             raise TypeError("permission_classes must be of list type.")
+        elif not isinstance(queue, str):
+            raise TypeError("queue must be of string type.")
 
         self.func = func
         self.validator = validator
         self.priority = priority.upper()
+        self.queue = queue
 
         self.permissions = [perm() for perm in permission_classes]
 
-        self.job_id = kwargs.pop("job_id", None)
-        self.cancellable = kwargs.pop("cancellable", False)
-        self.track_progress = kwargs.pop("track_progress", False)
+        self.job_id = job_id
+        self.cancellable = cancellable
+        self.track_progress = track_progress
 
     def enqueue(self, *args, **kwargs):
         """
@@ -305,11 +316,8 @@ class RegisteredJob(object):
 
         :return: enqueued job's id.
         """
-        from kolibri.core.tasks.main import PRIORITY_TO_QUEUE_MAP
-
         job_obj = self._ready_job(*args, **kwargs)
-        queue = PRIORITY_TO_QUEUE_MAP[self.priority]
-        return queue.enqueue(func=job_obj)
+        return job_storage.enqueue_job(job_obj, self.queue, self.priority)
 
     def enqueue_in(self, delta_time, interval=0, repeat=0, args=(), kwargs={}):
         """

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -146,7 +146,7 @@ job_storage = SimpleLazyObject(__job_storage)
 def initialize_workers():
     logger.info("Starting async task workers.")
     single_worker_pool = Worker(connection=connection, num_workers=4)
-    return single_worker_pool
+    return [single_worker_pool]
 
 
 def import_tasks_module_from_django_apps(app_configs=None):

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -11,7 +11,6 @@ from sqlalchemy import exc
 
 from kolibri.core.sqlite.utils import check_sqlite_integrity
 from kolibri.core.sqlite.utils import repair_sqlite_db
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.queue import Queue
 from kolibri.core.tasks.scheduler import Scheduler
 from kolibri.core.tasks.storage import Storage
@@ -144,18 +143,10 @@ def __job_storage():
 job_storage = SimpleLazyObject(__job_storage)
 
 
-PRIORITY_TO_QUEUE_MAP = {
-    Priority.REGULAR: queue,
-    Priority.HIGH: priority_queue,
-}
-
-
 def initialize_workers():
-    logger.info("Starting scheduler workers.")
-    regular_worker = Worker(task_queue_name, connection=connection, num_workers=1)
-    priority_worker = Worker(priority_queue_name, connection=connection, num_workers=3)
-    facility_worker = Worker(facility_queue_name, connection=connection, num_workers=1)
-    return regular_worker, priority_worker, facility_worker
+    logger.info("Starting async task workers.")
+    single_worker_pool = Worker(connection=connection, num_workers=4)
+    return single_worker_pool
 
 
 def import_tasks_module_from_django_apps(app_configs=None):

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -145,7 +145,9 @@ job_storage = SimpleLazyObject(__job_storage)
 
 def initialize_workers():
     logger.info("Starting async task workers.")
-    single_worker_pool = Worker(connection=connection, num_workers=4)
+    single_worker_pool = Worker(
+        connection=connection, regular_workers=4, high_workers=2
+    )
     return [single_worker_pool]
 
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -120,7 +120,7 @@ class Storage(StorageMixin):
             orm_job = ORMJob(
                 id=j.job_id,
                 state=j.state,
-                priority=priority,
+                priority=priority.upper(),
                 queue=queue,
                 obj=j,
             )

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -147,7 +147,7 @@ class Storage(StorageMixin):
         """
         self._update_job(job_id, State.CANCELING)
 
-    def get_next_queued_job(self, queues=None, priority_order=Priority.PriorityOrder):
+    def get_next_queued_job(self, priority_order=Priority.PriorityOrder):
         """
         Looks for the oldest queued job with priorities provided in `priority_order`. It
         runs through the `priority_oder` list sequentially.
@@ -161,9 +161,6 @@ class Storage(StorageMixin):
         """
         with self.session_scope() as s:
             q = s.query(ORMJob).filter(ORMJob.state == State.QUEUED)
-
-            if queues:
-                q = q.filter(ORMJob.queue.in_(queues))
 
             orm_job = None
             for priority in priority_order:

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -149,7 +149,7 @@ class Storage(StorageMixin):
         """
         self._update_job(job_id, State.CANCELING)
 
-    def get_next_queued_job(self, queues=None):
+    def get_next_queued_job(self, queues=None, priority_levels=Priority.PriorityOrder):
         with self.session_scope() as s:
             q = s.query(ORMJob).filter(ORMJob.state == State.QUEUED)
 
@@ -157,7 +157,7 @@ class Storage(StorageMixin):
                 q = q.filter(ORMJob.queue.in_(queues))
 
             orm_job = None
-            for priority in Priority.PriorityOrder:
+            for priority in priority_levels:
                 orm_job = (
                     q.filter(ORMJob.priority == priority)
                     .order_by(ORMJob.time_created)

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -28,7 +28,7 @@ def backend():
 @pytest.fixture
 def inmem_queue():
     with connection() as conn:
-        e = Worker(queues="pytest", connection=conn)
+        e = Worker(connection=conn)
         c = Queue(queue="pytest", connection=conn)
         c.e = e
         c.storage.clear(force=True)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import unittest
+import time
 
 import pytest
 
@@ -8,7 +8,6 @@ from kolibri.core.tasks.job import State
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.test.base import connection
 from kolibri.core.tasks.utils import stringify_func
-from kolibri.utils.conf import OPTIONS
 
 
 QUEUE = "pytest"
@@ -49,15 +48,14 @@ class TestBackend:
         # is the job marked with the CANCELED state?
         assert defaultbackend.get_job(job_id).state == State.CANCELED
 
-    @unittest.skipIf(
-        OPTIONS["Database"]["DATABASE_ENGINE"] == "postgres",
-        "Intermittently fails on postgresql in CI",
-    )
     def test_can_get_first_job_queued(self, defaultbackend):
         job1 = Job(open)
         job2 = Job(open)
 
         job1_id = defaultbackend.enqueue_job(job1, QUEUE)
+
+        # Sleep to prevent same time_created timestamp.
+        time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)
 
         assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job1_id
@@ -110,3 +108,20 @@ class TestBackend:
         defaultbackend.save_job_as_cancellable(job_id)
         job = defaultbackend.get_job(job_id)
         assert job.cancellable, "Job is not cancellable default"
+
+    def test_can_get_high_priority_job_first(self, defaultbackend, simplejob):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE, "HIGH")
+
+        defaultbackend.enqueue_job(simplejob, QUEUE, "REGULAR")
+        defaultbackend.enqueue_job(simplejob, QUEUE, "REGULAR")
+
+        assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job_id
+
+    def test_gets_oldest_high_priority_job_first(self, defaultbackend, simplejob):
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE, "HIGH")
+
+        # Sleep to prevent same time_created timestamp.
+        time.sleep(2)
+        defaultbackend.enqueue_job(simplejob, QUEUE, "HIGH")
+
+        assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job_id

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -58,7 +58,7 @@ class TestBackend:
         time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)
 
-        assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job1_id
+        assert defaultbackend.get_next_queued_job().job_id == job1_id
 
     def test_can_complete_job(self, defaultbackend, simplejob):
         """
@@ -115,7 +115,7 @@ class TestBackend:
         defaultbackend.enqueue_job(simplejob, QUEUE, "REGULAR")
         defaultbackend.enqueue_job(simplejob, QUEUE, "REGULAR")
 
-        assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job_id
+        assert defaultbackend.get_next_queued_job().job_id == job_id
 
     def test_gets_oldest_high_priority_job_first(self, defaultbackend, simplejob):
         job_id = defaultbackend.enqueue_job(simplejob, QUEUE, "HIGH")
@@ -124,4 +124,4 @@ class TestBackend:
         time.sleep(2)
         defaultbackend.enqueue_job(simplejob, QUEUE, "HIGH")
 
-        assert defaultbackend.get_next_queued_job([QUEUE]).job_id == job_id
+        assert defaultbackend.get_next_queued_job().job_id == job_id

--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -26,7 +26,7 @@ def error_func():
 @pytest.fixture
 def worker():
     with connection() as c:
-        b = Worker(QUEUE, c)
+        b = Worker(c)
         b.storage.clear(force=True)
         yield b
         b.storage.clear(force=True)

--- a/kolibri/core/tasks/test/test_decorators.py
+++ b/kolibri/core/tasks/test/test_decorators.py
@@ -21,6 +21,7 @@ class TestTaskDecorators(TestCase):
             validator=id,
             permission_classes=[int],
             priority="high",
+            queue="test",
             cancellable=True,
             track_progress=True,
         )
@@ -33,6 +34,7 @@ class TestTaskDecorators(TestCase):
             validator=id,
             permission_classes=[int],
             priority="high",
+            queue="test",
             cancellable=True,
             track_progress=True,
         )
@@ -58,6 +60,7 @@ class TestTaskDecorators(TestCase):
             validator=id,
             permission_classes=[int],
             priority="high",
+            queue="test",
             cancellable=True,
             track_progress=True,
         )

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -99,8 +99,9 @@ class Worker(object):
         Returns: None
         """
         job_to_start = self.get_next_job()
-        if job_to_start:
+        while job_to_start:
             self.start_next_job(job_to_start)
+            job_to_start = self.get_next_job()
 
         for job in self.storage.get_canceling_jobs():
             job_id = job.job_id

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -105,8 +105,6 @@ class Worker(object):
 
         Returns: None
         """
-        job_to_start = None
-
         while len(self.future_job_mapping) < self.max_workers:
             if len(self.future_job_mapping) < self.regular_workers:
                 job_to_start = self.storage.get_next_queued_job()


### PR DESCRIPTION
## Summary

This PR implements a dynamic single worker pool for tasks. Dynamic as in `high workers` come into action only when `regular workers` are busy and we still have jobs with `high` priority. 

If there are less workers running than there are `regular workers`, we look first for jobs with `high` priority, if found one we run it else we look for jobs with `regular` priority, if found we run it. 

If all `regular workers` are busy, then the remaining workers only look for `high` priority jobs. If found one, we run it.

This algorithm will make sure `high` priority jobs don't need to wait. 


## Reviewer guidance

Is the single worker pool logic suitable for our tasks needs? Do you see any edge cases?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
