### PR TITLE
Setup wizard redirect fix

### DIFF
--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -89,7 +89,11 @@ class ProvisioningErrorHandler(object):
         self.get_response = get_response
 
     def process_exception(self, request, exception):
-        if isinstance(exception, DeviceNotProvisioned) and SetupHook.provision_url():
+        if (
+            isinstance(exception, DeviceNotProvisioned)
+            and SetupHook.provision_url()
+            and not request.path.startswith(SetupHook.provision_url())
+        ):
             return redirect(SetupHook.provision_url())
         return None
 

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -128,7 +128,9 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
             "languageGlobals": self.language_globals(),
             "oidcProviderEnabled": OIDCProviderHook.is_enabled(),
             "kolibriTheme": ThemeHook.get_theme(),
-            "isSubsetOfUsersDevice": get_device_setting("subset_of_users_device"),
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
         }
 
     def language_globals(self):


### PR DESCRIPTION
## Summary
* If a device provisioned error was thrown during rendering of the setup wizard page it would result in an infinite redirect
* Fixes the redirect to not redirect if we are already on the URL for the provisioning page
* Fixes the issue that was causing the DeviceProvisioned error to be thrown during rendering of the setup wizard page

## References
Fixes #8338
Fixes #8271

## Reviewer guidance
Can you get to the setup wizard?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
