### PR TITLE
Update Content Renderer to use Props

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -96,6 +96,28 @@
       AssessmentWrapper,
     },
     mixins: [commonLearnStrings],
+    props: {
+      content: {
+        type: Object,
+        required: true,
+        default: null,
+      },
+      contentId: {
+        type: String,
+        required: true,
+        default: null,
+      },
+      channelId: {
+        type: String,
+        required: true,
+        default: null,
+      },
+      contentKind: {
+        type: String,
+        required: true,
+        default: null,
+      },
+    },
     data() {
       return {
         wasIncomplete: false,
@@ -105,14 +127,6 @@
     computed: {
       ...mapGetters(['isUserLoggedIn', 'currentUserId']),
       ...mapState(['pageName']),
-      ...mapState('topicsTree', {
-        content: state => state.content,
-        contentId: state => state.content.content_id,
-        contentNodeId: state => state.content.id,
-        channel: state => state.channel,
-        channelId: state => state.content.channel_id,
-        contentKind: state => state.content.kind,
-      }),
       ...mapState({
         masteryAttempts: state => state.core.logging.mastery.totalattempts,
         summaryProgress: state => state.core.logging.summary.progress,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -100,7 +100,9 @@
       content: {
         type: Object,
         required: true,
-        default: null,
+        validator(val) {
+          return val.kind && val.content_id;
+        },
       },
       channelId: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -102,17 +102,7 @@
         required: true,
         default: null,
       },
-      contentId: {
-        type: String,
-        required: true,
-        default: null,
-      },
       channelId: {
-        type: String,
-        required: true,
-        default: null,
-      },
-      contentKind: {
         type: String,
         required: true,
         default: null,
@@ -144,6 +134,12 @@
           return this.summaryProgress;
         }
         return this.sessionProgress;
+      },
+      contentKind() {
+        return this.content && this.content.kind ? this.content.kind : null;
+      },
+      contentId() {
+        return this.content && this.content.content_id ? this.content.content_id : null;
       },
       nextContentNodeRoute() {
         // HACK Use a the Resource Viewer Link instead

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -48,6 +48,10 @@
       <ContentPage
         class="content"
         data-test="contentPage"
+        :content="content"
+        :contentId="content.content_id"
+        :channelId="content.channel_id"
+        :contentKind="content.kind"
       />
     </div>
     <GlobalSnackbar />

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -49,9 +49,7 @@
         class="content"
         data-test="contentPage"
         :content="content"
-        :contentId="content.content_id"
         :channelId="content.channel_id"
-        :contentKind="content.kind"
       />
     </div>
     <GlobalSnackbar />


### PR DESCRIPTION
- Switches from using mapState to using props passed by `LearnImmersiveLayout`. This is to fix the issues with the content renderer, and now it seems to be working correctly, no matter which page it is accessed from. 

Reviewer guidance: 
Any edge cases I am missing?