### PR TITLE
Make setup.cfg optional for kolibri-tools JS.

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -18,10 +18,19 @@ function list(val) {
 }
 
 function filePath(val) {
-  return path.resolve(process.cwd(), val);
+  if (val) {
+    return path.resolve(process.cwd(), val);
+  }
 }
 
-const config = ini.parse(fs.readFileSync(path.join(process.cwd(), './setup.cfg'), 'utf-8'));
+let configFile;
+try {
+  configFile = fs.readFileSync(path.join(process.cwd(), './setup.cfg'), 'utf-8');
+} catch (e) {
+  // do nothing
+}
+
+const config = ini.parse(configFile || '');
 
 program.version(version).description('Tools for Kolibri frontend plugins');
 


### PR DESCRIPTION
## Summary
* Fixes oversight in kolibri-tools whereby setup.cfg was required to exist for JS tooling



## Reviewer guidance
Do kolibri-tools commands run when setup.cfg doesn't exist?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
