### PR TITLE
Fix syncing when password-less flow is enabled

### DIFF
--- a/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
+++ b/kolibri/plugins/device/assets/src/views/syncTaskUtils.js
@@ -93,7 +93,9 @@ export function syncFacilityTaskDisplayInfo(task) {
       description: statusDescription,
     });
   } else {
-    statusMsg = statusDescription;
+    if (task.type === TaskTypes.SYNCLOD && task.status === TaskStatuses.FAILED)
+      statusMsg = `${statusDescription}: ${task.exception}`;
+    else statusMsg = statusDescription;
   }
 
   if (task.status === TaskStatuses.COMPLETED) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -151,20 +151,23 @@
       },
       handleSubmit() {
         const task_name = 'kolibri.plugins.setup_wizard.tasks.startprovisionsoud';
+        const password = this.password === '' ? 'NOT_SPECIFIED' : this.password;
         const params = {
           baseurl: this.device.baseurl,
           username: this.username,
-          password: this.password,
+          password: password,
           facility_id: this.facility.id,
           device_name: this.device.name,
         };
         SetupSoUDTasksResource.createTask(task_name, params)
           .then(task => {
+            task['device_id'] = this.device.id;
+            task['facility_name'] = this.facility.name;
             this.lodService.send({
               type: 'CONTINUE',
               value: {
                 username: this.username,
-                password: this.password,
+                password: password,
                 full_name: task.full_name,
                 task: task,
               },

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -84,7 +84,7 @@
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
+  import { DemographicConstants, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
   import { FacilityImportResource, SetupSoUDTasksResource } from '../../api';
@@ -151,7 +151,7 @@
       },
       handleSubmit() {
         const task_name = 'kolibri.plugins.setup_wizard.tasks.startprovisionsoud';
-        const password = this.password === '' ? 'NOT_SPECIFIED' : this.password;
+        const password = this.password === '' ? DemographicConstants.NOT_SPECIFIED : this.password;
         const params = {
           baseurl: this.device.baseurl,
           username: this.username,

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -148,7 +148,7 @@
         this.isPolling = false;
         this.clearTasks();
         // after importing the first user, let's sign him in to continue:
-        if (this.state.value.users.length === 1) {
+        if (this.state.value.users.length === 1 && this.user.password) {
           SessionResource.saveModel({
             data: {
               username: this.user.username,

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -61,7 +61,7 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
   import WelcomeModal from '../../../../../device/assets/src/views/WelcomeModal.vue';
-  import { TaskStatuses, TaskTypes } from '../../../../../device/assets/src/constants.js';
+  import { TaskStatuses } from '../../../../../device/assets/src/constants.js';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
   import { SetupSoUDTasksResource } from '../../api';
 
@@ -77,7 +77,7 @@
     mixins: [commonCoreStrings, commonSyncElements],
     data() {
       return {
-        loadingTask: {},
+        loadingTask: this.state.value.task,
         isPolling: false,
         welcomeModal: false,
         user: null,
@@ -86,8 +86,11 @@
     inject: ['lodService', 'state'],
     computed: {
       usersDevice() {
-        const users = this.state.value.users.filter(user => user.task === null);
+        const users = this.state.value.users.filter(u => u.task === null);
         return users;
+      },
+      loadingTaskID() {
+        return this.state.value.task.id;
       },
       facility() {
         return this.state.value.facility;
@@ -98,22 +101,25 @@
       this.pollTask();
     },
     methods: {
-      fullName(task_id) {
-        const user = this.state.value.users.filter(u => u.task == task_id)[0];
-        this.user = user;
-        return user.full_name;
+      userForTask() {
+        return this.state.value.users.filter(u => u.task == this.loadingTaskID)[0];
       },
       pollTask() {
         SetupSoUDTasksResource.fetchCollection({ force: true }).then(tasks => {
-          const soudTasks = tasks.filter(t => t.type === TaskTypes.SYNCLOD);
+          const soudTasks = tasks.filter(t => t.id == this.loadingTaskID);
           if (soudTasks.length > 0) {
+            if (this.user === null) this.user = this.userForTask();
             this.loadingTask = {
               ...soudTasks[0],
-              facility_name: this.facility.name,
-              full_name: this.fullName(soudTasks[0].id),
-              device_id: this.state.value.device.id,
+              facility_name: this.loadingTask.facility_name,
+              full_name: this.loadingTask.full_name,
+              device_id: this.loadingTask.device_id,
             };
             if (this.loadingTask.status === TaskStatuses.COMPLETED) this.finishedTask();
+            if (this.loadingTask.status === TaskStatuses.FAILED) {
+              this.state.value.users.pop();
+              this.isPolling = false;
+            }
           } else this.isPolling = false;
         });
         if (this.isPolling) {
@@ -142,7 +148,7 @@
         this.isPolling = false;
         this.clearTasks();
         // after importing the first user, let's sign him in to continue:
-        if (this.state.value.users.length === 1 && this.user.password) {
+        if (this.state.value.users.length === 1) {
           SessionResource.saveModel({
             data: {
               username: this.user.username,

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
@@ -114,6 +114,8 @@
         };
         SetupSoUDTasksResource.createTask(task_name, params)
           .then(task => {
+            task['device_id'] = this.device.id;
+            task['facility_name'] = this.facility.name;
             this.lodService.send({
               type: 'CONTINUE',
               value: {


### PR DESCRIPTION
## Summary
This PR fixes several issues found when testing a scenario where users can sync and login without passwords, according to the server settings:
1. NOT_SPECIFIED is correctly sent when there's no password
2. Provides to the user more details with the error excepcion in case the syncing task fails
3. Failed sync users are removed from the list of synced users

It also improves the handling of the syncing task , avoiding possible conflicts if more than a browser is connected.

## References
Closes: #8325 

## Reviewer guidance
Try to provision one device syncing normal users from a server that allow users to login without password.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
