### PR TITLE
Pin docs build test to Python 3.9.

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["docs/**", "requirements/docs.txt"]'
+          paths: '["docs/**", "requirements/docs.txt", ".github/workflows/check_docs.yml"]'
   docs:
     name: Checking docs build
     needs: pre_job
@@ -22,7 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
     - name: pip cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
## Summary
* Version was unpinned previously
* Django 1.11 is incompatible with Python 3.10 so docs building broke
* Updates docs build to run when the workflow file is changed

## Reviewer guidance
Does the docs build test pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
