### PR TITLE
Do not use the default queue when requesting sync in the wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/tasks.py
+++ b/kolibri/plugins/setup_wizard/tasks.py
@@ -131,6 +131,7 @@ def validate_soud_credentials(request, task_description):
     validator=validate_soud_credentials,
     cancellable=True,
     track_progress=True,
+    queue="kolibri",
     permission_classes=[
         IsSuperuser | NotProvisionedCanPost | LODUserHasSyncPermissions
     ],


### PR DESCRIPTION
## Summary
After this commit https://github.com/learningequality/kolibri/commit/1019d597e26566d8518646ee8860035e8bac4b60 the default tasks queue name was changed from `kolibri` to `ICEQUBE_DEFAULT_QUEUE` 

The setup wizard uses the `register_task` decorator that sets the default queue by default. However the 'new' default queue is not one of the queues of `TasksViewSet` at kolibri/core/tasks/api.py thus its functions didn't work any more.

This PR ensures the wizard does use the `kolibri` queue instead of so `TasksViewSet` works fine


## References
Closes: #8561 , #8489

## Reviewer guidance

Check the wizards work properly when importing users from a SoUD

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
