### PR TITLE
Properly store answer state after initial attempt for exercises

### DIFF
--- a/kolibri/core/assets/src/state/modules/logging.js
+++ b/kolibri/core/assets/src/state/modules/logging.js
@@ -22,6 +22,7 @@ const replaceBlocklist = {
   correct: true,
   answer: true,
   simple_answer: true,
+  replace: true,
 };
 
 export default {
@@ -83,7 +84,8 @@ export default {
       }
     },
     UPDATE_ATTEMPT(state, interaction) {
-      const blocklist = interaction.replace ? {} : replaceBlocklist;
+      // We never store replace into the store.
+      const blocklist = interaction.replace ? { replace: true } : replaceBlocklist;
       if (interaction.id) {
         if (!state.pastattemptMap[interaction.id]) {
           const nowSavedInteraction = state.pastattempts.find(

--- a/kolibri/core/assets/src/state/modules/logging.js
+++ b/kolibri/core/assets/src/state/modules/logging.js
@@ -13,6 +13,17 @@ function threeDecimalPlaceRoundup(num) {
   return num;
 }
 
+// Items to only update on an
+// already existing attempt if
+// replace is set to true.
+// We use an object rather than
+// an array for easy lookup.
+const replaceBlocklist = {
+  correct: true,
+  answer: true,
+  simple_answer: true,
+};
+
 export default {
   state: () => ({
     complete: null,
@@ -72,6 +83,7 @@ export default {
       }
     },
     UPDATE_ATTEMPT(state, interaction) {
+      const blocklist = interaction.replace ? {} : replaceBlocklist;
       if (interaction.id) {
         if (!state.pastattemptMap[interaction.id]) {
           const nowSavedInteraction = state.pastattempts.find(
@@ -84,7 +96,9 @@ export default {
           state.totalattempts += 1;
         } else {
           for (let key in interaction) {
-            Vue.set(state.pastattemptMap[interaction.id], key, interaction[key]);
+            if (!blocklist[key]) {
+              Vue.set(state.pastattemptMap[interaction.id], key, interaction[key]);
+            }
           }
         }
       }

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -647,6 +647,62 @@ describe('Vuex store/actions for core module', () => {
       });
       expect(client).not.toHaveBeenCalled();
     });
+    it('should not overwrite correct, answer or simple_answer if not passed with the replace flag', async () => {
+      const store = await initStore();
+      client.__setPayload({
+        attempts: [
+          {
+            id: 'testid',
+            item: 'testitem',
+            answer: { response: 'answer' },
+            correct: 1,
+            complete: true,
+          },
+        ],
+      });
+      await store.dispatch('updateContentSession', {
+        interaction: {
+          item: 'testitem',
+          answer: { response: 'answer' },
+          simple_answer: 'nah',
+          correct: 1,
+          complete: true,
+        },
+      });
+      client.__reset();
+      await store.dispatch('updateContentSession', {
+        interaction: {
+          id: 'testid',
+          item: 'testitem',
+          answer: { response: 'not an answer' },
+          simple_answer: 'yeah',
+          correct: 0,
+          complete: true,
+          hinted: true,
+        },
+      });
+      expect(store.state.core.logging.pastattempts).toHaveLength(1);
+      expect(store.state.core.logging.pastattempts[0]).toEqual({
+        id: 'testid',
+        item: 'testitem',
+        answer: { response: 'answer' },
+        simple_answer: 'nah',
+        correct: 1,
+        complete: true,
+        hinted: true,
+      });
+      expect(store.state.core.logging.pastattemptMap).toEqual({
+        testid: {
+          id: 'testid',
+          item: 'testitem',
+          answer: { response: 'answer' },
+          simple_answer: 'nah',
+          correct: 1,
+          complete: true,
+          hinted: true,
+        },
+      });
+    });
     it('should multiple unrelated interactions without overwriting', async () => {
       const store = await initStore();
       client.__setPayload({
@@ -758,6 +814,7 @@ describe('Vuex store/actions for core module', () => {
           id: 'testid2',
           item: 'testitem2',
           answer: { response: 'answer' },
+          replace: true,
           correct: 0,
           complete: true,
         },


### PR DESCRIPTION
## Summary
* Answer state in the frontend was being erroneously overwritten, meaning the appropriate corrected state was not being shown to the user
* This fixes that by not storing these fields into the vuex store when the attempt already exists there, if the 'replace' flag is not specified.

## References
Fixes #8606

## Reviewer guidance
Answer an exercise question incorrectly - now get it right - does it show as 'corrected' (small black dot) rather than 'correct' (big green tick/check mark)?

![corrected](https://user-images.githubusercontent.com/1680573/141028095-36bbef7d-f0e5-4786-85b1-e6d531ba279e.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
