### PR TITLE
Filter search results by coach content when relevant.

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
@@ -201,7 +201,11 @@ describe(`useSearch`, () => {
       store.commit('SET_QUERY', { categories: 'test1,test2' });
       await Vue.nextTick();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories: ['test1', 'test2'], max_results: 25 },
+        getParams: {
+          categories: ['test1', 'test2'],
+          max_results: 25,
+          include_coach_content: false,
+        },
       });
     });
     it('should not call ContentNodeResource.fetchCollection if there is no search', () => {
@@ -226,7 +230,13 @@ describe(`useSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { tree_id: 1, lft__gt: 10, rght__lt: 20, max_results: 1 },
+        getParams: {
+          tree_id: 1,
+          lft__gt: 10,
+          rght__lt: 20,
+          max_results: 1,
+          include_coach_content: false,
+        },
       });
     });
     it('should set labels and clear more if there is no search but a descendant is set', async () => {
@@ -249,7 +259,11 @@ describe(`useSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories: ['test1', 'test2'], max_results: 25 },
+        getParams: {
+          categories: ['test1', 'test2'],
+          max_results: 25,
+          include_coach_content: false,
+        },
       });
     });
     it('should ignore other categories when AllCategories is set and search for isnull false', () => {
@@ -258,7 +272,7 @@ describe(`useSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories__isnull: false, max_results: 25 },
+        getParams: { categories__isnull: false, max_results: 25, include_coach_content: false },
       });
     });
     it('should ignore other categories when NoCategories is set and search for isnull true', () => {
@@ -267,7 +281,7 @@ describe(`useSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { categories__isnull: true, max_results: 25 },
+        getParams: { categories__isnull: true, max_results: 25, include_coach_content: false },
       });
     });
     it('should ignore channels when descendant is set', () => {
@@ -286,6 +300,7 @@ describe(`useSearch`, () => {
           tree_id: 1,
           lft__gt: 10,
           rght__lt: 20,
+          include_coach_content: false,
         },
       });
     });
@@ -295,7 +310,11 @@ describe(`useSearch`, () => {
       ContentNodeResource.fetchCollection.mockReturnValue(Promise.resolve({}));
       search();
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({
-        getParams: { keywords: `this is just a test`, max_results: 25 },
+        getParams: {
+          keywords: `this is just a test`,
+          max_results: 25,
+          include_coach_content: false,
+        },
       });
     });
     it('should set results, labels, and more with returned data', async () => {

--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -85,7 +85,10 @@ export default function useSearch(store, router) {
   );
 
   function search() {
-    const getParams = {};
+    const getParams = {
+      include_coach_content:
+        store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+    };
     if (descendant) {
       getParams.tree_id = descendant.tree_id;
       getParams.lft__gt = descendant.lft;


### PR DESCRIPTION
## Summary
* Adds filter to conditionally filter search results by coach content depending on the user.

## References
Fixes #8608

## Reviewer guidance
Does coach content get excluded from search results for a learner?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
