### PR TITLE
User strings corrections and improvements

### DIFF
--- a/kolibri/core/assets/src/views/AuthMessage.vue
+++ b/kolibri/core/assets/src/views/AuthMessage.vue
@@ -138,7 +138,7 @@
       },
       contentManager: {
         message:
-          'You must be signed in as a superuser or have resource management permissions to view this page',
+          'You must be signed in as a super admin or have resource management permissions to view this page',
         context:
           'Message presented to any user *without* super admin or resource management permissions who accidentally lands on a Kolibri page that is reserved for super admins.',
       },

--- a/kolibri/core/assets/src/views/ContentIcon.vue
+++ b/kolibri/core/assets/src/views/ContentIcon.vue
@@ -177,9 +177,9 @@
     },
     $trs: {
       topic: {
-        message: 'Topic',
+        message: 'Folder',
         context:
-          'A topic is a collection of learning resources and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy.',
+          'A folder contains a set of learning resources and other subfolders within a channel. Nested folders allow a channel to be organized as a tree or hierarchy.',
       },
       channel: {
         message: 'Channel',

--- a/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
+++ b/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
@@ -115,7 +115,7 @@
           "String appears on the 'Quiz report' that a learner can access after they submit the quiz. Value is expressed as a percentage of correctly answered questions. Can be translated as 'Score'.  ",
       },
       questionsCorrectLabel: {
-        message: 'Questions correct',
+        message: 'Questions answered correctly',
         context:
           "When reviewing a learner's report, a coach can see how many questions the learner has got correct in a quiz. The 'Questions correct' label will indicate something like 4 out of 5, or 8 out of 10, for example.",
       },

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -318,7 +318,7 @@
       forgetAddressButtonLabel: {
         message: 'Remove',
         context:
-          "Removes a network address from the list of network addresses which have been registered in the Device > Facilities section.",
+          'Removes a network address from the list of network addresses which have been registered in the Device > Facilities section.',
       },
       header: {
         message: 'Select network address',

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -316,9 +316,9 @@
           'Error message that displays when an admin attempts to find a network address, but the address is not found.',
       },
       forgetAddressButtonLabel: {
-        message: 'Forget',
+        message: 'Remove',
         context:
-          "Selecting 'Forget' removes a network address from the list of network addresses which have been registered in the Device > Facilities section.",
+          "Removes a network address from the list of network addresses which have been registered in the Device > Facilities section.",
       },
       header: {
         message: 'Select network address',

--- a/kolibri/core/assets/src/views/sync/SelectSyncSourceModal.vue
+++ b/kolibri/core/assets/src/views/sync/SelectSyncSourceModal.vue
@@ -85,7 +85,7 @@
       },
       localNetworkDescription: {
         message:
-          'Sync facility data with another Kolibri server in your local network or the internet',
+          'Sync facility data with another Kolibri server on your local network or the internet',
 
         context: 'Description of the sync option',
       },

--- a/kolibri/core/assets/src/views/sync/SelectSyncSourceModal.vue
+++ b/kolibri/core/assets/src/views/sync/SelectSyncSourceModal.vue
@@ -85,7 +85,7 @@
       },
       localNetworkDescription: {
         message:
-          'Sync facility data with another instance of Kolibri on your local network or the internet',
+          'Sync facility data with another Kolibri server in your local network or the internet',
 
         context: 'Description of the sync option',
       },

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -79,7 +79,7 @@ MESSAGES = {
         "Error when the command is executed in the Terminal (command prompt)",
         "Value in column '{}' has too many characters",
     ),
-    INVALID: _("Invalid value in column '{}'"),
+    INVALID: _("Value in column '{}' not valid"),
     DUPLICATED_USERNAME: _("Username is duplicated"),
     INVALID_USERNAME: _(
         "Username only can contain characters, numbers and underscores"
@@ -90,7 +90,7 @@ MESSAGES = {
     ),
     INVALID_HEADER: pgettext_lazy(
         "Error message indicating that one column header in the CSV file selected for import is missing or incorrect",
-        "Invalid header label found in the first row",
+        "Incorrect header label found in the first row",
     ),
     NO_FACILITY: pgettext_lazy(
         "Error when the command is executed in the Terminal (command prompt)",

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -485,7 +485,7 @@ const MissingContentStrings = createTranslator('MissingContentStrings', {
   },
   resourcesUnavailableP2: {
     message:
-      'Consult your administrator for guidance, or use an account with device permissions to manage content channels.',
+      'Consult your administrator for guidance, or use an account with device permissions to manage channels and resources.',
 
     context: 'Second paragraph of the "Resources Unavailable - Learn More" modal',
   },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -531,9 +531,9 @@
         context: "Title of the screen launched from the 'New quiz' button on the 'Plan' tab.",
       },
       chooseExercises: {
-        message: 'Select topics or exercises',
+        message: 'Select folders or exercises from these channels',
         context:
-          'When creating a new quiz, coaches can choose which topics or excercises they want to include in the quiz from the list of resources available.',
+          'When creating a new quiz, coaches can choose which folders or excercises they want to include in the quiz from the channels that contain exercise resources.',
       },
       numQuestions: {
         message: 'Number of questions',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchFilters.vue
@@ -191,8 +191,8 @@
           "Title of search filter. Users have the option to either 'Show' or 'Hide' coach resources in a search.\n\nCoach resources can be lesson plans, professional development readings, training materials, etc. only viewable by coaches and not learners.",
       },
       topics: {
-        message: 'Topics',
-        context: 'Type of resource material.',
+        message: 'Folders',
+        context: 'Group of resource materials.',
       },
       videos: {
         message: 'Videos',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -424,7 +424,7 @@
     $trs: {
       selectionInformation: {
         message:
-          '{count, number, integer} of {total, number, integer} {total, plural, one {resource} other {resources}} selected',
+          '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
         context:
           "Indicates the amount of resources selected for a lesson in the 'Manage lesson resources' section.",
       },

--- a/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
+++ b/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
@@ -50,7 +50,7 @@
         context: 'Title on Kolibri demo site sign in page.',
       },
       demoServerP1: {
-        message: 'Explore any of the three primary user types:',
+        message: 'Explore any of these user types:',
         context: 'Description text on demo sign in page.',
       },
       demoServerL1: {

--- a/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
+++ b/kolibri/plugins/demo_server/assets/src/DemoServerBannerContent.vue
@@ -54,7 +54,7 @@
         context: 'Description text on demo sign in page.',
       },
       demoServerL1: {
-        message: 'Learner ({user}/{pass} or access as a guest)',
+        message: 'Learner ({user}/{pass} or explore without an account)',
         context:
           "Provides a username and password for a user to sign in to the demo facility as a Learner. Also indicates that there's an option to sign in as a guest without the need for a username or password.",
       },

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -9,7 +9,7 @@ const translator = createTranslator('UserPermissionToolbarTitles', {
     context: 'Link to go back to the list of users.',
   },
   invalidUserTitle: {
-    message: 'Invalid user ID',
+    message: 'User ID not valid',
     context: 'Error message.',
   },
 });

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -440,9 +440,9 @@
           '\nAllow the user to select entire channels instead of individual topics/resources within a channel',
       },
       selectTopicsAndResources: {
-        message: 'Select topics and resources instead',
+        message: 'Select folders and resources instead',
         context:
-          '\nAllow the user to select individual topics/resources within a channel instead of entire channels',
+          '\nAllow the user to select individual folders/resources within a channel instead of entire channels',
       },
       notEnoughSpaceForChannelsWarning: {
         message:

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -107,13 +107,13 @@
       },
       networkDescription: {
         message:
-          'Import resources from another instance of Kolibri running on another device, either in the same local network or on the internet',
+          'Import resources from another Kolibri server running on a device in your local network, or on the internet',
         context:
           'Description referring to importing channels from a local network or the internet.',
       },
       localDescription: {
         message:
-          'Import resources from a drive. Channels must have first been exported onto the drive from another instance of Kolibri',
+          'Import resources from a drive. Channels must have first been exported onto the drive from another Kolibri server',
         context:
           'Description referring to importing channels from an attached drive or memory card.',
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/SelectTransferSourceModal/SelectImportSourceModal.vue
@@ -107,7 +107,7 @@
       },
       networkDescription: {
         message:
-          'Import resources from another Kolibri server running on a device in your local network, or on the internet',
+          'Import resources from another Kolibri server running on a device on your local network or the internet',
         context:
           'Description referring to importing channels from a local network or the internet.',
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
@@ -6,7 +6,7 @@ export default createTranslator('ChannelUpdateStrings', {
     context: "Error message that displays if channel can't be found on an external disk drive.",
   },
   notAvailableFromNetwork: {
-    message: 'This channel was not found on any Kolibri server in your network',
+    message: 'This channel was not found on any Kolibri server on your network',
     context:
       "Error message that displays if a channel can't be found on the Kolibri network. This may display when the user imports resources from a different device running Kolibri in their same local network, or from a Kolibri server hosted outside their LAN.\n\nKolibri will try to automatically detect other instances (peers) running in the same LAN. If detection is unsuccessful, this message displays.",
   },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/channelUpdateStrings.js
@@ -6,7 +6,7 @@ export default createTranslator('ChannelUpdateStrings', {
     context: "Error message that displays if channel can't be found on an external disk drive.",
   },
   notAvailableFromNetwork: {
-    message: 'This channel was not found on other instances of Kolibri',
+    message: 'This channel was not found on any Kolibri server in your network',
     context:
       "Error message that displays if a channel can't be found on the Kolibri network. This may display when the user imports resources from a different device running Kolibri in their same local network, or from a Kolibri server hosted outside their LAN.\n\nKolibri will try to automatically detect other instances (peers) running in the same LAN. If detection is unsuccessful, this message displays.",
   },

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
@@ -249,7 +249,7 @@
         context: 'Refers to the Device > Permissions page.',
       },
       canManageContentLabel: {
-        message: 'Can manage content',
+        message: 'Can manage resources',
         context: 'Type of permission that can be given to a user.',
       },
       superAdminLabel: {

--- a/kolibri/plugins/device/assets/src/views/PermissionsChangeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/PermissionsChangeModal.vue
@@ -57,7 +57,7 @@
           "Description of permission. This window displays if a user's permissions are changed.",
       },
       manageContentMessage1: {
-        message: 'You have been given permissions to manage content on this device.',
+        message: 'You have been given permissions to manage channels and resources on this device.',
         context:
           "Description of permission. This window displays if a user's permissions are changed.",
       },

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -269,8 +269,8 @@
         context: 'Channel picker.',
       },
       topicHasNoContents: {
-        message: 'This topic has no sub-topics or resources',
-        context: 'Message displays if a topic has no content.',
+        message: 'This folder has no subfolders or resources',
+        context: 'Message displays if a folder is empty.',
       },
     },
   };

--- a/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
@@ -238,12 +238,12 @@
         context: 'Refers to number of search results. Only translate "result" and "results".',
       },
       enterSearchQuery: {
-        message: 'Enter search query',
-        context: 'Refers to the to the search field in the EPUB reader.',
+        message: 'Enter a word to search',
+        context: 'Label for the search field in the EPUB reader.',
       },
       submitSearchQuery: {
-        message: 'Submit search query',
-        context: 'Refers to initialing a search query in an EPUB book.',
+        message: 'Start the search',
+        context: 'Label for a button to initiate a search in an EPUB book.',
       },
     },
   };

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -188,12 +188,12 @@
     },
     $trs: {
       exitFullscreen: {
-        message: 'Exit Fullscreen',
+        message: 'Exit fullscreen',
         context:
           "Learners can use the Esc key or the 'exit fullscreen' button to close the fullscreen view on an html5 app.",
       },
       enterFullscreen: {
-        message: 'View Fullscreen',
+        message: 'Enter fullscreen',
         context:
           'Learners can use the full screen button in the upper right corner to open an html5 app in fullscreen view.\n',
       },

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -535,7 +535,7 @@ oriented data synchronization.
         context: 'Button that takes user to next question.',
       },
       itemError: {
-        message: 'There was an error showing this item',
+        message: 'There was an error showing this question',
         context:
           'Error message a user sees if there was a problem accessing a learning resource. This may be because the resource has been removed, for example.',
       },

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -354,7 +354,7 @@
       keepUpTheGreatProgress: 'Keep up the great progress!',
       close: 'Close',
       moveOnTitle: 'Keep going',
-      moveOnDescription: 'Move on to the next resource in the topic',
+      moveOnDescription: 'Move on to the next resource in the folder',
       moveOnButtonLabel: 'Move on',
       stayTitle: 'Stay and practice',
       stayDescription: 'Stay on this resource to keep practicing',

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -54,7 +54,7 @@
         context: "Description on the 'No resources available' page.",
       },
       documentTitle: {
-        message: 'Content Unavailable',
+        message: 'Resource unavailable',
         context: '\nThis string should actually say "Resource unavailable"',
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -341,7 +341,7 @@
       },
       questionsAnswered: {
         message:
-          '{numAnswered, number} of {numTotal, number} {numTotal, plural, one {question} other {questions}} answered',
+          '{numAnswered, number} of {numTotal, number} {numTotal, plural, one {question answered} other {questions answered}}',
         context:
           'Indicates the number of questions a learner has answered. Only translate "of" and "question/questions answered".',
       },
@@ -360,7 +360,7 @@
       },
       unanswered: {
         message:
-          'You have {numLeft, number} {numLeft, plural, one {question} other {questions}} unanswered',
+          'You have {numLeft, number} {numLeft, plural, one {question unanswered} other {questions unanswered}}',
         context: 'Indicates how many unanswered questions the learner has.',
       },
       noItemId: {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -273,7 +273,7 @@
       viewTopicResources: 'View folder resources',
       removeFromBookmarks: 'Remove from bookmarks',
       saveToBookmarks: 'Save to bookmarks',
-      markResourceAsFinished: 'Mark resource as finished',
+      markResourceAsFinished: 'Mark resource as completed',
       viewInformation: 'View information',
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -270,7 +270,7 @@
       goBack: 'Go back',
       moreOptions: 'More options',
       viewLessonPlan: 'View lesson plan',
-      viewTopicResources: 'View topic resources',
+      viewTopicResources: 'View folder resources',
       removeFromBookmarks: 'Remove from bookmarks',
       saveToBookmarks: 'Save to bookmarks',
       markResourceAsFinished: 'Mark resource as finished',

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -264,9 +264,9 @@
           'Learners can filter their searches for resources by type. For example, audio files, video files etc.',
       },
       topics: {
-        message: 'Topics',
+        message: 'Folders',
         context:
-          'Learners can filter their searches for resources by type. In this case, topics.\n\nA topic is a collection of resources and other topics within a channel.',
+          'Learners can also search for comlplete folders.\n\nA folder is a collection of resources and other subfolders within a channel.',
       },
       exercises: {
         message: 'Exercises',

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -266,7 +266,7 @@
       topics: {
         message: 'Folders',
         context:
-          'Learners can also search for comlplete folders.\n\nA folder is a collection of resources and other subfolders within a channel.',
+          'Learners can also search for complete folders.\n\nA folder is a collection of resources and other subfolders within a channel.',
       },
       exercises: {
         message: 'Exercises',

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -168,9 +168,9 @@
     },
     $trs: {
       documentTitleForChannel: {
-        message: 'Topics - { channelTitle }',
+        message: 'Folders - { channelTitle }',
         context:
-          'A topic is a collection of resources and other topics within a channel. This string indicates the topics grouped under a specific channel.',
+          'A folder is a collection of resources and other subfolders within a channel. This string indicates the folders grouped under a specific channel.',
       },
       documentTitleForTopic: {
         message: '{ topicTitle } - { channelTitle }',

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -485,12 +485,12 @@
           'Describes the time tracker indicator bar in the bottom of the media player which allows a learner to view the progress through a media file and skip to specific times.',
       },
       fullscreen: {
-        message: 'Fullscreen',
+        message: 'Enter fullscreen',
         context:
           'Learners can use the full screen button in the bottom right corner to open the media player in fullscreen view.\n',
       },
       nonFullscreen: {
-        message: 'Non-fullscreen',
+        message: 'Exit fullscreen',
         context:
           'Learners can use the full screen button in the bottom right corner to exit the media player from fullscreen view. This text appears upon mouse over of the button.\n',
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
@@ -57,7 +57,7 @@
     },
     $trs: {
       adminAccountCreationDescriptionPersonal: {
-        message: 'This account allows you to manage all content and user accounts on this device',
+        message: 'This account allows you to manage all resource channels and user accounts on this device',
         context: 'Alternative description for SuperuserCredentialsForm when doing a personal setup',
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/PersonalSetup.vue
@@ -57,7 +57,8 @@
     },
     $trs: {
       adminAccountCreationDescriptionPersonal: {
-        message: 'This account allows you to manage all resource channels and user accounts on this device',
+        message:
+          'This account allows you to manage all resource channels and user accounts on this device',
         context: 'Alternative description for SuperuserCredentialsForm when doing a personal setup',
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/SelectSuperAdminAccountForm.vue
@@ -213,7 +213,7 @@
       },
       description: {
         message:
-          'This account allows you to manage all facilities, content, and user accounts on this device.',
+          'This account allows you to manage all facilities, resources, and user accounts on this device.',
 
         context: 'Explanation of what the super admin account is used for on device',
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
@@ -124,19 +124,19 @@
       fullDevice: {
         message: 'Full device',
         context:
-          'Create or import a device that will be a server to be used by coaches and learners',
+          'Device that will be fully featured Kolibri server used by admins, coaches and learners',
       },
       fullDeviceTooltip: {
         message:
-          'Create or import a device that will be a server to be used by coaches and learners',
+          'Device will be fully featured Kolibri server used by admins, coaches and learners',
         context: 'Tooltip for full device',
       },
       lod: {
         message: 'Learn-only device',
-        context: 'Import one more learners from an existing Kolibri server',
+        context: 'Device that has Kolibri features for learners, but not those for coaches and admins',
       },
       lodTooltip: {
-        message: 'Import one more learners from an existing Kolibri server',
+        message: 'Device will have Kolibri features for learners, but not those for coaches and admins',
         context: 'Tooltip for Learn-only device',
       },
       descriptionParagraph1: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
@@ -124,11 +124,11 @@
       fullDevice: {
         message: 'Full device',
         context:
-          'Device that will be fully featured Kolibri server used by admins, coaches and learners',
+          'Device that will be a fully featured Kolibri server used by admins, coaches and learners',
       },
       fullDeviceTooltip: {
         message:
-          'Device will be fully featured Kolibri server used by admins, coaches and learners',
+          'Device will be a fully featured Kolibri server used by admins, coaches and learners',
         context: 'Tooltip for full device',
       },
       lod: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetupMethod.vue
@@ -133,10 +133,12 @@
       },
       lod: {
         message: 'Learn-only device',
-        context: 'Device that has Kolibri features for learners, but not those for coaches and admins',
+        context:
+          'Device that has Kolibri features for learners, but not those for coaches and admins',
       },
       lodTooltip: {
-        message: 'Device will have Kolibri features for learners, but not those for coaches and admins',
+        message:
+          'Device will have Kolibri features for learners, but not those for coaches and admins',
         context: 'Tooltip for Learn-only device',
       },
       descriptionParagraph1: {

--- a/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
+++ b/kolibri/plugins/user/assets/src/modules/signIn/handlers.js
@@ -4,7 +4,7 @@ import { createTranslator } from 'kolibri.utils.i18n';
 
 const snackbarTranslator = createTranslator('UserPageSnackbars', {
   dismiss: {
-    message: 'Dismiss',
+    message: 'Close',
     context:
       'Button which upon selecting will hide the notification that has appeared on the screen at that moment.',
   },

--- a/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user/assets/src/views/ProfilePage/index.vue
@@ -242,7 +242,7 @@
           'A super admin is an account type that can manage the device. Super admin accounts also have permission to do everything that admins, coaches, and learners can do.',
       },
       manageContent: {
-        message: 'Manage content',
+        message: 'Manage channels and resources',
         context: 'A type of device permission.',
       },
       manageDevicePermissions: {


### PR DESCRIPTION
## Summary
Various relatively minor changes in user strings to consolidate, simplify and avoid tech jargon, mostly inspired by reviewing questions from translators on Crowdin in releases v0.13 and v0.14.

## References
Fixes https://github.com/learningequality/clearinghouse/issues/543

## Reviewer guidance
Check if changes make sense.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
