### PR TITLE
Pin mac installer version to 0.15 compatible.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
     label: ":mac:"
     build:
       message: "${BUILDKITE_MESSAGE}"
+      branch: "v0.2.0"
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"


### PR DESCRIPTION
## Summary
* Pins mac installer to new version that invokes CLI start properly for 0.15

## References
https://github.com/learningequality/kolibri-app/compare/v0.1.4...v0.2.0

