### PR TITLE
fixed import issue of six

### DIFF
--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -16,7 +16,7 @@ from django.db.models import Max
 from django.db.models import Min
 from django.db.models import Q
 from django.db.models import Sum
-from django.utils.six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin
 from django.utils.timezone import get_current_timezone
 from django.utils.timezone import localtime
 from morango.models import InstanceIDModel

--- a/kolibri/core/theme_hook.py
+++ b/kolibri/core/theme_hook.py
@@ -7,7 +7,7 @@ import os
 from abc import abstractproperty
 
 from django.conf import settings
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib import parse
 
 import kolibri
 from kolibri.plugins import hooks

--- a/kolibri/core/theme_hook.py
+++ b/kolibri/core/theme_hook.py
@@ -7,7 +7,7 @@ import os
 from abc import abstractproperty
 
 from django.conf import settings
-from django.utils.six.moves.urllib import parse
+from six.moves.urllib.parse import urljoin
 
 import kolibri
 from kolibri.plugins import hooks


### PR DESCRIPTION
Six has been removed from django.utils after django 3.0

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
