### PR TITLE
Fix topic filtering for channel quiz creation.

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -77,6 +77,7 @@ export function showChannelQuizCreationTopicPage(store, params) {
       getParams: {
         parent: topicId,
         kind_in: [ContentNodeKinds.TOPIC, ContentNodeKinds.EXERCISE],
+        contains_quiz: true,
       },
     });
     const loadRequirements = [topicNodePromise, childNodesPromise];


### PR DESCRIPTION
## Summary
* Filters topics to only show ones that include channel quizzes in their descendants

## References
Fixes #8550

## Reviewer guidance
Use the Kolibri QA channel and confirm that only the 'Exercises' folder shows when creating a quiz from a channel quiz

![Screenshot from 2021-11-03 18-32-14](https://user-images.githubusercontent.com/1680573/140242364-8d7d0048-f9a9-4203-8288-8715171fb92f.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
