### PR TITLE
Examattemptlog migration in case where no examlog has been changed

### DIFF
--- a/kolibri/core/logger/kolibri_plugin.py
+++ b/kolibri/core/logger/kolibri_plugin.py
@@ -2,6 +2,7 @@ import logging
 
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.sync_operations import KolibriVersionedSyncOperation
+from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
 from kolibri.core.logger.utils.exam_log_migration import migrate_from_exam_logs
 from kolibri.plugins.hooks import register_hook
@@ -21,8 +22,14 @@ class ExamLogsCompatibilityOperation(KolibriVersionedSyncOperation):
         exam_logs_ids = context.transfer_session.get_touched_record_ids_for_model(
             ExamLog
         )
+        exam_attempt_logs_ids = (
+            context.transfer_session.get_touched_record_ids_for_model(ExamAttemptLog)
+        )
         logger.info("Migrating {} ExamLogs records".format(len(exam_logs_ids)))
-        migrate_from_exam_logs(ExamLog.objects.filter(id__in=exam_logs_ids))
+        migrate_from_exam_logs(
+            ExamLog.objects.filter(id__in=exam_logs_ids),
+            source_attempt_log_ids=exam_attempt_logs_ids,
+        )
 
 
 @register_hook

--- a/kolibri/core/logger/test/test_exam_log_migration.py
+++ b/kolibri/core/logger/test/test_exam_log_migration.py
@@ -211,3 +211,87 @@ class UpdatedForwardMigrateTestCase(TestCase):
             models.ContentSummaryLog.objects.filter(progress=1).count(),
             3,
         )
+
+
+class UpdatedExamAttemptLogOnlyForwardMigrateTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        coach = FacilityUserFactory.create(facility=cls.facility)
+        cls.exam = Exam.objects.create(
+            title="quiz", question_count=5, collection=cls.facility, creator=coach
+        )
+        for i in range(0, 3):
+            user = FacilityUserFactory.create(facility=cls.facility)
+
+            examlog = models.ExamLog.objects.create(user=user, exam=cls.exam)
+            for j in range(0, 4):
+                models.ExamAttemptLog.objects.create(
+                    item=str(j),
+                    user=user,
+                    examlog=examlog,
+                    start_timestamp=now(),
+                    end_timestamp=now(),
+                    correct=j % 2,
+                    content_id=uuid4().hex,
+                )
+
+        migrate_from_exam_logs(models.ExamLog.objects.all())
+        updated_ids = []
+        for examlog in models.ExamLog.objects.all():
+            oldattempt = examlog.attemptlogs.first()
+            oldattempt.end_timestamp = now() + timedelta(hours=1)
+            oldattempt.answer = {"something": "something"}
+            oldattempt.simple_answer = "test_filter"
+            oldattempt.correct = True
+            oldattempt.save()
+            updated_ids.append(oldattempt.id)
+            olderattempt = examlog.attemptlogs.last()
+            olderattempt.end_timestamp = now() - timedelta(hours=1)
+            olderattempt.answer = {"nothing": "nothing"}
+            olderattempt.simple_answer = "test_none_filter"
+            olderattempt.correct = 0
+            olderattempt.save()
+            updated_ids.append(olderattempt.id)
+            newattempt = models.ExamAttemptLog.objects.create(
+                item=str(j),
+                user=examlog.user,
+                examlog=examlog,
+                start_timestamp=now(),
+                end_timestamp=now(),
+                correct=0,
+                content_id=uuid4().hex,
+            )
+            updated_ids.append(newattempt.id)
+        migrate_from_exam_logs(
+            models.ExamLog.objects.none(), source_attempt_log_ids=updated_ids
+        )
+
+    def test_masterylogs(self):
+        self.assertEqual(models.MasteryLog.objects.all().count(), 3)
+
+    def test_attemptlogs(self):
+        self.assertEqual(models.AttemptLog.objects.all().count(), 15)
+        modified_attempts = models.AttemptLog.objects.filter(
+            simple_answer="test_filter"
+        )
+        self.assertEqual(modified_attempts.count(), 3)
+        for attempt in modified_attempts:
+            self.assertEqual(attempt.answer, {"something": "something"})
+            self.assertEqual(attempt.correct, True)
+        unmodified_attempts = models.AttemptLog.objects.filter(
+            simple_answer="test_none_filter"
+        )
+        self.assertEqual(unmodified_attempts.count(), 0)
+
+    def test_contentsessionlogs(self):
+        self.assertEqual(
+            models.ContentSessionLog.objects.all().count(),
+            3,
+        )
+
+    def test_contentsummarylogs(self):
+        self.assertEqual(
+            models.ContentSummaryLog.objects.all().count(),
+            3,
+        )

--- a/kolibri/core/logger/utils/exam_log_migration.py
+++ b/kolibri/core/logger/utils/exam_log_migration.py
@@ -69,6 +69,13 @@ attempt_log_fields_for_update = [
 ]
 
 
+BATCH_READ_SIZE = 750
+
+# Things that we will set as constant for every examlog we migrate
+kind = content_kinds.QUIZ
+mastery_criterion = {"type": content_kinds.QUIZ, "coach_assigned": True}
+
+
 def _update_attempt_logs(masterylog_id, logs):
     existing_logs = AttemptLog.objects.filter(masterylog_id=masterylog_id)
     existing_log_items = {log.item: log for log in existing_logs}
@@ -135,6 +142,100 @@ def _create_attemptlog(examattemptlog, sessionlog_id, masterylog_id):
     return attemptlog
 
 
+def _handle_examlog(examlog, unprocessed_attempt_log_ids):
+    examattemptlogs = examlog.attemptlogs.all()
+    try:
+        start_timestamp = min(e.start_timestamp for e in examattemptlogs)
+    except ValueError:
+        start_timestamp = local_now()
+    content_id = examlog.exam_id
+    user = examlog.user
+    complete = examlog.closed
+    progress = 1 if examlog.closed else 0
+    completion_timestamp = examlog.completion_timestamp
+    end_timestamp = examlog.completion_timestamp
+    dataset_id = user.dataset_id
+    session_log = ContentSessionLog(
+        user=user,
+        content_id=content_id,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        progress=progress,
+        kind=kind,
+        dataset_id=dataset_id,
+    )
+    session_log.id = session_log.calculate_uuid()
+
+    summary_log = ContentSummaryLog(
+        user=user,
+        content_id=content_id,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        completion_timestamp=completion_timestamp,
+        progress=progress,
+        kind=kind,
+        dataset_id=dataset_id,
+    )
+    summary_log.id = summary_log.calculate_uuid()
+
+    mastery_log = MasteryLog(
+        user=user,
+        summarylog_id=summary_log.id,
+        mastery_criterion=mastery_criterion,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
+        completion_timestamp=completion_timestamp,
+        # Do this rather than just generating a random value
+        # so that the mastery log id is deterministic.
+        mastery_level=int(str(int(content_id, 16))[-9:]),
+        complete=complete,
+        dataset_id=dataset_id,
+    )
+    mastery_log.id = mastery_log.calculate_uuid()
+
+    attempt_logs = []
+
+    for examattemptlog in examattemptlogs:
+        attemptlog = _create_attemptlog(examattemptlog, session_log.id, mastery_log.id)
+        attempt_logs.append(attemptlog)
+        try:
+            unprocessed_attempt_log_ids.remove(examattemptlog.id)
+        except KeyError:
+            pass
+    return session_log, summary_log, mastery_log, attempt_logs
+
+
+def _handle_unprocessed_attemptlog_ids(unprocessed_attempt_log_ids):
+    if unprocessed_attempt_log_ids:
+        examlog_id_to_masterylog = {}
+        unprocessed_attempt_log_ids = list(unprocessed_attempt_log_ids)
+        attempt_logs = []
+        i = 0
+        source_logs = ExamAttemptLog.objects.filter(
+            id__in=unprocessed_attempt_log_ids[i : i + BATCH_READ_SIZE]
+        ).annotate(exam_id=F("examlog__exam_id"))
+        for examattemptlog in source_logs:
+            if examattemptlog.examlog_id not in examlog_id_to_masterylog:
+                examlog_id_to_masterylog[examattemptlog.examlog_id] = (
+                    MasteryLog.objects.filter(
+                        user_id=examattemptlog.user_id,
+                        summarylog__content_id=examattemptlog.exam_id,
+                    )
+                    .values_list("id", flat=True)
+                    .first()
+                )
+            masterylog_id = examlog_id_to_masterylog[examattemptlog.examlog_id]
+            if masterylog_id:
+                attemptlog = _create_attemptlog(examattemptlog, None, masterylog_id)
+                attempt_logs.append(attemptlog)
+
+        for masterylog_id, logs in groupby(
+            sorted(attempt_logs, key=lambda x: x.masterylog_id),
+            lambda x: x.masterylog_id,
+        ):
+            _update_attempt_logs(masterylog_id, logs)
+
+
 def migrate_from_exam_logs(source_logs, source_attempt_log_ids=None):  # noqa C901
     """
     This function performs a forward migration to generate logs of the following kinds:
@@ -187,19 +288,13 @@ def migrate_from_exam_logs(source_logs, source_attempt_log_ids=None):  # noqa C9
     channel_id (ContentSessionLog + ContentSummaryLog), None
     kind (ContentSessionLog + ContentSummaryLog), quiz
     """
-    if source_attempt_log_ids is None:
-        unprocessed_attempt_log_ids = set()
-    else:
-        unprocessed_attempt_log_ids = set(source_attempt_log_ids)
+    unprocessed_attempt_log_ids = (
+        set() if source_attempt_log_ids is None else set(source_attempt_log_ids)
+    )
 
     source_logs = source_logs.prefetch_related("attemptlogs")
 
-    kind = content_kinds.QUIZ
-    mastery_criterion = {"type": content_kinds.QUIZ, "coach_assigned": True}
-
     i = 0
-
-    BATCH_READ_SIZE = 750
 
     logs = source_logs[i : i + BATCH_READ_SIZE]
 
@@ -210,69 +305,15 @@ def migrate_from_exam_logs(source_logs, source_attempt_log_ids=None):  # noqa C9
         attempt_logs = []
         summary_log_ids = []
         for examlog in logs:
-            examattemptlogs = examlog.attemptlogs.all()
-            try:
-                start_timestamp = min(e.start_timestamp for e in examattemptlogs)
-            except ValueError:
-                start_timestamp = local_now()
-            content_id = examlog.exam_id
-            user = examlog.user
-            complete = examlog.closed
-            progress = 1 if examlog.closed else 0
-            completion_timestamp = examlog.completion_timestamp
-            end_timestamp = examlog.completion_timestamp
-            dataset_id = user.dataset_id
-            session_log = ContentSessionLog(
-                user=user,
-                content_id=content_id,
-                start_timestamp=start_timestamp,
-                end_timestamp=end_timestamp,
-                progress=progress,
-                kind=kind,
-                dataset_id=dataset_id,
+            session_log, summary_log, mastery_log, attempts = _handle_examlog(
+                examlog, unprocessed_attempt_log_ids
             )
-            session_log.id = session_log.calculate_uuid()
             content_session_logs.append(session_log)
-
-            summary_log = ContentSummaryLog(
-                user=user,
-                content_id=content_id,
-                start_timestamp=start_timestamp,
-                end_timestamp=end_timestamp,
-                completion_timestamp=completion_timestamp,
-                progress=progress,
-                kind=kind,
-                dataset_id=dataset_id,
-            )
-            summary_log.id = summary_log.calculate_uuid()
             content_summary_logs.append(summary_log)
             summary_log_ids.append(summary_log.id)
-
-            mastery_log = MasteryLog(
-                user=user,
-                summarylog_id=summary_log.id,
-                mastery_criterion=mastery_criterion,
-                start_timestamp=start_timestamp,
-                end_timestamp=end_timestamp,
-                completion_timestamp=completion_timestamp,
-                # Do this rather than just generating a random value
-                # so that the mastery log id is deterministic.
-                mastery_level=int(str(int(content_id, 16))[-9:]),
-                complete=complete,
-                dataset_id=dataset_id,
-            )
-            mastery_log.id = mastery_log.calculate_uuid()
             mastery_logs.append(mastery_log)
+            attempt_logs.extend(attempts)
 
-            for examattemptlog in examattemptlogs:
-                attemptlog = _create_attemptlog(
-                    examattemptlog, session_log.id, mastery_log.id
-                )
-                attempt_logs.append(attemptlog)
-                try:
-                    unprocessed_attempt_log_ids.remove(examattemptlog.id)
-                except KeyError:
-                    pass
         pre_existing_summary_logs = set(
             ContentSummaryLog.objects.filter(id__in=summary_log_ids).values_list(
                 "id", flat=True
@@ -303,30 +344,4 @@ def migrate_from_exam_logs(source_logs, source_attempt_log_ids=None):  # noqa C9
         i += BATCH_READ_SIZE
         logs = source_logs[i : i + BATCH_READ_SIZE]
 
-    if unprocessed_attempt_log_ids:
-        examlog_id_to_masterylog = {}
-        unprocessed_attempt_log_ids = list(unprocessed_attempt_log_ids)
-        attempt_logs = []
-        i = 0
-        source_logs = ExamAttemptLog.objects.filter(
-            id__in=unprocessed_attempt_log_ids[i : i + BATCH_READ_SIZE]
-        ).annotate(exam_id=F("examlog__exam_id"))
-        for examattemptlog in source_logs:
-            if examattemptlog.examlog_id not in examlog_id_to_masterylog:
-                examlog_id_to_masterylog[examattemptlog.examlog_id] = (
-                    MasteryLog.objects.filter(
-                        user_id=examattemptlog.user_id,
-                        summarylog__content_id=examattemptlog.exam_id,
-                    )
-                    .values_list("id", flat=True)
-                    .first()
-                )
-            masterylog_id = examlog_id_to_masterylog[examattemptlog.examlog_id]
-            if masterylog_id:
-                attemptlog = _create_attemptlog(examattemptlog, None, masterylog_id)
-                attempt_logs.append(attemptlog)
-
-    for masterylog_id, logs in groupby(
-        sorted(attempt_logs, key=lambda x: x.masterylog_id), lambda x: x.masterylog_id
-    ):
-        _update_attempt_logs(masterylog_id, logs)
+    _handle_unprocessed_attemptlog_ids(unprocessed_attempt_log_ids)


### PR DESCRIPTION
## Summary
* The examlog migration code assumed that an examlog would always have been when needed
* However, it is possible for examattemptlogs to have been updated without an associated examlog being updated
* This adds a test for this scenario, and adds the ability to pass an iterable of modified ids for exam attempt logs
* It then narrows down that list to those that have not otherwise been updated and then updates them
* Further, it reads touched examattemptlog ids in the morango sync hook and passes them to the utility

## References
Follow up to #8527 and #8502

## Reviewer guidance
Does the test cover the relevant cases? Is there anything we should add on the sync hook side?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
