### PR TITLE
Change immersive toolbar

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <CoreBase
-    :immersivePage="false"
+    :immersivePage="getUserPermissions.can_manage_content"
     immersivePageIcon="close"
     :immersivePagePrimary="false"
     :immersivePageRoute="exitButtonRoute"
@@ -133,6 +133,7 @@
         'ancestors',
       ]),
       ...mapGetters('lessonSummary/resources', ['numRemainingSearchResults']),
+      ...mapGetters(['getUserPermissions']),
       toolbarRoute() {
         if (this.$route.query.last) {
           return this.$router.getRoute(this.$route.query.last);

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <CoreBase
-    :immersivePage="true"
+    :immersivePage="false"
     immersivePageIcon="close"
     :immersivePagePrimary="false"
     :immersivePageRoute="exitButtonRoute"


### PR DESCRIPTION

## Summary
The PR is made after the issues described in https://github.com/learningequality/kolibri/issues/5890 . In short the problem is that  when you are in lesson creation page and you suddenly drop connection and try to reopen the page, the 'X' button doesn't work and you can't go back to Login. From what I have seen the second problem had already been fixed before I started working on the PR and you have a button to go back to login.

![Screenshot 2021-09-20 154321](https://user-images.githubusercontent.com/52789571/134004343-5cf8c553-02ab-4c74-810a-8c3feb83b959.png)

The problem I'm addressing with this PR is the 'X' button that doesn't work as intended. Because originally you need to have a session for it to work properly, when you drop connection it gives errors. As it was mentioned in one of the comments, I changed it so that it show the immersive toolbar only when you have a session and the normal App bar otherwise. I wasn't sure what getter to use in order to check if the user is authenticated and I decided to use getUserPermissions (it seems to be working correctly).

![Screenshot 2021-09-20 154709](https://user-images.githubusercontent.com/52789571/134004874-101fb566-fbb8-408f-9ad4-1be6194dc054.png)



## Reviewer guidance

You can test it by opening the create lesson resource page and quitting the browser. After that reopening it and you could be able to see the lost session menu.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
