### PR TITLE
Update icons

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1050,6 +1050,7 @@ const nonconformingKeys = {
   digitalLiteracy: 'digitialLiteracy',
   BASIC_SKILLS: 'allLevelsBasicSkills',
   FOUNDATIONS: 'basicSkills',
+  toolsAndSoftwareTraining: 'softwareToolsAndTraining',
   FOUNDATIONS_LOGIC_AND_CRITICAL_THINKING: 'logicAndCriticalThinking',
 };
 

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchModalOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchModalOptions.vue
@@ -12,16 +12,15 @@
       :disabled="availablePaths && !availablePaths[nestedObject.value]"
       :style="availablePaths && !availablePaths[nestedObject.value] ?
         { textColor: 'grey' } : { cursor: 'pointer' }"
+      class="category-item"
     >
       <div class="filter-list-title">
-        <!-- TO DO swap out KDS Icons -->
         <KIcon
-          icon="info"
+          :icon="icon(key)"
           size="large"
         />
         <h2 @click="$emit('input', nestedObject.value)">
           {{ coreString(camelCase(key)) }}
-
         </h2>
       </div>
       <div
@@ -54,10 +53,11 @@
       :disabled="availablePaths && !availablePaths[value.value]"
       :style="availablePaths && !availablePaths[value.value] ?
         { color: 'grey' } : { cursor: 'pointer' }"
+      class="category-item"
       @click="$emit('input', value.value)"
     >
       <KIcon
-        icon="info"
+        :icon="icon(key)"
         size="large"
       />
       <h2
@@ -175,6 +175,23 @@
       camelCase(val) {
         return camelCase(val);
       },
+      icon(key) {
+        // 'language' icon is already in use and it doesn't follow the
+        // same naming pattern for category resources, so set separate
+        // case to return the correct icon
+        if (camelCase(key) === 'languageLearning') {
+          return 'language';
+        } else if (
+          camelCase(key) === 'technicalAndVocationalTraining' ||
+          camelCase(key) === 'professionalSkills'
+        ) {
+          // similarly, 'skills' icon is used for both of these resources
+          // and doesn't follow same pattern
+          return 'skillsResource';
+        } else {
+          return `${camelCase(key)}Resource`;
+        }
+      },
     },
   };
 
@@ -186,6 +203,14 @@
   .filter-list-title {
     margin-top: 24px;
     margin-bottom: 8px;
+  }
+
+  .filter-list-item {
+    margin-top: 16px;
+  }
+
+  .category-item {
+    margin-bottom: 32px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
@@ -25,7 +25,7 @@
         :disabled="availableActivities && !availableActivities[value]"
         @click="$emit('input', value)"
       >
-        <KIcon :icon="`${camelCase(activity) + 'Shaded'}`" class="activity-icon" />
+        <KIcon :icon="activityIcon(activity)" class="activity-icon" />
         <p class="activity-button-text">
           {{ coreString(camelCase(activity)) }}
         </p>
@@ -106,6 +106,13 @@
     methods: {
       camelCase(id) {
         return camelCase(id);
+      },
+      activityIcon(activity) {
+        if (activity == 'EXPLORE') {
+          return 'interactShaded';
+        } else {
+          return `${camelCase(activity) + 'Shaded'}`;
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -64,21 +64,12 @@
         />
         <KIconButton
           v-if="isLeaf"
-          icon="infoPrimary"
+          icon="infoOutline"
           size="mini"
-          :color="$themePalette.grey.v_400"
+          :color="$themePalette.grey.v_600"
           :ariaLabel="coreString('viewInformation')"
           :tooltip="coreString('viewInformation')"
           @click="$emit('toggleInfoPanel')"
-        />
-        <KIconButton
-          icon="optionsVertical"
-          class="info-icon"
-          size="mini"
-          :color="$themePalette.grey.v_400"
-          :ariaLabel="coreString('moreOptions')"
-          :tooltip="coreString('moreOptions')"
-          @click="$emit('toggleOptions')"
         />
         <KButton
           v-if="copiesCount > 1"

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -30,7 +30,7 @@
     >
       <!-- todo update icon -->
       <KIcon
-        icon="channel"
+        icon="library"
         style="top: 0; width: 24px; height: 24px;"
         :color="$themeTokens.textInverted"
       />

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -8,7 +8,7 @@
       <div v-if="!windowIsLarge">
         <!-- TO DO Marcella swap out new icon after KDS update -->
         <KButton
-          icon="channel"
+          icon="filter"
           :text="coreString('searchLabel')"
           :primary="false"
           @click="toggleSidePanelVisibility"

--- a/kolibri/plugins/learn/assets/src/views/SearchChips.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchChips.vue
@@ -5,7 +5,7 @@
       <span>
         <p class="filter-chip-text">{{ item.text }}</p>
         <KIconButton
-          icon="close"
+          icon="delete"
           size="mini"
           class="filter-chip-button"
           @click="$emit('removeItem', item)"
@@ -119,14 +119,10 @@
   }
 
   .filter-chip-button {
-    padding-top: 4px;
+    min-width: 24px !important;
     margin: 2px;
     color: #dadada;
     vertical-align: middle;
-    /deep/ svg {
-      width: 20px;
-      height: 20px;
-    }
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -127,7 +127,7 @@
           <div v-if="(windowIsMedium && searchActive)">
             <!-- TO DO Marcella swap out new icon after KDS update -->
             <KButton
-              icon="channel"
+              icon="filter"
               class="filter-overlay-toggle-button"
               :text="coreString('searchLabel')"
               :primary="false"


### PR DESCRIPTION
## Summary

Fixes #8560 by adding the new KDS icons that were missing and noted in https://github.com/learningequality/kolibri-design-system/issues/260

- filter
- library
- swap delete
- explore icon
- category icons
- info outline (and darkens value of grey per conversation with @radinamatic)


## Reviewer guidance
Some naming changes were made to our icons for consistency. Some category icons depend on [open KDS PR](https://github.com/learningequality/kolibri-design-system/pull/275) for constant/string consistency


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
