### PR TITLE
filter SoUD devices when scanning the network to import new facilities

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/api.js
@@ -48,26 +48,28 @@ function fetchAddressesForLOD(LocationResource = NetworkLocationResource) {
 }
 
 function fetchAddressesWithChannel(withChannelId = '', LocationResource = NetworkLocationResource) {
-  return LocationResource.fetchCollection({ force: true }).then(locations => {
-    // If channelId is provided, then we are in an 'import-more' workflow and disable
-    // locations that do not have the channel we are importing from.
-    if (withChannelId !== '') {
-      const locationsWithAvailabilityPromises = locations.map(location => {
-        // Need to wrap in normal promise, otherwise Promise.all will cause some of these
-        // to resolve as undefined
-        return new Promise(resolve => {
-          return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
-            resolve({ ...location, hasContent: isAvailable });
+  return LocationResource.fetchCollection({ force: true, getParams: { filterSoUD: true } }).then(
+    locations => {
+      // If channelId is provided, then we are in an 'import-more' workflow and disable
+      // locations that do not have the channel we are importing from.
+      if (withChannelId !== '') {
+        const locationsWithAvailabilityPromises = locations.map(location => {
+          // Need to wrap in normal promise, otherwise Promise.all will cause some of these
+          // to resolve as undefined
+          return new Promise(resolve => {
+            return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
+              resolve({ ...location, hasContent: isAvailable });
+            });
           });
         });
-      });
-      return Promise.all(locationsWithAvailabilityPromises);
-    }
+        return Promise.all(locationsWithAvailabilityPromises);
+      }
 
-    // If channelId is not provided, then we are at top-level import workflow and do not
-    // disable any locations unless it is unavailable
-    return locations.map(location => ({ ...location, hasContent: location.available }));
-  });
+      // If channelId is not provided, then we are at top-level import workflow and do not
+      // disable any locations unless it is unavailable
+      return locations.map(location => ({ ...location, hasContent: location.available }));
+    }
+  );
 }
 
 function facilityIsAvailableAtLocation(facilityId, location) {
@@ -83,25 +85,27 @@ function facilityIsAvailableAtLocation(facilityId, location) {
 }
 
 function fetchAddressesWithFacility(facilityId = '', LocationResource = NetworkLocationResource) {
-  return LocationResource.fetchCollection({ force: true }).then(locations => {
-    if (facilityId !== '') {
-      const locationsWithAvailabilityPromises = locations.map(location => {
-        // Need to wrap in normal promise, otherwise Promise.all will cause some of these
-        // to resolve as undefined
-        return new Promise(resolve => {
-          return facilityIsAvailableAtLocation(facilityId, location).then(isAvailable => {
-            // NOTE: we're reusing 'hasContent' for both the facility/content cases for now
-            resolve({ ...location, hasContent: isAvailable });
+  return LocationResource.fetchCollection({ force: true, getParams: { filterSoUD: true } }).then(
+    locations => {
+      if (facilityId !== '') {
+        const locationsWithAvailabilityPromises = locations.map(location => {
+          // Need to wrap in normal promise, otherwise Promise.all will cause some of these
+          // to resolve as undefined
+          return new Promise(resolve => {
+            return facilityIsAvailableAtLocation(facilityId, location).then(isAvailable => {
+              // NOTE: we're reusing 'hasContent' for both the facility/content cases for now
+              resolve({ ...location, hasContent: isAvailable });
+            });
           });
         });
-      });
-      return Promise.all(locationsWithAvailabilityPromises);
-    }
+        return Promise.all(locationsWithAvailabilityPromises);
+      }
 
-    // If facilityId is not provided, then we are at the initial Facility Import workflow
-    // disable any locations unless it is unavailable/offline
-    return locations.map(location => ({ ...location, hasContent: location.available }));
-  });
+      // If facilityId is not provided, then we are at the initial Facility Import workflow
+      // disable any locations unless it is unavailable/offline
+      return locations.map(location => ({ ...location, hasContent: location.available }));
+    }
+  );
 }
 
 export function fetchStaticAddresses(args) {

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/api.js
@@ -48,28 +48,26 @@ function fetchAddressesForLOD(LocationResource = NetworkLocationResource) {
 }
 
 function fetchAddressesWithChannel(withChannelId = '', LocationResource = NetworkLocationResource) {
-  return LocationResource.fetchCollection({ force: true, getParams: { filterSoUD: true } }).then(
-    locations => {
-      // If channelId is provided, then we are in an 'import-more' workflow and disable
-      // locations that do not have the channel we are importing from.
-      if (withChannelId !== '') {
-        const locationsWithAvailabilityPromises = locations.map(location => {
-          // Need to wrap in normal promise, otherwise Promise.all will cause some of these
-          // to resolve as undefined
-          return new Promise(resolve => {
-            return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
-              resolve({ ...location, hasContent: isAvailable });
-            });
+  return LocationResource.fetchCollection({ force: true }).then(locations => {
+    // If channelId is provided, then we are in an 'import-more' workflow and disable
+    // locations that do not have the channel we are importing from.
+    if (withChannelId !== '') {
+      const locationsWithAvailabilityPromises = locations.map(location => {
+        // Need to wrap in normal promise, otherwise Promise.all will cause some of these
+        // to resolve as undefined
+        return new Promise(resolve => {
+          return channelIsAvailableAtLocation(withChannelId, location).then(isAvailable => {
+            resolve({ ...location, hasContent: isAvailable });
           });
         });
-        return Promise.all(locationsWithAvailabilityPromises);
-      }
-
-      // If channelId is not provided, then we are at top-level import workflow and do not
-      // disable any locations unless it is unavailable
-      return locations.map(location => ({ ...location, hasContent: location.available }));
+      });
+      return Promise.all(locationsWithAvailabilityPromises);
     }
-  );
+
+    // If channelId is not provided, then we are at top-level import workflow and do not
+    // disable any locations unless it is unavailable
+    return locations.map(location => ({ ...location, hasContent: location.available }));
+  });
 }
 
 function facilityIsAvailableAtLocation(facilityId, location) {
@@ -85,27 +83,28 @@ function facilityIsAvailableAtLocation(facilityId, location) {
 }
 
 function fetchAddressesWithFacility(facilityId = '', LocationResource = NetworkLocationResource) {
-  return LocationResource.fetchCollection({ force: true, getParams: { filterSoUD: true } }).then(
-    locations => {
-      if (facilityId !== '') {
-        const locationsWithAvailabilityPromises = locations.map(location => {
-          // Need to wrap in normal promise, otherwise Promise.all will cause some of these
-          // to resolve as undefined
-          return new Promise(resolve => {
-            return facilityIsAvailableAtLocation(facilityId, location).then(isAvailable => {
-              // NOTE: we're reusing 'hasContent' for both the facility/content cases for now
-              resolve({ ...location, hasContent: isAvailable });
-            });
+  return LocationResource.fetchCollection({
+    force: true,
+    getParams: { subset_of_users_device: false },
+  }).then(locations => {
+    if (facilityId !== '') {
+      const locationsWithAvailabilityPromises = locations.map(location => {
+        // Need to wrap in normal promise, otherwise Promise.all will cause some of these
+        // to resolve as undefined
+        return new Promise(resolve => {
+          return facilityIsAvailableAtLocation(facilityId, location).then(isAvailable => {
+            // NOTE: we're reusing 'hasContent' for both the facility/content cases for now
+            resolve({ ...location, hasContent: isAvailable });
           });
         });
-        return Promise.all(locationsWithAvailabilityPromises);
-      }
-
-      // If facilityId is not provided, then we are at the initial Facility Import workflow
-      // disable any locations unless it is unavailable/offline
-      return locations.map(location => ({ ...location, hasContent: location.available }));
+      });
+      return Promise.all(locationsWithAvailabilityPromises);
     }
-  );
+
+    // If facilityId is not provided, then we are at the initial Facility Import workflow
+    // disable any locations unless it is unavailable/offline
+    return locations.map(location => ({ ...location, hasContent: location.available }));
+  });
 }
 
 export function fetchStaticAddresses(args) {

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -1,4 +1,5 @@
 import requests
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
@@ -15,16 +16,10 @@ class NetworkLocationViewSet(viewsets.ModelViewSet):
     permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.all()
-
-    def filter_queryset(self, queryset):
-        if (
-            self.request.method == "GET"
-            and self.request.resolver_match.url_name.endswith("-list")
-        ):
-            # only filter down the queryset in the case of the list view being requested
-            if self.request.query_params.get("filterSoUD", False):
-                return queryset.filter(subset_of_users_device=False)
-        return queryset
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = [
+        "subset_of_users_device",
+    ]
 
 
 class DynamicNetworkLocationViewSet(NetworkLocationViewSet):

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -16,6 +16,16 @@ class NetworkLocationViewSet(viewsets.ModelViewSet):
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.all()
 
+    def filter_queryset(self, queryset):
+        if (
+            self.request.method == "GET"
+            and self.request.resolver_match.url_name.endswith("-list")
+        ):
+            # only filter down the queryset in the case of the list view being requested
+            if self.request.query_params.get("filterSoUD", False):
+                return queryset.filter(subset_of_users_device=False)
+        return queryset
+
 
 class DynamicNetworkLocationViewSet(NetworkLocationViewSet):
     queryset = DynamicNetworkLocation.objects.all()


### PR DESCRIPTION
## Summary
When a superuser tries to import new facilities, subsets of users devices should not be shown nor found in the list of available devices to look for new facilites

## References
Closes: #8276 

## Reviewer guidance
1.  Setup a subset of users device (a.k.a. learn only device) a
2. Setup another kolibri server, both in your network

Before this PR:

- superuser of the kolibri server will see the SoUD when scanning facilities to import

After this PR:

 - superuser of the kolibri server will NOT see the SoUD when scanning facilities to import


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
