### PR TITLE
Remove precaching of Django static files.

### DIFF
--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -15,7 +15,7 @@ from django.db.utils import OperationalError
 
 from kolibri.core.content.utils import paths
 from kolibri.utils import conf
-from kolibri.utils.kolibri_whitenoise import DjangoWhiteNoise
+from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
@@ -30,7 +30,7 @@ def generate_wsgi_application():
     content_dirs = [paths.get_content_dir_path()] + paths.get_content_fallback_paths()
 
     # Mount static files
-    return DjangoWhiteNoise(
+    return DynamicWhiteNoise(
         django_application,
         static_prefix=settings.STATIC_URL,
         dynamic_locations=[


### PR DESCRIPTION
## Summary
* When we startup the Kolibri server, on my dev machine we spend about 0.4 seconds precaching all Django static files
* This removes that startup bottleneck by switching to a purely dynamic static file loading

## Reviewer guidance
This does not seem to affect static file serving performance, as after the first request, the file is cached just in the same way that it would have been previously.

Whitenoise does not do this by default, because it assumes it can wrap and serve any static file. We have modified whitenoise to only check for specific prefixes (like /static/) which reduces the search space for files.

Doing this change removes the startup bottleneck and seems to have no effect on siege performance for static files.
Before:
```
** SIEGE 4.0.4
** Preparing 25 concurrent users for battle.
The server is now under siege...
Lifting the server siege...
Transactions:		       44018 hits
Availability:		      100.00 %
Elapsed time:		       59.32 secs
Data transferred:	      217.70 MB
Response time:		        0.03 secs
Transaction rate:	      742.04 trans/sec
Throughput:		        3.67 MB/sec
Concurrency:		       24.94
Successful transactions:       44018
Failed transactions:	           0
Longest transaction:	        0.19
Shortest transaction:	        0.01
```
After:
```
** SIEGE 4.0.4
** Preparing 25 concurrent users for battle.
The server is now under siege...
Lifting the server siege...
Transactions:		       44640 hits
Availability:		      100.00 %
Elapsed time:		       59.38 secs
Data transferred:	      220.78 MB
Response time:		        0.03 secs
Transaction rate:	      751.77 trans/sec
Throughput:		        3.72 MB/sec
Concurrency:		       24.94
Successful transactions:       44640
Failed transactions:	           0
Longest transaction:	        0.13
Shortest transaction:	        0.02

```

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
