### PR TITLE
Escape " in JSON generation.

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -861,7 +861,7 @@ def set_channel_ancestors(channel_id):
                 )
                 + parent_id_expression
                 + '","title": "'
-                + parent.c.title
+                + func.replace(parent.c.title, '"', '\\"')
                 + '"}]'
             ]
         ).where(


### PR DESCRIPTION
## Summary
* Fixes a bug in ancestor JSON generation where any title with `"` in it would cause invalid JSON to be generated
* Escapes any textual `"` during JSON generation
* Adds test for regression

## References
Fixes issue detailed here: https://github.com/learningequality/kolibri/pull/8570#pullrequestreview-795917618

## Reviewer guidance
Rerun ancestor generation in `kolibri shell`:
```
from kolibri.core.content.upgrade import metadata_annotation_update
metadata_annotation_update()
```

Check that the error no longer occurs.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
