### PR TITLE
Server sync queue

### DIFF
--- a/kolibri/core/device/test/test_syncqueue.py
+++ b/kolibri/core/device/test/test_syncqueue.py
@@ -4,17 +4,11 @@ from uuid import uuid4
 
 import mock
 import pytest
-from django.core.urlresolvers import reverse
 from django.test import TestCase
-from rest_framework import status
-from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import SyncQueue
-from kolibri.core.public.api import HANDSHAKING_TIME
-from kolibri.core.public.api import MAX_CONCURRENT_SYNCS
-from kolibri.core.public.api import position_in_queue
 from kolibri.core.public.constants.user_sync_statuses import QUEUED
 from kolibri.core.public.constants.user_sync_statuses import SYNC
 from kolibri.core.public.utils import begin_request_soud_sync
@@ -56,138 +50,6 @@ class SyncQueueTestBase(TestCase):
         assert SyncQueue.objects.count() == 5
         SyncQueue.clean_stale()  # default expiry time = 180 seconds
         assert SyncQueue.objects.count() == 3
-
-
-class SyncQueueViewSetAPITestCase(APITestCase):
-    def setUp(self):
-        self.default_facility = Facility.objects.create(name="Test")
-        Facility.objects.create(name="Test2")
-        self.test_user = FacilityUser.objects.create(
-            username="test", facility=self.default_facility
-        )
-
-    def test_list(self):
-        response = self.client.get(
-            reverse("kolibri:core:syncqueue-list"), format="json"
-        )
-        assert len(response.data) == Facility.objects.count()
-        assert response.status_code == status.HTTP_200_OK
-
-    def test_list_queue_length(self):
-        queue_length = 3
-        for i in range(queue_length):
-            SyncQueue.objects.create(
-                user=FacilityUser.objects.create(
-                    username="test{}".format(i), facility=self.default_facility
-                )
-            )
-        response = self.client.get(
-            reverse("kolibri:core:syncqueue-list"), format="json"
-        )
-        assert response.data[self.default_facility.id] == queue_length
-
-    @mock.patch(
-        "kolibri.core.public.api.get_device_setting",
-        return_value=True,
-    )
-    def test_soud(self, mock_device_setting):
-        response = self.client.post(
-            reverse("kolibri:core:syncqueue-list"), {"user": uuid4()}, format="json"
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "I'm a Subset of users device" in response.data
-
-    def test_user_needed(self):
-        response = self.client.post(reverse("kolibri:core:syncqueue-list"))
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-    def test_existing_user(self):
-        response = self.client.post(
-            reverse("kolibri:core:syncqueue-list"),
-            {"user": uuid4()},
-            format="json",
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_allow_sync(self):
-        response = self.client.post(
-            reverse("kolibri:core:syncqueue-list"),
-            {
-                "user": self.test_user.id,
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["action"] == SYNC
-
-    @mock.patch("kolibri.core.public.api.TransferSession.objects.filter")
-    def test_enqueued(self, _filter):
-        _filter().count.return_value = MAX_CONCURRENT_SYNCS + 1
-        response = self.client.post(
-            reverse("kolibri:core:syncqueue-list"),
-            {"user": self.test_user.id},
-            format="json",
-        )
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["action"] == QUEUED
-        assert "id" in response.data
-        assert response.data["keep_alive"] == MAX_CONCURRENT_SYNCS * HANDSHAKING_TIME
-
-    def test_update(self):
-        response = self.client.put(
-            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": uuid4()})
-        )
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["action"] == SYNC
-
-    @mock.patch("kolibri.core.public.api.TransferSession.objects.filter")
-    def test_not_in_queue(self, _filter):
-        _filter().count.return_value = MAX_CONCURRENT_SYNCS + 1
-        response = self.client.put(
-            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": uuid4()})
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert "Missing element" in response.data
-
-    @mock.patch("kolibri.core.public.api.TransferSession.objects.filter")
-    def test_updated_enqueued(self, _filter):
-        _filter().count.return_value = MAX_CONCURRENT_SYNCS + 1
-        element = SyncQueue.objects.create(user=self.test_user)
-        previous_time = element.updated
-        response = self.client.put(
-            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": element.id})
-        )
-        element = SyncQueue.objects.get(id=element.id)
-        assert element.updated >= previous_time
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["action"] == QUEUED
-        assert response.data["id"] == element.id
-        assert (
-            response.data["keep_alive"] == MAX_CONCURRENT_SYNCS * HANDSHAKING_TIME
-        )  # first in queue, position does not change
-
-    @mock.patch("kolibri.core.public.api.TransferSession.objects.filter")
-    def test_position_in_queue(self, _filter):
-        _filter().count.return_value = MAX_CONCURRENT_SYNCS + 1
-        for n in range(10):
-            user = FacilityUser.objects.create(
-                username="test{}".format(n), facility=self.default_facility
-            )
-            element = SyncQueue.objects.create(user=user)
-            if n == 5:
-                pk = element.id
-        response = self.client.put(
-            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": pk})
-        )
-        assert position_in_queue(pk) == 5
-        assert response.data["keep_alive"] == HANDSHAKING_TIME * 6
-        SyncQueue.objects.all().order_by("datetime").first().delete()
-        SyncQueue.objects.all().order_by("datetime").first().delete()
-        assert position_in_queue(pk) == 3
-        response = self.client.put(
-            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": pk})
-        )
-        assert response.data["keep_alive"] == HANDSHAKING_TIME * 4
 
 
 @pytest.mark.django_db

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -251,11 +251,13 @@ class SyncQueueViewSet(viewsets.ViewSet):
         else:
             # polling time at least HANDSHAKING_TIME seconds per position in the queue to
             # be greater than the time needed for the handshake part of the ssl protocol
+            # we add one to the zero based position, as if the position is zero and it
+            # got to here, it means the sync queue is currently full, so we need to wait
             # we make sure that it is never less than half of the stale queue time, to
             # prevent a malignant loop whereby very long queues cause clients to lose
             # their place in the queue by only polling again after their queue has
             # already expired!
-            polling = min(HANDSHAKING_TIME * pos, STALE_QUEUE_TIME / 2)
+            polling = min(HANDSHAKING_TIME * (pos + 1), STALE_QUEUE_TIME / 2)
             data = {
                 "action": QUEUED,
                 "keep_alive": polling,

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -215,7 +215,7 @@ class SyncQueueViewSet(viewsets.ViewSet):
         # Make sure it is no longer than half the time by which we measure 'recently synced'
         # to make sure we are never letting syncing drift too far.
         sync_interval = min(
-            OPTIONS["Deployment"]["SYNC_INTERVAL"] * total_queue_size, DELAYED_SYNC / 2
+            OPTIONS["Deployment"]["SYNC_INTERVAL"] * (total_queue_size + 1), DELAYED_SYNC / 2
         )
         last_activity = timezone.now() - datetime.timedelta(minutes=5)
         queue_object = SyncQueue.objects.filter(id=pk).first()

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -215,7 +215,8 @@ class SyncQueueViewSet(viewsets.ViewSet):
         # Make sure it is no longer than half the time by which we measure 'recently synced'
         # to make sure we are never letting syncing drift too far.
         sync_interval = min(
-            OPTIONS["Deployment"]["SYNC_INTERVAL"] * (total_queue_size + 1), DELAYED_SYNC / 2
+            OPTIONS["Deployment"]["SYNC_INTERVAL"] * (total_queue_size + 1),
+            DELAYED_SYNC / 2,
         )
         last_activity = timezone.now() - datetime.timedelta(minutes=5)
         queue_object = SyncQueue.objects.filter(id=pk).first()

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -11,6 +11,7 @@ from django.http import HttpResponseNotFound
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.gzip import gzip_page
+from morango.constants import transfer_statuses
 from morango.models.core import TransferSession
 from rest_framework import status
 from rest_framework import viewsets
@@ -32,8 +33,10 @@ from kolibri.core.content.utils.file_availability import generate_checksum_integ
 from kolibri.core.device.models import SyncQueue
 from kolibri.core.device.models import UserSyncStatus
 from kolibri.core.device.utils import allow_peer_unlisted_channel_import
+from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
 from kolibri.core.public.constants.user_sync_options import HANDSHAKING_TIME
 from kolibri.core.public.constants.user_sync_options import MAX_CONCURRENT_SYNCS
+from kolibri.core.public.constants.user_sync_options import STALE_QUEUE_TIME
 from kolibri.utils.conf import OPTIONS
 
 
@@ -166,20 +169,17 @@ def get_public_file_checksums(request, version):
     )
 
 
-def position_in_queue(id):
-    try:
-        client_time = SyncQueue.objects.get(pk=id)
-        before_client = SyncQueue.objects.filter(datetime__lt=client_time.datetime)
-        pos = before_client.count()
-    except SyncQueue.DoesNotExist:
-        pos = 0  # in case the queue is empty
-    return pos
-
-
 class SyncQueueViewSet(viewsets.ViewSet):
     def list(self, request):
         """Returns length of the queue for each of the available facilities"""
-        SyncQueue.clean_stale()  # first, ensure not expired devices are in the queue
+        is_SoUD = get_device_setting("subset_of_users_device", False)
+        if is_SoUD:
+            content = {"I'm a Subset of users device": "Nothing to do here"}
+            # would love to use HTTP 418, but it's not fully usable in browsers
+            return Response(content, status=status.HTTP_400_BAD_REQUEST)
+        SyncQueue.clean_stale(
+            expire=STALE_QUEUE_TIME
+        )  # first, ensure not expired devices are in the queue
         facilities = Facility.objects.all()
         queue = {}
         for facility in facilities:
@@ -188,86 +188,99 @@ class SyncQueueViewSet(viewsets.ViewSet):
             ).count()
         return Response(queue)
 
-    def check_queue(self, pk=None):
-        sync_interval = OPTIONS["Deployment"]["SYNC_INTERVAL"]
-        last_activity = timezone.now() - datetime.timedelta(minutes=5)
-        current_transfers = TransferSession.objects.filter(
-            active=True, last_activity_timestamp__gte=last_activity
-        ).count()
-        if current_transfers < MAX_CONCURRENT_SYNCS:
-            allow_sync = True
-            data = {"action": SYNC, "sync_interval": sync_interval}
-        else:
-            # polling time at least HANDSHAKING_TIME seconds per position in the queue to
-            # be greater than the time needed for the handshake part of the ssl protocol
-            if pk is not None:
-                # if updating the element let's assign
-                # its time depending on its position in the queue
-                polling = HANDSHAKING_TIME * (
-                    MAX_CONCURRENT_SYNCS + position_in_queue(pk)
-                )
-            else:
-                polling = HANDSHAKING_TIME * (
-                    MAX_CONCURRENT_SYNCS + SyncQueue.objects.all().count()
-                )
-            data = {
-                "action": QUEUED,
-                "keep_alive": polling,
-            }
-            allow_sync = False
-        return (allow_sync, data)
-
-    def create(self, request):
-        SyncQueue.clean_stale()  # first, ensure not expired devices are in the queue
+    def check_queue(self, request, pk=None):
         is_SoUD = get_device_setting("subset_of_users_device", False)
         if is_SoUD:
-            content = {"I'm a Subset of users device": "Nothing to do here"}
+            content = "I'm a Subset of users device. Nothing to do here"
             # would love to use HTTP 418, but it's not fully usable in browsers
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
         user = request.data.get("user") or request.query_params.get("user")
         if user is None:
-            content = {"Missing parameter": "User is required"}
-            return Response(content, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+            content = "Missing parameter: user is required"
+            return Response(content, status=status.HTTP_412_PRECONDITION_FAILED)
 
         if not FacilityUser.objects.filter(id=user).exists():
-            content = {"This user is not registered in any of this server facilities"}
+            content = "This user is not registered in any of this server facilities"
             return Response(content, status=status.HTTP_404_NOT_FOUND)
 
-        allow_sync, data = self.check_queue()
-        if not allow_sync:
-            element, _ = SyncQueue.objects.get_or_create(
-                user_id=user,
-                keep_alive=data["keep_alive"],
-            )
-            data["id"] = element.id
+        # first, ensure no expired devices are in the queue
+        SyncQueue.clean_stale(expire=STALE_QUEUE_TIME)
 
-        UserSyncStatus.objects.update_or_create(
-            user_id=user, defaults={"queued": not allow_sync}
+        # Calculate the total size of the queue to scale things
+        total_queue_size = SyncQueue.objects.count()
+
+        # Scale the sync_interval we send to clients based on the total number of
+        # queued single user sync requests.
+        # Make sure it is no longer than half the time by which we measure 'recently synced'
+        # to make sure we are never letting syncing drift too far.
+        sync_interval = min(
+            OPTIONS["Deployment"]["SYNC_INTERVAL"] * total_queue_size, DELAYED_SYNC / 2
         )
+        last_activity = timezone.now() - datetime.timedelta(minutes=5)
+        queue_object = SyncQueue.objects.filter(id=pk).first()
 
+        # Default the position to the total queue size, so that
+        # if the id does not exist, send them to the back of the queue
+        pos = total_queue_size
+        if queue_object is not None:
+            if queue_object.user_id != user:
+                return Response(
+                    "Queue did not match user in request",
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            # To work out the position in the queue, find all queued sync requests
+            # that were made before this request. If pk is None or the queue
+            # has expired (3 minutes), we will set the position to the length of the
+            # queue.
+            queue_object = SyncQueue.objects.get(pk=pk)
+            before_client = SyncQueue.objects.filter(datetime__lt=queue_object.datetime)
+            pos = before_client.count()
+
+        current_transfers = (
+            TransferSession.objects.filter(
+                active=True, last_activity_timestamp__gte=last_activity
+            )
+            .exclude(transfer_stage_status=transfer_statuses.ERRORED)
+            .count()
+        )
+        if MAX_CONCURRENT_SYNCS - current_transfers > pos:
+            data = {"action": SYNC, "sync_interval": sync_interval}
+            if queue_object is not None:
+                queue_object.delete()
+        else:
+            # polling time at least HANDSHAKING_TIME seconds per position in the queue to
+            # be greater than the time needed for the handshake part of the ssl protocol
+            # we make sure that it is never less than half of the stale queue time, to
+            # prevent a malignant loop whereby very long queues cause clients to lose
+            # their place in the queue by only polling again after their queue has
+            # already expired!
+            polling = min(HANDSHAKING_TIME * pos, STALE_QUEUE_TIME / 2)
+            data = {
+                "action": QUEUED,
+                "keep_alive": polling,
+            }
+            if queue_object is not None:
+                # If the queue object exists, update it here.
+                queue_object.updated = time.time()
+                queue_object.keep_alive = polling
+                queue_object.save()
+            else:
+                # If no queue object, either because there was no pk
+                # or the pk was stale, generate a new object here.
+                queue_object = SyncQueue.objects.create(
+                    user_id=user,
+                    keep_alive=polling,
+                )
+
+            data["id"] = queue_object.id
+        UserSyncStatus.objects.update_or_create(
+            user_id=user, defaults={"queued": data["action"] == QUEUED}
+        )
         return Response(data)
+
+    def create(self, request):
+        return self.check_queue(request)
 
     def update(self, request, pk=None):
-        SyncQueue.clean_stale()  # first, ensure not expired devices are in the queue
-        allow_sync, data = self.check_queue(pk)
-
-        element = SyncQueue.objects.filter(id=pk).first()
-        if not allow_sync:
-            if not element:
-                # this device has been deleted from the queue, likely due to keep alive expiration
-                content = {
-                    "Missing element": "This device is not registered in any of this server facilities"
-                }
-                return Response(content, status=status.HTTP_404_NOT_FOUND)
-            element.keep_alive = data["keep_alive"]
-            element.updated = time.time()
-            element.save()
-            data["id"] = element.id
-        else:
-            SyncQueue.objects.filter(id=pk).delete()
-        if element is not None:
-            UserSyncStatus.objects.update_or_create(
-                user=element.user, defaults={"queued": not allow_sync}
-            )
-        return Response(data)
+        return self.check_queue(request, pk=pk)

--- a/kolibri/core/public/constants/user_sync_options.py
+++ b/kolibri/core/public/constants/user_sync_options.py
@@ -3,8 +3,11 @@ This module contains constants representing options for SoUD sync
 """
 from __future__ import unicode_literals
 
-SYNC_INTERVAL = 5  # client: recommended seconds between sync intervals
 DELAYED_SYNC = 900  # client: seconds to mark sync as not recent
 
 MAX_CONCURRENT_SYNCS = 1  # Server: max number of concurrent syncs allowed
 HANDSHAKING_TIME = 5  # Server: minimum time (seconds) considered as the ttl for the next sync request from an enqueued client
+
+STALE_QUEUE_TIME = (
+    180  # Server: time (seconds) after which a sync queue entry is considered stale
+)

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -444,6 +444,7 @@ class SyncQueueViewSetTestCase(APITestCase):
                 user_id=learner.id,
                 keep_alive=10,
             )
+        time.sleep(1)
         response = self.client.post(
             reverse("kolibri:core:syncqueue-list"),
             data={"user": self.learner.id},
@@ -515,6 +516,7 @@ class SyncQueueViewSetTestCase(APITestCase):
                 keep_alive=10,
                 updated=time.time() - STALE_QUEUE_TIME * 2,
             )
+        time.sleep(1)
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
         response = self.client.put(
             reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
@@ -539,6 +541,7 @@ class SyncQueueViewSetTestCase(APITestCase):
                 user_id=learner.id,
                 keep_alive=10,
             )
+        time.sleep(1)
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
         old_updated = queue.updated
         response = self.client.put(
@@ -563,6 +566,7 @@ class SyncQueueViewSetTestCase(APITestCase):
             updated=time.time() - STALE_QUEUE_TIME * 2,
             keep_alive=10,
         )
+        time.sleep(1)
         for i in range(0, MAX_CONCURRENT_SYNCS):
             learner = FacilityUser.objects.create(
                 username="test{}".format(i),
@@ -614,6 +618,7 @@ class SyncQueueViewSetTestCase(APITestCase):
                 user_id=learner.id,
                 keep_alive=10,
             )
+        time.sleep(1)
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
         response = self.client.put(
             reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
@@ -635,6 +640,7 @@ class SyncQueueViewSetTestCase(APITestCase):
                 user_id=learner.id,
                 keep_alive=10,
             )
+        time.sleep(1)
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
         response = self.client.put(
             reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
@@ -647,6 +653,7 @@ class SyncQueueViewSetTestCase(APITestCase):
 
     def test_update_first_full_queue_should_scale_interval(self):
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        time.sleep(1)
         for i in range(0, 5):
             learner = FacilityUser.objects.create(
                 username="test{}".format(i),
@@ -670,6 +677,7 @@ class SyncQueueViewSetTestCase(APITestCase):
 
     def test_update_first_full_queue_should_max_interval(self):
         queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        time.sleep(1)
         for i in range(0, 100):
             learner = FacilityUser.objects.create(
                 username="test{}".format(i),

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -1,15 +1,20 @@
 import platform
+import time
 import uuid
 
 import factory
 from django.core.urlresolvers import reverse
 from le_utils.constants import content_kinds
 from morango.models import InstanceIDModel
+from rest_framework.test import APITestCase
 from rest_framework.test import APITransactionTestCase
 from six import iteritems
 
 import kolibri
+from kolibri.core.auth.models import Facility
+from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.auth.test.helpers import setup_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
@@ -18,7 +23,16 @@ from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import set_channel_metadata_fields
 from kolibri.core.content.utils.paths import get_channel_lookup_url
 from kolibri.core.device.models import DeviceSettings
+from kolibri.core.device.models import SyncQueue
+from kolibri.core.device.models import UserSyncStatus
 from kolibri.core.device.utils import set_device_settings
+from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
+from kolibri.core.public.constants.user_sync_options import HANDSHAKING_TIME
+from kolibri.core.public.constants.user_sync_options import MAX_CONCURRENT_SYNCS
+from kolibri.core.public.constants.user_sync_options import STALE_QUEUE_TIME
+from kolibri.core.public.constants.user_sync_statuses import QUEUED
+from kolibri.core.public.constants.user_sync_statuses import SYNC
+from kolibri.utils.conf import OPTIONS
 
 
 class ContentNodeFactory(factory.DjangoModelFactory):
@@ -258,3 +272,340 @@ class PublicAPITestCase(APITransactionTestCase):
         response = self.client.get(get_channel_lookup_url(baseurl="/"))
         data = response.json()
         self.assertEqual(len(data), 2)
+
+
+class SyncQueueViewSetTestCase(APITestCase):
+    """
+    IMPORTANT: These tests are to never be changed. They are enforcing a
+    public API contract. If the tests fail, then the implementation needs
+    to be changed, and not the tests themselves.
+    """
+
+    def setUp(self):
+        provision_device()
+        setup_device()
+        self.facility = Facility.get_default_facility()
+        self.learner = FacilityUser.objects.create(
+            username="test",
+            password="***",
+            facility=self.facility,
+        )
+
+    def test_create_soud(self):
+        settings = DeviceSettings.objects.get()
+        settings.subset_of_users_device = True
+        settings.save()
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_user_required(self):
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 412)
+
+    def test_create_user_not_exist(self):
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            data={"user": uuid.uuid4()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_empty_queue_should_sync(self):
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], SYNC)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=False).exists()
+        )
+
+    def test_create_stale_queue_should_sync(self):
+        for i in range(0, 10):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+                updated=time.time() - STALE_QUEUE_TIME * 2,
+            )
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], SYNC)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=False).exists()
+        )
+
+    def test_create_full_queue_should_queue(self):
+        for i in range(0, MAX_CONCURRENT_SYNCS):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        response = self.client.post(
+            reverse("kolibri:core:syncqueue-list"),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], QUEUED)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=True).exists()
+        )
+        queue_id = data["id"]
+        self.assertTrue(
+            SyncQueue.objects.filter(id=queue_id, user_id=self.learner.id).exists()
+        )
+
+    def test_update_soud(self):
+        settings = DeviceSettings.objects.get()
+        settings.subset_of_users_device = True
+        settings.save()
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_user_required(self):
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            format="json",
+        )
+        self.assertEqual(response.status_code, 412)
+
+    def test_update_user_not_exist(self):
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": uuid.uuid4()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_empty_queue_should_sync(self):
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], SYNC)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=False).exists()
+        )
+
+    def test_update_stale_queue_should_sync(self):
+        for i in range(0, 10):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+                updated=time.time() - STALE_QUEUE_TIME * 2,
+            )
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], SYNC)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=False).exists()
+        )
+
+    def test_update_full_queue_should_queue(self):
+        for i in range(0, MAX_CONCURRENT_SYNCS):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        old_updated = queue.updated
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], QUEUED)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=True).exists()
+        )
+        queue_id = data["id"]
+        queue = SyncQueue.objects.filter(id=queue_id, user_id=self.learner.id).first()
+        self.assertIsNotNone(queue)
+        self.assertGreater(queue.updated, old_updated)
+
+    def test_update_stale_queue_item_should_queue(self):
+        queue = SyncQueue.objects.create(
+            user_id=self.learner.id,
+            updated=time.time() - STALE_QUEUE_TIME * 2,
+            keep_alive=10,
+        )
+        for i in range(0, MAX_CONCURRENT_SYNCS):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["action"], QUEUED)
+        self.assertTrue(
+            UserSyncStatus.objects.filter(user=self.learner, queued=True).exists()
+        )
+        queue_id = data["id"]
+        self.assertTrue(
+            SyncQueue.objects.filter(id=queue_id, user_id=self.learner.id).exists()
+        )
+
+    def test_update_wrong_user_reject(self):
+        wrong_learner = FacilityUser.objects.create(
+            username="test_wrong",
+            password="***",
+            facility=self.facility,
+        )
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": wrong_learner.id},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_full_queue_should_scale_keep_alive(self):
+        for i in range(0, 5):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["keep_alive"], 5 * HANDSHAKING_TIME)
+
+    def test_update_full_queue_should_max_keep_alive(self):
+        for i in range(0, 20):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["keep_alive"], STALE_QUEUE_TIME / 2)
+
+    def test_update_first_full_queue_should_scale_interval(self):
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        for i in range(0, 5):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            data["sync_interval"], OPTIONS["Deployment"]["SYNC_INTERVAL"] * 6
+        )
+
+    def test_update_first_full_queue_should_max_interval(self):
+        queue = SyncQueue.objects.create(user_id=self.learner.id, keep_alive=10)
+        for i in range(0, 100):
+            learner = FacilityUser.objects.create(
+                username="test{}".format(i),
+                password="***",
+                facility=self.facility,
+            )
+            SyncQueue.objects.create(
+                user_id=learner.id,
+                keep_alive=10,
+            )
+        response = self.client.put(
+            reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
+            data={"user": self.learner.id},
+            format="json",
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["sync_interval"], DELAYED_SYNC / 2)

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -672,7 +672,7 @@ class SyncQueueViewSetTestCase(APITestCase):
         data = response.json()
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            data["sync_interval"], OPTIONS["Deployment"]["SYNC_INTERVAL"] * 6
+            data["sync_interval"], OPTIONS["Deployment"]["SYNC_INTERVAL"] * 7
         )
 
     def test_update_first_full_queue_should_max_interval(self):


### PR DESCRIPTION
## Summary
* Adds test to the sync queue endpoint to guarantee behaviour
* Consolidates logic so that behaviour is unified between the 'create' and 'update' flows
* Scales the `keep_alive` and `sync_interval` values based on how busy the server is, but with maximum values so that there is no runaway interval
* Ensures that the next person to queue is the one that is first in the queue, not just the first person to ask after the last sync finished
* Requires the user parameter to be added on both create and update, and confirms that the user in question is the user in the queue
* Adds more verbose logging to client side utilities
* Updates client side utilities to match new API endpoint signatures
* Ignores errored transfersessions when working out how many active syncs there are!

## Reviewer guidance
A bit hard to test without a few instances running with this code, but I think this makes the queue work as expected. The only slight issue might be that it will slow syncing down slightly because of the stricter enforcement of the queue order, but I don't think it will make it any slower than one person hogging the queue!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
