### PR TITLE
Fix URL prefixing for static urls

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -98,6 +98,7 @@
 
   import JSZip from 'jszip';
   import client from 'kolibri.client';
+  import urls from 'kolibri.urls';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import scriptLoader from 'kolibri.utils.scriptLoader';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
@@ -116,7 +117,7 @@
   // because MathJax isn't compatible with webpack, we are loading it this way.
   const mathJaxConfigFileName = require('../constants').ConfigFileName;
   // the config is fragile, Khan may change it and we need to update the following hardcoded path.
-  const mathJaxUrl = `/static/mathjax/2.1/MathJax.js?config=${mathJaxConfigFileName}`;
+  const mathJaxUrl = urls.static(`mathjax/2.1/MathJax.js?config=${mathJaxConfigFileName}`);
 
   const mathJaxPromise = scriptLoader(mathJaxUrl);
 


### PR DESCRIPTION
## Summary
Gets rid of hardcoded URL for finding mathjax and uses static URL function.

## References
Fixes #8358

## Reviewer guidance
Run Kolibri with this env var set: `KOLIBRI_URL_PATH_PREFIX="/kolibri"`

Without this PR, it will 404 trying to load the Mathjax static file when rendering an exercise. With this PR it loads correctly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
