### PR TITLE
SidePanel to show on BookmarksPage

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -16,6 +16,7 @@
       :cardViewStyle="windowIsSmall ? 'card' : 'list'"
       :footerIcons="footerIcons"
       @removeFromBookmarks="removeFromBookmarks"
+      @toggleInfoPanel="toggleInfoPanel"
     />
 
     <KButton
@@ -28,6 +29,13 @@
       v-else-if="loading"
       :delay="false"
     />
+
+    <FullScreenSidePanel
+      v-if="sidePanelContent"
+      @closePanel="sidePanelContent = null"
+    >
+      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />
+    </FullScreenSidePanel>
   </div>
 
 </template>
@@ -37,6 +45,7 @@
 
   import { mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import FullScreenSidePanel from 'kolibri.coreVue.components.FullScreenSidePanel';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { ContentNodeResource } from 'kolibri.resources';
   import client from 'kolibri.client';
@@ -45,6 +54,7 @@
   import { PageNames } from '../constants';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
   import HybridLearningCardGrid from './HybridLearningCardGrid';
+  import BrowseResourceMetadata from './BrowseResourceMetadata';
 
   export default {
     name: 'BookmarkPage',
@@ -54,6 +64,8 @@
       };
     },
     components: {
+      BrowseResourceMetadata,
+      FullScreenSidePanel,
       HybridLearningCardGrid,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
@@ -62,6 +74,7 @@
         loading: true,
         bookmarks: [],
         more: null,
+        sidePanelContent: null,
       };
     },
     computed: {
@@ -102,6 +115,9 @@
             this.createSnackbar(this.$tr('removedNotification'));
           });
         }
+      },
+      toggleInfoPanel(content) {
+        this.sidePanelContent = content;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -54,7 +54,7 @@
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
-      @toggleInfoPanel="$emit('toggleInfoPanel', content)"
+      @viewInformation="$emit('toggleInfoPanel', content)"
       @removeFromBookmarks="removeFromBookmarks(content, contents)"
     />
     <CopiesModal


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds side panel & metadata component along with toggling logic to `BookmarksPage`. 

Also changes the event used in `Hybrid*CardGrid` on the `Hybrid*ListView` component to match the one given in `footerIcons`.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8594 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Add bookmarks - then go to the Bookmarks tab in the Learn section, then try to view the side panel metadata by clicking the (i) icon.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
