### PR TITLE
Only run upgrade task for network locations on SQLite.

### DIFF
--- a/kolibri/core/discovery/upgrade.py
+++ b/kolibri/core/discovery/upgrade.py
@@ -5,10 +5,12 @@ import logging
 
 from django.db import connection
 from django.db.utils import OperationalError
+from django.db.utils import ProgrammingError
 
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.upgrade import version_upgrade
 from kolibri.deployment.default.sqlite_db_names import NETWORK_LOCATION
+from kolibri.utils.conf import OPTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +20,10 @@ def move_network_location_entries():
     """
     Move network location entries from the default database to the new standalone database
     """
+    # Only do this upgrade on SQLite
+    if OPTIONS["Database"]["DATABASE_ENGINE"] != "sqlite":
+        return
+
     source_queryset = NetworkLocation.objects.using("default").all()
 
     i = 0
@@ -30,7 +36,7 @@ def move_network_location_entries():
                 break
         cursor = connection.cursor()
         cursor.execute("DROP TABLE {}".format(NetworkLocation._meta.db_table))
-    except OperationalError:
+    except (OperationalError, ProgrammingError):
         # This will happen if the default database has not been migrated with the network location table
         # this may happen if we are upgrading from a version before the NetworkLocation model existed
         # and so the default database never had these migrations run on it.


### PR DESCRIPTION
## Summary
* Fixes errors that may occur when attempting to upgrade a postgres instance that has stored network locations
* Catches any programming errors from upgrade
* Adds a regression test

## References
Follow up from #8442

## Reviewer guidance
I think the test covers it?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
