### PR TITLE
Process bus consolidation

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -500,6 +500,19 @@ def stop():
 
 
 class KolibriProcessBus(ProcessBus):
+    """
+    This class is the state machine that manages the starting, restarting, and shutdown of
+    a running Kolibri instance. It is responsible for starting any WSGI servers that respond
+    to HTTP requests in the Kolibri lifecycle, and also other ancillary services like
+    a ZeroConf server, task runner work pool, scheduler, etc.
+
+    The primary use case for this process bus is for running Kolibri in a consumer server or
+    application context - although it can still be used to run the background services in
+    other contexts. One possible example for the extensibility of this class is if it is used
+    in conjunction with uwsgi, the 'restart' method of this class can be updated in a subclass
+    to run the specific `uwsgi.restart()` function that would otherwise not get invoked.
+    """
+
     def __init__(
         self,
         port=0,

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -322,11 +322,8 @@ IS_RUNNING = set([STATUS_RUNNING, STATUS_STARTING_UP, STATUS_SHUTTING_DOWN])
 
 
 class PIDPlugin(SimplePlugin):
-    def __init__(self, bus, port, zip_port, pid_file=PID_FILE):
+    def __init__(self, bus):
         self.bus = bus
-        self.port = port
-        self.zip_port = zip_port
-        self.pid_file = pid_file
         # Do this during initialization to set a startup lock
         self.set_pid_file(STATUS_STARTING_UP)
         self.bus.subscribe("SERVING", self.SERVING)
@@ -342,22 +339,24 @@ class PIDPlugin(SimplePlugin):
 
         :param: status: status of the process
         """
-        with open(self.pid_file, "w") as f:
+        with open(self.bus.pid_file, "w") as f:
             f.write(
-                "{}\n{}\n{}\n{}\n".format(os.getpid(), self.port, self.zip_port, status)
+                "{}\n{}\n{}\n{}\n".format(
+                    os.getpid(), self.bus.port, self.bus.zip_port, status
+                )
             )
 
     def SERVING(self, port):
-        self.port = port or self.port
+        self.bus.port = port or self.bus.port
         self.set_pid_file(STATUS_RUNNING)
 
     def ZIP_SERVING(self, zip_port):
-        self.zip_port = zip_port or self.zip_port
+        self.bus.zip_port = zip_port or self.bus.zip_port
         self.set_pid_file(STATUS_RUNNING)
 
     def EXIT(self):
         try:
-            os.unlink(self.pid_file)
+            os.unlink(self.bus.pid_file)
         except OSError:
             pass
 
@@ -500,82 +499,156 @@ def stop():
     return STATUS_STOPPED
 
 
-def configure_http_server(port, zip_port, bus):
-    from kolibri.deployment.default.wsgi import application
-    from kolibri.deployment.default.alt_wsgi import alt_application
-
-    server_config = {
-        "numthreads": conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"],
-        "request_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
-        "timeout": conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"],
-        "accepted_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
-        "accepted_queue_timeout": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_TIMEOUT"],
-    }
-
-    kolibri_address = (LISTEN_ADDRESS, port)
-
-    kolibri_server = KolibriServerPlugin(
-        bus,
-        httpserver=Server(kolibri_address, application, **server_config),
-        bind_addr=kolibri_address,
-    )
-
-    alt_port_addr = (
-        LISTEN_ADDRESS,
-        zip_port,
-    )
-
-    alt_port_server = ZipContentServerPlugin(
-        bus,
-        httpserver=Server(alt_port_addr, alt_application, **server_config),
-        bind_addr=alt_port_addr,
-    )
-    # Subscribe these servers
-    kolibri_server.subscribe()
-    alt_port_server.subscribe()
-
-
-def background_port_check(port, zip_port):
-    # Do this before daemonization, otherwise just let the server processes handle this
-    # In case that something other than Kolibri occupies the port,
-    # check the port's availability.
-    # Bypass check when socket activation is used
-    # https://manpages.debian.org/testing/libsystemd-dev/sd_listen_fds.3.en.html#ENVIRONMENT
-    # Also bypass when the port is 0, as that will choose a port
-    port = int(port)
-    zip_port = int(zip_port)
-    if (
-        not os.environ.get("LISTEN_PID", None)
-        and port
-        and not check_port_availability(LISTEN_ADDRESS, port)
+class KolibriProcessBus(ProcessBus):
+    def __init__(
+        self,
+        port=0,
+        zip_port=0,
+        serve_http=True,
+        background=False,
+        pid_file=PID_FILE,
+        listen_address=LISTEN_ADDRESS,
     ):
-        # Port is occupied
-        logger.error(
-            "Port {} is occupied.\n"
-            "Please check that you do not have other processes "
-            "running on this port and try again.\n".format(port)
-        )
-        sys.exit(1)
-    if (
-        not os.environ.get("LISTEN_PID", None)
-        and zip_port
-        and not check_port_availability(LISTEN_ADDRESS, zip_port)
-    ):
-        # Port is occupied
-        logger.error(
-            "Port {} is occupied.\n"
-            "Please check that you do not have other processes "
-            "running on this port and try again.\n".format(zip_port)
-        )
-        sys.exit(1)
-    if port:
-        __, urls = get_urls(listen_port=port)
-        for url in urls:
-            logger.info("Kolibri running on: {}".format(url))
-    else:
-        logger.info(
-            "No port specified, for information about accessing the server, run kolibri status"
-        )
+        self.listen_address = listen_address
+        self.pid_file = pid_file
+        self.background = background
+        self.serve_http = serve_http
+        self.port = int(port)
+        port_cache.lock_port(self.port)
+        self.zip_port = int(zip_port)
+        port_cache.lock_port(self.zip_port)
+        # On Mac, Python crashes when forking the process, so prevent daemonization until we can figure out
+        # a better fix. See https://github.com/learningequality/kolibri/issues/4821
+        if sys.platform == "darwin":
+            self.background = False
+
+        # Check if there are other kolibri instances running
+        # If there are, then we need to stop users from starting kolibri again.
+        pid, _, _, status = _read_pid_file(self.pid_file)
+
+        if status in IS_RUNNING and pid_exists(pid):
+            logger.error(
+                "There is another Kolibri server running. "
+                "Please use `kolibri stop` and try again."
+            )
+            sys.exit(1)
+
+        super(KolibriProcessBus, self).__init__()
+        # Setup plugin for handling PID file cleanup
+        # Do this first to obtain a PID file lock as soon as
+        # possible and reduce the risk of competing servers
+        pid_plugin = PIDPlugin(self)
+        pid_plugin.subscribe()
+
+        self.background_port_check()
+
+        logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
+
+        if self.background:
+            daemonize_plugin = DaemonizePlugin(self)
+            daemonize_plugin.subscribe()
+
+        log_plugin = LogPlugin(self)
+        log_plugin.subscribe()
+
+        self.configure_http_server()
+
+        # Setup plugin for services
+        service_plugin = ServicesPlugin(self)
+        service_plugin.subscribe()
+
+        # Setup zeroconf plugin
+        zeroconf_plugin = ZeroConfPlugin(self, port)
+        zeroconf_plugin.subscribe()
+
+        signal_handler = SignalHandler(self)
+
+        signal_handler.subscribe()
+
+        if getattr(settings, "DEVELOPER_MODE", False):
+            autoreloader = Autoreloader(self)
+            autoreloader.subscribe()
+
+        reload_plugin = ProcessControlPlugin(self)
+        reload_plugin.subscribe()
+
+    def _port_check(self, port):
+        # In case that something other than Kolibri occupies the port,
+        # check the port's availability.
+        # Bypass check when socket activation is used
+        # https://manpages.debian.org/testing/libsystemd-dev/sd_listen_fds.3.en.html#ENVIRONMENT
+        # Also bypass when the port is 0, as that will choose a port
+        port = int(port)
+        if (
+            not os.environ.get("LISTEN_PID", None)
+            and port
+            and not check_port_availability(self.listen_address, port)
+        ):
+            # Port is occupied
+            logger.error(
+                "Port {} is occupied.\n"
+                "Please check that you do not have other processes "
+                "running on this port and try again.\n".format(port)
+            )
+            sys.exit(1)
+
+    def background_port_check(self):
+        # Do this before daemonization, otherwise just let the server processes handle this
+        if self.background and self.serve_http:
+            self._port_check(self.port)
+            self._port_check(self.zip_port)
+            if self.port:
+                __, urls = get_urls(listen_port=self.port)
+                for url in urls:
+                    logger.info("Kolibri running on: {}".format(url))
+            else:
+                logger.info(
+                    "No port specified, for information about accessing the server, run kolibri status"
+                )
+
+    def configure_http_server(self):
+        if self.serve_http:
+            from kolibri.deployment.default.wsgi import application
+            from kolibri.deployment.default.alt_wsgi import alt_application
+
+            server_config = {
+                "numthreads": conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"],
+                "request_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
+                "timeout": conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"],
+                "accepted_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
+                "accepted_queue_timeout": conf.OPTIONS["Server"][
+                    "CHERRYPY_QUEUE_TIMEOUT"
+                ],
+            }
+
+            kolibri_address = (self.listen_address, self.port)
+
+            kolibri_server = KolibriServerPlugin(
+                self,
+                httpserver=Server(kolibri_address, application, **server_config),
+                bind_addr=kolibri_address,
+            )
+
+            alt_port_addr = (
+                self.listen_address,
+                self.zip_port,
+            )
+
+            alt_port_server = ZipContentServerPlugin(
+                self,
+                httpserver=Server(alt_port_addr, alt_application, **server_config),
+                bind_addr=alt_port_addr,
+            )
+            # Subscribe these servers
+            kolibri_server.subscribe()
+            alt_port_server.subscribe()
+
+    def run(self):
+        self.graceful()
+        if not self.serve_http:
+            self.publish("SERVING", None)
+
+        self.block()
 
 
 def start(port=0, zip_port=0, serve_http=True, background=False):
@@ -584,73 +657,12 @@ def start(port=0, zip_port=0, serve_http=True, background=False):
 
     :param: port: Port number (default: 0) - assigned by free port
     """
-    port = int(port)
-    port_cache.lock_port(port)
-    zip_port = int(zip_port)
-    port_cache.lock_port(zip_port)
-    # On Mac, Python crashes when forking the process, so prevent daemonization until we can figure out
-    # a better fix. See https://github.com/learningequality/kolibri/issues/4821
-    if sys.platform == "darwin":
-        background = False
 
-    # Check if there are other kolibri instances running
-    # If there are, then we need to stop users from starting kolibri again.
-    pid, _, _, status = _read_pid_file(PID_FILE)
+    bus = KolibriProcessBus(
+        port=port, zip_port=zip_port, serve_http=serve_http, background=background
+    )
 
-    if status in IS_RUNNING and pid_exists(pid):
-        logger.error(
-            "There is another Kolibri server running. "
-            "Please use `kolibri stop` and try again."
-        )
-        sys.exit(1)
-
-    bus = ProcessBus()
-
-    # Setup plugin for handling PID file cleanup
-    # Do this first to obtain a PID file lock as soon as
-    # possible and reduce the risk of competing servers
-    pid_plugin = PIDPlugin(bus, port, zip_port)
-    pid_plugin.subscribe()
-
-    if background and serve_http:
-        background_port_check(port, zip_port)
-
-    logger.info("Starting Kolibri {version}".format(version=kolibri.__version__))
-
-    if background:
-        daemonize_plugin = DaemonizePlugin(bus)
-        daemonize_plugin.subscribe()
-
-    log_plugin = LogPlugin(bus)
-    log_plugin.subscribe()
-
-    if serve_http:
-        configure_http_server(port, zip_port, bus)
-
-    # Setup plugin for services
-    service_plugin = ServicesPlugin(bus)
-    service_plugin.subscribe()
-
-    # Setup zeroconf plugin
-    zeroconf_plugin = ZeroConfPlugin(bus, port)
-    zeroconf_plugin.subscribe()
-
-    signal_handler = SignalHandler(bus)
-
-    signal_handler.subscribe()
-
-    if getattr(settings, "DEVELOPER_MODE", False):
-        autoreloader = Autoreloader(bus)
-        autoreloader.subscribe()
-
-    reload_plugin = ProcessControlPlugin(bus)
-    reload_plugin.subscribe()
-
-    bus.graceful()
-    if not serve_http:
-        bus.publish("SERVING", None)
-
-    bus.block()
+    bus.run()
 
 
 def restart():
@@ -674,7 +686,7 @@ def _read_pid_file(filename):
                           if they exist. If the port number doesn't exist, then
                           port is None. Lastly, the status code is returned.
     """
-    if not os.path.isfile(PID_FILE):
+    if not os.path.isfile(filename):
         return None, None, None, STATUS_STOPPED
 
     try:

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -211,46 +211,56 @@ class TestZeroConfPlugin(object):
         unregister_zeroconf_service.assert_called_once()
 
 
+@mock.patch(
+    "kolibri.utils.server._read_pid_file", return_value=((None, None, None, None))
+)
 class ServerInitializationTestCase(TestCase):
     @mock.patch("kolibri.utils.server.logging.error")
     @mock.patch("kolibri.utils.server.wait_for_free_port")
-    def test_port_occupied(self, wait_for_port_mock, logging_mock):
+    def test_port_occupied(self, wait_for_port_mock, logging_mock, read_pid_file_mock):
         wait_for_port_mock.side_effect = OSError
         with self.assertRaises(SystemExit):
-            server.background_port_check("8080", "8081")
+            process = server.KolibriProcessBus("8080", "8081")
+            process.background = True
+            process.background_port_check()
             logging_mock.assert_called()
 
     @mock.patch("kolibri.utils.server.logging.error")
     @mock.patch("kolibri.utils.server.wait_for_free_port")
-    def test_port_occupied_socket_activation(self, wait_for_port_mock, logging_mock):
+    def test_port_occupied_socket_activation(
+        self, wait_for_port_mock, logging_mock, read_pid_file_mock
+    ):
         wait_for_port_mock.side_effect = OSError
         # LISTEN_PID environment variable would be set if using socket activation
         with mock.patch.dict(os.environ, {"LISTEN_PID": "1234"}):
-            server.background_port_check("8080", "8081")
+            process = server.KolibriProcessBus("8080", "8081")
+            process.background = True
+            process.background_port_check()
             logging_mock.assert_not_called()
 
     @mock.patch("kolibri.utils.server.logging.error")
     @mock.patch("kolibri.utils.server.wait_for_free_port")
-    def test_port_zero_zip_port_zero(self, wait_for_port_mock, logging_mock):
+    def test_port_zero_zip_port_zero(
+        self, wait_for_port_mock, logging_mock, read_pid_file_mock
+    ):
         wait_for_port_mock.side_effect = OSError
-        server.background_port_check("0", "0")
+        process = server.KolibriProcessBus(0, 0)
+        process.background = True
+        process.background_port_check()
         logging_mock.assert_not_called()
 
     @mock.patch("kolibri.utils.server.pid_exists")
-    @mock.patch("kolibri.utils.server.ProcessBus")
-    def test_unclean_shutdown(self, process_bus_mock, pid_exists_mock):
+    def test_unclean_shutdown(self, pid_exists_mock, read_pid_file_mock):
         pid_exists_mock.return_value = False
-        with open(server.PID_FILE, "w") as f:
-            f.write("{}\n{}\n{}\n{}\n".format(1000, 8000, 8001, server.STATUS_RUNNING))
-        server.start()
-        process_bus_mock.assert_called()
+        read_pid_file_mock.return_value = (1000, 8000, 8001, server.STATUS_RUNNING)
+        with mock.patch.object(server.KolibriProcessBus, "run") as run_mock:
+            server.start()
+            run_mock.assert_called()
 
     @mock.patch("kolibri.utils.server.pid_exists")
-    @mock.patch("kolibri.utils.server.ProcessBus")
-    def test_server_running(self, process_bus_mock, pid_exists_mock):
+    def test_server_running(self, pid_exists_mock, read_pid_file_mock):
         pid_exists_mock.return_value = True
-        with open(server.PID_FILE, "w") as f:
-            f.write("{}\n{}\n{}\n{}\n".format(1000, 8000, 8001, server.STATUS_RUNNING))
+        read_pid_file_mock.return_value = (1000, 8000, 8001, server.STATUS_RUNNING)
         with self.assertRaises(SystemExit):
             server.start()
 


### PR DESCRIPTION
## Summary
* Consolidates our server start logic into a ProcessBus subclass
* Does this to allow external wrappers for Kolibri to more easily extend the server process
* This will allow apps to define their own plugins to hook into the state machine to trigger e.g. loading Kolibri in a WebView.
* Reduces reliance on module globals, `PID_FILE` and `LISTEN_ADDRESS` in case they are made more configurable in future.
* Adds fix for Python 3.9 until magicbus releases a new version

## References
Follow up from #8026
Provides an initial possible fix for https://github.com/learningequality/kolibri/issues/8273 by allowing the process to be run with a different LISTEN_ADDRESS.

## Reviewer guidance
Does the code still make sense? Does everything load as it ought?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
