### PR TITLE
CLI Fixes

### DIFF
--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -335,7 +335,7 @@ def services(port, background):
 
     logger.info("Starting Kolibri background services")
 
-    server.start(port=port, zip_port=None, serve_http=False, background=background)
+    server.start(port=port, zip_port=0, serve_http=False, background=background)
 
 
 @main.command(cls=KolibriCommand, help="Restart the Kolibri process")

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -16,7 +16,7 @@ import kolibri
 try:
     from kolibri.plugins import config
 except RuntimeError as e:
-    logging.error(str(e))
+    logging.error("Loading plugin configuration failed with error '{}'".format(e))
     sys.exit(1)
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins.utils import disable_plugin

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -12,7 +12,12 @@ import click
 from django.core.management import execute_from_command_line
 
 import kolibri
-from kolibri.plugins import config
+
+try:
+    from kolibri.plugins import config
+except RuntimeError as e:
+    logging.error(str(e))
+    sys.exit(1)
 from kolibri.plugins import DEFAULT_PLUGINS
 from kolibri.plugins.utils import disable_plugin
 from kolibri.plugins.utils import enable_plugin


### PR DESCRIPTION
## Summary
* Fixes the service cli command to not always error
* Catches runtime errors when doing an import that imports KOLIBRI_HOME, and formats them for the user, rather than showing a traceback

## References
Fixes #8332
Fixes #8330

## Reviewer guidance
If you run `kolibri services` does it run?
If you run `kolibri --version` with a KOLIBRI_HOME whose parent directory does not exist, does it show a formatted error and quit?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
