### PR TITLE
Add setup cli command.

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -491,3 +491,11 @@ def _get_env_vars():
 @configure.command(help="List all available environment variables to configure Kolibri")
 def list_env():
     click.echo_via_pager(_get_env_vars())
+
+
+@configure.command(cls=KolibriDjangoCommand, help="Setup Kolibri")
+def setup():
+    """
+    Setup Kolibri.
+    """
+    logger.info("Kolibri has successfully been setup")


### PR DESCRIPTION
## Summary
* Adds `setup` command under the `configure` command group
* Allows running setup without running kolibri

## References
Fixes #5669

## Reviewer guidance
Does `kolibri configure setup` work? Is it the right command?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
