### PR TITLE
Fix back button in LearnImmersiveLayout

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -303,6 +303,7 @@ function clearTrackingInterval() {
  * To be called on page load for content renderers
  */
 export function initContentSession(store, { nodeId, lessonId, quizId } = {}) {
+  const data = {};
   if (!nodeId && !quizId) {
     throw TypeError('Must define either nodeId or quizId');
   }
@@ -313,15 +314,18 @@ export function initContentSession(store, { nodeId, lessonId, quizId } = {}) {
 
   if (quizId) {
     sessionStarted = store.state.logging.context && store.state.logging.context.quiz_id === quizId;
+    data.quiz_id = quizId;
   }
 
   if (nodeId) {
     sessionStarted = store.state.logging.context && store.state.logging.context.node_id === nodeId;
+    data.node_id = nodeId;
     if (lessonId) {
       sessionStarted =
         sessionStarted &&
         store.state.logging.context &&
         store.state.logging.context.lesson_id === lessonId;
+      data.lesson_id = lessonId;
     }
   }
 
@@ -338,7 +342,7 @@ export function initContentSession(store, { nodeId, lessonId, quizId } = {}) {
   return client({
     method: 'post',
     url: urls['kolibri:core:trackprogress-list'](),
-    data: { node_id: nodeId, lesson_id: lessonId, quiz_id: quizId },
+    data: data,
   }).then(response => {
     store.commit('INITIALIZE_LOGGING_STATE', response.data);
   });

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -117,6 +117,26 @@ describe('Vuex store/actions for core module', () => {
         );
       }
     });
+    it('should not set a lessonId if the lessonId is a falsey value', async () => {
+      const store = makeStore();
+      const node_id = 'test_node_id';
+      const lesson_id = null;
+      client.__setPayload({
+        context: { node_id, lesson_id },
+      });
+      await store.dispatch('initContentSession', { nodeId: node_id, lessonId: lesson_id });
+      expect(client.mock.calls[0][0].data).toEqual({ node_id: node_id });
+    });
+    it('should not set a nodeId if the nodeId is a falsey value', async () => {
+      const store = makeStore();
+      const node_id = null;
+      const quiz_id = 'test-quiz-id';
+      client.__setPayload({
+        context: { node_id, quiz_id },
+      });
+      await store.dispatch('initContentSession', { nodeId: node_id, quizId: quiz_id });
+      expect(client.mock.calls[0][0].data).toEqual({ quiz_id: quiz_id });
+    });
     it('should set the logging state with the return data from the client', async () => {
       const store = makeStore();
       const session_id = 'test_session_id';

--- a/kolibri/plugins/learn/assets/src/utils/genContentLink.js
+++ b/kolibri/plugins/learn/assets/src/utils/genContentLink.js
@@ -1,8 +1,10 @@
 import { PageNames } from '../constants';
 
-export default function genContentLink(id, isLeaf) {
+// previous context allows to pass in ids or params from the last route
+export default function genContentLink(id, isLeaf, last, prevContext) {
   return {
     name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
     params: { id },
+    query: { last: last, prevContext },
   };
 }

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -101,6 +101,12 @@
           return val.kind && val.content_id;
         },
       },
+      // only present when the content node is being viewed as part of lesson
+      decodedLessonId: {
+        type: String,
+        required: false,
+        default: null,
+      },
     },
     data() {
       return {
@@ -119,7 +125,7 @@
       }),
       lessonId() {
         // This should be undefined when not in a lesson
-        return this.$route.params.lessonId;
+        return this.$route.params.lessonId ? this.$route.params.lessonId : this.decodedLessonId;
       },
       nextContentNodeRoute() {
         // HACK Use a the Resource Viewer Link instead

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -125,7 +125,7 @@
       }),
       lessonId() {
         // This should be undefined when not in a lesson
-        return this.$route.params.lessonId ? this.$route.params.lessonId : this.decodedLessonId;
+        return this.$route.params.lessonId || this.decodedLessonId;
       },
       nextContentNodeRoute() {
         // HACK Use a the Resource Viewer Link instead

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -18,7 +18,7 @@
           :isLeaf="content.is_leaf"
           :progress="content.progress_fraction || 0"
           :numCoachContents="content.num_coach_contents"
-          :link="genContentLink(content.id, content.is_leaf, backRoute)"
+          :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
           :contentId="content.content_id"
           :copiesCount="content.copies_count"
           :description="content.description"
@@ -57,7 +57,7 @@
 
         :key="`resource-${idx}`"
         :contentNode="content"
-        :to="genContentLink(content.id, content.is_leaf)"
+        :to="genContentLink(content.id, content.is_leaf, backRoute, context)"
       />
     </CardGrid>
 
@@ -79,7 +79,7 @@
       :isLeaf="content.is_leaf"
       :progress="content.progress_fraction || 0"
       :numCoachContents="content.num_coach_contents"
-      :link="genContentLink(content.id, content.is_leaf, backRoute)"
+      :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
       :contentId="content.content_id"
       :copiesCount="content.copies_count"
       :footerIcons="footerIcons"
@@ -171,10 +171,13 @@
         return this.pageName === PageNames.LIBRARY;
       },
       context() {
-        let context = {
-          lessonId: this.currentLesson.id,
-          classId: this.currentLesson.classroom.id,
-        };
+        let context = {};
+        if (this.currentLesson) {
+          context = {
+            lessonId: this.currentLesson.id,
+            classId: this.currentLesson.classroom.id,
+          };
+        }
         return encodeURI(JSON.stringify(context));
       },
       backRoute() {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -18,7 +18,7 @@
           :isLeaf="content.is_leaf"
           :progress="content.progress_fraction || 0"
           :numCoachContents="content.num_coach_contents"
-          :link="genContentLink(content.id, content.is_leaf)"
+          :link="genContentLink(content.id, content.is_leaf, backRoute)"
           :contentId="content.content_id"
           :copiesCount="content.copies_count"
           :description="content.description"
@@ -46,7 +46,7 @@
         :isLeaf="content.is_leaf"
         :progress="content.progress || content.progress_fraction || 0"
         :numCoachContents="content.num_coach_contents"
-        :link="genContentLink(content.id, content.is_leaf)"
+        :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
       />
     </div>
     <CardGrid
@@ -79,7 +79,7 @@
       :isLeaf="content.is_leaf"
       :progress="content.progress_fraction || 0"
       :numCoachContents="content.num_coach_contents"
-      :link="genContentLink(content.id, content.is_leaf)"
+      :link="genContentLink(content.id, content.is_leaf, backRoute)"
       :contentId="content.content_id"
       :copiesCount="content.copies_count"
       :footerIcons="footerIcons"
@@ -101,6 +101,7 @@
 
 <script>
 
+  import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { PageNames } from '../constants';
   import genContentLink from '../utils/genContentLink';
@@ -161,11 +162,22 @@
       uniqueId: null,
     }),
     computed: {
+      ...mapState(['pageName']),
+      ...mapState('lessonPlaylist', ['currentLesson']),
       isBookmarksPage() {
-        return this.currentPage === PageNames.BOOKMARKS;
+        return this.pageName === PageNames.BOOKMARKS;
       },
       isLibraryPage() {
-        return this.currentPage === PageNames.LIBRARY;
+        return this.pageName === PageNames.LIBRARY;
+      },
+      context() {
+        return {
+          lessonId: this.currentLesson.id,
+          classId: this.currentLesson.classroom.id,
+        };
+      },
+      backRoute() {
+        return this.pageName;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -171,10 +171,11 @@
         return this.pageName === PageNames.LIBRARY;
       },
       context() {
-        return {
+        let context = {
           lessonId: this.currentLesson.id,
           classId: this.currentLesson.classroom.id,
         };
+        return encodeURI(JSON.stringify(context));
       },
       backRoute() {
         return this.pageName;

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -51,6 +51,7 @@
         data-test="contentPage"
         :content="content"
         :channelId="content.channel_id"
+        :decodedLessonId="lessonId"
       />
     </div>
     <GlobalSnackbar />
@@ -197,6 +198,13 @@
       lessonContext() {
         return this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER;
       },
+      lessonId() {
+        if (this.back.params.length > 0) {
+          let params = JSON.parse(decodeURI(this.back.params));
+          return params.lessonId ? params.lessonId : null;
+        }
+        return null;
+      },
     },
     beforeUpdate() {
       client({
@@ -209,7 +217,7 @@
     },
     methods: {
       navigateBack() {
-        if (this.back.params) {
+        if (this.back.params.length > 0) {
           let params = JSON.parse(decodeURI(this.back.params));
           let route = { ...this.back, params };
           this.$router.push(route);

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -199,7 +199,7 @@
         return this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER;
       },
       lessonId() {
-        if (this.back.params.length > 0) {
+        if (this.back && this.back.params && this.back.params.length > 0) {
           let params = JSON.parse(decodeURI(this.back.params));
           return params.lessonId ? params.lessonId : null;
         }

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -209,8 +209,13 @@
     },
     methods: {
       navigateBack() {
-        // return to previous page using the route object set through props
-        this.$router.push(this.back);
+        if (this.back.params) {
+          let params = JSON.parse(decodeURI(this.back.params));
+          let route = { ...this.back, params };
+          this.$router.push(route);
+        } else {
+          this.$router.push(this.back);
+        }
       },
       openSidePanel() {
         this.sidePanelContent = this.content;

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -308,15 +308,20 @@
         // extract the key pieces of routing from immersive page props, but since we don't need
         // them all, just create two alternative route paths for return/'back' navigation
         let route = {};
-        if (this.$route.query.last == PageNames.RECOMMENDED) {
-          route = this.$router.getRoute(PageNames.RECOMMENDED);
-        } else if (this.pageName === ClassesPageNames.LESSON_RESOURCE_VIEWER) {
-          route = this.$router.getRoute(ClassesPageNames.LESSON_PLAYLIST);
-        } else if (this.topicsTreeContent.parent) {
+        if (this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH) {
           // Need to guard for parent being non-empty to avoid console errors
           route = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
             id: this.topicsTreeContent.parent,
           });
+        } else if (this.$route.query && this.$route.query.last) {
+          let last = this.$route.query.last;
+          route = this.$router.getRoute(last);
+          if (this.$route.query.prevContext) {
+            let params = this.$route.query.prevContext;
+            route = { ...route, params };
+          }
+        } else {
+          route = this.$router.getRoute(PageNames.HOME);
         }
         return route;
       },


### PR DESCRIPTION
## Summary
When leaving content renderer, back button should correctly revert to home, lesson, library, topic, or bookmarks page. 


## References
Fixes #8512

## Reviewer guidance
I tried to use `last` and `prevContext` to account for both the previous page name and the previous page params, rather than having many conditions trying to match up with page names, but I'm not sure if this is more confusing, since it's less explicit.

Any scenarios this doesn't account for?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
