### PR TITLE
Prevent too many variables error

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1203,13 +1203,21 @@ class ContentNodeProgressViewset(ReadOnlyValuesViewset):
         progress_lookup = {}
 
         if not self.request.user.is_anonymous():
+            # if there are too many leaf_content_ids we'll have a
+            # 'too many SQL variables' errors in sqlite
+            # so we batch the leaf ids here:
+            total = len(leaf_content_ids)
+            i = 0
+            batch_size = 998
+            while i < total:
+                leaf_content_ids_batch = leaf_content_ids[i : i + batch_size]
+                logs = ContentSummaryLog.objects.filter(
+                    user=self.request.user, content_id__in=leaf_content_ids_batch
+                )
+                for log in logs.values("content_id", "progress"):
+                    progress_lookup[log["content_id"]] = round(log["progress"], 4)
 
-            logs = ContentSummaryLog.objects.filter(
-                user=self.request.user, content_id__in=leaf_content_ids
-            )
-
-            for log in logs.values("content_id", "progress"):
-                progress_lookup[log["content_id"]] = round(log["progress"], 4)
+                i += batch_size
 
         output = []
 


### PR DESCRIPTION
## Summary

Logs received from a partner show a` sqlite3.OperationalError: too many SQL variables `error happening sometimes on the `contentnodeprogress` api
The error seems to be caused by content nodes having more descendants than the max number of parameters sql can allow in a query.
This PR batches the query request to ensure the problem won't appear even in old versions of sqlite (with a 999 max number of allowed parameters)

## References

The error has begin to appear after #8046 was merged

## Reviewer guidance

- Does code look good?
- do tests pass?
- Does Learn tab in kolibri works fine even with big channels having multiple node children?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
