### PR TITLE
8110/mark resource as finished modal part deux

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -13,7 +13,7 @@
       :learningActivities="mappedLearningActivities"
       :isLessonContext="true"
       :isBookmarked="true"
-      :allowMarkComplete="false"
+      :allowMarkComplete="allowMarkComplete"
       data-test="learningActivityBar"
       @navigateBack="navigateBack"
     />
@@ -46,6 +46,7 @@
         data-test="contentPage"
       />
     </div>
+    <GlobalSnackbar />
   </div>
 
 </template>
@@ -59,6 +60,7 @@
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import GlobalSnackbar from '../../../../../../kolibri/core/assets/src/views/GlobalSnackbar';
   import SkipNavigationLink from '../../../../../../kolibri/core/assets/src/views/SkipNavigationLink';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
   import ContentPage from './ContentPage';
@@ -93,6 +95,7 @@
       AppError,
       AuthMessage,
       ContentPage,
+      GlobalSnackbar,
       LearningActivityBar,
       SkipNavigationLink,
     },
@@ -140,6 +143,11 @@
       },
       resourceTitle() {
         return this.content ? this.content.title : '';
+      },
+      allowMarkComplete() {
+        // TODO: This should be determined by some other means. Content metadata?
+        const DEV_ONLY = process.env.NODE_ENV !== 'production';
+        return DEV_ONLY;
       },
       mappedLearningActivities() {
         let learningActivities = [];

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -80,7 +80,7 @@
     </template>
     <MarkAsCompleteModal
       v-if="showMarkAsCompleteModal && allowMarkComplete"
-      @completed="showMarkAsCompleteModal = false"
+      @complete="showMarkAsCompleteModal = false"
       @cancel="showMarkAsCompleteModal = false"
     />
   </UiToolbar>

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -78,6 +78,11 @@
         </CoreMenu>
       </span>
     </template>
+    <MarkAsCompleteModal
+      v-if="showMarkAsCompleteModal && allowMarkComplete"
+      @completed="showMarkAsCompleteModal = false"
+      @cancel="showMarkAsCompleteModal = false"
+    />
   </UiToolbar>
 
 </template>
@@ -92,7 +97,8 @@
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
-  import LearningActivityIcon from './LearningActivityIcon.vue';
+  import LearningActivityIcon from './LearningActivityIcon';
+  import MarkAsCompleteModal from './MarkAsCompleteModal';
 
   export default {
     name: 'LearningActivityBar',
@@ -102,6 +108,7 @@
       UiToolbar,
       TextTruncator,
       LearningActivityIcon,
+      MarkAsCompleteModal,
     },
     mixins: [KResponsiveWindowMixin],
     /**
@@ -159,6 +166,7 @@
     data() {
       return {
         isMenuOpen: false,
+        showMarkAsCompleteModal: false,
       };
     },
     computed: {
@@ -224,6 +232,7 @@
     },
     created() {
       window.addEventListener('click', this.onWindowClick);
+      this.$on('markComplete', () => (this.showMarkAsCompleteModal = true));
     },
     beforeDestroy() {
       window.removeEventListener('click', this.onWindowClick);

--- a/kolibri/plugins/learn/assets/src/views/MarkAsCompleteModal.vue
+++ b/kolibri/plugins/learn/assets/src/views/MarkAsCompleteModal.vue
@@ -1,7 +1,6 @@
 <template>
 
   <KModal
-    v-if="contentSessionLogId"
     :title="$tr('markResourceAsCompleteLabel')"
     :submitText="coreString('confirmAction')"
     :cancelText="coreString('cancelAction')"
@@ -17,33 +16,18 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { ContentSessionLogResource } from 'kolibri.resources';
 
   export default {
     name: 'MarkAsCompleteModal',
     mixins: [commonCoreStrings],
-    props: {
-      // When truthy, the modal is shown. It is the implementer's charge
-      // to decide when this is visible. The `complete` event will be
-      // emitted upon successful API request in markResourceAsCompleted().
-      contentSessionLogId: {
-        type: String,
-        default: null,
-      },
-    },
     methods: {
       /*
        * Emits "complete" event on success.
        * Errors handled using the `handleApiError` action.
        */
       markResourceAsCompleted() {
-        ContentSessionLogResource.saveModel({
-          id: this.contentSessionLogId,
-          data: {
-            progress: 1,
-          },
-          exists: true,
-        })
+        this.$store
+          .dispatch('updateProgress', { progressPercent: 1 })
           .then(() => {
             this.$emit('complete');
             this.$store.dispatch('createSnackbar', this.$tr('resourceCompletedSnackbar'));

--- a/kolibri/plugins/learn/assets/test/views/mark-as-complete.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/mark-as-complete.spec.js
@@ -1,21 +1,17 @@
 import KModal from 'kolibri-design-system/lib/KModal';
 import { mount } from '@vue/test-utils';
-import { ContentSessionLogResource } from 'kolibri.resources';
 import MarkAsCompleteModal from '../../src/views/MarkAsCompleteModal';
 
 describe('Mark as complete modal', () => {
   let wrapper;
   let markSpy;
   let mockStore;
-  let resourceSpy;
   let testSessionId = 'test';
 
   beforeAll(() => {
     // Mock $store.dispatch to return a Promise
     mockStore = { dispatch: jest.fn().mockImplementation(() => Promise.resolve()) };
     markSpy = jest.spyOn(MarkAsCompleteModal.methods, 'markResourceAsCompleted');
-    resourceSpy = jest.spyOn(ContentSessionLogResource, 'saveModel');
-    resourceSpy.mockImplementation(() => Promise.resolve());
 
     wrapper = mount(MarkAsCompleteModal, {
       propsData: {
@@ -29,10 +25,9 @@ describe('Mark as complete modal', () => {
 
   describe('When the user cancels the modal', () => {
     // This describe() should go before subsequent ones
-    // to avoid needing to resourceSpy.mockReset()
     it('emits a cancel event', () => {
       wrapper.findComponent(KModal).vm.$emit('cancel');
-      expect(resourceSpy).not.toHaveBeenCalled();
+      expect(mockStore.dispatch).not.toHaveBeenCalled();
       expect(wrapper.emitted().cancel).toBeTruthy();
     });
   });
@@ -48,18 +43,10 @@ describe('Mark as complete modal', () => {
       expect(wrapper.emitted().complete).toBeTruthy();
     });
     it('dispatches an createSnackbar message', () => {
-      expect(mockStore.dispatch).toHaveBeenCalledWith('createSnackbar', 'Resource completed');
+      expect(mockStore.dispatch).toHaveBeenCalledWith('updateProgress', { progressPercent: 1 });
     });
-  });
-
-  describe('markResourceAsCompleted', () => {
-    it('makes a PATCH request to /api/logger/contentsessionlog', () => {
-      wrapper.findComponent(KModal).vm.$emit('submit');
-      expect(resourceSpy).toHaveBeenCalledWith({
-        id: testSessionId,
-        data: { progress: 1 },
-        exists: true,
-      });
+    it('dispatches an createSnackbar message', () => {
+      expect(mockStore.dispatch).toHaveBeenCalledWith('createSnackbar', 'Resource completed');
     });
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Now the pop-up for Mark As Complete works when the context menu item is clicked.

Note: There is currently no indicator of resource status on the immersive view so you must go back to the topic page to see that the completion occurred. 

Note: Whether the menu option is available is currently determined by whether you're `process.env.NODE_ENV === 'production'` or not. So - devs will see it, nobody else will *until we hook in the correct content metadata*.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8110 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to resources you've not completed. Find the "Mark as Complete" menu item top-right context menu when viewing the resource.

Test canceling and submitting - make sure that the outcome you expect occurred by going back to the topic where you found the resource.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
