### PR TITLE
Refactors hybrid learning cards to use content object, not passed props

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -14,7 +14,6 @@
       :currentPage="currentPage"
       :genContentLink="genContentLink"
       :cardViewStyle="windowIsSmall ? 'card' : 'list'"
-      numCols="1"
       :footerIcons="footerIcons"
       @removeFromBookmarks="removeFromBookmarks"
     />

--- a/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentCard/index.vue
@@ -11,7 +11,8 @@
   >
     <CardThumbnail
       class="thumbnail"
-      v-bind="{ thumbnail, progress, kind, isMobile, showContentIcon }"
+      :kind="content.kind"
+      v-bind="{ thumbnail, progress, isMobile, showContentIcon }"
     />
     <div class="text" :style="{ color: $themeTokens.text }">
       <h3 class="title" dir="auto">
@@ -52,7 +53,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import { validateLinkObject } from 'kolibri.utils.validators';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import CardThumbnail from './CardThumbnail';
@@ -72,11 +73,6 @@
       thumbnail: {
         type: String,
         default: null,
-      },
-      kind: {
-        type: String,
-        required: true,
-        validator: validateContentNodeKind,
       },
       isLeaf: {
         type: Boolean,

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -2,7 +2,7 @@
 
   <div class="content-grid">
     <KFixedGrid
-      v-if="(cardViewStyle === 'card' && numCols)"
+      v-if="(cardViewStyle === 'card' && !!numCols)"
       :numCols="numCols"
       gutter="24"
     >
@@ -10,19 +10,10 @@
         <HybridLearningContentCard
           class="card-grid-item"
           :isMobile="windowIsSmall"
-          :contentNode="content"
-          :title="content.title"
+          :content="content"
           :thumbnail="content.thumbnail"
           :kind="content.kind"
-          :activityLength="content.duration"
-          :isLeaf="content.is_leaf"
-          :numCoachContents="content.num_coach_contents"
           :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
-          :contentId="content.content_id"
-          :copiesCount="content.copies_count"
-          :description="content.description"
-          :channelThumbnail="content.channel_thumbnail"
-          :channelTitle="content.channel_title"
           @openCopiesModal="openCopiesModal"
           @toggleInfoPanel="$emit('toggleInfoPanel', content)"
         />
@@ -32,18 +23,11 @@
       <HybridLearningLessonCard
         v-for="content in contents"
         :key="content.id"
-        :contentNode="content"
-        :channelThumbnail="content.channel_thumbnail"
-        :channelTitle="content.channel_title"
-        :description="content.description"
-        :activityLength="content.duration"
+        :content="content"
+        :kind="content.kind"
         :thumbnail="content.thumbnail || getContentNodeThumbnail(content)"
         class="card-grid-item"
         :isMobile="windowIsSmall"
-        :title="content.title"
-        :kind="content.kind"
-        :isLeaf="content.is_leaf"
-        :numCoachContents="content.num_coach_contents"
         :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
       />
     </div>
@@ -63,22 +47,13 @@
       v-for="content in contents"
       v-else
       :key="content.id"
-      :contentNode="content"
-      :channelThumbnail="content.channel_thumbnail"
-      :channelTitle="content.channel_title"
-      :description="content.description"
-      :activityLength="content.duration"
+      :content="content"
+      :kind="content.kind"
+      :thumbnail="content.thumbnail"
       :currentPage="currentPage"
       class="card-grid-item"
       :isMobile="windowIsSmall"
-      :title="content.title"
-      :thumbnail="content.thumbnail"
-      :kind="content.kind"
-      :isLeaf="content.is_leaf"
-      :numCoachContents="content.num_coach_contents"
       :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
-      :contentId="content.content_id"
-      :copiesCount="content.copies_count"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
@@ -140,7 +115,8 @@
       },
       numCols: {
         type: Number,
-        required: true,
+        required: false,
+        default: null,
       },
       getContentNodeThumbnail: {
         type: Function,

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -12,7 +12,6 @@
           :isMobile="windowIsSmall"
           :content="content"
           :thumbnail="content.thumbnail"
-          :kind="content.kind"
           :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
           @openCopiesModal="openCopiesModal"
           @toggleInfoPanel="$emit('toggleInfoPanel', content)"
@@ -24,7 +23,6 @@
         v-for="content in contents"
         :key="content.id"
         :content="content"
-        :kind="content.kind"
         :thumbnail="content.thumbnail || getContentNodeThumbnail(content)"
         class="card-grid-item"
         :isMobile="windowIsSmall"
@@ -48,7 +46,6 @@
       v-else
       :key="content.id"
       :content="content"
-      :kind="content.kind"
       :thumbnail="content.thumbnail"
       :currentPage="currentPage"
       class="card-grid-item"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -13,23 +13,24 @@
       class="card-link"
     >
       <div class="header-bar" :style="headerStyles">
-        <div v-if="!isLeaf">
+        <div v-if="!content.is_leaf">
           <KIcon icon="topic" color="white" class="folder-header-bar" />
           <p class="folder-header-text">
             {{ coreString('folder') }}
           </p>
         </div>
         <LearningActivityLabel
-          v-if="isLeaf"
-          :contentNode="contentNode"
+          v-if="content.is_leaf"
+          :labelAfter="true"
+          :contentNode="content"
           :hideDuration="true"
           class="learning-activity-label"
           :style="{ color: $themeTokens.text }"
         />
         <img
-          v-if="isLeaf"
-          :src="channelThumbnail"
-          :alt="learnString('logo', { channelTitle: channelTitle })"
+          v-if="content.is_leaf"
+          :src="content.channel_thumbnail"
+          :alt="learnString('logo', { channelTitle: content.channel_title })"
           class="channel-logo"
         >
       </div>
@@ -40,7 +41,7 @@
       <div class="text" :style="{ color: $themeTokens.text }">
         <h3 class="title" dir="auto">
           <TextTruncator
-            :text="title"
+            :text="content.title"
             :maxHeight="maxTitleHeight"
           />
         </h3>
@@ -48,18 +49,18 @@
     </router-link>
     <div class="footer">
       <ProgressBar
-        :contentNode="contentNode"
+        :contentNode="content"
         :style="{ maxWidth: `calc(100% - ${32 * footerLength}px)` }"
       />
       <div class="footer-icons">
         <CoachContentLabel
-          v-if="isUserLoggedIn && !isLearner && numCoachContents"
+          v-if="isUserLoggedIn && !isLearner && content.numCoachContents"
           class="coach-content-label"
-          :value="numCoachContents"
+          :value="content.numCoachContents"
           :isTopic="isTopic"
         />
         <KIconButton
-          v-if="isLeaf"
+          v-if="content.is_leaf"
           icon="infoOutline"
           size="mini"
           :color="$themePalette.grey.v_600"
@@ -68,10 +69,10 @@
           @click="$emit('toggleInfoPanel')"
         />
         <KButton
-          v-if="copiesCount > 1"
+          v-if="content.copies_count > 1"
           appearance="basic-link"
           class="copies"
-          :text="coreString('copies', { num: copiesCount })"
+          :text="coreString('copies', { num: content.copies_count })"
           @click.prevent="$emit('openCopiesModal', contentId)"
         />
         <slot name="actions"></slot>
@@ -105,23 +106,7 @@
     },
     mixins: [commonLearnStrings, commonCoreStrings],
     props: {
-      title: {
-        type: String,
-        required: true,
-      },
-      subtitle: {
-        type: String,
-        default: null,
-      },
       thumbnail: {
-        type: String,
-        default: null,
-      },
-      channelThumbnail: {
-        type: String,
-        default: null,
-      },
-      channelTitle: {
         type: String,
         default: null,
       },
@@ -129,17 +114,6 @@
         type: String,
         required: true,
         validator: validateContentNodeKind,
-      },
-      isLeaf: {
-        type: Boolean,
-        required: true,
-      },
-      // ContentNode.coach_content will be `0` if not a coach content leaf node,
-      // or a topic without coach content. It will be a positive integer if a topic
-      // with coach content, and `1` if a coach content leaf node.
-      numCoachContents: {
-        type: Number,
-        default: 0,
       },
       link: {
         type: Object,
@@ -150,27 +124,19 @@
         type: Boolean,
         default: false,
       },
-      contentId: {
-        type: String,
-        default: null,
-      },
-      contentNode: {
+      content: {
         type: Object,
         required: true,
-      },
-      copiesCount: {
-        type: Number,
-        default: null,
       },
     },
     computed: {
       ...mapGetters(['isLearner', 'isUserLoggedIn']),
       isTopic() {
-        return !this.isLeaf;
+        return !this.content.is_leaf;
       },
       headerStyles() {
         let styles = {};
-        if (!this.isLeaf) {
+        if (!this.content.is_leaf) {
           styles = {
             backgroundColor: this.$themeTokens.text,
             borderRadius: '8px 8px 0 0',
@@ -185,15 +151,15 @@
         } else if (this.footerLength || this.subtitle) {
           return 40;
         }
-        return 66;
+        return 120;
       },
       footerLength() {
         return (
           1 +
-          this.isLeaf +
-          (this.isUserLoggedIn && !this.isLearner && this.numCoachContents) +
-          (this.numCoachContents > 0) +
-          (this.copiesCount > 1) +
+          this.content.is_leaf +
+          (this.isUserLoggedIn && !this.isLearner && this.content.numCoachContents) +
+          (this.content.numCoachContents > 0) +
+          (this.content.copies_count > 1) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );
       },
@@ -208,7 +174,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
   @import './card';
 
-  $margin: 24px;
+  $margin: 16px;
   $margin-thin: 8px;
 
   .card {
@@ -236,7 +202,7 @@
   .header-bar {
     display: flex;
     justify-content: space-between;
-    padding: 8px 18px;
+    padding: 8px 16px;
     font-size: 13px;
     .channel-logo {
       align-self: end;
@@ -269,7 +235,7 @@
   .text {
     position: relative;
     height: 190px;
-    padding: $margin;
+    padding: 0 $margin $margin $margin;
   }
 
   .footer {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -14,12 +14,12 @@
       <div
         v-if="!isMobile"
         class="folder-header"
-        :style="{ backgroundColor: (!isLeaf ? $themeTokens.text : null ) }"
+        :style="{ backgroundColor: (!content.is_leaf ? $themeTokens.text : null ) }"
       ></div>
       <div class="thumbnail">
         <CardThumbnail
           v-bind="{ thumbnail, kind, isMobile }"
-          :activityLength="activityLength"
+          :activityLength="content.duration"
         />
         <p
           v-if="!isMobile && isBookmarksPage"
@@ -34,17 +34,17 @@
           class="metadata-info"
           :style="{ color: $themePalette.grey.v_700 }"
         >
-          <LearningActivityLabel :contentNode="contentNode" class="learning-activity-label" />
+          <LearningActivityLabel :contentNode="content" class="learning-activity-label" />
         </div>
         <h3 class="title">
           <TextTruncator
-            :text="title"
+            :text="content.title"
             :maxHeight="maxTitleHeight"
           />
         </h3>
         <p class="text">
           <TextTruncator
-            :text="description"
+            :text="content.description"
             :maxHeight="maxDescriptionHeight"
           />
         </p>
@@ -53,16 +53,16 @@
         </div>
         <img
           v-if="!isMobile"
-          :src="channelThumbnail"
-          :alt="learnString('logo', { channelTitle: channelTitle })"
+          :src="content.channel_thumbnail"
+          :alt="learnString('logo', { channelTitle: content.channel_title })"
           class="channel-logo"
         >
         <KButton
-          v-if="!isMobile && isLibraryPage"
+          v-if="!isMobile && isLibraryPage && content.copies_count && (content.copies_count > 0)"
           appearance="basic-link"
           class="copies"
           :style="{ color: $themeTokens.text }"
-          :text="coreString('copies', { num: copiesCount })"
+          :text="coreString('copies', { num: content.copies_count })"
           @click.prevent="$emit('openCopiesModal', contentId)"
         />
       </span>
@@ -75,7 +75,7 @@
       >
         {{ bookmarkCreated }}
       </p>
-      <ProgressBar v-else :contentNode="contentNode" />
+      <ProgressBar v-else :contentNode="content" />
       <div class="footer-icons">
         <KIconButton
           v-for="(value, key) in footerIcons"
@@ -116,14 +116,6 @@
     },
     mixins: [commonLearnStrings, commonCoreStrings],
     props: {
-      title: {
-        type: String,
-        required: true,
-      },
-      description: {
-        type: String,
-        default: null,
-      },
       createdDate: {
         type: String,
         default: null,
@@ -132,28 +124,12 @@
         type: String,
         default: null,
       },
-      channelThumbnail: {
-        type: String,
-        default: null,
-      },
-      channelTitle: {
-        type: String,
-        default: null,
-      },
       kind: {
         type: String,
         required: true,
         validator: validateContentNodeKind,
       },
-      level: {
-        type: String,
-        default: null,
-      },
-      category: {
-        type: String,
-        default: null,
-      },
-      contentNode: {
+      content: {
         type: Object,
         required: true,
       },
@@ -161,10 +137,6 @@
         type: Object,
         required: true,
         validator: validateLinkObject,
-      },
-      isLeaf: {
-        type: Boolean,
-        default: false,
       },
       isMobile: {
         type: Boolean,
@@ -175,14 +147,6 @@
         default: null,
       },
       currentPage: {
-        type: String,
-        default: null,
-      },
-      copiesCount: {
-        type: Number,
-        default: null,
-      },
-      activityLength: {
         type: String,
         default: null,
       },

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -18,7 +18,8 @@
       ></div>
       <div class="thumbnail">
         <CardThumbnail
-          v-bind="{ thumbnail, kind, isMobile }"
+          :kind="content.kind"
+          v-bind="{ thumbnail, isMobile }"
           :activityLength="content.duration"
         />
         <p
@@ -96,7 +97,7 @@
 
 <script>
 
-  import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import { validateLinkObject } from 'kolibri.utils.validators';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { now } from 'kolibri.utils.serverClock';
@@ -123,11 +124,6 @@
       thumbnail: {
         type: String,
         default: null,
-      },
-      kind: {
-        type: String,
-        required: true,
-        validator: validateContentNodeKind,
       },
       content: {
         type: Object,

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -14,23 +14,23 @@
       <div class="thumbnail">
         <CardThumbnail
           v-bind="{ thumbnail, kind, isMobile }"
-          :activityLength="activityLength"
+          :activityLength="content.duration"
         />
       </div>
       <h3 class="title">
         <TextTruncator
-          :text="title"
+          :text="content.title"
           :maxHeight="maxTitleHeight"
           :style="{ color: $themeTokens.text }"
         />
       </h3>
       <LearningActivityLabel
-        :contentNode="contentNode"
+        :contentNode="content"
         class="learning-activity-label"
         :style="{ color: $themeTokens.text }"
       />
       <div class="footer">
-        <ProgressBar :contentNode="contentNode" />
+        <ProgressBar :contentNode="content" />
       </div>
     </router-link>
   </div>
@@ -58,10 +58,6 @@
     },
     mixins: [commonLearnStrings, commonCoreStrings],
     props: {
-      title: {
-        type: String,
-        required: true,
-      },
       thumbnail: {
         type: String,
         default: null,
@@ -71,7 +67,7 @@
         required: true,
         validator: validateContentNodeKind,
       },
-      contentNode: {
+      content: {
         type: Object,
         required: true,
       },
@@ -83,10 +79,6 @@
       isMobile: {
         type: Boolean,
         default: false,
-      },
-      activityLength: {
-        type: String,
-        default: null,
       },
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -13,7 +13,8 @@
     >
       <div class="thumbnail">
         <CardThumbnail
-          v-bind="{ thumbnail, kind, isMobile }"
+          v-bind="{ thumbnail, isMobile }"
+          :kind="content.kind"
           :activityLength="content.duration"
         />
       </div>
@@ -40,7 +41,7 @@
 
 <script>
 
-  import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import { validateLinkObject } from 'kolibri.utils.validators';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ProgressBar from './ProgressBar';
@@ -61,11 +62,6 @@
       thumbnail: {
         type: String,
         default: null,
-      },
-      kind: {
-        type: String,
-        required: true,
-        validator: validateContentNodeKind,
       },
       content: {
         type: Object,


### PR DESCRIPTION
To allow for better concision and readibility. Also fixes issues with "numCols" failing validator checks. A couple of very minor spacing/css tweaks.

## References
Fixes #8564
Fixes #8589

…

## Reviewer guidance

Did I lose any references?
Did I miss any place where numCols was used?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
