### PR TITLE
Ensure the user will see the welcome modal after login

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -72,7 +72,10 @@
       ...mapState({ welcomeModalVisibleState: 'welcomeModalVisible' }),
       ...mapState('coreBase', ['appBarTitle']),
       welcomeModalVisible() {
-        return this.welcomeModalVisibleState && !window.sessionStorage.getItem(welcomeDimissalKey);
+        return (
+          this.welcomeModalVisibleState &&
+          window.sessionStorage.getItem(welcomeDimissalKey) !== 'true'
+        );
       },
       pageName() {
         return this.$route.name;

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -38,16 +38,14 @@
     computed: {
       paragraphs() {
         if (this.isLOD) {
-          const facility =
-            this.importedFacility === null
-              ? this.$store.getters.facilities[0]
-              : this.importedFacility;
-          return [
-            this.$tr('learnOnlyDeviceWelcomeMessage1'),
-            this.$tr('learnOnlyDeviceWelcomeMessage2', {
-              facilityName: facility.name,
-            }),
-          ];
+          let facility = this.importedFacility;
+          if (this.$store.getters.facilities.length > 0 && facility === null)
+            facility = this.$store.getters.facilities[0];
+          const sndParagraph =
+            facility === null
+              ? this.$tr('learnOnlyDeviceWelcomeMessage2')
+              : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
+          return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
         }
         if (this.importedFacility) {
           return [
@@ -62,9 +60,7 @@
         }
       },
     },
-    beforeCreate() {
-      if (this.$store.state.core.facilities.length === 0) this.$store.dispatch('getFacilities');
-    },
+
     render: createElement => window.setTimeout(createElement, 750),
     $trs: {
       welcomeModalHeader: {
@@ -95,7 +91,7 @@
         context: 'Welcome message for user which appears after provisioning a Learner Only Device.',
       },
       learnOnlyDeviceWelcomeMessage2: {
-        message: `The user reports, lessons, and quizzes in  '{facilityName}' will not display properly until you import the resources associated with them.`,
+        message: `The user reports, lessons, and quizzes will not display properly until you import the resources associated with them.`,
         context: 'Welcome message for user indicating that they need to import resources.',
       },
     },

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -20,6 +20,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'WelcomeModal',
@@ -31,16 +32,20 @@
       },
       isLOD: {
         type: Boolean,
-        default: false,
+        default: plugin_data.isSubsetOfUsersDevice,
       },
     },
     computed: {
       paragraphs() {
         if (this.isLOD) {
+          const facility =
+            this.importedFacility === null
+              ? this.$store.getters.facilities[0]
+              : this.importedFacility;
           return [
             this.$tr('learnOnlyDeviceWelcomeMessage1'),
             this.$tr('learnOnlyDeviceWelcomeMessage2', {
-              facilityName: this.importedFacility.name,
+              facilityName: facility.name,
             }),
           ];
         }
@@ -56,6 +61,9 @@
           ];
         }
       },
+    },
+    beforeCreate() {
+      if (this.$store.state.core.facilities.length === 0) this.$store.dispatch('getFacilities');
     },
     render: createElement => window.setTimeout(createElement, 750),
     $trs: {

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from kolibri.core.auth.constants.user_kinds import SUPERUSER
+from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
@@ -18,6 +19,14 @@ class DeviceManagementPlugin(KolibriPluginBase):
 @register_hook
 class DeviceManagementAsset(WebpackBundleHook):
     bundle_id = "app"
+
+    @property
+    def plugin_data(self):
+        return {
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
+        }
 
 
 @register_hook

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -17,6 +17,8 @@
 
   import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -25,6 +27,7 @@
         title: this.$tr('documentTitle'),
       };
     },
+
     computed: {
       ...mapGetters(['canManageContent', 'isLearner']),
       deviceContentUrl() {
@@ -38,6 +41,12 @@
       showLearnerText() {
         return this.isLearner && !this.canManageContent;
       },
+    },
+    beforeMount() {
+      if (plugin_data.isSubsetOfUsersDevice) {
+        const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
+        redirectBrowser(deviceContentUrl());
+      }
     },
     $trs: {
       header: {

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -17,8 +17,6 @@
 
   import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
-  import redirectBrowser from 'kolibri.utils.redirectBrowser';
-  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -41,12 +39,6 @@
       showLearnerText() {
         return this.isLearner && !this.canManageContent;
       },
-    },
-    beforeMount() {
-      if (plugin_data.isSubsetOfUsersDevice) {
-        const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
-        redirectBrowser(deviceContentUrl());
-      }
     },
     $trs: {
       header: {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -56,6 +56,9 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             "enableCustomChannelNav": conf.OPTIONS["Learn"][
                 "ENABLE_CUSTOM_CHANNEL_NAV"
             ],
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
         }
 
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -19,16 +19,9 @@
         primary
         :text="coreString('finishAction')"
         :disabled="users.length === 0"
-        @click="welcomeModal = true"
+        @click="redirectToChannels"
       />
     </BottomAppBar>
-
-    <WelcomeModal
-      v-if="welcomeModal"
-      :importedFacility="facility"
-      :isLOD="true"
-      @submit="redirectToChannels"
-    />
   </div>
 
 </template>
@@ -42,7 +35,6 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { lodImportMachine } from '../machines/lodImportMachine';
-  import WelcomeModal from '../../../../device/assets/src/views/WelcomeModal.vue';
   import ProgressToolbar from './ProgressToolbar';
 
   const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
@@ -52,7 +44,6 @@
     components: {
       BottomAppBar,
       ProgressToolbar,
-      WelcomeModal,
     },
     mixins: [commonSyncElements, commonCoreStrings],
 
@@ -63,7 +54,6 @@
         state: lodImportMachine.initialState,
         total_steps: 4,
         stateID: null,
-        welcomeModal: false,
       };
     },
     provide() {
@@ -89,9 +79,6 @@
       removeNavIcon() {
         // TODO disable backwards navigation at the router level
         return this.currentStep > 1;
-      },
-      facility() {
-        return this.state.context.facility;
       },
       users() {
         return this.state.context.users;
@@ -145,8 +132,7 @@
         else this.service.send('BACK');
       },
       redirectToChannels() {
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
-        this.welcomeModal = false;
+        window.sessionStorage.setItem(welcomeDimissalKey, false);
         this.$store.dispatch('kolibriLogout');
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -29,6 +29,8 @@
 
 <script>
 
+  import urls from 'kolibri.urls';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import { computed } from 'kolibri.lib.vueCompositionApi';
   import { interpret } from 'xstate';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -133,7 +135,8 @@
       },
       redirectToChannels() {
         window.sessionStorage.setItem(welcomeDimissalKey, false);
-        this.$store.dispatch('kolibriLogout');
+        const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
+        redirectBrowser(device_url);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -152,8 +152,7 @@
       redirectToChannels() {
         window.sessionStorage.setItem(welcomeDimissalKey, false);
         const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
-        if (this.lodService.state.matches('importingUser')) redirectBrowser(device_url);
-        else this.$store.dispatch('kolibriLogout');
+        redirectBrowser(device_url);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -24,7 +24,7 @@
         <KButton
           primary
           :text="coreString('finishAction')"
-          @click="welcomeModal = true"
+          @click="redirectToChannels"
         />
         <KButton
           class="another-user"
@@ -41,12 +41,6 @@
       />
       <span v-else></span>
     </template>
-    <WelcomeModal
-      v-if="welcomeModal"
-      :importedFacility="facility"
-      :isLOD="true"
-      @submit="redirectToChannels"
-    />
   </OnboardingForm>
 
 </template>
@@ -60,7 +54,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
-  import WelcomeModal from '../../../../../device/assets/src/views/WelcomeModal.vue';
   import { TaskStatuses } from '../../../../../device/assets/src/constants.js';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
   import { SetupSoUDTasksResource } from '../../api';
@@ -72,14 +65,12 @@
     components: {
       FacilityTaskPanel,
       OnboardingForm,
-      WelcomeModal,
     },
     mixins: [commonCoreStrings, commonSyncElements],
     data() {
       return {
         loadingTask: this.state.value.task,
         isPolling: false,
-        welcomeModal: false,
         user: null,
       };
     },
@@ -159,8 +150,7 @@
         }
       },
       redirectToChannels() {
-        this.welcomeModal = false;
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
+        window.sessionStorage.setItem(welcomeDimissalKey, false);
         const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
         if (this.lodService.state.matches('importingUser')) redirectBrowser(device_url);
         else this.$store.dispatch('kolibriLogout');


### PR DESCRIPTION
## Summary

According to the proposed design, when finishing the setup wizard on a Learning Only Device, the modal window to recommend import channels will appear _after_ the user logins

## References
Closes: #8308 

## Reviewer guidance
Do a clean installation importing some user and check after the user logins, he's redirected to the device tab and sees the modal window
![prueba](https://user-images.githubusercontent.com/1008178/131541885-a3663676-50b2-4a35-9ea3-ea05423e9113.gif)



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
