### PR TITLE
Focus and keyboard updates

### DIFF
--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -29,7 +29,7 @@
       <div
         ref="label"
         class="ui-select-label"
-
+        :class="$computedClass({ ':focus': $coreOutline })"
         :tabindex="disabled ? null : '0'"
 
         @click="toggleDropdown"
@@ -865,6 +865,12 @@
     }
 
     &.is-active:not(.is-disabled) {
+      .ui-select-display {
+        border-bottom-width: $ui-input-border-width--active;
+      }
+    }
+
+    &.is-active {
       .ui-select-display {
         border-bottom-width: $ui-input-border-width--active;
       }

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -1,16 +1,14 @@
 <template>
 
-  <div
-    class="card"
-    :class="[
-      { 'mobile-card': isMobile },
-      $computedClass({ ':focus': $coreOutline })
-    ]"
-    :style="{ backgroundColor: $themeTokens.surface }"
-  >
+  <div class="card drop-shadow">
     <router-link
       :to="link"
-      class="card-link"
+      class="card card-link"
+      :class="[
+        { 'mobile-card': isMobile },
+        $computedClass({ ':focus': $coreOutline })
+      ]"
+      :style="{ backgroundColor: $themeTokens.surface }"
     >
       <div class="header-bar" :style="headerStyles">
         <div v-if="!isLeaf">
@@ -211,18 +209,20 @@
   $margin: 24px;
   $margin-thin: 8px;
 
-  .card {
+  .drop-shadow {
     @extend %dropshadow-1dp;
+    &:hover {
+      @extend %dropshadow-8dp;
+    }
+  }
 
+  .card {
     position: relative;
     display: inline-block;
     width: 100%;
     vertical-align: top;
     border-radius: 8px;
     transition: box-shadow $core-time ease;
-    &:hover {
-      @extend %dropshadow-8dp;
-    }
     &:focus {
       outline-width: 4px;
       outline-offset: 6px;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -1,15 +1,14 @@
 <template>
 
-  <div
-    class="card"
-    :class="[
-      { 'mobile-card': isMobile },
-      $computedClass({ ':focus': $coreOutline })
-    ]"
-    :style="{ backgroundColor: $themeTokens.surface }"
-  >
+  <div class="card drop-shadow">
     <router-link
       :to="link"
+      class="card"
+      :class="[
+        { 'mobile-card': isMobile },
+        $computedClass({ ':focus': $coreOutline })
+      ]"
+      :style="{ backgroundColor: $themeTokens.surface }"
     >
       <div
         v-if="!isMobile"
@@ -241,9 +240,13 @@
 
   $margin: 24px;
 
-  .card {
+  .drop-shadow {
     @extend %dropshadow-1dp;
-
+    &:hover {
+      @extend %dropshadow-4dp;
+    }
+  }
+  .card {
     position: relative;
     display: inline-block;
     width: 100%;
@@ -252,9 +255,7 @@
     vertical-align: top;
     border-radius: 8px;
     transition: box-shadow $core-time ease;
-    &:hover {
-      @extend %dropshadow-8dp;
-    }
+
     &:focus {
       outline-width: 4px;
       outline-offset: 6px;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -1,15 +1,14 @@
 <template>
 
-  <div
-    :class="[
-      { 'mobile-card': isMobile },
-      $computedClass({ ':focus': $coreOutline })
-    ]"
-    :style="{ backgroundColor: $themeTokens.surface }"
-  >
+  <div class="card drop-shadow">
     <router-link
       :to="link"
       class="card card-content"
+      :class="[
+        { 'mobile-card': isMobile },
+        $computedClass({ ':focus': $coreOutline })
+      ]"
+      :style="{ backgroundColor: $themeTokens.surface }"
     >
       <div class="thumbnail">
         <CardThumbnail
@@ -106,9 +105,14 @@
 
   $margin: 24px;
 
-  .card {
+  .drop-shadow {
     @extend %dropshadow-1dp;
+    &:hover {
+      @extend %dropshadow-4dp;
+    }
+  }
 
+  .card {
     position: relative;
     display: inline-block;
     width: 100%;
@@ -116,9 +120,6 @@
     vertical-align: top;
     border-radius: 8px;
     transition: box-shadow $core-time ease;
-    &:hover {
-      @extend %dropshadow-4dp;
-    }
     &:focus {
       outline-width: 4px;
       outline-offset: 6px;


### PR DESCRIPTION
## Summary
Updates for keyboard tab nav focus for new hybrid learning cards, and adds a focus outline to the UI select. Pages for manual QA to check this are: Classes -> lesson activities, Bookmarks, and Library/Topics - both as cards and as list view.

## References
Addresses the first two to-dos in #8620 (Mac app issues will be follow up)


## Reviewer guidance
Do the card work? 
Are there any issues with clicking on "view info" and accidentally linking to the content renderer due to button/card link overlap? (I think this is resolved, but extra perspectives/feedback helpful)
Was there some reason this focus outline was not already added to the select dropdown in this place? Should I handle this differently? (I tried a lot of other ways first in components that were parents/wrappers and all were failures)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
