### PR TITLE
Zeroconf updates

### DIFF
--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -12,6 +12,7 @@ from zeroconf import Zeroconf
 from ..utils.network.search import _id_from_name
 from ..utils.network.search import get_peer_instances
 from ..utils.network.search import initialize_zeroconf_listener
+from ..utils.network.search import KolibriZeroconfListener
 from ..utils.network.search import KolibriZeroconfService
 from ..utils.network.search import LOCAL_DOMAIN
 from ..utils.network.search import NonUniqueNameException
@@ -137,7 +138,6 @@ class TestNetworkSearch(TransactionTestCase):
 
     def test_register_zeroconf_service(self, mock_db, get_device_mock):
         assert len(get_peer_instances()) == 0
-        initialize_zeroconf_listener()
         register_zeroconf_service(MOCK_PORT)
         assert [x for x in get_peer_instances()] == [
             {
@@ -158,7 +158,9 @@ class TestNetworkSearch(TransactionTestCase):
                 ),
             }
         ]
-        register_zeroconf_service(MOCK_PORT)
+        listener = KolibriZeroconfListener()
+        mock_zeroconf = MockZeroconf()
+        listener.add_service(mock_zeroconf, SERVICE_TYPE, "mock." + SERVICE_TYPE)
         unregister_zeroconf_service()
         assert len(get_peer_instances()) == 0
 

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -32,6 +32,7 @@ ZEROCONF_STATE = {
     "listener": None,
     "service": None,
     "addresses": None,
+    "port": None,
 }
 
 
@@ -241,7 +242,8 @@ class KolibriZeroconfListener(object):
         connection.close()
 
 
-def register_zeroconf_service(port):
+def register_zeroconf_service(port=None):
+    port = port or ZEROCONF_STATE["port"]
     device_info = get_device_info()
     DynamicNetworkLocation.objects.all().delete()
     connection.close()
@@ -257,6 +259,7 @@ def register_zeroconf_service(port):
         )
     )
     data = device_info
+    ZEROCONF_STATE["port"] = port
     ZEROCONF_STATE["service"] = KolibriZeroconfService(id=id, port=port, data=data)
     ZEROCONF_STATE["service"].register()
 
@@ -267,6 +270,7 @@ def unregister_zeroconf_service():
     ZEROCONF_STATE["service"] = None
     if ZEROCONF_STATE["zeroconf"] is not None:
         ZEROCONF_STATE["zeroconf"].close()
+    ZEROCONF_STATE["zeroconf"] = None
 
 
 def initialize_zeroconf_listener():
@@ -276,25 +280,6 @@ def initialize_zeroconf_listener():
         SERVICE_TYPE, ZEROCONF_STATE["listener"]
     )
     ZEROCONF_STATE["addresses"] = set(get_all_addresses())
-
-
-def reinitialize_zeroconf_if_network_has_changed():
-    if ZEROCONF_STATE["addresses"] == set(get_all_addresses()):
-        return
-    if ZEROCONF_STATE["listener"] is None:
-        initialize_zeroconf_listener()
-        return
-    logger.info(
-        "New addresses detected since zeroconf was initialized, re-initializing now"
-    )
-    if ZEROCONF_STATE["zeroconf"] is not None:
-        ZEROCONF_STATE["zeroconf"].close()
-    ZEROCONF_STATE["zeroconf"] = Zeroconf()
-    ZEROCONF_STATE["zeroconf"].add_service_listener(
-        SERVICE_TYPE, ZEROCONF_STATE["listener"]
-    )
-    ZEROCONF_STATE["addresses"] = set(get_all_addresses())
-    logger.info("Zeroconf has reinitialized")
 
 
 def get_peer_instances():

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -259,9 +259,9 @@ def register_zeroconf_service(port=None):
         )
     )
     data = device_info
-    ZEROCONF_STATE["port"] = port
     ZEROCONF_STATE["service"] = KolibriZeroconfService(id=id, port=port, data=data)
     ZEROCONF_STATE["service"].register()
+    ZEROCONF_STATE["port"] = port
 
 
 def unregister_zeroconf_service():
@@ -271,6 +271,9 @@ def unregister_zeroconf_service():
     if ZEROCONF_STATE["zeroconf"] is not None:
         ZEROCONF_STATE["zeroconf"].close()
     ZEROCONF_STATE["zeroconf"] = None
+    ZEROCONF_STATE["listener"] = None
+    ZEROCONF_STATE["addresses"] = None
+    ZEROCONF_STATE["port"] = None
 
 
 def initialize_zeroconf_listener():

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -187,12 +187,10 @@ class SetupWizardRestartZeroconf(ViewSet):
     def restart(self, request):
         import logging
         from kolibri.core.discovery.utils.network.search import (
-            unregister_zeroconf_service,
-            initialize_zeroconf_listener,
+            register_zeroconf_service,
         )
 
         logger = logging.getLogger(__name__)
-        unregister_zeroconf_service()
-        initialize_zeroconf_listener()
+        register_zeroconf_service()
         logger.info("Zeroconf has reinitialized")
         return Response({})

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -303,7 +303,15 @@ class ZeroConfPlugin(Monitor):
         )
 
         if (
+            # If the current addresses that zeroconf is listening on does not
+            # match the current set of all addresses for this device, then
+            # we should reinitialize zeroconf, the listener, and the broadcasted
+            # kolibri service.
             ZEROCONF_STATE["addresses"] == set(get_all_addresses())
+            # The only time we shouldn't do this is if we haven't actually finished
+            # registering the zeroconf service yet, and the port hasn't been defined.
+            # Without the port being defined here, we cannot make the call to register_zeroconf_service
+            # below that we do without invoking the port.
             or ZEROCONF_STATE["port"] is None
         ):
             return

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -277,7 +277,7 @@ class ZeroConfPlugin(Monitor):
     def __init__(self, bus, port):
         self.addresses = set()
         self.port = port
-        Monitor.__init__(self, bus, self.run, 1)
+        Monitor.__init__(self, bus, self.run, 5)
         self.bus.subscribe("SERVING", self.SERVING)
 
     def SERVING(self, port):
@@ -297,13 +297,21 @@ class ZeroConfPlugin(Monitor):
         unregister_zeroconf_service()
 
     def run(self):
-        from kolibri.core.discovery.utils.network.search import ZEROCONF_STATE
         from kolibri.core.discovery.utils.network.search import (
-            reinitialize_zeroconf_if_network_has_changed,
+            ZEROCONF_STATE,
+            register_zeroconf_service,
         )
 
-        if ZEROCONF_STATE["service"] is not None:
-            reinitialize_zeroconf_if_network_has_changed()
+        if (
+            ZEROCONF_STATE["addresses"] == set(get_all_addresses())
+            or ZEROCONF_STATE["port"] is None
+        ):
+            return
+        logger.info(
+            "New addresses detected since zeroconf was initialized, re-initializing now"
+        )
+        register_zeroconf_service()
+        logger.info("Zeroconf has reinitialized")
 
 
 status_map = {

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -95,14 +95,10 @@ class TestServerServices(object):
             register_zeroconf_service.assert_not_called()
 
     @mock.patch("kolibri.core.tasks.main.initialize_workers")
-    @mock.patch(
-        "kolibri.core.discovery.utils.network.search.unregister_zeroconf_service"
-    )
     @mock.patch("kolibri.core.discovery.utils.network.search.register_zeroconf_service")
     def test_scheduled_jobs_persist_on_restart(
         self,
         register_zeroconf_service,
-        unregister_zeroconf_service,
         initialize_workers,
         scheduler,
     ):
@@ -175,12 +171,8 @@ class TestServerServices(object):
 
 class TestZeroConfPlugin(object):
     @mock.patch("kolibri.core.discovery.utils.network.search.register_zeroconf_service")
-    @mock.patch(
-        "kolibri.core.discovery.utils.network.search.reinitialize_zeroconf_if_network_has_changed"
-    )
     def test_required_services_initiate_on_start(
         self,
-        reinitialize_zeroconf_if_network_has_changed,
         register_zeroconf_service,
     ):
 
@@ -189,8 +181,6 @@ class TestZeroConfPlugin(object):
         zeroconf_plugin.START()
 
         register_zeroconf_service.assert_not_called()
-
-        reinitialize_zeroconf_if_network_has_changed.assert_not_called()
 
         zeroconf_plugin.SERVING(1234)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ semver==2.8.1
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-zeroconf-py2compat==0.19.10
+zeroconf-py2compat==0.19.11
 ifcfg==0.21
 Click==7.0
 ua-parser==0.10.0


### PR DESCRIPTION
## Summary
* Updates zeroconf library to a version that uses ifaddr
* Updates zeroconf service restarting to give consistent results, restarting zeroconf broadcasting and the Kolibri service

## References
Zeroconf diff: https://github.com/learningequality/python-zeroconf-py2compat/compare/965b57820eb3344e0a300d8fba25282a768f846a...learningequality:0.19.11



## Reviewer guidance
Does zeroconf fully reinitialize when a new IP address is available to the device?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
