### PR TITLE
Build Parallelization Mods + BCK Build Requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,10 +252,10 @@ docker-whl: docker-envlist docker-clean
 	docker run \
 		--env-file ./docker/env.list \
 		--cidfile docker-whl.cid \
-		-v $$PWD/dist:/kolibridist \
 		-v yarn_cache:/yarn_cache \
 		-v cext_cache:/cext_cache \
 		`cat docker-whl.iid`
+	docker cp `cat docker-whl.cid`:/kolibridist/* dist
 	git checkout -- ./docker/env.list  # restore env.list file
 
 docker-build-base: writeversion

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ i18n-download-glossary:
 i18n-upload-glossary:
 	python packages/kolibri-tools/lib/i18n/crowdin.py upload-glossary
 
-docker-whl: writeversion docker-envlist
+docker-whl: docker-envlist
 	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .
 	docker run \
 		--env-file ./docker/env.list \

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ docker-whl: docker-envlist docker-clean
 		-v yarn_cache:/yarn_cache \
 		-v cext_cache:/cext_cache \
 		`cat docker-whl.iid`
-	docker cp `cat docker-whl.cid`:/kolibridist/* dist
+	docker cp `cat docker-whl.cid`:/kolibri/dist dist
 	git checkout -- ./docker/env.list  # restore env.list file
 
 docker-build-base: writeversion

--- a/Makefile
+++ b/Makefile
@@ -242,14 +242,20 @@ i18n-download-glossary:
 i18n-upload-glossary:
 	python packages/kolibri-tools/lib/i18n/crowdin.py upload-glossary
 
-docker-whl: docker-envlist
-	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .
+docker-clean:
+	rm -f *.iid *.cid
+
+docker-whl: docker-envlist docker-clean
+	docker build \
+		--iidfile docker-whl.iid \
+		-f docker/build_whl.dockerfile .
 	docker run \
 		--env-file ./docker/env.list \
+		--cidfile docker-whl.cid \
 		-v $$PWD/dist:/kolibridist \
 		-v yarn_cache:/yarn_cache \
 		-v cext_cache:/cext_cache \
-		"learningequality/kolibri-whl"
+		`cat docker-whl.iid`
 	git checkout -- ./docker/env.list  # restore env.list file
 
 docker-build-base: writeversion

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ docker-whl: docker-envlist docker-clean
 		-v yarn_cache:/yarn_cache \
 		-v cext_cache:/cext_cache \
 		`cat docker-whl.iid`
-	docker cp `cat docker-whl.cid`:/kolibri/dist dist
+	docker cp `cat docker-whl.cid`:/kolibri/dist/. dist/
 	git checkout -- ./docker/env.list  # restore env.list file
 
 docker-build-base: writeversion

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -52,5 +52,4 @@ CMD echo '--- Installing JS dependencies' && \
     echo '--- Making whl' && \
     make dist && \
     echo '--- Making pex' && \
-    make pex && \
-    cp /kolibri/dist/* /kolibridist/
+    make pex


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Hello! Guest PR from infra.

This should be a fairly simple modification to the way we extract build assets from the docker container that builds them.

I'll add more comments in the PR, but in a nutshell: we copy the assets out of the container post-build. As opposed to mounting a folder into the container prior to build, only to copy assets into it afterwards (within the same build context). Happy side effect (🌈) is that the asset is no longer owned by root, which has caused weird issues in the past (see the awkward/seemingly unnecessary `mkdir -p` in the buildkite YAML of this repo, as well as in the BCK pipeline.

The reason I'm doing this _now_ is that it became important to be able to reference _the exact build container_ for BCK; we're extracting assets other than the WHL for that pipeline. 
> Note: I could have added more commands to Kolibri's build steps to do the same, or at least to trigger the other pipeline without rebuilding the entire WHL. But I thought it'd be best to avoid adding complexity to this pipeline, given the recent discussions around GHActions with @rtibbles. For the same reason, I've avoided consolidating more of the build logic to runtime and slimming down the build image. 

*_HOWEVER_*, I'd like to point out that all (most?) of the other installers have been given this treatment (where we forego image/container names in favor of IDs). In these cases, it was done to allow for build parallelization, because reusing image/container between builds means that there could be collisions in a parallel-build scenario. Bad times.

Hence the name of feature branch. Another happy side effect (🌈 🌈 ) to getting this merged would be that we could (in theory) add more build agent processes to our builders, which would parallelize builds and reduce wait times. But I'd hold off on those experiments until after release :)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Keep an eye on the build associated with this PR and ensure that the right assets are uploaded to buildkite when it ends.

During testing, I noticed some odd GHAction check errors around documentation. Please advise @rtibbles 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually


## PR process

- [ ] PR has the correct target branch and milestone
    It wouldn't HURT to merge this back to older Kolibri versions. And if we end up moving forward with parallelization, it might be necessary. Looking for guidance here @rtibbles 
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
