### PR TITLE
Unsupported browser theme

### DIFF
--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -20,7 +20,7 @@
     .topbar {
       width: 100%;
       color: white;
-      background-color: #996189;
+      background-color: {{ brand_primary_v400 }} !important;
     }
     .topbar h1 {
       display: inline-block;

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -29,6 +29,10 @@ from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.hooks import LogoutRedirectHook
 from kolibri.core.hooks import RoleBasedRedirectHook
+from kolibri.core.theme_hook import BRAND_COLORS
+from kolibri.core.theme_hook import COLOR_V400
+from kolibri.core.theme_hook import PRIMARY
+from kolibri.core.theme_hook import ThemeHook
 
 
 # Modified from django.views.i18n
@@ -165,6 +169,16 @@ class RootURLRedirectView(View):
 @method_decorator(cache_no_user_data, name="dispatch")
 class UnsupportedBrowserView(TemplateView):
     template_name = "kolibri/unsupported_browser.html"
+
+    def get_context_data(self, **kwargs):
+        context = super(UnsupportedBrowserView, self).get_context_data(**kwargs)
+        context["brand_primary_v400"] = (
+            ThemeHook.get_theme()
+            .get(BRAND_COLORS, {})
+            .get(PRIMARY, {})
+            .get(COLOR_V400, "purple")
+        )
+        return context
 
 
 class StatusCheckView(View):


### PR DESCRIPTION
## Summary
* Uses the dynamic Kolibri theming rather than hard coded Kolibri purple for the background of the toolbar for the unsupported browser page

## References
Fixes #7510

## Reviewer guidance
If you update the PRIMARY V400 colour in the theme plugin, does this cause the unsupported browser page at `/en/unsupported/` to also change its colour accordingly?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
