### PR TITLE
Do not show password if not needed

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -111,6 +111,8 @@ import UiToolbar from '../views/KeenUiToolbar.vue';
 import shuffled from '../utils/shuffled';
 import appCapabilities from '../utils/appCapabilities';
 import * as client from './client';
+import clientFactory from './baseClient';
+
 import urls from './urls';
 
 export default {
@@ -208,6 +210,7 @@ export default {
     browserInfo,
     bytesForHumans,
     CatchErrors,
+    clientFactory,
     contentNode,
     coreBannerContent,
     exams,

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -108,9 +108,14 @@ class FacilitySerializer(serializers.ModelSerializer):
 
 
 class PublicFacilitySerializer(serializers.ModelSerializer):
+    learner_can_login_with_no_password = serializers.SerializerMethodField()
+
+    def get_learner_can_login_with_no_password(self, instance):
+        return instance.dataset.learner_can_login_with_no_password
+
     class Meta:
         model = Facility
-        fields = ("id", "dataset", "name")
+        fields = ("id", "dataset", "name", "learner_can_login_with_no_password")
 
 
 class PublicFacilityUserSerializer(serializers.ModelSerializer):

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -2,7 +2,7 @@ import { Resource } from 'kolibri.lib.apiResource';
 import pickBy from 'lodash/pickBy';
 import urls from 'kolibri.urls';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
-import clientFactory from '../../../../core/assets/src/core-app/baseClient';
+import clientFactory from 'kolibri.utils.clientFactory';
 
 export const FacilityImportResource = new Resource({
   name: 'facilityimport',

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -2,6 +2,7 @@ import { Resource } from 'kolibri.lib.apiResource';
 import pickBy from 'lodash/pickBy';
 import urls from 'kolibri.urls';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
+import clientFactory from '../../../../core/assets/src/core-app/baseClient';
 
 export const FacilityImportResource = new Resource({
   name: 'facilityimport',
@@ -55,6 +56,8 @@ export const SetupSoUDTasksResource = new Resource({
    */
   createTask(task, params) {
     const args = { task: task, ...pickBy(params) };
+    // use baseClient to  avoid interceptors from client:
+    this.client = clientFactory();
     return this.postListEndpoint('list', args).then(response => {
       return response.data;
     });

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -23,6 +23,7 @@
       @blur="blurred = true"
     />
     <PasswordTextbox
+      v-if="!facility.learner_can_login_with_no_password"
       ref="passwordTextbox"
       :value.sync="password"
       :showConfirmationInput="false"

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -4,7 +4,7 @@
     :header="$tr('importIndividualUsersHeader')"
     :description="formDescription"
     :submitText="coreString('importAction')"
-    :disabled="username === ''"
+    :disabled="checkFormDisabled"
     @submit="handleSubmit"
   >
     <p class="facility-name">
@@ -117,6 +117,12 @@
       },
       facility() {
         return this.state.value.facility;
+      },
+      checkFormDisabled() {
+        return (
+          this.username === '' ||
+          this.state.value.users.find(f => f.username === this.username) !== undefined
+        );
       },
       formDescription() {
         if (this.device.name) {


### PR DESCRIPTION


## Summary
When syncing from a facility that has password-free login enabled, the setup wizard does not show the password input in order to sync an user:

![image](https://user-images.githubusercontent.com/1008178/134909551-7cd31c2f-2bf2-413e-82da-0782e8391b17.png)



## References
Closes #8390 

## Reviewer guidance
Start provisioning a new kolibri installation syncing users from another facility. Check that if the facility has the password-free login option enabled, only username is required to sync (and syncing keeps working).

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
