### PR TITLE
Also in this sidepanel

### DIFF
--- a/integration_testing/features/learner/learner-view-next-content-side-panel.feature
+++ b/integration_testing/features/learner/learner-view-next-content-side-panel.feature
@@ -1,6 +1,6 @@
 Feature: Learner view selection of next content
   In a lesson context, the learner needs to see the contents of the lesson
-  when opening the side panel. 
+  when opening the side panel.
   In a regular context, the learner should see content also in the same topic
   and be linked to the next topic when opening the side panel
 

--- a/integration_testing/features/learner/learner-view-next-content-side-panel.feature
+++ b/integration_testing/features/learner/learner-view-next-content-side-panel.feature
@@ -1,0 +1,47 @@
+Feature: Learner view selection of next content
+  In a lesson context, the learner needs to see the contents of the lesson
+  when opening the side panel. 
+  In a regular context, the learner should see content also in the same topic
+  and be linked to the next topic when opening the side panel
+
+  Background:
+    Given that I am signed in as a Learner
+      And that I have been assigned a <lesson> with multiple items
+
+    Scenario: Opening the side panel and clicking another resource
+      Given I am viewing <resource-1> in <lesson>
+      When I click the the *View lesson resources* icon in the top menu
+      Then I see a side bar appear on the right
+        And it says *Also in this lesson*
+        And it lists resources, not including the one being currently viewed
+      When I click <resource-2>
+      Then I am redirected to view <resource-2>
+      When I click again on the *View lesson resources* icon in the top menu
+      Then I should see <resource-1> as an option, but not <resource-2>
+        And I should see my progress reflected next to the entry for <resource-1>
+      When I click on the gray area, hit the ESC key or click the X icon
+      Then the side bar is closed and I see <resource-2> unobstructed
+
+    Scenario: Viewing a resource whose sibling has a duration set
+      Given I am viewing <resource> in the same lesson as <resource-2>, which has a set duration property
+      When I click the *View lesson resources* icon in the top menu
+      Then I see a side bar appear on the right
+        And I see <resource-2> and it displays its duration under its title
+
+  Background:
+
+    Scenario: Viewing content as a guest users
+      Given I can view <channel> which has multiple resources nested in folders
+      When I view a <topic> which has no sibling topics in the same folder
+        And I click to view a <resource> within that <topic>
+        And I click to open the side panel while viewing <resource>
+      Then I will see all items belonging to <topic> except <resource>
+      When I view a <topic-2> which has another folder alongside it <topic-3>
+        And I click to view a <resource> within <topic-2>
+        And I click to open the side panel while viewing <resource>
+      Then I will see all items belonging to <topic-2> except <resource>
+        And I will see a link at the bottom, linking me to <topic-3>
+
+  Examples:
+  | channel     | resource  | topic-n | lesson          |
+  | KA English  | Counting  | Topic N | Counting Lesson |

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -94,8 +94,8 @@ export default new Resource({
   fetchCopiesCount(getParams = {}) {
     return this.fetchListCollection('copies_count', getParams);
   },
-  fetchNextContent(id) {
-    return this.fetchDetailModel('next_content', id);
+  fetchNextContent(id, getParams = {}) {
+    return this.fetchDetailModel('next_content', id, getParams);
   },
   fetchNodeAssessments(ids) {
     return this.getListEndpoint('node_assessments', { ids });

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -115,12 +115,11 @@
       },
     },
     $trs: {
-      /*
+      /* eslint-disable kolibri/vue-no-unused-translations */
       topicHeader: {
         message: 'Also in this folder',
         context: 'Title of the panel with all topic contents. ',
       },
-      */
     },
   };
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -631,7 +631,9 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
 
     @detail_route(methods=["get"])
     def next_content(self, request, **kwargs):
-        # retrieve the "next" content node, according to depth-first tree traversal
+        # retrieve the "next" content node, according to depth-first tree traversal.
+        # topicOnly flag set to true will find the next topic node after the parent
+        # of this item. Will return this_item parent if nothing found
         this_item = self.get_object()
         topic_only = request.query_params.get("topicOnly")
         next_item_query = (

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -633,13 +633,17 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
     def next_content(self, request, **kwargs):
         # retrieve the "next" content node, according to depth-first tree traversal
         this_item = self.get_object()
-        next_item = (
+        topic_only = request.query_params.get("topicOnly")
+        next_item_query = (
             models.ContentNode.objects.filter(
                 available=True, tree_id=this_item.tree_id, lft__gt=this_item.rght
             )
-            .order_by("lft")
-            .first()
         )
+        if topic_only:
+            next_item_query.filter(kind=content_kinds.TOPIC)
+
+        next_item = next_item_query.order_by("lft").first()
+
         if not next_item:
             next_item = this_item.get_root()
 

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -636,10 +636,8 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
         # of this item. Will return this_item parent if nothing found
         this_item = self.get_object()
         topic_only = request.query_params.get("topicOnly")
-        next_item_query = (
-            models.ContentNode.objects.filter(
-                available=True, tree_id=this_item.tree_id, lft__gt=this_item.rght
-            )
+        next_item_query = models.ContentNode.objects.filter(
+            available=True, tree_id=this_item.tree_id, lft__gt=this_item.rght
         )
         if topic_only:
             next_item_query.filter(kind=content_kinds.TOPIC)

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -43,6 +43,22 @@
         </div>
       </KRouterLink>
     </div>
+
+    <KRouterLink
+      v-if="nextContent"
+      :to="genContentLink(nextContent.id, nextContent.is_leaf)"
+      class="next-content-link" 
+      :style="{ backgroundColor: $themeTokens.fineLine }"
+    >
+      <KIcon class="folder-icon" icon="topic" />
+      <div class="next-label">
+        Next folder
+      </div>
+      <div class="next-title">
+        {{ nextContent.title }}
+      </div>
+      <KIcon class="forward-icon" icon="forward" />
+    </KRouterLink>
   </div>
 
 </template>
@@ -66,7 +82,7 @@
     },
     props: {
       /**
-       * @param {Array<object>} contentNodes - The contentNode objects to be displayed. Each
+       * contentNodes - The contentNode objects to be displayed. Each
        * contentNode must include the following keys id, title, duration, progress, is_leaf.
        */
       contentNodes: {
@@ -79,6 +95,16 @@
       title: {
         type: String,
         required: true,
+      },
+      /** Content node with the following parameters: id, is_leaf, title */
+      nextContent: {
+        type: Object,
+        required: false,
+        default: () => {},
+        validator(node) {
+          const { id, is_leaf, title } = node;
+          return id && is_leaf && title;
+        },
       },
     },
     computed: {
@@ -100,6 +126,7 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
+  $parent-padding: 32px; // The SidePanel
   $icon-size: 32px;
   $progress-width: 48px;
   $item-padding-x: 8px;
@@ -107,7 +134,47 @@
   .wrapper {
     position: relative;
     width: 100%;
-    height: 100%;
+
+    /* Avoids overflow issues, aligns bottom bit */
+    height: calc(100% - 16px);
+  }
+
+  /** Most of the styles for the footer piece */
+  .next-content-link {
+    position: absolute;
+    right: -32px;
+    bottom: 0;
+    left: -32px;
+    height: 100px;
+    padding: 12px 32px 8px;
+
+    .next-label {
+      position: absolute;
+      top: 30px;
+      left: 80px;
+      display: inline-block;
+      min-width: 150px;
+    }
+
+    .next-title {
+      position: absolute;
+      left: 80px;
+      font-weight: bold;
+    }
+
+    .folder-icon {
+      top: 24px;
+      left: 0;
+      width: $icon-size;
+      height: $icon-size;
+    }
+    .forward-icon {
+      position: absolute;
+      top: 34px;
+      right: $parent-padding;
+      width: $icon-size;
+      height: $icon-size;
+    }
   }
 
   .item {
@@ -120,13 +187,18 @@
   }
 
   .activity-icon,
+  .next-label,
   .topic-icon {
     position: absolute;
-    top: 0;
     left: $item-padding-x;
     display: inline-block;
     width: $icon-size;
     height: $icon-size;
+  }
+
+  .activity-icon,
+  .topic-icon {
+    top: 0;
   }
 
   .content-meta {
@@ -151,7 +223,7 @@
 
   .mastered-icon {
     top: 0;
-    right: 0;
+    right: 16px;
     width: 24px;
     height: 24px;
   }

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -6,20 +6,40 @@
     </div>
 
     <div class="content-list">
-      <KRouterLink 
-        v-for="content in contentNodes" 
-        :key="content.id" 
+      <KRouterLink
+        v-for="content in contentNodes"
+        :key="content.id"
         :to="genContentLink(content.id, content.is_leaf)"
         class="item"
+        :style="linkStyles"
       >
-        <LearningActivityIcon class="activity-icon" :kind="content.learning_activities" />
-        <div class="content-meta">
-          <div>{{ content.title }}</div>
-          <TimeDuration :seconds="content.duration" />
+        <LearningActivityIcon
+          v-if="content.is_leaf"
+          class="activity-icon"
+          :kind="content.learning_activities"
+        />
+        <KIcon v-else class="topic-icon" icon="topic" />
+        <div class="content-meta" :style="{ top: (content.duration ? '0px' : '8px') }">
+          <TextTruncator
+            :text="content.title"
+            :maxHeight="24"
+            :style="{ marginTop: (content.duration ? '8px' : '0px') }"
+          />
+          <TimeDuration
+            v-if="content.duration"
+            class="time-duration"
+            :style="{ color: $themeTokens.annotation }"
+            :seconds="content.duration"
+          />
         </div>
         <div class="progress">
-          <KIcon v-if="content.progress === 1" icon="mastered" />
-          <ProgressBar :progress="content.progress" />
+          <KIcon
+            v-if="content.progress === 1"
+            icon="star"
+            class="mastered-icon"
+            :style="{ fill: $themeTokens.mastered }"
+          />
+          <ProgressBar v-else :progress="content.progress" class="bar" />
         </div>
       </KRouterLink>
     </div>
@@ -27,8 +47,10 @@
 
 </template>
 
+
 <script>
 
+  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import genContentLink from '../utils/genContentLink';
   import LearningActivityIcon from './LearningActivityIcon.vue';
@@ -39,6 +61,7 @@
     components: {
       LearningActivityIcon,
       ProgressBar,
+      TextTruncator,
       TimeDuration,
     },
     props: {
@@ -58,33 +81,97 @@
         required: true,
       },
     },
+    computed: {
+      /** Overrides some styles in KRouterLink */
+      linkStyles() {
+        return {
+          color: this.$themeTokens.text + '!important',
+          fontSize: '14px',
+        };
+      },
+    },
     methods: { genContentLink },
   };
 
 </script>
 
-<style scoped>
 
-.wrapper {
-  position: relative;
-  width: 100%;
-  height: 100%;
-}
+<style scoped lang="scss">
 
-.item {
-  height: 80px;
-  width: 100%;
-  display: block;
-}
+  @import '~kolibri-design-system/lib/styles/definitions';
 
-.top-bar {
-  position: relative;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 40px;
-  /*line-height: 40px;*/
-  background-color: #fff;
+  $icon-size: 32px;
+  $progress-width: 48px;
+  $item-padding-x: 8px;
 
-}
+  .wrapper {
+    position: relative;
+    width: 100%;
+    height: 100%;
+  }
+
+  .item {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 56px;
+    padding: 16px $item-padding-x;
+    margin-top: 8px;
+  }
+
+  .activity-icon,
+  .topic-icon {
+    position: absolute;
+    top: 0;
+    left: $item-padding-x;
+    display: inline-block;
+    width: $icon-size;
+    height: $icon-size;
+  }
+
+  .content-meta {
+    position: absolute;
+    left: calc(#{$icon-size} + #{$item-padding-x});
+    display: inline-block;
+    width: calc(100% - #{$icon-size} - #{$progress-width} - #{$item-padding-x * 2});
+    height: 56px;
+    padding: 0 16px;
+  }
+
+  .progress {
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    .bar {
+      width: $progress-width;
+      margin-top: 16px;
+    }
+  }
+
+  .mastered-icon {
+    top: 0;
+    right: 0;
+    width: 24px;
+    height: 24px;
+  }
+
+  .top-bar {
+    position: relative;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: 40px;
+
+    /* line-height: 40px; */
+    background-color: #ffffff;
+  }
+
+  /** Just ensures a newline precedes this. So it is always
+  positioned under the title at the start of the line */
+  .time-duration::before {
+    white-space: pre;
+    content: '\a';
+  }
+
 </style>

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -1,0 +1,90 @@
+<template>
+
+  <div class="wrapper">
+    <div class="top-bar">
+      <h2>{{ title }}</h2>
+    </div>
+
+    <div class="content-list">
+      <KRouterLink 
+        v-for="content in contentNodes" 
+        :key="content.id" 
+        :to="genContentLink(content.id, content.is_leaf)"
+        class="item"
+      >
+        <LearningActivityIcon class="activity-icon" :kind="content.learning_activities" />
+        <div class="content-meta">
+          <div>{{ content.title }}</div>
+          <TimeDuration :seconds="content.duration" />
+        </div>
+        <div class="progress">
+          <KIcon v-if="content.progress === 1" icon="mastered" />
+          <ProgressBar :progress="content.progress" />
+        </div>
+      </KRouterLink>
+    </div>
+  </div>
+
+</template>
+
+<script>
+
+  import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
+  import genContentLink from '../utils/genContentLink';
+  import LearningActivityIcon from './LearningActivityIcon.vue';
+  import ProgressBar from './ProgressBar';
+
+  export default {
+    name: 'AlsoInThis',
+    components: {
+      LearningActivityIcon,
+      ProgressBar,
+      TimeDuration,
+    },
+    props: {
+      /**
+       * @param {Array<object>} contentNodes - The contentNode objects to be displayed. Each
+       * contentNode must include the following keys id, title, duration, progress, is_leaf.
+       */
+      contentNodes: {
+        type: Array,
+        required: true,
+      },
+      /**
+       * Title text for the component.
+       */
+      title: {
+        type: String,
+        required: true,
+      },
+    },
+    methods: { genContentLink },
+  };
+
+</script>
+
+<style scoped>
+
+.wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.item {
+  height: 80px;
+  width: 100%;
+  display: block;
+}
+
+.top-bar {
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  /*line-height: 40px;*/
+  background-color: #fff;
+
+}
+</style>

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -111,7 +111,6 @@
   import GlobalSnackbar from '../../../../../../kolibri/core/assets/src/views/GlobalSnackbar';
   import SkipNavigationLink from '../../../../../../kolibri/core/assets/src/views/SkipNavigationLink';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';
-  import { ClassesPageNames } from '../constants';
   import useCoreLearn from '../composables/useCoreLearn';
   import LessonResourceViewer from './classes/LessonResourceViewer';
   import CurrentlyViewedResourceMetadata from './CurrentlyViewedResourceMetadata';

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -69,15 +69,15 @@
     </FullScreenSidePanel>
 
     <!-- Side Panel for "view resources" or "lesson resources" -->
-    <FullScreenSidePanel 
+    <FullScreenSidePanel
       v-if="showViewResourcesSidePanel"
       class="also-in-this-side-panel"
       @closePanel="showViewResourcesSidePanel = false"
     >
-      <AlsoInThis 
-        :contentNodes="viewResourcesContents" 
+      <AlsoInThis
+        :contentNodes="viewResourcesContents"
         :nextContent="nextContent"
-        :title="viewResourcesTitle" 
+        :title="viewResourcesTitle"
       />
     </FullScreenSidePanel>
 
@@ -102,7 +102,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
-  import { _collectionState } from '../modules/coreLearn/utils.js';
   import GlobalSnackbar from '../../../../../../kolibri/core/assets/src/views/GlobalSnackbar';
   import SkipNavigationLink from '../../../../../../kolibri/core/assets/src/views/SkipNavigationLink';
   import AppError from '../../../../../../kolibri/core/assets/src/views/AppError';

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -336,13 +336,14 @@
         if (this.lessonId) {
           return;
         }
-        const store = this.$store;
 
         ContentNodeResource.fetchTree({
           id: this.content.parent,
           params: {
             include_coach_content:
-              store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+              this.$store.getters.isAdmin ||
+              this.$store.getters.isCoach ||
+              this.$store.getters.isSuperuser,
           },
         }).then(parent => {
           // Filter out this.content

--- a/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
@@ -56,7 +56,11 @@
     },
     computed: {
       progress() {
-        return this.contentNodeProgressMap[this.contentNode && this.contentNode.content_id] || 0;
+        return (
+          this.contentNode.progress ||
+          this.contentNodeProgressMap[this.contentNode && this.contentNode.content_id] ||
+          0
+        );
       },
       completed() {
         return this.progress >= 1;

--- a/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-immersive-layout.spec.js
@@ -30,6 +30,12 @@ store.state.topicsTree = {
   },
 };
 
+store.getters = {
+  isAdmin() {
+    return false;
+  },
+};
+
 function makeWrapper({ propsData } = {}) {
   return shallowMount(LearnImmersiveLayout, {
     propsData,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Provides context-informed side panel for content viewing per [Figma specs](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=212%3A0).

Video shows, roughly in order:
- Guest user (no progresses shown - no lesson available)
- Logged in user in library context (progress shown)
- "Next folder navigation"
- Back route navigation
- Lesson content viewing
- Lesson content navigation (within the lesson)

https://user-images.githubusercontent.com/6356129/141061287-40fe4d11-7154-41dc-ada9-7b89a97ae69a.mp4

Overall, this was more complicated than I anticipated. Some notes:

- This is not particularly pretty. I added to the bloat in `LearnImmersiveLayout` with some methods that gather and map progresses to (if user is logged in) the returned nodes. It gets the Lesson model when in lesson context as well - this is all to pass it on to the `AlsoInThis` component (which is the body of the Side Panel). I hope the comments help clarify this.
- The CSS uses a lot of absolute positioning - I don't suspect it would break if the styles of the side panel width was changed but would be simple enough to fix if it did. It's not often you are given a finite space to work in the web as the side panel fits comfortably on nearly all screen sizes.
- The `detail_route` `next_content` now looks for a query param `topicOnly` - if true, then it will return the next topic. This was in order to easily get the "Next folder" content node
- ProgressBar had a `contentNode` prop, but didn't check if there was a `progress` property set - instead opting to look into a progress mapping. Perhaps I've missed something w/ that `useContentNodeProgress()` composable @rtibbles .
- I tried my hand at a quick Gherkin - definitely would love some feedback @radinamatic - I hope this covers enough and gets the idea across.
- The routing currently will go 2 resources deep - then if you back out twice it'll pop you back into the Library or Lesson you were in. This isn't intentional but I think it's a good UX overall. Interested in thoughts @jtamiace 


General thoughts on future improvements:
- `fetchSiblings` `detail_route` might be helpful and simplify this a bit? 
- Move fetching business into `AlsoInThis` to pare down `LearnImmersiveLayout` 
- `AlsoInThis` should probably be two separate components `AlsoInThisLesson` and `AlsoInThisFolder` I just wish I'd seen it earlier on :-/ 


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8107 
Fixes #8307 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

It ended up being more complicated than I had anticipated but it should be good to go :) 

Mainly be sure that you can get the 

**General**
- Progress indicator on content where there is progress. Just a star if completed
- Scrollbar appears in largely populated folders and all items are visible when scrolled down
- The content you're viewing doesn't get listed in the side bar
- Content which has a duration will show the time under the title
- A channel with lots of folders, if you view a content a level or two deep, then you should be guaranteed to see the link on the bottom of the sidebar linking to the folder.

**Lesson context**
- The contents listed should be from within the same lesson, not from siblings of that content in it's other locations (in channels in the library).
- Links should remain in Lesson context - so you should always see the "view lesson resources" icon as you click through side panel "next in lesson" resources

**Mobile**
- The progress / completed icon appears underneath the title (and optionally the duration if present)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
