### PR TITLE
Handle 500+ status codes when requesting a SoUD sync

### DIFF
--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -9,6 +9,7 @@ from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from morango.models import InstanceIDModel
+from requests.exceptions import ConnectionError
 from rest_framework import status
 
 import kolibri
@@ -222,8 +223,9 @@ def request_soud_sync(server, user, queue_id=None, ttl=4):
             # got a place in the queue to sync with this server, so we can be
             # more sure that the server is actually available.
             response = requests.put(server_url, json=data, timeout=30)
-
-    except requests.exceptions.ConnectionError:
+        if response.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+            raise ConnectionError()
+    except ConnectionError:
         # Algorithm to try several times if the server is not responding
         # Randomly it can be trying it up to 1560 seconds (26 minutes)
         # before desisting


### PR DESCRIPTION
## Summary
* Fixed some assertions in tests
* Added test for handling ConnectionError in request
* Fixed issue where using `requests.exceptions.ConnectionError` made Python report that it was not derived from `BaseException`
* Handle 500+ status codes from the queue endpoint by initiating ttl back off

## Reviewer guidance
Tests cover the changes?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
