### PR TITLE
Remove all user strings with instances of 'active/inactive' 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonActive.vue
@@ -28,15 +28,15 @@
         required: true,
       },
     },
-    computed: {
-      label() {
-        return this.active ? this.$tr('lessonActiveLabel') : this.$tr('lessonInactiveLabel');
-      },
-    },
-    $trs: {
-      lessonActiveLabel: 'Active',
-      lessonInactiveLabel: 'Inactive',
-    },
+    // computed: {
+    //   label() {
+    //     return this.active ? this.$tr('lessonActiveLabel') : this.$tr('lessonInactiveLabel');
+    //   },
+    // },
+    // $trs: {
+    //   lessonActiveLabel: 'Active',
+    //   lessonInactiveLabel: 'Inactive',
+    // },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizActive.vue
@@ -28,15 +28,15 @@
         required: true,
       },
     },
-    computed: {
-      label() {
-        return this.active ? this.$tr('activeQuizLabel') : this.$tr('inactiveQuizLabel');
-      },
-    },
-    $trs: {
-      activeQuizLabel: 'Active',
-      inactiveQuizLabel: 'Inactive',
-    },
+    // computed: {
+    //   label() {
+    //     return this.active ? this.$tr('activeQuizLabel') : this.$tr('inactiveQuizLabel');
+    //   },
+    // },
+    // $trs: {
+    //   activeQuizLabel: 'Active',
+    //   inactiveQuizLabel: 'Inactive',
+    // },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -53,11 +53,11 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   },
 
   // labels, phrases, titles, headers...
-  activeLabel: 'Active',
-  activeQuizzesLabel: {
-    message: 'Active quizzes',
-    context: 'An active quiz is one that is in progress.',
-  },
+  // activeLabel: 'Active',
+  // activeQuizzesLabel: {
+  //   message: 'Active quizzes',
+  //   context: 'An active quiz is one that is in progress.',
+  // },
   activityLabel: {
     message: 'Activity',
     context:
@@ -153,12 +153,12 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       "In the 'Difficult questions' sub-tab within the 'Reports' section, there's a column called 'Help needed' which shows the coach which learners need help on what questions.\n\nCoaches can also filter class activity by 'Help needed'",
   },
-  inactiveQuizzesLabel: 'Inactive quizzes',
+  // inactiveQuizzesLabel: 'Inactive quizzes',
   lastActivityLabel: {
     message: 'Last activity',
     context: 'Indicates when a learner was last active on a particular resource.',
   },
-  inactiveLabel: 'Inactive',
+  // inactiveLabel: 'Inactive',
   learnersLabel: {
     message: 'Learners',
     context:

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -96,7 +96,7 @@
       <p v-if="!exams.length">
         {{ $tr('noExams') }}
       </p>
-<!--       <p
+      <!--       <p
         v-else-if="statusSelected.value === coachString('activeQuizzesLabel') &&
           !activeExams.length"
       >
@@ -160,10 +160,10 @@
     mixins: [commonCoach, commonCoreStrings],
     data() {
       return {
-        statusSelected: {
-          label: this.coachString('allQuizzesLabel'),
-          value: this.coachString('allQuizzesLabel'),
-        },
+        // statusSelected: {
+        //   label: this.coachString('allQuizzesLabel'),
+        //   value: this.coachString('allQuizzesLabel'),
+        // },
         showOpenConfirmationModal: false,
         showCloseConfirmationModal: false,
       };
@@ -199,7 +199,7 @@
       //   return this.sortedExams.filter(exam => exam.active === false);
       // },
       filteredExams() {
-        const filter = this.statusSelected.label;
+        // const filter = this.statusSelected.label;
         // if (filter === this.coachString('activeQuizzesLabel')) {
         //   return this.activeExams;
         // } else if (filter === this.coachString('inactiveQuizzesLabel')) {
@@ -272,7 +272,9 @@
       // noInactiveExams: {
       //   message: 'No inactive quizzes',
       //   context:
-      //     "Inactive quizzes are ones that are no longer in progress. When the coach presses the 'End quiz' button, the quiz passes from 'active' to 'inactive'.",
+      //     "Inactive quizzes are ones that are no longer in progress.
+      //     When the coach presses the 'End quiz' button, the quiz
+      //passes from 'active' to 'inactive'.",
       // },
       newQuiz: 'Create new quiz',
       selectQuiz: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -96,7 +96,7 @@
       <p v-if="!exams.length">
         {{ $tr('noExams') }}
       </p>
-      <p
+<!--       <p
         v-else-if="statusSelected.value === coachString('activeQuizzesLabel') &&
           !activeExams.length"
       >
@@ -107,7 +107,7 @@
           !inactiveExams.length"
       >
         {{ $tr('noInactiveExams') }}
-      </p>
+      </p> -->
 
       <!-- Modals for Close & Open of quiz from right-most column -->
       <KModal
@@ -192,19 +192,19 @@
         ];
       },
       */
-      activeExams() {
-        return this.sortedExams.filter(exam => exam.active === true);
-      },
-      inactiveExams() {
-        return this.sortedExams.filter(exam => exam.active === false);
-      },
+      // activeExams() {
+      //   return this.sortedExams.filter(exam => exam.active === true);
+      // },
+      // inactiveExams() {
+      //   return this.sortedExams.filter(exam => exam.active === false);
+      // },
       filteredExams() {
         const filter = this.statusSelected.label;
-        if (filter === this.coachString('activeQuizzesLabel')) {
-          return this.activeExams;
-        } else if (filter === this.coachString('inactiveQuizzesLabel')) {
-          return this.inactiveExams;
-        }
+        // if (filter === this.coachString('activeQuizzesLabel')) {
+        //   return this.activeExams;
+        // } else if (filter === this.coachString('inactiveQuizzesLabel')) {
+        //   return this.inactiveExams;
+        // }
         return this.sortedExams;
       },
       dropdownOptions() {
@@ -268,12 +268,12 @@
         message: 'You do not have any quizzes',
         context: 'CoachExamsPage.noExams\n\n-- CONTEXT --',
       },
-      noActiveExams: 'No active quizzes',
-      noInactiveExams: {
-        message: 'No inactive quizzes',
-        context:
-          "Inactive quizzes are ones that are no longer in progress. When the coach presses the 'End quiz' button, the quiz passes from 'active' to 'inactive'.",
-      },
+      // noActiveExams: 'No active quizzes',
+      // noInactiveExams: {
+      //   message: 'No inactive quizzes',
+      //   context:
+      //     "Inactive quizzes are ones that are no longer in progress. When the coach presses the 'End quiz' button, the quiz passes from 'active' to 'inactive'.",
+      // },
       newQuiz: 'Create new quiz',
       selectQuiz: {
         message: 'Select channel quiz',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -80,7 +80,7 @@
       <p v-if="!lessons.length">
         {{ $tr('noLessons') }}
       </p>
-      <!--       <p v-else-if="!activeLessonCounts.true && filterSelection.value === 'activeLessons'">
+      <!-- <p v-else-if="!activeLessonCounts.true && filterSelection.value === 'activeLessons'">
         {{ $tr('noActiveLessons') }}
       </p>
       <p v-else-if="!activeLessonCounts.false && filterSelection.value === 'inactiveLessons'">
@@ -123,7 +123,7 @@
 
   import { mapState, mapActions } from 'vuex';
   import { LessonResource } from 'kolibri.resources';
-  import countBy from 'lodash/countBy';
+  //  import countBy from 'lodash/countBy';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
@@ -223,11 +223,12 @@
       },
     },
     $trs: {
-      allLessons: {
-        message: 'All lessons',
-        context:
-          'Indicates a link that takes the user back to the main list of lessons from an individual lesson.',
-      },
+      // allLessons: {
+      //   message: 'All lessons',
+      //   context:
+      //     'Indicates a link that takes the user back to the
+      //main list of lessons from an individual lesson.',
+      // },
       // activeLessons: 'Active lessons',
       // inactiveLessons: 'Inactive lessons',
       size: {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -80,12 +80,12 @@
       <p v-if="!lessons.length">
         {{ $tr('noLessons') }}
       </p>
-      <p v-else-if="!activeLessonCounts.true && filterSelection.value === 'activeLessons'">
+      <!--       <p v-else-if="!activeLessonCounts.true && filterSelection.value === 'activeLessons'">
         {{ $tr('noActiveLessons') }}
       </p>
       <p v-else-if="!activeLessonCounts.false && filterSelection.value === 'inactiveLessons'">
         {{ $tr('noInactiveLessons') }}
-      </p>
+      </p> -->
 
       <KModal
         v-if="showModal"
@@ -155,23 +155,23 @@
       sortedLessons() {
         return this._.orderBy(this.lessons, ['date_created'], ['desc']);
       },
-      filterOptions() {
-        const filters = ['allLessons', 'activeLessons', 'inactiveLessons'];
-        return filters.map(filter => ({
-          label: this.$tr(filter),
-          value: filter,
-        }));
-      },
-      activeLessonCounts() {
-        return countBy(this.lessons, 'is_active');
-      },
+      // filterOptions() {
+      //   const filters = ['allLessons', 'activeLessons', 'inactiveLessons'];
+      //   return filters.map(filter => ({
+      //     label: this.$tr(filter),
+      //     value: filter,
+      //   }));
+      // },
+      // activeLessonCounts() {
+      //   return countBy(this.lessons, 'is_active');
+      // },
       newLessonRoute() {
         return { name: LessonsPageNames.LESSON_CREATION_ROOT };
       },
     },
-    beforeMount() {
-      this.filterSelection = this.filterOptions[0];
-    },
+    // beforeMount() {
+    //   this.filterSelection = this.filterOptions[0];
+    // },
     methods: {
       ...mapActions('lessonsRoot', ['createLesson']),
       showLesson(lesson) {
@@ -228,8 +228,8 @@
         context:
           'Indicates a link that takes the user back to the main list of lessons from an individual lesson.',
       },
-      activeLessons: 'Active lessons',
-      inactiveLessons: 'Inactive lessons',
+      // activeLessons: 'Active lessons',
+      // inactiveLessons: 'Inactive lessons',
       size: {
         message: 'Size',
         context:
@@ -240,8 +240,8 @@
         context:
           "Text displayed in the 'Lessons' tab of the 'Plan' section if there are no lessons created",
       },
-      noActiveLessons: 'No active lessons',
-      noInactiveLessons: 'No inactive lessons',
+      // noActiveLessons: 'No active lessons',
+      // noInactiveLessons: 'No inactive lessons',
       visibleToLearnersLabel: {
         message: 'Visible to learners',
         context:

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
@@ -7,9 +7,9 @@
 
     <HeaderTable>
       <HeaderTableRow :keyText="coachString('statusLabel')">
-        <template #value>
+<!--         <template #value>
           <LessonActive :active="active" />
-        </template>
+        </template> -->
       </HeaderTableRow>
       <HeaderTableRow :keyText="coachString('recipientsLabel')">
         <template #value>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentSummary.vue
@@ -7,7 +7,7 @@
 
     <HeaderTable>
       <HeaderTableRow :keyText="coachString('statusLabel')">
-<!--         <template #value>
+        <!--         <template #value>
           <LessonActive :active="active" />
         </template> -->
       </HeaderTableRow>
@@ -35,7 +35,7 @@
   import HeaderTable from '../../common/HeaderTable';
   import HeaderTableRow from '../../common/HeaderTable/HeaderTableRow';
   import Recipients from '../../common/Recipients';
-  import LessonActive from '../../common/LessonActive';
+  // import LessonActive from '../../common/LessonActive';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
 
   // This is actually only used on the LessonSummaryPage, so Assignment type is
@@ -43,7 +43,7 @@
   export default {
     name: 'AssignmentSummary',
     components: {
-      LessonActive,
+      //      LessonActive,
       HeaderTable,
       HeaderTableRow,
       Recipients,
@@ -54,10 +54,10 @@
         type: String,
         required: true,
       },
-      active: {
-        type: Boolean,
-        required: true,
-      },
+      // active: {
+      //   type: Boolean,
+      //   required: true,
+      // },
       description: {
         type: String,
         required: false,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -31,7 +31,7 @@
           </template>
         </HeaderTableRow>
         <HeaderTableRow v-show="!$isPrint" :keyText="coachString('statusLabel')">
-<!--           <template #value>
+          <!--           <template #value>
             <LessonActive :active="lesson.active" />
           </template> -->
         </HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonPage.vue
@@ -31,9 +31,9 @@
           </template>
         </HeaderTableRow>
         <HeaderTableRow v-show="!$isPrint" :keyText="coachString('statusLabel')">
-          <template #value>
+<!--           <template #value>
             <LessonActive :active="lesson.active" />
-          </template>
+          </template> -->
         </HeaderTableRow>
         <HeaderTableRow
           v-show="!$isPrint"

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
@@ -25,9 +25,9 @@
         <template #key>
           {{ coachString('statusLabel') }}
         </template>
-        <template #value>
+<!--         <template #value>
           <QuizActive :active="exam.active" />
-        </template>
+        </template> -->
       </HeaderTableRow>
       <HeaderTableRow>
         <template #key>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizHeader.vue
@@ -25,7 +25,7 @@
         <template #key>
           {{ coachString('statusLabel') }}
         </template>
-<!--         <template #value>
+        <!--         <template #value>
           <QuizActive :active="exam.active" />
         </template> -->
       </HeaderTableRow>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -79,14 +79,14 @@
             label: this.coachString('allQuizzesLabel'),
             value: 'allQuizzes',
           },
-          {
-            label: this.coachString('activeQuizzesLabel'),
-            value: 'activeQuizzes',
-          },
-          {
-            label: this.coachString('inactiveQuizzesLabel'),
-            value: 'inactiveQuizzes',
-          },
+          // {
+          //   label: this.coachString('activeQuizzesLabel'),
+          //   value: 'activeQuizzes',
+          // },
+          // {
+          //   label: this.coachString('inactiveQuizzesLabel'),
+          //   value: 'inactiveQuizzes',
+          // },
         ];
       },
       group() {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -36,9 +36,9 @@
           <template #key>
             {{ coachString('statusLabel') }}
           </template>
-          <template #value>
+          <!--           <template #value>
             <LessonActive :active="lesson.active" />
-          </template>
+          </template> -->
         </HeaderTableRow>
         <HeaderTableRow v-show="!$isPrint">
           <template #key>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -99,12 +99,12 @@
         if (this.filter.value === 'allLessons') {
           return this.coachString('lessonListEmptyState');
         }
-        if (this.filter.value === 'activeLessons') {
-          return this.$tr('noActiveLessons');
-        }
-        if (this.filter.value === 'inactiveLessons') {
-          return this.$tr('noInactiveLessons');
-        }
+        // if (this.filter.value === 'activeLessons') {
+        //   return this.$tr('noActiveLessons');
+        // }
+        // if (this.filter.value === 'inactiveLessons') {
+        //   return this.$tr('noInactiveLessons');
+        // }
 
         return '';
       },
@@ -114,14 +114,14 @@
             label: this.coreString('allLessonsLabel'),
             value: 'allLessons',
           },
-          {
-            label: this.$tr('activeLessons'),
-            value: 'activeLessons',
-          },
-          {
-            label: this.$tr('inactiveLessons'),
-            value: 'inactiveLessons',
-          },
+          // {
+          //   label: this.$tr('activeLessons'),
+          //   value: 'activeLessons',
+          // },
+          // {
+          //   label: this.$tr('inactiveLessons'),
+          //   value: 'inactiveLessons',
+          // },
         ];
       },
       table() {
@@ -184,10 +184,10 @@
       },
     },
     $trs: {
-      activeLessons: 'Active lessons',
-      inactiveLessons: 'Inactive lessons',
-      noActiveLessons: 'No active lessons',
-      noInactiveLessons: 'No inactive lessons',
+      // activeLessons: 'Active lessons',
+      // inactiveLessons: 'Inactive lessons',
+      // noActiveLessons: 'No active lessons',
+      // noInactiveLessons: 'No inactive lessons',
       visibleToLearnersLabel: {
         message: 'Visible to learners',
         context:

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
@@ -91,14 +91,14 @@
             label: this.coachString('allQuizzesLabel'),
             value: 'allQuizzes',
           },
-          {
-            label: this.coachString('activeQuizzesLabel'),
-            value: 'activeQuizzes',
-          },
-          {
-            label: this.coachString('inactiveQuizzesLabel'),
-            value: 'inactiveQuizzes',
-          },
+          // {
+          //   label: this.coachString('activeQuizzesLabel'),
+          //   value: 'activeQuizzes',
+          // },
+          // {
+          //   label: this.coachString('inactiveQuizzesLabel'),
+          //   value: 'inactiveQuizzes',
+          // },
         ];
       },
     },
@@ -127,8 +127,8 @@
         context:
           "Link that takes user back to the list of quizzes on the 'Reports' tab, from the individual learner's information page.",
       },
-      activeQuizzes: 'Active quizzes',
-      inactiveQuizzes: 'Inactive quizzes',
+      // activeQuizzes: 'Active quizzes',
+      // inactiveQuizzes: 'Inactive quizzes',
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizLearnerListPage.vue
@@ -97,14 +97,14 @@
             label: this.coachString('allQuizzesLabel'),
             value: 'allQuizzes',
           },
-          {
-            label: this.coachString('activeQuizzesLabel'),
-            value: 'activeQuizzes',
-          },
-          {
-            label: this.coachString('inactiveQuizzesLabel'),
-            value: 'inactiveQuizzes',
-          },
+          // {
+          //   label: this.coachString('activeQuizzesLabel'),
+          //   value: 'activeQuizzes',
+          // },
+          // {
+          //   label: this.coachString('inactiveQuizzesLabel'),
+          //   value: 'inactiveQuizzes',
+          // },
         ];
       },
       exam() {
@@ -165,8 +165,8 @@
         context:
           "Link that takes user back to the list of quizzes on the 'Reports' tab, from the individual learner's information page.\n",
       },
-      activeQuizzes: 'Active quizzes',
-      inactiveQuizzes: 'Inactive quizzes',
+      // activeQuizzes: 'Active quizzes',
+      // inactiveQuizzes: 'Inactive quizzes',
       allQuestionsAnswered: {
         message: 'All questions answered',
         context: 'Indicates that a learner has answered all the questions in an exercise.',

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -150,12 +150,12 @@
         if (this.filter.value === 'allQuizzes') {
           return this.coachString('quizListEmptyState');
         }
-        if (this.filter.value === 'activeQuizzes') {
-          return this.$tr('noActiveExams');
-        }
-        if (this.filter.value === 'inactiveQuizzes') {
-          return this.$tr('noInactiveExams');
-        }
+        // if (this.filter.value === 'activeQuizzes') {
+        //   return this.$tr('noActiveExams');
+        // }
+        // if (this.filter.value === 'inactiveQuizzes') {
+        //   return this.$tr('noInactiveExams');
+        // }
 
         return '';
       },
@@ -164,17 +164,17 @@
           {
             label: this.coachString('allQuizzesLabel'),
             value: 'allQuizzes',
-            noActiveExams: 'No active quizzes',
-            noInactiveExams: 'No inactive quizzes',
+            // noActiveExams: 'No active quizzes',
+            // noInactiveExams: 'No inactive quizzes',
           },
-          {
-            label: this.coachString('activeQuizzesLabel'),
-            value: 'activeQuizzes',
-          },
-          {
-            label: this.coachString('inactiveQuizzesLabel'),
-            value: 'inactiveQuizzes',
-          },
+          // {
+          //   label: this.coachString('activeQuizzesLabel'),
+          //   value: 'activeQuizzes',
+          // },
+          // {
+          //   label: this.coachString('inactiveQuizzesLabel'),
+          //   value: 'inactiveQuizzes',
+          // },
         ];
       },
       table() {
@@ -260,8 +260,8 @@
       },
     },
     $trs: {
-      noActiveExams: 'No active quizzes',
-      noInactiveExams: 'No inactive quizzes',
+      // noActiveExams: 'No active quizzes',
+      // noInactiveExams: 'No inactive quizzes',
       printLabel: {
         message: '{className} Quizzes',
         context:


### PR DESCRIPTION
## Summary
For the time being I just commented out the relative pieces of code so the strings do not get extracted. Ideally we should delete them, but this should be enough to avoid them ending up on Crowdin.

My commenting out may not be the _prettiest_, but it seems to do the job, and at least I did not see any errors in the terminal or the browser console.

## References
Fixes #8420 

## Reviewer guidance
Test if pages:

- Reports > Lessons
- Reports > Quizzes
- Plan > Lessons
- Plan > Quizzes

work as expected.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
