### PR TITLE
Add version truncation utility to avoid QA headaches

### DIFF
--- a/kolibri/core/auth/sync_operations.py
+++ b/kolibri/core/auth/sync_operations.py
@@ -11,6 +11,7 @@ from .sync_event_hook_utils import other_side_using_single_user_cert
 from .sync_event_hook_utils import this_side_using_single_user_cert
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.upgrade import matches_version
+from kolibri.utils.version import truncate_version
 
 
 logger = logging.getLogger(__name__)
@@ -170,7 +171,7 @@ class KolibriVersionedSyncOperation(KolibriSyncOperationMixin, LocalOperation):
 
         # pre-0.15.0 won't have the kolibri version
         if remote_version is None or matches_version(
-            remote_version, self.version_threshold
+            truncate_version(remote_version), self.version_threshold
         ):
             if context.is_receiver:
                 self.upgrade(context)

--- a/kolibri/core/notifications/kolibri_plugin.py
+++ b/kolibri/core/notifications/kolibri_plugin.py
@@ -11,6 +11,7 @@ from kolibri.core.notifications.api import batch_process_masterylogs_for_quizzes
 from kolibri.core.notifications.api import batch_process_summarylogs
 from kolibri.core.upgrade import matches_version
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils.version import truncate_version
 
 
 @register_hook
@@ -41,7 +42,9 @@ class NotificationsSyncHook(FacilityDataSyncHook):
             # exam logs are deprecated beyond 0.15.0, but process them if syncing with version
             # pre-0.15.0
             remote_version = get_other_side_kolibri_version(context)
-            if remote_version is None or matches_version(remote_version, "<0.15.0"):
+            if remote_version is None or matches_version(
+                truncate_version(remote_version), "<0.15.0"
+            ):
                 batch_process_examlogs(
                     context.transfer_session.get_touched_record_ids_for_model(ExamLog),
                     context.transfer_session.get_touched_record_ids_for_model(

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -403,3 +403,30 @@ class TestKolibriVersion(unittest.TestCase):
             ).base_version
             == "0.2.3"
         )
+
+    def test_truncate_version(self):
+        self.assertEqual(
+            "0.15.0a5.dev0+git.682.g0be46de2",
+            version.truncate_version(
+                "0.15.0a5.dev0+git.682.g0be46de2",
+                truncation_level=version.BUILD_VERSION,
+            ),
+        )
+        self.assertEqual(
+            "0.15.0a5",
+            version.truncate_version(
+                "0.15.0a5.dev0+git.682.g0be46de2",
+                truncation_level=version.PRERELEASE_VERSION,
+            ),
+        )
+        self.assertEqual(
+            "0.15.0", version.truncate_version("0.15.0a5.dev0+git.682.g0be46de2")
+        )
+        self.assertEqual(
+            "0.15.0",
+            version.truncate_version("0.15.1", truncation_level=version.MINOR_VERSION),
+        )
+        self.assertEqual(
+            "1.0.0",
+            version.truncate_version("1.15.1", truncation_level=version.MAJOR_VERSION),
+        )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds `truncate_version` util
- Updates 0.15 syncing version comparisons to truncate other instance's version such that pre-releases don't satisfy the condition like they do now

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
- Fixes notification generation syncing between 2 pre-release instances

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
