### PR TITLE
Fixes issue where perseus files were not reloading when the source file changed.

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -408,7 +408,7 @@
       loadPerseusFile() {
         if (this.defaultFile && this.defaultFile.storage_url) {
           this.loading = true;
-          if (!this.perseusFile) {
+          if (!this.perseusFile || this.perseusFileUrl !== this.defaultFile.storage_url) {
             return client({
               method: 'get',
               url: this.defaultFile.storage_url,
@@ -420,6 +420,7 @@
               })
               .then(perseusFile => {
                 this.perseusFile = perseusFile;
+                this.perseusFileUrl = this.defaultFile.storage_url;
               });
           } else {
             return Promise.resolve();


### PR DESCRIPTION
## Summary
* In the switch of loading strategy for perseus, additional reactivity was needed to load the new perseus file when the default file changed
* This had not been previously added, but had gone unnoticed because it did not affect exercises
* In quizzes, where multiple exercises are used together, this was more obvious

## References
Fixes #8600  

## Reviewer guidance

Coach Quiz Preview now functioning:
![quizpreview](https://user-images.githubusercontent.com/1680573/140530021-1a8bc4a5-622c-446e-b412-0733d3fe99d9.gif)

Learner Quiz taking now functioning:
![quiztake](https://user-images.githubusercontent.com/1680573/140530063-fb9dcaec-b335-4cb1-9310-4085e00f3786.gif)



----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
