### PR TITLE
Add yarn license list checking to ensure no GPL only packages in our dependencies

### DIFF
--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["requirements/*.txt"]'
+          paths: '["requirements/*.txt", "package.json", "**/package.json", "yarn.lock", "test/conditional/test_licenses.sh"]'
   licenses:
     name: Licenses check
     needs: pre_job
@@ -22,8 +22,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Cache Node.js modules
+      uses: actions/cache@v2
+      with:
+        path: '**/node_modules'
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
     - uses: actions/setup-python@v2
     - name: Install dependencies
-      run: python -m pip install --upgrade pip
+      run: |
+        python -m pip install --upgrade pip
+        yarn --frozen-lockfile
+        npm rebuild node-sass
     - name: Check Licenses
       run: ./test/conditional/test_licenses.sh

--- a/test/conditional/test_licenses.sh
+++ b/test/conditional/test_licenses.sh
@@ -35,4 +35,11 @@ do
     fi
 done
 
+if yarn licenses list | grep -iP '(?<!OR )(?<!L)GPL(?! OR)'
+# If any output from the above, then we have found something, use && true to coerce to boolean
+then
+    echo "Problem! Incompatible license found in Javascript dependencies"
+    exit 14
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
* Adds checking of our JS dependencies to our license checking

## References
Fixes #2321

## Reviewer guidance
Does the regex look right? I tested it with these examples and it worked. matching only GPL by itself:
```
MIT OR GPL
GPL
GPL OR MIT
GPL or MIT
MIT or GPL
├─ (LGPL-2.0 or MIT)
```

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
