### PR TITLE
Clear process control flag at startup, make process killing more lenient

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -484,6 +484,12 @@ def stop():
     with open(PROCESS_CONTROL_FLAG, "w") as f:
         f.write(STOP)
     wait_for_status(STATUS_STOPPED, timeout=10)
+    starttime = time.time()
+    while time.time() - starttime <= 10:
+        if pid_exists(pid):
+            time.sleep(0.1)
+        else:
+            break
     if pid_exists(pid):
         logger.debug("Process wth pid %s still exists; attempting a SIGKILL." % pid)
         try:
@@ -492,12 +498,6 @@ def stop():
             logger.debug(
                 "Received an error while trying to kill the Kolibri process: %s" % e
             )
-    starttime = time.time()
-    while time.time() - starttime <= 10:
-        if pid_exists(pid):
-            time.sleep(0.1)
-        else:
-            break
     if pid_exists(pid):
         logging.error("Kolibri process has failed to shutdown")
         return STATUS_UNCLEAN_SHUTDOWN

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -424,13 +424,17 @@ class SignalHandler(BaseSignalHandler):
 
 class ProcessControlPlugin(Monitor):
     def __init__(self, bus):
+        try:
+            os.remove(PROCESS_CONTROL_FLAG)
+        except (IOError, OSError):
+            pass
         self.mtime = self.get_mtime()
         Monitor.__init__(self, bus, self.run, 1)
 
     def get_mtime(self):
         try:
             return os.stat(PROCESS_CONTROL_FLAG).st_mtime
-        except OSError:
+        except (IOError, OSError):
             return 0
 
     def run(self):


### PR DESCRIPTION
## Summary
* Clears process control flag when system initializes to prevent left over commands being enacted
* Gives process a chance to terminate before killing

## References
Fixes #8338

## Reviewer guidance
Do the Windows and Debian installers start as expected?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
