### PR TITLE
Don't use SIGKILL on windows as it doesn't exist.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -467,6 +467,15 @@ def wait_for_status(target, timeout=10):
     return False
 
 
+# The SIGKILL signal does not exist on windows
+# We use CTRL_C_EVENT instead, as it is intended
+# to be passed to the os.kill command.
+if sys.platform == "win32":
+    SIGKILL = signal.CTRL_C_EVENT
+else:
+    SIGKILL = signal.SIGKILL
+
+
 def stop():
     """
     Stops the kolibri server
@@ -483,7 +492,7 @@ def stop():
     if pid_exists(pid):
         logger.debug("Process wth pid %s still exists; attempting a SIGKILL." % pid)
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, SIGKILL)
         except SystemError as e:
             logger.debug(
                 "Received an error while trying to kill the Kolibri process: %s" % e


### PR DESCRIPTION
## Summary
* Fixes long running oversight in our process stopping code that is more evident now because of updates to our stop command
* [SIGKILL](https://docs.python.org/3/library/signal.html#signal.SIGKILL) signal is not available on Windows, so uses [CTRL_C_EVENT](https://docs.python.org/3/library/signal.html#signal.CTRL_C_EVENT) instead 

## Reviewer guidance
Does calling `kolibri stop` on Windows work without errors?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
