### PR TITLE
Hybrid learning progress bar

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
@@ -1,0 +1,64 @@
+<template>
+
+  <div
+    v-if="progress"
+    class="progress-bar-wrapper"
+    :style="{ backgroundColor: $themePalette.grey.v_200 }"
+    role="progressbar"
+    :aria-valuemin="0"
+    :aria-valuemax="100"
+    :aria-valuenow="progress * 100"
+  >
+    <div
+      class="progress-bar"
+      :style="{
+        width: `${progress * 100}%`,
+        backgroundColor: progress === 1 ?
+          $themeTokens.mastered : (progress > 0 ? $themeTokens.progress : ''),
+      }"
+    >
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  /**
+   * A progress bar that has three states:
+   * - won't display when not started (progress = 0)
+   * - blue bar when in progress (0 < progress < 1)
+   * - full width yellow bar when complete (progress = 1)
+   */
+  export default {
+    name: 'ProgressBar',
+    props: {
+      /**
+       * A fraction between 0 and 1
+       */
+      progress: {
+        type: Number,
+        required: false,
+        default: null,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .progress-bar-wrapper {
+    width: 100%;
+    height: 4px;
+    border-radius: 4px;
+    opacity: 0.9;
+
+    .progress-bar {
+      height: 100%;
+    }
+  }
+
+</style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is a progress bar component that JB has prepared for cards on the new hybrid learning home page. @marcellamaki mentioned that it might be helpful for some of her work on hybrid learning so sharing here.

Screenshots from cards that are using it on my home page branch:


![Screenshot from 2021-09-21 14-57-12](https://user-images.githubusercontent.com/13509191/134175172-b807455d-4c4e-4a3d-83c3-a2f0a2973169.png)
![Screenshot from 2021-09-21 14-57-38](https://user-images.githubusercontent.com/13509191/134175176-293531a6-ab52-457e-9622-60409b26b5e6.png)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Part of  #8137

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
