### PR TITLE
Revert "Handle special case when viewing Kolibri on translation server"

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -188,17 +188,6 @@ function _setUpVueIntl() {
     return $trWrapper(nameSpace, this.$options.$trs, this.$formatMessage, messageId, args);
   };
 
-  // This handles the special 'ach-ug' locale on the Crowdin translation server at
-  // https://kolibri-translate.learningequality.org/ach-ug/
-  // The Crowdin jipt.js script will inject the real language's code at this localStorage key.
-  if (currentLanguage === 'ach-ug' && localStorage.jipt_language_code_kolibri) {
-    // After making this substitution and calling Vue.setLocale, the messages injected
-    // under 'ach-ug' will be remapped to the real locale within vue-intl's methods.
-    // Thus, Vue.prototype.$formatMessage should still work as expected, while also fixing
-    // #7330 and similar issues related to the Intl API.
-    currentLanguage = localStorage.jipt_language_code_kolibri;
-  }
-
   Vue.setLocale(currentLanguage);
   if (languageGlobals.coreLanguageMessages) {
     Vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);


### PR DESCRIPTION
This reverts commit dade0f87acd30fd8c7481dbc365ec49b31c4db6f.

## Summary
The above change caused inconsistent translations in the in-context translation server.
This reverts that, meaning that time translations will be incorrect, but all messages should be properly recognized in context.

## References
Reverts the key part of https://github.com/learningequality/kolibri/pull/8100


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
