### PR TITLE
Faster null import

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -149,7 +149,7 @@ class Command(AsyncCommand):
             total=total_file_deletion_operations + additional_progress
         ) as progress_update:
 
-            for file in LocalFile.objects.delete_unused_files():
+            for _ in LocalFile.objects.delete_unused_files():
                 progress_update(1, progress_extra_data)
 
             with db_lock():

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -7,6 +7,7 @@ from ...utils import paths
 from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.utils.import_export_content import get_import_export_data
+from kolibri.core.content.utils.paths import get_content_file_name
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
 
@@ -102,19 +103,19 @@ class Command(AsyncCommand):
                 self.cancel()
 
     def export_file(self, f, data_dir, overall_progress_update):
-        filename = f.get_filename()
+        filename = get_content_file_name(f)
 
         try:
             srcpath = paths.get_content_storage_file_path(filename)
             dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
         except InvalidStorageFilenameError:
             # If any files have an invalid storage file name, don't export them.
-            overall_progress_update(f.file_size)
+            overall_progress_update(f["file_size"])
             return
 
         # if the file already exists, add its size to our overall progress, and skip
-        if os.path.isfile(dest) and os.path.getsize(dest) == f.file_size:
-            overall_progress_update(f.file_size)
+        if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
+            overall_progress_update(f["file_size"])
             return
 
         copy = transfer.FileCopy(srcpath, dest, cancel_check=self.is_cancelled)

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -15,6 +15,7 @@ from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.content.utils.import_export_content import compare_checksums
 from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.paths import get_channel_lookup_url
+from kolibri.core.content.utils.paths import get_content_file_name
 from kolibri.core.content.utils.upgrade import get_import_data_for_update
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
@@ -286,21 +287,21 @@ class Command(AsyncCommand):
                 if self.is_cancelled():
                     break
 
-                filename = f.get_filename()
+                filename = get_content_file_name(f)
                 try:
                     dest = paths.get_content_storage_file_path(filename)
                 except InvalidStorageFilenameError:
                     # If the destination file name is malformed, just stop now.
-                    overall_progress_update(f.file_size)
+                    overall_progress_update(f["file_size"])
                     continue
 
                 # if the file already exists, or we are using remote storage, add its size to our overall progress, and skip
                 if paths.using_remote_storage() or (
-                    os.path.isfile(dest) and os.path.getsize(dest) == f.file_size
+                    os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]
                 ):
-                    overall_progress_update(f.file_size)
-                    file_checksums_to_annotate.append(f.id)
-                    transferred_file_size += f.file_size
+                    overall_progress_update(f["file_size"])
+                    file_checksums_to_annotate.append(f["id"])
+                    transferred_file_size += f["file_size"]
                     continue
 
                 # determine where we're downloading/copying from, and create appropriate transfer object
@@ -319,13 +320,12 @@ class Command(AsyncCommand):
                         )
                     except InvalidStorageFilenameError:
                         # If the source file name is malformed, just stop now.
-                        overall_progress_update(f.file_size)
+                        overall_progress_update(f["file_size"])
                         continue
                     filetransfer = transfer.FileCopy(
                         srcpath, dest, cancel_check=self.is_cancelled
                     )
                     file_transfers.append((f, filetransfer))
-
             with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
                 batch_size = 100
                 # ThreadPoolExecutor allows us to download files concurrently,
@@ -333,10 +333,10 @@ class Command(AsyncCommand):
                 # all the downloads into the pool requires considerable memory,
                 # so we divide the downloads into batches to keep memory usage down.
                 # In batches of 100, total RAM usage doesn't exceed 250MB in testing.
-                while len(file_transfers) > 0:
+                while file_transfers:
                     future_file_transfers = {}
                     for i in range(batch_size):
-                        if len(file_transfers) > 0:
+                        if file_transfers:
                             f, filetransfer = file_transfers.pop()
                             future = executor.submit(
                                 self._start_file_transfer, f, filetransfer
@@ -356,8 +356,8 @@ class Command(AsyncCommand):
                             if status == FILE_SKIPPED:
                                 number_of_skipped_files += 1
                             else:
-                                file_checksums_to_annotate.append(f.id)
-                                transferred_file_size += f.file_size
+                                file_checksums_to_annotate.append(f["id"])
+                                transferred_file_size += f["file_size"]
                         except transfer.TransferCanceled:
                             break
                         except Exception as e:
@@ -369,7 +369,7 @@ class Command(AsyncCommand):
                                 and e.response.status_code == 404
                             ) or (isinstance(e, OSError) and e.errno == 2):
                                 # Continue file import when the current file is not found from the source and is skipped.
-                                overall_progress_update(f.file_size)
+                                overall_progress_update(f["file_size"])
                                 number_of_skipped_files += 1
                                 continue
                             else:
@@ -432,13 +432,13 @@ class Command(AsyncCommand):
             # the difference so that the overall progress is never incorrect.
             # This could happen, for example for a local transfer if a file
             # has been replaced or corrupted (which we catch below)
-            data_transferred += f.file_size - filetransfer.total_size
+            data_transferred += f["file_size"] - filetransfer.total_size
 
             # If checksum of the destination file is different from the localfile
             # id indicated in the database, it means that the destination file
             # is corrupted, either from origin or during import. Skip importing
             # this file.
-            checksum_correctness = compare_checksums(filetransfer.dest, f.id)
+            checksum_correctness = compare_checksums(filetransfer.dest, f["id"])
             if not checksum_correctness:
                 e = "File {} is corrupted.".format(filetransfer.source)
                 logger.error("An error occurred during content import: {}".format(e))

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -264,7 +264,11 @@ class ImportContentTestCase(TestCase):
     ):
         # Check behaviour if cancellation is called before any file download starts
         FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")),
+            10,
+        )
         call_command("importcontent", "network", self.the_channel_id)
         is_cancelled_mock.assert_has_calls([call(), call()])
         FileDownloadMock.assert_not_called()
@@ -305,7 +309,11 @@ class ImportContentTestCase(TestCase):
         remote_path_mock.return_value = "notest"
         # Mock this __iter__ so that the filetransfer can be looped over
         FileDownloadMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")),
+            10,
+        )
         call_command("importcontent", "network", self.the_channel_id)
         # is_cancelled should be called thrice.
         is_cancelled_mock.assert_has_calls([call(), call()])
@@ -363,7 +371,11 @@ class ImportContentTestCase(TestCase):
         FileDownloadMock.return_value.total_size = 1
         FileDownloadMock.return_value.dest = local_path_1
         LocalFile.objects.update(file_size=1)
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()[:3]), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")[:3]),
+            10,
+        )
         call_command("importcontent", "network", self.the_channel_id)
         # Check that the command itself was also cancelled.
         cancel_mock.assert_called_with()
@@ -388,7 +400,11 @@ class ImportContentTestCase(TestCase):
     ):
         # Local version of test above
         FileCopyMock.return_value.__iter__.return_value = ["one", "two", "three"]
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")),
+            10,
+        )
         call_command("importcontent", "disk", self.the_channel_id, tempfile.mkdtemp())
         is_cancelled_mock.assert_has_calls([call(), call()])
         FileCopyMock.assert_not_called()
@@ -423,7 +439,11 @@ class ImportContentTestCase(TestCase):
         os.close(fd2)
         local_path_mock.side_effect = [local_dest_path, local_src_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")),
+            10,
+        )
         call_command("importcontent", "disk", self.the_channel_id, tempfile.mkdtemp())
         is_cancelled_mock.assert_has_calls([call(), call()])
         FileCopyMock.assert_called_with(
@@ -511,7 +531,7 @@ class ImportContentTestCase(TestCase):
             list(
                 LocalFile.objects.filter(
                     files__contentnode__pk="2b6926ed22025518a8b9da91745b51d3"
-                )
+                ).values("id", "file_size", "extension")
             ),
             10,
         )
@@ -565,7 +585,11 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(
             files__contentnode__channel_id=self.the_channel_id
         ).update(file_size=1)
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
         call_command("importcontent", "network", self.the_channel_id)
 
         sleep_mock.assert_called_once()
@@ -593,7 +617,11 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(
             files__contentnode__channel_id=self.the_channel_id
         ).update(file_size=1)
-        get_import_export_mock.return_value = (1, list(LocalFile.objects.all()), 10)
+        get_import_export_mock.return_value = (
+            1,
+            list(LocalFile.objects.all().values("id", "file_size", "extension")),
+            10,
+        )
         with self.assertRaises(HTTPError):
             call_command("importcontent", "network", self.the_channel_id)
         annotation_mock.set_content_visibility.assert_called_with(
@@ -634,7 +662,7 @@ class ImportContentTestCase(TestCase):
                         "6bdfea4a01830fdd4a585181c0b8068c",
                         "211523265f53825b82f70ba19218a02e",
                     ]
-                )
+                ).values("id", "file_size", "extension")
             ),
             10,
         )
@@ -672,7 +700,11 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(
             files__contentnode__channel_id=self.the_channel_id
         ).update(file_size=1)
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
         call_command("importcontent", "disk", self.the_channel_id, "destination")
         self.assertTrue("1 files are skipped" in logger_mock.call_args_list[0][0][0])
         annotation_mock.set_content_visibility.assert_called()
@@ -695,7 +727,11 @@ class ImportContentTestCase(TestCase):
         os.close(fd)
         path_mock.side_effect = [dest_path, "/test/dne"]
         getsize_mock.side_effect = ["1", OSError("Permission denied")]
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
         with self.assertRaises(OSError):
             call_command("importcontent", "disk", self.the_channel_id, "destination")
             self.assertTrue("Permission denied" in logger_mock.call_args_list[0][0][0])
@@ -738,7 +774,9 @@ class ImportContentTestCase(TestCase):
             [
                 LocalFile.objects.filter(
                     files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
-                ).first()
+                )
+                .values("id", "file_size", "extension")
+                .first()
             ],
             10,
         )
@@ -779,7 +817,7 @@ class ImportContentTestCase(TestCase):
         that the overall progress tracking for the content import process is properly updated
         to reflect the size of the file in the database, not the file on disk.
         This is important, as the total progress for the overall process is measured against
-        the total file size recorded in the database for all files, not for the the
+        the total file size recorded in the database for all files, not for the
         transferred file size.
         """
         local_src_path = tempfile.mkstemp()[1]
@@ -803,20 +841,16 @@ class ImportContentTestCase(TestCase):
             list(
                 LocalFile.objects.filter(
                     files__contentnode="32a941fb77c2576e8f6b294cde4c3b0c"
-                )
+                ).values("id", "file_size", "extension")
             ),
             10,
         )
         path_mock.side_effect = [local_dest_path, local_src_path]
         mock_overall_progress = MagicMock()
-        mock_file_progress = MagicMock()
         with patch(
             "kolibri.core.tasks.management.commands.base.ProgressTracker"
         ) as progress_mock:
-            progress_mock.return_value.__enter__.side_effect = [
-                mock_overall_progress,
-                mock_file_progress,
-            ]
+            progress_mock.return_value.update_progress = mock_overall_progress
             call_command(
                 "importcontent",
                 "disk",
@@ -865,7 +899,7 @@ class ImportContentTestCase(TestCase):
                         "6bdfea4a01830fdd4a585181c0b8068c",
                         "211523265f53825b82f70ba19218a02e",
                     ]
-                )
+                ).values("id", "file_size", "extension")
             ),
             10,
         )
@@ -921,7 +955,7 @@ class ImportContentTestCase(TestCase):
                         "6bdfea4a01830fdd4a585181c0b8068c",
                         "211523265f53825b82f70ba19218a02e",
                     ]
-                )
+                ).values("id", "file_size", "extension")
             ),
             10,
         )
@@ -963,7 +997,11 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.filter(
             files__contentnode__channel_id=self.the_channel_id
         ).update(file_size=1)
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
 
         m = mock_open()
         with patch("kolibri.core.content.utils.transfer.open", m) as open_mock:
@@ -1050,7 +1088,11 @@ class ExportContentTestCase(TestCase):
     ):
         # If cancel comes in before we do anything, make sure nothing happens!
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
         call_command("exportcontent", self.the_channel_id, tempfile.mkdtemp())
         is_cancelled_mock.assert_has_calls([call()])
         FileCopyMock.assert_not_called()
@@ -1084,7 +1126,11 @@ class ExportContentTestCase(TestCase):
         os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (1, [LocalFile.objects.first()], 10)
+        get_import_export_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
         call_command("exportcontent", self.the_channel_id, tempfile.mkdtemp())
         is_cancelled_mock.assert_has_calls([call(), call()])
         FileCopyMock.assert_called_with(
@@ -1138,7 +1184,7 @@ class TestFilesToTransfer(TestCase):
             root_node.channel_id, [node1.id], [node2.id], False, renderable_only=False
         )
         self.assertEqual(
-            len(list(filter(lambda x: x.id == local_file.id, files_to_transfer))), 1
+            len(list(filter(lambda x: x["id"] == local_file.id, files_to_transfer))), 1
         )
 
     @patch(

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -661,8 +661,8 @@ def calculate_dummy_progress_for_annotation(node_ids, exclude_node_ids, total_pr
     return int(annotation_proportion * total_progress / (100 - annotation_proportion))
 
 
-def propagate_forced_localfile_removal(localfiles_list):
-    total = len(localfiles_list)
+def propagate_forced_localfile_removal(localfiles_dict_list):
+    total = len(localfiles_dict_list)
     i = 0
     # Even thought we are using the filter_by_uuids method below
     # which prevents too many SQL parameters from being passed in to the query
@@ -670,11 +670,11 @@ def propagate_forced_localfile_removal(localfiles_list):
     # and cause issues - so we batch the ids here.
     batch_size = 10000
     while i < total:
-        file_slice = localfiles_list[i : i + batch_size]
+        file_slice = localfiles_dict_list[i : i + batch_size]
         files = File.objects.filter(
             supplementary=False,
             local_file__in=LocalFile.objects.filter_by_uuids(
-                [f.id for f in file_slice]
+                [f["id"] for f in file_slice]
             ),
         )
         ContentNode.objects.filter(files__in=files).update(available=False)

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -109,7 +109,7 @@ def filter_by_file_availability(nodes_to_include, channel_id, drive_id, peer_id)
     return nodes_to_include
 
 
-def get_import_export_data(
+def get_import_export_data(  # noqa: C901
     channel_id,
     node_ids,
     exclude_node_ids,
@@ -174,16 +174,16 @@ def get_import_export_data(
             "content_id", flat=True
         ).distinct()
 
-        content_ids.update(included_content_ids)
-
         # Only bother with this query if there were any resources returned above.
         if included_content_ids:
+            content_ids.update(included_content_ids)
             file_objects = LocalFile.objects.filter(
                 files__contentnode__in=nodes_segment
-            )
+            ).values("id", "file_size", "extension")
             if available is not None:
                 file_objects = file_objects.filter(available=available)
-            queried_file_objects.update(file_objects.in_bulk())
+            for f in file_objects:
+                queried_file_objects[f["id"]] = f
 
             if topic_thumbnails:
                 # Do a query to get all the descendant and ancestor topics for this segment
@@ -196,27 +196,21 @@ def get_import_export_data(
 
                 file_objects = LocalFile.objects.filter(
                     files__contentnode__in=segment_topics,
-                )
+                ).values("id", "file_size", "extension")
                 if available is not None:
                     file_objects = file_objects.filter(available=available)
-                queried_file_objects.update(file_objects.in_bulk())
+                for f in file_objects:
+                    queried_file_objects[f["id"]] = f
 
         min_boundary += dynamic_chunksize
 
     files_to_download = list(queried_file_objects.values())
 
-    total_bytes_to_transfer = sum(map(lambda x: x.file_size or 0, files_to_download))
+    total_bytes_to_transfer = sum(
+        map(lambda x: x.get("file_size", 0), files_to_download)
+    )
 
     return len(content_ids), files_to_download, total_bytes_to_transfer
-
-
-def _get_node_ids(node_ids):
-
-    return (
-        ContentNode.objects.filter_by_uuids(node_ids)
-        .get_descendants(include_self=True)
-        .values_list("id", flat=True)
-    )
 
 
 def retry_import(e):

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -206,9 +206,7 @@ def get_import_export_data(  # noqa: C901
 
     files_to_download = list(queried_file_objects.values())
 
-    total_bytes_to_transfer = sum(
-        map(lambda x: x.get("file_size", 0), files_to_download)
-    )
+    total_bytes_to_transfer = sum(map(lambda x: x["file_size"] or 0, files_to_download))
 
     return len(content_ids), files_to_download, total_bytes_to_transfer
 

--- a/kolibri/core/content/utils/upgrade.py
+++ b/kolibri/core/content/utils/upgrade.py
@@ -597,7 +597,7 @@ def get_import_data_for_update(
 
             files_to_transfer = LocalFile.objects.filter(
                 available=False, files__contentnode__in=batch_nodes
-            )
+            ).values("id", "file_size", "extension")
 
             queried_file_objects.extend(files_to_transfer)
 
@@ -612,7 +612,7 @@ def get_import_data_for_update(
             files__contentnode__in=ContentNode.objects.filter(
                 available=True, channel_id=channel_id
             ),
-        )
+        ).values("id", "file_size", "extension")
     )
 
     checksums = set()
@@ -622,9 +622,9 @@ def get_import_data_for_update(
     files_to_download = []
 
     for file in queried_file_objects:
-        if file.id not in checksums:
-            checksums.add(file.id)
-            total_bytes_to_transfer += file.file_size
+        if file["id"] not in checksums:
+            checksums.add(file["id"])
+            total_bytes_to_transfer += file["file_size"]
             files_to_download.append(file)
 
     return len(content_ids), files_to_download, total_bytes_to_transfer

--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -125,7 +125,7 @@ class CalculateImportExportSizeView(APIView):
         try:
             (
                 total_resource_count,
-                files_to_download,
+                _,
                 total_bytes_to_transfer,
             ) = get_import_export_data(
                 channel_id,


### PR DESCRIPTION
## Summary
* Uses values call to get all files to download instead of instantiating as models 3-4 x speed up (which should also improve performance for all imports)
* Gives a much earlier and simpler trapdoor for content import when remote content storage is being used
* Should give approximately 4-5x speedup overall for remote storage content import

## Reviewer guidance
Does content import and upgrade still work as expected?
Is it faster for remote storage import?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
