### PR TITLE
Don't require `label` and `icon` prop in `CoreMenuOption`

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -12,13 +12,13 @@
     >
       <slot>
         <KLabeledIcon>
-          <template #icon>
+          <template v-if="icon" #icon>
             <KIcon
               :icon="icon"
               :class="$computedClass(optionIconStyle)"
             />
           </template>
-          <div>{{ label }}</div>
+          <div v-if="label">{{ label }}</div>
         </KLabeledIcon>
         <div
           v-if="secondaryText"

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -37,7 +37,8 @@
     props: {
       label: {
         type: String,
-        required: true,
+        required: false,
+        default: '',
       },
       link: {
         type: String,
@@ -49,7 +50,8 @@
       },
       icon: {
         type: String,
-        required: true,
+        required: false,
+        default: '',
       },
     },
     inject: ['showActive'],


### PR DESCRIPTION
`CoreMenuOption` provides two ways of defining its content - one through props and one through the default slot. When I was creating `LearningActivityBar`, I needed [to use slot](https://github.com/learningequality/kolibri/blob/develop/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue#L68) to be able to define the icon color and I didn't notice that there are two errors in the console caused by `label` and `icon` props being required by `CoreMenuOption`:

![Screenshot from 2021-09-15 14-30-18](https://user-images.githubusercontent.com/13509191/133435738-13b2c699-bae4-4bd3-b8a7-836920bef7a8.png)


This PR fixes these errors by making `label` and `icon` props optional so it works properly when `CoreMenuOption`'s content is provided through its default slot.