### PR TITLE
Home page follow-up fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HomePage/ContinueLearning.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/ContinueLearning.vue
@@ -32,6 +32,7 @@
           v-for="(contentNode, idx) in resumableNonClassesContentNodes"
           :key="idx"
           :contentNode="contentNode"
+          :contentNodeProgress="getResumableContentNodeProgress(contentNode.id)"
           :to="getTopicContentNodeLink(contentNode.id)"
           :collectionTitle="getContentNodeTopicName(contentNode)"
         />

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
@@ -22,7 +22,6 @@
       v-if="!hideDuration"
       class="duration"
       data-test="duration"
-      :style="{ marginTop: '8px' }"
     >
       <TimeDuration
         v-if="displayMinutes"
@@ -169,6 +168,7 @@
   }
 
   .duration {
+    margin-top: 8px;
     text-align: right;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
@@ -20,6 +20,7 @@
     </div>
     <div
       v-if="!hideDuration"
+      class="duration"
       data-test="duration"
       :style="{ marginTop: '8px' }"
     >
@@ -165,6 +166,10 @@
       position: static;
       padding-left: 2px;
     }
+  }
+
+  .duration {
+    text-align: right;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

(1) fixes missing progress bars in "Continue learning on your own" section
(2) makes sure that content nodes that have progress `0` won't get displayed in "Continue learning from your classes/on your own" sections even though API returns them as resumable - frontend fix for #8573
(3) fixes alignment of learning activity label
| Before | After |
| -------- | ------- |
| ![Screenshot from 2021-11-02 12-20-17](https://user-images.githubusercontent.com/13509191/139839219-edbe3bec-06ee-405a-b99a-e2fa435ebb1a.png) | ![Screenshot from 2021-11-02 12-26-07](https://user-images.githubusercontent.com/13509191/139839242-fe0066d5-83e5-403b-a3de-2097c99a0d2e.png) |

---

@pcenov I also checked why duration information is not displayed on cards and on my server it's because API returns `null` values. Cards are ready to display duration when it's available. For example, for video resources it looks like:

![Screenshot from 2021-11-02 12-31-56](https://user-images.githubusercontent.com/13509191/139839714-554330fd-bf12-4e7d-9364-78721089bad3.png)

so hopefully it will work as soon as we have all data available, but would be definitely good to check on it again. Thank you.

## References
<!--
 * references to related issues and PRs

 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes  #8553

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Preview cards on the home page in "Continue learning from your classes/on your own" sections

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
