### PR TITLE
Properly fetch more progress for tree data.

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
@@ -43,7 +43,7 @@ export default function useContentNodeProgress() {
    * @returns {Promise}
    * @public
    */
-  function fetchContentNodeTreeProgress(id, params) {
+  function fetchContentNodeTreeProgress({ id, params }) {
     return ContentNodeProgressResource.fetchTree({
       params,
       id,

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -43,7 +43,7 @@ export function showTopicsTopic(store, { id, pageName }) {
         store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
     };
     if (store.getters.isUserLoggedIn) {
-      fetchContentNodeTreeProgress(id, params);
+      fetchContentNodeTreeProgress({ id, params });
     }
     return ContentNodeResource.fetchTree({
       id,

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
@@ -43,7 +43,9 @@ export default {
     loadMoreTopics(store) {
       const more = store.state.topic.children.more;
       if (more) {
-        fetchContentNodeTreeProgress(more);
+        if (store.rootGetters.isUserLoggedIn) {
+          fetchContentNodeTreeProgress(more);
+        }
         return ContentNodeResource.fetchTree(more)
           .then(data => {
             store.commit('ADD_MORE_CONTENTS', data);
@@ -58,7 +60,9 @@ export default {
       const parent = parentIndex > -1 ? store.state.contents[parentIndex] : null;
       const more = parent && parent.children && parent.children.more;
       if (more) {
-        fetchContentNodeTreeProgress(more);
+        if (store.rootGetters.isUserLoggedIn) {
+          fetchContentNodeTreeProgress(more);
+        }
         return ContentNodeResource.fetchTree(more)
           .then(data => {
             data.index = parentIndex;


### PR DESCRIPTION
## Summary
* fetchContentNodeTreeProgress was being invoked with inconsistent function signatures
* Standardize its invocation on an options object
* Conditionalize fetching based on whether the user is logged in

## References
Fixes #8607

## Reviewer guidance
Load a topic in a channel with more than 12 descendants
Go to 'view all'
Ensure that it does not briefly suggest that Kolibri is disconnected

![showmoreprogress](https://user-images.githubusercontent.com/1680573/141026589-633ff7e6-5582-4c67-a831-9de87346b2e0.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
