### PR TITLE
First pass at regression test and fix for SoUD FacilityUser sync conflict

### DIFF
--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -1,0 +1,26 @@
+from kolibri.core.auth.hooks import FacilityDataSyncHook
+from kolibri.core.auth.models import FacilityUser
+from kolibri.plugins.hooks import register_hook
+
+
+@register_hook
+class SingleFacilityUserChangeClearingHook(FacilityDataSyncHook):
+    def pre_transfer(
+        self,
+        dataset_id,
+        local_is_single_user,
+        remote_is_single_user,
+        single_user_id,
+        context,
+    ):
+
+        # If this is a single-user device, make sure we ignore any changes
+        # that have been made to FacilityUsers, to avoid conflicts.
+        if local_is_single_user and single_user_id is not None:
+            try:
+                user = FacilityUser.objects.get(
+                    id=single_user_id, _morango_dirty_bit=True
+                )
+                user.save(update_dirty_bit_to=False)
+            except FacilityUser.DoesNotExist:
+                pass

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -71,6 +71,17 @@ class KolibriServer(object):
             )
         )
 
+    def update_model(self, model, pk, **kwargs):
+        kwarg_text = json.dumps(kwargs, default=str)
+        self.pipe_shell(
+            'import json; from {module_path} import {model_nm}; kwargs = json.loads("""{}"""); {model_nm}.objects.filter(pk="{pk}").update(**kwargs)'.format(
+                kwarg_text,
+                module_path=model.__module__,
+                model_nm=model.__name__,
+                pk=pk,
+            )
+        )
+
     def delete_model(self, model, **kwargs):
         kwarg_text = json.dumps(kwargs, default=str)
         self.pipe_shell(

--- a/kolibri/plugins/registry.py
+++ b/kolibri/plugins/registry.py
@@ -32,6 +32,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
+from importlib import import_module
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -54,6 +55,34 @@ class PluginExistsInApp(Exception):
     This exception is raise when a plugin is initialized inside a Django app and
     it is found to actually have defined a plugin. NO!
     """
+
+
+def parse_installed_app_entry(app):
+    # In case we are registering non-plugins from INSTALLED_APPS (the usual use case)
+    # that could include Django AppConfig objects, or module paths to Django AppConfig objects.
+    if isinstance(app, AppConfig):
+        return app.name
+    # Check if this is a module path or an import path to an AppConfig object.
+    # Logic here modified from:
+    # https://github.com/django/django/blob/c669cf279ae7b3e02a61db4fb077030a4db80e4f/django/apps/config.py#L86
+    try:
+        # If import_module succeeds, entry is a path to an app module,
+        # so we carry on.
+        # Otherwise, entry is a path to an app config class or an error.
+        import_module(app)
+    except ImportError:
+        mod_path, _, cls_name = app.rpartition(".")
+        try:
+            module = import_module(mod_path)
+            cls = getattr(module, cls_name)
+            return cls.name
+        except (ImportError, AttributeError):
+            # If none of this works out, something has been misconfigured
+            # Django will be picking this up soon and give more detailed debugging
+            # so we just let this pass silently for now.
+            pass
+    # If we get to here, just return the original.
+    return app
 
 
 class Registry(object):
@@ -111,12 +140,10 @@ class Registry(object):
         by the Kolibri plugin machinery, but may wish to still register Kolibri Hooks
         """
         for app in apps:
-            # In case we are registering non-plugins from INSTALLED_APPS (the usual use case)
-            # that could include Django AppConfig objects.
-            if isinstance(app, AppConfig):
-                app = app.name
+            app = parse_installed_app_entry(app)
             if app not in self._apps:
                 try:
+
                     initialize_kolibri_plugin(app)
                     # Raise an error here because non-plugins should raise a PluginDoesNotExist exception
                     # if they are properly configured.


### PR DESCRIPTION
## Summary

In Morango, when a model is modified on both sides, it results in a merge conflict, and one copy of the data wins (and the serialized copy of the one that didn't win is stored in case the app wants to resolve the conflict later).

We don't allow FacilityUsers to be synced back across a single-user connection -- they can only be read. That's why we don't allow users to edit their profile on a SoUD -- but that doesn't stop some backend machinery from still writing to the FacilityUser on a SoUD. In particular, we saw a case with Django writing to the `last_login` field on the `FacilityUser` that made it "dirty", and then when a `full_name` change was synced in from a full-facility device, it conflicted, and the tablet's copy won, so the data with the updated `full_name` was relegated to the `conflicting_serialized_data` field in the Store.

This PR ~prevents~ attempts to prevent changes made to a FacilityUser on a SoUD from causing a conflict with incoming changes. **The regression tests work as intended, but my hook doesn't currently seem to be getting picked up, so the tests are still failing. Ideas welcome around what I may be missing.**

## Reviewer guidance

I'm running the tests with:

```
INTEGRATION_TEST=true pytest kolibri/core/auth/test/test_morango_integration.py::EcosystemSingleUserAssignmentTestCase::test_facility_user_conflict_syncing_from_tablet --pdb --capture=no
```

and

```
INTEGRATION_TEST=true pytest kolibri/core/auth/test/test_morango_integration.py::EcosystemSingleUserAssignmentTestCase::test_facility_user_conflict_syncing_from_laptop --pdb --capture=no
```

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [x] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
