### PR TITLE
Reduce the default sync retry interval.

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -456,7 +456,7 @@ base_option_spec = {
         },
         "SYNC_INTERVAL": {
             "type": "integer",
-            "default": 5,
+            "default": 60,
             "description": """
                 In case a SoUD connects to this server, the SoUD should use this interval to resync every user.
             """,


### PR DESCRIPTION
## Summary
Reduces default sync retry interval to 60 seconds to reduce the rate of syncing precautionarily.

## Reviewer guidance
Does syncing happen less frantically for a single device on a network with a server?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
