### PR TITLE
Validate sync credentials before task enqueue

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1012,12 +1012,11 @@ class FacilityTasksViewSet(BaseViewSet):
         """
 
         baseurl, facility_id, username, password = validate_peer_sync_job(request)
+        validate_and_create_sync_credentials(baseurl, facility_id, username, password)
         sync_args = validate_sync_task(request)
         job_data = prepare_peer_sync_job(
             baseurl,
             facility_id,
-            username,
-            password,
             no_push=True,
             no_provision=True,
             extra_metadata=prepare_sync_task(*sync_args, type="SYNCPEER/PULL"),
@@ -1036,12 +1035,11 @@ class FacilityTasksViewSet(BaseViewSet):
         Initiate a SYNC (PULL + PUSH) of a specific facility from another device.
         """
         baseurl, facility_id, username, password = validate_peer_sync_job(request)
+        validate_and_create_sync_credentials(baseurl, facility_id, username, password)
         sync_args = validate_sync_task(request)
         job_data = prepare_peer_sync_job(
             baseurl,
             facility_id,
-            username,
-            password,
             extra_metadata=prepare_sync_task(*sync_args, type="SYNCPEER/FULL"),
         )
         job_id = facility_queue.enqueue(call_command, "sync", **job_data)
@@ -1218,15 +1216,15 @@ def validate_peer_sync_job(request):
     return (baseurl, facility_id, username, password)
 
 
-def prepare_peer_sync_job(baseurl, facility_id, username, password, **kwargs):
+def validate_and_create_sync_credentials(
+    baseurl, facility_id, username, password, user_id=None
+):
     """
-    Initializes and validates connection to peer with username and password for the sync command. If
-    already initialized, the username and password do not need to be supplied
-    """
-    # get the `user` for the sync command if present for provisioning
-    user_id = kwargs.get("user", None)
-    job_data = prepare_sync_job(facility_id, baseurl=baseurl, **kwargs)
+    Validates user credentials for syncing by performing certificate verification, which will also
+    save any certificates after successful authentication
 
+    :param user_id: Optional user ID for SoUD use case
+    """
     # call this in case user directly syncs without migrating database
     if not ScopeDefinition.objects.filter():
         call_command("loaddata", "scopedefinitions")
@@ -1257,7 +1255,13 @@ def prepare_peer_sync_job(baseurl, facility_id, username, password, **kwargs):
         else:
             raise AuthenticationFailed(e)
 
-    return job_data
+
+def prepare_peer_sync_job(baseurl, facility_id, **kwargs):
+    """
+    Initializes and validates connection to peer with username and password for the sync command. If
+    already initialized, the username and password do not need to be supplied
+    """
+    return prepare_sync_job(facility_id, baseurl=baseurl, **kwargs)
 
 
 def prepare_soud_sync_job(baseurl, facility_id, user_id, **kwargs):

--- a/kolibri/plugins/setup_wizard/tasks.py
+++ b/kolibri/plugins/setup_wizard/tasks.py
@@ -19,9 +19,9 @@ from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.permissions import LODUserHasSyncPermissions
 from kolibri.core.device.permissions import NotProvisionedCanPost
 from kolibri.core.error_constants import DEVICE_LIMITATIONS
-from kolibri.core.tasks.api import prepare_peer_sync_job
 from kolibri.core.tasks.api import prepare_soud_sync_job
 from kolibri.core.tasks.api import prepare_sync_task
+from kolibri.core.tasks.api import validate_and_create_sync_credentials
 from kolibri.core.tasks.decorators import register_task
 
 
@@ -102,6 +102,9 @@ def validate_soud_credentials(request, task_description):
 
     instance_model = InstanceIDModel.get_or_create_current_instance()[0]
 
+    validate_and_create_sync_credentials(
+        baseurl, facility_id, username, password, user_id=user_id
+    )
     extra_metadata = prepare_sync_task(
         facility_id,
         user_id,
@@ -117,8 +120,6 @@ def validate_soud_credentials(request, task_description):
     extra_metadata["full_name"] = full_name
 
     return {
-        "username": username,
-        "password": password,
         "user_id": user_id,
         "extra_metadata": extra_metadata,
         "baseurl": baseurl,
@@ -135,14 +136,11 @@ def validate_soud_credentials(request, task_description):
     ],
 )
 def startprovisionsoud(
-    username=None,
-    password=None,
     baseurl=None,
     facility_id=None,
     user_id=None,
     extra_metadata={},
 ):
-    prepare_peer_sync_job(baseurl, facility_id, username, password, user=user_id)
     job_data = prepare_soud_sync_job(
         baseurl, facility_id, user_id, extra_metadata=extra_metadata
     )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
To avoid leakage of user credentials, validate them before queuing SoUD sync. The validation will generate the appropriate certificates if they do not exist, allowing for future authentication without user credentials.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Run through setup wizard for the following scenarios:
1) Provision from full facility import
2) Provision as learn-only device

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
