### PR TITLE
Do not create accounts in Subset of users devices

### DIFF
--- a/kolibri/plugins/user/assets/src/routes.js
+++ b/kolibri/plugins/user/assets/src/routes.js
@@ -10,6 +10,7 @@ import ProfileEditPage from './views/ProfileEditPage';
 import SignInPage from './views/SignInPage';
 import SignUpPage from './views/SignUpPage';
 import NewPasswordPage from './views/SignInPage/NewPasswordPage';
+import plugin_data from 'plugin_data';
 
 router.beforeEach((to, from, next) => {
   const profileRoutes = [ComponentMap.PROFILE, ComponentMap.PROFILE_EDIT];
@@ -75,7 +76,7 @@ export default [
     path: '/create_account',
     component: SignUpPage,
     beforeEnter(to, from, next) {
-      if (store.getters.isUserLoggedIn) {
+      if (plugin_data.isSubsetOfUsersDevice || store.getters.isUserLoggedIn) {
         next(router.getRoute(ComponentMap.PROFILE));
         return Promise.resolve();
       } else {

--- a/kolibri/plugins/user/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user/assets/src/views/AuthBase.vue
@@ -209,7 +209,7 @@
         return urls['kolibri:core:guest']();
       },
       canSignUp() {
-        return this.facilityConfig.learner_can_sign_up;
+        return !plugin_data.isSubsetOfUsersDevice && this.facilityConfig.learner_can_sign_up;
       },
       nextParam() {
         // query is after hash

--- a/kolibri/plugins/user/kolibri_plugin.py
+++ b/kolibri/plugins/user/kolibri_plugin.py
@@ -27,6 +27,9 @@ class UserAsset(webpack_hooks.WebpackBundleHook):
         return {
             "oidcProviderEnabled": OIDCProviderHook.is_enabled(),
             "allowGuestAccess": get_device_setting("allow_guest_access"),
+            "isSubsetOfUsersDevice": get_device_setting(
+                "subset_of_users_device", False
+            ),
         }
 
 


### PR DESCRIPTION
## Summary
In a subset of users device (aka Learner only device) creation of new accounts must not be allowed, no matter the facility settings.


## References
Closes: #8274 

## Reviewer guidance
Setup a subset of users device (a.k.a. learn only device) from a kolibri server facility that allows creation of new accounts by the uers

Before this PR:

- Sign in screen shows the "Create account" button

After this PR:

- Sign in screen does not show  the "Create account" button


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
