### PR TITLE
Add defensive guard for ref.

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -213,7 +213,7 @@
           if (isShown) {
             window.addEventListener('focus', this.containFocus, true);
             this.previouslyFocusedElement = document.activeElement;
-            this.$refs.sideNav.focus();
+            this.$refs.sideNav && this.$refs.sideNav.focus();
           } else {
             window.removeEventListener('focus', this.containFocus, true);
             this.previouslyFocusedElement.focus();


### PR DESCRIPTION
## Summary
* Adds a defensive guard for a ref not being defined yet.

## References
Fixes #5372


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
