### PR TITLE
Do simple diff tracking of extra_fields to prevent unnecessary updates.

### DIFF
--- a/kolibri/core/assets/src/state/modules/logging.js
+++ b/kolibri/core/assets/src/state/modules/logging.js
@@ -1,5 +1,6 @@
 import Vue from 'kolibri.lib.vue';
 import fromPairs from 'lodash/fromPairs';
+import { diff } from 'deep-object-diff';
 
 function valOrNull(val) {
   return typeof val !== 'undefined' ? val : null;
@@ -93,8 +94,10 @@ export default {
       state.time_spent_delta = threeDecimalPlaceRoundup(state.time_spent_delta + timeDelta);
     },
     SET_LOGGING_CONTENT_STATE(state, contentState) {
+      const delta = diff(state.extra_fields, { ...state.extra_fields, contentState });
       state.extra_fields.contentState = contentState;
-      state.extra_fields_dirty_bit = true;
+      state.extra_fields_dirty_bit =
+        state.extra_fields_dirty_bit || Boolean(Object.keys(delta).length);
     },
     SET_LOGGING_PROGRESS(state, progress) {
       progress = threeDecimalPlaceRoundup(progress);

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -445,6 +445,37 @@ describe('Vuex store/actions for core module', () => {
         contentState: { newState: 0.2 },
       });
     });
+    it('should update extra_fields and but not store to backend if not an update', async () => {
+      const store = await initStore();
+      await store.dispatch('updateContentSession', {
+        contentState: { statements: [{ test: 'statement' }] },
+      });
+      expect(store.state.core.logging.extra_fields).toEqual({
+        contentState: { statements: [{ test: 'statement' }] },
+      });
+      expect(client).toHaveBeenCalled();
+      expect(client.mock.calls[0][0].data.extra_fields).toEqual({
+        contentState: { statements: [{ test: 'statement' }] },
+      });
+      await store.dispatch('updateContentSession', {
+        contentState: { statements: [{ test: 'statement' }, { test2: 'statement2' }] },
+      });
+      expect(store.state.core.logging.extra_fields).toEqual({
+        contentState: { statements: [{ test: 'statement' }, { test2: 'statement2' }] },
+      });
+      expect(client).toHaveBeenCalled();
+      expect(client.mock.calls[1][0].data.extra_fields).toEqual({
+        contentState: { statements: [{ test: 'statement' }, { test2: 'statement2' }] },
+      });
+      client.__reset();
+      await store.dispatch('updateContentSession', {
+        contentState: { statements: [{ test: 'statement' }, { test2: 'statement2' }] },
+      });
+      expect(store.state.core.logging.extra_fields).toEqual({
+        contentState: { statements: [{ test: 'statement' }, { test2: 'statement2' }] },
+      });
+      expect(client).not.toHaveBeenCalled();
+    });
     it('should update pastattempts and store if interaction is passed without an id', async () => {
       const store = await initStore();
       await store.dispatch('updateContentSession', {

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.13",
     "csv-generator-client": "^2.1.1",
     "date-fns": "^1.28.2",
+    "deep-object-diff": "^1.1.0",
     "fontfaceobserver": "^2.0.13",
     "frame-throttle": "^3.0.0",
     "fuse.js": "^6.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,6 +5102,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+deep-object-diff@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
+  integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
+
 deepmerge@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"


### PR DESCRIPTION
## Summary
* Content renderer plugins that emit updates to `contentState` (e.g. media player, HTML5 viewer, PDF plugin) do so prolifically, and not always when there is a change
* At the moment we are just setting a flag to `true` if anything has set the `contentState`
* This can lead to multiple updates to the backend when no real changes have occurred
* This adds a simple diff check every time the contentState is set to see if there is a change, and sets the flag to its current value OR if there is a change now
* Benchmarking the object diffing library on RunKit gave a consistent 3ms time for doing the diffing on the biggest `extra_fields` values I could find in my local DB, so I don't think this should affect user performance

## References
Follow up to #8525 (although this issue existed previous to it, it was just less noticeable in among all the other logging API request noise).

## Reviewer guidance
Is video track position is retained between viewing sessions of a video? Do the automated test additions cover the change?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
