### PR TITLE
Dev docs - update version of `node` in `nodeenv`

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -163,7 +163,7 @@ The Python project-specific dependencies installed above will install ``nodeenv`
 .. code-block:: bash
 
   # node.js, npm, and yarn
-  nodeenv -p --node=10.15.3
+  nodeenv -p --node=10.24.1
   npm install -g yarn
 
   # other required project dependencies


### PR DESCRIPTION
## Summary
Our current dev docs have `node` pinned to v10.15.3, but devs now need at least v10.17.0 based on some dependencies that were updated.

## References

## Reviewer guidance
Double check to see that this is the correct version of node required

## Testing checklist

- [x] Contributor has fully tested the PR manually

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
