### PR TITLE
Use, when possible, an ENV var to get the installation type

### DIFF
--- a/kolibri/utils/constants/installation_types.py
+++ b/kolibri/utils/constants/installation_types.py
@@ -1,0 +1,22 @@
+"""
+This module contains constants representing the type of "installers" used to install Kolibri.
+"""
+from __future__ import unicode_literals
+
+APK = "apk"
+APT = "apt"
+KOLIBRI_SERVER = "kolibri-server"
+MACOS = "Mac"
+PEX = "pex"
+WHL = "whl"
+WINDOWS = "Windows"
+
+install_type_map = {
+    APK: "APK",
+    APT: "APT - Debian package",
+    KOLIBRI_SERVER: "kolibri(apt) with kolibri_server",
+    MACOS: "MacOS Installer",
+    PEX: "PEX file",
+    WHL: "WHL Python package",
+    WINDOWS: "Windows Installer",
+}

--- a/kolibri/utils/constants/installation_types.py
+++ b/kolibri/utils/constants/installation_types.py
@@ -8,6 +8,7 @@ APT = "apt"
 KOLIBRI_SERVER = "kolibri-server"
 MACOS = "Mac"
 PEX = "pex"
+UWSGI = "uwsgi"
 WHL = "whl"
 WINDOWS = "Windows"
 
@@ -17,6 +18,7 @@ install_type_map = {
     KOLIBRI_SERVER: "kolibri(apt) with kolibri_server",
     MACOS: "MacOS Installer",
     PEX: "PEX file",
+    UWSGI: "UWSGI process",
     WHL: "WHL Python package",
     WINDOWS: "Windows Installer",
 }

--- a/kolibri/utils/constants/installation_types.py
+++ b/kolibri/utils/constants/installation_types.py
@@ -4,7 +4,7 @@ This module contains constants representing the type of "installers" used to ins
 from __future__ import unicode_literals
 
 APK = "apk"
-APT = "apt"
+DEB = "deb"
 KOLIBRI_SERVER = "kolibri-server"
 MACOS = "Mac"
 PEX = "pex"
@@ -14,10 +14,10 @@ WINDOWS = "Windows"
 
 install_type_map = {
     APK: "APK",
-    APT: "APT - Debian package",
-    KOLIBRI_SERVER: "kolibri(apt) with kolibri_server",
-    MACOS: "MacOS Installer",
-    PEX: "PEX file",
+    DEB: "Debian package",
+    KOLIBRI_SERVER: "kolibri Debian package with kolibri_server",
+    MACOS: "macOS desktop app",
+    PEX: "PEX executable",
     UWSGI: "UWSGI process",
     WHL: "WHL Python package",
     WINDOWS: "Windows Installer",

--- a/kolibri/utils/constants/installation_types.py
+++ b/kolibri/utils/constants/installation_types.py
@@ -5,20 +5,24 @@ from __future__ import unicode_literals
 
 APK = "apk"
 DEB = "deb"
-KOLIBRI_SERVER = "kolibri-server"
-MACOS = "Mac"
+FLATPAK = "flatpak"
+GNOME = "gnome"
+KOLIBRI_SERVER = "kolibriserver"
+MACOS = "mac"
 PEX = "pex"
-UWSGI = "uwsgi"
 WHL = "whl"
-WINDOWS = "Windows"
+WINDOWS = "windows"
+WINDOWS_APP = "windowsapp"
 
 install_type_map = {
-    APK: "APK",
-    DEB: "Debian package",
-    KOLIBRI_SERVER: "kolibri Debian package with kolibri_server",
-    MACOS: "macOS desktop app",
-    PEX: "PEX executable",
-    UWSGI: "UWSGI process",
-    WHL: "WHL Python package",
-    WINDOWS: "Windows Installer",
+    APK: "apk - {}",
+    DEB: "deb kolibri - {}",
+    FLATPAK: "Flatpak - {}",
+    GNOME: "GNOME - {}",
+    KOLIBRI_SERVER: "deb kolibri-server - {}",
+    MACOS: "Mac - {}",
+    PEX: "pex",
+    WHL: "whl",
+    WINDOWS: "Windows - {}",
+    WINDOWS_APP: "Windows App - {}",
 }

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -25,6 +25,7 @@ from zeroconf import get_all_addresses
 from zeroconf import InterfaceChoice
 
 import kolibri
+from .constants.installation_types import install_type_map
 from .system import become_daemon
 from .system import pid_exists
 from kolibri.utils import conf
@@ -919,6 +920,12 @@ def installation_type(cmd_line=None):  # noqa:C901
 
     :returns: install_type is the type of detected installation
     """
+
+    installation_type_env = os.environ.get("KOLIBRI_INSTALLATION_TYPE", None)
+    if installation_type_env is not None:
+        if installation_type_env in install_type_map:
+            return install_type_map[installation_type_env]
+
     if cmd_line is None:
         cmd_line = sys.argv
     install_type = "Unknown"

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -25,7 +25,7 @@ from zeroconf import get_all_addresses
 from zeroconf import InterfaceChoice
 
 import kolibri
-from .constants.installation_types import install_type_map
+from .constants import installation_types
 from .system import become_daemon
 from .system import pid_exists
 from kolibri.utils import conf
@@ -914,6 +914,46 @@ def get_urls(listen_port=None):
         return e.status_code, []
 
 
+def get_installer_version(installer_type):
+    def get_debian_pkg_version(package):
+        """
+        In case we want to distinguish between dpkg and apt installations
+        we can use apt-cache show madison and compare versions with dpkg
+        if dpkg > madison, it's dpkg otherwise it's apt
+        """
+        try:
+            package_info = (
+                check_output(["dpkg", "-s", package]).decode("utf-8").split("\n")
+            )
+            version_info = [output for output in package_info if "Version" in output]
+            if version_info:
+                version = version_info[0].split(":")[1].strip()
+                return version
+        except CalledProcessError:  # package not installed!
+            pass  # will return None
+        return None
+
+    def get_deb_kolibriserver_version():
+        return get_debian_pkg_version("kolibri-server")
+
+    def get_deb_version():
+        return get_debian_pkg_version("kolibri")
+
+    def get_apk_version():
+        return os.environ.get("KOLIBRI_APK_VERSION_NAME")
+
+    version_funcs = {
+        installation_types.DEB: get_deb_version,
+        installation_types.KOLIBRI_SERVER: get_deb_kolibriserver_version,
+        installation_types.APK: get_apk_version,
+    }
+
+    if installer_type in version_funcs:
+        return version_funcs[installer_type]()
+    else:
+        return None
+
+
 def installation_type(cmd_line=None):  # noqa:C901
     """
     Tries to guess how the running kolibri server was installed
@@ -921,76 +961,64 @@ def installation_type(cmd_line=None):  # noqa:C901
     :returns: install_type is the type of detected installation
     """
 
-    installation_type_env = os.environ.get("KOLIBRI_INSTALLATION_TYPE", None)
-    if installation_type_env is not None:
-        if installation_type_env in install_type_map:
-            return install_type_map[installation_type_env]
+    install_type = os.environ.get("KOLIBRI_INSTALLATION_TYPE", "Unknown")
 
     if cmd_line is None:
         cmd_line = sys.argv
-    install_type = "Unknown"
 
     def is_debian_package():
         # find out if this is from the debian package
-        install_type = "dpkg"
+        install_type = installation_types.DEB
         try:
-            check_output(["apt-cache", "show", "kolibri"])
-            apt_repo = str(check_output(["apt-cache", "madison", "kolibri"]))
-            if len(apt_repo) > 4:  # repo will have at least http
-                install_type = "apt"
+            check_output(["dpkg", "-s", "kolibri"])
         except (
             CalledProcessError,
             FileNotFoundError,
         ):  # kolibri package not installed!
             if sys.path[-1] != "/usr/lib/python3/dist-packages":
-                install_type = "whl"
+                install_type = installation_types.WHL
         return install_type
 
     def is_kolibri_server():
         # running under uwsgi, finding out if we are using kolibri-server
-        install_type = ""
+        install_type = "Unknown"
         try:
-            package_info = (
-                check_output(["apt-cache", "show", "kolibri-server"])
-                .decode("utf-8")
-                .split("\n")
-            )
-            version = [output for output in package_info if "Version" in output]
-            install_type = "kolibri-server {}".format(version[0])
+            check_output(["dpkg", "-s", "kolibri-server"]).decode("utf-8").split("\n")
+            install_type = installation_types.KOLIBRI_SERVER
         except CalledProcessError:  # kolibri-server package not installed!
-            install_type = "uwsgi"
+            install_type = installation_types.WHL
         return install_type
 
-    if len(cmd_line) > 1 or "uwsgi" in cmd_line:
-        launcher = cmd_line[0]
-        if launcher.endswith(".pex"):
-            install_type = "pex"
-        elif "runserver" in cmd_line:
-            install_type = "devserver"
-        elif launcher == "/usr/bin/kolibri":
-            install_type = is_debian_package()
-        elif launcher == "uwsgi":
-            package = is_debian_package()
-            if package != "whl":
-                kolibri_server = is_kolibri_server()
-                install_type = "kolibri({kolibri_type}) with {kolibri_server}".format(
-                    kolibri_type=package, kolibri_server=kolibri_server
-                )
-        elif "\\Scripts\\kolibri" in launcher:
-            paths = sys.path
-            for path in paths:
-                if "kolibri.exe" in path:
-                    install_type = "Windows"
-                    break
-        elif "start" in cmd_line:
-            install_type = "whl"
-    if on_android():
+    # in case the KOLIBRI_INSTALLATION_TYPE is not set, let's use the old method:
+    if install_type == "Unknown":
+        if on_android():
+            install_type = installation_types.APK
+        elif len(cmd_line) > 1 or "uwsgi" in cmd_line:
+            launcher = cmd_line[0]
+            if launcher.endswith(".pex"):
+                install_type = installation_types.PEX
+            elif "runserver" in cmd_line:
+                install_type = "devserver"
+            elif launcher == "/usr/bin/kolibri":
+                install_type = is_debian_package()
+            elif launcher == "uwsgi":
+                package = is_debian_package()
+                if package != "whl":
+                    install_type = is_kolibri_server()
+            elif "\\Scripts\\kolibri" in launcher:
+                paths = sys.path
+                for path in paths:
+                    if "kolibri.exe" in path:
+                        install_type = installation_types.WINDOWS
+                        break
+            elif "start" in cmd_line:
+                install_type = installation_types.WHL
 
-        version_name = os.environ.get("KOLIBRI_APK_VERSION_NAME")
-
-        if version_name:
-            install_type = "apk - {}".format(version_name)
+    if install_type in installation_types.install_type_map:
+        version = get_installer_version(install_type)
+        if version:
+            return installation_types.install_type_map[install_type].format(version)
         else:
-            install_type = "apk"
+            return installation_types.install_type_map[install_type].split(" - ")[0]
 
     return install_type

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -14,13 +14,14 @@ import pytest
 from kolibri.core.tasks.scheduler import Scheduler
 from kolibri.core.tasks.test.base import connection
 from kolibri.utils import server
+from kolibri.utils.constants import installation_types
 
 
 class TestServerInstallation(object):
     @mock.patch("sys.argv", ["kolibri-0.9.3.pex", "start"])
     def test_pex(self):
         install_type = server.installation_type()
-        assert install_type == "pex"
+        assert install_type == installation_types.PEX
 
     def test_dev(self):
         sys_args = [
@@ -36,27 +37,38 @@ class TestServerInstallation(object):
             assert install_type == "devserver"
 
     @mock.patch("sys.argv", ["/usr/bin/kolibri", "start"])
+    @mock.patch("os.environ", {"KOLIBRI_INSTALLER_VERSION": "1.0"})
     def test_dpkg(self):
         with mock.patch("kolibri.utils.server.check_output", return_value=""):
             install_type = server.installation_type()
-            assert install_type == "dpkg"
+            assert install_type == installation_types.install_type_map[
+                installation_types.DEB
+            ].format("1.0")
 
     @mock.patch("sys.argv", ["/usr/bin/kolibri", "start"])
+    @mock.patch("os.environ", {"KOLIBRI_INSTALLER_VERSION": "1.0"})
     def test_apt(apt):
         with mock.patch("kolibri.utils.server.check_output", return_value="any repo"):
             install_type = server.installation_type()
-            assert install_type == "apt"
+            assert install_type == installation_types.install_type_map[
+                installation_types.DEB
+            ].format("1.0")
 
     @mock.patch("sys.argv", ["C:\\Python34\\Scripts\\kolibri", "start"])
     @mock.patch("sys.path", ["", "C:\\Program Files\\Kolibri\\kolibri.exe"])
+    @mock.patch("os.environ", {"KOLIBRI_INSTALLER_VERSION": "1.0"})
     def test_windows(self):
         install_type = server.installation_type()
-        assert install_type == "Windows"
+        assert install_type == installation_types.install_type_map[
+            installation_types.WINDOWS
+        ].format("1.0")
 
     @mock.patch("sys.argv", ["/usr/local/bin/kolibri", "start"])
     def test_whl(self):
         install_type = server.installation_type()
-        assert install_type == "whl"
+        assert (
+            install_type == installation_types.install_type_map[installation_types.WHL]
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Whenever it's available, use the `KOLIBRI_INSTALLATION_TYPE` env var to show the installation type instead of trying to guess it 

In any case, with or without the env var, the output of the installation type follow the specs at https://docs.google.com/spreadsheets/d/1EpN4yIO9H0qkP0pY6jiEtfQIdyrEPChs3aDZwOMupcI/edit#gid=0

Example:
![image](https://user-images.githubusercontent.com/1008178/142486885-82e1eaca-dbdd-48d7-b7dc-1defc784c9f0.png)


## References
Closes: #7957 

## Reviewer guidance
Do the new constants names and descriptions make sense?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
