### PR TITLE
Fix zip content origin behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,14 +242,20 @@ i18n-download-glossary:
 i18n-upload-glossary:
 	python packages/kolibri-tools/lib/i18n/crowdin.py upload-glossary
 
-docker-whl: writeversion docker-envlist
-	docker image build -t "learningequality/kolibri-whl" -f docker/build_whl.dockerfile .
+docker-clean:
+	rm -f *.iid *.cid
+
+docker-whl: docker-envlist docker-clean
+	docker build \
+		--iidfile docker-whl.iid \
+		-f docker/build_whl.dockerfile .
 	docker run \
 		--env-file ./docker/env.list \
-		-v $$PWD/dist:/kolibridist \
+		--cidfile docker-whl.cid \
 		-v yarn_cache:/yarn_cache \
 		-v cext_cache:/cext_cache \
-		"learningequality/kolibri-whl"
+		`cat docker-whl.iid`
+	docker cp `cat docker-whl.cid`:/kolibri/dist/. dist/
 	git checkout -- ./docker/env.list  # restore env.list file
 
 docker-build-base: writeversion

--- a/docker/build_whl.dockerfile
+++ b/docker/build_whl.dockerfile
@@ -52,5 +52,4 @@ CMD echo '--- Installing JS dependencies' && \
     echo '--- Making whl' && \
     make dist && \
     echo '--- Making pex' && \
-    make pex && \
-    cp /kolibri/dist/* /kolibridist/
+    make pex

--- a/kolibri/core/content/test/test_paths.py
+++ b/kolibri/core/content/test/test_paths.py
@@ -3,6 +3,7 @@ import hashlib
 from django.test import TestCase
 
 from kolibri.core.content.models import LocalFile
+from kolibri.core.content.utils.paths import get_zip_content_config
 from kolibri.utils.tests.helpers import override_option
 
 
@@ -29,3 +30,11 @@ class LocalFilePathsTest(TestCase):
 @override_option("Deployment", "URL_PATH_PREFIX", "prefix_test/")
 class PrefixedLocalFilesPathsTest(LocalFilePathsTest):
     pass
+
+
+class ZipContentConfigTest(TestCase):
+    @override_option("Deployment", "ZIP_CONTENT_ORIGIN", "https://kolibri.example.com")
+    def test_zip_content_origin_set(self):
+        zip_content_origin, zip_content_port = get_zip_content_config()
+        self.assertEqual("https://kolibri.example.com", zip_content_origin)
+        self.assertEqual(zip_content_port, "")

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -71,7 +71,7 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
             {js_name}.__zipContentUrl = '{zip_content_url}';
             {js_name}.__hashiUrl = '{hashi_url}';
             {js_name}.__zipContentOrigin = '{zip_content_origin}';
-            {js_name}.__zipContentPort = {zip_content_port};
+            {js_name}.__zipContentPort = '{zip_content_port}';
             </script>
             """.format(
                     js_name=js_name,

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -158,7 +158,7 @@
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData,
         this.defaultFile.extension === 'zip'
-          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension)
+          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension, 'index.html')
           : this.defaultFile.storage_url,
         this.defaultFile.checksum
       );

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -103,7 +103,7 @@
       this.hashi.initialize(
         {},
         {},
-        urls.zipContentUrl(zipFile.checksum, zipFile.extension),
+        urls.zipContentUrl(zipFile.checksum, zipFile.extension, 'index.html'),
         zipFile.checksum
       );
     },


### PR DESCRIPTION
## Summary
* Fixes bug that causes frontend to break when ZIP_CONTENT_ORIGIN is set
* Add test for setting zip content origin.
* Add '' around zip content port when injecting into the page.

## Reviewer guidance
HTML5 apps still work
![Screenshot from 2021-10-27 15-18-28](https://user-images.githubusercontent.com/1680573/139155442-eda5cc7d-2ffc-4d95-873e-be3de8ba4945.png)

With KOLIBRI_ZIP_CONTENT_ORIGIN set, attempts to load from the correct origin, properly loads hashi from that origin, but there seems to be an issue loading the zipcontent itself - this seems to be an issue with the zipcontent not being where it ought?
![Screenshot from 2021-10-27 15-20-04](https://user-images.githubusercontent.com/1680573/139155660-2ddd643b-47f6-40f2-b22a-5ccec3dd8443.png)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
