### PR TITLE
Side Panel Metadata

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1075,7 +1075,7 @@ export default {
      * if available.
      *
      * @param {string} key - A key as defined in the coreStrings translator; also accepts keys
-     * for the object kolibri.coreVue.vuex.constants.MetadataLookup.
+     * for the object MetadataLookup.
      * @param {object} args - An object with keys matching ICU syntax arguments for the translation
      * string mapping to the values to be passed for those arguments.
      */

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1091,7 +1091,7 @@ export default {
         return coreStrings.$tr(nonconformingKeys[key], args);
       }
 
-      return coreStrings.$tr(camelCase(key), args);
+      return coreStrings.$tr(key, args);
     },
     /**
      * Shows a specific snackbar notification from our notificationStrings translator.

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -75,38 +75,15 @@
       isMobile() {
         return this.windowBreakpoint == 0;
       },
-      /**
-      ---- hope to move the responsibility for this to other avenues ----
-      ...mapState('topicsTree', ['content', 'contents']),
-      panelType() {
-        return 'resourceMetadata';
-      },
-      siblingNodes() {
-        let siblings = this.contents.filter(
-          currentContent => currentContent.parent === this.content.parent
-        );
-        return siblings;
-      },
-      nextTopic() {
-        let currentContentGrandparent = this.content.ancestors[0].id;
-        let topicsWithSameAncestor = this.contents.filter(
-          item =>
-            !item.is_leaf && item.ancestors[0] && item.ancestors[0].id === currentContentGrandparent
-        );
-        let currentIndex = topicsWithSameAncestor
-          .map(topic => topic.id)
-          .indexOf(this.content.parent);
-        let nextTopic = topicsWithSameAncestor[currentIndex + 1] || null;
-        return nextTopic;
-      },
-      title() {
-        if (this.panelType === 'resourceMetadata') {
-          return this.content.title;
-        } else {
-          return this.$tr('topicHeader');
-        }
-      },
-      */
+    },
+    /* this is the easiest way I could think to avoid having dual scroll bars */
+    mounted() {
+      const htmlTag = window.document.getElementsByTagName('html')[0];
+      htmlTag.style['overflow-y'] = 'hidden';
+    },
+    beforeDestroy() {
+      const htmlTag = window.document.getElementsByTagName('html')[0];
+      htmlTag.style['overflow-y'] = 'auto';
     },
     methods: {
       closePanel() {

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -249,18 +249,35 @@
       };
     },
     computed: {
+      /**
+       * Returns whether or not the LearnerNeeds.FOR_BEGINNERS constant is present in
+       * this.content.learner_needs
+       * @returns {Boolean}
+       */
       forBeginners() {
         return get(this.content, 'learner_needs', []).includes(LearnerNeeds.FOR_BEGINNERS);
       },
+      /**
+       * Returns a list of this.content.learner_needs without the FOR_BEGINNERS key, if present
+       * @returns {string[]}
+       */
       learnerNeeds() {
         // Remove FOR_BEGINNERS in this list because it is indicated separately, above, if present
         return get(this.content, 'learner_needs', []).filter(
           need => need !== LearnerNeeds.FOR_BEGINNERS
         );
       },
+      /**
+       * Joins this.content.accessibility_labels with a comma & space for display purposes
+       * @returns {string}
+       */
       accessibilityLabels() {
         return this.content.accessibility_labels.map(label => this.coreString(label)).join(', ');
       },
+      /**
+       * Joins this.learnerNeeds with a comma & space for display purposes
+       * @returns {string}
+       */
       learnerNeedsLabels() {
         return this.learnerNeeds.map(label => this.coreString(label)).join(', ');
       },

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -186,9 +186,9 @@
       <div v-for="location in locationsInChannel" :key="location.id">
         <div>
           <KRouterLink
-            :to="genContentLink(location.ancestors[location.ancestors.length - 1].id, false)"
+            :to="genContentLink(location.ancestors.splice(-1)[0].id, false)"
           >
-            {{ location.ancestors[location.ancestors.length - 1].title }}
+            {{ location.ancestors.splice(-1)[0].title }}
           </KRouterLink>
         </div>
       </div>
@@ -304,7 +304,9 @@
         // Retreives any topics in this same channel
         ContentNodeResource.fetchCollection({
           getParams: { content_id: this.content.content_id, channel_id: this.content.channel_id },
-        }).then(parents => (this.locationsInChannel = parents && parents.length ? parents : null));
+        }).then(
+          locations => (this.locationsInChannel = locations && locations.length ? locations : null)
+        );
       }
 
       this.metadataStrings = crossComponentTranslator(SidePanelResourceMetadata);
@@ -438,6 +440,7 @@
 
   .related {
     .list-item {
+      padding-left: 4px;
       margin: 8px 0;
     }
   }

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -1,11 +1,7 @@
 <template>
 
-  <!-- For the sidebar when browsing all content -->
-
   <section class="metadata">
-    <!-- placeholder for learning activity type chips TODO update with chip component -->
 
-    <!-- Whatever data will come in this place may be an array? -->
     <div class="chips section">
       <div v-for="activity in content.learning_activities" :key="activity">
         <LearningActivityChip
@@ -19,7 +15,7 @@
         properly even when one isn't there -->
       <div>
         <span
-          v-if="content.forBeginners"
+          v-if="forBeginners"
           class="beginners-chip"
           :style="{ 'background-color': $themeBrand.secondary.v_600 }"
           data-test="beginners-chip"
@@ -34,6 +30,7 @@
           appearance="raised-button"
           :primary="false"
           :to="genContentLink(content.id, content.is_leaf)"
+          data-test="view-resource-link"
         />
       </div>
     </div>
@@ -68,7 +65,7 @@
     <!-- this v-else ensures spacing remains consistent without show more -->
     <div v-else class="section"></div>
 
-    <div v-if="content.duration" class="section">
+    <div v-if="content.duration" class="section" data-test="estimated-time">
       <span class="label">
         {{ metadataStrings.$tr('estimatedTime') }}:
       </span>
@@ -77,16 +74,20 @@
       </span>
     </div>
 
-    <div v-if="content.grade_levels && content.grade_levels.length" class="section">
+    <div
+      v-if="content.grade_levels && content.grade_levels.length"
+      class="section"
+      data-test="grade-levels"
+    >
       <span class="label">
         {{ metadataStrings.$tr('level') }}:
       </span>
       <span>
-        {{ content.lang.grade_levels.join(", ") }}
+        {{ content.grade_levels.join(", ") }}
       </span>
     </div>
 
-    <div v-if="content.lang" class="section">
+    <div v-if="content.lang" class="section" data-test="lang">
       <span class="label">
         {{ metadataStrings.$tr('language') }}:
       </span>
@@ -95,25 +96,25 @@
       </span>
     </div>
 
-    <div v-if="content.accessibility" class="section">
+    <div v-if="accessibilityLabels" class="section" data-test="accessibility-labels">
       <span class="label">
         {{ coreString('accessibility') }}:
       </span>
       <span>
-        {{ content.accessibility.join(", ") }}
+        {{ accessibilityLabels }}
       </span>
     </div>
 
-    <div v-if="content.whatYouWillNeed" class="section">
+    <div v-if="content.learner_needs" class="section" data-test="learner-needs">
       <span class="label">
         {{ metadataStrings.$tr('whatYouWillNeed') }}:
       </span>
       <span>
-        {{ content.whatYouWillNeed.join(", ") }}
+        {{ learnerNeedsLabels }}
       </span>
     </div>
 
-    <div v-if="content.author" class="section">
+    <div v-if="content.author" class="section" data-test="author">
       <span class="label">
         {{ metadataStrings.$tr('author') }}:
       </span>
@@ -122,7 +123,7 @@
       </span>
     </div>
 
-    <div v-if="content.license_owner" class="section">
+    <div v-if="content.license_owner" class="section" data-test="license-owner">
       <span class="label">
         {{ metadataStrings.$tr('copyrightHolder') }}:
       </span>
@@ -131,7 +132,7 @@
       </span>
     </div>
 
-    <div v-if="licenseDescription" class="section">
+    <div v-if="licenseDescription" class="section" data-test="license-desc">
       <span class="label">
         {{ metadataStrings.$tr('license') }}:
       </span>
@@ -154,7 +155,7 @@
       </span>
     </div>
 
-    <div v-if="recommendations" class="related section">
+    <div v-if="recommendations" class="related section" data-test="recommendations">
       <div class="label">
         {{ coreString('related') }}:
       </div>
@@ -176,7 +177,7 @@
       </div>
     </div>
 
-    <div v-if="showLocationsInChannel && locationsInChannel" class="section">
+    <div v-if="showLocationsInChannel && locationsInChannel" class="section" data-test="locations">
       <div class="label">
         {{
           metadataStrings.$tr('locationsInChannel', { 'channelname': content.ancestors[0].title })
@@ -208,6 +209,7 @@
     licenseLongName,
     licenseDescriptionForConsumer,
   } from 'kolibri.utils.licenseTranslations';
+  import LearnerNeeds from 'kolibri-constants/labels/Needs';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { ContentNodeResource } from 'kolibri.resources';
   import genContentLink from '../utils/genContentLink';
@@ -247,6 +249,21 @@
       };
     },
     computed: {
+      forBeginners() {
+        return get(this.content, 'learner_needs', []).includes(LearnerNeeds.FOR_BEGINNERS);
+      },
+      learnerNeeds() {
+        // Remove FOR_BEGINNERS in this list because it is indicated separately, above, if present
+        return get(this.content, 'learner_needs', []).filter(
+          need => need !== LearnerNeeds.FOR_BEGINNERS
+        );
+      },
+      accessibilityLabels() {
+        return this.content.accessibility_labels.map(label => this.coreString(label)).join(', ');
+      },
+      learnerNeedsLabels() {
+        return this.learnerNeeds.map(label => this.coreString(label)).join(', ');
+      },
       licenseShortName() {
         return licenseShortName(get(this, 'content.license_name', null));
       },

--- a/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
@@ -1,12 +1,7 @@
 <template>
 
-  <!-- For the sidebar when viewing content -->
+  <section v-if="content" class="metadata">
 
-  <section class="metadata">
-    <!-- placeholder for learning activity type chips TODO update with chip component -->
-
-
-    <!-- Whatever data will come in this place may be an array? -->
     <div class="chips section">
       <div v-for="activity in content.learning_activities" :key="activity">
         <LearningActivityChip
@@ -15,26 +10,32 @@
       </div>
     </div>
 
-    <!-- The key here is not set in stone -->
-    <div class="section">
-      <!-- For Beginners Chip Here -->
-      <div
+    <div>
+      <span
+        v-if="forBeginners"
         class="beginners-chip"
         :style="{ 'background-color': $themeBrand.secondary.v_600 }"
+        data-test="beginners-chip"
       >
         {{ coreString("ForBeginners") }}
-      </div>
+      </span>
     </div>
 
     <div class="section">
       <ContentNodeThumbnail :contentNode="content" />
     </div>
 
-    <div v-if="content.title" class="section title">
+    <div v-if="content.title" class="section title" data-test="content-title">
       {{ content.title }}
     </div>
 
-    <div v-if="content.description" ref="description" class="content" :class="truncate">
+    <div
+      v-if="content.description"
+      ref="description"
+      class="content"
+      :class="truncate"
+      data-test="content-description"
+    >
       {{ content.description }}
     </div>
 
@@ -56,7 +57,7 @@
       </span>
     </div>
 
-    <div v-if="content.duration" class="section">
+    <div v-if="content.duration" class="section" data-test="estimated-time">
       <span class="label">
         {{ metadataStrings.$tr('estimatedTime') }}:
       </span>
@@ -65,7 +66,20 @@
       </span>
     </div>
 
-    <div v-if="content.lang" class="section">
+    <div
+      v-if="content.grade_levels && content.grade_levels.length"
+      class="section"
+      data-test="grade-levels"
+    >
+      <span class="label">
+        {{ metadataStrings.$tr('level') }}:
+      </span>
+      <span>
+        {{ content.grade_levels.join(", ") }}
+      </span>
+    </div>
+
+    <div v-if="content.lang" class="section" data-test="lang">
       <span class="label">
         {{ metadataStrings.$tr('language') }}:
       </span>
@@ -74,7 +88,7 @@
       </span>
     </div>
 
-    <div v-if="content.author" class="section">
+    <div v-if="content.author" class="section" data-test="author">
       <span class="label">
         {{ metadataStrings.$tr('author') }}:
       </span>
@@ -83,7 +97,7 @@
       </span>
     </div>
 
-    <div v-if="content.license_owner" class="section">
+    <div v-if="content.license_owner" class="section" data-test="license-owner">
       <span class="label">
         {{ metadataStrings.$tr('copyrightHolder') }}:
       </span>
@@ -92,7 +106,7 @@
       </span>
     </div>
 
-    <div v-if="licenseDescription" class="section">
+    <div v-if="licenseDescription" class="section" data-test="license-desc">
       <span class="label">
         {{ metadataStrings.$tr('license') }}:
       </span>
@@ -120,6 +134,7 @@
       :files="downloadableFiles"
       :nodeTitle="content.title"
       class="download-button"
+      data-test="download-button"
     />
 
   </section>
@@ -131,6 +146,7 @@
 
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
+  import LearnerNeeds from 'kolibri-constants/labels/Needs';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -175,6 +191,9 @@
       };
     },
     computed: {
+      forBeginners() {
+        return get(this.content, 'learner_needs', []).includes(LearnerNeeds.FOR_BEGINNERS);
+      },
       licenseShortName() {
         return licenseShortName(get(this, 'content.license_name', null));
       },

--- a/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
@@ -19,7 +19,6 @@
     <div class="section">
       <!-- For Beginners Chip Here -->
       <div
-        v-if="content.forBeginners"
         class="beginners-chip"
         :style="{ 'background-color': $themeBrand.secondary.v_600 }"
       >
@@ -47,15 +46,6 @@
       :primary="true"
       @click="toggleShowMoreOrLess"
     />
-
-    <!-- No "Subject" string available - but it is noted in Figma as a possible metadata
-    <div v-if="content.subject" class="section">
-      <span class="label">
-      </span>
-      <span>
-      </span>
-    </div>
-    -->
 
     <div v-if="content.level" class="section">
       <span class="label">
@@ -312,7 +302,6 @@
       // Ensures space on line w/ closing X icon whether
       // chips are visible or not
       min-height: 40px;
-      padding: 12px;
     }
 
     .label {
@@ -323,6 +312,12 @@
   .content {
     font-size: 16px;
     line-height: 24px;
+  }
+
+  .related {
+    .list-item {
+      margin: 8px 0;
+    }
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityChip.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityChip.vue
@@ -46,6 +46,7 @@
 
   .activity-chip {
     display: inline-block;
+    padding: 12px;
     font-weight: bold;
     background-color: #f5f5f5;
     border-radius: 4px;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -144,7 +144,7 @@
       v-if="sidePanelContent"
       @closePanel="sidePanelContent = null"
     >
-      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" :channelToShowLocationsFor="channel" />
+      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
     </FullScreenSidePanel>
   </div>
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -144,7 +144,7 @@
       v-if="sidePanelContent"
       @closePanel="sidePanelContent = null"
     >
-      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />
+      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" :channelToShowLocationsFor="channel" />
     </FullScreenSidePanel>
   </div>
 

--- a/kolibri/plugins/learn/assets/test/views/currently-viewed-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/currently-viewed-resource-metadata.spec.js
@@ -1,21 +1,12 @@
 import { shallowMount } from '@vue/test-utils';
-import { ContentNodeResource } from 'kolibri.resources';
-import KRouterLink from 'kolibri-design-system/lib/buttons-and-links/KRouterLink';
 import LearnerNeeds from 'kolibri-constants/labels/Needs';
 import AccessibilityCategories from 'kolibri-constants/labels/AccessibilityCategories';
 import GradeLevels from 'kolibri-constants/labels/Levels';
 import ResourceTypes from 'kolibri-constants/labels/ResourceType';
 import Subjects from 'kolibri-constants/labels/Subjects';
 import LearningActivities from 'kolibri-constants/labels/LearningActivities';
-import ContentNodeThumbnail from '../../src/views/thumbnails/ContentNodeThumbnail';
 import LearningActivityChip from '../../src/views/LearningActivityChip';
-import BrowseResourceMetadata from '../../src/views/BrowseResourceMetadata';
-import genContentLink from '../../src/utils/genContentLink';
-
-const promise = new Promise(() => []);
-
-ContentNodeResource.fetchRecommendationsFor = jest.fn(() => promise);
-ContentNodeResource.fetchCollection = jest.fn(() => promise);
+import CurrentlyViewedResourceMetadata from '../../src/views/CurrentlyViewedResourceMetadata';
 
 const baseContentNode = {
   id: '2ea9bda8703241be89b5b9fd87f88815',
@@ -30,15 +21,15 @@ const baseContentNode = {
   parent: '55b3dffe512c4d93bcdc85efde1046f5',
   title: 'Intro to addition',
   learning_activities: [LearningActivities.READ],
-  // Include FOR_BEGINNERS which shows the related Chip, then another because
-  // FOR_BEGINNERS is handled specially, so we need another to test that we show
-  // the "learner needs" section
   learner_needs: [LearnerNeeds.FOR_BEGINNERS, LearnerNeeds.PAPER_PENCIL],
   grade_levels: [GradeLevels.WORK_SKILLS, GradeLevels.UPPER_PRIMARY],
   resource_types: [ResourceTypes.TUTORIAL],
   accessibility_labels: [AccessibilityCategories.CAPTIONS_SUBTITLES],
   categories: [Subjects.NUMERACY],
   duration: 3600,
+  // Need a file with a preset that doesn't end in "thumbnail" to ensure that
+  // the download button will show when the canDownloadContent prop is also true
+  files: [{ preset: 'fake' }],
   lang: {
     id: 'en',
     lang_code: 'en',
@@ -65,14 +56,14 @@ function makeContentNode(metadata = {}) {
 
 function makeWrapper(metadata = {}, options = {}) {
   const content = makeContentNode(metadata);
-  const propsData = { content };
-  return shallowMount(BrowseResourceMetadata, {
+  const propsData = { content, canDownloadContent: true };
+  return shallowMount(CurrentlyViewedResourceMetadata, {
     propsData,
     ...options,
   });
 }
 
-describe('BrowseResourceMetadata', () => {
+describe('CurrentlyViewedResourceMetadata', () => {
   /* The base makeWrapper bootstraps a content item that has all of the metadata
    * for a fully loaded component in place.
    *
@@ -84,23 +75,16 @@ describe('BrowseResourceMetadata', () => {
   describe('metadata is displayed when present on given content', () => {
     beforeAll(() => (wrapper = makeWrapper()));
 
+    it('shows the download button when told to', () => {
+      expect(wrapper.find("[data-test='download-button']").exists()).toBeTruthy();
+    });
+
     it('shows properly translated learning activities as LearningActivityChip', () => {
       expect(wrapper.findComponent(LearningActivityChip).exists()).toBeTruthy();
     });
 
     it('shows the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeTruthy();
-    });
-
-    it('shows the view resource button-link with genContentLink-generated path', () => {
-      const link = wrapper.findComponent(KRouterLink);
-      expect(link.exists()).toBeTruthy();
-      const to = link.props().to;
-      expect(to).toEqual(genContentLink(baseContentNode.id, baseContentNode.is_leaf));
-    });
-
-    it('displays a ContentNodeThumbnail', () => {
-      expect(wrapper.findComponent(ContentNodeThumbnail).exists()).toBeTruthy();
     });
 
     it('shows the title', () => {
@@ -132,23 +116,26 @@ describe('BrowseResourceMetadata', () => {
     // With the metadata wiped
     beforeAll(
       () =>
-        (wrapper = makeWrapper({
-          learner_needs: [],
-          learning_activities: [],
-          grade_levels: [],
-          accessibility_labels: [],
-          thumbnail: null, // Should still render the component though
-          resource_types: [],
-          categories: [],
-          duration: null,
-          lang: null,
-          title: null,
-          description: null,
-          author: null,
-          license_description: null,
-          license_name: null,
-          license_owner: null,
-        }))
+        (wrapper = makeWrapper(
+          {
+            learner_needs: [],
+            learning_activities: [],
+            grade_levels: [],
+            accessibility_labels: [],
+            thumbnail: null, // Should still render the component though
+            resource_types: [],
+            categories: [],
+            duration: null,
+            lang: null,
+            title: null,
+            description: null,
+            author: null,
+            license_description: null,
+            license_name: null,
+            license_owner: null,
+          },
+          { propsData: { canDownloadContent: false } }
+        ))
     );
 
     it('does not show properly translated learning activities as LearningActivityChip', () => {
@@ -158,10 +145,6 @@ describe('BrowseResourceMetadata', () => {
     it('does not show the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       console.log(wrapper.vm.forBeginners);
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeFalsy();
-    });
-
-    it('displays a ContentNodeThumbnail - which handles showing the placeholder', () => {
-      expect(wrapper.findComponent(ContentNodeThumbnail).exists()).toBeTruthy();
     });
 
     it('does not show the title', () => {
@@ -186,6 +169,10 @@ describe('BrowseResourceMetadata', () => {
 
     it('does not show license description section without the data', () => {
       expect(wrapper.find("[data-test='license-desc']").exists()).toBeFalsy();
+    });
+
+    it('does not show the download button when canDownloadContent is not true', () => {
+      expect(wrapper.find("[data-test='download-button']").exists()).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Implements 2 / 3 major Side Panel displays **with proper metadata** and tests and such. 

The two of the three which are done here are:

- When you are browsing the library/channels, there is an (i) icon which will open extended metadata in  the right sidepanel.

![image](https://user-images.githubusercontent.com/6356129/139091400-50a2216c-ea96-43b7-a326-b45d767f4f0d.png)

- When you are viewing content, you can click the top-right context menu, then "view more information" to see a smaller subset of metadata.

![image](https://user-images.githubusercontent.com/6356129/139091360-79e35542-96b7-4462-9ade-f7bbf8ca8c1a.png)

The one which is not completed (maybe even two of its own, but Figma seems like they'll look the same anway):
- When viewing a piece of content, you can click "View Folder Resources" or "View Lesson Resources" which shows the currently viewed piece of content's siblings.

This will be done in a follow-up PR because I have a bad habit of making monolithic PRs and caught myself before I just plowed on to the next bit. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Continues to work toward #8107 #8307 - soon to be closed!

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check to see if anything breaks, that the panels appear with the content they should have. You'll need to get like KA English and import some folders that have the same content to test that the Locations section in the browse resource metadata shows "other locations in this channel" properly. I used KA-en early math stuff.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
