### PR TITLE
Update Topics Page for pagination and more

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1090,8 +1090,12 @@ export default {
       const metadataKey = get(MetadataLookup, key, null);
       key = metadataKey ? camelCase(metadataKey) : key;
 
-      if (Object.keys(nonconformingKeys).includes(key)) {
+      if (nonconformingKeys[key]) {
         return coreStrings.$tr(nonconformingKeys[key], args);
+      }
+
+      if (nonconformingKeys[metadataKey]) {
+        return coreStrings.$tr(nonconformingKeys[metadataKey], args);
       }
 
       return coreStrings.$tr(key, args);

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -59,9 +59,18 @@
               hasFloatingLabel && isLabelInline) ? null : placeholder }}
           </div>
 
-          <UiIcon class="ui-select-dropdown-button">
+          <UiIcon v-if="!clearableState" class="ui-select-dropdown-button">
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M6.984 9.984h10.03L12 15z" /></svg>
           </UiIcon>
+          <KIconButton
+            v-else
+            class="overlay-close-button"
+            icon="close"
+            :ariaLabel="coreString('clearAction')"
+            :color="$themeTokens.text"
+            :tooltip="coreString('clearAction')"
+            @click.stop="setValue()"
+          />
         </div>
 
         <transition name="ui-select-transition-fade">
@@ -190,15 +199,16 @@
     resetScroll,
   } from 'kolibri-design-system/lib/keen/helpers/element-scroll';
   import config from 'kolibri-design-system/lib/keen/config';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import KeenUiSelectOption from './KeenUiSelectOption.vue';
 
   export default {
     name: 'KeenUiSelect',
-
     components: {
       UiIcon,
       KeenUiSelectOption,
     },
+    mixins: [commonCoreStrings],
     props: {
       name: {
         type: String,
@@ -289,6 +299,10 @@
         default: null,
       },
       disabled: {
+        type: Boolean,
+        default: false,
+      },
+      clearable: {
         type: Boolean,
         default: false,
       },
@@ -455,13 +469,20 @@
         return {};
       },
       activeBorderStyle() {
-        if (this.isActive) {
+        if (this.isActive && !this.clearableState) {
           return {
             borderBottomColor: this.$themeTokens.primary,
+          };
+        } else if (this.clearableState) {
+          return {
+            cursor: 'default',
           };
         }
 
         return {};
+      },
+      clearableState() {
+        return this.clearable && this.value && Object.keys(this.value).length;
       },
     },
 
@@ -702,7 +723,7 @@
       },
 
       openDropdown() {
-        if (this.disabled) {
+        if (this.disabled || this.clearableState) {
           return;
         }
 
@@ -1119,5 +1140,10 @@
   }
 
   /* stylelint-enable */
+
+  .overlay-close-button {
+    position: absolute;
+    right: 0;
+  }
 
 </style>

--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -14,6 +14,7 @@
     :invalid="invalid"
     :error="invalidText"
     :name="name"
+    :clearable="clearable"
     :placeholder="placeholder"
     @change="handleChange"
     @blur="$emit('blur')"
@@ -118,6 +119,14 @@
       placeholder: {
         type: String,
         default: null,
+      },
+      /**
+       * Whether to turn into a clearable state
+       * when an option has been selected.
+       */
+      clearable: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -398,7 +398,7 @@ class ContentNodeAPITestCase(APITestCase):
                     self.assertGreater(len(child_nodes), len(children["results"]))
                     self.assertEqual(children["more"]["id"], expected.id)
                     self.assertEqual(
-                        children["more"]["params"]["next__gt"], child_nodes[24].rght
+                        children["more"]["params"]["next__gt"], child_nodes[11].rght
                     )
                     self.assertEqual(
                         children["more"]["params"]["depth"], 2 - recursion_depth
@@ -445,18 +445,18 @@ class ContentNodeAPITestCase(APITestCase):
         "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
     )
     def test_contentnode_tree_next__gt(self):
-        builder = ChannelBuilder(levels=2, num_children=30)
+        builder = ChannelBuilder(levels=2, num_children=17)
         builder.insert_into_default_db()
         content.ContentNode.objects.all().update(available=True)
         root = content.ContentNode.objects.get(id=builder.root_node["id"])
-        next__gt = content.ContentNode.objects.filter(parent=root)[24].rght
+        next__gt = content.ContentNode.objects.filter(parent=root)[11].rght
         response = self.client.get(
             reverse("kolibri:core:contentnode_tree-detail", kwargs={"pk": root.id}),
             data={"next__gt": next__gt},
         )
         self.assertEqual(len(response.data["children"]["results"]), 5)
         self.assertIsNone(response.data["children"]["more"])
-        first_node = content.ContentNode.objects.filter(parent=root)[25]
+        first_node = content.ContentNode.objects.filter(parent=root)[12]
         self._recurse_and_assert(
             [response.data["children"]["results"][0]], [first_node], recursion_depth=1
         )
@@ -467,7 +467,7 @@ class ContentNodeAPITestCase(APITestCase):
         "Skipping postgres as not as vulnerable to large queries and large insertions are less performant",
     )
     def test_contentnode_tree_more(self):
-        builder = ChannelBuilder(levels=2, num_children=30)
+        builder = ChannelBuilder(levels=2, num_children=17)
         builder.insert_into_default_db()
         content.ContentNode.objects.all().update(available=True)
         root = content.ContentNode.objects.get(id=builder.root_node["id"])

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
@@ -52,9 +52,13 @@ export default {
     loadMoreTopics(store) {
       const more = store.state.topic.children.more;
       if (more) {
-        return ContentNodeResource.fetchTree(more).then(data => {
-          store.commit('ADD_MORE_CONTENTS', data);
-        });
+        return ContentNodeResource.fetchTree(more)
+          .then(data => {
+            store.commit('ADD_MORE_CONTENTS', data);
+          })
+          .catch(err => {
+            store.dispatch('handleApiError', err);
+          });
       }
     },
     loadMoreContents(store, parentId) {
@@ -62,10 +66,14 @@ export default {
       const parent = parentIndex > -1 ? store.state.contents[parentIndex] : null;
       const more = parent && parent.children && parent.children.more;
       if (more) {
-        return ContentNodeResource.fetchTree(more).then(data => {
-          data.index = parentIndex;
-          store.commit('ADD_MORE_CHILD_CONTENTS', data);
-        });
+        return ContentNodeResource.fetchTree(more)
+          .then(data => {
+            data.index = parentIndex;
+            store.commit('ADD_MORE_CHILD_CONTENTS', data);
+          })
+          .catch(err => {
+            store.dispatch('handleApiError', err);
+          });
       }
     },
   },

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
@@ -1,4 +1,6 @@
 import Vue from 'kolibri.lib.vue';
+import { ContentNodeResource } from 'kolibri.resources';
+import { _collectionState } from '../coreLearn/utils';
 
 function defaultState() {
   return {
@@ -26,13 +28,13 @@ export default {
       state.recommended = payload.recommended || [];
     },
     ADD_MORE_CONTENTS(state, payload) {
-      state.contents = state.contents.concat(payload.results);
-      state.topic.children.more = payload.more;
+      state.contents = state.contents.concat(_collectionState(payload.children.results));
+      state.topic.children.more = payload.children.more;
     },
     ADD_MORE_CHILD_CONTENTS(state, payload) {
       const child = state.contents[payload.index];
-      child.children.results = child.children.results.concat(payload.results);
-      child.children.more = payload.more;
+      child.children.results = child.children.results.concat(payload.children.results);
+      child.children.more = payload.children.more;
     },
     RESET_STATE(state) {
       Object.assign(state, defaultState());
@@ -44,6 +46,27 @@ export default {
           Vue.set(contentNode, 'progress', progress.progress_fraction);
         }
       });
+    },
+  },
+  actions: {
+    loadMoreTopics(store) {
+      const more = store.state.topic.children.more;
+      if (more) {
+        return ContentNodeResource.fetchTree(more).then(data => {
+          store.commit('ADD_MORE_CONTENTS', data);
+        });
+      }
+    },
+    loadMoreContents(store, parentId) {
+      const parentIndex = store.state.contents.findIndex(p => p.id === parentId);
+      const parent = parentIndex > -1 ? store.state.contents[parentIndex] : null;
+      const more = parent && parent.children && parent.children.more;
+      if (more) {
+        return ContentNodeResource.fetchTree(more).then(data => {
+          data.index = parentIndex;
+          store.commit('ADD_MORE_CHILD_CONTENTS', data);
+        });
+      }
     },
   },
 };

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -104,7 +104,7 @@ export default [
   },
   {
     name: PageNames.TOPICS_TOPIC,
-    path: '/topics/t/:id',
+    path: '/topics/t/:id/:subtopic?',
     handler: (toRoute, fromRoute) => {
       if (unassignedContentGuard()) {
         return unassignedContentGuard();

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -102,9 +102,11 @@ export default [
       };
     },
   },
+  // Have to put TOPICS_TOPIC_SEARCH before TOPICS_TOPIC to ensure
+  // search gets picked up before being interpreted as a subtopic id.
   {
-    name: PageNames.TOPICS_TOPIC,
-    path: '/topics/t/:id/:subtopic?',
+    name: PageNames.TOPICS_TOPIC_SEARCH,
+    path: '/topics/t/:id/search',
     handler: (toRoute, fromRoute) => {
       if (unassignedContentGuard()) {
         return unassignedContentGuard();
@@ -118,8 +120,8 @@ export default [
     },
   },
   {
-    name: PageNames.TOPICS_TOPIC_SEARCH,
-    path: '/topics/t/:id/search',
+    name: PageNames.TOPICS_TOPIC,
+    path: '/topics/t/:id/:subtopic?',
     handler: (toRoute, fromRoute) => {
       if (unassignedContentGuard()) {
         return unassignedContentGuard();

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
@@ -5,6 +5,7 @@
       v-if="languageOptionsList.length"
       :options="languageOptionsList"
       class="selector"
+      :clearable="true"
       :value="selectedLanguage"
       :label="coreString('languageLabel')"
       :style="{ color: $themeTokens.text }"
@@ -14,6 +15,7 @@
       v-if="contentLevelsList.length"
       :options="contentLevelsList"
       class="selector"
+      :clearable="true"
       :value="selectedLevel"
       :label="coreString('levelLabel')"
       :style="{ color: $themeTokens.text }"
@@ -23,6 +25,7 @@
       v-if="showChannels && channelOptionsList.length"
       :options="channelOptionsList"
       class="selector"
+      :clearable="true"
       :value="selectedChannel"
       :label="coreString('channelLabel')"
       :style="{ color: $themeTokens.text }"
@@ -32,6 +35,7 @@
       v-if="accessibilityOptionsList.length"
       :options="accessibilityOptionsList"
       class="selector"
+      :clearable="true"
       :value="selectedAccessibilityFilter"
       :label="coreString('accessibility')"
       :style="{ color: $themeTokens.text }"
@@ -155,6 +159,8 @@
       handleChange(field, value) {
         if (value && value.value) {
           this.$emit('input', { ...this.value, [field]: { [value.value]: true } });
+        } else {
+          this.$emit('input', { ...this.value, [field]: {} });
         }
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -17,9 +17,10 @@
           :to="genContentLink(t.id)"
         />
       </div>
-      <KButton v-if="more" appearance="basic-link" @click="loadMoreTopics">
+      <KButton v-if="more && !topicsLoading" appearance="basic-link" @click="handleLoadMoreTopics">
         {{ coreString('viewMoreAction') }}
       </KButton>
+      <KCircularLoader v-if="topicsLoading" />
     </div>
     <div v-else>
       <!-- search by keyword -->
@@ -215,6 +216,11 @@
         default: true,
       },
     },
+    data() {
+      return {
+        topicsLoading: false,
+      };
+    },
     computed: {
       inputValue: {
         get() {
@@ -309,6 +315,12 @@
             learner_needs: { ...this.value.learner_needs, [need]: true },
           });
         }
+      },
+      handleLoadMoreTopics() {
+        this.topicsLoading = true;
+        this.loadMoreTopics().then(() => {
+          this.topicsLoading = false;
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -17,7 +17,11 @@
           :to="genContentLink(t.id)"
         />
       </div>
-      <KButton v-if="more && !topicsLoading" appearance="basic-link" @click="handleLoadMoreTopics">
+      <KButton
+        v-if="more && !topicsLoading"
+        appearance="basic-link"
+        @click="$emit('loadMoreTopics')"
+      >
         {{ coreString('viewMoreAction') }}
       </KButton>
       <KCircularLoader v-if="topicsLoading" />
@@ -117,7 +121,6 @@
 
   import pick from 'lodash/pick';
   import uniq from 'lodash/uniq';
-  import { mapActions } from 'vuex';
   import {
     AllCategories,
     CategoriesLookup,
@@ -196,6 +199,10 @@
         type: Object,
         default: null,
       },
+      topicsLoading: {
+        type: Boolean,
+        default: false,
+      },
       width: {
         type: [Number, String],
         required: true,
@@ -215,11 +222,6 @@
         type: Boolean,
         default: true,
       },
-    },
-    data() {
-      return {
-        topicsLoading: false,
-      };
     },
     computed: {
       inputValue: {
@@ -281,7 +283,6 @@
       },
     },
     methods: {
-      ...mapActions('topicsTree', ['loadMoreTopics']),
       genContentLink,
       allCategories() {
         this.$emit('input', { ...this.value, categories: { [AllCategories]: true } });
@@ -315,12 +316,6 @@
             learner_needs: { ...this.value.learner_needs, [need]: true },
           });
         }
-      },
-      handleLoadMoreTopics() {
-        this.topicsLoading = true;
-        this.loadMoreTopics().then(() => {
-          this.topicsLoading = false;
-        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -17,6 +17,9 @@
           :to="genContentLink(t.id)"
         />
       </div>
+      <KButton v-if="more" appearance="basic-link" @click="loadMoreTopics">
+        {{ coreString('viewMoreAction') }}
+      </KButton>
     </div>
     <div v-else>
       <!-- search by keyword -->
@@ -114,6 +117,7 @@
   import camelCase from 'lodash/camelCase';
   import pick from 'lodash/pick';
   import uniq from 'lodash/uniq';
+  import { mapActions } from 'vuex';
   import {
     AllCategories,
     CategoriesLookup,
@@ -200,6 +204,10 @@
           return [];
         },
       },
+      more: {
+        type: Object,
+        default: null,
+      },
       width: {
         type: [Number, String],
         required: true,
@@ -280,6 +288,7 @@
       },
     },
     methods: {
+      ...mapActions('topicsTree', ['loadMoreTopics']),
       genContentLink,
       allCategories() {
         this.$emit('input', { ...this.value, categories: { [AllCategories]: true } });

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -55,7 +55,7 @@
           class="category-list-item"
         >
           <KButton
-            :text="coreString(camelCase(category))"
+            :text="coreString(val)"
             appearance="flat-button"
             :appearanceOverrides="customCategoryStyles"
             :disabled="availableRootCategories && !availableRootCategories[val]"
@@ -114,7 +114,6 @@
 
 <script>
 
-  import camelCase from 'lodash/camelCase';
   import pick from 'lodash/pick';
   import uniq from 'lodash/uniq';
   import { mapActions } from 'vuex';
@@ -139,18 +138,6 @@
     const value = ResourcesNeededTypes[key];
     // TODO rtibbles: remove this condition
     if (plugin_data.learnerNeeds.includes(value) || process.env.NODE_ENV !== 'production') {
-      // For some reason the string ids for these items are in PascalCase not camelCase
-      if (key === 'PEOPLE') {
-        key = 'ToUseWithTeachersAndPeers';
-      } else if (key === 'PAPER_PENCIL') {
-        key = 'ToUseWithPaperAndPencil';
-      } else if (key === 'INTERNET') {
-        key = 'NeedsInternet';
-      } else if (key === 'MATERIALS') {
-        key = 'NeedsMaterials';
-      } else if (key === 'FOR_BEGINNERS') {
-        key = 'ForBeginners';
-      }
       resourcesNeeded[key] = value;
     }
   });
@@ -322,9 +309,6 @@
             learner_needs: { ...this.value.learner_needs, [need]: true },
           });
         }
-      },
-      camelCase(val) {
-        return camelCase(val);
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -8,7 +8,7 @@
     >
       <KFixedGridItem v-for="content in contents" :key="content.id" span="1">
         <HybridLearningContentCard
-          class="grid-item"
+          class="card-grid-item"
           :isMobile="windowIsSmall"
           :contentNode="content"
           :title="content.title"
@@ -39,7 +39,7 @@
         :description="content.description"
         :activityLength="content.duration"
         :thumbnail="content.thumbnail || getContentNodeThumbnail(content)"
-        class="grid-item"
+        class="card-grid-item"
         :isMobile="windowIsSmall"
         :title="content.title"
         :kind="content.kind"
@@ -71,7 +71,7 @@
       :description="content.description"
       :activityLength="content.duration"
       :currentPage="currentPage"
-      class="grid-item"
+      class="card-grid-item"
       :isMobile="windowIsSmall"
       :title="content.title"
       :thumbnail="content.thumbnail"
@@ -188,7 +188,7 @@
 
   $gutters: 16px;
 
-  .grid-item {
+  .card-grid-item {
     margin-bottom: $gutters;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -10,13 +10,22 @@
       <div v-if="!windowIsSmall" class="header">
         <KGrid>
           <KGridItem
+            v-if="!displayingSearchResults"
+            class="breadcrumbs"
             :layout4="{ span: 4 }"
             :layout8="{ span: 8 }"
             :layout12="{ span: 12 }"
           >
-            <h3 class="title">
+            <slot name="breadcrumbs"></slot>
+          </KGridItem>
+          <KGridItem
+            :layout4="{ span: 4 }"
+            :layout8="{ span: 8 }"
+            :layout12="{ span: 12 }"
+          >
+            <h1 class="title">
               {{ topic.title }}
-            </h3>
+            </h1>
           </KGridItem>
 
           <KGridItem
@@ -103,18 +112,6 @@
         <div
           class="card-grid"
         >
-          <!-- breadcrumbs - for large screens, or when there are no more folders -->
-          <KGrid v-if="!displayingSearchResults">
-            <KGridItem
-              class="breadcrumbs"
-              :layout4="{ span: 4 }"
-              :layout8="{ span: 8 }"
-              :layout12="{ span: 12 }"
-            >
-              <slot name="breadcrumbs"></slot>
-            </KGridItem>
-          </KGrid>
-
           <div v-if="(windowIsMedium && searchActive)">
             <!-- TO DO Marcella swap out new icon after KDS update -->
             <KButton


### PR DESCRIPTION
## Summary
* Adds the ability to show more resources inline in the TopicsPage when they have been cut off
* Adds ability to navigate to a topic subpage to see all loaded resources
* Adds ability to load additional resources within the topic subpage
* Adds ability to load additional topics in the side bar
* Consolidates all folder selection logic in the topics page in the side bar
* Move breadcrumbs above the topic header
* Updates header to h1 (from h3)
* Adds an optional clearable state to KSelect
* Uses this for all KSelects used in categorical search to provide an easy way of deselecting.

## References
Fixes #8571 and some unfiled design updates

## Reviewer guidance
Do the interactions all work? Do the code changes make sense? Are we loading enough items at once?

1. Show more inline:
![showmore](https://user-images.githubusercontent.com/1680573/140236144-4fc8876c-5964-4624-b397-6e3cc8112ece.gif)

2. View all loaded
![viewall](https://user-images.githubusercontent.com/1680573/140236155-dc854284-e73b-4c8e-96aa-36157c629d97.gif)

3. View more within a topic
![viewmore](https://user-images.githubusercontent.com/1680573/140236178-8339fdea-6c5c-4a6d-ad3b-35a5f7bc4e21.gif)

4. View more topics
![viewmoretopics](https://user-images.githubusercontent.com/1680573/140236206-f59ae3ce-46fa-48cd-983a-ea4146645ee1.gif)

5. Clearable dropdown for label selection
![clearabledropdown](https://user-images.githubusercontent.com/1680573/140236236-2cfd61a1-e938-4c52-afa3-02529ce904c9.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
