### PR TITLE
Restart zeroconf after setup

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -72,7 +72,10 @@
       ...mapState({ welcomeModalVisibleState: 'welcomeModalVisible' }),
       ...mapState('coreBase', ['appBarTitle']),
       welcomeModalVisible() {
-        return this.welcomeModalVisibleState && !window.sessionStorage.getItem(welcomeDimissalKey);
+        return (
+          this.welcomeModalVisibleState &&
+          window.sessionStorage.getItem(welcomeDimissalKey) !== 'true'
+        );
       },
       pageName() {
         return this.$route.name;

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -38,16 +38,14 @@
     computed: {
       paragraphs() {
         if (this.isLOD) {
-          const facility =
-            this.importedFacility === null
-              ? this.$store.getters.facilities[0]
-              : this.importedFacility;
-          return [
-            this.$tr('learnOnlyDeviceWelcomeMessage1'),
-            this.$tr('learnOnlyDeviceWelcomeMessage2', {
-              facilityName: facility.name,
-            }),
-          ];
+          let facility = this.importedFacility;
+          if (this.$store.getters.facilities.length > 0 && facility === null)
+            facility = this.$store.getters.facilities[0];
+          const sndParagraph =
+            facility === null
+              ? this.$tr('learnOnlyDeviceWelcomeMessage2')
+              : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
+          return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
         }
         if (this.importedFacility) {
           return [
@@ -62,9 +60,7 @@
         }
       },
     },
-    beforeCreate() {
-      if (this.$store.state.core.facilities.length === 0) this.$store.dispatch('getFacilities');
-    },
+
     render: createElement => window.setTimeout(createElement, 750),
     $trs: {
       welcomeModalHeader: {
@@ -95,7 +91,7 @@
         context: 'Welcome message for user which appears after provisioning a Learner Only Device.',
       },
       learnOnlyDeviceWelcomeMessage2: {
-        message: `The user reports, lessons, and quizzes in  '{facilityName}' will not display properly until you import the resources associated with them.`,
+        message: `The user reports, lessons, and quizzes will not display properly until you import the resources associated with them.`,
         context: 'Welcome message for user indicating that they need to import resources.',
       },
     },

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -20,6 +20,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'WelcomeModal',
@@ -31,16 +32,20 @@
       },
       isLOD: {
         type: Boolean,
-        default: false,
+        default: plugin_data.isSubsetOfUsersDevice,
       },
     },
     computed: {
       paragraphs() {
         if (this.isLOD) {
+          const facility =
+            this.importedFacility === null
+              ? this.$store.getters.facilities[0]
+              : this.importedFacility;
           return [
             this.$tr('learnOnlyDeviceWelcomeMessage1'),
             this.$tr('learnOnlyDeviceWelcomeMessage2', {
-              facilityName: this.importedFacility.name,
+              facilityName: facility.name,
             }),
           ];
         }
@@ -56,6 +61,9 @@
           ];
         }
       },
+    },
+    beforeCreate() {
+      if (this.$store.state.core.facilities.length === 0) this.$store.dispatch('getFacilities');
     },
     render: createElement => window.setTimeout(createElement, 750),
     $trs: {

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from kolibri.core.auth.constants.user_kinds import SUPERUSER
+from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
@@ -18,6 +19,14 @@ class DeviceManagementPlugin(KolibriPluginBase):
 @register_hook
 class DeviceManagementAsset(WebpackBundleHook):
     bundle_id = "app"
+
+    @property
+    def plugin_data(self):
+        return {
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
+        }
 
 
 @register_hook

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -17,6 +17,8 @@
 
   import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -25,6 +27,7 @@
         title: this.$tr('documentTitle'),
       };
     },
+
     computed: {
       ...mapGetters(['canManageContent', 'isLearner']),
       deviceContentUrl() {
@@ -38,6 +41,12 @@
       showLearnerText() {
         return this.isLearner && !this.canManageContent;
       },
+    },
+    beforeMount() {
+      if (plugin_data.isSubsetOfUsersDevice) {
+        const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
+        redirectBrowser(deviceContentUrl());
+      }
     },
     $trs: {
       header: {

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -17,8 +17,6 @@
 
   import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
-  import redirectBrowser from 'kolibri.utils.redirectBrowser';
-  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -41,12 +39,6 @@
       showLearnerText() {
         return this.isLearner && !this.canManageContent;
       },
-    },
-    beforeMount() {
-      if (plugin_data.isSubsetOfUsersDevice) {
-        const deviceContentUrl = urls['kolibri:kolibri.plugins.device:device_management'];
-        redirectBrowser(deviceContentUrl());
-      }
     },
     $trs: {
       header: {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -56,6 +56,9 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             "enableCustomChannelNav": conf.OPTIONS["Learn"][
                 "ENABLE_CUSTOM_CHANNEL_NAV"
             ],
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
         }
 
 

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -173,3 +173,26 @@ class SetupWizardSoUDTaskView(TasksViewSet):
     """
 
     permission_classes = [HasPermissionDuringSetup | HasPermissionDuringLODSetup]
+
+
+class SetupWizardRestartZeroconf(ViewSet):
+    """
+    An utility endpoint to restart zeroconf after setup is finished
+    in case this is a SoUD
+    """
+
+    permission_classes = [HasPermissionDuringSetup | HasPermissionDuringLODSetup]
+
+    @decorators.action(methods=["post"], detail=False)
+    def restart(self, request):
+        import logging
+        from kolibri.core.discovery.utils.network.search import (
+            unregister_zeroconf_service,
+            initialize_zeroconf_listener,
+        )
+
+        logger = logging.getLogger(__name__)
+        unregister_zeroconf_service()
+        initialize_zeroconf_listener()
+        logger.info("Zeroconf has reinitialized")
+        return Response({})

--- a/kolibri/plugins/setup_wizard/api_urls.py
+++ b/kolibri/plugins/setup_wizard/api_urls.py
@@ -4,6 +4,7 @@ from rest_framework import routers
 
 from .api import FacilityImportViewSet
 from .api import SetupWizardFacilityImportTaskView
+from .api import SetupWizardRestartZeroconf
 from .api import SetupWizardSoUDTaskView
 
 router = routers.DefaultRouter()
@@ -11,5 +12,8 @@ router = routers.DefaultRouter()
 router.register(r"facilityimport", FacilityImportViewSet, base_name="facilityimport")
 router.register(r"tasks", SetupWizardFacilityImportTaskView, base_name="tasks")
 router.register(r"soudtasks", SetupWizardSoUDTaskView, base_name="soudtasks")
+router.register(
+    r"restartzeroconf", SetupWizardRestartZeroconf, base_name="restartzeroconf"
+)
 
 urlpatterns = [url(r"^", include(router.urls))]

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -64,15 +64,12 @@ export const SetupSoUDTasksResource = new Resource({
 export const FinishSoUDSyncingResource = new Resource({
   name: 'restartzeroconf',
   namespace: 'kolibri.plugins.setup_wizard',
-  finish(store, admin) {
+  finish() {
     const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
     const device_url = urls['kolibri:kolibri.plugins.device:device_management'];
     window.sessionStorage.setItem(welcomeDimissalKey, false);
     this.postListEndpoint('restart');
-    if (admin) store.dispatch('kolibriLogout');
-    else {
-      redirectBrowser(device_url());
-    }
+    redirectBrowser(device_url());
     return '';
   },
 });

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -61,7 +61,7 @@ export const SetupSoUDTasksResource = new Resource({
   },
 });
 
-export const FinishSouDSyncingResource = new Resource({
+export const FinishSoUDSyncingResource = new Resource({
   name: 'restartzeroconf',
   namespace: 'kolibri.plugins.setup_wizard',
   finish(store, admin) {

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -1,5 +1,7 @@
 import { Resource } from 'kolibri.lib.apiResource';
 import pickBy from 'lodash/pickBy';
+import urls from 'kolibri.urls';
+import redirectBrowser from 'kolibri.utils.redirectBrowser';
 
 export const FacilityImportResource = new Resource({
   name: 'facilityimport',
@@ -56,5 +58,21 @@ export const SetupSoUDTasksResource = new Resource({
     return this.postListEndpoint('list', args).then(response => {
       return response.data;
     });
+  },
+});
+
+export const FinishSouDSyncingResource = new Resource({
+  name: 'restartzeroconf',
+  namespace: 'kolibri.plugins.setup_wizard',
+  finish(store, admin) {
+    const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+    const device_url = urls['kolibri:kolibri.plugins.device:device_management'];
+    window.sessionStorage.setItem(welcomeDimissalKey, false);
+    this.postListEndpoint('restart');
+    if (admin) store.dispatch('kolibriLogout');
+    else {
+      redirectBrowser(device_url());
+    }
+    return '';
   },
 });

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -69,7 +69,7 @@ export const FinishSoUDSyncingResource = new Resource({
     const device_url = urls['kolibri:kolibri.plugins.device:device_management'];
     window.sessionStorage.setItem(welcomeDimissalKey, false);
     this.postListEndpoint('restart');
-    redirectBrowser(device_url());
+    redirectBrowser(device_url ? device_url() : null);
     return '';
   },
 });

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -19,16 +19,9 @@
         primary
         :text="coreString('finishAction')"
         :disabled="users.length === 0"
-        @click="welcomeModal = true"
+        @click="redirectToChannels"
       />
     </BottomAppBar>
-
-    <WelcomeModal
-      v-if="welcomeModal"
-      :importedFacility="facility"
-      :isLOD="true"
-      @submit="redirectToChannels"
-    />
   </div>
 
 </template>
@@ -42,7 +35,6 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { lodImportMachine } from '../machines/lodImportMachine';
-  import WelcomeModal from '../../../../device/assets/src/views/WelcomeModal.vue';
   import ProgressToolbar from './ProgressToolbar';
 
   const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
@@ -52,7 +44,6 @@
     components: {
       BottomAppBar,
       ProgressToolbar,
-      WelcomeModal,
     },
     mixins: [commonSyncElements, commonCoreStrings],
 
@@ -63,7 +54,6 @@
         state: lodImportMachine.initialState,
         total_steps: 4,
         stateID: null,
-        welcomeModal: false,
       };
     },
     provide() {
@@ -89,9 +79,6 @@
       removeNavIcon() {
         // TODO disable backwards navigation at the router level
         return this.currentStep > 1;
-      },
-      facility() {
-        return this.state.context.facility;
       },
       users() {
         return this.state.context.users;
@@ -145,8 +132,7 @@
         else this.service.send('BACK');
       },
       redirectToChannels() {
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
-        this.welcomeModal = false;
+        window.sessionStorage.setItem(welcomeDimissalKey, false);
         this.$store.dispatch('kolibriLogout');
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -37,7 +37,7 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { lodImportMachine } from '../machines/lodImportMachine';
-  import { FinishSouDSyncingResource } from '../api';
+  import { FinishSoUDSyncingResource } from '../api';
   import ProgressToolbar from './ProgressToolbar';
 
   export default {
@@ -133,7 +133,7 @@
         else this.service.send('BACK');
       },
       redirectToChannels() {
-        FinishSouDSyncingResource.finish(this.$store, false);
+        FinishSoUDSyncingResource.finish(this.$store, false);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -29,6 +29,8 @@
 
 <script>
 
+  import urls from 'kolibri.urls';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import { computed } from 'kolibri.lib.vueCompositionApi';
   import { interpret } from 'xstate';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -133,7 +135,8 @@
       },
       redirectToChannels() {
         window.sessionStorage.setItem(welcomeDimissalKey, false);
-        this.$store.dispatch('kolibriLogout');
+        const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
+        redirectBrowser(device_url);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -37,9 +37,8 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { lodImportMachine } from '../machines/lodImportMachine';
+  import { FinishSouDSyncingResource } from '../api';
   import ProgressToolbar from './ProgressToolbar';
-
-  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'ImportLODUsersSetup',
@@ -134,9 +133,7 @@
         else this.service.send('BACK');
       },
       redirectToChannels() {
-        window.sessionStorage.setItem(welcomeDimissalKey, false);
-        const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
-        redirectBrowser(device_url);
+        FinishSouDSyncingResource.finish(this.$store, false);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -133,7 +133,7 @@
         else this.service.send('BACK');
       },
       redirectToChannels() {
-        FinishSoUDSyncingResource.finish(this.$store, false);
+        FinishSoUDSyncingResource.finish();
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -29,8 +29,6 @@
 
 <script>
 
-  import urls from 'kolibri.urls';
-  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import { computed } from 'kolibri.lib.vueCompositionApi';
   import { interpret } from 'xstate';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -152,8 +152,7 @@
       redirectToChannels() {
         window.sessionStorage.setItem(welcomeDimissalKey, false);
         const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
-        if (this.lodService.state.matches('importingUser')) redirectBrowser(device_url);
-        else this.$store.dispatch('kolibriLogout');
+        redirectBrowser(device_url);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -48,17 +48,13 @@
 
 <script>
 
-  import urls from 'kolibri.urls';
-  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import { SessionResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
   import { TaskStatuses } from '../../../../../device/assets/src/constants.js';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
-  import { SetupSoUDTasksResource } from '../../api';
-
-  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+  import { FinishSouDSyncingResource, SetupSoUDTasksResource } from '../../api';
 
   export default {
     name: 'LoadingTaskPage',
@@ -150,9 +146,7 @@
         }
       },
       redirectToChannels() {
-        window.sessionStorage.setItem(welcomeDimissalKey, false);
-        const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
-        redirectBrowser(device_url);
+        FinishSouDSyncingResource.finish(this.$store);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -54,7 +54,7 @@
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
   import { TaskStatuses } from '../../../../../device/assets/src/constants.js';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
-  import { FinishSouDSyncingResource, SetupSoUDTasksResource } from '../../api';
+  import { FinishSoUDSyncingResource, SetupSoUDTasksResource } from '../../api';
 
   export default {
     name: 'LoadingTaskPage',
@@ -146,7 +146,8 @@
         }
       },
       redirectToChannels() {
-        FinishSouDSyncingResource.finish(this.$store);
+        const admin = !this.lodService.state.matches('importingUser');
+        FinishSoUDSyncingResource.finish(this.$store, admin);
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -146,8 +146,7 @@
         }
       },
       redirectToChannels() {
-        const admin = !this.lodService.state.matches('importingUser');
-        FinishSoUDSyncingResource.finish(this.$store, admin);
+        FinishSoUDSyncingResource.finish();
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -24,7 +24,7 @@
         <KButton
           primary
           :text="coreString('finishAction')"
-          @click="welcomeModal = true"
+          @click="redirectToChannels"
         />
         <KButton
           class="another-user"
@@ -41,12 +41,6 @@
       />
       <span v-else></span>
     </template>
-    <WelcomeModal
-      v-if="welcomeModal"
-      :importedFacility="facility"
-      :isLOD="true"
-      @submit="redirectToChannels"
-    />
   </OnboardingForm>
 
 </template>
@@ -60,7 +54,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
-  import WelcomeModal from '../../../../../device/assets/src/views/WelcomeModal.vue';
   import { TaskStatuses } from '../../../../../device/assets/src/constants.js';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
   import { SetupSoUDTasksResource } from '../../api';
@@ -72,14 +65,12 @@
     components: {
       FacilityTaskPanel,
       OnboardingForm,
-      WelcomeModal,
     },
     mixins: [commonCoreStrings, commonSyncElements],
     data() {
       return {
         loadingTask: this.state.value.task,
         isPolling: false,
-        welcomeModal: false,
         user: null,
       };
     },
@@ -159,8 +150,7 @@
         }
       },
       redirectToChannels() {
-        this.welcomeModal = false;
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
+        window.sessionStorage.setItem(welcomeDimissalKey, false);
         const device_url = urls['kolibri:kolibri.plugins.device:device_management']();
         if (this.lodService.state.matches('importingUser')) redirectBrowser(device_url);
         else this.$store.dispatch('kolibriLogout');


### PR DESCRIPTION
## Summary

Create a new endpoint + an api resource to restart zerconf when the setup wizard ends after syncing one or more users in a SoUD


## References
Closes: #8344 
Depends on #8367 been merged

## Reviewer guidance
Create a new Kolibri device provisioning it importing users from another device.
Before this PR users were not synced unless the server is restarted. After this pr, syncing processes will start as soon as the setup is finished

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
