### PR TITLE
Add suggested time component with strings

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SuggestedTime.vue
+++ b/kolibri/plugins/learn/assets/src/views/SuggestedTime.vue
@@ -1,13 +1,10 @@
 <template>
 
   <div class="time-context">
-    <div v-if="time > 0">
-      {{ $tr('shortTime', { time: 120 }) }}
-    </div>
-    <div v-if="time > 0">
-      {{ $tr('suggestedTimeLabel', { time: 120 }) }}
-    </div>
-    {{ $tr('suggestedTimeTooltip') }}
+    <span v-if="seconds > 0">
+      {{ $tr('suggestedTimeLabel') }}
+      <TimeDuration :seconds="seconds" :expand="true" />
+    </span>
   </div>
 
 </template>
@@ -15,29 +12,23 @@
 
 <script>
 
+  import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
+
   export default {
     name: 'SuggestedTime',
+    components: { TimeDuration },
     props: {
       /* Time in ms */
-      time: {
+      seconds: {
         type: Number,
-        default: 0,
+        default: 8100,
       },
     },
     $trs: {
-      suggestedTimeTooltip: {
+      suggestedTimeLabel: {
         message: 'Suggested time to complete',
         context:
-          'A tooltip explaning what the clock icon and time indicates about the resource  they are viewing',
-      },
-      shortTime: {
-        message: '{time} {time, plural, one {minute} other {minutes}}',
-        context: 'Converts the time given into internationalized time. Nothing to translate here.',
-      },
-      suggestedTimeLabel: {
-        message: 'Suggested time to complete: {time} {time, plural, one {minute} other {minutes}}',
-        context:
-          "Indicates to the user the suggested time the resource should take to complete. The '# minutes' string is internationalized automatically",
+          'A label preceding a number of minutes that the current resource is estimated to take to complete',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/SuggestedTime.vue
+++ b/kolibri/plugins/learn/assets/src/views/SuggestedTime.vue
@@ -1,0 +1,48 @@
+<template>
+
+  <div class="time-context">
+    <div v-if="time > 0">
+      {{ $tr('shortTime', { time: 120 }) }}
+    </div>
+    <div v-if="time > 0">
+      {{ $tr('suggestedTimeLabel', { time: 120 }) }}
+    </div>
+    {{ $tr('suggestedTimeTooltip') }}
+  </div>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'SuggestedTime',
+    props: {
+      /* Time in ms */
+      time: {
+        type: Number,
+        default: 0,
+      },
+    },
+    $trs: {
+      suggestedTimeTooltip: {
+        message: 'Suggested time to complete',
+        context:
+          'A tooltip explaning what the clock icon and time indicates about the resource  they are viewing',
+      },
+      shortTime: {
+        message: '{time} {time, plural, one {minute} other {minutes}}',
+        context: 'Converts the time given into internationalized time. Nothing to translate here.',
+      },
+      suggestedTimeLabel: {
+        message: 'Suggested time to complete: {time} {time, plural, one {minute} other {minutes}}',
+        context:
+          "Indicates to the user the suggested time the resource should take to complete. The '# minutes' string is internationalized automatically",
+      },
+    },
+  };
+
+</script>
+
+
+<style scoped lang="scss"></style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is only to add strings and includes minimal functionality.

![screenshot-localhost_8000-2021 09 13-14_09_17](https://user-images.githubusercontent.com/6356129/133157686-11efa720-f28d-49b5-81d2-c9f062964d6a.png)

Adding strings and component for "Suggested Time" frontend feature. 

Does not do anything except provide three possible strings.

1) A pluralized "N minutes" or "N minute" string (depending on if N is 1 or not).
2) A tooltip message "Suggested time to complete" which is to be shown on hover [pending feedback here](https://github.com/learningequality/kolibri/pull/8395#issuecomment-913896554) from @jtamiace 
3) If the decision is to opt for showing the label up front, there is a pluralized "Suggested time to complete: N minutes" string as well in case we do not make the decision before string freeze.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8111 
#8395 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Are these going to work? Do we need different strings for this use case?

Do we need to have it go "X hours Y minutes"?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
