### PR TITLE
Preseed the sqlite database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,15 @@ writeversion:
 	@echo ""
 	@echo "Current version is now `cat kolibri/VERSION`"
 
+preseeddb:
+	$(eval TEMPKHOME := $(shell mktemp -d /tmp/kolibri-preseeddb-XXXXXXXX))
+	PYTHONPATH=".:$$PYTHONPATH" KOLIBRI_HOME=$(TEMPKHOME) python -m kolibri manage migrate
+	yes yes | PYTHONPATH=".:$$PYTHONPATH" KOLIBRI_HOME=$(TEMPKHOME) python -m kolibri manage deprovision
+	mkdir kolibri/dist/home
+	mv $(TEMPKHOME)/db.sqlite3 kolibri/dist/home/db.sqlite3
+	mv $(TEMPKHOME)/notifications.sqlite3 kolibri/dist/home/notifications.sqlite3
+	rm -r $(TEMPKHOME)
+
 setrequirements:
 	rm -r requirements.txt || true # remove requirements.txt
 	git checkout -- requirements.txt # restore requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ i18n-transfer-context:
 i18n-django-compilemessages:
 	# Change working directory to kolibri/ such that compilemessages
 	# finds only the .po files nested there.
-	cd kolibri && PYTHONPATH="..:$$PYTHONPATH" python -m kolibri manage compilemessages
+	cd kolibri && PYTHONPATH="..:$$PYTHONPATH" python -m kolibri manage compilemessages --skip-update
 
 i18n-upload: i18n-extract
 	python packages/kolibri-tools/lib/i18n/crowdin.py upload-sources ${branch}

--- a/kolibri/core/test/test_upgrade.py
+++ b/kolibri/core/test/test_upgrade.py
@@ -107,7 +107,7 @@ def test_blank_old_version():
 
     with patch("kolibri.core.upgrade.get_upgrades", return_value=[first]):
         run_upgrades("", "1.1.2")
-        function.assert_called_once()
+        function.assert_not_called()
 
 
 def test_invalid_old_version():

--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -147,7 +147,10 @@ def run_upgrades(old_version, new_version, app_configs=None):
             and matches_version(new_version, upgrade.NEW_VERSION)
         )
 
-    for version_upgrade in sorted(
-        filter(filter_upgrade, get_upgrades(app_configs=app_configs))
-    ):
-        version_upgrade()
+    # Only run upgrades if we had a previous version, otherwise
+    # we're just upgrading from a blank slate, so no need to run anything
+    if old_version:
+        for version_upgrade in sorted(
+            filter(filter_upgrade, get_upgrades(app_configs=app_configs))
+        ):
+            version_upgrade()

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -155,7 +155,7 @@ def _setup_django():
 
 
 def _upgrades_before_django_setup(updated, version):
-    if updated:
+    if version and updated:
         check_plugin_config_file_location(version)
         # Reset the enabled plugins to the defaults
         # This needs to be run before dbbackup because

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -157,6 +157,8 @@ def _setup_django():
 def _upgrades_before_django_setup(updated, version):
     if version and updated:
         check_plugin_config_file_location(version)
+
+    if updated:
         # Reset the enabled plugins to the defaults
         # This needs to be run before dbbackup because
         # dbbackup relies on settings.INSTALLED_APPS
@@ -169,20 +171,24 @@ def _upgrades_before_django_setup(updated, version):
         logger.info("Attempting to setup using pre-migrated databases")
         try:
             import kolibri.dist
+
             main_db_path = os.path.join(kolibri.dist.__file__, "home/db.sqlite3")
             shutil.copy(main_db_path, KOLIBRI_HOME)
         except (ImportError, IOError, OSError):
-            logging.warning(
+            logger.warning(
                 "Unable to copy pre-migrated database from {} to {}".format(
                     main_db_path, KOLIBRI_HOME
                 )
             )
         try:
             import kolibri.dist
-            notifications_db_path = os.path.join(kolibri.dist.__file__, "home/notifications.sqlite3")
+
+            notifications_db_path = os.path.join(
+                kolibri.dist.__file__, "home/notifications.sqlite3"
+            )
             shutil.copy(notifications_db_path, KOLIBRI_HOME)
         except (ImportError, IOError, OSError):
-            logging.warning(
+            logger.warning(
                 "Unable to copy pre-migrated database from {} to {}".format(
                     notifications_db_path, KOLIBRI_HOME
                 )

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import shutil
 import sys
 from sqlite3 import DatabaseError as SQLite3DatabaseError
 
@@ -160,6 +161,32 @@ def _upgrades_before_django_setup(updated, version):
         # This needs to be run before dbbackup because
         # dbbackup relies on settings.INSTALLED_APPS
         enable_new_default_plugins()
+
+    if not version and OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
+        # If there is no registered version, and we are using sqlite,
+        # we can shortcut migrations by using the preseeded databases
+        # that we bundle in the Kolibri whl file.
+        logger.info("Attempting to setup using pre-migrated databases")
+        try:
+            import kolibri.dist
+            main_db_path = os.path.join(kolibri.dist.__file__, "home/db.sqlite3")
+            shutil.copy(main_db_path, KOLIBRI_HOME)
+        except (ImportError, IOError, OSError):
+            logging.warning(
+                "Unable to copy pre-migrated database from {} to {}".format(
+                    main_db_path, KOLIBRI_HOME
+                )
+            )
+        try:
+            import kolibri.dist
+            notifications_db_path = os.path.join(kolibri.dist.__file__, "home/notifications.sqlite3")
+            shutil.copy(notifications_db_path, KOLIBRI_HOME)
+        except (ImportError, IOError, OSError):
+            logging.warning(
+                "Unable to copy pre-migrated database from {} to {}".format(
+                    notifications_db_path, KOLIBRI_HOME
+                )
+            )
 
 
 def _upgrades_after_django_setup(updated, version):

--- a/kolibri/utils/tests/test_handler.py
+++ b/kolibri/utils/tests/test_handler.py
@@ -5,13 +5,16 @@ from time import sleep
 
 from django.conf import settings
 from django.test import TestCase
+from mock import patch
 
 from kolibri.utils import cli
 from kolibri.utils.logger import KolibriTimedRotatingFileHandler
 
 
 class KolibriTimedRotatingFileHandlerTestCase(TestCase):
-    def test_do_rollover(self):
+    # Mock this function to avoid calling the logger in a way that prevents the archive
+    @patch("kolibri.utils.main._upgrades_before_django_setup")
+    def test_do_rollover(self, upgrades_mock):
         archive_dir = os.path.join(os.environ["KOLIBRI_HOME"], "logs", "archive")
         orig_value = settings.LOGGING["handlers"]["file"]["when"]
 


### PR DESCRIPTION
## Summary
* Mainlines logic from the android installer to preseed a SQLite database for faster first time startup
* Skips update during our makemessages task to avoid unnecessary migrations
* Only runs upgrade logic when version upgrades are detected, not from scratch

## References


## Reviewer guidance
Mainlined from https://github.com/learningequality/kolibri-installer-android/blob/develop/Makefile#L55

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
