### PR TITLE
Enforce linux-style end of line characters in prettier.

### DIFF
--- a/packages/kolibri-tools/.prettierrc.js
+++ b/packages/kolibri-tools/.prettierrc.js
@@ -7,4 +7,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
   parser: 'babel',
+  endOfLine: 'lf',
 };


### PR DESCRIPTION
## Summary
Windows developers running linting might be alarmed to discover a bunch of file changes - which ultimately amounted to changing line separators from Linux to Windows.
Prevent this by enforcing Linux style line endings in our prettier config.

## Reviewer guidance
Does running `pre-commit run --all-files` on a Windows machine result in 0 diff?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
