### PR TITLE
Listing of practice quiz difficult questions

### DIFF
--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.db import connections
 from django.db.models import Count
+from django.db.models import F
 from django.db.models import OuterRef
 from django.db.models import Subquery
 from django.db.models import Sum
@@ -456,8 +457,12 @@ class PracticeQuizDifficultQuestionsViewset(BaseExerciseDifficultQuestionsViewse
         masterylog_queryset = masterylog_queryset.filter(
             id__in=Subquery(
                 MasteryLog.objects.all()
-                .order_by("-completion_timestamp")
-                .filter(user_id=OuterRef("user_id"), summarylog__content_id=pk)
+                .order_by(F("completion_timestamp").desc(nulls_last=True))
+                .filter(
+                    user_id=OuterRef("user_id"),
+                    summarylog__content_id=pk,
+                    complete=True,
+                )
                 .values_list("id")[:1]
             )
         )

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -2,6 +2,8 @@ import datetime
 
 from django.db import connections
 from django.db.models import Count
+from django.db.models import OuterRef
+from django.db.models import Subquery
 from django.db.models import Sum
 from django.db.utils import DatabaseError
 from django.db.utils import OperationalError
@@ -405,6 +407,72 @@ class QuizDifficultQuestionsViewset(viewsets.ViewSet):
             .distinct()
             .count()
         )
+        for datum in data:
+            datum["total"] = total
+        return Response(data)
+
+
+class PracticeQuizDifficultQuestionsViewset(BaseExerciseDifficultQuestionsViewset):
+    permission_classes = (permissions.IsAuthenticated, ExerciseDifficultiesPermissions)
+
+    def retrieve(self, request, pk):
+        """
+        Get the difficult questions for a particular practice quiz.
+        pk maps to the content_id of the practice quiz in question.
+        """
+        classroom_id = request.GET.get("classroom_id", None)
+        group_id = request.GET.get("group_id", None)
+        lesson_id = request.GET.get("lesson_id", None)
+        # For practice quizzes we only look at complete MasteryLogs because there practice quiz
+        # itself can never be made inactive, unlike for a coach assigned quiz (see above)
+        masterylog_queryset = MasteryLog.objects.filter(
+            summarylog__content_id=pk, complete=True
+        )
+        attemptlog_queryset = AttemptLog.objects.all()
+        if lesson_id is not None:
+            collection_ids = Lesson.objects.get(
+                id=lesson_id
+            ).lesson_assignments.values_list("collection_id", flat=True)
+            if group_id is not None:
+                if (
+                    group_id not in collection_ids
+                    and classroom_id not in collection_ids
+                ):
+                    # In the special case that the group is not in the lesson assignments
+                    # nor the containing classroom, just return an empty queryset.
+                    attemptlog_queryset = AttemptLog.objects.none()
+            else:
+                # Only filter by all the collections in the lesson if we are not also
+                # filtering by a specific group. Otherwise the group should be sufficient.
+                masterylog_queryset = masterylog_queryset.filter(
+                    user__memberships__collection_id__in=collection_ids
+                )
+        if group_id is not None:
+            collection_id = group_id or classroom_id
+            masterylog_queryset = masterylog_queryset.filter(
+                user__memberships__collection_id=collection_id
+            )
+
+        masterylog_queryset = masterylog_queryset.filter(
+            id__in=Subquery(
+                MasteryLog.objects.all()
+                .order_by("-completion_timestamp")
+                .filter(user_id=OuterRef("user_id"), summarylog__content_id=pk)
+                .values_list("id")[:1]
+            )
+        )
+
+        masterylog_queryset = masterylog_queryset.values_list("id", flat=True)
+
+        attemptlog_queryset = attemptlog_queryset.filter(
+            masterylog_id__in=masterylog_queryset
+        )
+
+        data = attemptlog_queryset.values("item").annotate(correct=Sum("correct"))
+
+        # Instead of inferring the totals from the number of attempt logs, use the total
+        # number of people who have a completed try on the practice quiz
+        total = masterylog_queryset.count()
         for datum in data:
             datum["total"] = total
         return Response(data)

--- a/kolibri/plugins/coach/api.py
+++ b/kolibri/plugins/coach/api.py
@@ -472,7 +472,7 @@ class PracticeQuizDifficultQuestionsViewset(BaseExerciseDifficultQuestionsViewse
 
         # Instead of inferring the totals from the number of attempt logs, use the total
         # number of people who have a completed try on the practice quiz
-        total = masterylog_queryset.count()
+        total = masterylog_queryset.distinct().count()
         for datum in data:
             datum["total"] = total
         return Response(data)

--- a/kolibri/plugins/coach/api_urls.py
+++ b/kolibri/plugins/coach/api_urls.py
@@ -5,6 +5,7 @@ from rest_framework import routers
 from .api import ClassroomNotificationsViewset
 from .api import ExerciseDifficultQuestionsViewset
 from .api import LessonReportViewset
+from .api import PracticeQuizDifficultQuestionsViewset
 from .api import QuizDifficultQuestionsViewset
 from .class_summary_api import ClassSummaryViewSet
 
@@ -22,6 +23,11 @@ router.register(
 )
 router.register(
     r"quizdifficulties", QuizDifficultQuestionsViewset, base_name="quizdifficulties"
+)
+router.register(
+    r"practicequizdifficulties",
+    PracticeQuizDifficultQuestionsViewset,
+    base_name="practicequizdifficulties",
 )
 
 urlpatterns = [url(r"^", include(router.urls))]

--- a/kolibri/plugins/coach/assets/src/apiResources/practiceQuizDifficulties.js
+++ b/kolibri/plugins/coach/assets/src/apiResources/practiceQuizDifficulties.js
@@ -1,0 +1,6 @@
+import { Resource } from 'kolibri.lib.apiResource';
+
+export default new Resource({
+  name: 'practicequizdifficulties',
+  namespace: 'kolibri.plugins.coach',
+});

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -1069,6 +1069,28 @@ class PracticeQuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(response.data[0]["total"], 2)
         self.assertEqual(response.data[0]["correct"], 1)
 
+    def test_coach_difficult_by_classroom_id_after_repeated_tries_last_completion_timestamp_but_not_complete(
+        self,
+    ):
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner, difficult=False)
+        self.masterylog.complete = False
+        self.masterylog.save()
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
     def test_coach_one_difficult_by_lesson_id(self):
         self._set_one_difficult(self.classroom_group_learner)
         self.client.login(

--- a/kolibri/plugins/coach/test/test_difficult_questions.py
+++ b/kolibri/plugins/coach/test/test_difficult_questions.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+from datetime import timedelta
 
 from django.core.urlresolvers import reverse
 from django.utils.timezone import now
@@ -768,3 +769,524 @@ class QuizDifficultQuestionTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["total"], 1)
         self.assertEqual(response.data[0]["correct"], 0)
+
+
+class PracticeQuizDifficultQuestionTestCase(APITestCase):
+    def setUp(self):
+        provision_device()
+        self.facility = Facility.objects.create(name="My Facility")
+        self.classroom = Classroom.objects.create(
+            name="My Classroom", parent=self.facility
+        )
+        self.group = LearnerGroup.objects.create(name="My Group", parent=self.classroom)
+
+        self.facility_and_classroom_coach = helpers.create_coach(
+            username="facility_and_classroom_coach",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            is_facility_coach=True,
+        )
+        self.learner = helpers.create_learner(
+            username="learner", password=DUMMY_PASSWORD, facility=self.facility
+        )
+        self.classroom_group_learner = helpers.create_learner(
+            username="classroom_group_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            learner_group=self.group,
+        )
+
+        # Need ContentNodes
+        self.channel_id = "15f32edcec565396a1840c5413c92450"
+        self.lesson_id = "15f32edcec565396a1840c5413c92452"
+
+        self.content_ids = [
+            "15f32edcec565396a1840c5413c92451",
+            "15f32edcec565396a1840c5413c92452",
+            "15f32edcec565396a1840c5413c92453",
+        ]
+        self.contentnode_ids = [
+            "25f32edcec565396a1840c5413c92451",
+            "25f32edcec565396a1840c5413c92452",
+            "25f32edcec565396a1840c5413c92453",
+        ]
+        self.node_1 = ContentNode.objects.create(
+            title="Node 1",
+            available=True,
+            id=self.contentnode_ids[0],
+            content_id=self.content_ids[0],
+            channel_id=self.channel_id,
+        )
+        self.lesson = Lesson.objects.create(
+            id=self.lesson_id,
+            title="My Lesson",
+            created_by=self.facility_and_classroom_coach,
+            collection=self.classroom,
+            resources=json.dumps(
+                [
+                    {
+                        "contentnode_id": self.node_1.id,
+                        "content_id": self.node_1.content_id,
+                        "channel_id": self.channel_id,
+                    }
+                ]
+            ),
+        )
+        self.assignment_1 = LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.facility_and_classroom_coach,
+            collection=self.classroom,
+        )
+        self.exercise_difficulties_basename = (
+            "kolibri:kolibri.plugins.coach:practicequizdifficulties"
+        )
+
+    def test_learner_cannot_access_by_classroom_id(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_by_lesson_id(self):
+        self.client.login(username=self.learner.username, password=DUMMY_PASSWORD)
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_learner_cannot_access_by_group_id(self):
+        self.client.login(username="learner", password=DUMMY_PASSWORD)
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"group_id": self.group.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_coach_classroom_id_required(self):
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            )
+        )
+        self.assertEqual(response.status_code, 412)
+
+    def test_coach_no_progress_by_classroom_id(self):
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_no_progress_by_lesson_id(self):
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_no_progress_by_group_id(self):
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"group_id": self.group.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 0)
+
+    def _set_one_difficult(self, user, complete=True, difficult=True):
+        # Ensure that even in Windows subsequent calls to
+        # this function make tries that are after one
+        # another.
+        if not hasattr(self, "now"):
+            self.now = now()
+        else:
+            self.now = self.now + timedelta(minutes=1)
+
+        self.sessionlog = ContentSessionLog.objects.create(
+            user=user,
+            content_id=self.content_ids[0],
+            channel_id=self.node_1.channel_id,
+            kind="exercise",
+            progress=0.1,
+            start_timestamp=self.now,
+        )
+        if not hasattr(self, "summarylog"):
+            self.summarylog = ContentSummaryLog.objects.create(
+                user=user,
+                content_id=self.content_ids[0],
+                channel_id=self.node_1.channel_id,
+                kind="exercise",
+                progress=0.1,
+                start_timestamp=self.now,
+            )
+
+        if not hasattr(self, "masterylog"):
+            mastery_level = 1
+        else:
+            mastery_level = self.masterylog.mastery_level + 1
+
+        self.masterylog = MasteryLog.objects.create(
+            user=user,
+            summarylog=self.summarylog,
+            start_timestamp=self.now,
+            end_timestamp=self.now,
+            completion_timestamp=self.now if complete else None,
+            mastery_level=mastery_level,
+            complete=complete,
+        )
+
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=self.now,
+            end_timestamp=self.now,
+            complete=True,
+            correct=0 if difficult else 1,
+            user=user,
+            item="test",
+        )
+
+    def test_coach_one_difficult_by_classroom_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_one_difficult_by_classroom_id_repeated_tries(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner, complete=False)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_no_difficult_by_classroom_id_after_repeated_tries(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner, difficult=False)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 1)
+        helpers.create_learner(
+            username="classroom_group_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            learner_group=self.group,
+        )
+
+    def test_coach_multiple_learners_one_difficult_by_classroom_id_after_repeated_tries(
+        self,
+    ):
+        other_learner = helpers.create_learner(
+            username="classroom_group_learner",
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+            classroom=self.classroom,
+            learner_group=self.group,
+        )
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner)
+        self._set_one_difficult(self.classroom_group_learner, difficult=False)
+        self._set_one_difficult(other_learner, difficult=False)
+        self._set_one_difficult(other_learner, complete=False)
+        self._set_one_difficult(other_learner)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 2)
+        self.assertEqual(response.data[0]["correct"], 1)
+
+    def test_coach_one_difficult_by_lesson_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_one_difficult_by_lesson_id_repeated_assignment(self):
+        LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.facility_and_classroom_coach,
+            collection=self.group,
+        )
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_one_difficult_by_group_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"group_id": self.group.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_two_difficult_by_lesson_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=now(),
+            end_timestamp=now(),
+            complete=True,
+            correct=0,
+            user=self.classroom_group_learner,
+            item="nottest",
+        )
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+        self.assertEqual(response.data[1]["total"], 1)
+        self.assertEqual(response.data[1]["correct"], 0)
+
+    def test_coach_one_difficult_one_not_by_lesson_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=now(),
+            end_timestamp=now(),
+            complete=True,
+            correct=1,
+            user=self.classroom_group_learner,
+            item="nottest",
+        )
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(
+            any(map(lambda x: x["total"] == 1 and x["correct"] == 0, response.data))
+        )
+        self.assertTrue(
+            any(map(lambda x: x["total"] == 1 and x["correct"] == 1, response.data))
+        )
+
+    def test_coach_difficult_no_assigned_by_lesson_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=now(),
+            end_timestamp=now(),
+            complete=True,
+            correct=1,
+            user=self.classroom_group_learner,
+            item="nottest",
+        )
+        LessonAssignment.objects.all().delete()
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"lesson_id": self.lesson.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 0)
+
+    def test_coach_difficult_no_assigned_by_group_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        AttemptLog.objects.create(
+            masterylog=self.masterylog,
+            sessionlog=self.sessionlog,
+            start_timestamp=now(),
+            end_timestamp=now(),
+            complete=True,
+            correct=1,
+            user=self.classroom_group_learner,
+            item="nottest",
+        )
+        LessonAssignment.objects.all().delete()
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={"group_id": self.group.id, "classroom_id": self.classroom.id},
+        )
+        self.assertEqual(len(response.data), 2)
+        self.assertTrue(
+            any(map(lambda x: x["total"] == 1 and x["correct"] == 0, response.data))
+        )
+        self.assertTrue(
+            any(map(lambda x: x["total"] == 1 and x["correct"] == 1, response.data))
+        )
+
+    def test_coach_difficult_both_assigned_by_lesson_id_group_id(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        learner2 = FacilityUser.objects.create(
+            username="learner2", facility=self.facility
+        )
+        self.classroom.add_member(learner2)
+        self._set_one_difficult(learner2)
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={
+                "lesson_id": self.lesson.id,
+                "group_id": self.group.id,
+                "classroom_id": self.classroom.id,
+            },
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["total"], 1)
+        self.assertEqual(response.data[0]["correct"], 0)
+
+    def test_coach_difficult_group_id_not_in_lesson(self):
+        self._set_one_difficult(self.classroom_group_learner)
+        learner2 = FacilityUser.objects.create(
+            username="learner2", facility=self.facility
+        )
+        self.classroom.add_member(learner2)
+        self._set_one_difficult(learner2)
+        self.group.remove_member(self.classroom_group_learner)
+        self.assignment_1.delete()
+        LessonAssignment.objects.create(
+            lesson=self.lesson,
+            assigned_by=self.facility_and_classroom_coach,
+            collection=self.group,
+        )
+        self.client.login(
+            username=self.facility_and_classroom_coach.username, password=DUMMY_PASSWORD
+        )
+        response = self.client.get(
+            reverse(
+                self.exercise_difficulties_basename + "-detail",
+                kwargs={"pk": self.content_ids[0]},
+            ),
+            data={
+                "lesson_id": self.lesson.id,
+                "group_id": self.group.id,
+                "classroom_id": self.classroom.id,
+            },
+        )
+        self.assertEqual(len(response.data), 0)


### PR DESCRIPTION
## Summary
* Adds an endpoint for providing listings of question correctness for practice quizzes
* Adds testing to ensure only the most recent completed tries of a quiz are used to calculate results
* Adds initial integration inside the `questionList` module with a 'practiceQuiz' boolean flag to disambiguate an exercise from a practice quiz.

## References
Necessary precursor to #8554 but does not implement the fix detailed therein.

## Reviewer guidance
Does the API endpoint provide the required unique functionality for returning a list of all the questions that have been answered in completed tries, and return a summary of their correct responses and total responses?

Does the integration into the existing questionList module make sense? Should we use something other than a boolean flag to indicate the practiceQuiz?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
