### PR TITLE
Setting right device permissions in the setup wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -36,6 +36,7 @@ export default {
           learner_can_edit_username: null,
           // Set in RequirePasswordForLearnersForm
           learner_can_login_with_no_password: null,
+          learner_can_edit_password: null,
         },
         // Set in SuperuserCredentialsForm
         superuser: {
@@ -162,6 +163,7 @@ export default {
     },
     SET_LEARNER_CAN_LOGIN_WITH_NO_PASSWORD(state, setting) {
       state.onboardingData.settings.learner_can_login_with_no_password = setting;
+      state.onboardingData.settings.learner_can_edit_password = !setting;
     },
     SET_LOADING(state, loadingFlag) {
       state.loading = loadingFlag;


### PR DESCRIPTION
## Summary

When provisioning a  new device, if `learner_can_login_with_no_password` is set as true, the wizard must unset `learner_can_edit_password` (if not, it's defaulted to True in the Django model)

## References
Closes: #8250 

## Reviewer guidance
Run the wizard following the steps described in #8250 . The process should finish correctly, without server errors.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
