### PR TITLE
Give a better error from RemoteViewset when Kolibri is offline

### DIFF
--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1813,5 +1813,22 @@ class KolibriStudioAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    @mock.patch.object(requests, "get", side_effect=requests.exceptions.ConnectionError)
+    def test_channel_info_offline(self, mock_get):
+        response = self.client.get(
+            reverse("kolibri:core:remotechannel-detail", kwargs={"pk": "abc"}),
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.json()["status"], "offline")
+
+    @mock.patch.object(requests, "get", side_effect=requests.exceptions.ConnectionError)
+    def test_channel_list_offline(self, mock_get):
+        response = self.client.get(
+            reverse("kolibri:core:remotechannel-list"), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.json()["status"], "offline")
+
     def tearDown(self):
         cache.clear()


### PR DESCRIPTION
## Summary
* Prevents an unhandled error when the server is offline and returns a 503 instead

## References
* Fixes #6375

## Reviewer guidance
Does this seem like the right change? It still gives an error so shouldn't affect the frontend.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
