### PR TITLE
Defers content schema initialization until needed.

### DIFF
--- a/kolibri/core/content/apps.py
+++ b/kolibri/core/content/apps.py
@@ -12,7 +12,4 @@ class KolibriContentConfig(AppConfig):
 
     def ready(self):
         from .signals import reorder_channels_upon_deletion  # noqa: F401
-        from kolibri.core.content.utils.sqlalchemybridge import prepare_bases
         from .signals import cascade_delete_node  # noqa: F401
-
-        prepare_bases()


### PR DESCRIPTION
## Summary
* After some quick profiling of the load times for running the kolibri `initialize` method, it was clear that we were spending a fair amount of time preparing content schemas in SQLAlchemy
* These are not required at startup, and unless importing from older content databases, most of these schemas are never used
* This PR defers initialization of these content schemas until they are actually needed
* In so doing, on local testing it seems to reduce initialization time from ~2.8 seconds to ~1.6 seconds. A roughly 40% improvement.

## Reviewer guidance
Do all channel metadata import and manipulation operations still run as expected?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
