### PR TITLE
Experiment with pure CSS alternative to `TextTruncator` for simpler use cases

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -100,6 +100,7 @@ import AttemptLogList from '../views/AttemptLogList';
 import InteractionList from '../views/InteractionList';
 import ExamReport from '../views/ExamReport';
 import TextTruncator from '../views/TextTruncator';
+import TextTruncatorCss from '../views/TextTruncatorCss';
 import TimeDuration from '../views/TimeDuration';
 
 import MultiPaneLayout from '../views/MultiPaneLayout';
@@ -162,6 +163,7 @@ export default {
       InteractionList,
       ExamReport,
       TextTruncator,
+      TextTruncatorCss,
       TimeDuration,
       MultiPaneLayout,
       CoreFullscreen,

--- a/kolibri/core/assets/src/views/TextTruncatorCss.vue
+++ b/kolibri/core/assets/src/views/TextTruncatorCss.vue
@@ -1,0 +1,133 @@
+<template>
+
+  <!--
+    Text is wrapped in two `div`s to allow parent components adding
+    padding style directly on `<TextTruncatorCss>` component no matter
+    of what truncating technique is used. Otherwise adding padding directly
+    would break when using technique (B) since text that should be truncated
+    would show in padding area.
+  -->
+  <div>
+    <div :class="$computedClass(truncate)">
+      {{ text }}
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  /**
+   * Truncates text to a certain number of lines and adds "..."
+   *
+   * This is a pure CSS alternative to `TextTruncator` for simpler
+   * use cases like card titles since `TextTruncator` is causing performance
+   * issues (https://github.com/learningequality/kolibri/issues/8124)
+   * and thus its usage is currently not recommended for larger
+   * amounts of instances on one page.
+   *
+   * Compared to `TextTruncator` there are two disadvantages:
+   * - depending on length of words of the text, there might be a gap
+   *   between the last visible word and "..." in Internet Explorer
+   *   and old versions of some other browsers (see implementation comments)
+   * - it currently doesn't offer "View all"/"View less" functionality
+   */
+  export default {
+    name: 'TextTruncatorCss',
+    props: {
+      text: {
+        type: String,
+        required: true,
+      },
+      maxLines: {
+        type: Number,
+        required: false,
+        default: 1,
+      },
+      /**
+       * Text line height in rem.
+       * Used only for Internet Explorer fallback.
+       */
+      lineHeightIE: {
+        type: Number,
+        required: false,
+        default: 1.4,
+      },
+    },
+    computed: {
+      truncate() {
+        /*
+          (A)
+          For one line, use standard ellipsis text overflow
+          that works well for such scenario
+        */
+        if (this.maxLines === 1) {
+          return {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          };
+        }
+
+        // 54 is random number only to be able to define `supports` test condition
+        if ('CSS' in window && CSS.supports && CSS.supports('-webkit-line-clamp: 54')) {
+          /*
+            (B)
+            For multiple lines, use line clamp in browsers that support it
+            (https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp)
+          */
+          return {
+            overflow: 'hidden',
+            display: '-webkit-box',
+            '-webkit-line-clamp': `${this.maxLines}`,
+            '-webkit-box-orient': 'vertical',
+            // needed to make line clamp work for very long word with no spaces
+            overflowWrap: 'break-word',
+          };
+        } else {
+          /*
+            (C)
+            Fallback for multiple lines in Internet Explorer and some older versions
+            of other browsers that don't support line clamp
+            (https://caniuse.com/mdn-css_properties_-webkit-line-clamp).
+            Calculate max height and add "..." in `::before` while covering it with
+            white rectangle defined in `::after` when text doesn't need to be truncated.
+            Adapted from https://hackingui.com/a-pure-css-solution-for-multiline-text-truncation/
+            and https://css-tricks.com/line-clampin/#the-hide-overflow-place-ellipsis-pure-css-way.
+          */
+          const ellipsisWidth = '1rem';
+          return {
+            overflow: 'hidden',
+            position: 'relative',
+            lineHeight: `${this.lineHeightIE}rem`,
+            maxHeight: `${this.maxLines * this.lineHeightIE}rem`,
+            // needed to make truncation work for very long word with no spaces
+            // `word-wrap` is a legacy name for `overflow-wrap` that needs to be used for IE
+            wordWrap: 'break-word',
+            // create space for "..."
+            paddingRight: ellipsisWidth,
+            marginRigth: `-${ellipsisWidth}`,
+            '::before': {
+              content: "'...'",
+              position: 'absolute',
+              right: 0,
+              bottom: 0,
+            },
+            // cover "..." with white rectangle when text
+            // doesn't need to be truncated
+            '::after': {
+              content: "''",
+              position: 'absolute',
+              right: 0,
+              width: ellipsisWidth,
+              height: '50%',
+              background: 'white',
+            },
+          };
+        }
+      },
+    },
+  };
+
+</script>

--- a/kolibri/core/assets/src/views/TextTruncatorCss.vue
+++ b/kolibri/core/assets/src/views/TextTruncatorCss.vue
@@ -19,19 +19,12 @@
 <script>
 
   /**
-   * Truncates text to a certain number of lines and adds "..."
+   * Truncates text to a certain number of lines
+   * and adds an ellipsis character "…"
    *
-   * This is a pure CSS alternative to `TextTruncator` for simpler
-   * use cases like card titles since `TextTruncator` is causing performance
-   * issues (https://github.com/learningequality/kolibri/issues/8124)
-   * and thus its usage is currently not recommended for larger
-   * amounts of instances on one page.
-   *
-   * Compared to `TextTruncator` there are two disadvantages:
-   * - depending on length of words of the text, there might be a gap
-   *   between the last visible word and "..." in Internet Explorer
-   *   and old versions of some other browsers (see implementation comments)
-   * - it currently doesn't offer "View all"/"View less" functionality
+   * Internet Explorer note:
+   * Depending on length of words of the text, there might
+   * be a gap between the last visible word and "…"
    */
   export default {
     name: 'TextTruncatorCss',
@@ -109,7 +102,7 @@
             paddingRight: ellipsisWidth,
             marginRigth: `-${ellipsisWidth}`,
             '::before': {
-              content: "'...'",
+              content: "'…'",
               position: 'absolute',
               right: 0,
               bottom: 0,


### PR DESCRIPTION
## Summary

Introduces `TextTruncatorCss` as a simpler pure CSS solution to our current JavaScript based `TextTruncator`. It is meant to be temporary or additional to the JS solution and for shorter texts like titles on cards.

### Motivation

While working on the new home page in the hybrid learning project, I need to truncate cards titles to two lines. We have some [performance issues with `TextTruncator`](https://github.com/learningequality/kolibri/issues/8124) that are caused by `ResizeSensor` and `shave.js` where `shave.js` seems to be even bigger bottleneck than `ResizeSensor`. To avoid risking introducing similar problems to new pages, I used this task as an opportunity to play with some CSS alternatives that could be potentially used for simpler use cases, at least until we decide on what to do with `TextTruncator` issues.

Although my primary focus was on cards since there can be many instances of them on one page and risk of performance problems is thus higher, I also thought that having the CSS solution available might be useful for other simple use-cases like the [one-line resource title in the learning activity bar](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=1944%3A83765) and similar.

### Solution

The component is built with a progressive enhancement approach, using three CSS truncation techniques. Please check the comments in the component for details.

## `TextTruncator` and `TextTruncatorCss` comparison

Tested on a small sample of texts resembling cards titles in Firefox, Chrome, and IE11. I tried to locate differences and take screenshots of `TextTruncatorCss` results that looked the worst.

### (1) One line

```javascript
<TextTruncatorCss
  :maxLines="1"
  text="Idiopathic pulmonary fibrosis - causes, symptoms, diagnosis, treatment, pathology"
/>

<TextTruncator
  :maxHeight="23"
  text="Idiopathic pulmonary fibrosis - causes, symptoms, diagnosis, treatment, pathology"
/>
```

`TextTruncator` and `TextTruncatorCss` seem to behave identically in all Firefox, Chrome, and IE11.

![230px-css-firefox,chrome,ie](https://user-images.githubusercontent.com/13509191/134673394-7e4f9368-b441-489e-a7c2-90dbed12ad0c.png)

### (2) Multiple lines

```javascript
<TextTruncatorCss
  :maxLines="2"
  text="Idiopathic pulmonary fibrosis - causes, symptoms, diagnosis, treatment, pathology"
/>

<TextTruncator
  :maxHeight="46"
  text="Idiopathic pulmonary fibrosis - causes, symptoms, diagnosis, treatment, pathology"
/>
```

Similar behavior in Firefox and Chrome, however `TextTruncatorCss` seems to truncate by word rather than by character more often than `TextTruncator`. `TextTruncator` works well in IE 11. `TextTruncatorCss` is giving bad results in IE11 since in some cases, there can be a gap between ellipsis dots and the last character of a text. Seems to be a major problem with the CSS-based solution.

| | Width 200px - Firefox, Chrome | Width 230px - Firefox, Chrome | Width 230px - IE11 |
| -- | -- | -- | -- |
| `TextTruncatorCss` | ![200px-css-firefox,chrome](https://user-images.githubusercontent.com/13509191/134674213-ac58af40-b87c-490f-9bdc-4bcceca28b2f.png) | ![230px-css-firefox,chrome](https://user-images.githubusercontent.com/13509191/134675518-35a51981-9ded-43a2-9cb0-58eb3845c711.png) | ![230px-css-ie](https://user-images.githubusercontent.com/13509191/134675907-945b43f3-c60d-4cf8-950a-abb6281c5930.png) |
| `TextTruncator` | ![200px-js-firefox,chrome](https://user-images.githubusercontent.com/13509191/134674259-87452559-8e8a-4001-8e39-4b19a047f986.png) | ![230px-js-firefox,chrome](https://user-images.githubusercontent.com/13509191/134675583-e1b7c01e-5808-4754-b81d-a690caa96ce8.png) | ![230px-js-ie](https://user-images.githubusercontent.com/13509191/134675940-b592f0d3-0274-4432-b3f9-304a1b8c481a.png) |

### (3) Multiple lines - a long word with no breaks

```javascript
<TextTruncatorCss
  :maxLines="2"
  text="Idiopathicpulmonaryfibrosiscausessymptomsdiagnosistreatmentpathology"
/>

<TextTruncator
  :maxHeight="46"
  text="Idiopathicpulmonaryfibrosiscausessymptomsdiagnosistreatmentpathology"
/>
```

`TextTruncator` doesn't respect height settings and only shows one line in all Firefox, Chrome, and IE11. However, I guess that it's just a bug rather than the JS solution limitation. `TextTruncatorCss` works well in Firefox and Chrome, but has the same problem like in (2) in IE11.

|    | Firefox, Chrome | IE11 |
| -- | -- | -- |
| `TextTruncatorCss` | ![03-css-firefox,chrome](https://user-images.githubusercontent.com/13509191/134677564-03974d7a-34bb-4697-923c-63b89a8643a6.png) | ![03-css-ie](https://user-images.githubusercontent.com/13509191/134678328-c451caac-a445-4d60-8106-ab1ab07f9307.png) |
| `TextTruncator` | ![03-js-firefox,chrome,ie](https://user-images.githubusercontent.com/13509191/134677349-9f7a548b-6fdd-450f-8e02-515e97b3e57b.png) | ![03-js-ie](https://user-images.githubusercontent.com/13509191/134678414-cc2a2773-bc49-4878-9593-c0800141739d.png) |

## References

- [Figma designs for the home page](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=1788%3A6234)
- [`TextTruncator` performance issue](https://github.com/learningequality/kolibri/issues/8124)

## Comments

There's an issue in IE11 with three ellipsis dots not showing in some situations. It seems to be a font issue. The problem disappears after unchecking this rule

```css
.partial-fonts-loaded body, .partial-fonts-loaded button, .partial-fonts-loaded input, .partial-fonts-loaded select, .partial-fonts-loaded textarea {
	font-family: noto-subset,noto-common,sans-serif;
}
```

and falling back to `sans-serif`. I haven't included it in comparison because I saw it happen for both `TextTruncator` and `TextTruncatorCss` in some scenarios.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I moved this logic from the home page branch to get some feedback from the team if this could be an acceptable way forward for us, so please review the advantages and disadvantages of both approaches for shorter texts. For more background on reasons to use `TextTruncator`, please see @indirectlylit's [comment](https://github.com/learningequality/kolibri/issues/8124#issuecomment-923977618). An alternative solution for home page cards could be to use the existing `TextTruncator`. In that case, I'd suggest prioritizing refactoring of `TextTruncator` performance-wise.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md