### PR TITLE
Implementation of new LearnImmersiveLayout parent component for Content Renderer

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -753,15 +753,11 @@
   .epub-renderer {
     position: relative;
     max-height: 100%;
-    padding-top: calc(100% * 8.5 / 11);
+    padding-top: calc(100vh - #{$bottom-bar-height});
     overflow: hidden;
     font-size: smaller;
     border: solid 1px;
     border-radius: $radius;
-  }
-
-  .epub-renderer.small {
-    padding-top: calc(100% * 11 / 8.5);
   }
 
   .epub-renderer:fullscreen,
@@ -823,6 +819,7 @@
     right: 0;
     bottom: 0;
     left: 0;
+    padding: 0 40px;
   }
 
   .d-t {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -126,6 +126,15 @@
           />
         </div>
       </div>
+
+      <BottomBar
+        class="bottom-bar"
+        :locationsAreReady="locations.length > 0"
+        :heading="bottomBarHeading"
+        :sliderValue="sliderValue"
+        :sliderStep="sliderStep"
+        @sliderChanged="handleSliderChanged"
+      />
     </div>
   </CoreFullscreen>
 
@@ -152,6 +161,7 @@
   import TableOfContentsSideBar from './TableOfContentsSideBar.vue';
   import SettingsSideBar from './SettingsSideBar';
   import SearchSideBar from './SearchSideBar';
+  import BottomBar from './BottomBar';
   import PreviousButton from './PreviousButton';
   import NextButton from './NextButton';
   import TocButton from './TocButton';
@@ -183,6 +193,7 @@
       SettingsSideBar,
       SearchSideBar,
       LoadingScreen,
+      BottomBar,
       PreviousButton,
       NextButton,
       FocusLock,
@@ -306,6 +317,18 @@
         return darkThemeNames.some(themeName => isEqual(this.theme.name, themeName))
           ? 'white'
           : 'black';
+      },
+      bottomBarHeading() {
+        if (this.currentSection) {
+          return this.currentSection.label.trim();
+        }
+        return '';
+      },
+      sliderStep() {
+        if (this.locations.length > 0) {
+          return Math.floor(Math.min(Math.max(100 / this.locations.length, 0.1), 100));
+        }
+        return 1;
       },
       decreaseFontSizeDisabled() {
         return this.fontSize === `${FONT_SIZE_MIN}px`;
@@ -687,6 +710,13 @@
         this.storeVisitedPage(this.currentLocation);
         this.updateProgress();
         this.updateContentState();
+      },
+      handleSliderChanged(newSliderValue) {
+        const indexOfLocationToJumpTo = Math.floor(
+          (this.locations.length - 1) * (newSliderValue / 100)
+        );
+        const locationToJumpTo = this.locations[indexOfLocationToJumpTo];
+        this.jumpToLocation(locationToJumpTo);
       },
       updateContentState() {
         let contentState;

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -126,15 +126,6 @@
           />
         </div>
       </div>
-
-      <BottomBar
-        class="bottom-bar"
-        :locationsAreReady="locations.length > 0"
-        :heading="bottomBarHeading"
-        :sliderValue="sliderValue"
-        :sliderStep="sliderStep"
-        @sliderChanged="handleSliderChanged"
-      />
     </div>
   </CoreFullscreen>
 
@@ -161,7 +152,6 @@
   import TableOfContentsSideBar from './TableOfContentsSideBar.vue';
   import SettingsSideBar from './SettingsSideBar';
   import SearchSideBar from './SearchSideBar';
-  import BottomBar from './BottomBar';
   import PreviousButton from './PreviousButton';
   import NextButton from './NextButton';
   import TocButton from './TocButton';
@@ -193,7 +183,6 @@
       SettingsSideBar,
       SearchSideBar,
       LoadingScreen,
-      BottomBar,
       PreviousButton,
       NextButton,
       FocusLock,
@@ -317,18 +306,6 @@
         return darkThemeNames.some(themeName => isEqual(this.theme.name, themeName))
           ? 'white'
           : 'black';
-      },
-      bottomBarHeading() {
-        if (this.currentSection) {
-          return this.currentSection.label.trim();
-        }
-        return '';
-      },
-      sliderStep() {
-        if (this.locations.length > 0) {
-          return Math.floor(Math.min(Math.max(100 / this.locations.length, 0.1), 100));
-        }
-        return 1;
       },
       decreaseFontSizeDisabled() {
         return this.fontSize === `${FONT_SIZE_MIN}px`;
@@ -710,13 +687,6 @@
         this.storeVisitedPage(this.currentLocation);
         this.updateProgress();
         this.updateContentState();
-      },
-      handleSliderChanged(newSliderValue) {
-        const indexOfLocationToJumpTo = Math.floor(
-          (this.locations.length - 1) * (newSliderValue / 100)
-        );
-        const locationToJumpTo = this.locations[indexOfLocationToJumpTo];
-        this.jumpToLocation(locationToJumpTo);
       },
       updateContentState() {
         let contentState;

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -10,92 +10,98 @@ oriented data synchronization.
 <template v-if="ready">
 
   <div>
-    <UiAlert v-if="itemError" :dismissible="false" type="error">
-      {{ $tr('itemError') }}
-      <KButton
-        appearance="basic-link"
-        :text="$tr('tryDifferentQuestion')"
-        @click="nextQuestion"
-      />
-    </UiAlert>
+    <LessonMasteryBar
+      data-test="lessonMasteryBar"
+    />
     <div>
-      <KContentRenderer
-        ref="contentRenderer"
-        :kind="kind"
-        :lang="lang"
-        :files="files"
-        :available="available"
-        :extraFields="extraFields"
-        :assessment="true"
-        :itemId="itemId"
-        :progress="progress"
-        :userId="userId"
-        :userFullName="userFullName"
-        :timeSpent="timeSpent"
-        @answerGiven="answerGiven"
-        @hintTaken="hintTaken"
-        @itemError="handleItemError"
-        @startTracking="startTracking"
-        @stopTracking="stopTracking"
-        @updateProgress="updateProgress"
-        @updateContentState="updateContentState"
-      />
+      <UiAlert v-if="itemError" :dismissible="false" type="error">
+        {{ $tr('itemError') }}
+        <KButton
+          appearance="basic-link"
+          :text="$tr('tryDifferentQuestion')"
+          @click="nextQuestion"
+        />
+      </UiAlert>
+      <div class="content-wrapper">
+        <KContentRenderer
+          ref="contentRenderer"
+          :kind="kind"
+          :lang="lang"
+          :files="files"
+          :available="available"
+          :extraFields="extraFields"
+          :assessment="true"
+          :itemId="itemId"
+          :progress="progress"
+          :userId="userId"
+          :userFullName="userFullName"
+          :timeSpent="timeSpent"
+          @answerGiven="answerGiven"
+          @hintTaken="hintTaken"
+          @itemError="handleItemError"
+          @startTracking="startTracking"
+          @stopTracking="stopTracking"
+          @updateProgress="updateProgress"
+          @updateContentState="updateContentState"
+        />
+      </div>
+
+      <BottomAppBar
+        class="attempts-container"
+        :class="{ 'mobile': windowIsSmall }"
+      >
+        <div class="overall-status" :style="{ color: $themeTokens.text }">
+          <KIcon
+            icon="mastered"
+            :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
+          />
+          <div class="overall-status-text">
+            <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
+              {{ coreString('completedLabel') }}
+            </span>
+            <span>
+              {{ $tr('goal', { count: totalCorrectRequiredM }) }}
+            </span>
+          </div>
+        </div>
+        <div class="table">
+          <div class="row">
+            <div class="left">
+              <transition mode="out-in">
+                <KButton
+                  v-if="!complete"
+                  appearance="raised-button"
+                  :text="$tr('check')"
+                  :primary="true"
+                  :class="{ shaking: shake }"
+                  :disabled="checkingAnswer"
+                  @click="checkAnswer"
+                />
+                <KButton
+                  v-else
+                  appearance="raised-button"
+                  :text="$tr('next')"
+                  :primary="true"
+                  @click="nextQuestion"
+                />
+              </transition>
+            </div>
+
+            <div class="right">
+              <ExerciseAttempts
+                :waitingForAttempt="firstAttemptAtQuestion || itemError"
+                :numSpaces="attemptsWindowN"
+                :log="recentAttempts"
+              />
+              <p class="current-status">
+                {{ currentStatus }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </BottomAppBar>
     </div>
 
-    <BottomAppBar
-      class="attempts-container"
-      :class="{ 'mobile': windowIsSmall }"
-    >
-      <div class="overall-status" :style="{ color: $themeTokens.text }">
-        <KIcon
-          icon="mastered"
-          :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
-        />
-        <div class="overall-status-text">
-          <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
-            {{ coreString('completedLabel') }}
-          </span>
-          <span>
-            {{ $tr('goal', { count: totalCorrectRequiredM }) }}
-          </span>
-        </div>
-      </div>
-      <div class="table">
-        <div class="row">
-          <div class="left">
-            <transition mode="out-in">
-              <KButton
-                v-if="!complete"
-                appearance="raised-button"
-                :text="$tr('check')"
-                :primary="true"
-                :class="{ shaking: shake }"
-                :disabled="checkingAnswer"
-                @click="checkAnswer"
-              />
-              <KButton
-                v-else
-                appearance="raised-button"
-                :text="$tr('next')"
-                :primary="true"
-                @click="nextQuestion"
-              />
-            </transition>
-          </div>
-
-          <div class="right">
-            <ExerciseAttempts
-              :waitingForAttempt="firstAttemptAtQuestion || itemError"
-              :numSpaces="attemptsWindowN"
-              :log="recentAttempts"
-            />
-            <p class="current-status">
-              {{ currentStatus }}
-            </p>
-          </div>
-        </div>
-      </div>
-    </BottomAppBar>
   </div>
 
 </template>
@@ -112,6 +118,7 @@ oriented data synchronization.
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { defaultLanguage } from 'kolibri-design-system/lib/utils/i18n';
+  import LessonMasteryBar from '../classes/LessonMasteryBar';
   import { updateContentNodeProgress } from '../../modules/coreLearn/utils';
   import ExerciseAttempts from './ExerciseAttempts';
 
@@ -121,6 +128,7 @@ oriented data synchronization.
       ExerciseAttempts,
       UiAlert,
       BottomAppBar,
+      LessonMasteryBar,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
@@ -577,6 +585,11 @@ oriented data synchronization.
   .attempts-container {
     height: 111px;
     text-align: left;
+  }
+
+  .content-wrapper {
+    padding: 50px;
+    background-color: white;
   }
 
   .mobile {

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -157,7 +157,6 @@
       },
     },
     created() {
-      console.log('created');
       return this.$store
         .dispatch('initContentSession', {
           channelId: this.channelId,

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -157,6 +157,7 @@
       },
     },
     created() {
+      console.log('created');
       return this.$store
         .dispatch('initContentSession', {
           channelId: this.channelId,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -57,6 +57,7 @@
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { ContentNodeResource } from 'kolibri.resources';
   import router from 'kolibri.coreVue.router';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { updateContentNodeProgress } from '../modules/coreLearn/utils';
   import AssessmentWrapper from './AssessmentWrapper';
   import commonLearnStrings from './commonLearnStrings';
@@ -91,16 +92,16 @@
         fullName: state => state.core.session.full_name,
       }),
 
-      // progress() {
-      //   if (this.isUserLoggedIn) {
-      //     // if there no attempts for this exercise, there is no progress
-      //     if (this.content.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
-      //       return undefined;
-      //     }
-      //     return this.summaryProgress;
-      //   }
-      //   return this.sessionProgress;
-      // },
+      progress() {
+        if (this.isUserLoggedIn) {
+          // if there no attempts for this exercise, there is no progress
+          if (this.content.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
+            return undefined;
+          }
+          return this.summaryProgress;
+        }
+        return this.sessionProgress;
+      },
     },
     created() {
       return this.initSessionAction({
@@ -155,6 +156,7 @@
             this.$store.dispatch('handleApiError', error);
           });
       },
+      // TODO: markAsComplete not used but may be re-added for upcoming progress/status work
       // markAsComplete() {
       //   this.wasIncomplete = false;
       // },
@@ -171,6 +173,7 @@
 
   .content {
     z-index: 0;
+    max-height: 100vh;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -75,7 +75,6 @@
     },
     computed: {
       ...mapGetters(['currentUserId']),
-      // ...mapState(['pageName']),
       ...mapState('topicsTree', ['content']),
       ...mapState('topicsTree', {
         contentId: state => state.content.content_id,
@@ -84,10 +83,10 @@
         contentKind: state => state.content.kind,
       }),
       ...mapState({
-        // masteryAttempts: state => state.core.logging.mastery.totalattempts,
+        masteryAttempts: state => state.core.logging.mastery.totalattempts,
         summaryProgress: state => state.core.logging.summary.progress,
         summaryTimeSpent: state => state.core.logging.summary.time_spent,
-        // sessionProgress: state => state.core.logging.session.progress,
+        sessionProgress: state => state.core.logging.session.progress,
         extraFields: state => state.core.logging.summary.extra_fields,
         fullName: state => state.core.session.full_name,
       }),

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -1,286 +1,165 @@
 <template>
 
-  <KPageContainer>
-    <!-- isUserLoggedIn is used here to check if user is logged in or not.-->
-    <!-- If in guest mode, do not show progress icon at all-->
-    <PageHeader
-      :title="content.title"
-      :progress="isUserLoggedIn ? progress : null"
-      dir="auto"
-      :contentType="content.kind"
-    />
-    <CoachContentLabel
-      class="coach-content-label"
-      :value="content.coach_content ? 1 : 0"
-      :isTopic="isTopic"
-    />
-    <template v-if="sessionReady">
-      <KContentRenderer
-        v-if="!content.assessment"
-        class="content-renderer"
-        :kind="content.kind"
-        :lang="content.lang"
-        :files="content.files"
-        :options="content.options"
-        :available="content.available"
-        :duration="content.duration"
-        :extraFields="extraFields"
-        :progress="summaryProgress"
-        :userId="currentUserId"
-        :userFullName="fullName"
-        :timeSpent="summaryTimeSpent"
-        @startTracking="startTracking"
-        @stopTracking="stopTracking"
-        @updateProgress="updateProgress"
-        @addProgress="addProgress"
-        @updateContentState="updateContentState"
-        @navigateTo="navigateTo"
-        @error="onError"
-      />
+  <div v-if="sessionReady" class="content">
 
-      <AssessmentWrapper
-        v-else
-        :id="content.id"
-        class="content-renderer"
-        :kind="content.kind"
-        :files="content.files"
-        :lang="content.lang"
-        :randomize="content.randomize"
-        :masteryModel="content.masteryModel"
-        :assessmentIds="content.assessmentIds"
-        :channelId="channelId"
-        :available="content.available"
-        :extraFields="extraFields"
-        :progress="summaryProgress"
-        :userId="currentUserId"
-        :userFullName="fullName"
-        :timeSpent="summaryTimeSpent"
-        @startTracking="startTracking"
-        @stopTracking="stopTracking"
-        @updateProgress="updateExerciseProgress"
-        @updateContentState="updateContentState"
-      />
-    </template>
-    <KCircularLoader v-else />
-
-    <!-- TODO consolidate this metadata table with coach/lessons -->
-    <!-- eslint-disable-next-line vue/no-v-html -->
-    <p dir="auto" v-html="description"></p>
-
-
-    <section class="metadata">
-      <!-- TODO: RTL - Do not interpolate strings -->
-      <p v-if="content.author">
-        {{ $tr('author', { author: content.author }) }}
-      </p>
-      <p v-if="licenseShortName">
-        {{ $tr('license', { license: licenseShortName }) }}
-
-        <template v-if="licenseDescription">
-          <KIconButton
-            :icon="licenceDescriptionIsVisible ? 'chevronUp' : 'chevronDown'"
-            :ariaLabel="$tr('toggleLicenseDescription')"
-            size="small"
-            type="secondary"
-            @click="licenceDescriptionIsVisible = !licenceDescriptionIsVisible"
-          />
-          <div v-if="licenceDescriptionIsVisible" dir="auto" class="license-details">
-            <p class="license-details-name">
-              {{ licenseLongName }}
-            </p>
-            <p>{{ licenseDescription }}</p>
-          </div>
-        </template>
-      </p>
-
-      <p v-if="content.license_owner">
-        {{ $tr('copyrightHolder', { copyrightHolder: content.license_owner }) }}
-      </p>
-    </section>
-
-    <div>
-
-      <DownloadButton
-        v-if="canDownload"
-        :files="downloadableFiles"
-        :nodeTitle="content.title"
-        class="download-button"
-      />
-
-      <KButton
-        v-if="canShare"
-        :text="$tr('shareFile')"
-        class="share-button"
-        @click="launchIntent()"
-      />
-
-    </div>
-
-    <slot name="below_content">
-      <template v-if="content.next_content">
-        <h2>{{ $tr('nextResource') }}</h2>
-        <ContentCardGroupCarousel
-          :genContentLink="genContentLink"
-          :contents="[content.next_content]"
-        />
-      </template>
-    </slot>
-
-    <CompletionModal
-      v-if="progress >= 1 && wasIncomplete"
-      :isUserLoggedIn="isUserLoggedIn"
-      :nextContentNode="content.next_content"
-      :nextContentNodeRoute="nextContentNodeRoute"
-      :recommendedContentNodes="recommended"
-      :genContentLink="genContentLink"
-      @close="markAsComplete"
+    <KContentRenderer
+      v-if="!content.assessment"
+      :kind="content.kind"
+      :lang="content.lang"
+      :files="content.files"
+      :options="content.options"
+      :available="content.available"
+      :duration="content.duration"
+      :extraFields="extraFields"
+      :progress="summaryProgress"
+      :userId="currentUserId"
+      :userFullName="fullName"
+      :timeSpent="summaryTimeSpent"
+      @startTracking="startTracking"
+      @stopTracking="stopTracking"
+      @updateProgress="updateProgress"
+      @addProgress="addProgress"
+      @updateContentState="updateContentState"
+      @navigateTo="navigateTo"
+      @error="onError"
     />
 
-  </KPageContainer>
+    <AssessmentWrapper
+      v-else
+      :id="content.id"
+      class="content-renderer"
+      :kind="content.kind"
+      :files="content.files"
+      :lang="content.lang"
+      :randomize="content.randomize"
+      :masteryModel="content.masteryModel"
+      :assessmentIds="content.assessmentIds"
+      :channelId="channelId"
+      :available="content.available"
+      :extraFields="extraFields"
+      :progress="summaryProgress"
+      :userId="currentUserId"
+      :userFullName="fullName"
+      :timeSpent="summaryTimeSpent"
+      @startTracking="startTracking"
+      @stopTracking="stopTracking"
+      @updateProgress="updateExerciseProgress"
+      @updateContentState="updateContentState"
+    />
+  </div>
+  <KCircularLoader v-else />
 
 </template>
 
 
 <script>
 
-  import { mapState, mapGetters, mapActions } from 'vuex';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { mapState, mapGetters } from 'vuex';
   import { ContentNodeResource } from 'kolibri.resources';
   import router from 'kolibri.coreVue.router';
-  import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
-  import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
-  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
-  import { shareFile } from 'kolibri.utils.appCapabilities';
-  import markdownIt from 'markdown-it';
-  import {
-    licenseShortName,
-    licenseLongName,
-    licenseDescriptionForConsumer,
-  } from 'kolibri.utils.licenseTranslations';
-  import { PageNames, ClassesPageNames } from '../constants';
-  import { updateContentNodeProgress } from '../modules/coreLearn/utils';
-  import PageHeader from './PageHeader';
-  import ContentCardGroupCarousel from './ContentCardGroupCarousel';
   import AssessmentWrapper from './AssessmentWrapper';
-  import CompletionModal from './CompletionModal';
-  import { lessonResourceViewerLink } from './classes/classPageLinks';
   import commonLearnStrings from './commonLearnStrings';
 
   export default {
     name: 'ContentPage',
-    metaInfo() {
-      // Do not overwrite metaInfo of LessonResourceViewer
-      if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-        return {};
-      }
-      return {
-        title: this.$tr('documentTitle', {
-          contentTitle: this.content.title,
-          channelTitle: this.channel.title,
-        }),
-      };
-    },
     components: {
-      CoachContentLabel,
-      PageHeader,
-      ContentCardGroupCarousel,
-      DownloadButton,
       AssessmentWrapper,
-      CompletionModal,
     },
     mixins: [commonLearnStrings],
     data() {
       return {
-        wasIncomplete: false,
-        licenceDescriptionIsVisible: false,
         sessionReady: false,
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'facilityConfig', 'currentUserId']),
-      ...mapState(['pageName']),
-      ...mapState('topicsTree', ['content', 'channel', 'recommended']),
+      ...mapGetters(['currentUserId']),
+      ...mapState('topicsTree', ['content']),
       ...mapState('topicsTree', {
         contentId: state => state.content.content_id,
-        contentNodeId: state => state.content.id,
+        // contentNodeId: state => state.content.id,
         channelId: state => state.content.channel_id,
       }),
-      ...mapState({
-        masteryAttempts: state => state.core.logging.mastery.totalattempts,
-        summaryProgress: state => state.core.logging.summary.progress,
-        summaryTimeSpent: state => state.core.logging.summary.time_spent,
-        sessionProgress: state => state.core.logging.session.progress,
-        extraFields: state => state.core.logging.summary.extra_fields,
-        fullName: state => state.core.session.full_name,
-      }),
-      isTopic() {
-        return this.content.kind === ContentNodeKinds.TOPIC;
-      },
-      canDownload() {
-        if (this.facilityConfig.show_download_button_in_learn && this.content) {
-          return (
-            this.downloadableFiles.length &&
-            this.content.kind !== ContentNodeKinds.EXERCISE &&
-            !isEmbeddedWebView
-          );
-        }
-        return false;
-      },
-      canShare() {
-        let supported_types = ['mp4', 'mp3', 'pdf', 'epub'];
-        return shareFile && supported_types.includes(this.primaryFile.extension);
-      },
-      description() {
-        if (this.content && this.content.description) {
-          const md = new markdownIt({ breaks: true });
-          return md.render(this.content.description);
-        }
-        return '';
-      },
-      progress() {
-        if (this.isUserLoggedIn) {
-          // if there no attempts for this exercise, there is no progress
-          if (this.content.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
-            return undefined;
-          }
-          return this.summaryProgress;
-        }
-        return this.sessionProgress;
-      },
-      downloadableFiles() {
-        return this.content.files.filter(file => !file.preset.endsWith('thumbnail'));
-      },
-      primaryFile() {
-        return this.content.files.filter(file => !file.preset.supplementary)[0];
-      },
-      primaryFilename() {
-        return `${this.primaryFile.checksum}.${this.primaryFile.extension}`;
-      },
-      nextContentNodeRoute() {
-        // HACK Use a the Resource Viewer Link instead
-        if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-          return lessonResourceViewerLink(Number(this.$route.params.resourceNumber) + 1);
-        }
-        return {
-          name:
-            this.content.next_content.kind === ContentNodeKinds.TOPIC
-              ? PageNames.TOPICS_TOPIC
-              : PageNames.TOPICS_CONTENT,
-          params: { id: this.content.next_content.id },
-        };
-      },
-      licenseShortName() {
-        return licenseShortName(this.content.license_name);
-      },
-      licenseLongName() {
-        return licenseLongName(this.content.license_name);
-      },
-      licenseDescription() {
-        return licenseDescriptionForConsumer(
-          this.content.license_name,
-          this.content.license_description
-        );
-      },
+      // ...mapState({
+      //   masteryAttempts: state => state.core.logging.mastery.totalattempts,
+      //   summaryProgress: state => state.core.logging.summary.progress,
+      //   summaryTimeSpent: state => state.core.logging.summary.time_spent,
+      //   sessionProgress: state => state.core.logging.session.progress,
+      //   extraFields: state => state.core.logging.summary.extra_fields,
+      //   fullName: state => state.core.session.full_name,
+      // }),
+      // canDownload() {
+      //   if (this.facilityConfig.show_download_button_in_learn && this.content) {
+      //     return (
+      //       this.downloadableFiles.length &&
+      //       this.content.kind !== ContentNodeKinds.EXERCISE &&
+      //       !isEmbeddedWebView
+      //     );
+      //   }
+      //   return false;
+      // },
+      // canShare() {
+      //   let supported_types = ['mp4', 'mp3', 'pdf', 'epub'];
+      //   return shareFile && supported_types.includes(this.primaryFile.extension);
+      // },
+      // description() {
+      //   if (this.content && this.content.description) {
+      //     const md = new markdownIt({ breaks: true });
+      //     return md.render(this.content.description);
+      //   }
+      //   return '';
+      // },
+      // recommendedText() {
+      //   return this.learnString('recommendedLabel');
+      // },
+      // progress() {
+      //   if (this.isUserLoggedIn) {
+      //     // if there no attempts for this exercise, there is no progress
+      //     if (this.content.kind === ContentNodeKinds.EXERCISE && this.masteryAttempts === 0) {
+      //       return undefined;
+      //     }
+      //     return this.summaryProgress;
+      //   }
+      //   return this.sessionProgress;
+      // },
+      // showRecommended() {
+      //   return (
+      //     this.recommended && this.recommended.length && this.pageMode === PageModes.RECOMMENDED
+      //   );
+      // },
+      // downloadableFiles() {
+      //   return this.content.files.filter(file => !file.preset.endsWith('thumbnail'));
+      // },
+      // primaryFile() {
+      //   return this.content.files.filter(file => !file.preset.supplementary)[0];
+      // },
+      // primaryFilename() {
+      //   return `${this.primaryFile.checksum}.${this.primaryFile.extension}`;
+      // },
+      // nextContentLink() {
+      //   // HACK Use a the Resource Viewer Link instead
+      //   if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
+      //     return lessonResourceViewerLink(Number(this.$route.params.resourceNumber) + 1);
+      //   }
+      //   return {
+      //     name:
+      //       this.content.next_content.kind === ContentNodeKinds.TOPIC
+      //         ? PageNames.TOPICS_TOPIC
+      //         : PageNames.TOPICS_CONTENT,
+      //     params: { id: this.content.next_content.id },
+      //   };
+      // },
+      // licenseShortName() {
+      //   return licenseShortName(this.content.license_name);
+      // },
+      // licenseLongName() {
+      //   return licenseLongName(this.content.license_name);
+      // },
+      // licenseDescription() {
+      //   return licenseDescriptionForConsumer(
+      //     this.content.license_name,
+      //     this.content.license_description
+      //   );
+      // },
     },
     created() {
       return this.initSessionAction({
@@ -296,35 +175,51 @@
       this.stopTracking();
     },
     methods: {
-      ...mapActions({
-        initSessionAction: 'initContentSession',
-        updateProgressAction: 'updateProgress',
-        addProgressAction: 'addProgress',
-        startTracking: 'startTrackingProgress',
-        stopTracking: 'stopTrackingProgress',
-        updateContentNodeState: 'updateContentState',
-      }),
-      setWasIncomplete() {
-        this.wasIncomplete = this.progress < 1;
-      },
-      updateProgress(progressPercent, forceSave = false) {
-        this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-        );
-        this.$emit('updateProgress', progressPercent);
-      },
-      addProgress(progressPercent, forceSave = false) {
-        this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-        );
-        this.$emit('addProgress', progressPercent);
-      },
-      updateExerciseProgress(progressPercent) {
-        this.$emit('updateProgress', progressPercent);
-      },
-      updateContentState(contentState, forceSave = true) {
-        this.updateContentNodeState({ contentState, forceSave });
-      },
+      // ...mapActions({
+      //   initSessionAction: 'initContentSession',
+      //   updateProgressAction: 'updateProgress',
+      //   addProgressAction: 'addProgress',
+      //   startTracking: 'startTrackingProgress',
+      //   stopTracking: 'stopTrackingProgress',
+      //   updateContentNodeState: 'updateContentState',
+      // }),
+      // setWasIncomplete() {
+      //   this.wasIncomplete = this.progress < 1;
+      // },
+      // updateProgress(progressPercent, forceSave = false) {
+      //   this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+      //     updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
+      //   );
+      //   this.$emit('updateProgress', progressPercent);
+      // },
+      // addProgress(progressPercent, forceSave = false) {
+      //   this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+      //     updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
+      //   );
+      //   this.$emit('addProgress', progressPercent);
+      // },
+      // updateExerciseProgress(progressPercent) {
+      //   this.$emit('updateProgress', progressPercent);
+      // },
+      // updateContentState(contentState, forceSave = true) {
+      //   this.updateContentNodeState({ contentState, forceSave });
+      // },
+      // genContentLink(id, isLeaf) {
+      //   return {
+      //     name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
+      //     params: { id },
+      //   };
+      // },
+      // launchIntent() {
+      //   return shareFile({
+      //     filename: this.primaryFilename,
+      //     message: this.$tr('shareMessage', {
+      //       title: this.content.title,
+      //       topic: this.content.breadcrumbs.slice(-1)[0].title,
+      //       copyrightHolder: this.content.license_owner,
+      //     }),
+      //   }).catch(() => {});
+      // },
       navigateTo(message) {
         let id = message.nodeId;
         return ContentNodeResource.fetchModel({ id })
@@ -335,66 +230,11 @@
             this.$store.dispatch('handleApiError', error);
           });
       },
-      markAsComplete() {
-        this.wasIncomplete = false;
-      },
-      genContentLink(id, isLeaf) {
-        return {
-          name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
-          params: { id },
-        };
-      },
-      launchIntent() {
-        return shareFile({
-          filename: this.primaryFilename,
-          message: this.$tr('shareMessage', {
-            title: this.content.title,
-            topic: this.content.breadcrumbs.slice(-1)[0].title,
-            copyrightHolder: this.content.license_owner,
-          }),
-        }).catch(() => {});
-      },
+      // markAsComplete() {
+      //   this.wasIncomplete = false;
+      // },
       onError(error) {
         this.$store.dispatch('handleApiError', error);
-      },
-    },
-    $trs: {
-      author: {
-        message: 'Author: {author}',
-        context:
-          'Indicates who is the author of that specific learning resource. For example, "Author: Learning Equality".',
-      },
-      license: {
-        message: 'License: {license}',
-        context:
-          'Indicates the type of license of that specific learning resource. For example, "License: CC BY-NC-ND".\n',
-      },
-      toggleLicenseDescription: {
-        message: 'Toggle license description',
-        context:
-          'Describes the arrow which a learner can select to view more information about the type of license that a resource has.',
-      },
-      copyrightHolder: {
-        message: 'Copyright holder: {copyrightHolder}',
-        context:
-          'Indicates who holds the copyright of that specific learning resource. For example, "Copyright holder: Ubongo Media".',
-      },
-      shareMessage: {
-        message: '"{title}" (in "{topic}"), from {copyrightHolder}',
-        context: 'Refers to a specific learning resource. Only translate "in" and "from".',
-      },
-      nextResource: {
-        message: 'Next resource',
-        context:
-          "Indicates the next learning resource that the learner should go to once they've finished the current one.",
-      },
-      documentTitle: {
-        message: '{ contentTitle } - { channelTitle }',
-        context: 'DO NOT TRANSLATE.',
-      },
-      shareFile: {
-        message: 'Share',
-        context: 'Option to share a specific file from a learning resource.',
       },
     },
   };
@@ -404,32 +244,9 @@
 
 <style lang="scss" scoped>
 
-  .content-renderer {
+  .content {
     // Needs to be one less than the ScrollingHeader's z-index of 4
-    z-index: 3;
-  }
-
-  .coach-content-label {
-    margin: 8px 0;
-  }
-
-  .metadata {
-    font-size: smaller;
-  }
-
-  .download-button,
-  .share-button {
-    display: inline-block;
-    margin: 16px 16px 0 0;
-  }
-
-  .license-details {
-    margin-bottom: 24px;
-    margin-left: 16px;
-  }
-
-  .license-details-name {
-    font-weight: bold;
+    z-index: 0;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -67,13 +67,6 @@
       AssessmentWrapper,
     },
     mixins: [commonLearnStrings],
-    props: {
-      content: {
-        type: Object,
-        required: true,
-        default: null,
-      },
-    },
     data() {
       return {
         sessionReady: false,
@@ -82,7 +75,7 @@
     computed: {
       ...mapGetters(['currentUserId']),
       // ...mapState(['pageName']),
-      // ...mapState('topicsTree', ['content', 'channel', 'recommended']),
+      ...mapState('topicsTree', ['content']),
       ...mapState('topicsTree', {
         contentId: state => state.content.content_id,
         contentNodeId: state => state.content.id,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -57,6 +57,7 @@
   import { mapState, mapGetters, mapActions } from 'vuex';
   import { ContentNodeResource } from 'kolibri.resources';
   import router from 'kolibri.coreVue.router';
+  import { updateContentNodeProgress } from '../modules/coreLearn/utils';
   import AssessmentWrapper from './AssessmentWrapper';
   import commonLearnStrings from './commonLearnStrings';
 
@@ -66,6 +67,13 @@
       AssessmentWrapper,
     },
     mixins: [commonLearnStrings],
+    props: {
+      content: {
+        type: Object,
+        required: true,
+        default: null,
+      },
+    },
     data() {
       return {
         sessionReady: false,
@@ -73,44 +81,22 @@
     },
     computed: {
       ...mapGetters(['currentUserId']),
-      ...mapState('topicsTree', ['content']),
+      // ...mapState(['pageName']),
+      // ...mapState('topicsTree', ['content', 'channel', 'recommended']),
       ...mapState('topicsTree', {
-        contentId: state => state.content.content_id,
-        // contentNodeId: state => state.content.id,
+        // contentId: state => state.content.content_id,
+        contentNodeId: state => state.content.id,
         channelId: state => state.content.channel_id,
       }),
-      // ...mapState({
-      //   masteryAttempts: state => state.core.logging.mastery.totalattempts,
-      //   summaryProgress: state => state.core.logging.summary.progress,
-      //   summaryTimeSpent: state => state.core.logging.summary.time_spent,
-      //   sessionProgress: state => state.core.logging.session.progress,
-      //   extraFields: state => state.core.logging.summary.extra_fields,
-      //   fullName: state => state.core.session.full_name,
-      // }),
-      // canDownload() {
-      //   if (this.facilityConfig.show_download_button_in_learn && this.content) {
-      //     return (
-      //       this.downloadableFiles.length &&
-      //       this.content.kind !== ContentNodeKinds.EXERCISE &&
-      //       !isEmbeddedWebView
-      //     );
-      //   }
-      //   return false;
-      // },
-      // canShare() {
-      //   let supported_types = ['mp4', 'mp3', 'pdf', 'epub'];
-      //   return shareFile && supported_types.includes(this.primaryFile.extension);
-      // },
-      // description() {
-      //   if (this.content && this.content.description) {
-      //     const md = new markdownIt({ breaks: true });
-      //     return md.render(this.content.description);
-      //   }
-      //   return '';
-      // },
-      // recommendedText() {
-      //   return this.learnString('recommendedLabel');
-      // },
+      ...mapState({
+        // masteryAttempts: state => state.core.logging.mastery.totalattempts,
+        summaryProgress: state => state.core.logging.summary.progress,
+        summaryTimeSpent: state => state.core.logging.summary.time_spent,
+        // sessionProgress: state => state.core.logging.session.progress,
+        extraFields: state => state.core.logging.summary.extra_fields,
+        fullName: state => state.core.session.full_name,
+      }),
+
       // progress() {
       //   if (this.isUserLoggedIn) {
       //     // if there no attempts for this exercise, there is no progress
@@ -121,50 +107,12 @@
       //   }
       //   return this.sessionProgress;
       // },
-      // showRecommended() {
-      //   return (
-      //     this.recommended && this.recommended.length && this.pageMode === PageModes.RECOMMENDED
-      //   );
-      // },
-      // downloadableFiles() {
-      //   return this.content.files.filter(file => !file.preset.endsWith('thumbnail'));
-      // },
-      // primaryFile() {
-      //   return this.content.files.filter(file => !file.preset.supplementary)[0];
-      // },
-      // primaryFilename() {
-      //   return `${this.primaryFile.checksum}.${this.primaryFile.extension}`;
-      // },
-      // nextContentLink() {
-      //   // HACK Use a the Resource Viewer Link instead
-      //   if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-      //     return lessonResourceViewerLink(Number(this.$route.params.resourceNumber) + 1);
-      //   }
-      //   return {
-      //     name:
-      //       this.content.next_content.kind === ContentNodeKinds.TOPIC
-      //         ? PageNames.TOPICS_TOPIC
-      //         : PageNames.TOPICS_CONTENT,
-      //     params: { id: this.content.next_content.id },
-      //   };
-      // },
-      // licenseShortName() {
-      //   return licenseShortName(this.content.license_name);
-      // },
-      // licenseLongName() {
-      //   return licenseLongName(this.content.license_name);
-      // },
-      // licenseDescription() {
-      //   return licenseDescriptionForConsumer(
-      //     this.content.license_name,
-      //     this.content.license_description
-      //   );
-      // },
     },
     created() {
+      console.log(this.content);
       return this.initSessionAction({
-        channelId: this.channelId,
-        contentId: this.contentId,
+        channelId: this.content.channel_id,
+        contentId: this.content.content_id,
         contentKind: this.content.kind,
       }).then(() => {
         this.sessionReady = true;
@@ -177,49 +125,33 @@
     methods: {
       ...mapActions({
         initSessionAction: 'initContentSession',
-        // updateProgressAction: 'updateProgress',
-        // addProgressAction: 'addProgress',
-        // startTracking: 'startTrackingProgress',
-        // stopTracking: 'stopTrackingProgress',
-        // updateContentNodeState: 'updateContentState',
+        updateProgressAction: 'updateProgress',
+        addProgressAction: 'addProgress',
+        startTracking: 'startTrackingProgress',
+        stopTracking: 'stopTrackingProgress',
+        updateContentNodeState: 'updateContentState',
       }),
-      // setWasIncomplete() {
-      //   this.wasIncomplete = this.progress < 1;
-      // },
-      // updateProgress(progressPercent, forceSave = false) {
-      //   this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-      //     updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-      //   );
-      //   this.$emit('updateProgress', progressPercent);
-      // },
-      // addProgress(progressPercent, forceSave = false) {
-      //   this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
-      //     updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
-      //   );
-      //   this.$emit('addProgress', progressPercent);
-      // },
-      // updateExerciseProgress(progressPercent) {
-      //   this.$emit('updateProgress', progressPercent);
-      // },
-      // updateContentState(contentState, forceSave = true) {
-      //   this.updateContentNodeState({ contentState, forceSave });
-      // },
-      // genContentLink(id, isLeaf) {
-      //   return {
-      //     name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
-      //     params: { id },
-      //   };
-      // },
-      // launchIntent() {
-      //   return shareFile({
-      //     filename: this.primaryFilename,
-      //     message: this.$tr('shareMessage', {
-      //       title: this.content.title,
-      //       topic: this.content.breadcrumbs.slice(-1)[0].title,
-      //       copyrightHolder: this.content.license_owner,
-      //     }),
-      //   }).catch(() => {});
-      // },
+      setWasIncomplete() {
+        this.wasIncomplete = this.progress < 1;
+      },
+      updateProgress(progressPercent, forceSave = false) {
+        this.updateProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
+        );
+        this.$emit('updateProgress', progressPercent);
+      },
+      addProgress(progressPercent, forceSave = false) {
+        this.addProgressAction({ progressPercent, forceSave }).then(updatedProgressPercent =>
+          updateContentNodeProgress(this.channelId, this.contentNodeId, updatedProgressPercent)
+        );
+        this.$emit('addProgress', progressPercent);
+      },
+      updateExerciseProgress(progressPercent) {
+        this.$emit('updateProgress', progressPercent);
+      },
+      updateContentState(contentState, forceSave = true) {
+        this.updateContentNodeState({ contentState, forceSave });
+      },
       navigateTo(message) {
         let id = message.nodeId;
         return ContentNodeResource.fetchModel({ id })
@@ -245,7 +177,6 @@
 <style lang="scss" scoped>
 
   .content {
-    // Needs to be one less than the ScrollingHeader's z-index of 4
     z-index: 0;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -84,9 +84,10 @@
       // ...mapState(['pageName']),
       // ...mapState('topicsTree', ['content', 'channel', 'recommended']),
       ...mapState('topicsTree', {
-        // contentId: state => state.content.content_id,
+        contentId: state => state.content.content_id,
         contentNodeId: state => state.content.id,
         channelId: state => state.content.channel_id,
+        contentKind: state => state.content.kind,
       }),
       ...mapState({
         // masteryAttempts: state => state.core.logging.mastery.totalattempts,
@@ -109,11 +110,10 @@
       // },
     },
     created() {
-      console.log(this.content);
       return this.initSessionAction({
-        channelId: this.content.channel_id,
-        contentId: this.content.content_id,
-        contentKind: this.content.kind,
+        channelId: this.channelId,
+        contentId: this.contentId,
+        contentKind: this.contentKind,
       }).then(() => {
         this.sessionReady = true;
         this.setWasIncomplete();

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -54,7 +54,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState, mapGetters, mapActions } from 'vuex';
   import { ContentNodeResource } from 'kolibri.resources';
   import router from 'kolibri.coreVue.router';
   import AssessmentWrapper from './AssessmentWrapper';
@@ -175,14 +175,14 @@
       this.stopTracking();
     },
     methods: {
-      // ...mapActions({
-      //   initSessionAction: 'initContentSession',
-      //   updateProgressAction: 'updateProgress',
-      //   addProgressAction: 'addProgress',
-      //   startTracking: 'startTrackingProgress',
-      //   stopTracking: 'stopTrackingProgress',
-      //   updateContentNodeState: 'updateContentState',
-      // }),
+      ...mapActions({
+        initSessionAction: 'initContentSession',
+        // updateProgressAction: 'updateProgress',
+        // addProgressAction: 'addProgress',
+        // startTracking: 'startTrackingProgress',
+        // stopTracking: 'stopTrackingProgress',
+        // updateContentNodeState: 'updateContentState',
+      }),
       // setWasIncomplete() {
       //   this.wasIncomplete = this.progress < 1;
       // },

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -17,10 +17,6 @@
       data-test="learningActivityBar"
       @navigateBack="navigateBack"
     />
-    <LessonMasteryBar
-      v-if="isPracticeActivity"
-      data-test="lessonMasteryBar"
-    />
     <KLinearLoader
       v-if="loading"
       class="loader"
@@ -61,12 +57,11 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
-  import { LearningActivities, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
+  import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import SkipNavigationLink from '../../../../../../kolibri/core/assets/src/views/SkipNavigationLink';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
   import ContentPage from './ContentPage';
-  import LessonMasteryBar from './classes/LessonMasteryBar';
   import LearningActivityBar from './LearningActivityBar';
 
   const mapOldContentTypesToLearningActivities = {
@@ -99,7 +94,6 @@
       AuthMessage,
       ContentPage,
       LearningActivityBar,
-      LessonMasteryBar,
       SkipNavigationLink,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
@@ -159,9 +153,6 @@
         }
         return learningActivities;
       },
-      isPracticeActivity() {
-        return this.content ? this.content.kind === ContentNodeKinds.EXERCISE : false;
-      },
     },
     methods: {
       navigateBack() {
@@ -192,6 +183,7 @@
   .main-wrapper {
     display: inline-block;
     width: 100%;
+    background-color: white;
 
     @media print {
       /* Without this, things won't print correctly

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -7,6 +7,7 @@
   >
 
     <div v-if="blockDoubleClicks" class="click-mask"></div>
+    <SkipNavigationLink />
     <LearningActivityBar
       :resourceTitle="resourceTitle"
       :learningActivities="mappedLearningActivities"
@@ -62,6 +63,7 @@
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import { LearningActivities, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import SkipNavigationLink from '../../../../../../kolibri/core/assets/src/views/SkipNavigationLink';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
   import ContentPage from './ContentPage';
   import LessonMasteryBar from './classes/LessonMasteryBar';
@@ -98,6 +100,7 @@
       ContentPage,
       LearningActivityBar,
       LessonMasteryBar,
+      SkipNavigationLink,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -1,0 +1,217 @@
+<template>
+
+  <div
+    v-if="!loading"
+    ref="mainWrapper"
+    class="main-wrapper"
+    :style="mainWrapperStyles"
+  >
+
+    <div v-if="blockDoubleClicks" class="click-mask"></div>
+    <LearningActivityBar
+      :resourceTitle="content.title"
+      :learningActivities="mappedLearningActivities"
+      :isLessonContext="true"
+      :isBookmarked="true"
+      :allowMarkComplete="false"
+      @navigateBack="navigateBack"
+    />
+    <LessonMasteryBar
+      v-if="isPracticeActivity"
+    />
+    <KLinearLoader
+      v-if="loading"
+      class="loader"
+      type="indeterminate"
+      :delay="false"
+    />
+    <KPageContainer v-if="notAuthorized">
+      <AuthMessage
+        :authorizedRole="authorizedRole"
+        :header="authorizationErrorHeader"
+        :details="authorizationErrorDetails"
+      />
+    </KPageContainer>
+    <KPageContainer v-else-if="error">
+      <AppError />
+    </KPageContainer>
+
+    <div
+      v-else
+      id="main"
+      role="main"
+      tabindex="-1"
+      class="main"
+      :style="mainStyles"
+    >
+      <ContentPage class="content" />
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapState } from 'vuex';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
+  import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
+  import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
+  import ContentPage from './ContentPage';
+  import LessonMasteryBar from './classes/LessonMasteryBar';
+  import LearningActivityBar from './LearningActivityBar';
+
+  const mapOldContentTypesToLearningActivities = {
+    audio: LearningActivities.LISTEN,
+    document: LearningActivities.READ,
+    html5: LearningActivities.EXPLORE,
+    video: LearningActivities.WATCH,
+  };
+  export default {
+    name: 'LearnImmersiveLayout',
+    metaInfo() {
+      return {
+        // Use arrow function to bind $tr to this component
+        titleTemplate: title => {
+          if (this.error) {
+            return this.$tr('kolibriTitleMessage', { title: this.$tr('errorPageTitle') });
+          }
+          if (!title) {
+            // If no child component sets title, it reads 'Kolibri'
+            return this.coreString('kolibriLabel');
+          }
+          // If child component sets title, it reads 'Child Title - Kolibri'
+          return this.$tr('kolibriTitleMessage', { title });
+        },
+        title: this.pageTitle,
+      };
+    },
+    components: {
+      AppError,
+      AuthMessage,
+      ContentPage,
+      LearningActivityBar,
+      LessonMasteryBar,
+    },
+    mixins: [responsiveWindowMixin, commonCoreStrings],
+    props: {
+      content: {
+        type: Function,
+        required: false,
+        default: null,
+      },
+      // AUTHORIZATION SPECIFIC
+      authorized: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
+      authorizedRole: {
+        type: String,
+        default: null,
+      },
+      // link to where the 'back' button should go
+      back: {
+        type: Object,
+        required: true,
+        default: null,
+      },
+    },
+    computed: {
+      ...mapState({
+        error: state => state.core.error,
+        loading: state => state.core.loading,
+        blockDoubleClicks: state => state.core.blockDoubleClicks,
+      }),
+      notAuthorized() {
+        // catch "not authorized" error, display AuthMessage
+        if (
+          this.error &&
+          this.error.response &&
+          this.error.response.status &&
+          this.error.response.status == 403
+        ) {
+          return true;
+        }
+        return !this.authorized;
+      },
+      mainWrapperStyles() {
+        return {
+          backgroundColor: this.$themePalette.grey.v_100,
+          paddingTop: `${this.appbarHeight}px`,
+          paddingBottom: `${this.marginBottom}px`,
+        };
+      },
+      mappedLearningActivities() {
+        let learningActivities = [];
+        learningActivities.push(mapOldContentTypesToLearningActivities[this.content.kind]);
+        return learningActivities;
+      },
+      isPracticeActivity() {
+        // TODO Update when secondary header bar is conneted
+        return false;
+      },
+    },
+    methods: {
+      navigateBack() {
+        // return to previous page using the route object set through props
+        this.$router.push(this.back);
+      },
+    },
+    $trs: {
+      kolibriTitleMessage: {
+        message: '{ title } - Kolibri',
+        context: 'DO NOT TRANSLATE.',
+      },
+      errorPageTitle: {
+        message: 'Error',
+        context:
+          "When Kolibri throws an error, this is the text that's used as the title of the error page. The description of the error follows below.",
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .main-wrapper {
+    display: inline-block;
+    width: 100%;
+
+    @media print {
+      /* Without this, things won't print correctly
+       *  - Firefox: Tables will get cutoff
+       *  - Chrome: Table header won't repeat correctly on each page
+       */
+      display: block;
+    }
+  }
+
+  // When focused by SkipNavigationLink, don't outline non-buttons/links
+  /deep/ [tabindex='-1'] {
+    outline-style: none !important;
+  }
+
+  .click-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 24;
+    width: 100%;
+    height: 100%;
+  }
+
+  .loader {
+    position: fixed;
+    right: 0;
+    left: 0;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -8,15 +8,17 @@
 
     <div v-if="blockDoubleClicks" class="click-mask"></div>
     <LearningActivityBar
-      :resourceTitle="content.title"
+      :resourceTitle="resourceTitle"
       :learningActivities="mappedLearningActivities"
       :isLessonContext="true"
       :isBookmarked="true"
       :allowMarkComplete="false"
+      data-test="learningActivityBar"
       @navigateBack="navigateBack"
     />
     <LessonMasteryBar
       v-if="isPracticeActivity"
+      data-test="lessonMasteryBar"
     />
     <KLinearLoader
       v-if="loading"
@@ -44,7 +46,7 @@
     >
       <ContentPage
         class="content"
-        :content="content"
+        data-test="contentPage"
       />
     </div>
   </div>
@@ -139,13 +141,26 @@
         }
         return !this.authorized;
       },
+      resourceTitle() {
+        return this.content ? this.content.title : '';
+      },
       mappedLearningActivities() {
         let learningActivities = [];
-        learningActivities.push(mapOldContentTypesToLearningActivities[this.content.kind]);
+        if (this.content && this.content.kind) {
+          this.content.kind.forEach(kind => {
+            // validate to see the content has updated metadata type
+            if (Object.values(LearningActivities).includes(kind)) {
+              learningActivities.push(kind);
+            } else {
+              // otherwise reassign the old content types to the new metadata
+              learningActivities.push(mapOldContentTypesToLearningActivities[kind]);
+            }
+          });
+        }
         return learningActivities;
       },
       isPracticeActivity() {
-        return this.content.kind === ContentNodeKinds.EXERCISE;
+        return this.content ? this.content.kind === ContentNodeKinds.EXERCISE : false;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -102,7 +102,7 @@
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
       content: {
-        type: Function,
+        type: Object,
         required: false,
         default: null,
       },
@@ -147,15 +147,12 @@
       mappedLearningActivities() {
         let learningActivities = [];
         if (this.content && this.content.kind) {
-          this.content.kind.forEach(kind => {
-            // validate to see the content has updated metadata type
-            if (Object.values(LearningActivities).includes(kind)) {
-              learningActivities.push(kind);
-            } else {
-              // otherwise reassign the old content types to the new metadata
-              learningActivities.push(mapOldContentTypesToLearningActivities[kind]);
-            }
-          });
+          if (Object.values(LearningActivities).includes(this.content.kind)) {
+            learningActivities.push(this.content.kind);
+          } else {
+            // otherwise reassign the old content types to the new metadata
+            learningActivities.push(mapOldContentTypesToLearningActivities[this.content.kind]);
+          }
         }
         return learningActivities;
       },

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -4,7 +4,6 @@
     v-if="!loading"
     ref="mainWrapper"
     class="main-wrapper"
-    :style="mainWrapperStyles"
   >
 
     <div v-if="blockDoubleClicks" class="click-mask"></div>
@@ -42,9 +41,11 @@
       role="main"
       tabindex="-1"
       class="main"
-      :style="mainStyles"
     >
-      <ContentPage class="content" />
+      <ContentPage
+        class="content"
+        :content="content"
+      />
     </div>
   </div>
 
@@ -57,7 +58,7 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
-  import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
+  import { LearningActivities, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
   import ContentPage from './ContentPage';
@@ -138,21 +139,13 @@
         }
         return !this.authorized;
       },
-      mainWrapperStyles() {
-        return {
-          backgroundColor: this.$themePalette.grey.v_100,
-          paddingTop: `${this.appbarHeight}px`,
-          paddingBottom: `${this.marginBottom}px`,
-        };
-      },
       mappedLearningActivities() {
         let learningActivities = [];
         learningActivities.push(mapOldContentTypesToLearningActivities[this.content.kind]);
         return learningActivities;
       },
       isPracticeActivity() {
-        // TODO Update when secondary header bar is conneted
-        return false;
+        return this.content.kind === ContentNodeKinds.EXERCISE;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -267,7 +267,9 @@
         // them all, just create two alternative route paths for return/'back' navigation
         let route = {};
         const { searchTerm } = this.$route.query;
-        if (searchTerm) {
+        if (this.$route.query.last == PageNames.RECOMMENDED) {
+          route = this.$router.getRoute(PageNames.RECOMMENDED);
+        } else if (searchTerm) {
           route = this.$router.getRoute(PageNames.SEARCH, {}, this.$route.query);
         } else if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
           route = this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST);

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -1,11 +1,11 @@
 <template>
 
   <LearnImmersiveLayout
-    v-if="currentPageIsContent"
+    v-if="currentPageIsContentOrLesson"
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
     :back="learnBackPageRoute"
-    :content="topicsTreeContent"
+    :content="content"
   />
 
   <CoreBase
@@ -127,7 +127,6 @@
       ...mapGetters(['isUserLoggedIn', 'canAccessUnassignedContent']),
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
-        currentLesson: 'currentLesson',
       }),
       ...mapState('classAssignments', {
         classroomName: state => state.currentClassroom.name,
@@ -153,8 +152,11 @@
           pageNameToComponentMap[PageNames.TOPICS_CHANNEL],
         ].includes(this.currentPage);
       },
-      currentPageIsContent() {
-        return this.pageName === PageNames.TOPICS_CONTENT;
+      currentPageIsContentOrLesson() {
+        return (
+          this.pageName === PageNames.TOPICS_CONTENT ||
+          this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER
+        );
       },
       currentChannelIsCustom() {
         return (
@@ -169,15 +171,6 @@
             appBarTitle: this.classroomName || '',
             immersivePage: true,
             immersivePageRoute: this.$router.getRoute(ClassesPageNames.CLASS_ASSIGNMENTS),
-            immersivePagePrimary: true,
-            immersivePageIcon: 'close',
-          };
-        }
-        if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-          return {
-            appBarTitle: this.currentLesson.title || '',
-            immersivePage: true,
-            immersivePageRoute: this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST),
             immersivePagePrimary: true,
             immersivePageIcon: 'close',
           };
@@ -231,6 +224,15 @@
           !this.immersivePageProps.immersivePage
         );
       },
+      content() {
+        let content;
+        if (this.pageName === PageNames.TOPICS_CONTENT) {
+          content = this.topicsTreeContent;
+        } else if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
+          content = this.lessonContent;
+        }
+        return content;
+      },
       bottomSpaceReserved() {
         if (this.pageName === ClassesPageNames.EXAM_VIEWER) {
           return QUIZ_FOOTER;
@@ -267,6 +269,8 @@
         const { searchTerm } = this.$route.query;
         if (searchTerm) {
           route = this.$router.getRoute(PageNames.SEARCH, {}, this.$route.query);
+        } else if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
+          route = this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST);
         } else if (this.topicsTreeContent.parent) {
           // Need to guard for parent being non-empty to avoid console errors
           route = this.$router.getRoute(PageNames.TOPICS_TOPIC, {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -291,6 +291,7 @@
     position: absolute;
     top: 50%;
     right: 10px; // right-align to the menu icon
+    z-index: 2; // set the z-index higher than epub renderer
     min-width: 270px;
     transform: translateY(16px);
   }

--- a/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
@@ -21,7 +21,6 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
 
   export default {
@@ -29,7 +28,6 @@
     components: {
       CoreInfoIcon,
     },
-    mixins: [responsiveWindowMixin],
     /** https://github.com/learningequality/kolibri-exercise-perseus-plugin/blob/develop/
      * kolibri_exercise_perseus_plugin/assets/src/views/PerseusRendererIndex.vue
      */

--- a/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
@@ -1,32 +1,19 @@
 <template>
 
-  <div>
-    <div
-      class="hint-btn-container"
-    >
-      <KButton
-        class="hint-btn"
-        appearance="basic-link"
-        :text="$tr('hint', { hintsLeft: availableHints })"
-        :primary="false"
-        @click="takeHint"
-      />
-
-      <CoreInfoIcon
-        class="info-icon"
-        tooltipPosition="bottom right"
-        :iconAriaLabel="$tr('hintExplanation')"
-        :tooltipText="$tr('hintExplanation')"
-      />
-    </div>
-
-
-    <div v-if="hinted" id="hintlabel" :dir="contentDirection">
-      {{ $tr("hintLabel") }}
-    </div>
-    <div id="hintsarea" :dir="contentDirection" style="margin-left: 0px"></div>
-
-    <div style="clear: both;"></div>
+  <div class="hint-btn-container">
+    <KButton
+      class="hint-btn"
+      appearance="basic-link"
+      :text="$tr('hint', { hintsLeft: availableHints })"
+      :primary="false"
+      @click="takeHint"
+    />
+    <CoreInfoIcon
+      class="info-icon"
+      tooltipPosition="bottom right"
+      :iconAriaLabel="$tr('hintExplanation')"
+      :tooltipText="$tr('hintExplanation')"
+    />
   </div>
 
 </template>
@@ -35,25 +22,20 @@
 <script>
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
 
   export default {
     name: 'Hint',
-    mixins: [responsiveWindowMixin],
-    props: {},
-    data() {
-      return {};
+    components: {
+      CoreInfoIcon,
     },
-    computed: {},
-    watch: {},
-
-    methods: {},
+    mixins: [responsiveWindowMixin],
     /** https://github.com/learningequality/kolibri-exercise-perseus-plugin/blob/develop/
      * kolibri_exercise_perseus_plugin/assets/src/views/PerseusRendererIndex.vue
      */
     $trs: {
       hint: 'Use a hint ({hintsLeft, number} left)',
       hintExplanation: 'If you use a hint, this question will not be added to your progress',
-      hintLabel: 'Hint:',
     },
   };
 
@@ -65,11 +47,15 @@
   @import '~kolibri-design-system/lib/styles/definitions';
 
   .hint-btn-container {
+    margin-top: 4px; // to align with OverallStatus text
     text-align: right;
   }
   .hint-btn {
+    position: relative;
     vertical-align: text-bottom;
-    border: 2px solid red;
+  }
+  .info-icon {
+    margin-left: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/Hint.vue
@@ -1,0 +1,75 @@
+<template>
+
+  <div>
+    <div
+      class="hint-btn-container"
+    >
+      <KButton
+        class="hint-btn"
+        appearance="basic-link"
+        :text="$tr('hint', { hintsLeft: availableHints })"
+        :primary="false"
+        @click="takeHint"
+      />
+
+      <CoreInfoIcon
+        class="info-icon"
+        tooltipPosition="bottom right"
+        :iconAriaLabel="$tr('hintExplanation')"
+        :tooltipText="$tr('hintExplanation')"
+      />
+    </div>
+
+
+    <div v-if="hinted" id="hintlabel" :dir="contentDirection">
+      {{ $tr("hintLabel") }}
+    </div>
+    <div id="hintsarea" :dir="contentDirection" style="margin-left: 0px"></div>
+
+    <div style="clear: both;"></div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
+  export default {
+    name: 'Hint',
+    mixins: [responsiveWindowMixin],
+    props: {},
+    data() {
+      return {};
+    },
+    computed: {},
+    watch: {},
+
+    methods: {},
+    /** https://github.com/learningequality/kolibri-exercise-perseus-plugin/blob/develop/
+     * kolibri_exercise_perseus_plugin/assets/src/views/PerseusRendererIndex.vue
+     */
+    $trs: {
+      hint: 'Use a hint ({hintsLeft, number} left)',
+      hintExplanation: 'If you use a hint, this question will not be added to your progress',
+      hintLabel: 'Hint:',
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .hint-btn-container {
+    text-align: right;
+  }
+  .hint-btn {
+    vertical-align: text-bottom;
+    border: 2px solid red;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -1,0 +1,117 @@
+<template>
+
+  <div
+    class="header-container"
+    :class="{ 'header-container--sticky': isHeaderSticky, 'header-sm': windowIsSmall }"
+    :style="{ backgroundColor: $themeTokens.surface }"
+  >
+    <div class="inner-header" :style="innerStyle">
+      <div class="overall-status" :style="{ color: $themeTokens.text }">
+        <KIcon
+          icon="mastered"
+          :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
+        />
+        <div class="overall-status-text">
+          <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
+            {{ coreString('completedLabel') }}
+          </span>
+          <span>
+            {{ $tr('goal', { count: totalCorrectRequiredM }) }}
+          </span>
+        </div>
+      </div>
+      <slot></slot>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
+  export default {
+    name: 'LessonMasteryBar',
+    mixins: [responsiveWindowMixin],
+    props: {
+      maxWidth: {
+        type: Number,
+        default: 960,
+      },
+    },
+    data() {
+      return {
+        scrollY: null,
+        headerTop: 0,
+        isHeaderSticky: false,
+      };
+    },
+    computed: {
+      innerStyle() {
+        if (this.maxWidth) {
+          return { maxWidth: `${this.maxWidth}px` };
+        }
+        return null;
+      },
+    },
+    watch: {
+      scrollY(newValue) {
+        if (newValue > this.headerTop) {
+          this.isHeaderSticky = true;
+        } else {
+          this.isHeaderSticky = false;
+        }
+      },
+    },
+    mounted() {
+      window.addEventListener('load', () => {
+        window.addEventListener('scroll', () => {
+          this.scrollY = Math.round(window.scrollY);
+        });
+        this.headerTop = this.$refs.header.getBoundingClientRect().top;
+      });
+    },
+    methods: {},
+
+    $trs: {
+      goal: {
+        message: 'Get {count, number, integer} {count, plural, other {correct}}',
+        context:
+          '\nMessage that indicates to the learner how many correct answers they need to give in order to master the given topic, and for the exercise to be considered completed.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .header-container {
+    position: fixed;
+    right: 0;
+    left: 0;
+    z-index: 8; // material - Bottom app bar
+    height: 63px;
+    padding: 8px 16px;
+    margin: 0;
+    overflow-x: hidden;
+    font-size: 14px;
+    border: 1px red solid;
+  }
+
+  .header-sm {
+    height: auto;
+    min-height: 72px;
+  }
+
+  .inner-header {
+    height: 100%;
+    padding: 10px 0;
+    margin: auto;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -18,7 +18,7 @@
           alignment="right"
           :style="{ backgroundColor: 'yellow', margin: 'auto' }"
         >
-          <p>HELLO</p>
+          <Hint />
         </KFixedGridItem>
       </KFixedGrid>
     </div>
@@ -31,11 +31,13 @@
 
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import OverallStatus from './OverallStatus';
+  import Hint from './Hint';
 
   export default {
     name: 'LessonMasteryBar',
     components: {
       OverallStatus,
+      Hint,
       UiToolbar,
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -6,20 +6,7 @@
     :style="{ backgroundColor: $themeTokens.surface }"
   >
     <div class="inner-header" :style="innerStyle">
-      <div class="overall-status" :style="{ color: $themeTokens.text }">
-        <KIcon
-          icon="mastered"
-          :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
-        />
-        <div class="overall-status-text">
-          <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
-            {{ coreString('completedLabel') }}
-          </span>
-          <span>
-            {{ $tr('goal', { count: totalCorrectRequiredM }) }}
-          </span>
-        </div>
-      </div>
+      <OverallStatus />
       <slot></slot>
     </div>
   </div>
@@ -30,9 +17,13 @@
 <script>
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import OverallStatus from './OverallStatus';
 
   export default {
     name: 'LessonMasteryBar',
+    components: {
+      OverallStatus,
+    },
     mixins: [responsiveWindowMixin],
     props: {
       maxWidth: {
@@ -73,14 +64,6 @@
       });
     },
     methods: {},
-
-    $trs: {
-      goal: {
-        message: 'Get {count, number, integer} {count, plural, other {correct}}',
-        context:
-          '\nMessage that indicates to the learner how many correct answers they need to give in order to master the given topic, and for the exercise to be considered completed.',
-      },
-    },
   };
 
 </script>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -1,68 +1,50 @@
 <template>
 
-  <div
-    class="header-container"
-    :class="{ 'header-container--sticky': isHeaderSticky, 'header-sm': windowIsSmall }"
+  <UiToolbar
+    :title="appBarTitle"
+    textColor="black"
+    type="clear"
     :style="{ backgroundColor: $themeTokens.surface }"
+    class="header-container"
+    removeNavIcon="true"
   >
-    <div class="inner-header" :style="innerStyle">
-      <OverallStatus />
-      <slot></slot>
+    <div class="inner-header">
+      <KFixedGrid numCols="2">
+        <KFixedGridItem span="1" :style="{ backgroundColor: 'purple', margin: 'auto' }">
+          <OverallStatus />
+        </KFixedGridItem>
+        <KFixedGridItem
+          span="1"
+          alignment="right"
+          :style="{ backgroundColor: 'yellow', margin: 'auto' }"
+        >
+          <p>HELLO</p>
+        </KFixedGridItem>
+      </KFixedGrid>
     </div>
-  </div>
+  </UiToolbar>
 
 </template>
 
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import OverallStatus from './OverallStatus';
 
   export default {
     name: 'LessonMasteryBar',
     components: {
       OverallStatus,
+      UiToolbar,
     },
-    mixins: [responsiveWindowMixin],
     props: {
-      maxWidth: {
-        type: Number,
-        default: 960,
+      appBarTitle: {
+        type: String,
+        required: true,
       },
     },
-    data() {
-      return {
-        scrollY: null,
-        headerTop: 0,
-        isHeaderSticky: false,
-      };
-    },
-    computed: {
-      innerStyle() {
-        if (this.maxWidth) {
-          return { maxWidth: `${this.maxWidth}px` };
-        }
-        return null;
-      },
-    },
-    watch: {
-      scrollY(newValue) {
-        if (newValue > this.headerTop) {
-          this.isHeaderSticky = true;
-        } else {
-          this.isHeaderSticky = false;
-        }
-      },
-    },
-    mounted() {
-      window.addEventListener('load', () => {
-        window.addEventListener('scroll', () => {
-          this.scrollY = Math.round(window.scrollY);
-        });
-        this.headerTop = this.$refs.header.getBoundingClientRect().top;
-      });
-    },
+    computed: {},
     methods: {},
   };
 
@@ -86,15 +68,12 @@
     border: 1px red solid;
   }
 
-  .header-sm {
-    height: auto;
-    min-height: 72px;
-  }
-
   .inner-header {
+    width: 100%;
     height: 100%;
-    padding: 10px 0;
+    padding: 0 20px;
     margin: auto;
+    border: 1px blue solid;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -17,7 +17,6 @@
 
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  // import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
   import OverallStatus from './OverallStatus.vue';
   import Hint from './Hint.vue';
 

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonMasteryBar.vue
@@ -1,27 +1,13 @@
 <template>
 
-  <UiToolbar
-    :title="appBarTitle"
-    textColor="black"
-    type="clear"
-    :style="{ backgroundColor: $themeTokens.surface }"
-    class="header-container"
-    removeNavIcon="true"
-  >
-    <div class="inner-header">
-      <KFixedGrid numCols="2">
-        <KFixedGridItem span="1" :style="{ backgroundColor: 'purple', margin: 'auto' }">
-          <OverallStatus />
-        </KFixedGridItem>
-        <KFixedGridItem
-          span="1"
-          alignment="right"
-          :style="{ backgroundColor: 'yellow', margin: 'auto' }"
-        >
-          <Hint />
-        </KFixedGridItem>
-      </KFixedGrid>
-    </div>
+  <UiToolbar>
+    <template #icon>
+      <OverallStatus :style="{ 'margin-left': '8px' }" />
+    </template>
+
+    <template #actions>
+      <Hint :style="{ 'margin-right': '32px' }" />
+    </template>
   </UiToolbar>
 
 </template>
@@ -29,53 +15,20 @@
 
 <script>
 
+  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  import OverallStatus from './OverallStatus';
-  import Hint from './Hint';
+  // import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
+  import OverallStatus from './OverallStatus.vue';
+  import Hint from './Hint.vue';
 
   export default {
     name: 'LessonMasteryBar',
     components: {
+      UiToolbar,
       OverallStatus,
       Hint,
-      UiToolbar,
     },
-    props: {
-      appBarTitle: {
-        type: String,
-        required: true,
-      },
-    },
-    computed: {},
-    methods: {},
+    mixins: [KResponsiveWindowMixin],
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '~kolibri-design-system/lib/styles/definitions';
-
-  .header-container {
-    position: fixed;
-    right: 0;
-    left: 0;
-    z-index: 8; // material - Bottom app bar
-    height: 63px;
-    padding: 8px 16px;
-    margin: 0;
-    overflow-x: hidden;
-    font-size: 14px;
-    border: 1px red solid;
-  }
-
-  .inner-header {
-    width: 100%;
-    height: 100%;
-    padding: 0 20px;
-    margin: auto;
-    border: 1px blue solid;
-  }
-
-</style>

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -37,7 +37,6 @@
       ...mapState('topicsTree', ['content']),
       ...mapState({
         mastered: state => state.core.logging.mastery.complete,
-        // userid: state => state.core.session.user_id,
       }),
       masteryModel() {
         return this.content.masteryModel;

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -26,6 +26,7 @@
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { mapState } from 'vuex';
+  import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
@@ -33,9 +34,14 @@
     mixins: [responsiveWindowMixin, commonCoreStrings],
 
     computed: {
+      ...mapState('topicsTree', ['content']),
       ...mapState({
         mastered: state => state.core.logging.mastery.complete,
+        // userid: state => state.core.session.user_id,
       }),
+      masteryModel() {
+        return this.content.masteryModel;
+      },
       success() {
         return this.exerciseProgress === 1;
       },
@@ -45,14 +51,18 @@
         }
         return 0; //TODO: switch back to 0
       },
+      mOfNMasteryModel() {
+        return MasteryModelGenerators[this.masteryModel.type](
+          this.assessmentIds,
+          this.masteryModel
+        );
+      },
       totalCorrectRequiredM() {
-        console.log('mOfNMasteryModel', this);
+        console.log('in OverallStatus', this);
         return this.mOfNMasteryModel.m;
       },
     },
-    methods: {
-      // ...mapActions(['updateExerciseProgress']),
-    },
+
     $trs: {
       goal: {
         message: 'Get {count, number, integer} {count, plural, other {correct}}',

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -1,18 +1,21 @@
 <template>
 
-  <div class="overall-status" :style="{ color: $themeTokens.text }">
+  <div class="overall-container" :style="{ color: $themeTokens.text }">
     <KIconButton
       icon="mastered"
-      disabled="true"
+      :disabled="true"
       :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
     />
-    <div class="overall-status-text">
-      <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
-        {{ coreString('completedLabel') }}
-      </span>
+    <div class="overall-status">
       <span>
         {{ $tr('goal', { count: totalCorrectRequiredM }) }}
       </span>
+      <KIconButton
+        v-if="success"
+        icon="done"
+        :disabled="true"
+        :color="$themeTokens.mastered"
+      />
     </div>
   </div>
 
@@ -22,11 +25,34 @@
 <script>
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  // import LearningActivityIcon from './LearningActivityIcon.vue';
+  import { mapState } from 'vuex';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'OverallStatus',
-    mixins: [responsiveWindowMixin],
+    mixins: [responsiveWindowMixin, commonCoreStrings],
+
+    computed: {
+      ...mapState({
+        mastered: state => state.core.logging.mastery.complete,
+      }),
+      success() {
+        return this.exerciseProgress === 1;
+      },
+      exerciseProgress() {
+        if (this.mastered) {
+          return 1;
+        }
+        return 0; //TODO: switch back to 0
+      },
+      totalCorrectRequiredM() {
+        console.log('mOfNMasteryModel', this);
+        return this.mOfNMasteryModel.m;
+      },
+    },
+    methods: {
+      // ...mapActions(['updateExerciseProgress']),
+    },
     $trs: {
       goal: {
         message: 'Get {count, number, integer} {count, plural, other {correct}}',
@@ -43,11 +69,11 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .overall-status {
+  .overall-container {
     margin-bottom: auto;
   }
 
-  .overall-status-text {
+  .overall-status {
     display: inline-block;
     margin-left: 4px;
   }

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -1,0 +1,62 @@
+<template>
+
+  <div class="overall-status" :style="{ color: $themeTokens.text }">
+    <KIcon
+      icon="mastered"
+      :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
+    />
+    <div class="overall-status-text">
+      <span v-if="success" class="completed" :style="{ color: $themeTokens.annotation }">
+        {{ coreString('completedLabel') }}
+      </span>
+      <span>
+        {{ $tr('goal', { count: totalCorrectRequiredM }) }}
+      </span>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
+  export default {
+    name: 'OverallStatus',
+    mixins: [responsiveWindowMixin],
+    props: {},
+    data() {
+      return {};
+    },
+    computed: {},
+    watch: {},
+
+    methods: {},
+
+    $trs: {
+      goal: {
+        message: 'Get {count, number, integer} {count, plural, other {correct}}',
+        context:
+          '\nMessage that indicates to the learner how many correct answers they need to give in order to master the given topic, and for the exercise to be considered completed.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .overall-status {
+    margin-bottom: 8px;
+  }
+
+  .overall-status-text {
+    display: inline-block;
+    margin-left: 4px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -1,8 +1,9 @@
 <template>
 
   <div class="overall-status" :style="{ color: $themeTokens.text }">
-    <KIcon
+    <KIconButton
       icon="mastered"
+      disabled="true"
       :color="success ? $themeTokens.mastered : $themePalette.grey.v_200"
     />
     <div class="overall-status-text">
@@ -21,19 +22,11 @@
 <script>
 
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  // import LearningActivityIcon from './LearningActivityIcon.vue';
 
   export default {
     name: 'OverallStatus',
     mixins: [responsiveWindowMixin],
-    props: {},
-    data() {
-      return {};
-    },
-    computed: {},
-    watch: {},
-
-    methods: {},
-
     $trs: {
       goal: {
         message: 'Get {count, number, integer} {count, plural, other {correct}}',

--- a/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/OverallStatus.vue
@@ -51,7 +51,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
 
   .overall-status {
-    margin-bottom: 8px;
+    margin-bottom: auto;
   }
 
   .overall-status-text {

--- a/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
@@ -22,10 +22,6 @@ function makeWrapper({ propsData } = {}) {
         },
         template: '<div></div>',
       },
-      LessonMasteryBar: {
-        name: 'LessonMasteryBar',
-        template: '<div></div>',
-      },
       ContentPage: {
         name: 'ContentPage',
         template: '<div><slot></slot></div>',
@@ -43,11 +39,6 @@ describe('LearnImmersiveLayout', () => {
   it('shows the Learning Activity Bar', () => {
     const wrapper = makeWrapper();
     expect(wrapper.find('[data-test="learningActivityBar"]').exists()).toBeTruthy();
-  });
-
-  it('does not show the Mastery Bar by default', () => {
-    const wrapper = makeWrapper();
-    expect(wrapper.find('[data-test="lessonMasteryBar"]').exists()).toBeFalsy();
   });
 
   it('shows the Content Page', () => {

--- a/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
@@ -1,0 +1,57 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import makeStore from '../makeStore';
+import LearnImmersiveLayout from '../../src/views/LearnImmersiveLayout';
+
+const localVue = createLocalVue();
+
+const store = makeStore();
+store.state.core = {
+  blockDoubleClicks: true,
+};
+
+function makeWrapper({ propsData } = {}) {
+  return shallowMount(LearnImmersiveLayout, {
+    propsData,
+    store,
+    localVue,
+    stubs: {
+      LearningActivityBar: {
+        name: 'LearningActivityBar',
+        propsData: {
+          resourceTitle: 'Test Title',
+        },
+        template: '<div></div>',
+      },
+      LessonMasteryBar: {
+        name: 'LessonMasteryBar',
+        template: '<div></div>',
+      },
+      ContentPage: {
+        name: 'ContentPage',
+        template: '<div><slot></slot></div>',
+      },
+    },
+  });
+}
+
+describe('LearnImmersiveLayout', () => {
+  const wrapper = makeWrapper();
+  it('smoke test', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('shows the Learning Activity Bar', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-test="learningActivityBar"]').exists()).toBeTruthy();
+  });
+
+  it('does not show the Mastery Bar by default', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-test="lessonMasteryBar"]').exists()).toBeFalsy();
+  });
+
+  it('shows the Content Page', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.find('[data-test="contentPage"]').exists()).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

This PR creates a new `LearnImmersiveLayout` component that is based on CoreBase and is rendered instead of `CoreBase` for all pages that use the content renderer. This decision was made after discussion in Slack (with JB, @MisRob and @nucleogenesis) and based on the timeline for the hybrid learning work. 

The layout component is the parent for the new toolbars, the simplified content renderer layout, and the side informational panel.

## References

Fixes #8234 

### Figma references: 
<img width="414" alt="Screen Shot 2021-08-17 at 12 34 32 PM" src="https://user-images.githubusercontent.com/17235236/129765358-e796666b-828d-4b2e-8d46-80f9e3e408a0.png">

**Note:** The content renderer display was updated in the implementation following [a conversation on Slack that determined that the renderer should fill the viewport](https://learningequality.slack.com/archives/C023DNC5GCX/p1628543607006500)

### Implementation: 

**Accessing channel content**
![content-renderer-channels](https://user-images.githubusercontent.com/17235236/129765398-c13241de-a205-4c66-9ac8-08def2f7ce27.gif)

**Accessing class content**
![content-renderer-classes](https://user-images.githubusercontent.com/17235236/129765394-a15cc382-1467-4586-ad72-31fc20f382a4.gif)

**Accessing practice activity**
![content-renderer-practice](https://user-images.githubusercontent.com/17235236/129765408-cf1ad130-8bae-418b-9fbf-94c47f085e9d.gif)
…

## Reviewer guidance

### Notes:  
- Some elements of the content renderer layout still need to be adjusted according to the new designs, including the Assessment Wrapper for practice activities (spacing issues can be seen in gif), and adjustments as needed to include metadata such as the progress bar, estimated time, etc. around the content. I have considered this out-of-scope of the issue and focused just on creating the parent component, which was a blocker.
- The LearningMasteryBar (the "secondary header bar") is still a WIP, with Sairina working on a draft PR #8158. I have likewise considered me taking over and finishing that work out of scope for this issue. (I am happy to pick it up as needed as a followup, however)
- I have left some commented-out code related to progress tracking in the `ContentPage` that is not used now (and therefore was causing many, many linting errors), but can be repurposes for #8112. (Note also that there is an issue opened for #8309)

### Manual QA: 
- Access the content renderer as both a learner and a coach through channels and classes
- Both the Content Page and the Lesson Resource Viewer should have the new layout and be working correctly
- The interactions on these pages in the toolbar are not set up yet and are out of scope for this issue

#### Any potential areas of concern that need extra testing?
- The `ContentPage` component has been updated significantly. Most of this has been a _reduction_ in functionality, but I do want to be sure that nothing has been taken out that needs to remain. 
- My biggest concerns are: 1) that there are other places that the content renderer is used that also need to be updated that I somehow have just missed entirely (I almost missed updating `LESSON_RESOURCE_VIEWER` 😄)  and 2) that I have caused too much chaos in `LearnIndex.vue` by making these changes


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
