### PR TITLE
Reuse kolibriLogin to begin user sessions in the setup wizard

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -259,14 +259,16 @@ export function kolibriLogin(store, sessionPayload) {
     method: 'post',
   })
     .then(() => {
-      // OIDC redirect
-      if (sessionPayload.next) {
-        redirectBrowser(sessionPayload.next);
-      }
-      // Normal redirect on login
-      else {
-        redirectBrowser();
-      }
+      // check redirect is disabled:
+      if (!sessionPayload.disableRedirect)
+        if (sessionPayload.next) {
+          // OIDC redirect
+          redirectBrowser(sessionPayload.next);
+        }
+        // Normal redirect on login
+        else {
+          redirectBrowser();
+        }
     })
     .catch(error => {
       const errorsCaught = CatchErrors(error, [

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -49,11 +49,12 @@ export default {
     };
   },
   actions: {
-    logIntoImportedFacility(store, credentials) {
-      store.dispatch('kolibriLogin', {
+    logIntoSyncedFacility(store, credentials) {
+      return store.dispatch('kolibriLogin', {
         username: credentials.username,
         password: credentials.password,
         facility: credentials.facility,
+        disableRedirect: true,
       });
     },
     provisionDeviceAfterImport(store, credentials) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -146,7 +146,7 @@
             .then(() => {
               this.loginFinished = true;
             });
-        }
+        } else this.loginFinished = true; // when importing from the admin account
       },
       redirectToChannels() {
         FinishSoUDSyncingResource.finish();

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/LoadingTaskPage.vue
@@ -23,6 +23,7 @@
       <div v-if="loadingTask.status === 'COMPLETED'">
         <KButton
           primary
+          :disabled="!loginFinished"
           :text="coreString('finishAction')"
           @click="redirectToChannels"
         />
@@ -48,7 +49,6 @@
 
 <script>
 
-  import { SessionResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import FacilityTaskPanel from '../../../../../device/assets/src/views/FacilitiesPage/FacilityTaskPanel.vue';
@@ -68,6 +68,7 @@
         loadingTask: this.state.value.task,
         isPolling: false,
         user: null,
+        loginFinished: false,
       };
     },
     inject: ['lodService', 'state'],
@@ -136,13 +137,15 @@
         this.clearTasks();
         // after importing the first user, let's sign him in to continue:
         if (this.state.value.users.length === 1 && this.user.password) {
-          SessionResource.saveModel({
-            data: {
+          this.$store
+            .dispatch('logIntoSyncedFacility', {
               username: this.user.username,
               password: this.user.password,
               facility: this.facility.id,
-            },
-          });
+            })
+            .then(() => {
+              this.loginFinished = true;
+            });
         }
       },
       redirectToChannels() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
@@ -46,7 +46,6 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { SessionResource } from 'kolibri.resources';
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import UserTable from '../../../../../facility/assets/src/views/UserTable.vue';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
@@ -144,17 +143,17 @@
             };
             if (this.loadingTask.status === TaskStatuses.COMPLETED) {
               // after importing the admin, let's sign him in to continue:
-              SessionResource.saveModel({
-                data: {
+              this.$store
+                .dispatch('logIntoSyncedFacility', {
                   username: this.facility.adminUser,
                   password: this.facility.adminPassword,
                   facility: this.facility.id,
-                },
-              }).then(() => {
-                this.isPolling = false;
-                this.lodService.send('CONTINUE');
-                SetupSoUDTasksResource.cleartasks();
-              });
+                })
+                .then(() => {
+                  this.isPolling = false;
+                  this.lodService.send('CONTINUE');
+                  SetupSoUDTasksResource.cleartasks();
+                });
             }
           }
           if (tasks.length == 0) this.isPolling = false;


### PR DESCRIPTION
## Summary
After #8401 the session model is not available to be used to start a session from JS. This was causing problems after the wizard finished its tasks.


This PR
* reuses `kolibriLogin` from core to start user sessions in the setup wizard plugin
* adds a `disableRedirect` option to the `kolibriLogin` payload so it won't redirect the user after signs in


## Reviewer guidance
Can you use the setup wizard to sync users from another server and you stay logged into the new kolibri machine after it finishes?


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
