### PR TITLE
sidepanel was hidden by mistake on channels, fixed some errors in BrowseResourceMetadata

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -180,15 +180,16 @@
     <div v-if="showLocationsInChannel && locationsInChannel" class="section" data-test="locations">
       <div class="label">
         {{
-          metadataStrings.$tr('locationsInChannel', { 'channelname': content.ancestors[0].title })
+          metadataStrings
+            .$tr('locationsInChannel', { 'channelname': (content.ancestors[0] || {}).title })
         }}:
       </div>
       <div v-for="location in locationsInChannel" :key="location.id">
         <div>
           <KRouterLink
-            :to="genContentLink(location.ancestors.splice(-1)[0].id, false)"
+            :to="genContentLink((location.ancestors.splice(-1)[0] || {}).id, false)"
           >
-            {{ location.ancestors.splice(-1)[0].title }}
+            {{ (location.ancestors.splice(-1)[0] || {}).title }}
           </KRouterLink>
         </div>
       </div>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -744,11 +744,6 @@
     max-width: 920px;
   }
 
-  /deep/.side-panel {
-    position: relative;
-    bottom: 0;
-  }
-
   /deep/.card-thumbnail-wrapper {
     max-width: 100%;
     height: 110px;


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Takes care of a couple issues around showing metadata side panel with BrowseResourceMetadata.

1) In `TopicsPage` the side panel was being coerced with some /deep/ css to be off screen so I removed that.
2) Some errors around keys not being available on `undefined` w/ the ancestors splicing business in showing channel locations were showing up and I made sure it always got an object instead of undefined.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes do not reference an issue (that I know of anyway).

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to a channel (with the black top bar) and try to open the side panel. Do you see everything where it ought to be?

Check the console, any errors about `title` or similar not being defined? Any errors at all pointing to `BrowseResourceMetadata` directly?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
