### PR TITLE
Epub: when relocating to the last page, ensure we put the slider at 100

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -382,6 +382,7 @@
     created() {
       // Try to load the appropriate directional CSS for the particular content
       this.cssPromise = this.$options.contentModule.loadDirectionalCSS(this.contentDirection);
+      this.visitedPages = this.savedVisitedPages || {};
     },
     beforeMount() {
       global.ePub = Epub;
@@ -485,7 +486,7 @@
             // update progress using number of pages seen out of available pages
             this.$emit(
               'updateProgress',
-              Object.keys(this.visitedPages).length / this.locations.length
+              Object.keys(this.visitedPages || {}).length / this.locations.length
             );
           }
         }
@@ -704,7 +705,7 @@
         this.currentSection = this.getCurrentSection(currentLocationStart);
       },
       relocatedHandler(location) {
-        console.log(location);
+        //console.log(location);
         // Ensures that when we're on the last page, we set the slider value to 100
         // otherwise, we show the slider % using the start
         if (location.atEnd) {

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -704,10 +704,11 @@
         this.currentSection = this.getCurrentSection(currentLocationStart);
       },
       relocatedHandler(location) {
+        console.log(location);
         // Ensures that when we're on the last page, we set the slider value to 100
         // otherwise, we show the slider % using the start
-        if (location.end.percentage === 100) {
-          this.sliderValue = location.end.percentage * 100;
+        if (location.atEnd) {
+          this.sliderValue = 100;
         } else {
           this.sliderValue = location.start.percentage * 100;
         }

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -485,7 +485,7 @@
             // update progress using number of pages seen out of available pages
             this.$emit(
               'updateProgress',
-              Object.keys(this.savedVisitedPages).length / this.locations.length
+              Object.keys(this.visitedPages).length / this.locations.length
             );
           }
         }

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -704,7 +704,13 @@
         this.currentSection = this.getCurrentSection(currentLocationStart);
       },
       relocatedHandler(location) {
-        this.sliderValue = location.start.percentage * 100;
+        // Ensures that when we're on the last page, we set the slider value to 100
+        // otherwise, we show the slider % using the start
+        if (location.end.percentage === 100) {
+          this.sliderValue = location.end.percentage * 100;
+        } else {
+          this.sliderValue = location.start.percentage * 100;
+        }
         this.updateCurrentSection(location.start);
         this.currentLocation = location.start.cfi;
         this.storeVisitedPage(this.currentLocation);

--- a/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/EpubRendererIndex.spec.js
@@ -10,17 +10,17 @@ describe('updateProgress', () => {
       forceDurationBasedProgress: null,
       $emit: jest.fn(),
       durationBasedProgress: 0.1,
-      savedVisitedPages: { 1: 'true', 2: 'true', 3: 'true' },
+      visitedPages: { 1: 'true', 2: 'true', 3: 'true' },
       locations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     };
   });
 
-  it('should be able to calculate progress using "pages savedVisited/total" by default', () => {
+  it('should be able to calculate progress using "pages visitedPages/total" by default', () => {
     methods.updateProgress.call(context);
 
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toEqual(
-      Object.keys(context.savedVisitedPages).length / context.locations.length
+      Object.keys(context.visitedPages).length / context.locations.length
     );
     expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
   });
@@ -32,7 +32,7 @@ describe('updateProgress', () => {
     expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
     expect(context.$emit.mock.calls[0][1]).toBe(0.1);
     expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      Object.keys(context.savedVisitedPages).length / context.locations.length
+      Object.keys(context.visitedPages).length / context.locations.length
     );
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Previously we always used the `location.start.percentage` value in the Epub renderer to set the slider's percentage. This ensures that when we are moving to a location whose `location.end.percentage` is 100, we set the slider value to 100 (completing the resource).

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8309 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does it fix it?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
