### PR TITLE
Always pass through facility during syncing cert authentication

### DIFF
--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -6,7 +6,7 @@ from django.core.management.base import CommandError
 from morango.models import ScopeDefinition
 
 from ..utils import get_client_and_server_certs
-from ..utils import get_dataset_id
+from ..utils import get_facility_dataset_id
 from kolibri.core.auth.constants.morango_sync import DATA_PORTAL_SYNCING_BASE_URL
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.management.utils import get_facility
@@ -101,7 +101,7 @@ class Command(MorangoSyncCommand):
             if not re.match("[a-f0-9]{32}", user_id):
                 raise CommandError("User ID must be a 32-character UUID (no dashes)")
 
-            dataset_id = get_dataset_id(
+            facility_id, dataset_id = get_facility_dataset_id(
                 baseurl, identifier=facility_id, noninteractive=True
             )
 
@@ -160,7 +160,7 @@ class Command(MorangoSyncCommand):
             )
 
         else:  # do P2P setup
-            dataset_id = get_dataset_id(
+            facility_id, dataset_id = get_facility_dataset_id(
                 baseurl, identifier=facility_id, noninteractive=noninteractive
             )
 

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -85,7 +85,7 @@ def _interactive_server_facility_selection(facilities):
         message += "{}. {}\n".format(idx + 1, f["name"])
     idx = input(message)
     try:
-        return facilities[int(idx) - 1]["dataset"]
+        return facilities[int(idx) - 1]
     except IndexError:
         raise CommandError(
             (
@@ -130,7 +130,7 @@ def get_facility(facility_id=None, noninteractive=False):
     return facility
 
 
-def get_dataset_id(baseurl, identifier=None, noninteractive=False):
+def get_facility_dataset_id(baseurl, identifier=None, noninteractive=False):
     # get list of facilities and if more than 1, display all choices to user
     facility_url = urljoin(baseurl, reverse("kolibri:core:publicfacility-list"))
     response = requests.get(facility_url)
@@ -142,7 +142,7 @@ def get_dataset_id(baseurl, identifier=None, noninteractive=False):
     if identifier:
         for obj in facilities:
             if identifier == obj["dataset"] or identifier == obj.get("id"):
-                return obj["dataset"]
+                return identifier, obj["dataset"]
         raise CommandError(
             "Facility with ID {} does not exist on server".format(identifier)
         )
@@ -154,12 +154,13 @@ def get_dataset_id(baseurl, identifier=None, noninteractive=False):
                 "Please pass in a facility ID by passing in --facility {ID} after the command."
             )
         )
-    else:
-        return (
-            _interactive_server_facility_selection(facilities)
-            if len(facilities) > 1
-            else facilities[0]["dataset"]
-        )
+
+    facility = (
+        _interactive_server_facility_selection(facilities)
+        if len(facilities) > 1
+        else facilities[0]
+    )
+    return facility["id"], facility["dataset"]
 
 
 def is_portal_sync(baseurl):
@@ -274,7 +275,7 @@ def get_client_and_server_certs(
                 password = getpass.getpass("Please enter password: ")
 
         userargs = username
-        if user_id:
+        if facility_id:
             # add facility so `FacilityUserBackend` can validate
             userargs = {
                 FacilityUser.USERNAME_FIELD: username,

--- a/kolibri/core/device/test/test_syncqueue.py
+++ b/kolibri/core/device/test/test_syncqueue.py
@@ -99,10 +99,10 @@ class TestRequestSoUDSync(TestCase):
     @mock.patch("kolibri.core.public.utils.requests")
     @mock.patch("kolibri.core.tasks.api.MorangoProfileController")
     @mock.patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @mock.patch("kolibri.core.tasks.api.get_dataset_id")
+    @mock.patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_request_soud_sync(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         MorangoProfileController,
         requests_mock,
@@ -110,7 +110,10 @@ class TestRequestSoUDSync(TestCase):
     ):
 
         get_client_and_server_certs.return_value = None
-        get_dataset_id.return_value = self.facility.dataset_id
+        get_facility_dataset_id.return_value = (
+            self.facility.id,
+            self.facility.dataset_id,
+        )
 
         requests_mock.post.return_value.status_code = 200
         requests_mock.post.return_value.json.return_value = {"action": SYNC}
@@ -135,10 +138,10 @@ class TestRequestSoUDSync(TestCase):
     @mock.patch("kolibri.core.public.utils.requests")
     @mock.patch("kolibri.core.tasks.api.MorangoProfileController")
     @mock.patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @mock.patch("kolibri.core.tasks.api.get_dataset_id")
+    @mock.patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_request_soud_sync_server_error(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         MorangoProfileController,
         requests_mock,
@@ -146,7 +149,10 @@ class TestRequestSoUDSync(TestCase):
     ):
 
         get_client_and_server_certs.return_value = None
-        get_dataset_id.return_value = self.facility.dataset_id
+        get_facility_dataset_id.return_value = (
+            self.facility.id,
+            self.facility.dataset_id,
+        )
 
         requests_mock.post.return_value.status_code = 500
 
@@ -162,10 +168,10 @@ class TestRequestSoUDSync(TestCase):
     @mock.patch("kolibri.core.public.utils.requests")
     @mock.patch("kolibri.core.tasks.api.MorangoProfileController")
     @mock.patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @mock.patch("kolibri.core.tasks.api.get_dataset_id")
+    @mock.patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_request_soud_sync_connection_error(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         MorangoProfileController,
         requests_mock,
@@ -173,7 +179,10 @@ class TestRequestSoUDSync(TestCase):
     ):
 
         get_client_and_server_certs.return_value = None
-        get_dataset_id.return_value = self.facility.dataset_id
+        get_facility_dataset_id.return_value = (
+            self.facility.id,
+            self.facility.dataset_id,
+        )
 
         requests_mock.post.side_effect = ConnectionError
 

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -36,7 +36,7 @@ from .permissions import FacilitySyncPermissions
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import State as FacilitySyncState
 from kolibri.core.auth.management.utils import get_client_and_server_certs
-from kolibri.core.auth.management.utils import get_dataset_id
+from kolibri.core.auth.management.utils import get_facility_dataset_id
 from kolibri.core.auth.models import Facility
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.permissions import CanExportLogs
@@ -1233,7 +1233,7 @@ def validate_and_create_sync_credentials(
     # try to get the certificate, which will save it if successful
     try:
         # make sure we get the dataset ID
-        dataset_id = get_dataset_id(
+        facility_id, dataset_id = get_facility_dataset_id(
             baseurl, identifier=facility_id, noninteractive=True
         )
 

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -955,10 +955,10 @@ class FacilityTaskHelperTestCase(TestCase):
     @patch("kolibri.core.tasks.api.MorangoProfileController")
     @patch("kolibri.core.tasks.api.NetworkClient")
     @patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @patch("kolibri.core.tasks.api.get_dataset_id")
+    @patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_validate_peer_sync_job(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         NetworkClient,
         MorangoProfileController,
@@ -981,7 +981,7 @@ class FacilityTaskHelperTestCase(TestCase):
         controller = MorangoProfileController.return_value
         controller.create_network_connection.return_value = network_connection
 
-        get_dataset_id.return_value = dataset_id
+        get_facility_dataset_id.return_value = (123, dataset_id)
         get_client_and_server_certs.return_value = None
 
         expected = dict(
@@ -1005,7 +1005,7 @@ class FacilityTaskHelperTestCase(TestCase):
             "https://some.server.test/"
         )
 
-        get_dataset_id.assert_called_with(
+        get_facility_dataset_id.assert_called_with(
             "https://some.server.test/", identifier=123, noninteractive=True
         )
 
@@ -1046,9 +1046,9 @@ class FacilityTaskHelperTestCase(TestCase):
 
     @patch("kolibri.core.tasks.api.MorangoProfileController")
     @patch("kolibri.core.tasks.api.NetworkClient")
-    @patch("kolibri.core.tasks.api.get_dataset_id")
+    @patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_validate_and_create_sync_credentials__unknown_facility(
-        self, get_dataset_id, NetworkClient, MorangoProfileController
+        self, get_facility_dataset_id, NetworkClient, MorangoProfileController
     ):
         req = Mock(
             spec=Request,
@@ -1067,7 +1067,7 @@ class FacilityTaskHelperTestCase(TestCase):
         controller = MorangoProfileController.return_value
         controller.create_network_connection.return_value = network_connection
 
-        get_dataset_id.side_effect = CommandError()
+        get_facility_dataset_id.side_effect = CommandError()
 
         with self.assertRaises(AuthenticationFailed):
             validate_and_create_sync_credentials(*validate_peer_sync_job(req))
@@ -1075,10 +1075,10 @@ class FacilityTaskHelperTestCase(TestCase):
     @patch("kolibri.core.tasks.api.MorangoProfileController")
     @patch("kolibri.core.tasks.api.NetworkClient")
     @patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @patch("kolibri.core.tasks.api.get_dataset_id")
+    @patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_validate_and_create_sync_credentials__not_authenticated(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         NetworkClient,
         MorangoProfileController,
@@ -1095,7 +1095,7 @@ class FacilityTaskHelperTestCase(TestCase):
         controller = MorangoProfileController.return_value
         controller.create_network_connection.return_value = network_connection
 
-        get_dataset_id.return_value = 456
+        get_facility_dataset_id.return_value = (123, 456)
         get_client_and_server_certs.side_effect = CommandError()
 
         with self.assertRaises(PermissionDenied):
@@ -1104,10 +1104,10 @@ class FacilityTaskHelperTestCase(TestCase):
     @patch("kolibri.core.tasks.api.MorangoProfileController")
     @patch("kolibri.core.tasks.api.NetworkClient")
     @patch("kolibri.core.tasks.api.get_client_and_server_certs")
-    @patch("kolibri.core.tasks.api.get_dataset_id")
+    @patch("kolibri.core.tasks.api.get_facility_dataset_id")
     def test_validate_and_create_sync_credentials__authentication_failed(
         self,
-        get_dataset_id,
+        get_facility_dataset_id,
         get_client_and_server_certs,
         NetworkClient,
         MorangoProfileController,
@@ -1129,7 +1129,7 @@ class FacilityTaskHelperTestCase(TestCase):
         controller = MorangoProfileController.return_value
         controller.create_network_connection.return_value = network_connection
 
-        get_dataset_id.return_value = 456
+        get_facility_dataset_id.return_value = (123, 456)
         get_client_and_server_certs.side_effect = CommandError()
 
         with self.assertRaises(AuthenticationFailed):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes issue with full-facility sync authentication for users of same username in multiple facilities

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
[Slack](https://learningequality.slack.com/archives/CB37UM23A/p1636067722086400)
Resolves https://github.com/learningequality/kolibri/issues/7541

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
