### PR TITLE
Initial pass for estimated time label in content page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -63,6 +63,22 @@
     </template>
     <KCircularLoader v-else />
 
+    <p v-if="estimatedTime">
+      <!--
+        TODO This icon should be updated ot an alarm clock style
+        clock per the figma linked in #8111
+      -->
+      <KLabeledIcon
+        ref="estimatedTime"
+        class="estimated-time"
+        icon="schedule"
+        :label="$tr('estimatedTime', { estimatedTime })"
+      />
+      <KTooltip reference="estimatedTime" :refs="$refs">
+        {{ $tr("estimatedTimeTooltip") }}
+      </KTooltip>
+    </p>
+
     <!-- TODO consolidate this metadata table with coach/lessons -->
     <!-- eslint-disable-next-line vue/no-v-html -->
     <p dir="auto" v-html="description"></p>
@@ -213,6 +229,17 @@
         extraFields: state => state.core.logging.summary.extra_fields,
         fullName: state => state.core.session.full_name,
       }),
+      estimatedTime() {
+        /*
+          TODO: This should return something like `this.content.estimatedTime`
+          once the metadata is made available
+        */
+        if (process.env.NODE_ENV !== 'production') {
+          return 100;
+        } else {
+          return null;
+        }
+      },
       isTopic() {
         return this.content.kind === ContentNodeKinds.TOPIC;
       },
@@ -396,6 +423,15 @@
         message: 'Share',
         context: 'Option to share a specific file from a learning resource.',
       },
+      estimatedTime: {
+        message: '{ estimatedTime } minutes',
+        context: 'A label indicating the estimated time that the content will take to complete',
+      },
+      estimatedTimeTooltip: {
+        message: 'Suggested time to complete',
+        context:
+          'When a user hovers the estimatedTime string, this message shows in a small tooltip popup to clarify',
+      },
     },
   };
 
@@ -430,6 +466,13 @@
 
   .license-details-name {
     font-weight: bold;
+  }
+
+  .estimated-time {
+    width: auto; // override KLabeledIcon default to 100%
+    font-size: 14px;
+    font-weight: 700;
+    cursor: default; // arrow instead of text cursor
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -69,12 +69,18 @@
         clock per the figma linked in #8111
       -->
       <KLabeledIcon
-        ref="estimatedTime"
         class="estimated-time"
         icon="schedule"
-        :label="$tr('estimatedTime', { estimatedTime })"
-      />
-      <KTooltip reference="estimatedTime" :refs="$refs">
+      >
+        <span ref="estimatedTime">
+          {{ $tr('estimatedTime', { estimatedTime }) }}
+        </span>
+      </KLabeledIcon>
+      <KTooltip
+        placement="bottom-start"
+        reference="estimatedTime"
+        :refs="$refs"
+      >
         {{ $tr("estimatedTimeTooltip") }}
       </KTooltip>
     </p>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds estimated time to ContentPage under the content.

Currently uses a placeholder value - will show "100 minutes" on every content item until the metadata is available.

Also, the display is hidden when `process.env.NODE_ENV === "production"` for now.

https://user-images.githubusercontent.com/6356129/132058556-dd5839be-17d8-4bbb-8fca-f62d368d6395.mp4

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8111 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

@jtamiace does this look okay? It's a little closer to the text than in the Figma but implements the default.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
