### PR TITLE
Refactor bookmarks cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -23,6 +23,7 @@
 
       <KButton
         v-if="more && !loading"
+        data-test="load-more-button"
         :text="coreString('viewMoreAction')"
         @click="loadMore"
       />

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -1,37 +1,33 @@
 <template>
 
   <div>
-
-    <p v-if="!bookmarks.length && !loading" class="no-bookmarks">
+    <h1>
+      {{ $tr('bookmarksHeader') }}
+    </h1>
+    <p v-if="!bookmarks.length && !loading">
       {{ $tr('noBookmarks') }}
     </p>
 
+    <HybridLearningCardGrid
+      v-if="bookmarks.length"
+      :contents="bookmarks"
+      :genContentLink="genContentLink"
+      :cardViewStyle="windowIsSmall ? 'card' : 'list'"
+      numCols="1"
+      :footerIcons="footerIcons"
+      @removeFromBookmarks="removeFromBookmarks"
+    />
 
-    <template v-else>
-      <h1 class="bookmarks-header">
-        {{ $tr('bookmarksHeader') }}
-      </h1>
-      <ContentCardGroupGrid
-        v-if="bookmarks.length"
-        :contents="bookmarks"
-        :genContentLink="genContentLink"
-        :cardViewStyle="windowIsSmall ? 'card' : 'list'"
-        numCols="1"
-        :footerIcons="footerIcons"
-        @removeFromBookmarks="removeFromBookmarks"
-      />
-
-      <KButton
-        v-if="more && !loading"
-        data-test="load-more-button"
-        :text="coreString('viewMoreAction')"
-        @click="loadMore"
-      />
-      <KCircularLoader
-        v-else-if="loading"
-        :delay="false"
-      />
-    </template>
+    <KButton
+      v-if="more && !loading"
+      data-test="load-more-button"
+      :text="coreString('viewMoreAction')"
+      @click="loadMore"
+    />
+    <KCircularLoader
+      v-else-if="loading"
+      :delay="false"
+    />
   </div>
 
 </template>
@@ -48,7 +44,7 @@
   import urls from 'kolibri.urls';
   import { PageNames } from '../constants';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
-  import ContentCardGroupGrid from './ContentCardGroupGrid';
+  import HybridLearningCardGrid from './HybridLearningCardGrid';
 
   export default {
     name: 'BookmarkPage',
@@ -58,7 +54,7 @@
       };
     },
     components: {
-      ContentCardGroupGrid,
+      HybridLearningCardGrid,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     data() {
@@ -70,13 +66,13 @@
     },
     computed: {
       footerIcons() {
-        return { close: 'removeFromBookmarks', info: 'viewInformation' };
+        return { info: 'viewInformation', close: 'removeFromBookmarks' };
       },
     },
     created() {
       ContentNodeResource.fetchBookmarks({ params: { limit: 25 } }).then(data => {
         this.more = data.more;
-        this.bookmarks = data.results.map(normalizeContentNode);
+        this.bookmarks = data.results ? data.results.map(normalizeContentNode) : [];
         this.loading = false;
       });
     },
@@ -123,23 +119,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  .no-bookmarks {
-    width: 100%;
-    height: 100%;
-    padding-top: 170px;
-    text-align: center;
-  }
-
-  .bookmarks-header {
-    margin-bottom: 34px;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: normal;
-    line-height: 33px;
-  }
-
-</style>

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -89,13 +89,13 @@
           });
         }
       },
-      removeFromBookmarks(bookmark, index) {
+      removeFromBookmarks(bookmark) {
         if (bookmark) {
           client({
             method: 'delete',
             url: urls['kolibri:core:bookmarks_detail'](bookmark.id),
           }).then(() => {
-            this.bookmarks.pop(index);
+            this.bookmarks = this.bookmarks.filter(bm => bm.bookmark.id !== bookmark.id);
             this.createSnackbar(this.$tr('removedNotification'));
           });
         }

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -18,6 +18,7 @@
         :cardViewStyle="windowIsSmall ? 'card' : 'list'"
         numCols="1"
         :footerIcons="footerIcons"
+        @removeFromBookmarks="removeFromBookmarks"
       />
 
       <KButton
@@ -37,13 +38,14 @@
 
 <script>
 
-  // import { mapActions } from 'vuex';
-  // import client from 'kolibri.client';
-  // import urls from 'kolibri.urls';
+  import { mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { ContentNodeResource } from 'kolibri.resources';
   import genContentLink from '../utils/genContentLink';
+  import client from 'kolibri.client';
+  import urls from 'kolibri.urls';
+  import { PageNames } from '../constants';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
   import ContentCardGroupGrid from './ContentCardGroupGrid';
 
@@ -90,15 +92,17 @@
           });
         }
       },
-      // removeBookmark(bookmark, index) {
-      //   client({
-      //     method: 'delete',
-      //     url: urls['kolibri:core:bookmarks_delete_by_node_id'](bookmark.id),
-      //   }).then(() => {
-      //     this.bookmarks.pop(index);
-      //     this.createSnackbar(this.$tr('removedNotification'));
-      //   });
-      // },
+      removeFromBookmarks(bookmark, index) {
+        if (bookmark) {
+          client({
+            method: 'delete',
+            url: urls['kolibri:core:bookmarks_detail'](bookmark.id),
+          }).then(() => {
+            this.bookmarks.pop(index);
+            this.createSnackbar(this.$tr('removedNotification'));
+          });
+        }
+      },
     },
     $trs: {
       bookmarksHeader: {
@@ -106,10 +110,10 @@
         context:
           "Header on the 'Bookmarks' page with the list of the resources user previously saved.",
       },
-      // removedNotification: {
-      //   message: 'Removed from bookmarks',
-      //   context: 'Message indicating that a resource has been removed from the Bookmarks page.',
-      // },
+      removedNotification: {
+        message: 'Removed from bookmarks',
+        context: 'Message indicating that a resource has been removed from the Bookmarks page.',
+      },
       noBookmarks: {
         message: 'You have no bookmarked resources',
         context: "Status message in the 'Bookmarks' page when user did not bookmark any resources.",

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -5,13 +5,60 @@
     :class="{ 'mobile-thumbnail': isMobile }"
     :style="thumbnailBackground"
   >
+
+    <ContentIcon
+      v-if="!thumbnail"
+      :kind="kind"
+      class="type-icon"
+      :color="$themeTokens.annotation"
+    />
+
+    <ProgressIcon
+      v-if="progress > 0"
+      class="progress-icon"
+      :progress="progress"
+    />
+
     <div
-      v-if="activityLength && !isMobile"
-      :class="isRtl ? 'chip-right' : 'chip-left' "
-      :style="{ color: $themeTokens.textInverted }"
+      v-if="showContentIcon"
+      class="content-icon-wrapper"
     >
-      {{ coreString(activityLength) }}
+      <svg
+        height="64"
+        width="64"
+        viewBox="0 0 64 64"
+        class="content-icon-bg"
+        :style="contentIconBgColor"
+      >
+        <polygon
+          stroke-width="0"
+          :points="contentIconBgCoords"
+        />
+      </svg>
+      <ContentIcon
+        :kind="kind"
+        :showTooltip="true"
+        class="content-icon"
+        :color="$themeTokens.textInverted"
+      />
     </div>
+
+    <div
+      v-if="progress !== undefined && progress !== 0"
+      class="progress-bar-wrapper"
+      :style="{ backgroundColor: $themePalette.grey.v_200 }"
+    >
+      <div
+        class="progress-bar"
+        :style="{
+          width: `${progress * 100}%`,
+          backgroundColor: isMastered ?
+            $themeTokens.mastered : (isInProgress ? $themeTokens.progress : ''),
+        }"
+      >
+      </div>
+    </div>
+
   </div>
 
 </template>
@@ -19,31 +66,85 @@
 
 <script>
 
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
+  import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
+  import { validateContentNodeKind } from 'kolibri.utils.validators';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     name: 'CardThumbnail',
-    mixins: [commonCoreStrings],
+    components: {
+      ContentIcon,
+      ProgressIcon,
+    },
     props: {
       thumbnail: {
         type: String,
         default: null,
       },
+      kind: {
+        type: String,
+        required: true,
+        validator: validateContentNodeKind,
+      },
+      // If true, shows the content icon on the upper left of the thumbnail
+      showContentIcon: {
+        type: Boolean,
+        default: true,
+      },
+      progress: {
+        type: Number,
+        required: false,
+        default: 0.0,
+        validator(value) {
+          return value >= 0.0 && value <= 1.0;
+        },
+      },
       isMobile: {
         type: Boolean,
         default: false,
       },
-      activityLength: {
-        type: String,
-        default: null,
-      },
     },
     computed: {
+      isMastered() {
+        return this.progress === 1;
+      },
+      isInProgress() {
+        return this.progress > 0 && this.progress < 1;
+      },
       thumbnailBackground() {
         return {
           backgroundColor: this.$themeTokens.surface,
           backgroundImage: this.thumbnail ? `url('${this.thumbnail}')` : '',
         };
+      },
+      contentIconBgCoords() {
+        const topLeft = '0,0';
+        const topRight = '64,0';
+        const bottomLeft = '0,64';
+        const bottomRight = '64,64';
+        if (this.isRtl) {
+          return `${topLeft} ${topRight} ${bottomRight}`;
+        }
+        return `${topLeft} ${topRight} ${bottomLeft}`;
+      },
+      contentIconBgColor() {
+        switch (this.kind) {
+          case ContentNodeKinds.EXERCISE:
+            return { fill: this.$themeTokens.exercise };
+          case ContentNodeKinds.VIDEO:
+            return { fill: this.$themeTokens.video };
+          case ContentNodeKinds.AUDIO:
+            return { fill: this.$themeTokens.audio };
+          case ContentNodeKinds.DOCUMENT:
+            return { fill: this.$themeTokens.document };
+          case ContentNodeKinds.HTML5:
+            return { fill: this.$themeTokens.html5 };
+          case ContentNodeKinds.SLIDESHOW:
+            return { fill: this.$themeTokens.slideshow };
+          default:
+            return { fill: this.$themeTokens.topic };
+        }
       },
     },
   };
@@ -57,11 +158,26 @@
 
   .card-thumbnail-wrapper {
     position: relative;
-    width: 100%;
+    width: $thumb-width-desktop;
     height: $thumb-height-desktop;
     background-repeat: no-repeat;
     background-position: center;
     background-size: contain;
+    // Add an extra border to contain the progress bar and not have it overlap the image
+    border-bottom: solid transparent 5px;
+  }
+
+  .type-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(3);
+  }
+
+  .progress-icon {
+    position: absolute;
+    top: 4px;
+    right: 4px;
   }
 
   .content-icon-wrapper {
@@ -70,31 +186,34 @@
     height: 56px;
   }
 
-  .chip-right {
+  .content-icon {
     position: absolute;
-    right: 10px;
-    bottom: 20px;
-    height: 34px;
-    padding: 8px;
-    font-size: 13px;
-    background-color: rgba(0, 0, 0, 0.7);
-    border-radius: 4px;
+    font-size: 20px;
+    transform: translate(25%, 0);
   }
 
-  .chip-left {
+  .content-icon-bg {
     position: absolute;
-    bottom: 20px;
-    left: 10px;
-    height: 34px;
-    padding: 8px;
-    font-size: 13px;
-    background-color: rgba(0, 0, 0, 0.7);
-    border-radius: 4px;
+    width: 100%;
+    height: 100%;
+    fill-opacity: 0.9;
+  }
+
+  .progress-bar-wrapper {
+    position: absolute;
+    bottom: -5px;
+    width: 100%;
+    height: 5px;
+    opacity: 0.9;
+  }
+
+  .progress-bar {
+    height: 100%;
   }
 
   /* MOBILE OVERRIDES */
   .mobile-thumbnail.card-thumbnail-wrapper {
-    width: 100%;
+    width: $thumb-width-mobile;
     height: $thumb-height-mobile;
   }
 
@@ -110,9 +229,6 @@
 
     .content-icon {
       font-size: 18px;
-    }
-    .activity-length-chip {
-      bottom: 20px;
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -6,7 +6,7 @@
     :style="thumbnailBackground"
   >
     <div
-      v-if="activityLength"
+      v-if="activityLength && !isMobile"
       :class="isRtl ? 'chip-right' : 'chip-left' "
       :style="{ color: $themeTokens.textInverted }"
     >

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/CardThumbnail.vue
@@ -4,15 +4,26 @@
     class="card-thumbnail-wrapper"
     :class="{ 'mobile-thumbnail': isMobile }"
     :style="thumbnailBackground"
-  ></div>
+  >
+    <div
+      v-if="activityLength"
+      :class="isRtl ? 'chip-right' : 'chip-left' "
+      :style="{ color: $themeTokens.textInverted }"
+    >
+      {{ coreString(activityLength) }}
+    </div>
+  </div>
 
 </template>
 
 
 <script>
 
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
   export default {
     name: 'CardThumbnail',
+    mixins: [commonCoreStrings],
     props: {
       thumbnail: {
         type: String,
@@ -21,6 +32,10 @@
       isMobile: {
         type: Boolean,
         default: false,
+      },
+      activityLength: {
+        type: String,
+        default: null,
       },
     },
     computed: {
@@ -55,6 +70,28 @@
     height: 56px;
   }
 
+  .chip-right {
+    position: absolute;
+    right: 10px;
+    bottom: 20px;
+    height: 34px;
+    padding: 8px;
+    font-size: 13px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 4px;
+  }
+
+  .chip-left {
+    position: absolute;
+    bottom: 20px;
+    left: 10px;
+    height: 34px;
+    padding: 8px;
+    font-size: 13px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 4px;
+  }
+
   /* MOBILE OVERRIDES */
   .mobile-thumbnail.card-thumbnail-wrapper {
     width: 100%;
@@ -73,6 +110,9 @@
 
     .content-icon {
       font-size: 18px;
+    }
+    .activity-length-chip {
+      bottom: 20px;
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
@@ -1,7 +1,7 @@
 $ratio: 16 / 9;
 
-$thumb-height-desktop: 160px;
-$thumb-width-desktop: round($thumb-height-desktop * $ratio);
+$thumb-width-desktop: 210px;
+$thumb-height-desktop: round($thumb-width-desktop / $ratio);
 
-$thumb-height-mobile: 185px;
-$thumb-width-mobile: round($thumb-height-mobile / $ratio);
+$thumb-height-mobile: 92px;
+$thumb-width-mobile: round($thumb-height-mobile * $ratio);

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
@@ -3,5 +3,5 @@ $ratio: 16 / 9;
 $thumb-height-desktop: 160px;
 $thumb-width-desktop: round($thumb-height-desktop * $ratio);
 
-$thumb-height-mobile: 200px;
-$thumb-width-mobile: round($thumb-height-mobile * $ratio);
+$thumb-height-mobile: 185px;
+$thumb-width-mobile: round($thumb-height-mobile / $ratio);

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/card.scss
@@ -1,7 +1,7 @@
 $ratio: 16 / 9;
 
-$thumb-height-desktop: 180px;
+$thumb-height-desktop: 160px;
 $thumb-width-desktop: round($thumb-height-desktop * $ratio);
 
-$thumb-height-mobile: 92px;
+$thumb-height-mobile: 200px;
 $thumb-width-mobile: round($thumb-height-mobile * $ratio);

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
@@ -30,8 +30,8 @@
     <ContentCardListViewItem
       v-for="content in contents"
       :key="content.id"
-      :channelThumbnail="setChannelThumbnail(content)"
-      :channelTitle="channelTitle(content)"
+      :channelThumbnail="content.channel_thumbnail"
+      :channelTitle="content.channel_thumbnail"
       :description="content.description"
       activityLength="shortActivity"
       class="grid-item"
@@ -49,6 +49,7 @@
       :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
       @toggleInfoPanel="$emit('toggleInfoPanel', content)"
+      @removeFromBookmarks="removeFromBookmarks(content, contents)"
     />
     <CopiesModal
       v-if="modalIsOpen"
@@ -63,7 +64,6 @@
 
 <script>
 
-  import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import genContentLink from '../utils/genContentLink';
   import ContentCardListViewItem from './ContentCardListViewItem';
@@ -90,11 +90,6 @@
           return ['card', 'list'].includes(value);
         },
       },
-      channelThumbnail: {
-        type: String,
-        required: false,
-        default: null,
-      },
       footerIcons: {
         type: Object,
         required: false,
@@ -106,9 +101,6 @@
       sharedContentId: null,
       uniqueId: null,
     }),
-    computed: {
-      ...mapState('topicsRoot', { channels: 'rootNodes' }),
-    },
     methods: {
       genContentLink,
       openCopiesModal(contentId) {
@@ -116,17 +108,8 @@
         this.uniqueId = this.contents.find(content => content.content_id === contentId).id;
         this.modalIsOpen = true;
       },
-      setChannelThumbnail(content) {
-        if (this.channelThumbnail) {
-          return this.channelThumbnail;
-        } else {
-          let match = this.channels.find(channel => channel.id === content.channel_id);
-          return match ? match.thumbnail : null;
-        }
-      },
-      channelTitle(content) {
-        let match = this.channels.find(channel => channel.id === content.channel_id);
-        return match ? match.title : null;
+      removeFromBookmarks(content, contents) {
+        return this.$emit('removeFromBookmarks', content.bookmark, contents.indexOf(content));
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardGroupGrid.vue
@@ -1,34 +1,39 @@
 <template>
 
   <div class="content-grid">
-    <KFixedGrid v-if="cardViewStyle === 'card'" numCols="3" gutter="24">
+    <!-- <KFixedGrid
+      v-if="cardViewStyle === 'card'"
+      :numCols="this.windowIsSmall ? 1
+      : numCols" gutter="24">
       <KFixedGridItem v-for="content in contents" :key="content.id" span="1">
         <ContentCard
           class="grid-item"
           :isMobile="windowIsSmall"
           :title="content.title"
-          :thumbnail="setContentThumbnail(content)"
+          :thumbnail="content.thumbnail"
           :kind="content.kind"
+          activityLength="shortActivity"
           :isLeaf="content.is_leaf"
           :progress="content.progress || 0"
           :numCoachContents="content.num_coach_contents"
           :link="genContentLink(content.id, content.is_leaf)"
           :contentId="content.content_id"
           :copiesCount="content.copies_count"
+          :description="content.description"
           :channelThumbnail="setChannelThumbnail(content)"
           :channelTitle="channelTitle(content)"
           @openCopiesModal="openCopiesModal"
           @toggleInfoPanel="$emit('toggleInfoPanel', content)"
         />
       </KFixedGridItem>
-    </KFixedGrid>
+    </KFixedGrid> -->
     <ContentCardListViewItem
       v-for="content in contents"
-      v-else
       :key="content.id"
       :channelThumbnail="setChannelThumbnail(content)"
       :channelTitle="channelTitle(content)"
       :description="content.description"
+      activityLength="shortActivity"
       class="grid-item"
       :isMobile="windowIsSmall"
       :title="content.title"
@@ -40,6 +45,8 @@
       :link="genContentLink(content.id, content.is_leaf)"
       :contentId="content.content_id"
       :copiesCount="content.copies_count"
+      :footerIcons="footerIcons"
+      :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
       @toggleInfoPanel="$emit('toggleInfoPanel', content)"
     />
@@ -59,14 +66,13 @@
   import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import genContentLink from '../utils/genContentLink';
-  import ContentCard from './ContentCard';
   import ContentCardListViewItem from './ContentCardListViewItem';
   import CopiesModal from './CopiesModal';
 
   export default {
     name: 'ContentCardGroupGrid',
     components: {
-      ContentCard,
+      // ContentCard,
       CopiesModal,
       ContentCardListViewItem,
     },
@@ -86,6 +92,11 @@
       },
       channelThumbnail: {
         type: String,
+        required: false,
+        default: null,
+      },
+      footerIcons: {
+        type: Object,
         required: false,
         default: null,
       },
@@ -111,11 +122,6 @@
         } else {
           let match = this.channels.find(channel => channel.id === content.channel_id);
           return match ? match.thumbnail : null;
-        }
-      },
-      setContentThumbnail(content) {
-        if (content.thumbnail) {
-          return content.thumbnail;
         }
       },
       channelTitle(content) {

--- a/kolibri/plugins/learn/assets/src/views/ContentCardListViewItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardListViewItem.vue
@@ -72,6 +72,7 @@
           v-if="!isMobile && isLibraryPage"
           appearance="basic-link"
           class="copies"
+          :style="{ color: $themeTokens.text }"
           :text="coreString('copies', { num: copiesCount })"
           @click.prevent="$emit('openCopiesModal', contentId)"
         />
@@ -333,7 +334,6 @@
     display: inline-block;
     padding: 6px 8px;
     font-size: 13px;
-    color: black;
     text-decoration: none;
     vertical-align: top;
   }

--- a/kolibri/plugins/learn/assets/src/views/ContentCardListViewItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCardListViewItem.vue
@@ -20,7 +20,11 @@
           v-bind="{ thumbnail, kind, isMobile }"
           :activityLength="activityLength"
         />
-        <p v-if="!isMobile" class="metadata-info">
+        <p
+          v-if="!isMobile"
+          class="metadata-info"
+          :style="{ color: $themePalette.grey.v_700 }"
+        >
           {{ bookmarkCreated }}
         </p>
         <KLinearLoader
@@ -33,15 +37,14 @@
         />
       </div>
       <span class="details" :style="{ color: $themeTokens.text }">
-        <div class="metadata-info">
+        <div
+          class="metadata-info"
+          :style="{ color: $themePalette.grey.v_700 }"
+        >
           <KLabeledIcon
             :icon="kind === 'topic' ? 'topic' : `${kindToLearningActivity}Solid`"
             size="mini"
-            :label="
-              `${coreString(kindToLearningActivity)}
-              ${isMobile ? ' | ' : '' }
-              ${isMobile ? coreString(activityLength) : ''}`
-            "
+            :label="iconLabel"
           />
         </div>
         <h3 class="title">
@@ -56,7 +59,7 @@
             :maxHeight="maxDescriptionHeight"
           />
         </p>
-        <div v-if="displayCategoryAndLevelMetadata" class="metadata-info">
+        <div v-if="displayCategoryAndLevelMetadata && !isMobile" class="metadata-info">
           <p> {{ coreString(displayCategoryAndLevelMetadata) }}</p>
         </div>
         <img
@@ -75,7 +78,11 @@
       </span>
     </router-link>
     <div class="footer">
-      <p v-if="isMobile" class="metadata-info-footer">
+      <p
+        v-if="isMobile"
+        class="metadata-info-footer"
+        :style="{ color: $themePalette.grey.v_700 }"
+      >
         {{ bookmarkCreated }}
       </p>
       <KIconButton
@@ -212,7 +219,7 @@
       },
       displayCategoryAndLevelMetadata() {
         if (this.category && this.level) {
-          return this.category`| ${this.level} `;
+          return `${this.category}| ${this.level} `;
         } else if (this.category) {
           return this.category;
         } else if (this.level) {
@@ -233,6 +240,16 @@
           activity = ContentKindsToLearningActivitiesMap[this.kind];
           return `${activity}`;
         }
+      },
+      iconLabel() {
+        const kindToLearningActivity = this.coreString(this.kindToLearningActivity);
+        let addedMobileDisplay = '';
+        // append the | and the activity length on mobile views only
+        // make all part of the same string for correct RTL display
+        if (this.isMobile) {
+          addedMobileDisplay = ` | ${this.coreString(this.activityLength)}`;
+        }
+        return `${kindToLearningActivity} ${addedMobileDisplay}`;
       },
       isLibraryPage() {
         return this.pageName === PageNames.LIBRARY;
@@ -298,14 +315,12 @@
   .metadata-info {
     margin-bottom: 6px;
     font-size: 13px;
-    color: #616161;
   }
 
   .metadata-info-footer {
     display: inline-block;
     margin: 0;
     font-size: 13px;
-    color: #616161;
   }
 
   .channel-logo {
@@ -370,12 +385,12 @@
     .thumbnail {
       position: absolute;
       width: 100%;
-      margin: 0;
+      margin: auto;
+      margin-top: 10px;
     }
     .details {
       max-width: 100%;
-      padding: 8px;
-      margin-top: $thumb-height-mobile;
+      margin-top: ($thumb-height-mobile + 20px);
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -1,0 +1,101 @@
+<template>
+
+  <div
+    class="card-thumbnail-wrapper"
+    :class="{ 'mobile-thumbnail': isMobile }"
+    :style="thumbnailBackground"
+  >
+    <div
+      v-if="activityLength && !isMobile"
+      class="chip"
+      :style="{ color: $themeTokens.textInverted }"
+    >
+      {{ coreString(activityLength) }}
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'CardThumbnail',
+    mixins: [commonCoreStrings],
+    props: {
+      thumbnail: {
+        type: String,
+        default: null,
+      },
+      isMobile: {
+        type: Boolean,
+        default: false,
+      },
+      activityLength: {
+        type: String,
+        default: null,
+      },
+    },
+    computed: {
+      thumbnailBackground() {
+        return {
+          backgroundColor: this.$themePalette.grey.v_200,
+          backgroundImage: this.thumbnail ? `url('${this.thumbnail}')` : '',
+        };
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import './card';
+  .card-thumbnail-wrapper {
+    position: relative;
+    width: 100%;
+    height: $thumb-height-desktop-hybrid-learning;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+  }
+  .content-icon-wrapper {
+    position: absolute;
+    width: 56px;
+    height: 56px;
+  }
+  .chip {
+    position: absolute;
+    bottom: 16px;
+    left: 10px;
+    padding: 8px;
+    font-size: 13px;
+    background-color: rgba(0, 0, 0, 0.7);
+    border-radius: 4px;
+  }
+
+  /* MOBILE OVERRIDES */
+  .mobile-thumbnail.card-thumbnail-wrapper {
+    width: 100%;
+    height: $thumb-height-mobile-hybrid-learning;
+  }
+  .mobile-thumbnail {
+    .type-icon {
+      transform: translate(-50%, -50%) scale(2);
+    }
+    .content-icon-wrapper {
+      width: 48px;
+      height: 48px;
+    }
+    .content-icon {
+      font-size: 18px;
+    }
+    .activity-length-chip {
+      bottom: 20px;
+    }
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/card.scss
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/card.scss
@@ -1,0 +1,7 @@
+$ratio: 16 / 9;
+
+$thumb-height-desktop-hybrid-learning: 160px;
+$thumb-width-desktop-hybrid-learning: round($thumb-height-desktop-hybrid-learning * $ratio);
+
+$thumb-height-mobile-hybrid-learning: 185px;
+$thumb-width-mobile-hybrid-learning: round($thumb-height-mobile-hybrid-learning / $ratio);

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -1,0 +1,313 @@
+<template>
+
+  <div
+    class="card"
+    :class="[
+      { 'mobile-card': isMobile },
+      $computedClass({ ':focus': $coreOutline })
+    ]"
+    :style="{ backgroundColor: $themeTokens.surface }"
+  >
+    <router-link
+      :to="link"
+    >
+      <div class="header-bar">
+        <KLabeledIcon
+          :icon="kind === 'topic' ? 'topic' : `${kindToLearningActivity}Solid`"
+          :label="coreString(kindToLearningActivity)"
+          class="k-labeled-icon"
+        />
+        <img
+          :src="channelThumbnail"
+          :alt="learnString('logo', { channelTitle: channelTitle })"
+          class="channel-logo"
+        >
+      </div>
+      <CardThumbnail
+        class="thumbnail"
+        v-bind="{ thumbnail, kind, isMobile }"
+      />
+      <div class="text" :style="{ color: $themeTokens.text }">
+        <h3 class="title" dir="auto">
+          <TextTruncator
+            :text="title"
+            :maxHeight="maxTitleHeight"
+          />
+        </h3>
+        <p
+          v-if="subtitle"
+          dir="auto"
+          class="subtitle"
+        >
+          {{ subtitle }}
+        </p>
+      </div>
+    </router-link>
+    <div class="footer">
+      <KLinearLoader
+        class="k-linear-loader"
+        :delay="false"
+        :progress="progress"
+        type="determinate"
+        :style="{ backgroundColor: $themeTokens.fineLine }"
+      />
+      <div class="left">
+        <CoachContentLabel
+          v-if="isUserLoggedIn && !isLearner"
+          class="coach-content-label"
+          :value="numCoachContents"
+          :isTopic="isTopic"
+        />
+        <KIconButton
+          icon="optionsVertical"
+          class="info-icon"
+          size="mini"
+          :color="$themePalette.grey.v_400"
+          :ariaLabel="coreString('moreOptions')"
+          :tooltip="coreString('moreOptions')"
+          @click="$emit('toggleOptions')"
+        />
+      </div>
+      <div class="right">
+        <KIconButton
+          icon="infoPrimary"
+          size="mini"
+          :color="$themePalette.grey.v_400"
+          :ariaLabel="coreString('viewInformation')"
+          :tooltip="coreString('viewInformation')"
+          @click="$emit('toggleInfoPanel')"
+        />
+        <KButton
+          v-if="copiesCount > 1"
+          appearance="basic-link"
+          class="copies"
+          :text="coreString('copies', { num: copiesCount })"
+          @click.prevent="$emit('openCopiesModal', contentId)"
+        />
+        <slot name="actions"></slot>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapGetters } from 'vuex';
+  import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import {
+    LearningActivities,
+    ContentKindsToLearningActivitiesMap,
+  } from 'kolibri.coreVue.vuex.constants';
+  import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
+  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonLearnStrings from '../commonLearnStrings';
+  import CardThumbnail from './CardThumbnail.vue';
+
+  export default {
+    name: 'HybridLearningContentCard',
+    components: {
+      CardThumbnail,
+      CoachContentLabel,
+      TextTruncator,
+    },
+    mixins: [commonLearnStrings, commonCoreStrings],
+    props: {
+      title: {
+        type: String,
+        required: true,
+      },
+      subtitle: {
+        type: String,
+        default: null,
+      },
+      thumbnail: {
+        type: String,
+        default: null,
+      },
+      channelThumbnail: {
+        type: String,
+        default: null,
+      },
+      channelTitle: {
+        type: String,
+        default: null,
+      },
+      kind: {
+        type: String,
+        required: true,
+        validator: validateContentNodeKind,
+      },
+      isLeaf: {
+        type: Boolean,
+        required: true,
+      },
+      // ContentNode.coach_content will be `0` if not a coach content leaf node,
+      // or a topic without coach content. It will be a positive integer if a topic
+      // with coach content, and `1` if a coach content leaf node.
+      numCoachContents: {
+        type: Number,
+        default: 0,
+      },
+      progress: {
+        type: Number,
+        required: false,
+        default: 0.0,
+        validator(value) {
+          return value >= 0.0 && value <= 1.0;
+        },
+      },
+      link: {
+        type: Object,
+        required: true,
+        validator: validateLinkObject,
+      },
+      isMobile: {
+        type: Boolean,
+        default: false,
+      },
+      contentId: {
+        type: String,
+        default: null,
+      },
+      copiesCount: {
+        type: Number,
+        default: null,
+      },
+    },
+    computed: {
+      ...mapGetters(['isLearner', 'isUserLoggedIn']),
+      isTopic() {
+        return !this.isLeaf;
+      },
+      maxTitleHeight() {
+        if (this.hasFooter && this.subtitle) {
+          return 20;
+        } else if (this.hasFooter || this.subtitle) {
+          return 40;
+        }
+        return 66;
+      },
+      hasFooter() {
+        return this.numCoachContents > 0 || this.copiesCount > 1 || this.$slots.actions;
+      },
+      kindToLearningActivity() {
+        let activity = '';
+        if (this.kind === 'topic') {
+          return 'folder';
+        } else if (Object.values(LearningActivities).includes(this.kind)) {
+          activity = this.kind;
+          return `${activity}`;
+        } else {
+          // otherwise reassign the old content types to the new metadata
+          activity = ContentKindsToLearningActivitiesMap[this.kind];
+          return `${activity}`;
+        }
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+  @import './card';
+
+  $margin: 16px;
+
+  .coach-content-label {
+    display: inline-block;
+    padding-top: $margin;
+  }
+
+  .card {
+    @extend %dropshadow-1dp;
+
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    text-decoration: none;
+    vertical-align: top;
+    border-radius: 8px;
+    transition: box-shadow $core-time ease;
+    &:hover {
+      @extend %dropshadow-8dp;
+    }
+    &:focus {
+      outline-width: 4px;
+      outline-offset: 6px;
+    }
+  }
+
+  .header-bar {
+    padding: 13px 18px 0;
+    margin-bottom: 0;
+    font-size: 13px;
+  }
+
+  .k-labeled-icon {
+    display: inline-block;
+    max-width: calc(100% - 50px);
+    height: 24px;
+    margin-bottom: 0;
+    vertical-align: top;
+  }
+
+  .channel-logo {
+    display: inline-block;
+    float: right;
+    height: 24px;
+    margin-bottom: 0;
+  }
+
+  .text {
+    position: relative;
+    height: 190px;
+    padding: $margin;
+  }
+
+  .footer {
+    position: absolute;
+    right: $margin;
+    bottom: $margin;
+    left: $margin;
+    display: inline-block;
+    font-size: 12px;
+  }
+
+  .k-linear-loader {
+    display: inline-block;
+    max-width: 70%;
+  }
+
+  .left {
+    float: left;
+  }
+
+  .right {
+    float: right;
+  }
+
+  .mobile-card.card {
+    width: 100%;
+    height: $thumb-height-mobile;
+  }
+
+  .mobile-card {
+    .thumbnail {
+      position: absolute;
+    }
+    .text {
+      height: 84px;
+      margin-left: $thumb-width-mobile;
+    }
+    .subtitle {
+      top: 36px;
+    }
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -361,6 +361,13 @@
     right: 16px;
     bottom: 16px;
     display: inline;
+    .button {
+      width: 32px !important;
+      height: 32px !important;
+      /deep/ svg {
+        top: 4px !important;
+      }
+    }
   }
 
   .k-linear-loader {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -12,6 +12,7 @@
       :to="link"
     >
       <div
+        v-if="!isMobile"
         class="folder-header"
         :style="{ backgroundColor: (!isLeaf ? $themeTokens.text : null ) }"
       ></div>
@@ -86,17 +87,18 @@
       >
         {{ bookmarkCreated }}
       </p>
-      <KIconButton
-        v-for="(value, key) in footerIcons"
-        :key="key"
-        :icon="key"
-        :class="isRtl ? 'footer-right' : 'footer-left'"
-        size="mini"
-        :color="$themePalette.grey.v_400"
-        :ariaLabel="coreString(value)"
-        :tooltip="coreString(value)"
-        @click="$emit(value)"
-      />
+      <div class="footer-icons">
+        <KIconButton
+          v-for="(value, key) in footerIcons"
+          :key="key"
+          :icon="key"
+          size="mini"
+          :color="$themePalette.grey.v_400"
+          :ariaLabel="coreString(value)"
+          :tooltip="coreString(value)"
+          @click="$emit(value)"
+        />
+      </div>
       <KLinearLoader
         v-if="progress && isMobile"
         class="k-linear-loader"
@@ -123,10 +125,10 @@
   import { now } from 'kolibri.utils.serverClock';
   import { PageNames } from '../constants';
   import commonLearnStrings from './commonLearnStrings';
-  import CardThumbnail from './ContentCard/CardThumbnail';
+  import CardThumbnail from './HybridLearningContentCard/CardThumbnail';
 
   export default {
-    name: 'ContentCardListViewItem',
+    name: 'HybridLearningContentCardListView',
     components: {
       CardThumbnail,
       TextTruncator,
@@ -276,7 +278,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
   @import './ContentCard/card';
 
-  $margin: 16px;
+  $margin: 24px;
 
   .card {
     @extend %dropshadow-1dp;
@@ -302,6 +304,7 @@
     display: inline-block;
     max-width: calc(100% - 350px);
     margin: 24px;
+    margin-top: 8px;
     vertical-align: top;
   }
 
@@ -314,14 +317,8 @@
   }
 
   .metadata-info {
-    margin-bottom: 6px;
-    font-size: 13px;
-  }
-
-  .metadata-info-footer {
-    display: inline-block;
-    margin: 0;
-    font-size: 13px;
+    margin-top: 8px;
+    margin-bottom: 8px;
   }
 
   .channel-logo {
@@ -332,7 +329,7 @@
 
   .copies {
     display: inline-block;
-    padding: 6px 8px;
+    padding: 8px;
     font-size: 13px;
     text-decoration: none;
     vertical-align: top;
@@ -346,11 +343,24 @@
 
   .footer {
     position: absolute;
-    right: $margin;
-    bottom: $margin;
-    left: $margin;
-    min-height: 30px;
-    font-size: 12px;
+    bottom: 0;
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    padding: $margin;
+  }
+
+  .metadata-info-footer {
+    flex: auto;
+    align-self: center;
+    margin: 0;
+  }
+
+  .footer-icons {
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+    display: inline;
   }
 
   .k-linear-loader {
@@ -363,17 +373,9 @@
     display: inline-block;
     width: 240px;
     height: 100px;
+    margin-top: 8px;
     margin-right: 24px;
     margin-left: 24px;
-  }
-
-  .footer-left {
-    display: block;
-    float: right;
-  }
-  .footer-right {
-    display: block;
-    float: left;
   }
 
   .mobile-card.card {
@@ -384,13 +386,14 @@
   .mobile-card {
     .thumbnail {
       position: absolute;
-      width: 100%;
-      margin: auto;
-      margin-top: 10px;
+      top: 24px;
+      width: calc(100% - 48px);
+      height: calc(100% - 24px);
+      margin-left: 24px;
     }
     .details {
       max-width: 100%;
-      margin-top: ($thumb-height-mobile + 20px);
+      margin-top: 224px;
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -193,7 +193,7 @@
         return learningActivities;
       },
     },
-    created() {
+    beforeUpdate() {
       client({
         method: 'get',
         url: urls['kolibri:core:bookmarks-list'](),

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -43,7 +43,7 @@
     </div>
 
     <div v-else>
-      <Breadcrumbs v-if="pageName !== 'TOPICS_CONTENT'" />
+      <Breadcrumbs v-if="(pageName !== 'TOPICS_CONTENT') && (pageName !== 'BOOKMARKS')" />
       <component :is="currentPage" v-if="currentPage" />
       <router-view />
     </div>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -44,7 +44,7 @@
             />
           </div>
           <h2>{{ $tr('recent') }}</h2>
-          <ContentCardGroupGrid
+          <HybridLearningCardGrid
             v-if="popular.length"
             :cardViewStyle="currentViewStyle"
             :contents="trimmedPopular"
@@ -117,7 +117,7 @@
   import BrowseResourceMetadata from './BrowseResourceMetadata';
   import commonLearnStrings from './commonLearnStrings';
   import ChannelCardGroupGrid from './ChannelCardGroupGrid';
-  import ContentCardGroupGrid from './ContentCardGroupGrid';
+  import HybridLearningCardGrid from './HybridLearningCardGrid';
   import EmbeddedSidePanel from './EmbeddedSidePanel';
   import CategorySearchModal from './CategorySearchModal';
 
@@ -144,6 +144,7 @@
     components: {
       BrowseResourceMetadata,
       CategorySearchModal,
+      HybridLearningCardGrid,
       ChannelCardGroupGrid,
       ContentCardGroupGrid,
       EmbeddedSidePanel,

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -68,7 +68,7 @@
               @click="searchMore"
             />
             <p>{{ $tr('clearAll') }}</p>
-            <ContentCardGroupGrid
+            <HybridLearningCardGrid
               v-if="results.length"
               :cardViewStyle="currentViewStyle"
               :genContentLink="genContentLink"
@@ -146,7 +146,6 @@
       CategorySearchModal,
       HybridLearningCardGrid,
       ChannelCardGroupGrid,
-      ContentCardGroupGrid,
       EmbeddedSidePanel,
       FullScreenSidePanel,
     },

--- a/kolibri/plugins/learn/assets/test/bookmark-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/bookmark-page.spec.js
@@ -1,0 +1,51 @@
+import { shallowMount } from '@vue/test-utils';
+import BookmarkPage from '../src/views/BookmarkPage';
+
+describe('Bookmark page', () => {
+  let wrapper;
+  let loadMoreSpy;
+  let createdSpy;
+  let removeFromBookmarksSpy;
+
+  beforeAll(() => {
+    loadMoreSpy = jest.spyOn(BookmarkPage.methods, 'loadMore');
+    createdSpy = jest.spyOn(BookmarkPage, 'created').mockImplementation(() => Promise.resolve());
+    removeFromBookmarksSpy = jest.spyOn(BookmarkPage.methods, 'removeFromBookmarks');
+
+    wrapper = shallowMount(BookmarkPage, {
+      stubs: {
+        ContentCardGroupGrid: {
+          name: 'ContentCardGroupGrid',
+          template: '<div></div>',
+        },
+      },
+    });
+    wrapper.setData({
+      loading: false,
+      more: true,
+      bookmarks: [{ a: 'b' }],
+    });
+  });
+
+  it('smoke test', () => {
+    const wrapper = shallowMount(BookmarkPage);
+    expect(createdSpy).toHaveBeenCalled();
+    expect(wrapper.exists()).toBe(true);
+  });
+  describe('When the user clicks the remove from bookmarks icon', () => {
+    it('will make a call to remove the bookmark from the list of bookmarks', () => {
+      wrapper.findComponent({ name: 'ContentCardGroupGrid' }).vm.$emit('removeFromBookmarks');
+      expect(removeFromBookmarksSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('When there are more bookmarks than in the default display', () => {
+    it('displays a load more button', () => {
+      expect(wrapper.find("[data-test='load-more-button']")).toBeTruthy();
+    });
+    it('clicking the load more button calls the load more function', () => {
+      wrapper.find("[data-test='load-more-button']").vm.$emit('click');
+      expect(loadMoreSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR updates some of UI element conflicts that surfaced during string freeze on the Learner bookmarks page, with the main changes being: 
- The cards used on the bookmarks page are now responsive, with mobile-specific layouts
- Slightly updated "no bookmarks" page
- Basic tests added for bookmarking

Notes (out of scope)
- The "remove from bookmarks" feature works, but the "view information" to open the side panel is not included in this PR since that work is still in progress.
- After refactoring, I have not applied all of the card changes to the channel browsing. It doesn't break things horribly, but that work is also not _included_ as part of this PR

## References

[Figma specs](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=76%3A6407)

### No bookmarks 
<img width="1440" alt="Screen Shot 2021-09-23 at 10 53 33 AM" src="https://user-images.githubusercontent.com/17235236/134595158-7e01c8a5-5a95-4ee6-be97-f4d7ca1e46f3.png">

### Desktop view
<img width="882" alt="Screen Shot 2021-09-23 at 11 02 26 AM" src="https://user-images.githubusercontent.com/17235236/134595150-95ef66a6-3458-4f7e-854c-1b33ffd71060.png">

**Note: the channel thumbnail is going to be added as new metadata, so it is not visible yet and you just see the alt text (and relatedly, the channel title is not yet added, so the title is not being added to the alt text as of yet)**

### Various mobile previews (Chrome dev tools)
<img width="281" alt="Screen Shot 2021-09-23 at 11 02 56 AM" src="https://user-images.githubusercontent.com/17235236/134595140-5cf5e566-3510-46f7-b5af-4f2587f82c3b.png">
<img width="333" alt="Screen Shot 2021-09-23 at 11 02 45 AM" src="https://user-images.githubusercontent.com/17235236/134595141-1e3b203b-90cc-4591-999c-7ad8200a0ee3.png">

…

## Reviewer guidance

- As these are mostly UI changes, there are not many interactions to test (other than removing a bookmark)
- I would most appreciate feedback in terms of making the code more readable or suggestions of how to refactor or simplify some of it
- I'd also love feedback about if I am using KDS theming correctly, and if there are places where I should be using theme tokens where I have hardcoded values (just because...I am not sure if I know what all of the tokens I might use are, honestly)
- Relatedly, some places where it might be useful to have slightly more dynamic css and fewer specific pixel values (not KDS, but maybe moving some of this into styles={} or setting values in computed. 
- How does this look from a design point of view? What adjustments are still needed? (I am most specifically noting the mobile thumbnails, but am planning to swap out with @MisRob's work on the new <Thumbnail/> if that seems like a better option) 
- I updated some of the values in `ContentCard/card.scss` - is this going to cause a conflict elsewhere?
- Test suggestions/guidance always very welcome 🙏 
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
