### PR TITLE
a way to handle pop-up blocker in mozilla

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
@@ -50,7 +50,7 @@ export default {
       return state.status === UsersExportStatuses.EXPORTING;
     },
     exported(state) {
-      return state.status === UsersExportStatuses.FINISHED;
+      return state.exportUsersStatus === UsersExportStatuses.FINISHED;
     },
   },
   mutations: {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
@@ -18,18 +18,24 @@
         @click="showInfoModal = true"
       />
     </p>
-    <p style="margin-top: 24px;">
+    <p style="margin-top: 24px; display:flex; flex-direction: column">
       <KRouterLink
         :text="$tr('import')"
         appearance="raised-button"
-        style="margin: 0 16px 0 0;"
+        style="width: max-content; margin: 0 16px 20px 0;"
         :to="$store.getters.facilityPageLinks.ImportCsvPage"
       />
       <KButton
-        :text="$tr('export')"
+        :text="$tr('downloadCSV')"
         appearance="raised-button"
-        style="margin: 0 16px 0 0;"
-        :disabled="isExporting"
+        style="width: max-content; margin: 0 16px 20px 0;"
+        :disabled="!exported"
+        @click="downloadCsv"
+      />
+      <KButton
+        appearance="basic-link"
+        :text="$tr('generateCSV')"
+        style="margin: 0px 8px 10px 0px"
         @click="exportCsv"
       />
       <DataPageTaskProgress v-if="isExporting">
@@ -51,7 +57,7 @@
 <script>
 
   import urls from 'kolibri.urls';
-  import { mapState, mapActions } from 'vuex';
+  import { mapState, mapActions, mapGetters } from 'vuex';
   import { UsersExportStatuses } from '../../../constants';
   import DataPageTaskProgress from '../DataPageTaskProgress';
   import CsvInfoModal from '../../CsvInfoModal';
@@ -69,29 +75,31 @@
       };
     },
     computed: {
+      ...mapGetters('manageCSV', ['exported']),
       ...mapState('manageCSV', ['exportUsersStatus', 'exportUsersFilename']),
       isExporting() {
         return this.exportUsersStatus === UsersExportStatuses.EXPORTING;
       },
     },
-    watch: {
-      exportUsersStatus(val) {
-        if (val === UsersExportStatuses.FINISHED) {
-          this.exportPage.location.href = urls[
-            'kolibri:kolibri.plugins.facility:download_csv_file'
-          ](this.exportUsersFilename, this.$store.getters.activeFacilityId);
-        }
-      },
-    },
     methods: {
       ...mapActions('manageCSV', ['startExportUsers']),
       exportCsv() {
-        this.exportPage = window.open('', '_blank');
-        this.exportPage.document.write('Loading...');
         this.startExportUsers();
+      },
+      downloadCsv() {
+        window.open(
+          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
+            this.exportUsersFilename,
+            this.$store.getters.activeFacilityId
+          ),
+          '_blank'
+        );
       },
     },
     $trs: {
+      generateCSV: {
+        message: 'Generate CSV file',
+      },
       sectionTitle: {
         message: 'Import and export users',
         context: 'Title for section about managing external spreadsheets.\n',
@@ -113,8 +121,8 @@
         message: 'Import a CSV file to create and update users',
         context: 'Additional information about importing external spreadsheets.\n',
       },
-      export: {
-        message: 'Export',
+      downloadCSV: {
+        message: 'Download CSV',
         context: 'Button used to export spreadsheets from Kolibri.',
       },
       import: {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
@@ -71,7 +71,6 @@
     data() {
       return {
         showInfoModal: false,
-        exportPage: null,
       };
     },
     computed: {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
@@ -65,6 +65,7 @@
     data() {
       return {
         showInfoModal: false,
+        exportPage: null,
       };
     },
     computed: {
@@ -75,20 +76,18 @@
     },
     watch: {
       exportUsersStatus(val) {
-        if (val == UsersExportStatuses.FINISHED) {
-          window.open(
-            urls['kolibri:kolibri.plugins.facility:download_csv_file'](
-              this.exportUsersFilename,
-              this.$store.getters.activeFacilityId
-            ),
-            '_blank'
-          );
+        if (val === UsersExportStatuses.FINISHED) {
+          this.exportPage.location.href = urls[
+            'kolibri:kolibri.plugins.facility:download_csv_file'
+          ](this.exportUsersFilename, this.$store.getters.activeFacilityId);
         }
       },
     },
     methods: {
       ...mapActions('manageCSV', ['startExportUsers']),
       exportCsv() {
+        this.exportPage = window.open('', '_blank');
+        this.exportPage.document.write('Loading...');
         this.startExportUsers();
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Following up on the https://github.com/learningequality/kolibri/issues/8191  issue, After testing on Chrome and Firefox, when the user tries to export for the first time on Firefox it show a pop-up blocker

![Screenshot 2021-09-10 124826](https://user-images.githubusercontent.com/52789571/132835347-4a166124-99de-4382-93f5-c0dbc035e7a0.png)

That blocker only happened on Firefox on the first try ( so I was testing on a private window ) and in Chrome it worked fine all the time. After reading some of the browser default settings, I see that there is a field block pop-up windows that is set to true as  default. When you manually allow the export to happen it adds that url in the exceptions tab and that's why the second and every seqential try it automatically downloads it. 

![Screenshot 2021-09-10 125345](https://user-images.githubusercontent.com/52789571/132835974-03f39963-a6fb-421c-be41-ce36e804f636.png)

One solution that I first started implementing was to add a browser extension called [browserSettings](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserSettings) which allowed me to change the browser settings of the user and I could untick the blocker field. I thought that the solution was somewhat malicious and it's not up to me to control the settings of the user so I tried with a different approach. I read that the main reason for the pop-up blocker was that the window.open() didn't happen from user action but from a state change(which was async)

`The general rule is that popup blockers will engage if window.open or similar is invoked from javascript that is not invoked by direct user action. That is, you can call window.open in response to a button click without getting hit by the popup blocker, but if you put the same code in a timer event it will be blocked.`

So the only solution that I found suitable in this case was to first create a new window with window.open and then after the state changes to make that link download the file. One problem that still persists is that the window still remains open after the user exported the data and, so that is something to be worked on.


## Reviewer guidance

You can test the pop-up blocker by opening firefox in a private window and trying to export the data.




----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
