### PR TITLE
Don't stop polling until admin actually initiates the session

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
@@ -151,10 +151,11 @@
               }).then(() => {
                 this.isPolling = false;
                 this.lodService.send('CONTINUE');
+                SetupSoUDTasksResource.cleartasks();
               });
-              SetupSoUDTasksResource.cleartasks();
             }
-          } else this.isPolling = false;
+          }
+          if (tasks.length == 0) this.isPolling = false;
         });
         if (this.isPolling) {
           setTimeout(() => {


### PR DESCRIPTION
## Summary
When syncing users in the setup wizard using admin credentials, polling was being stopped before the admin account could sign in to begin to work, so import was not possible.
This PR ensures polling does not stop until the admin has started his/her session.

## References
Closes: #8326 

## Reviewer guidance
Try to setup a new device using admin credentials to sync with a server that has some latency.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
