### PR TITLE
Fix debug logging

### DIFF
--- a/kolibri/core/tasks/compat.py
+++ b/kolibri/core/tasks/compat.py
@@ -1,28 +1,53 @@
+import multiprocessing
+import threading
+
+from concurrent import futures
+
 from kolibri.utils.conf import OPTIONS
 
-try:
-    if not OPTIONS["Tasks"]["USE_WORKER_MULTIPROCESSING"]:
-        raise ImportError()
-    # Import in order to check if multiprocessing is supported on this platform
-    from multiprocessing import synchronize  # noqa
 
-    # Proxy Process to Thread to allow seamless substitution
-    from multiprocessing import Process as Thread  # noqa
-    from multiprocessing import Event  # noqa
+def use_multiprocessing():
+    try:
+        if not OPTIONS["Tasks"]["USE_WORKER_MULTIPROCESSING"]:
+            raise ImportError()
+        # Import in order to check if multiprocessing is supported on this platform
+        from multiprocessing import synchronize  # noqa
 
-    # any variable is local to a process, so this is
-    # just a dummy
-    class local(object):
-        """
-        Dummy class to use for a local object for multiprocessing
-        """
+        return True
+    except ImportError:
+        return False
 
-        pass
 
-    from concurrent.futures import ProcessPoolExecutor as PoolExecutor  # noqa
+def Thread(*args, **kwargs):
+    if use_multiprocessing():
+        return multiprocessing.Process(*args, **kwargs)
+    return threading.Thread(*args, **kwargs)
 
-except ImportError:
-    from threading import Thread  # noqa
-    from threading import Event  # noqa
-    from threading import local  # noqa
-    from concurrent.futures import ThreadPoolExecutor as PoolExecutor  # noqa
+
+def Event(*args, **kwargs):
+    if use_multiprocessing():
+        return multiprocessing.Event(*args, **kwargs)
+    return threading.Event(*args, **kwargs)
+
+
+class _Local(object):
+    """
+    Dummy class to use for a local object for multiprocessing
+    """
+
+    pass
+
+
+def local(*args, **kwargs):
+    if use_multiprocessing():
+        # any variable is local to a process, so this is
+        # just a dummy
+
+        return _Local(*args, **kwargs)
+    return threading.local(*args, **kwargs)
+
+
+def PoolExecutor(*args, **kwargs):
+    if use_multiprocessing():
+        return futures.ProcessPoolExecutor(*args, **kwargs)
+    return futures.ThreadPoolExecutor(*args, **kwargs)

--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -16,7 +16,6 @@ from kolibri.core.tasks.job import State
 from kolibri.core.tasks.queue import Queue
 from kolibri.core.tasks.storage import StorageMixin
 from kolibri.core.tasks.utils import InfiniteLoopThread
-from kolibri.utils.conf import OPTIONS
 from kolibri.utils.time_utils import local_now
 from kolibri.utils.time_utils import naive_utc_datetime
 
@@ -44,7 +43,7 @@ class ScheduledJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType(protocol=OPTIONS["Python"]["PICKLE_PROTOCOL"]))
+    obj = Column(PickleType(protocol=2))
 
     scheduled_time = Column(DateTime())
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import sessionmaker
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
-from kolibri.utils.conf import OPTIONS
 
 Base = declarative_base()
 
@@ -44,7 +43,7 @@ class ORMJob(Base):
     queue = Column(String, index=True)
 
     # The original Job object, pickled here for so we can easily access it.
-    obj = Column(PickleType(protocol=OPTIONS["Python"]["PICKLE_PROTOCOL"]))
+    obj = Column(PickleType(protocol=2))
 
     time_created = Column(DateTime(timezone=True), server_default=func.now())
     time_updated = Column(DateTime(timezone=True), server_onupdate=func.now())

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -4,13 +4,15 @@ import time
 import uuid
 from threading import Thread
 
+from django.utils.functional import SimpleLazyObject
+
 from kolibri.core.tasks import compat
 
 
 # An object on which to store data about the current job
 # So far the only use is to track the job, but other metadata
 # could be added.
-current_state_tracker = compat.local()
+current_state_tracker = SimpleLazyObject(compat.local)
 
 
 def get_current_job():

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import importlib
 import logging
 import signal
 import sys
 import traceback
+from pkgutil import find_loader
 
 import click
 from django.core.management import execute_from_command_line
@@ -43,7 +43,8 @@ click.disable_unicode_literals_warning = True
 def validate_module(ctx, param, value):
     if value:
         try:
-            importlib.import_module(value)
+            if not find_loader(value):
+                raise ImportError
         except ImportError:
             raise click.BadParameter(
                 "{param} must be a valid python module import path"

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -208,6 +208,12 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },
+            "django.template": {
+                "handlers": DEFAULT_HANDLERS,
+                # Django template debug is very noisy, only log INFO and above.
+                "level": "INFO",
+                "propagate": False,
+            },
         },
     }
 

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -121,8 +121,8 @@ def setup_logging(debug=False, debug_database=False):
     """
     # Sets the global DEBUG flag to be picked up in other contexts
     # (Django settings)
-    OPTIONS["Server"]["DEBUG"] = debug
-    OPTIONS["Server"]["DEBUG_LOG_DATABASE"] = debug_database
+    os.environ["KOLIBRI_DEBUG"] = str(debug)
+    os.environ["KOLIBRI_DEBUG_LOG_DATABASE"] = str(debug_database)
 
     # Would be ideal to use the upgrade logic for this, but that is currently
     # only designed for post-Django initialization tasks. If there are more cases


### PR DESCRIPTION
## Summary
* Premature options evaluation from various modules accessing OPTIONS in the module scope led to logging being initialized without the debug argument
* This removes the use of PICKLE PROTOCOL for the job storage, and hard codes it to 2 - ideally we will change this to a JSON field instead and remove use of pickling.
* Refactors the kolibri.core.tasks.compat module to expose functions that return constructed objects, to avoid evaluation of the OPTION in the module scope
* Turns the current_job_tracker into a SimpleLazyObject so it is only evaluated when accessed.
* Suppresses Django template DEBUG messages

## References
Fixes #7294

## Reviewer guidance
Does running the python devserver show debug statements in the console?
Does trying to navigate to a 404 under e.g. `/en/learn/topics.js` not show huge DEBUG logs as shown in #7294 ?

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
