### PR TITLE
Revert unneccessary change that breaks question detail rendering.

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -85,7 +85,6 @@ function showQuestionDetailView(params) {
           .dispatch('questionDetail/setLearners', {
             ...params,
             exercise,
-            exerciseId: exerciseNodeId,
           })
           .then(learners => {
             // No learnerId was passed in, so we should trigger a url redirect


### PR DESCRIPTION
## Summary
* Reverts change that should not have been committed from #8525 

## References
Fixes extant bug in Exercise Question Details report.

## Reviewer guidance
Can you view Difficult Questions reports for Exercises?

![detailsreports](https://user-images.githubusercontent.com/1680573/140167553-8c4b1516-7c0a-4579-841c-ae05e246a569.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
