### PR TITLE
Add an upgrade function to remove the static directory to clean up unused files

### DIFF
--- a/kolibri/core/device/upgrade.py
+++ b/kolibri/core/device/upgrade.py
@@ -1,0 +1,15 @@
+"""
+A file to contain specific logic to handle version upgrades in Kolibri.
+"""
+from shutil import rmtree
+
+from django.conf import settings
+
+from kolibri.core.upgrade import version_upgrade
+
+
+# Before 0.15 we copied static files to the KOLIBRI_HOME directory.
+# After 0.15 we read them directly from their source directories.
+@version_upgrade(old_version="<0.15.0")
+def clear_static_dir():
+    rmtree(settings.STATIC_ROOT, ignore_errors=True)


### PR DESCRIPTION
## Summary
* We stopped using collectstatic in 0.15
* This upgrade function clears out the STATIC_ROOT to free up disk space

## References
Fixes #8320

## Reviewer guidance
Does upgrading from 0.14 to this branch delete static files from KOLIBRI_HOME?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
