### PR TITLE
remove a variable that hasn't been used

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -103,7 +103,6 @@
     data() {
       return {
         workingResourcesBackup: [...this.$store.state.lessonSummary.workingResources],
-        firstRemovalTitle: '',
       };
     },
     computed: {
@@ -142,7 +141,6 @@
         return this.resourceContentNodes[resourceId].kind;
       },
       removeResource(resource) {
-        this.firstRemovalTitle = this.resourceTitle(resource.contentnode_id);
         this.removeFromWorkingResources([resource]);
 
         this.autoSave(this.lessonId, this.workingResources);


### PR DESCRIPTION
## Summary
Follow up on https://github.com/learningequality/kolibri/issues/8092 issue. In short, the problem was that after you delete a lesson in kolibri studio and sync it with kolibri, you can't remove the resource from the lesson management page. Turns out the problem is that it is attepmpting to reference property title of undefined which happens in `resourceTitle()` function. The return value of `resourceTitle()` is assigned to `firstRemovalTitle` variable, but from what I have seen that variable is never used in the code. So the solution I found more suitable in this case is to remove that variable altogether since the use case for which it was created wasn't implemented anywhere in the code.


## Reviewer guidance

In order to test the issue, you can follow the steps described in https://github.com/learningequality/kolibri/issues/8092.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
