### PR TITLE
Update UI for `<LessonContentPreviewPage>` for practice quiz

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -41,37 +41,82 @@
           </KGridItem>
         </KGrid>
         <CoachContentLabel :value="content.num_coach_contents" :isTopic="false" />
-        <HeaderTable>
-          <HeaderTableRow
-            v-if="completionData"
-            :keyText="coachString('masteryModelLabel')"
-          >
-            <template #value>
-              <MasteryModel :masteryModel="completionData" />
-            </template>
-          </HeaderTableRow>
-        </HeaderTable>
-        <!-- eslint-disable-next-line vue/no-v-html -->
-        <p v-if="description" dir="auto" v-html="description"></p>
-        <ul class="meta">
-          <li v-if="content.author">
-            {{ $tr('authorDataHeader') }}:
-            {{ content.author }}
-          </li>
-          <li v-if="licenseName">
-            {{ $tr('licenseDataHeader') }}:
-            {{ licenseName }}
-            <InfoIcon
-              v-if="licenseDescription"
-              :tooltipText="licenseDescription"
-              :iconAriaLabel="licenseDescription"
-            />
-          </li>
-          <li v-if="content.license_owner">
-            {{ $tr('copyrightHolderDataHeader') }}:
-            {{ content.license_owner }}
-          </li>
-        </ul>
+        <template v-if="content.options.modality === 'QUIZ'">
+          <HeaderTable>
+            <HeaderTableRow
+              :keyText="$tr('totalQuestionsHeader')"
+            >
+              <template #value>
+                {{ content.assessmentmetadata.number_of_assessments }}
+              </template>
+            </HeaderTableRow>
+            <HeaderTableRow
+              :keyText="$tr('suggestedTimeToCompleteHeader')"
+            >
+              <template #value>
+                {{ currentContentNode.duration || 'Not available' }}
+              </template>
+            </HeaderTableRow>
+            <HeaderTableRow
+              v-if="licenseName"
+              :keyText="$tr('licenseDataHeader')"
+            >
+              <template #value>
+                {{ licenseName }}
+                <InfoIcon
+                  v-if="licenseDescription"
+                  :tooltipText="licenseDescription"
+                  :iconAriaLabel="licenseDescription"
+                />
+              </template>
+            </HeaderTableRow>
+            <HeaderTableRow
+              v-if="content.license_owner"
+              :keyText="$tr('copyrightHolderDataHeader')"
+            >
+              <template #value>
+                {{ content.license_owner }}
+              </template>
+            </HeaderTableRow>
+          </HeaderTable>
+        </template>
+
+        <template v-else>
+          <HeaderTable>
+            <HeaderTableRow
+              v-if="completionData"
+              :keyText="coachString('masteryModelLabel')"
+            >
+              <template #value>
+                <MasteryModel
+                  v-if="content"
+                  :masteryModel="completionData"
+                />
+              </template>
+            </HeaderTableRow>
+          </HeaderTable>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <p v-if="description" dir="auto" v-html="description"></p>
+          <ul class="meta">
+            <li v-if="content.author">
+              {{ $tr('authorDataHeader') }}:
+              {{ content.author }}
+            </li>
+            <li v-if="licenseName">
+              {{ $tr('licenseDataHeader') }}:
+              {{ licenseName }}
+              <InfoIcon
+                v-if="licenseDescription"
+                :tooltipText="licenseDescription"
+                :iconAriaLabel="licenseDescription"
+              />
+            </li>
+            <li v-if="content.license_owner">
+              {{ $tr('copyrightHolderDataHeader') }}:
+              {{ content.license_owner }}
+            </li>
+          </ul>
+        </template>
       </div>
     </template>
 
@@ -237,6 +282,15 @@
           'Notification that can refer to when resources are added to a lesson, for example.',
       },
       addButtonLabel: 'Add',
+      totalQuestionsHeader: {
+        message: 'Total questions',
+        context: 'Refers to the total number of questions in a quiz.',
+      },
+      suggestedTimeToCompleteHeader: {
+        message: 'Suggested time',
+        context:
+          'Refers to the recommended time it takes to complete a quiz.\n\nDuration is set by whoever made the quiz originally.',
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -9,7 +9,18 @@
             :layout12="{ span: 9 }"
           >
             <h1>
-              <KLabeledIcon :icon="content.kind" :label="content.title" />
+              <KLabeledIcon :icon="content.kind">
+                <template>
+                  {{ content.title }}
+                </template>
+                <template #iconAfter>
+                  <CoachContentLabel
+                    :value="content.num_coach_contents"
+                    :style="{ 'font-size': '0.65em' }"
+                    :isTopic="false"
+                  />
+                </template>
+              </KLabeledIcon>
             </h1>
           </KGridItem>
           <KGridItem
@@ -40,14 +51,28 @@
             </template>
           </KGridItem>
         </KGrid>
-        <CoachContentLabel :value="content.num_coach_contents" :isTopic="false" />
-        <template v-if="content.options.modality === 'QUIZ'">
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <p v-if="description" dir="auto" v-html="description"></p>
+        <template>
           <HeaderTable>
             <HeaderTableRow
+              v-if="content.options.modality === 'QUIZ'"
               :keyText="$tr('totalQuestionsHeader')"
             >
               <template #value>
                 {{ content.assessmentmetadata.number_of_assessments }}
+              </template>
+            </HeaderTableRow>
+
+            <HeaderTableRow
+              v-else-if="completionData"
+              :keyText="coachString('masteryModelLabel')"
+            >
+              <template #value>
+                <MasteryModel
+                  v-if="content"
+                  :masteryModel="completionData"
+                />
               </template>
             </HeaderTableRow>
             <HeaderTableRow
@@ -80,43 +105,6 @@
             </HeaderTableRow>
           </HeaderTable>
         </template>
-
-        <template v-else>
-          <HeaderTable>
-            <HeaderTableRow
-              v-if="completionData"
-              :keyText="coachString('masteryModelLabel')"
-            >
-              <template #value>
-                <MasteryModel
-                  v-if="content"
-                  :masteryModel="completionData"
-                />
-              </template>
-            </HeaderTableRow>
-          </HeaderTable>
-          <!-- eslint-disable-next-line vue/no-v-html -->
-          <p v-if="description" dir="auto" v-html="description"></p>
-          <ul class="meta">
-            <li v-if="content.author">
-              {{ $tr('authorDataHeader') }}:
-              {{ content.author }}
-            </li>
-            <li v-if="licenseName">
-              {{ $tr('licenseDataHeader') }}:
-              {{ licenseName }}
-              <InfoIcon
-                v-if="licenseDescription"
-                :tooltipText="licenseDescription"
-                :iconAriaLabel="licenseDescription"
-              />
-            </li>
-            <li v-if="content.license_owner">
-              {{ $tr('copyrightHolderDataHeader') }}:
-              {{ content.license_owner }}
-            </li>
-          </ul>
-        </template>
       </div>
     </template>
 
@@ -131,6 +119,7 @@
     </template>
 
     <template #main>
+
       <ContentArea
         class="content-area"
         :header="questionLabel(selectedQuestionIndex)"
@@ -138,6 +127,7 @@
         :content="content"
         :isExercise="isExercise"
       />
+
     </template>
   </MultiPaneLayout>
 
@@ -261,11 +251,6 @@
       },
     },
     $trs: {
-      authorDataHeader: {
-        message: 'Author',
-        context:
-          'Refers to the creator of the learning resource. For example, the author could be Learning Equality.',
-      },
       licenseDataHeader: {
         message: 'License',
         context:
@@ -313,6 +298,10 @@
 
   .content-area {
     padding: 16px 0;
+  }
+
+  /deep/ .icon-after {
+    margin-top: -5px;
   }
 
 </style>


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Seems that it is sufficient to just update the UI for `LessonContentPreviewPage` to change the header for content that is not an exercise or other content. See screenshots below for differences in headers.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Addresses #8514 

|Practice Quiz|Regular content|Exercise|
|--|--|--|
|![Screen Shot 2021-10-26 at 10 55 27 PM](https://user-images.githubusercontent.com/13563002/139007960-f3d7aa4c-ac95-4872-af51-d91e2336a7da.png)|![Screen Shot 2021-10-26 at 10 52 47 PM](https://user-images.githubusercontent.com/13563002/139007567-90761c85-afc6-483c-be77-eac4aa51a00d.png)|![Screen Shot 2021-10-26 at 10 53 51 PM](https://user-images.githubusercontent.com/13563002/139007697-5c8dbe72-3d53-44b2-aaba-70274764a9de.png)|


## Reviewer guidance
- [ ] coaches can add an independent practice quiz to a lesson resource list
```
Feature: Independent practice quizzes can be added to lessons
	Scenario: coaches can add an independent practice quiz to a lesson resource list
		Given that I am on the lesson resource management page
		When I browse the content tree
			And I find and select a checkbox to the left of the independent practice quiz card
		Then I see a snackbar appear confirming my action
		When I exit the lesson resource management page
		Then I see that the independent practice quiz is in the lesson resource list
```
- [ ] coaches can preview an independent practice quiz before adding it to a lesson
```
Feature: Independent practice quizzes can be added to lessons
	Scenario: coaches preview an independent practice quiz before adding it to a lesson
		Given that I am on the lesson resource management page
		When I browse the content tree
			And I find and click an independent practice quiz content card
		Then I see a preview of the independent practice quiz

```
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
