### PR TITLE
fix: make strings py2 compatible

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -4,6 +4,7 @@ import traceback
 import uuid
 
 from django.db import connection as django_connection
+from six import string_types
 
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.utils import current_state_tracker
@@ -175,7 +176,7 @@ class Job(object):
             kwargs["cancellable"] = func.cancellable
             kwargs["extra_metadata"] = func.extra_metadata.copy()
             func = func.func
-        elif not callable(func) and not isinstance(func, str):
+        elif not callable(func) and not isinstance(func, string_types):
             raise TypeError(
                 "Cannot create Job for object of type {}".format(type(func))
             )
@@ -296,7 +297,7 @@ class RegisteredJob(object):
             raise ValueError("priority must be one of 'regular' or 'high' (string).")
         elif not isinstance(permission_classes, list):
             raise TypeError("permission_classes must be of list type.")
-        elif not isinstance(queue, str):
+        elif not isinstance(queue, string_types):
             raise TypeError("queue must be of string type.")
 
         self.func = func

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -4,6 +4,8 @@ import time
 import uuid
 from threading import Thread
 
+from six import string_types
+
 from kolibri.core.tasks import compat
 
 
@@ -22,7 +24,7 @@ def stringify_func(func):
         funcstring = "{module}.{funcname}".format(
             module=func.__module__, funcname=func.__name__
         )
-    elif isinstance(func, str):
+    elif isinstance(func, string_types):
         funcstring = func
     else:
         raise TypeError("Can't handle a function of type {}".format(type(func)))
@@ -38,7 +40,7 @@ def import_stringified_func(funcstring):
     :param funcstring: String to try to import
     :return: callable
     """
-    if not isinstance(funcstring, str):
+    if not isinstance(funcstring, string_types):
         raise TypeError("Argument must be a string")
 
     modulestring, funcname = funcstring.rsplit(".", 1)


### PR DESCRIPTION
## Summary
This PR makes `isinstance` checks py2 compatible thus resolving errors when switching between py2 and py3. 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
