### PR TITLE
Fix invocations of read_channel_metadata_from_db_file to expect a dict

### DIFF
--- a/kolibri/core/content/management/commands/scanforcontent.py
+++ b/kolibri/core/content/management/commands/scanforcontent.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
             disk_channel = read_channel_metadata_from_db_file(disk_path)
             db_channel = ChannelMetadata.objects.get(id=channel_id)
             # the version in the primary database is older than the one on disk
-            return disk_channel.version > db_channel.version
+            return disk_channel["version"] > db_channel.version
         except DatabaseError:
             # problem with the database on disk; it can't be considered newer
             return False

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -121,17 +121,17 @@ def get_channels_for_data_folder(datafolder):
             continue
         channel_data = {
             "path": path,
-            "id": channel.id,
-            "name": channel.name,
-            "description": channel.description,
-            "tagline": getattr(channel, "tagline", ""),
-            "thumbnail": channel.thumbnail,
-            "version": channel.version,
-            "root": channel.root_id,
-            "author": channel.author,
-            "last_updated": getattr(channel, "last_updated", None),
-            "lang_code": getattr(channel, "lang_code", None),
-            "lang_name": getattr(channel, "lang_name", None),
+            "id": channel["id"],
+            "name": channel["name"],
+            "description": channel["description"],
+            "tagline": channel.get("tagline", ""),
+            "thumbnail": channel["thumbnail"],
+            "version": channel["version"],
+            "root": channel["root_id"],
+            "author": channel["author"],
+            "last_updated": channel.get("last_updated"),
+            "lang_code": channel.get("lang_code"),
+            "lang_name": channel.get("lang_name"),
         }
         channels.append(channel_data)
     return channels

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -927,7 +927,7 @@ class TasksViewSet(BaseViewSet):
             channel_metadata = read_channel_metadata_from_db_file(
                 get_content_database_file_path(channel_id, drive.datafolder)
             )
-            job_metadata["new_channel_version"] = channel_metadata.version
+            job_metadata["new_channel_version"] = channel_metadata["version"]
         else:
             raise serializers.ValidationError(
                 "'method' field should either be 'network' or 'disk'."


### PR DESCRIPTION
## Summary
* Fixes regressions introduced by https://github.com/learningequality/kolibri/pull/6115

## References
Fixes #8251

## Reviewer guidance
Can you now export to an external drive?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
