### PR TITLE
Always use from_db_value migrating attempt log fields

### DIFF
--- a/kolibri/core/logger/test/test_exam_log_migration.py
+++ b/kolibri/core/logger/test/test_exam_log_migration.py
@@ -36,6 +36,8 @@ class SimpleForwardMigrateTestCase(TestCase):
                     end_timestamp=now(),
                     correct=j % 2,
                     content_id=uuid4().hex,
+                    answer={"question": {"radio 1": {"numCorrect": 1}}},
+                    interaction_history=[{"history_a": 1}, {"history_b": 1}],
                 )
 
         migrate_from_exam_logs(models.ExamLog.objects.all())
@@ -48,7 +50,10 @@ class SimpleForwardMigrateTestCase(TestCase):
 
     def test_attemptlogs(self):
         self.assertEqual(models.AttemptLog.objects.all().count(), 12)
-        self.assertEqual(len(models.AttemptLog.objects.first().item.split(":")), 2)
+        attempt_log = models.AttemptLog.objects.first()
+        self.assertEqual(len(attempt_log.item.split(":")), 2)
+        for json_field in ("answer", "interaction_history"):
+            self.assertNotIsInstance(getattr(attempt_log, json_field), (str,))
 
     def test_contentsessionlogs(self):
         self.assertEqual(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes JSON objects becoming simple strings (of JSON itself) in exam log migration

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/8639

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
