### PR TITLE
Temporarily disable quiz syncing.

### DIFF
--- a/kolibri/core/exams/kolibri_plugin.py
+++ b/kolibri/core/exams/kolibri_plugin.py
@@ -1,35 +1,34 @@
-from .single_user_assignment_utils import (
-    update_assignments_from_individual_syncable_exams,
-)
-from .single_user_assignment_utils import (
-    update_individual_syncable_exams_from_assignments,
-)
-from kolibri.core.auth.hooks import FacilityDataSyncHook
-from kolibri.plugins.hooks import register_hook
-
-
-@register_hook
-class SingleUserExamSyncHook(FacilityDataSyncHook):
-    def pre_transfer(
-        self,
-        dataset_id,
-        local_is_single_user,
-        remote_is_single_user,
-        single_user_id,
-        context,
-    ):
-        # if we're about to send data to a single-user device, prep the syncable exam assignments
-        if context.is_producer and remote_is_single_user:
-            update_individual_syncable_exams_from_assignments(single_user_id)
-
-    def post_transfer(
-        self,
-        dataset_id,
-        local_is_single_user,
-        remote_is_single_user,
-        single_user_id,
-        context,
-    ):
-        # if we've just received data on a single-user device, update the exams and assignments
-        if context.is_receiver and local_is_single_user:
-            update_assignments_from_individual_syncable_exams(single_user_id)
+# To reinstate the original functionality, please remove this header comment
+# and uncomment the code below
+# from .single_user_assignment_utils import (
+#     update_assignments_from_individual_syncable_exams,
+# )
+# from .single_user_assignment_utils import (
+#     update_individual_syncable_exams_from_assignments,
+# )
+# from kolibri.core.auth.hooks import FacilityDataSyncHook
+# from kolibri.plugins.hooks import register_hook
+# @register_hook
+# class SingleUserExamSyncHook(FacilityDataSyncHook):
+#     def pre_transfer(
+#         self,
+#         dataset_id,
+#         local_is_single_user,
+#         remote_is_single_user,
+#         single_user_id,
+#         context,
+#     ):
+#         # if we're about to send data to a single-user device, prep the syncable exam assignments
+#         if context.is_producer and remote_is_single_user:
+#             update_individual_syncable_exams_from_assignments(single_user_id)
+#     def post_transfer(
+#         self,
+#         dataset_id,
+#         local_is_single_user,
+#         remote_is_single_user,
+#         single_user_id,
+#         context,
+#     ):
+#         # if we've just received data on a single-user device, update the exams and assignments
+#         if context.is_receiver and local_is_single_user:
+#             update_assignments_from_individual_syncable_exams(single_user_id)


### PR DESCRIPTION
## Summary
Disables the quiz syncing hook

## References
Simplify the quiz workflow until #8275 is resolved

## Reviewer guidance
Do tests pass? Does Kolibri still run?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
