### PR TITLE
update glossary.tbx file with latest

### DIFF
--- a/kolibri/locale/glossary.tbx
+++ b/kolibri/locale/glossary.tbx
@@ -457,7 +457,7 @@
         <langSet xml:lang="ur-PK">
           <tig>
             <term id="2290a7385ed77cc5592dc2153229f0821064-ur-PK">معلوماتی آزمائش</term>
-            <descrip type="definition">ایک سوالنامہ مشقوں سے اٹھائے گئے سوالات کو ملا کر بنایا گیا ایک خلاصہ جاتی جائزہ ہوتا  ہے۔ معلوماتی آزمائشیں کوچز کے ذریعہ بنائی جاتی ہیں اور پھر کلاس میں سیکھنے والوں کو دی جاتی ہیں۔ اساتذہ کے غیر رسمی طور پر استعمال کی حوصلہ افزائی کیلئے ہم نے جان بوجھ کر "امتحان" کا نام "معلوماتی آزمائش" رکھا ہے 
+            <descrip type="definition">ایک سوالنامہ مشقوں سے اٹھائے گئے سوالات کو ملا کر بنایا گیا ایک خلاصہ جاتی جائزہ ہوتا  ہے۔ معلوماتی آزمائشیں کوچز کے ذریعہ بنائی جاتی ہیں اور پھر کلاس میں سیکھنے والوں کو دی جاتی ہیں۔ اساتذہ کے غیر رسمی طور پر استعمال کی حوصلہ افزائی کیلئے ہم نے جان بوجھ کر "امتحان" کا نام "معلوماتی آزمائش" رکھا ہے
 </descrip>
           </tig>
         </langSet>
@@ -795,7 +795,7 @@
         <langSet xml:lang="ur-PK">
           <tig>
             <term id="522a9ae9a99880d39e5daec35375e9991078-ur-PK">ایپ</term>
-            <descrip type="definition">،کولیبری میں، ایک ایپ ایک خاص قسم کا وسائل ہے۔ خاص طور پر، 
+            <descrip type="definition">،کولیبری میں، ایک ایپ ایک خاص قسم کا وسائل ہے۔ خاص طور پر،
 HTML ایپس عام طور پر خود پر مشتمل، متعاملاتی
  اور جاوا اسکرپٹ کی ایپلی کیشنز ہوتی ہیں۔</descrip>
           </tig>
@@ -1786,7 +1786,7 @@ HTML ایپس عام طور پر خود پر مشتمل، متعاملاتی
         <langSet xml:lang="fr">
           <tig>
             <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-fr">modèle de maîtrise</term>
-            <descrip type="definition">Lorsqu'un apprenant a suffisamment internalisé et compris une ressource, on dit de lui qu'il maîtrise au moins temporairement la ressource. Les responsables des ressources éducationnelles sur Kolibri Studio assignent un modèle de maîtrise (nombre de réponses correctes pour être en mesure de maîtriser) sur une chaîne entière ou bien une ressource individuelle. 
+            <descrip type="definition">Lorsqu'un apprenant a suffisamment internalisé et compris une ressource, on dit de lui qu'il maîtrise au moins temporairement la ressource. Les responsables des ressources éducationnelles sur Kolibri Studio assignent un modèle de maîtrise (nombre de réponses correctes pour être en mesure de maîtriser) sur une chaîne entière ou bien une ressource individuelle.
 La maîtrise mesure le progrès et non la performance. Par exemple, un modèle de maîtrise peut indiquer qu'un apprenant doit répondre correctement à 3 questions à la suite afin de continuer ou bien qu'il doit au moins répondre correctement à 7 questions sur 10 au premier essai pour continuer. </descrip>
           </tig>
         </langSet>
@@ -1840,7 +1840,7 @@ O domínio mede o progresso, não o desempenho. Por exemplo, um critério de dom
         <langSet xml:lang="ur-PK">
           <tig>
             <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-ur-PK">مہارتی نمونہ</term>
-            <descrip type="definition">جب ایک سیکھنے والا کافی طور پر کچھ مواد کو اپنا لیتا ہے تو اُن کے بارے میں کہا جاتا 
+            <descrip type="definition">جب ایک سیکھنے والا کافی طور پر کچھ مواد کو اپنا لیتا ہے تو اُن کے بارے میں کہا جاتا
  کولیبری پر موجود تعملیمی وسائل کے ناظم ایک مہارتی نمونہ تفویض کرتے ہیں- ہے کہ اُنہوں نے عارضی مہارت حاصل کر لی ہے۔ </descrip>
           </tig>
         </langSet>

--- a/kolibri/locale/glossary.tbx
+++ b/kolibri/locale/glossary.tbx
@@ -13,550 +13,2866 @@
   </martifHeader>
   <text>
     <body>
-      <termEntry id="e4da3b7fbbce2345d7772b0674a318d55">
+      <termEntry id="7cce53cf90577442771720a370c3c7231048">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-fr">Kolibri</term>
+            <descrip type="definition">Ce nom propre est le nom de la plateforme éducative. Pour les langues n'utilisant pas de caractères latins, il faut transcrire phonétiquement le mot, tout comme on le ferait avec le nom d'une personne. Il ne faut pas le traduire par le nom commun "colibri".</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="e4da3b7fbbce2345d7772b0674a318d55-en">Kolibri</term>
+            <term id="7cce53cf90577442771720a370c3c7231048-en">Kolibri</term>
             <termNote type="partOfSpeech">proper noun</termNote>
             <descrip type="definition">This proper noun is the name of the learning platform, and is pronounced ko-lee-bree (/kolibɹi/). For languages with non-latin scripts, the word should be transcribed phonetically into the target language, similar to a person's name. It should not be translated as "hummingbird".</descrip>
           </tig>
         </langSet>
-        <langSet xml:lang="bn">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="e4da3b7fbbce2345d7772b0674a318d55-bn">কলিব্রি</term>
-            <termNote type="partOfSpeech">proper noun</termNote>
+            <term id="7cce53cf90577442771720a370c3c7231048-fa">کلیبری</term>
+            <descrip type="definition">این اسم خاص نام بستر یادگیری است و کُلیبری تلفظ می شود. برای زبانهای دارای اسکریپت های غیر لاتین، همانند نام شخص این کلمه باید به صورت آوایی به زبان مقصد رونویسی شود. نباید آن را به عنوان "hummingbird" ترجمه کرد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-la">Kolibri</term>
+            <descrip type="definition">Este nombre propio es el nombre de la plataforma de aprendizaje, y se pronuncia co-li-bri (/ko li 'βri/). Para los idiomas con escritura no latina, la palabra debe transcribirse fonéticamente en el idioma de destino, similar al nombre de una persona. No debe traducirse como "colibrí".</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-es-ES">Kolibri</term>
+            <descrip type="definition">Este nombre propio es el nombre de la plataforma de aprendizaje, y se pronuncia co-li-bri (/ko li 'βri/). Para los idiomas con escritura no latina, la palabra debe transcribirse fonéticamente en el idioma de destino, similar al nombre de una persona. No debe traducirse como "colibrí".</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-qu">Kolibri</term>
+            <descrip type="definition">Este nombre propio es el nombre de la plataforma de aprendizaje, y se pronuncia co-li-bri (/ko li 'βri/). Para los idiomas con escritura no latina, la palabra debe transcribirse fonéticamente en el idioma de destino, similar al nombre de una persona. No debe traducirse como "colibrí".</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-pt-BR">Kolibri</term>
+            <descrip type="definition">Este nome próprio é o nome de uma plataforma de aprendizagem e é pronunciado como cô-lii-brii (/kolibɹi/). Para línguas com alfabeto não latino, a palavra deve ser transcrita foneticamente para a língua-alvo, como o nome de uma pessoa. Não deve ser traduzida como "beija-flor".</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="7cce53cf90577442771720a370c3c7231048-ur-PK">کولیبری</term>
+            <descrip type="definition">یہ اسم معرفہ تدریسی  پلیٹ فارم کا نام ہے، اور اس کا تلفظ کو-لی-بری  ہے۔ ایسی زبانیں جن میں رسم الخط ترچھا نہیں ہے، کسی شخص کے نام کی طرح، لفظ کا ترجمہ از روئے صوت کیا جانا چاہیئے۔ اس کا ترجمہ "ہمنگ برڈ" کی طرح نہیں کیا جانا چاہیئے۔ </descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="642e92efb79421734881b53e1e1b18b648">
+      <termEntry id="5055cbf43fac3f7e2336b27310f0b9ef1050">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-fr">licence</term>
+            <descrip type="definition">Un mécanisme légal qui défini les termes sous lesquels les ressources peuvent être partagées, réutilisées et modifiées. La licence est choisie par le détenteur des droits d'auteur. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="642e92efb79421734881b53e1e1b18b648-en">license</term>
-            <descrip type="definition">A legal mechanism which defines the terms under which the resources can be shared, reused, and modified. The license is chosen by the copyright holder</descrip>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-en">license</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A legal mechanism which defines the terms under which the resources can be shared, reused, and modified. The license is chosen by the copyright holder.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-fa">مجوز</term>
+            <descrip type="definition">مکانیسم قانونی که شرایطی را که تحت آن منابع می توان به اشتراک گذاشته شود، استفاده مجدد شود وتغییر کند را تعریف می کند. مجوز توسط دارنده حق چاپ انتخاب می شود.</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="642e92efb79421734881b53e1e1b18b648-vi">giấy phép</term>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-vi">giấy phép</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-la">licencia</term>
+            <descrip type="definition">Un mecanismo legal que define los términos bajo los cuales los recursos pueden ser compartidos, reutilizados y modificados. La licencia es elegida por el titular de los derechos de autor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-es-ES">licencia</term>
+            <descrip type="definition">Un mecanismo legal que define los términos bajo los cuales los recursos pueden ser compartidos, reutilizados y modificados. La licencia es elegida por el titular de los derechos de autor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-qu">licencia</term>
+            <descrip type="definition">Un mecanismo legal que define los términos bajo los cuales los recursos pueden ser compartidos, reutilizados y modificados. La licencia es elegida por el titular de los derechos de autor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-pt-BR">licença</term>
+            <descrip type="definition">Um mecanismo legal que define os termos sob os quais os conteúdos podem ser compartilhados, reutilizados e modificados. A licença é escolhida pelo detentor dos direitos autorais.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="5055cbf43fac3f7e2336b27310f0b9ef1050-ur-PK">لائسنس</term>
+            <descrip type="definition">ایک قانونی طریقۂ کار جو ایسی شرائط کی تعریف کرتا ہے جن کے تحت وسائل کا اشتراک،  دوبارہ استعمال اور ترمیم کی جاسکتی ہے۔ لائسنس کا انتخاب حق اشاعت رکھنے والے کی طرف سے کیا جاتا ہے۔ </descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="f457c545a9ded88f18ecee47145a72c049">
+      <termEntry id="f4dd765c12f2ef67f98f3558c282a9cd1052">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-fr">propriétaire des droits d'auteur</term>
+            <descrip type="definition">Personne ou entreprise qui détient les droits légaux d'une ressource. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="f457c545a9ded88f18ecee47145a72c049-en">copyright holder</term>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-en">copyright holder</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Person or organization who has legal ownership over a resource</descrip>
+            <descrip type="definition">Person or organization who has legal ownership over a resource.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-fa">دارنده حق چاپ</term>
+            <descrip type="definition">شخص یا سازمانی که مالکیت قانونی بر روی یک منبع داشته باشد</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="f457c545a9ded88f18ecee47145a72c049-vi">chủ sở hữu bản quyền</term>
-            <termNote type="partOfSpeech">noun</termNote>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-vi">chủ sở hữu bản quyền</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-la">titular de derechos de autor</term>
+            <descrip type="definition">Persona u organización que tiene propiedad legal sobre un recurso.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-es-ES">titular de derechos de autor</term>
+            <descrip type="definition">Persona u organización que tiene titularidad legal sobre un recurso.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-qu">titular de derechos de autor</term>
+            <descrip type="definition">Persona u organización que tiene propiedad legal sobre un recurso.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-pt-BR">detentor dos direitos autorais</term>
+            <descrip type="definition">Pessoa ou organização que tem a propriedade legal de um conteúdo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="f4dd765c12f2ef67f98f3558c282a9cd1052-ur-PK">حقِ اشاعت رکھنے والا</term>
+            <descrip type="definition">ایک شخص یا تنظیم جو وسائل کی قانونی ملکیت رکھتا ہو۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="c0c7c76d30bd3dcaefc96f40275bdc0a50">
+      <termEntry id="db576a7d2453575f29eab4bac787b9191054">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-fr">éducateur</term>
+            <descrip type="definition">Type de compte avec permission de gérer les leçons et quiz relatifs à une classe et qui peut suivre le progrès et la performance des apprenants de cette classe. Les éducateurs sont assignés à une classe par un administrateur. Il y a deux types de éducateurs : les éducateurs d'établissement et les éducateurs de classe. Nous avons intentionnellement omis le mot "professeur" pour inclure les contextes n'étant pas formellement éducatifs. Alternativement, éducateur peut aussi se référer à un rôle d'utilisateur au sein d'une classe: les utilisateurs avec un compte de type éducateur de classe, éducateurs d'établissement, administrateur ou super-administrateur peuvent avoir le rôle de éducateurs dans une classe.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="c0c7c76d30bd3dcaefc96f40275bdc0a50-en">coach</term>
+            <term id="db576a7d2453575f29eab4bac787b9191054-en">coach</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">An account type that has the permission to manage lessons and quizzes within a class and track the progress and performance of learners enrolled in the class. Coaches are assigned to the class by an admin. There are two kinds of coach users: facility coaches and class coaches. We intentionally did not use the term "teacher" in order to be inclusive of non-formal education contexts. Alternatively, coach can refer to a user's role within a class: Users with an account of type class coach, coach, facility coach, admin, or super admin can all be assigned the coach role in a class.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-fa">مربی</term>
+            <descrip type="definition">یک نوع حساب که اجازه دارد دروس و آزمونها در یک کلاس را مدیریت و میزان پیشرفت وعملکرد یادگیرنده ها ثبت نام شده در کلاس را پیگیری کند. مربیان توسط یک مدیر به کلاس اختصاص می یابند. دو نوع کاربر مربی وجود دارد: مربیان امکانات و مربیان کلاس. ما عمداً از اصطلاح معلم استفاده نکردیم تا در بین آموزش غیر رسمی قرارگرفته شود. از طرف دیگر، مربی می تواند به نقش کاربر در یک کلاس اشاره کند: کاربرانی که دارای حساب کاربری مربی کلاس، مربی، مربی امکانات، مدیر و یا مدیر ارشد هستند ، همگی می توانند نقش مربی را در یک کلاس اختصاص </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="c0c7c76d30bd3dcaefc96f40275bdc0a50-vi">giáo viên</term>
-            <termNote type="partOfSpeech">noun</termNote>
+            <term id="db576a7d2453575f29eab4bac787b9191054-vi">giáo viên</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-la">tutor</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar lecciones y pruebas dentro de un grupo y seguir el progreso y rendimiento de los estudiantes inscritos en la clase. Los tutores son asignados al grupo por un administrador. Hay dos tipos de usuario tutor: tutor del centro educativo y tutor de grupo. No utilizamos intencionalmente el término "profesor" para ser inclusivos de contextos de educación no formales. Alternativamente, el tutor puede referirse al rol de un usuario dentro de una clase: todos los usuarios con una cuenta de tipo tutor (de grupo, del centro), administrador o superadministrador pueden ser asignados el rol de tutor en un grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-es-ES">tutor</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar lecciones y pruebas dentro de una clase y seguir el progreso y rendimiento de los estudiantes inscritos en la clase. Los tutores son asignados a clases por un administrador. Hay dos tipos de usuario tutor: tutor del centro educativo y tutor de clase. No utilizamos intencionalmente el término "profesor" para ser inclusivos de contextos de educación no formales. Alternativamente, el tutor puede referirse al rol de un usuario dentro de una clase: todos los usuarios con una cuenta de tipo tutor (de clase, del centro), administrador o superadministrador pueden ser asignados el rol de tutor en una clase.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-qu">tutor</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar lecciones y pruebas dentro de un grupo y seguir el progreso y rendimiento de los estudiantes inscritos en la clase. Los tutores son asignados al grupo por un administrador. Hay dos tipos de usuario tutor: tutor del centro educativo y tutor de grupo. No utilizamos intencionalmente el término "profesor" para ser inclusivos de contextos de educación no formales. Alternativamente, el tutor puede referirse al rol de un usuario dentro de una clase: todos los usuarios con una cuenta de tipo tutor (de grupo, del centro), administrador o superadministrador pueden ser asignados el rol de tutor en un grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-pt-BR">professor</term>
+            <descrip type="definition">Um tipo de conta que tem permissão para gerenciar lições e testes em uma classe e acompanhar o progresso e desempenho dos alunos inscritos nela. Professores são designados a uma classe por um administrador. Existem dois tipos de professores: os de centros educativos e os de classes. O termo professor refere-se às seguintes funções em uma classe: usuários com uma conta do tipo professor de classe, professor, professor de centro educativo, administrador ou super admin, todos podendo ser designados ao papel de professor em uma classe.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-ur-PK">کوچ</term>
+            <descrip type="definition">ایک اکاؤنٹ کی قسم جس میں ایک کلاس کے اندر اسباق اور کوئز کا انتظام کرنے اور کلاس میں داخل سیکھنے والوں کی پیشرفت اور کارکردگی کا پتہ لگانے کی اجازت ہے۔ کوچوں کو منتظم کے ذریعہ کلاس میں مقرر کیا جاتا ہے۔ دو قسم کے کوچ صارف ہوتے ہیں: سہولت کوچ اور کلاس کوچ۔ ہم نے غیر رسمی تعلیم کے سیاق و سباق میں شامل ہونے کے لئے جان بوجھ کر "ٹیچر" کی اصطلاح استعمال نہیں کی۔ متبادل کے طور پر ، کوچ کسی کلاس کے اندر صارف کے کردار کا حوالہ دے سکتا ہے: ٹائپ کلاس کوچ ، کوچ ، سہولت کوچ ، ایڈمن ، یا سپر ایڈمن کے اکاؤنٹ والے صارفین کو کلاس میں کوچ کا رول مقرر کیا جاسکتا ہے۔</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="db576a7d2453575f29eab4bac787b9191054-fv">Jannginoowo</term>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="66f041e16a60928b05a7e228a89c379958">
+      <termEntry id="4ca82782c5372a547c104929f03fe7a91056">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-fr">translation</term>
+            <descrip type="definition">Une translation est un transformation géométrique qui déplace chaque point d'une figure ou d'un espace d'une même distance en une direction donnée.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="66f041e16a60928b05a7e228a89c379958-en">translation</term>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-en">translation</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">Translation is a geometric transformation that moves every point of a figure or a space by the same distance in a given direction.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-fa">ترجمه</term>
+            <descrip type="definition">ترجمه یک تحول هندسی است که هر نقطه از یک شکل یا یک مکان را با همان فاصله در یک جهت معین حرکت می کند.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="66f041e16a60928b05a7e228a89c379958-vi">phép tịnh tiến</term>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-vi">phép tịnh tiến</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-la">traducción</term>
+            <descrip type="definition">La traducción es una transformación geométrica que mueve cada punto de una figura o un espacio por la misma distancia en una dirección determinada.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-es-ES">traslación</term>
+            <descrip type="definition">La traducción es una transformación geométrica que mueve cada punto de una figura o un espacio por la misma distancia en una dirección determinada.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-qu">traducción</term>
+            <descrip type="definition">La traducción es una transformación geométrica que mueve cada punto de una figura o un espacio por la misma distancia en una dirección determinada.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-pt-BR">translação</term>
+            <descrip type="definition">Translação é uma transformação geométrica que move todos os pontos de uma figura ou espaço pela mesma distância em uma determinada direção.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="4ca82782c5372a547c104929f03fe7a91056-ur-PK">ترجمہ</term>
+            <descrip type="definition">ترجمہ ایک ہندسی تغیر ہے جو کسی عدد یا جگہ کے ہر نقطے کو ایک خاص سمت میں یکساں فاصلے سے حرکت دیتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="44f683a84163b3523afe57c2e008bc8c62">
+      <termEntry id="b4d168b48157c623fbd095b4a565b5bb1058">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-fr">annuler</term>
+            <descrip type="definition">Révoquer une action. Annuler une action sans sauvegarder les modifications qui auraient étés faites si l'action avait été accomplie. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="44f683a84163b3523afe57c2e008bc8c62-en">cancel</term>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-en">cancel</term>
             <termNote type="partOfSpeech">verb</termNote>
             <descrip type="definition">To revoke an action. To quit an action without saving any changes that the action would result in.</descrip>
           </tig>
         </langSet>
-        <langSet xml:lang="vi">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="44f683a84163b3523afe57c2e008bc8c62-vi">hủy bỏ</term>
-          </tig>
-        </langSet>
-      </termEntry>
-      <termEntry id="ea5d2f1c4608232e07d3aa3d998e513564">
-        <langSet xml:lang="en">
-          <tig>
-            <term id="ea5d2f1c4608232e07d3aa3d998e513564-en">learner</term>
-            <descrip type="definition">An account type that has limited permissions. Learners can be enrolled in classes, get assigned resources through lessons and quizzes, and navigate channels directly. We intentionally did not use the term "student" to be more inclusive of non-formal educational contexts.</descrip>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-fa">لغو</term>
+            <descrip type="definition">برای ابطال عملی. برای انصراف از یک عمل بدون صرفه جویی در تغییراتی که نتیجه آن اعمال می شود.</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="ea5d2f1c4608232e07d3aa3d998e513564-vi">học viên</term>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-vi">hủy bỏ</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-la">cancelar</term>
+            <descrip type="definition">Revocar una acción. Salir de una acción sin guardar los cambios en los que la acción resultaría.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-es-ES">cancelar</term>
+            <descrip type="definition">Revocar una acción. Salir de una acción sin guardar los cambios en los que la acción resultaría.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-qu">cancelar</term>
+            <descrip type="definition">Revocar una acción. Salir de una acción sin guardar los cambios en los que la acción resultaría.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-pt-BR">cancelar</term>
+            <descrip type="definition">Anular uma ação. Interromper uma ação sem salvar as mudanças que dela resultariam.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="b4d168b48157c623fbd095b4a565b5bb1058-ur-PK">منسوخ کرنا</term>
+            <descrip type="definition">کسی عمل کو کالعدم کرنا۔ کسی  عمل کو، اس عمل کے کے نتیجے میں ہونے والی تبدیلیوں کو محفوظ کیے بنا چھوڑ دینا۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="3295c76acbf4caaed33c36b1b5fc2cb166">
-        <langSet xml:lang="en">
+      <termEntry id="cd89fef7ffdd490db800357f47722b201062">
+        <langSet xml:lang="fr">
           <tig>
-            <term id="3295c76acbf4caaed33c36b1b5fc2cb166-en">facility</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A set of accounts, classes, and their associated data. Examples of facilities could include physical schools, temporary learning hubs, organizations distributing devices across multiple locations, parent or family programs, and other types of learning environments featuring continuity between learners' activities.</descrip>
+            <term id="cd89fef7ffdd490db800357f47722b201062-fr">administrateur</term>
+            <descrip type="definition">Type de compte avec permission de gérer un établissement d'enseignement, classes et autres comptes. Les administrateurs ont également les mêmes droits que les éducateurs et apprenants. </descrip>
           </tig>
         </langSet>
-        <langSet xml:lang="vi">
-          <tig>
-            <term id="3295c76acbf4caaed33c36b1b5fc2cb166-vi">địa điểm</term>
-            <termNote type="partOfSpeech">noun</termNote>
-          </tig>
-        </langSet>
-      </termEntry>
-      <termEntry id="a3f390d88e4c41f2747bfa2f1b5f87db68">
         <langSet xml:lang="en">
           <tig>
-            <term id="a3f390d88e4c41f2747bfa2f1b5f87db68-en">admin</term>
+            <term id="cd89fef7ffdd490db800357f47722b201062-en">admin</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">An account type that has the permission to manage a facility, including classes and other accounts. Admins can also do everything that coaches and learners can do.</descrip>
           </tig>
         </langSet>
-        <langSet xml:lang="my">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="a3f390d88e4c41f2747bfa2f1b5f87db68-my">admin</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">There is no word for "Admin" in Myanmar translation. Burmese also use the word "Admin" for representation of it.</descrip>
+            <term id="cd89fef7ffdd490db800357f47722b201062-fa">مدیر</term>
+            <descrip type="definition">یک نوع حساب که مجوز مدیریت تسهیلات از جمله کلاس ها و سایر حساب ها را دارد. مدیرها همچنین می تواند همه کارهایی را که مربیان و یادگیرنده ها می توانند انجام دهند انجام دهند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-la">administrador</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar el centro, incluyendo grupos y otras cuentas. Los administradores también pueden hacer todo lo que pueden hacer tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-es-ES">administrador</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar el centro, incluyendo clases y otras cuentas. Los administradores también pueden hacer todo lo que pueden hacer tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-qu">administrador</term>
+            <descrip type="definition">Un tipo de cuenta que tiene el permiso para gestionar el centro, incluyendo grupos y otras cuentas. Los administradores también pueden hacer todo lo que pueden hacer tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-pt-BR">administrador</term>
+            <descrip type="definition">Um tipo de conta que tem permissão de gerenciar um centro educativo, incluindo classes e outras contas. Administradores podem fazer tudo o que professores e estudantes fazem.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-ur-PK">منتظم</term>
+            <descrip type="definition">اکاؤنٹ کی ایک قسم جس کو ایک سہولت، بشمول جماعتیں اور دیگر اکاؤنٹس کا انتظام کرنے کی اجازت حاصل ہوتی ہے۔ منتظم ہر وہ چیز کر سکتے ہیں جو کوچ اور سیکھنے والے کر سکتے ہیں۔</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="cd89fef7ffdd490db800357f47722b201062-fv">Dawroowo</term>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="35f4a8d465e6e1edc05f3d8ab658c55178">
+      <termEntry id="2290a7385ed77cc5592dc2153229f0821064">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-fr">quiz</term>
+            <descrip type="definition">Un quiz est une évaluation constituée de questions prises dans des exercices. Les quiz sont créés par les éducateurs et ensuite assignés aux apprenants d'une classe. Nous avons intentionnellement omis le mot "examen" pour inclure les contextes n'étant pas formellement éducatifs. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="35f4a8d465e6e1edc05f3d8ab658c55178-en">quiz</term>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-en">quiz</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A quiz is a summative assessment made up of questions taken from exercises. Quizzes are created by coaches and then assigned to learners in a class. We intentionally renamed "exam" to "quiz" in order to encourage use as an informal diagnostic tool for teachers.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-fa">امتحان</term>
+            <descrip type="definition">امتحان ارزیابی خلاصه ای است که از سؤالات گرفته شده از تمرین ها تشکیل شده است. آزمونها توسط مربیان ایجاد می شوند و سپس در یک کلاس به یادگیرنده ها اختصاص داده می شوند. ما به منظور ترغیب استفاده از آن به عنوان یک ابزار تشخیص غیررسمی برای معلمان ، عمداً "امتحان" را به "امتحان" تغییر نام دادیم.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="fv">
           <tig>
-            <term id="35f4a8d465e6e1edc05f3d8ab658c55178-fv">poondol pamarol</term>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-fv">poondol pamarol</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-la">prueba</term>
+            <descrip type="definition">Una prueba es una evaluación sumativa formada por preguntas en los ejercicios. Las pruebas son creadas por los tutores y luego asignadas a los estudiantes en una clase. Hemos cambiado intencionalmente el nombre de "examen" a "prueba" para fomentar su uso como una herramienta de diagnóstico informal para los profesores.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-es-ES">prueba</term>
+            <descrip type="definition">Una prueba es una evaluación sumativa formada por preguntas en los ejercicios. Las pruebas son creadas por los tutores y luego asignadas a los estudiantes en una clase. Hemos cambiado intencionalmente el nombre de "examen" a "prueba" para fomentar su uso como una herramienta de diagnóstico informal para los profesores.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-qu">prueba</term>
+            <descrip type="definition">Una prueba es una evaluación sumativa formada por preguntas en los ejercicios. Las pruebas son creadas por los tutores y luego asignadas a los estudiantes en una clase. Hemos cambiado intencionalmente el nombre de "examen" a "prueba" para fomentar su uso como una herramienta de diagnóstico informal para los profesores.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-pt-BR">teste</term>
+            <descrip type="definition">Um teste é uma avaliação somativa feita com questões retiradas de exercícios. Testes são criados por professores e designados a estudantes em uma classe. Renomeamos "exame" como "teste" intencionalmente, para poder encorajar o uso como uma ferramenta informal de diagnóstico para professores.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="2290a7385ed77cc5592dc2153229f0821064-ur-PK">معلوماتی آزمائش</term>
+            <descrip type="definition">ایک سوالنامہ مشقوں سے اٹھائے گئے سوالات کو ملا کر بنایا گیا ایک خلاصہ جاتی جائزہ ہوتا  ہے۔ معلوماتی آزمائشیں کوچز کے ذریعہ بنائی جاتی ہیں اور پھر کلاس میں سیکھنے والوں کو دی جاتی ہیں۔ اساتذہ کے غیر رسمی طور پر استعمال کی حوصلہ افزائی کیلئے ہم نے جان بوجھ کر "امتحان" کا نام "معلوماتی آزمائش" رکھا ہے 
+</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="2a38a4a9316c49e5a833517c45d3107088">
+      <termEntry id="43dd49b4fdb9bede653e94468ff8df1e1066">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-fr">question</term>
+            <descrip type="definition">Une question est une évaluation individuelle ayant une seule réponse possible et éventuellement quelques indices. Un exercice compte en général plusieurs questions. Les questions peuvent également être utilisées dans de multiples exercices ainsi que pour créer des quiz.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="2a38a4a9316c49e5a833517c45d3107088-en">question</term>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-en">question</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A question is an individual formative assessment item with a single correct answer and possibly a few hints. An exercise generally contains multiple questions. Questions can also be selected from across multiple exercises and used to create a quiz.</descrip>
           </tig>
         </langSet>
-        <langSet xml:lang="fv">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="2a38a4a9316c49e5a833517c45d3107088-fv">ƴamol</term>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-fa">سوال</term>
+            <descrip type="definition">یک سؤال یک مورد ارزیابی تشریحی فردی است که دارای یک جواب صحیح و احتمالاً چند نکته است. یک تمرین به طور کلی شامل چندین سوال است. همچنین می توانید سوالات را از بین تمرینهای مختلف انتخاب کرده و از آنها برای ایجاد امتحان استفاده کنید.</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="vi">
           <tig>
-            <term id="2a38a4a9316c49e5a833517c45d3107088-vi">câu hỏi</term>
-          </tig>
-        </langSet>
-      </termEntry>
-      <termEntry id="f899139df5e1059396431415e770c6dd100">
-        <langSet xml:lang="en">
-          <tig>
-            <term id="f899139df5e1059396431415e770c6dd100-en">class</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A group of enrolled learners and assigned coaches, created and managed by an admin. Coach can assign lessons and quizzes to the learners in a class, and view reports of their progress and performance</descrip>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-vi">câu hỏi</term>
           </tig>
         </langSet>
         <langSet xml:lang="fv">
           <tig>
-            <term id="f899139df5e1059396431415e770c6dd100-fv">suudu janngirde</term>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-fv">ƴamol</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-la">pregunta</term>
+            <descrip type="definition">Una pregunta es un elemento individual de evaluación formativa con una única respuesta correcta y posiblemente unas pocas pistas. Un ejercicio generalmente contiene múltiples preguntas. Las preguntas también pueden seleccionarse de entre múltiples ejercicios y utilizarse para crear una prueba.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-es-ES">pregunta</term>
+            <descrip type="definition">Una pregunta es un elemento individual de evaluación formativa con una única respuesta correcta y posiblemente unas pocas pistas. Un ejercicio generalmente contiene múltiples preguntas. Las preguntas también pueden seleccionarse de entre múltiples ejercicios y utilizarse para crear una prueba.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-qu">pregunta</term>
+            <descrip type="definition">Una pregunta es un elemento individual de evaluación formativa con una única respuesta correcta y posiblemente unas pocas pistas. Un ejercicio generalmente contiene múltiples preguntas. Las preguntas también pueden seleccionarse de entre múltiples ejercicios y utilizarse para crear una prueba.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-pt-BR">pergunta</term>
+            <descrip type="definition">Uma pergunta é um item de avaliação formativa individual com uma única resposta certa e possivelmente algumas dicas. Um exercício geralmente contém diversas perguntas. Perguntas também podem ser selecionadas de diversos exercícios e usadas para criar um teste.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="43dd49b4fdb9bede653e94468ff8df1e1066-ur-PK">سوال</term>
+            <descrip type="definition">  ایک سوال کچھ اشارات کے ساتھ۔ ابتدائی جائزہ کی شے ہے جس کا ایک ہی درست جواب ہوتا ہے۔ ایک مشق میں عام طور پر متعدد سوالات ہوتے ہیں۔ سوالات کا انتخاب متعدد مشقوں سے بھی کیا جاسکتا ہے اور معلوماتی آزمائش بنانے کے لئے استعمال کئیے جاتےہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="f0935e4cd5920aa6c7c996a5ee53a70f106">
+      <termEntry id="53adaf494dc89ef7196d73636eb2451b1068">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-fr">classe</term>
+            <descrip type="definition">Un groupe d'apprenants inscrits et des éducateurs assignés, créé et géré par un administrateur. Un éducateur peut assigner des leçons et quiz aux apprenants, ainsi que voir le compte-rendu de leur progrès et performance.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="f0935e4cd5920aa6c7c996a5ee53a70f106-en">channel</term>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-en">class</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A set of resources that can be imported to and exported from Kolibri. It is often curated in order to achieve certain pre-defined learning objectives. Channels are originally created within Kolibri Studio</descrip>
+            <descrip type="definition">A group of enrolled learners and assigned coaches, created and managed by an admin. Coach can assign lessons and quizzes to the learners in a class, and view reports of their progress and performance.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-fa">کلاس</term>
+            <descrip type="definition">گروهی از یادگیرندگان ثبت نام شده و مربیان اختصاص یافته توسط یک مدیر اداره می شوند. در یک کلاس، مربی می تواند درسها و آزمونها را به یادگیرنده ها اختصاص دهد و گزارش هایی از پیشرفت و عملکرد آنها را مشاهده کند.</descrip>
           </tig>
         </langSet>
         <langSet xml:lang="fv">
           <tig>
-            <term id="f0935e4cd5920aa6c7c996a5ee53a70f106-fv">wuro janngugo</term>
-            <termNote type="partOfSpeech">noun</termNote>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-fv">suudu janngirde</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-la">grupo</term>
+            <descrip type="definition">Un conjunto de estudiantes matriculados y tutores asignados, creados y gestionados por un administrador. El tutor puede asignar lecciones y pruebas a los estudiantes en un grupo, y ver los informes de su progreso y el rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-es-ES">clase</term>
+            <descrip type="definition">Un grupo de estudiantes matriculados y entrenadores asignados, creados y gestionados por un administrador. El tutor puede asignar lecciones y pruebas a los estudiantes en una clase, y ver los informes de su progreso y rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-qu">grupo</term>
+            <descrip type="definition">Un conjunto de estudiantes matriculados y tutores asignados, creados y gestionados por un administrador. El tutor puede asignar lecciones y pruebas a los estudiantes en un grupo, y ver los informes de su progreso y el rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-pt-BR">classe</term>
+            <descrip type="definition">Um grupo de estudantes inscritos e professores atribuídos, criado e gerenciado por um administrador. Professores podem atribuir lições e testes aos estudantes em uma classe, e ver relatórios do seu progresso e desempenho.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="53adaf494dc89ef7196d73636eb2451b1068-ur-PK">جماعت</term>
+            <descrip type="definition">اندراج شدہ سیکھنے والوں اور مقرر کردہ کوچوں کا ایک گروہ، جن کو ایک منتظم کے ذریعہ بنایا اور انتظام کیا گیا ہو۔ کوچ کلاس میں سیکھنے والوں کو اسباق اور مولوماتی آزمائشیں دے سکتا ہے، اور ان کی ترقی اور کارکردگی کی رپورٹس دیکھ سکتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="a3c65c2974270fd093ee8a9bf8ae7d0b108">
+      <termEntry id="dc58e3a306451c9d670adcd37004f48f1070">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-fr">chaîne</term>
+            <descrip type="definition">Un ensemble de ressources qui peuvent être importées ou exportées de Kolibri. Il est souvent organisé et sélectionné afin d'atteindre un certain objectif d'apprentissage prédéfini. Les chaînes sont à l'origine créées via Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="a3c65c2974270fd093ee8a9bf8ae7d0b108-en">assign</term>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-en">channel</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A set of resources that can be imported to and exported from Kolibri. It is often curated in order to achieve certain pre-defined learning objectives. Channels are originally created within Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-fa">کانال</term>
+            <descrip type="definition">مجموعه ای از منابعی که از کلیبری قابل وارد و صادر شدن هستند. غالباً برای دستیابی به اهداف یادگیری از پیش تعریف شده مشخص استفاده می شود. کانال ها در اصل در استودیوی کلیبری ساخته می شوند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-fv">wuro janngugo</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-la">canal</term>
+            <descrip type="definition">Un conjunto de recursos que pueden ser importados y exportados desde Kolibri. A menudo es curado para alcanzar ciertos objetivos de aprendizaje predefinidos. Los canales se crean originalmente en Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-es-ES">canal</term>
+            <descrip type="definition">Un conjunto de recursos que pueden ser importados y exportados desde Kolibri. A menudo es curado y organizado para alcanzar ciertos objetivos de aprendizaje predefinidos. Los canales se crean en la plataforma Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-qu">canal</term>
+            <descrip type="definition">Un conjunto de recursos que pueden ser importados y exportados desde Kolibri. A menudo es curado para alcanzar ciertos objetivos de aprendizaje predefinidos. Los canales se crean originalmente en Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-pt-BR">canal</term>
+            <descrip type="definition">Um conjunto de conteúdos que pode ser importado e exportado do Kolibri. É apurado frequentemente para atingir certos objetivos de aprendizagem pré-definidos. Canais são criados primeiramente no Kolibri Studio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="dc58e3a306451c9d670adcd37004f48f1070-ur-PK">چینل</term>
+            <descrip type="definition">وسائل کا ایک سیٹ جو کولیبری سے درآمد اور برآمد کیا جاسکتا ہے۔ یہ پہلے سے طے شدہ کچھ مخصوص سیکھنے کے مقاصد کے حصول کے لئے ترتیب دیا جاتا ہے۔ چینلز اصل میں کولیبری اسٹوڈیو میں تخلیق کیے جاتے ہیں۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="a1519de5b5d44b31a01de013b9b51a801072">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-fr">assigner</term>
+            <descrip type="definition">1. assigner un éducateur à une classe. Un administrateur assignera un utilisateur en tant que éducateur d'une classe. Ceci n'est techniquement pas la même chose que le compte de éducateur: un utilisateur assigné peut avoir un compte de éducateur mais peut également être un administrateur ou un super-admin. 2. assigner un quiz ou une leçon à des apprenants. Un éducateur peut assigner des ressources à des apprenants dans ses classes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-en">assign</term>
             <termNote type="partOfSpeech">verb</termNote>
-            <descrip type="definition">1. to assign a coach to a class. An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user may have a coach account, but that user can also be an admin or super admin
+            <descrip type="definition">1. To assign a coach to a class. An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user may have a coach account, but that user can also be an admin or super admin.
 
-2. to assign a quiz or a lesson to learners. A coach can assign resources to learners in their classes</descrip>
+2. To assign a quiz or a lesson to learners. A coach can assign resources to learners in their classes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-fa">اختصاص دادن</term>
+            <descrip type="definition">1. برای اختصاص مربی به یک کلاس. یک مدیر به کاربر اختصاص می دهد که به عنوان مربی برای یک کلاس فعالیت کند. این از نظر فنی از نظر حساب مربی متمایز است: کاربر اختصاص داده شده ممکن است یک حساب مربی داشته باشد ، اما آن کاربر همچنین می تواند یک مدیر یا مدیر ارشد باشید2. اختصاص یک امتحان یا یک درس به یادگیرنده ها. یک مربی می تواند در کلاسهای خود منابع را به یادگیرنده ها اختصاص دهد</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-la">asignar</term>
+            <descrip type="definition">1. Para asignar tutores a grupos. Un administrador asignará un usuario para que sirva como tutor para un grupo. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado puede tener una cuenta de tutor, pero ese usuario también puede ser un administrador o superadministrador.
+
+2. Para asignar pruebas o lecciones a los estudiantes. Un tutor puede asignar recursos a los estudiantes en sus grupos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-es-ES">asignar</term>
+            <descrip type="definition">1. Para asignar un tutor a una clase. Un administrador asignará un usuario para que sirva como tutor para una clase. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado puede tener una cuenta de tutor, pero ese usuario también puede ser un administrador o superadministrador.
+
+2. Para asignar una prueba o una lección a los estudiantes. Un tutor puede asignar recursos a los estudiantes en sus clases.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-qu">asignar</term>
+            <descrip type="definition">1. Para asignar tutores a grupos. Un administrador asignará un usuario para que sirva como tutor para un grupo. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado puede tener una cuenta de tutor, pero ese usuario también puede ser un administrador o superadministrador.
+
+2. Para asignar pruebas o lecciones a los estudiantes. Un tutor puede asignar recursos a los estudiantes en sus grupos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-pt-BR">atribuir</term>
+            <descrip type="definition">1. Atribuir um professor a uma classe. Um administrador atribuirá um usuário para servir como professor de uma classe. Tecnicamente, isso é diferente do tipo de conta de professor: o usuário atribuído pode ter uma conta de professor, mas esse usuário também pode ser um administrador ou super admin.
+
+2. Atribuir um teste ou lição para estudantes. Um professor pode atribuir recursos a estudantes em suas classes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="a1519de5b5d44b31a01de013b9b51a801072-ur-PK">تفویض کرنا</term>
+            <descrip type="definition">1 ایک کوچ کو کلاس میں مقرر کرنا۔ ایک منتظم صارف کو کلاس کے کوچ کی حیثیت سے خدمات انجام دینے کے لئے مقرر کرے گا۔ یہ کوچ اکاؤنٹ کی قسم سے تکنیکی لحاظ سے الگ ہے: تفویض کردہ صارف کا کوچ اکاؤنٹ ہوسکتا ہے، لیکن وہ صارف منتظم یا اعلیٰ منتظم بھی ہوسکتاہے۔
+                                                                                2 ۔ سیکھنے والوں کے لئے معلوماتی آزمائش یا سبق تفویض کرنا۔ ایک کوچ اپنی کلاسوں میں سیکھنے والوں کو وسائل تفویض کرسکتا ہے۔
+</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="5f93f983524def3dca464469d2cf9f3e110">
-        <langSet xml:lang="en">
+      <termEntry id="8a1e808b55fde9455cb3d8857ed883891076">
+        <langSet xml:lang="fr">
           <tig>
-            <term id="5f93f983524def3dca464469d2cf9f3e110-en">account</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A set of data associated with a particular user, including their name, username, password, and logs of their interactions with resources. Most users will have an account in order to track their progress as a learner, manage Kolibri as an admin, or manage their classes as a coach.</descrip>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-fr">quiz actif / leçon active</term>
+            <descrip type="definition">Attribut défini par l'éducateur pour permettre aux apprenants d'interagir avec un quiz ou une leçon. Contraire de inactif.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="7f6ffaa6bb0b408017b62254211691b5112">
         <langSet xml:lang="en">
           <tig>
-            <term id="7f6ffaa6bb0b408017b62254211691b5112-en">active (quiz or lesson)</term>
-            <termNote type="partOfSpeech">adjective</termNote>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-en">active (quiz or lesson)</term>
             <descrip type="definition">Attribute set by the coach to enable learners to interact with the quiz or lesson. Opposite of inactive.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-fa">فعال (امتحان یا درس)</term>
+            <descrip type="definition">صفتی که توسط مربی تعیین شده است تا یادگیرنده ها بتوانند با امتحان یا درس ارتباط برقرار کنند. برخلاف غیرفعال.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-la">activa (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'inactiva'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-es-ES">activa (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'inactiva'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-qu">activa (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'inactiva'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-pt-BR">ativados (teste ou lição)</term>
+            <descrip type="definition">Atributo designado pelo professor para possibilitar aos estudantes interagir com o teste ou lição. Oposto de desativados.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="8a1e808b55fde9455cb3d8857ed883891076-ur-PK">فعال (معلوماتی آزمائش یا سبق)</term>
+            <descrip type="definition">کوچ کی طرف سے مقرر کردہ اوصاف جو سیکھنے والوں کو معلوماتی آزمائش یا اسباق کے ساتھ تعامل کرنے کے قابل بناتا ہے۔ غیر فعال کا اُلٹ۔</descrip>
+          </tig>
+        </langSet>
       </termEntry>
-      <termEntry id="c45147dee729311ef5b5c3003946c48f116">
+      <termEntry id="522a9ae9a99880d39e5daec35375e9991078">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-fr">appli</term>
+            <descrip type="definition">Dans Kolibri une appli est un type de ressource. Plus particulièrement, les applis sont en général autonomes, interactives en HTML ou en applications JavaScript.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="c45147dee729311ef5b5c3003946c48f116-en">app</term>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-en">app</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">In Kolibri, an app is a certain kind of resource. Specifically, apps are generally self-contained, interactive HTML and Javascript applications.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="5ef059938ba799aaa845e1c2e8a762bd118">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="5ef059938ba799aaa845e1c2e8a762bd118-en">attempt</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">Within a question in an exercise, an attempt is recorded when a learner gives an answer, and checks to see if it is correct or not</descrip>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-fa">برنامه</term>
+            <descrip type="definition">در کلیبری ، یک برنامه نوع خاصی از منبع است. به طور خاص ، برنامه ها عموماً دارای برنامه های تعاملی HTML و جاوا اسکریپت هستند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-la">app</term>
+            <descrip type="definition">En Kolibri, una aplicación es un tipo de recurso. Específicamente, las aplicaciones generalmente son aplicaciones interactivas HTML y Javascript.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-es-ES">app</term>
+            <descrip type="definition">En Kolibri, una aplicación es un tipo de recurso. Específicamente, las aplicaciones generalmente son aplicaciones interactivas HTML y Javascript.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-qu">app</term>
+            <descrip type="definition">En Kolibri, una aplicación es un tipo de recurso. Específicamente, las aplicaciones generalmente son aplicaciones interactivas HTML y Javascript.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-pt-BR">aplicativo</term>
+            <descrip type="definition">No Kolibri, um aplicativo é uma certa forma de conteúdo. Especificamente, aplicativos em geral são aplicações HTML e Javascript interativas e independentes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="522a9ae9a99880d39e5daec35375e9991078-ur-PK">ایپ</term>
+            <descrip type="definition">،کولیبری میں، ایک ایپ ایک خاص قسم کا وسائل ہے۔ خاص طور پر، 
+HTML ایپس عام طور پر خود پر مشتمل، متعاملاتی
+ اور جاوا اسکرپٹ کی ایپلی کیشنز ہوتی ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="da4fb5c6e93e74d3df8527599fa62642120">
+      <termEntry id="731c83db8d2ff01bdc000083fd3c37401080">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-fr">tentative</term>
+            <descrip type="definition">Au sein d'une question d'exercice, une tentative est enregistrée quand l'apprenant donne une réponse et vérifie si elle est correcte ou non. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="da4fb5c6e93e74d3df8527599fa62642120-en">assign (a coach to a class)</term>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-en">attempt</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Within a question in an exercise, an attempt is recorded when a learner gives an answer, and checks to see if it is correct or not.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-fa">تلاش</term>
+            <descrip type="definition">در یک سؤال از یک تمرین ، یک تلاش ثبت می شود هنگامی که یادگیرنده پاسخ می دهد و بررسی می کند که پاسخ صحیح است یا نه.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-la">intento</term>
+            <descrip type="definition">Dentro de una pregunta en un ejercicio, un intento se registra cuando un estudiante da una respuesta, y comprueba si es correcta o no.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-es-ES">intento</term>
+            <descrip type="definition">Dentro de una pregunta en un ejercicio, un intento se registra cuando un estudiante envía una respuesta, y comprueba si es correcta o no.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-qu">intento</term>
+            <descrip type="definition">Dentro de una pregunta en un ejercicio, un intento se registra cuando un estudiante da una respuesta, y comprueba si es correcta o no.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-pt-BR">tentativa</term>
+            <descrip type="definition">Dentro de uma pergunta em um exercício, uma tentativa é registrada quando um estudante dá uma resposta e verifica para ver se está certa ou não.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="731c83db8d2ff01bdc000083fd3c37401080-ur-PK">کوشش کرنا</term>
+            <descrip type="definition">ایک مشق کے سوال کے اندر، ایک کوشش ریکارڈ کی جاتی ہے جب کوئی سیکھنے والا جواب دیتا ہے، اور پڑتال کرتا ہے کہ آیا یہ صحیح ہے یا نہیں۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="818f4654ed39a1c147d1e51a00ffb4cb1082">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-fr">assigner</term>
+            <descrip type="definition">Un administrateur assignera un utilisateur en tant que éducateur d'une classe. Ceci n'est techniquement pas la même chose que le compte de éducateur: un utilisateur assigné peut avoir un compte de éducateur mais peut également être un administrateur ou un super-admin.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-en">assign (a coach to a class)</term>
             <termNote type="partOfSpeech">verb</termNote>
-            <descrip type="definition">An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user will have permissions to coach the class, but their account type may be an admin or super admin</descrip>
+            <descrip type="definition">An admin will assign a user to serve as the coach for a class. This is technically distinct from the coach account type: the assigned user will have permissions to coach the class, but their account type may be an admin or super admin.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-fa">اختصاص دادن (مربی به کلاس)</term>
+            <descrip type="definition">سرپرست کاربر را به عنوان مربی یک کلاس اختصاص می دهد. این از نظر فنی از لحاظ حساب کاربری مربی متمایز است: کاربر اختصاص داده شده اجازه مربی کلاس را خواهد داشت ، اما نوع حساب آنها ممکن است یک مدیر یا مدیر ارشد باشد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-la">asignar (tutores a grupos)</term>
+            <descrip type="definition">Administradores pueden asignar usuarios para que sirvan como tutores de grupos. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado tendrá permisos para tutorizar el grupo, pero su tipo de cuenta también puede ser administrador o superadministrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-es-ES">asignar (tutores a clases)</term>
+            <descrip type="definition">Administrador asigna uno o más usuarios para que sean tutores de clase. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado tendrá permisos para tutorizar la clase, pero su tipo de cuenta puede ser un administrador o un superadministrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-qu">asignar (tutores a grupos)</term>
+            <descrip type="definition">Administradores pueden asignar usuarios para que sirvan como tutores de grupos. Esto es técnicamente distinto del tipo de cuenta de tutor: el usuario asignado tendrá permisos para tutorizar el grupo, pero su tipo de cuenta también puede ser administrador o superadministrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-pt-BR">atribuir (um professor a uma classe)</term>
+            <descrip type="definition">Um administrador atribuirá um usuário para servir como professor de uma classe. Tecnicamente, isso é diferente do tipo de conta de professor: o usuário atribuído pode ter uma conta de professor, mas esse usuário também pode ser um administrador ou super admin.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="818f4654ed39a1c147d1e51a00ffb4cb1082-ur-PK">(ایک جماعت پر ایک کوچ) تفویض کریں</term>
+            <descrip type="definition">ایک منتظم صارف کو کلاس کے کوچ کی حیثیت سے خدمات انجام دینے کے لئے مقرر کرے گا۔ یہ تکنیکی طور پر کوچ اکاؤنٹ کی قسم سے مختلف ہے: تفویض کردہ صارف کے پاس کلاس کوچ کرنے کی اجازت ہوگی ، لیکن ان کے اکاؤنٹ کی قسم منتظم یااعلیٰ منتظم ہوسکتی ہے۔
+</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="a0a080f42e6f13b3a2df133f073095dd122">
+      <termEntry id="9f36407ead0629fc166f14dde7970f681084">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-fr">assigner</term>
+            <descrip type="definition">Un éducateur peut assigner une ressource aux apprenants de leurs classes.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="a0a080f42e6f13b3a2df133f073095dd122-en">assign (a quiz or a lesson to learners)</term>
+            <term id="9f36407ead0629fc166f14dde7970f681084-en">assign (a quiz or a lesson to learners)</term>
             <termNote type="partOfSpeech">verb</termNote>
-            <descrip type="definition">A coach can assign a resource to learners in their classes</descrip>
+            <descrip type="definition">A coach can assign a resource to learners in their classes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-fa">اختصاص دادن (یک امتحان یا یک درس به یادگیرندها)</term>
+            <descrip type="definition">یک مربی می تواند منبعی را در کلاس های خود به یادگیرنده ها اختصاص دهد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-la">asignar (pruebas o lecciones a estudiantes)</term>
+            <descrip type="definition">Tutores pueden asignar recursos a los estudiantes en sus grupos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-es-ES">asignar (pruebas o lecciones a estudiantes)</term>
+            <descrip type="definition">Tutores pueden asignar recursos a los estudiantes en sus clases.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-qu">asignar (pruebas o lecciones a estudiantes)</term>
+            <descrip type="definition">Tutores pueden asignar recursos a los estudiantes en sus grupos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-pt-BR">atribuir (teste ou lição para estudantes)</term>
+            <descrip type="definition">Um professor pode atribuir conteúdos a estudantes em suas classes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="9f36407ead0629fc166f14dde7970f681084-ur-PK">تفویض (ایک سیکھنے والے کو ایک کوئز یا سبق)</term>
+            <descrip type="definition">ایک کوچ  اپنی کلاسوں میں سیکھنے والوں کو ایک وسیلہ تفویض کرسکتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="c8ffe9a587b126f152ed3d89a146b445124">
+      <termEntry id="d91d1b4d82419de8a614abce9cc0e6d41086">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-fr">groupe de chaînes</term>
+            <descrip type="definition">Un groupe de chaînes peut être importé en utilisant un seul jeton.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="c8ffe9a587b126f152ed3d89a146b445124-en">channel bundle</term>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-en">channel collection</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A group of channels that can be imported together using a single token</descrip>
+            <descrip type="definition">A group of channels that can be imported together using a single token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-fa">بسته کانال</term>
+            <descrip type="definition">گروهی از کانالهایی که با استفاده از یک نشانه واحد می توانند با هم وارد شوند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-la">colección de canales</term>
+            <descrip type="definition">Un grupo de canales que pueden ser importados juntos usando un solo token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-es-ES">colección de canales</term>
+            <descrip type="definition">Un grupo de canales que pueden ser importados juntos usando un solo token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-qu">colección de canales</term>
+            <descrip type="definition">Un grupo de canales que pueden ser importados juntos usando un solo token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-pt-BR">conjunto de canais</term>
+            <descrip type="definition">Um grupo de canais que pode ser importado usando um único token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="d91d1b4d82419de8a614abce9cc0e6d41086-ur-PK">چینلوں کا مجموعہ</term>
+            <descrip type="definition">چینلوں کا ایک گروہ جن کو ایک ہی ٹوکن سے اکٹھے درآمد کیا جا سکتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="069059b7ef840f0c74a814ec9237b6ec126">
-        <langSet xml:lang="en">
+      <termEntry id="b1563a78ec59337587f6ab6397699afc1088">
+        <langSet xml:lang="fr">
           <tig>
-            <term id="069059b7ef840f0c74a814ec9237b6ec126-en">token</term>
-            <descrip type="definition">A short sequence of characters that uniquely identifies a channel or a channel bundle</descrip>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-fr">jeton</term>
+            <descrip type="definition">Une courte séquence de caractères unique qui identifie une chaîne ou bien un group de chaînes. </descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="76dc611d6ebaafc66cc0879c71b5db5c128">
         <langSet xml:lang="en">
           <tig>
-            <term id="76dc611d6ebaafc66cc0879c71b5db5c128-en">class coach</term>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-en">token</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A type of coach account that has permission to view and manage only classes that they have been assigned to by an admin</descrip>
+            <descrip type="definition">A short sequence of characters that uniquely identifies a channel or a channel collection.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-fa">نشانه</term>
+            <descrip type="definition">دنباله ای کوتاه از کاراکترهایی که بطور جداگانه کانال یا بسته کانال را مشخص می کنند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-la">token</term>
+            <descrip type="definition">Una secuencia corta de caracteres que identifican de forma única un canal o una colección de canales.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-es-ES">token</term>
+            <descrip type="definition">Una secuencia corta de caracteres que identifica de forma única un canal o una colección de canales.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-qu">token</term>
+            <descrip type="definition">Una secuencia corta de caracteres que identifican de forma única un canal o una colección de canales.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-pt-BR">token</term>
+            <descrip type="definition">Uma sequência curta de caracteres que identifica unicamente um canal ou um conjunto de canais.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="b1563a78ec59337587f6ab6397699afc1088-ur-PK">ٹوکن</term>
+            <descrip type="definition">حروف کا ایک مختصر سلسلہ جو کسی چینل یا چینل کے بنڈل کی انفرادیت سے شناخت کرتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="9b8619251a19057cff70779273e95aa6130">
+      <termEntry id="8b4066554730ddfaa0266346bdc1b2021090">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-fr">éducateur de classe</term>
+            <descrip type="definition">Type de compte ayant uniquement la permission de lire et administrer les classes qui leur sont assignées. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="9b8619251a19057cff70779273e95aa6130-en">coach resource</term>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-en">class coach</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A resource that is only visible to accounts with type coach, facility coach, admin, or super admin. Coach resources might be answer keys, teacher training, or other similar materials</descrip>
+            <descrip type="definition">A type of coach account that has permission to view and manage only classes that they have been assigned to by an admin.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-fa">مربی کلاس</term>
+            <descrip type="definition">یک نوع حساب کاربری مربی که اجازه مشاهده و مدیریت فقط کلاسهایی را دارد که یک مدیر به آنها اختصاص داده است</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-la">tutor del grupo</term>
+            <descrip type="definition">Un tipo de cuenta de tutor que tiene permiso para ver y administrar sólo los grupos a los que han sido asignados por un administrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-es-ES">tutor de la clase</term>
+            <descrip type="definition">Un tipo de cuenta de tutor que tiene permiso para ver y administrar sólo las clases a las que ha sido asignado por un administrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-qu">tutor del grupo</term>
+            <descrip type="definition">Un tipo de cuenta de tutor que tiene permiso para ver y administrar sólo los grupos a los que han sido asignados por un administrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-pt-BR">professor da classe</term>
+            <descrip type="definition">Um tipo de conta de professor que tem permissão para visualizar e gerenciar apenas classes que lhe tenham sido atribuídas por um administrador.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="8b4066554730ddfaa0266346bdc1b2021090-ur-PK">جماعت کا کوچ</term>
+            <descrip type="definition">کوچ اکاؤنٹ کی ایک قسم جس میں صرف کلاس دیکھنے اور ان کو منظم کرنے کی اجازت  جس میں انہیں منتظم نے مقرر کیا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="02522a2b2726fb0a03bb19f2d8d9524d134">
+      <termEntry id="6a2feef8ed6a9fe76d6b3f30f02150b41092">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-fr">ressource pour l'éducateur</term>
+            <descrip type="definition">Ressource uniquement visible aux comptes suivants: éducateur d'établissement, administrateur ou super-administrateur.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="02522a2b2726fb0a03bb19f2d8d9524d134-en">data</term>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-en">coach resource</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A resource that is only visible to accounts with type coach, facility coach, admin, or super admin. Coach resources might be answer keys, teacher training, or other similar materials.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-fa">منبع مربی</term>
+            <descrip type="definition">منبعی که فقط برای حساب های دارای مربی نوع ، مربی امکانات ، مدیر و یا مدیرارشد قابل مشاهده است. منابع مربی ممکن است کلیدهای پاسخ ، آموزش معلمان یا سایر مطالب مشابه باشد</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-la">material para tutores</term>
+            <descrip type="definition">Materiales o recursos que sólo son visibles para usuarios con cuentas del tipo tutor del grupo, tutor del centro, administrador o superadministrador. Los recursos de tutores pueden ser hojas de respuesta, recursos para la capacitación profesional u otros materiales similares.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-es-ES">material para tutores</term>
+            <descrip type="definition">Un recurso que sólo es visible para cuentas con el tipo de tutor (de clase o centro), administrador o superadministrador. Los recursos y materiales para tutores pueden ser hojas con claves de respuesta, materiales para la capacitación del profesorado u otros materiales similares.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-qu">material para tutores</term>
+            <descrip type="definition">Materiales o recursos que sólo son visibles para usuarios con cuentas del tipo tutor del grupo, tutor del centro, administrador o superadministrador. Los recursos de tutores pueden ser hojas de respuesta, recursos para la capacitación profesional u otros materiales similares.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-pt-BR">material para professores</term>
+            <descrip type="definition">Um material que é visível apenas para contas do tipo professor, professor de centro educativo, administrador ou super admin. Os materiais de professores podem ser respostas-chave, treinamento de professores ou outros tipos de materiais similares.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="6a2feef8ed6a9fe76d6b3f30f02150b41092-ur-PK">کوچ کا وسیلہ</term>
+            <descrip type="definition">ایک ایسا وسیلہ جو صرف ٹائپ کوچ، سہولت کوچ، منتظم، یا اعلیٰ منتظم والے اکاؤنٹ میں نظر آتا ہے۔ کوچ کے وسائل سوالات کے جوابات، اساتذہ کی تربیت، یا اسی طرح کے دیگر مواد ہوسکتےہیں۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="41bfd20a38bb1b0bec75acf0845530a71094">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-fr">données</term>
+            <descrip type="definition">Informations associées aux comptes d'utilisateurs et contenues dans leurs profils. Elles contiennent la liste des classes et établissements qui leurs sont associés, ainsi que les logs montrant comment ils ont interagit avec les ressources. Les données ne contiennent pas de ressources mais peuvent inclure des liens vers ces ressources.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-en">data</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">Refers to information associated with users' accounts contained in their profile, which classes and facilities they are in, and the logs showing how they have interacted with resources. Data does not contain resources, but may contain references to them.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="42a0e188f5033bc65bf8d78622277c4e136">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="42a0e188f5033bc65bf8d78622277c4e136-en">demo site</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">An online "demonstration" version of Kolibri that can be accessed publicly. All data and resources on the demo site is liable to be deleted or changed periodically</descrip>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-fa">داده ها</term>
+            <descrip type="definition">به اطلاعات مربوط به حسابهای كاربران موجود در مشخصات آنها ، كلاسها و امكانات موجود در آنها و گزارشهای مربوط به تعامل آنها با منابع اشاره دارد. داده ها شامل منابع نیستند ، اما ممکن است شامل منابع آنها باشد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-la">datos</term>
+            <descrip type="definition">Se refiere a la información asociada con las cuentas de los usuarios contenida en sus perfiles, en qué grupo y centro están inscritos, y los registros que muestran cómo han interactuado con los recursos. Los datos no contienen recursos, pero pueden contener referencias a ellos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-es-ES">datos</term>
+            <descrip type="definition">Se refiere a la información asociada con las cuentas de los usuarios contenida en sus perfiles, en qué clase y centro están inscritos, y los registros que muestran cómo han interactuado con los recursos. Los datos no contienen recursos, pero pueden contener referencias a ellos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-qu">datos</term>
+            <descrip type="definition">Se refiere a la información asociada con las cuentas de los usuarios contenida en sus perfiles, en qué grupo y centro están inscritos, y los registros que muestran cómo han interactuado con los recursos. Los datos no contienen recursos, pero pueden contener referencias a ellos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-pt-BR">dados</term>
+            <descrip type="definition">Refere-se a informações ligadas às contas de usuário contidas em seus perfis, quais classes ou centros educativos estão e os registros mostrando como interagiram com os conteúdos. Os dados não contêm conteúdos, mas podem conter referências a eles.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="41bfd20a38bb1b0bec75acf0845530a71094-ur-PK">اعداد و شمار</term>
+            <descrip type="definition">ان کے پروفائل میں موجود صارفین کے اکاؤنٹس سے وابستہ معلومات کا حوالہ دیتا ہے ، وہ کونسی کلاس اور سہولیات میں ہیں ، اور نوشتہ جات یہ ظاہر کرتے ہیں کہ انہوں نے وسائل کس طرح استعمال کئیے ہیں۔ ڈیٹا میں وسائل شامل نہیں ہیں ، لیکن ان میں ان کے حوالہ جات ہوسکتے ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="013d407166ec4fa56eb1e1f8cbe183b9138">
+      <termEntry id="4e2545f819e67f0615003dd7e04a60871096">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-fr">site de démonstration</term>
+            <descrip type="definition">Une version de démonstration de Kolibri en ligne accessible publiquement. Toutes les données et ressources sur le site de démonstration sont supprimées et/ou modifiées régulièrement.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="013d407166ec4fa56eb1e1f8cbe183b9138-en">device</term>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-en">demo site</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">An online "demonstration" version of Kolibri that can be accessed publicly. All data and resources on the demo site is liable to be deleted or changed periodically.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-fa">سایت نسخه نمایشی</term>
+            <descrip type="definition">نسخه "نمایش" آنلاین از کلیبری است که می توانید به صورت عمومی دسترسی داشته باشید. کلیه داده ها و منابع موجود در سایت نسخه ی نمایشی احتمالاً به صورت دوره ای حذف یا تغییر می یابد</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-la">sitio demo</term>
+            <descrip type="definition">Una versión en línea de "demostración" de Kolibri a la que se puede acceder públicamente. Todos los datos y recursos del sitio de demostración son susceptibles de ser borrados o modificados periódicamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-es-ES">sitio demo</term>
+            <descrip type="definition">Una versión en línea de "demostración" de Kolibri a la que se puede acceder públicamente. Todos los datos y recursos del sitio de demostración son susceptibles de ser borrados o modificados periódicamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-qu">sitio demo</term>
+            <descrip type="definition">Una versión en línea de "demostración" de Kolibri a la que se puede acceder públicamente. Todos los datos y recursos del sitio de demostración son susceptibles de ser borrados o modificados periódicamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-pt-BR">site de demonstração</term>
+            <descrip type="definition">Uma versão de "demonstração" online do Kolibri que pode ser acessada publicamente. Todos os dados e conteúdos no site de demonstração são passíveis de serem deletados ou modificados periodicamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="4e2545f819e67f0615003dd7e04a60871096-ur-PK">ڈیمو سائٹ</term>
+            <descrip type="definition">کولیبری کا ایک آن لائن "مظاہرہ" ورژن جس تک عوامی طور پر رسائی حاصل کی جاسکتی ہے۔ ڈیمو سائٹ پر موجود تمام اعداد و شمار اور وسائل وقتاً فوقتاً حذف یا تبدیل کیے جانے کے پابند ہیں۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="a5e0ff62be0b08456fc7f1e88812af3d1098">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-fr">appareil</term>
+            <descrip type="definition">Machine physique ou virtuelle sur laquelle le serveur Kolibri est installé. Cette machine contient au minimum un CPU, du stockage et une mémoire. Elle peut éventuellement inclure un écran, une connexion réseau, une batterie, etc. Exemple d'appareils: un PC de bureau, un PC portable, un serveur en rack, un Raspberry Pi, une VM dans le cloud.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-en">device</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">The physical or virtual machine that has the Kolibri server installed on it. Kolibri server device will minimally include a processor, storage, and memory. It may also include a screen, a network connection, a battery, etc. Common examples of server devices are: a desktop or laptop computer; a rack-mounted server; a raspberry pi; a virtual machine running in the cloud.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="1385974ed5904a438616ff7bdb3f7439140">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="1385974ed5904a438616ff7bdb3f7439140-en">enroll, enrolled</term>
-            <termNote type="partOfSpeech">adjective</termNote>
-            <descrip type="definition">An admin or super admin can add learners to classes by enrolling them, after which they are enrolled in the class and can take lessons and quizzes. Likewise, the coach of a class can enroll learners in a group. After being enrolled, the learner is considered a member of the class and the group.</descrip>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-fa">دستگاه</term>
+            <descrip type="definition">دستگاه فیزیکی یا مجازی که سرور کلیبری روی آن نصب شده است. دستگاه سرور کلیبری حداقل یک پردازنده ، حافظه دایمی و حافظه موقتی را در بر می گیرد. همچنین ممکن است شامل صفحه نمایش ، اتصال شبکه ، باتری و غیره باشد. نمونه های رایج دستگاه های سرور عبارتند از: رایانه رومیزی یا لپ تاپ. یک رک سرور نصب شده. یک رزبری پای؛ یک ماشین مجازی که در کلود اجرا می شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-la">dispositivo</term>
+            <descrip type="definition">La máquina física o virtual que tiene el servidor Kolibri instalado en él. El dispositivo de servidor Kolibri incluirá mínimamente un procesador, almacenamiento y memoria. También puede incluir una pantalla, una conexión de red, una batería, etc. Ejemplos comunes de dispositivos de servidor son: un ordenador portátil o de escritorio; un servidor montado en rack; un dispositivo Raspberry Pi; una máquina virtual corriendo en la nube.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-es-ES">dispositivo</term>
+            <descrip type="definition">La máquina física o virtual que tiene el servidor Kolibri instalado en él. El dispositivo de servidor Kolibri incluirá mínimamente un procesador, almacenamiento y memoria. También puede incluir una pantalla, una conexión de red, una batería, etc. Ejemplos comunes de dispositivos de servidor son: un ordenador portátil o de escritorio; un servidor montado en rack; un dispositivo Raspberry Pi; una máquina virtual corriendo en la nube.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-qu">dispositivo</term>
+            <descrip type="definition">La máquina física o virtual que tiene el servidor Kolibri instalado en él. El dispositivo de servidor Kolibri incluirá mínimamente un procesador, almacenamiento y memoria. También puede incluir una pantalla, una conexión de red, una batería, etc. Ejemplos comunes de dispositivos de servidor son: un ordenador portátil o de escritorio; un servidor montado en rack; un dispositivo Raspberry Pi; una máquina virtual corriendo en la nube.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-pt-BR">dispositivo</term>
+            <descrip type="definition">A máquina física ou virtual que tem o servidor do Kolibri instalado. O dispositivo servidor com o Kolibri terá minimamente um processador, armazenamento e memória. Pode também ter uma tela, uma conexão de internet, bateria, etc. Exemplos comuns de dispositivos servidor são: um computador ou laptop; servidor em rack; um raspberry pi; uma máquina virtual sendo executada na nuvem.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="a5e0ff62be0b08456fc7f1e88812af3d1098-ur-PK">آلہ</term>
+            <descrip type="definition">مادی یا مجازی مشین جس میں کولبیری سرور انسٹال ہے۔ کولیبری سرور ڈیوائس میں کم سے کم ایک پروسیسر ، اسٹوریج ، اور میموری شامل ہوگی۔ اس میں ایک اسکرین ، ایک نیٹ ورک کنکشن ، ایک بیٹری ، وغیرہ بھی شامل ہوسکتا ہے سرور آلات کی عام مثالیں ہیں۔ سرور آلات کی عام مثالیں ہیں: ایک ڈیسک ٹاپ یا لیپ ٹاپ کمپیوٹر؛ ایک ریک ماؤنٹڈ سرور؛ ا ریسبری پائی؛ کلاؤڈ میں چلتی ایک مجازی مشین۔
+</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="a8baa56554f96369ab93e4f3bb068c22142">
+      <termEntry id="1e6e0a04d20f50967c64dac2d639a5771100">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-fr">inscrire, inscrit</term>
+            <descrip type="definition">Un administrateur ou un super-administrateur peut ajouter des apprenants aux classes en les inscrivant. Après être inscrits, ils peuvent participer aux leçons et quiz. De plus un éducateur de classe peut inscrire des apprenants à des groupes. Un apprenant est considéré comme membre d'une classe et d'un groupe. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="a8baa56554f96369ab93e4f3bb068c22142-en">exercise</term>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-en">enroll, enrolled</term>
+            <descrip type="definition">An admin or super admin can add learners to classes by enrolling them, after which they are enrolled in the class and can take lessons and quizzes. Likewise, the coach of a class can enroll learners in a group. After being enrolled, the learner is considered a member of the class and the group.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-fa">ثبت نام کرد ، ثبت نام کرده</term>
+            <descrip type="definition">یک مدیر یا مدیر ارشد می تواند با ثبت نام در آنها ، یادگیرنده ها را به کلاس ها اضافه کند ، پس از آن در کلاس ثبت نام می کنند و می توانند دروس و آزمون را بگیرند. به همین ترتیب ، مربی یک کلاس می تواند یادگیرنده ها را در یک گروه ثبت نام کند. پس از ثبت نام ، یادگیرنده عضو کلاس و گروه در نظر گرفته می شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-la">inscribirse, inscrito</term>
+            <descrip type="definition">Administradores y superadministradores pueden inscribir estudiantes a los grupos. Una vez están inscritos en el grupo, estudiantes pueden acceder las lecciones y pruebas. Del mismo modo, el tutor de un grupo puede inscribir a los estudiantes en equipos. Una vez inscrito, el estudiante es considerado miembro del grupo o equipo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-es-ES">inscribir, inscrito</term>
+            <descrip type="definition">Administradores y superadministradores pueden inscribir estudiantes a las clases. Una vez están inscritos a la clase, estudiantes pueden acceder a las lecciones y pruebas. Del mismo modo, el tutor de una clase puede inscribir los estudiantes a los grupos. Una vez inscrito, el estudiante es considerado miembro de la clase o el grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-qu">inscribirse, inscrito</term>
+            <descrip type="definition">Administradores y superadministradores pueden inscribir estudiantes a los grupos. Una vez están inscritos en el grupo, estudiantes pueden acceder las lecciones y pruebas. Del mismo modo, el tutor de un grupo puede inscribir a los estudiantes en equipos. Una vez inscrito, el estudiante es considerado miembro del grupo o equipo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-pt-BR">inscrever, inscrito</term>
+            <descrip type="definition">Um administrador ou super admin pode adicionar estudantes a classes ao inscrevê-los, e em seguida eles são inscritos nas aulas e podem ter lições e testes. Igualmente, um professor de uma classe pode inscrever estudantes em um grupo. Após ser inscrito, o estudante é considerado um membro da classe e do grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="1e6e0a04d20f50967c64dac2d639a5771100-ur-PK">اندراج، اندراج شدہ</term>
+            <descrip type="definition">کوئی منتظم یا اعلیٰ منتظم سیکھنے والوں کو داخلہ لیکر کلاسز میں شامل کرسکتا ہے، جس کے بعد وہ کلاس میں داخلہ ہو جاتے ہیں اور اسباق اور کوئز لے سکتے ہیں۔ اسی طرح، کلاس کا کوچ سیکھنے والوں کو  گروپ میں داخل کرسکتا ہے۔ اندراج کے بعد، سیکھنے والے کو کلاس اور گروپ کا ممبر سمجھا جاتا ہے۔
+</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="c667d53acd899a97a85de0c201ba99be1102">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-fr">exercice</term>
+            <descrip type="definition">Un exercice est une ressource d'évaluation interactive. Les exercices contiennent le plus souvent de multiples questions et sont associées à un modèle pédagogique.  Les questions  d'exercices peuvent être utilisées individuellement pour créer une évaluation sous forme de quizz.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-en">exercise</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">An exercise is an interactive formative assessment resource. Exercises usually contain multiple questions, and have an associated mastery model. Individual questions from exercises are also used to create summative assessments in the form of quizzes.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-fa">تمرین</term>
+            <descrip type="definition">تمرین یک منبع ارزیابی تعاملی تعاملی است. تمرینات معمولاً شامل چندین سؤال است و از مدل تسلط همراه برخوردار است. همچنین از سوالات فردی تمرینات برای ایجاد ارزیابی های خلاصه در قالب آزمون استفاده می شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="vi">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-vi">bài tập</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-la">ejercicio</term>
+            <descrip type="definition">Un ejercicio es un recurso interactivo de evaluación formativa. Los ejercicios generalmente contienen múltiples preguntas y tienen un modelo de maestría asociado. Las preguntas individuales de los ejercicios también se utilizan para crear evaluaciones resumidas en forma de pruebas.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-es-ES">ejercicio</term>
+            <descrip type="definition">Un ejercicio es un recurso interactivo de evaluación formativa. Los ejercicios generalmente contienen múltiples preguntas y tienen un criterio de dominio asociado. Las preguntas individuales de los ejercicios también se utilizan para crear evaluaciones resumidas en forma de pruebas.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-qu">ejercicio</term>
+            <descrip type="definition">Un ejercicio es un recurso interactivo de evaluación formativa. Los ejercicios generalmente contienen múltiples preguntas y tienen un modelo de maestría asociado. Las preguntas individuales de los ejercicios también se utilizan para crear evaluaciones resumidas en forma de pruebas.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-pt-BR">exercício</term>
+            <descrip type="definition">Um exercício é um conteúdo de avaliação formativa interativo. Exercícios geralmente contêm diversas perguntas e possuem um critério de domínio vinculado. Perguntas individuais de exercícios são também usadas para criar avaliações somativas na forma de testes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c667d53acd899a97a85de0c201ba99be1102-ur-PK">مشق</term>
+            <descrip type="definition">ایک مشق ایک متعاملاتی ابتدائی تشخیص کا وسیلہ ہے۔ مشقوں میں عام طور پر متعدد سوالات ہوتے ہیں، اور اس سے وابستہ ماسٹر ماڈل ہوتے ہیں۔ مشقوں سے انفرادی سوالات بھی معلوماتی آزمائش کی شکل میں مجموعی تشخص کیلئے استعمال ہوتے ہیں۔
+</descrip>
+          </tig>
+        </langSet>
       </termEntry>
-      <termEntry id="0a09c8844ba8f0936c20bd791130d6b6144">
+      <termEntry id="4da04049a062f5adfe81b67dd755cecc1104">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-fr">éducateur d'établissement</term>
+            <descrip type="definition">Type de compte éducateur avec permission de lire et administrer les classes d'un établissement qui leur sont assignées. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="0a09c8844ba8f0936c20bd791130d6b6144-en">facility coach</term>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-en">facility coach</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A type of coach account that has permission to view and manage all classes in a facility</descrip>
+            <descrip type="definition">A type of coach account that has permission to view and manage all classes in a facility.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-fa">مربی امکانات</term>
+            <descrip type="definition">نوعی حساب کاربری مربی که اجازه مشاهده و مدیریت کلیه کلاسها در یک مرکز را دارد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-la">tutor del centro educativo</term>
+            <descrip type="definition">Un tipo de cuenta de tutor que tiene permiso para ver y administrar todos grupos en el centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-es-ES">tutor del centro educativo</term>
+            <descrip type="definition">Tipo de cuenta de tutor que tiene permiso para ver y gestionar todas las clases del centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-qu">tutor del centro educativo</term>
+            <descrip type="definition">Un tipo de cuenta de tutor que tiene permiso para ver y administrar todos grupos en el centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-pt-BR">professor do centro educativo</term>
+            <descrip type="definition">Um tipo de conta de professor que tem permissão para visualizar e gerenciar todas as classes em um centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="4da04049a062f5adfe81b67dd755cecc1104-ur-PK">سہولت کا کوچ</term>
+            <descrip type="definition">کوچ اکاؤنٹ کی ایک قسم جس کو سہولت میں تمام کلاسز دیکھنے اور ان کا انتظام کرنے کی اجازت ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="a5e00132373a7031000fd987a3c9f87b146">
+      <termEntry id="c9f95a0a5af052bffce5c89917335f671106">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-fr">groupe</term>
+            <descrip type="definition">Un ensemble d'apprenants créé par un éducateur dans une classe pour leur donner des leçons particulières. Quiz et leçons peuvent être assignés à un groupe ou bien à une classe entière.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="a5e00132373a7031000fd987a3c9f87b146-en">group</term>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-en">group</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A collection of learners created by a coach inside a class to help with differentiated learning. Quizzes and lessons can be assigned to individual groups as well as to the whole class</descrip>
+            <descrip type="definition">A collection of learners created by a coach inside a class to help with differentiated learning. Quizzes and lessons can be assigned to individual groups as well as to the whole class.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-fa">گروه</term>
+            <descrip type="definition">مجموعه یادگیرندگان ایجاد شده توسط یک مربی در داخل کلاس برای کمک به یادگیری متمایز. آزمونها و دروس را می توان به گروههای فردی و همچنین به کل کلاس اختصاص داد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-la">equipo</term>
+            <descrip type="definition">Un conjunto de estudiantes creado por el tutor dentro de un grupo para ayudar con el aprendizaje diferenciado. Pruebas y lecciones pueden ser asignadas a equipos particulares, así como a todo el grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-es-ES">grupo</term>
+            <descrip type="definition">Una conjunto de estudiantes creado por un tutor dentro de una clase para ayudar con el aprendizaje diferenciado. Las pruebas y lecciones pueden ser asignadas a grupos particulares así como a toda la clase.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-qu">equipo</term>
+            <descrip type="definition">Un conjunto de estudiantes creado por el tutor dentro de un grupo para ayudar con el aprendizaje diferenciado. Pruebas y lecciones pueden ser asignadas a equipos particulares, así como a todo el grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-pt-BR">grupo</term>
+            <descrip type="definition">Um conjunto de estudantes criado por um professor dentro de uma classe para ajudar com aprendizagem diferenciada. Testes e lições podem ser atribuídos a grupos individuais, assim como para a classe inteira.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c9f95a0a5af052bffce5c89917335f671106-ur-PK">گروہ</term>
+            <descrip type="definition">مختلف استعداد علمی میں مدد کے لئے کلاس کے اندر کوچ کے ذریعہ تیار کردہ سیکھنے والوں کا ایک مجموعہ۔ معلوماتی آزمائش اور اسباق انفرادی گروہوں کے ساتھ ساتھ پوری کلاس کو دئیے جاسکتے ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="47d1e990583c9c67424d369f3414728e148">
+      <termEntry id="b9d487a30398d42ecff55c228ed5652b1108">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-fr">indice</term>
+            <descrip type="definition">Un indice donné aux apprenants pour les aider à répondre à une question d'un exercice donné. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="47d1e990583c9c67424d369f3414728e148-en">hint</term>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-en">hint</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A clue provided to learners in the context of answering questions within an exercise</descrip>
+            <descrip type="definition">A clue provided to learners in the context of answering questions within an exercise.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-fa">نکته</term>
+            <descrip type="definition">سرنخی که در زمینه پاسخ دادن به سؤالات درون یک تمرین ، در اختیار یادگیرنده ها قرار می گیرد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-la">pista</term>
+            <descrip type="definition">Una pista proporcionada a los estudiantes en el contexto de responder preguntas dentro de un ejercicio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-es-ES">pista</term>
+            <descrip type="definition">Una sugerencia proporcionada a los estudiantes en el contexto de responder preguntas dentro de un ejercicio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-qu">pista</term>
+            <descrip type="definition">Una pista proporcionada a los estudiantes en el contexto de responder preguntas dentro de un ejercicio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-pt-BR">dica</term>
+            <descrip type="definition">Uma pista dada aos estudantes no contexto de responder perguntas em um exercício.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="b9d487a30398d42ecff55c228ed5652b1108-ur-PK">اشارہ</term>
+            <descrip type="definition">مشقوں کے اندر سوالات و جوابات کے تناظر میں سیکھنے والوں کو دیا گیا ایک اشارہ۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="7ef605fc8dba5425d6965fbd4c8fbe1f150">
+      <termEntry id="2cbca44843a864533ec05b321ae1f9d11110">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-fr">quiz inactif / leçon inactive</term>
+            <descrip type="definition">Attribut défini par l'éducateur pour interdire aux apprenants d'interagir avec un quiz ou une leçon. Contraire de actif.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="7ef605fc8dba5425d6965fbd4c8fbe1f150-en">inactive (quiz or lesson)</term>
-            <termNote type="partOfSpeech">adjective</termNote>
-            <descrip type="definition">Attribute set by the coach to prevent learners from interacting with the quiz or lesson. Opposite of active</descrip>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-en">inactive (quiz or lesson)</term>
+            <descrip type="definition">Attribute set by the coach to prevent learners from interacting with the quiz or lesson. Opposite of active.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-fa">غیرفعال (امتحان یا درس)</term>
+            <descrip type="definition">ویژگی تعیین شده توسط مربی برای جلوگیری از تعامل یادگیرنده ها با امتحان یا درس. برخلاف فعال.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-la">inactiva (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'activa'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-es-ES">inactiva (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'activa'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-qu">inactiva (prueba o lección)</term>
+            <descrip type="definition">Atributo establecido por tutores para permitir a los estudiantes interactuar con la prueba o la lección. Opuesto de 'activa'.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-pt-BR">desativados (teste ou lição)</term>
+            <descrip type="definition">Atributo designado pelo professor para impedir aos estudantes de interagir com o teste ou lição. Oposto de ativados.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="2cbca44843a864533ec05b321ae1f9d11110-ur-PK">غیر فعال (معلوماتی آزمائش یا سبق)</term>
+            <descrip type="definition">سیکھنے والوں کو معلوماتی آزمائش یا سبق کے ساتھ تعامل کرنے سے روکنے کے لئے کوچ کی طرف سے مقرر کردہ اوصاف۔ فعال کا الٹ۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="37a749d808e46495a8da1e5352d03cae152">
+      <termEntry id="20d135f0f28185b84a4cf7aa51f295001112">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-fr">installeur</term>
+            <descrip type="definition">Un fichier téléchargeable et exécutable installant une version de Kolibri sur un appareil.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="37a749d808e46495a8da1e5352d03cae152-en">installer</term>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-en">installer</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A downloadable and executable file which installs some version of Kolibri on a device</descrip>
+            <descrip type="definition">A downloadable and executable file which installs some version of Kolibri on a device.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-fa">نصاب</term>
+            <descrip type="definition">یک فایل قابل بارگیری و اجرایی که نسخه ای از کلیبری را در یک دستگاه نصب می کند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-la">instalador</term>
+            <descrip type="definition">Un archivo descargable y ejecutable que instala una versión de Kolibri en un dispositivo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-es-ES">instalador</term>
+            <descrip type="definition">Un archivo descargable y ejecutable que instala una versión de Kolibri en un dispositivo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-qu">instalador</term>
+            <descrip type="definition">Un archivo descargable y ejecutable que instala una versión de Kolibri en un dispositivo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-pt-BR">instalador</term>
+            <descrip type="definition">Um arquivo baixável e executável que instala alguma das versões do Kolibri em um dispositivo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="20d135f0f28185b84a4cf7aa51f295001112-ur-PK">انسٹآلر</term>
+            <descrip type="definition">ایک ڈاؤن لوڈ اورایگز قابلِ عمل فائل جو کسی آلہ پر کولیبری کا کوئی ورژن انسٹال کرتی ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="1d7f7abc18fcb43975065399b0d1e48e154">
+      <termEntry id="d6ef5f7fa914c19931a55bb262ec879c1114">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-fr">leçon</term>
+            <descrip type="definition">Une leçon est un chemin d'apprentissage linéaire et défini par un éducateur. Ce dernier peut sélectionner des ressources de n'importe quel canal, les ajouter aux leçons, définir l'ordre et assigner la leçon aux apprenants de leurs classes.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="1d7f7abc18fcb43975065399b0d1e48e154-en">lesson</term>
-            <descrip type="definition">A lesson is a linear learning pathway defined by a coach. The coach can select resources from any channel, add them to the lesson, define the ordering, and assign the lesson to learners in their class</descrip>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-en">lesson</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A lesson is a linear learning pathway defined by a coach. The coach can select resources from any channel, add them to the lesson, define the ordering, and assign the lesson to learners in their class.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-fa">درس</term>
+            <descrip type="definition">یک درس یک مسیر یادگیری خطی است که توسط یک مربی تعریف شده است. مربی می تواند منابع را از هر کانال انتخاب کند ، آنها را به درس اضافه کند ، ترتیب را تعریف کند و درس را به یادگیرنده ها کلاس خود اختصاص دهد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="vi">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-vi">bài học</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-la">lección</term>
+            <descrip type="definition">Una lección es una ruta de aprendizaje lineal definida por un tutor. Tutor puede seleccionar recursos de cualquier canal, agregarlos a la lección, definir el orden y asignar la lección a los estudiantes en su grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-es-ES">lección</term>
+            <descrip type="definition">Una lección es una ruta de aprendizaje lineal definida por un tutor. El tutor puede seleccionar recursos de cualquier canal, agregarlos a la lección, definir el orden y asignar la lección a los estudiantes en su clase.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-qu">lección</term>
+            <descrip type="definition">Una lección es una ruta de aprendizaje lineal definida por un tutor. Tutor puede seleccionar recursos de cualquier canal, agregarlos a la lección, definir el orden y asignar la lección a los estudiantes en su grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-pt-BR">lição</term>
+            <descrip type="definition">Uma lição é um caminho linear de aprendizagem definido por um professor. O professor pode selecionar os conteúdos de qualquer canal, adicioná-los à lição, definir a ordem e atribuir a lição aos estudantes na sua classe.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="d6ef5f7fa914c19931a55bb262ec879c1114-ur-PK">سبق</term>
+            <descrip type="definition">ایک سبق ایک سیدھی سیکھنے کی راہ ہے جسے کوچ نے بیان کیا ہے۔ کوچ کسی بھی چینل سے وسائل منتخب کرسکتا ہے، اسے سبق میں شامل کرسکتا ہے، ترتیب کی تعریف کرسکتا ہے، اور اپنی کلاس میں سیکھنے والوں کو سبق دے سکتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="1c9ac0159c94d8d0cbedc973445af2da156">
+      <termEntry id="dd77279f7d325eec933f05b1672f6a1f1116">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-fr">logs / journaux</term>
+            <descrip type="definition">Un ensemble de données enregistré sur un appareil qui contient des informations sur la manière dont les utilisateurs ont interagis avec les ressources, en particulier leur progrès et performance. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="1c9ac0159c94d8d0cbedc973445af2da156-en">logs</term>
-            <descrip type="definition">A subset of data stored on the device which contains information about the way that users have interacted with resources, especially their progress and performance</descrip>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-en">logs</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A subset of data stored on the device which contains information about the way that users have interacted with resources, especially their progress and performance.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-fa">سیاهه ها</term>
+            <descrip type="definition">زیرمجموعه ای از داده های ذخیره شده در دستگاه که حاوی اطلاعاتی در مورد نحوه تعامل کاربران با منابع به ویژه پیشرفت و عملکرد آنها است.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-la">registros</term>
+            <descrip type="definition">Un subconjunto de datos almacenados en el dispositivo que contiene información sobre la forma en que los usuarios han interactuado con los recursos, especialmente su progreso y rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-es-ES">registros</term>
+            <descrip type="definition">Un subconjunto de datos almacenados en el dispositivo que contiene información sobre la forma en que los usuarios han interactuado con los recursos, especialmente su progreso y rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-qu">registros</term>
+            <descrip type="definition">Un subconjunto de datos almacenados en el dispositivo que contiene información sobre la forma en que los usuarios han interactuado con los recursos, especialmente su progreso y rendimiento.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-pt-BR">registros</term>
+            <descrip type="definition">Um subconjunto de dados armazenados em um dispositivo que contém informações sobre a forma que os usuários interagiram com os conteúdos, especialmente o seu progresso e desempenho.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="dd77279f7d325eec933f05b1672f6a1f1116-ur-PK">لاگ</term>
+            <descrip type="definition">ڈیوائس پر ذخیرہ شدہ ڈیٹا کا ایک ذیلی سیٹ جس میں صارفین کے وسائل کے ساتھ باہمی تعامل کی بات کے بارے میں معلومات، خاص طور پر ان کی ترقی اور کارکردگی کے بارے میں معلومات موجود ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="06409663226af2f3114485aa4e0a23b4158">
+      <termEntry id="c60d060b946d6dd6145dcbad5c4ccf6f1118">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-fr">modèle de maîtrise</term>
+            <descrip type="definition">Lorsqu'un apprenant a suffisamment internalisé et compris une ressource, on dit de lui qu'il maîtrise au moins temporairement la ressource. Les responsables des ressources éducationnelles sur Kolibri Studio assignent un modèle de maîtrise (nombre de réponses correctes pour être en mesure de maîtriser) sur une chaîne entière ou bien une ressource individuelle. 
+La maîtrise mesure le progrès et non la performance. Par exemple, un modèle de maîtrise peut indiquer qu'un apprenant doit répondre correctement à 3 questions à la suite afin de continuer ou bien qu'il doit au moins répondre correctement à 7 questions sur 10 au premier essai pour continuer. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="06409663226af2f3114485aa4e0a23b4158-en">mastery, mastery model</term>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-en">mastery model</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">When a learner has sufficiently internalized and understood some material, they are said to have at least temporarily achieved mastery. Educational resource curators on Kolibri Studio assign a mastery model- the number of correct answers considered to communicate mastery- across either entire channels or individual resources.
 
 Mastery measures progress, not performance. For example, a mastery model might say that the learner must correctly answer 3 questions in a row before they can move on, or perhaps that they must get 7 out of the last 10 questions correct on the first attempt before moving on.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="b73ce398c39f506af761d2277d853a92160">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="b73ce398c39f506af761d2277d853a92160-en">member</term>
-            <descrip type="definition">A learner is considered a member of a class or a group once they have been enrolled by an admin or a coach</descrip>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-fa">تسلط ، مدل تسلط</term>
+            <descrip type="definition">وقتی یادگیرنده به اندازه کافی برخی از مطالب را فهمیده و درک کرده باشد ، به آنها گفته می شود که حداقل به طور موقت تسلط پیدا کرده اند. متولیان منابع آموزشی در استودیو کلیبری یک الگوی تسلط - تعداد پاسخ های صحیح در نظر گرفته شده برای برقراری تسلط - در کل کانال ها یا افراد اختصاص می دهند. تسلط سطح پیشرفت را نشان می دهد ، نه عملکرد را. به عنوان مثال ، یک الگوی تسلط ممکن است بگوید که یادگیرنده قبل از ادامه باید به درستی به 3 سؤال پاسخ دهد یا شاید که آنها باید از 10 سؤال آخر صحیح در اولین تلاش قبل از ادامه ، دریافت</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-la">criterio de dominio</term>
+            <descrip type="definition">Cuando un alumno ha internalizado y comprendido suficientemente algunos materiales, se dice que al menos temporalmente ha logrado el dominio. Los curadores de recursos educativos en Kolibri Studio asignan un criterio de dominio - el número de respuestas correctas necesarias para lograr el domino - a través de canales completos o recursos individuales.
+
+El dominio mide el progreso, no el rendimiento. Por ejemplo, un criterio de dominio puede especificar que el estudiante debe responder correctamente a 3 preguntas seguidas antes de poder avanzar, o tal vez que deben obtener 7 de las últimas 10 preguntas correctas en el primer intento antes de continuar.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-es-ES">criterio de dominio</term>
+            <descrip type="definition">Cuando un alumno ha internalizado y comprendido suficientemente algunos materiales, se dice que al menos temporalmente ha logrado el dominio. Los curadores de recursos educativos en Kolibri Studio asignan un criterio de dominio - el número de respuestas correctas necesarias para lograr el domino - a través de canales completos o recursos individuales.
+
+El dominio mide el progreso, no el rendimiento. Por ejemplo, un criterio de dominio puede especificar que el estudiante debe responder correctamente a 3 preguntas seguidas antes de poder avanzar, o tal vez que debe obtener 7 de las últimas 10 preguntas correctas en el primer intento antes de continuar.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-qu">criterio de dominio</term>
+            <descrip type="definition">Cuando un alumno ha internalizado y comprendido suficientemente algunos materiales, se dice que al menos temporalmente ha logrado el dominio. Los curadores de recursos educativos en Kolibri Studio asignan un criterio de dominio - el número de respuestas correctas necesarias para lograr el domino - a través de canales completos o recursos individuales.
+
+El dominio mide el progreso, no el rendimiento. Por ejemplo, un criterio de dominio puede especificar que el estudiante debe responder correctamente a 3 preguntas seguidas antes de poder avanzar, o tal vez que deben obtener 7 de las últimas 10 preguntas correctas en el primer intento antes de continuar.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-pt-BR">critério de domínio</term>
+            <descrip type="definition">Quando um estudante internalizou e entendeu suficientemente algum conteúdo, diz-se que ao menos temporariamente atingiu domínio. Curadores de conteúdo educacional no Kolibri Studio atribuem um critério de domínio - o número de respostas certas considerado para transmitir domínio -, seja através de canais inteiros ou conteúdos individuais.
+
+O domínio mede o progresso, não o desempenho. Por exemplo, um critério de domínio pode declarar que um estudante deve responder corretamente a 3 perguntas sucessivamente antes de continuar, ou talvez que precise acertar 7 das últimas 10 perguntas corretamente na primeira tentativa antes de continuar.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c60d060b946d6dd6145dcbad5c4ccf6f1118-ur-PK">مہارتی نمونہ</term>
+            <descrip type="definition">جب ایک سیکھنے والا کافی طور پر کچھ مواد کو اپنا لیتا ہے تو اُن کے بارے میں کہا جاتا 
+ کولیبری پر موجود تعملیمی وسائل کے ناظم ایک مہارتی نمونہ تفویض کرتے ہیں- ہے کہ اُنہوں نے عارضی مہارت حاصل کر لی ہے۔ </descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="82aa4b0af34c2313a562076992e50aa3162">
+      <termEntry id="c6036a69be21cb660499b75718a3ef241120">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-fr">membre</term>
+            <descrip type="definition">Un apprenant est considéré membre d'une classe ou un groupe après avoir été inscrit par un administrateur ou un éducateur.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="82aa4b0af34c2313a562076992e50aa3162-en">network</term>
+            <term id="c6036a69be21cb660499b75718a3ef241120-en">member</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A network is a set of computers that can communicate with each other. This is how a Kolibri server installed on one device can communicate with client devices running web browsers</descrip>
+            <descrip type="definition">A learner is considered a member of a class or a group once they have been enrolled by an admin or a coach.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-fa">عضو</term>
+            <descrip type="definition">یادگیرنده پس از ثبت نام توسط مدیر یا مربی عضو یک کلاس یا گروه در نظر گرفته می شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-la">miembro</term>
+            <descrip type="definition">Estudiantes son considerados miembros un grupo o equipo en cuales han sido inscritos por un administrador o un tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-es-ES">miembro</term>
+            <descrip type="definition">Estudiantes se consideran miembros de una clase o un grupo en cuales han sido inscritos por un administrador o un tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-qu">miembro</term>
+            <descrip type="definition">Estudiantes son considerados miembros un grupo o equipo en cuales han sido inscritos por un administrador o un tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-pt-BR">membro</term>
+            <descrip type="definition">Um membro é considerado membro de uma classe ou grupo assim que é inscrito por um administrador ou professor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c6036a69be21cb660499b75718a3ef241120-ur-PK">رکن</term>
+            <descrip type="definition">ایک دفعہ جب ایک کوچ یا منتظم کے ذریعے داخل ہو جائے تو ایک سیکھنے والے کو ایک کلاس یا گروہ کا رکن سمجھا جاتا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="fa7cdfad1a5aaf8370ebeda47a1ff1c3164">
+      <termEntry id="3b712de48137572f3849aabd5666a4e31122">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-fr">réseau</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Un réseau est un ensemble d'ordinateurs pouvant communiquer entre eux. C'est de cette façon qu'un serveur Kolibri installé sur une machine peut communiquer avec des clients via leur navigateur.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="fa7cdfad1a5aaf8370ebeda47a1ff1c3164-en">performance</term>
+            <term id="3b712de48137572f3849aabd5666a4e31122-en">network</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A network is a set of computers that can communicate with each other. This is how a Kolibri server installed on one device can communicate with client devices running web browsers.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-fa">شبکه</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">شبکه مجموعه ای از رایانه ها است که می توانند با یکدیگر ارتباط برقرار کنند. اینگونه است که یک سرور کلیبری نصب شده در یک دستگاه می تواند با دستگاههای مشتری که مرورگرهای وب را اجرا می کنند ، ارتباط برقرار کنند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-la">red</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Una red es un conjunto de computadoras que pueden comunicarse entre sí. Así es como un servidor Kolibri instalado en un dispositivo puede comunicarse con dispositivos cliente a través de sus navegadores web.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-es-ES">red</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Una red es un conjunto de computadoras que pueden comunicarse entre sí. Así es como un servidor Kolibri instalado en un dispositivo puede comunicarse con dispositivos cliente que ejecutan navegadores web.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-qu">red</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Una red es un conjunto de computadoras que pueden comunicarse entre sí. Así es como un servidor Kolibri instalado en un dispositivo puede comunicarse con dispositivos cliente a través de sus navegadores web.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-pt-BR">rede</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Uma rede é um conjunto de computadores que pode comunicar entre si. É assim que um servidor do Kolibri instalado em um dispositivo pode se comunicar com dispositivos cliente sendo executados em navegadores web.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="3b712de48137572f3849aabd5666a4e31122-ur-PK">نیٹ ورک</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">ایک نیٹ ورک کمپیوٹروں کا ایک سیٹ ہے جو ایک دوسرے کے ساتھ ابلاغ کرسکتا ہے۔ اس طرح ایک آلہ پر نصب ایک کولبیری سرور ویب براؤزر چلانے والے کلائنٹ آلات کے ساتھ بات چیت کرسکتا ہے۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="c7635bfd99248a2cdef8249ef7bfbef41124">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-fr">performance</term>
+            <descrip type="definition">Le pourcentage de questions correctes obtenu lorsqu'un apprenant répond à un quiz est considéré comme sa performance. En général, la performance peut aussi être considérée comme l'inverse de la difficulté nécessaire à un apprenant pour atteindre un niveau de maîtrise parfaite et progresser.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-en">performance</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A percentage of questions that a learner gets correct when taking a quiz is considered their performance on the quiz. This is the same as their quiz score. More generally, performance might also be thought of as an inverse measure of how much a learner might struggle to achieve mastery and make progress.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="7e7757b1e12abcb736ab9a754ffb617a166">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="7e7757b1e12abcb736ab9a754ffb617a166-en">permissions</term>
-            <descrip type="definition">Accounts have different permissions to perform actions within facilities and devices. Permissions can be either granted by admins or given implicitly based on the account type</descrip>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-fa">کارایی</term>
+            <descrip type="definition">درصدی از سؤالاتی که یک یادگیرنده هنگام گرفتن امتحان صحیح می داند عملکرد آنها در امتحان است. این همان نمره امتحان آنها است. به طور کلی عملکرد نیز ممکن است به عنوان معیار معکوس به کار گرفته شود بدین صورت که نشاندهنده میزان سختی کشیده شده توسط یادگیرنده برای تسلط و پیشرفت در نظر گرفته شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-la">progreso</term>
+            <descrip type="definition">El porcentaje de preguntas a las que estudiante responde correctamente en una prueba se considera su progreso. Esta medida también representa el resultado de la prueba. En términos más generales, también se podría pensar en el progreso como una medida inversa de cuánto estudiante tendría que esforzarse para lograr el dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-es-ES">progreso</term>
+            <descrip type="definition">El porcentaje de preguntas a las que estudiante responde correctamente en una prueba se considera su progreso. Esta medida también representa el resultado de la prueba. En términos más generales, también se podría pensar en el progreso como una medida inversa de cuánto estudiante tendría que esforzarse para lograr el dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-qu">progreso</term>
+            <descrip type="definition">El porcentaje de preguntas a las que estudiante responde correctamente en una prueba se considera su progreso. Esta medida también representa el resultado de la prueba. En términos más generales, también se podría pensar en el progreso como una medida inversa de cuánto estudiante tendría que esforzarse para lograr el dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-pt-BR">desempenho</term>
+            <descrip type="definition">Uma porcentagem das perguntas que o estudante acerta quando faz um teste é considerada como o seu desempenho no teste. É o mesmo que a sua pontuação do teste. Em geral, o desempenho também pode ser pensado como uma medida inversa do quanto um estudante pode ter dificuldades para atingir domínio e progredir.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c7635bfd99248a2cdef8249ef7bfbef41124-ur-PK">کارکردگی</term>
+            <descrip type="definition">معلوماتی آزمائش لیتے وقت سوالوں کی درستگی کی فیصد کو سیکھنے والے کی کارکردگی سمجھا جاتا ہے۔ یہ ان کا معلوماتی آزمائش اسکور جیسا ہوتا ہے۔ عام طورپر، کارکردگی کو ایک سیکھنے والے کو دسترس اور ترقی کرنےمیں درکار دورانیے کے الٹ کے طور پر سمجھا جا سکتا ہے۔ </descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="006f52e9102a8d3be2fe5614f42ba989168">
+      <termEntry id="ffeed84c7cb1ae7bf4ec4bd78275bb981126">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-fr">autorisations</term>
+            <descrip type="definition">Les comptes ont différentes autorisations pour effectuer des actions sur un appareil ou un établissement d'enseignement. Les permissions sont données par un administrateur ou bien implicitement par le type de compte.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="006f52e9102a8d3be2fe5614f42ba989168-en">points</term>
-            <descrip type="definition">Points are an abstract reward given to learners as they make progress through resources</descrip>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-en">permissions</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Accounts have different permissions to perform actions within facilities and devices. Permissions can be either granted by admins or given implicitly based on the account type.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-fa">مجوزها</term>
+            <descrip type="definition">حساب ها مجوزهای متفاوتی برای انجام اقدامات درون امکانات و دستگاهها دارند. مجوزها توسط سرپرستها صادر می شوند یا براساس نوع حساب به طور ضمنی داده شد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-la">permisos</term>
+            <descrip type="definition">Las cuentas tienen diferentes permisos para realizar acciones dentro de centros y dispositivos. Los permisos pueden ser otorgados por los administradores o dados implícitamente en base al tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-es-ES">permisos</term>
+            <descrip type="definition">Las cuentas tienen diferentes permisos para realizar operaciones dentro de centros y dispositivos. Los permisos pueden ser otorgados por los administradores o ser implícitos en función del tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-qu">permisos</term>
+            <descrip type="definition">Las cuentas tienen diferentes permisos para realizar acciones dentro de centros y dispositivos. Los permisos pueden ser otorgados por los administradores o dados implícitamente en base al tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-pt-BR">permissões</term>
+            <descrip type="definition">Contas possuem permissões diferentes para realizar ações em centros educativos e dispositivos. Permissões podem ser tanto concedidas por administradores ou dadas implicitamente, dependendo do tipo de conta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="ffeed84c7cb1ae7bf4ec4bd78275bb981126-ur-PK">اجازتیں</term>
+            <descrip type="definition">سہولیات اور خدمات میں کام کرنے کی خاطر اکاؤنٹس کو مختلف اجازتیں حاصل ہیں۔ اجازتیں یا تو مہتمم کے ذریعہ دی جاسکتی ہیں یا اکاؤنٹ کی قسم کی بنیاد پر واضح طور ۔پر دی جاسکتی ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="149e9677a5989fd342ae44213df68868170">
+      <termEntry id="3fe78a8acf5fda99de95303940a2420c1128">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-fr">points</term>
+            <descrip type="definition">Les points sont une récompense virtuelle reçue par les apprenants au fil de leur progrès au sein des ressources.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="149e9677a5989fd342ae44213df68868170-en">profile</term>
-            <descrip type="definition">A page in Kolibri which contains information about the current user's account such as their permissions, username, full name, points, and account type</descrip>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-en">points</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Points are an abstract reward given to learners as they make progress through resources.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-fa">نکته ها</term>
+            <descrip type="definition">امتیازها یک پاداش انتزاعی هستند که به یادگیرنده ها در طی پیشرفت روی منابع داده می شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-la">puntos</term>
+            <descrip type="definition">Los puntos son una recompensa abstracta otorgada a los estudiantes a medida que progresan a través de recursos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-es-ES">puntos</term>
+            <descrip type="definition">Los puntos son una recompensa abstracta otorgada a los estudiantes a medida que progresan a través de los recursos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-qu">puntos</term>
+            <descrip type="definition">Los puntos son una recompensa abstracta otorgada a los estudiantes a medida que progresan a través de recursos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-pt-BR">pontos</term>
+            <descrip type="definition">Pontos são uma recompensa abstrata dada aos estudantes à medida que progridem nos conteúdos.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="3fe78a8acf5fda99de95303940a2420c1128-ur-PK">پوائنٹس</term>
+            <descrip type="definition">پوائنٹس تجریدی انعامات ہیں جو سیکھنے والوں کو وسائل کے ذریعے ترقی کرنے پر دیے جاتے ہیں۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="1ff8a7b5dc7a7d1f0ed65aaa29c04b1e172">
+      <termEntry id="4a213d37242bdcad8e7300e202e7caa41130">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-fr">profil</term>
+            <descrip type="definition">Une page dans Kolibri contenant les informations sur l'utilisateur actuel, telles que les permissions, le nom d'utilisateur, nom complet, points et type de compte</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="1ff8a7b5dc7a7d1f0ed65aaa29c04b1e172-en">progress</term>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-en">profile</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">User profile/details</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-fa">مشخصات</term>
+            <descrip type="definition">صفحه ای در کلیبری که حاوی اطلاعات مربوط به حساب کاربری فعلی مانند مجوزها ، نام کاربری ، نام کامل ، امتیازات و نوع حساب است.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-la">perfil</term>
+            <descrip type="definition">La página en Kolibri que contiene información sobre la cuenta del usuario actual como sus permisos, nombre de usuario, nombre completo, puntos y tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-es-ES">perfil</term>
+            <descrip type="definition">Una página en Kolibri que contiene información sobre la cuenta del usuario actual, como sus permisos, nombre de usuario, nombre completo, puntos y tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-qu">perfil</term>
+            <descrip type="definition">La página en Kolibri que contiene información sobre la cuenta del usuario actual como sus permisos, nombre de usuario, nombre completo, puntos y tipo de cuenta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-pt-BR">perfil</term>
+            <descrip type="definition">Uma página no Kolibri que contém informações sobre a conta atual do usuário como suas permissões, nome de usuário, nome completo, pontos e tipo de conta.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-ur-PK">پروفائل</term>
+            <descrip type="definition">کولیبری کا ایک ایسا صفحہ جس میں موجودہ صارف کے اکاؤنٹ کے بارے میں معلومات موجود ہیں جیسے ان کی اجازتیں، صارف کا نام، پورا نام ، پوائنٹس اور اکاؤنٹ کی قسم۔</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="4a213d37242bdcad8e7300e202e7caa41130-fv">tinndinoore</term>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="571e0f7e2d992e738adff8b1bd43a5211132">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-fr">progression</term>
+            <descrip type="definition">Donne une idée de combien un apprenant est impliqué dans l'utilisation des ressources, quizz et leçons. Le progrès est différemment  moyenné selon le type de ressource. Par exemple, pour les documents, le nombre total de pages ainsi que le temps d'ouverture du document sur le navigateur sont pris en compte. Pour les exercices, le progrès est directement lié au modèle de maîtrise.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-en">progress</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">This is a rough measure of how much a learner has engaged with resources, quizzes, and lessons. Progress is approximated differently depending on the type of resource. For example, documents factor in how many pages the document has and how long the learner has had the document open in the browser. For exercises, progress is directly related to the mastery model.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="bf8229696f7a3bb4700cfddef19fa23f174">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="bf8229696f7a3bb4700cfddef19fa23f174-en">report</term>
-            <descrip type="definition">Reports are representations of learner progress and performance data shown to coaches in a class</descrip>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-fa">پیش رفتن</term>
+            <descrip type="definition">این یک اندازه گیری ناخوشایند از میزان جذب یادگیرنده با منابع ، آزمونها و دروس است. بسته به نوع منبع ، پیشرفت متفاوت است. به عنوان مثال ، اسناد نشان می دهد که چند صفحه در سند وجود دارد و یادگیرنده تا چه مدت سند را در مرورگر باز كرده است. برای تمرینات ، پیشرفت ارتباط مستقیمی با مدل تسلط دارد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-la">progreso</term>
+            <descrip type="definition">Una medida aproximada de cuánto el estudiante haya interactuado con recursos, cuestionarios y lecciones. El progreso se calcula de forma diferente dependiendo del tipo de recurso. Por ejemplo, para los documentos se tiene en cuenta cuántas páginas tienen y cuánto tiempo el estudiante ha tenido el documento abierto en el navegador. Para los ejercicios, el progreso está directamente relacionado con el criterio de dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-es-ES">progreso</term>
+            <descrip type="definition">Una medida aproximada de cuánto el estudiante haya interactuado con recursos, cuestionarios y lecciones. El progreso se calcula de forma diferente dependiendo del tipo de recurso. Por ejemplo, para los documentos se tiene en cuenta cuántas páginas tienen y cuánto tiempo el estudiante ha tenido el documento abierto en el navegador. Para los ejercicios, el progreso está directamente relacionado con el criterio de dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-qu">progreso</term>
+            <descrip type="definition">Una medida aproximada de cuánto el estudiante haya interactuado con recursos, cuestionarios y lecciones. El progreso se calcula de forma diferente dependiendo del tipo de recurso. Por ejemplo, para los documentos se tiene en cuenta cuántas páginas tienen y cuánto tiempo el estudiante ha tenido el documento abierto en el navegador. Para los ejercicios, el progreso está directamente relacionado con el criterio de dominio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-pt-BR">progresso</term>
+            <descrip type="definition">É uma medida aproximada do quanto um estudante se envolveu com os conteúdos, testes e lições. O progresso é estimado de forma diferente dependendo do tipo de conteúdo. Por exemplo, os documentos levam em conta quantas páginas têm e quanto tempo o estudante manteve um documento aberto no navegador. Para exercícios, o progresso é ligado diretamente ao critério de domínio.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="571e0f7e2d992e738adff8b1bd43a5211132-ur-PK">ترقی</term>
+            <descrip type="definition">یہ اس بات کا ایک ناہموار اندازہ ہے کہ ایک سیکھنے والے نے وسائل، معلوماتی آزمائش ، اور اسباق سے کتنا فائدہ اُٹھایا ہے۔ ترقی کا اندازہ وسائل کی قسم کی بنیاد پر مختلف طریقے سے لگایا جاتا ہے۔ مثال کے طور پر، دستاویزات میں اس بات کا عنصر ہوتا ہے کہ دستاویز کتنے صفحات پر ہے اور سیکھنے والے نے کتنے عرصے سے براؤزر میں دستاویز کھولی ہوئی ہیں۔ مشقوں کے لئے ، ترقی براہ راست ماسٹر ماڈل سے وابستہ ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="38af86134b65d0f10fe33d30dd76442e176">
+      <termEntry id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-fr">rapport</term>
+            <descrip type="definition">Les rapports sont des représentations du progrès des apprenants ainsi que de leur performance. Ils sont disponibles aux éducateurs d'une classe.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="38af86134b65d0f10fe33d30dd76442e176-en">resource</term>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-en">report</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Reports are representations of learner progress and performance data shown to coaches in a class.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-fa">گزارش</term>
+            <descrip type="definition">گزارشات بازنمایی پیشرفت یادگیرنده و داده های عملکردی است که به مربیان یک کلاس نشان داده می شود</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-la">informe</term>
+            <descrip type="definition">Los informes son representaciones del progreso de los estudiantes y datos de rendimiento mostrados a los tutores en un grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-es-ES">informe</term>
+            <descrip type="definition">Los informes son representaciones del progreso de los estudiantes y datos de rendimiento mostrados a los tutores en una clase.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-qu">informe</term>
+            <descrip type="definition">Los informes son representaciones del progreso de los estudiantes y datos de rendimiento mostrados a los tutores en un grupo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-pt-BR">relatório</term>
+            <descrip type="definition">Relatórios são representações de dados do progresso e desempenho de estudantes mostrados aos professores em uma classe.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="7c9d0b1f96aebd7b5eca8c3edaa19ebb1134-ur-PK">رپورٹ</term>
+            <descrip type="definition">رپورٹس سیکھنے والے کی ترقی اور کارکردگی کی نمائندگی کرتی ہیں جن کو کلاس میں کوچوں کو دکھایا جاتا ہے</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="47a658229eb2368a99f1d032c88485421136">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-fr">ressource</term>
+            <descrip type="definition">Une terme général englobant les vidéos, exercices, applis et autres médias disponibles dans la plateforme d'apprentissage. </descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-en">resource</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A resource is a general term for the videos, exercises, apps, and other materials available in the learning platform.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-fa">منبع</term>
+            <descrip type="definition">یک منبع یک اصطلاح کلی برای فیلم ها ، تمرین ها ، برنامه ها و سایر مواد موجود در بستر یادگیری است.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-la">recurso</term>
+            <descrip type="definition">Un recurso es un término general para los vídeos, ejercicios, aplicaciones y otros materiales disponibles en la plataforma de aprendizaje.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-es-ES">recurso</term>
+            <descrip type="definition">Un recurso es un término general para los vídeos, ejercicios, aplicaciones y otros materiales disponibles en la plataforma de aprendizaje.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-qu">recurso</term>
+            <descrip type="definition">Un recurso es un término general para los vídeos, ejercicios, aplicaciones y otros materiales disponibles en la plataforma de aprendizaje.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-pt-BR">conteúdo</term>
+            <descrip type="definition">Um conteúdo é um termo geral para vídeos, exercícios, aplicativos e outros materiais disponíveis na plataforma de aprendizagem.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-ur-PK">اسم</term>
+            <descrip type="definition">ایک وسیلہویڈیوز، مشقوں، ایپس، اور پلیٹ فارم میں موجود دیگر مواد کے لیے ایک عمومی اصطلاح ہے۔</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="47a658229eb2368a99f1d032c88485421136-fv">jannginillum</term>
+          </tig>
+        </langSet>
       </termEntry>
-      <termEntry id="8f85517967795eeef66c225f7883bdcb178">
+      <termEntry id="c3e0c62ee91db8dc7382bde7419bb5731138">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-fr">rôle</term>
+            <descrip type="definition">Peut être utilisé en lieu et place de "type d'utilisateur". Défini si le compte est un super-administrateur, administrateur, éducateur, éducateur d'établissement ou apprenant.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="8f85517967795eeef66c225f7883bdcb178-en">role</term>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-en">role</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">Used interchangeably with user type. Refers to whether an account is a super admin, admin, coach, facility coach, or learner.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="4c5bde74a8f110656874902f07378009182">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="4c5bde74a8f110656874902f07378009182-en">super admin</term>
-            <descrip type="definition">An account type that can manage the device. Super admin accounts also have permission to do everything that admins, coaches, and learners can do</descrip>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-fa">نقش</term>
+            <descrip type="definition">قابل تعویض با نوع کاربر استفاده می شود. به اینكه آیا حساب مدیر ارشد، مدیر، مربی، مربی تسهیلات یا یادگیرنده است، اشاره دارد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-la">rol</term>
+            <descrip type="definition">Se usa indistintamente para referirse al tipo de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-es-ES">rol</term>
+            <descrip type="definition">Se usa indistintamente para referirse al tipo de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro, o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-qu">rol</term>
+            <descrip type="definition">Se usa indistintamente para referirse al tipo de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-pt-BR">modo</term>
+            <descrip type="definition">Usado de forma intercambiável com tipo de usuário. Refere-se a uma conta ser super admin, administrador, professor, professor de centro educativo ou estudante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="c3e0c62ee91db8dc7382bde7419bb5731138-ur-PK">کردار</term>
+            <descrip type="definition">صارف کی قسم کے ساتھ تبادلہ پزیری کے ساتھ استعمال کیا جاتا ہے۔ حوالہ دیتا ہے کہ آیا اکاؤنٹ ایک اعلیٰ منتظم، منتظم، کوچ، سہولت کوچ، یا سیکھنے والا ہے۔</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="6cdd60ea0045eb7a6ec44c54d29ed402184">
+      <termEntry id="8248a99e81e752cb9b41da3fc43fbe7f1140">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-fr">super-administrateur</term>
+            <descrip type="definition">Type de compte avec permission de gérer les appareils. Les super-administrateurs ont l'ensemble des permissions que les administrateurs, éducateurs et apprenants ont. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="6cdd60ea0045eb7a6ec44c54d29ed402184-en">topic</term>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-en">super admin</term>
             <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">A collection of resources and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy</descrip>
+            <descrip type="definition">An account type that can manage the device. Super admin accounts also have permission to do everything that admins, coaches, and learners can do.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-fa">مدیر ارشد</term>
+            <descrip type="definition">یک نوع حساب که می تواند دستگاه را مدیریت کند. حساب مدیر ارشد همچنین مجاز به انجام هر کاری هست که مدیران، مربیان و یادگیرنده ها می توانند انجام دهند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-la">superadministrador</term>
+            <descrip type="definition">Un tipo de cuenta que puede administrar el dispositivo. Las cuentas de superadministrador también tienen permiso para hacer todo lo que pueden hacer los administradores, tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-es-ES">superadministrador</term>
+            <descrip type="definition">Un tipo de cuenta que puede gestionar el dispositivo. Las cuentas de superadministrador también tienen permiso para hacer todo lo que puedan hacer los administradores, tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-qu">superadministrador</term>
+            <descrip type="definition">Un tipo de cuenta que puede administrar el dispositivo. Las cuentas de superadministrador también tienen permiso para hacer todo lo que pueden hacer los administradores, tutores y estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-pt-BR">super admin</term>
+            <descrip type="definition">Um tipo de conta que pode gerenciar o dispositivo. Contas super admin também têm permissão para fazer tudo o que administradores, professores e estudantes fazem.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="8248a99e81e752cb9b41da3fc43fbe7f1140-ur-PK">اعلیٰ منتظم</term>
+            <descrip type="definition">اکاؤنٹ کی قسم جو آلے کا نظام چلا سکتی ہے۔ اعلیٰ منتظم اکاؤنٹس کو بھی ہر وہ کام کرنے کی اجازت ہوتی ہے جو منتظم، کوچ اور سیکھنے والے کر سکتے ہیں۔
+</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="9872ed9fc22fc182d371c3e9ed316094186">
+      <termEntry id="8ce6790cc6a94e65f17f908f462fae851142">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-fr">sujet</term>
+            <descrip type="definition">Une collection de ressources et d'autres sujets au sein d'une chaîne. Les sujets imbriqués sont comme des dossiers de fichiers et offrent la possibilité d'organiser une chaîne en "arbre" ou hiérarchiquement. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="9872ed9fc22fc182d371c3e9ed316094186-en">user</term>
-            <descrip type="definition">A person who uses the Kolibri learning platform. Often, every user will have their own account. However, multiple users may sometimes share an account, or they may use Kolibri anonymously</descrip>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-en">topic</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A collection of resources and other topics within a channel. Nested topics are like folders, and allow a channel to be organized as a tree or hierarchy.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-fa">موضوع</term>
+            <descrip type="definition">مجموعه ای از منابع و موضوعات دیگر در یک کانال. مباحث تودرتو مانند پوشه ها هستند ، و به یک کانال اجازه می دهند به عنوان یک درخت یا سلسله مراتب سازماندهی شود</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-la">tema</term>
+            <descrip type="definition">Una conjunto de recursos y subtemas dentro de un canal. Los temas anidados son como carpetas, y permiten que un canal se organice como un árbol o jerarquía.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-es-ES">tema</term>
+            <descrip type="definition">Una conjunto de recursos y subtemas dentro de un canal. Los temas anidados son como carpetas, y permiten que un canal se organice como un árbol o jerarquía.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-qu">tema</term>
+            <descrip type="definition">Una conjunto de recursos y subtemas dentro de un canal. Los temas anidados son como carpetas, y permiten que un canal se organice como un árbol o jerarquía.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-pt-BR">tema</term>
+            <descrip type="definition">Um conjunto de conteúdos e outros temas em um canal. Temas agrupados são como pastas e permitem a um canal ser organizado como uma árvore ou hierarquia.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="8ce6790cc6a94e65f17f908f462fae851142-ur-PK">موضوع</term>
+            <descrip type="definition">کسی چینل میں وسائل اور دیگر عنوانات کا مجموعہ۔ نیسٹڈ عنوانات فولڈرز کی طرح ہوتے ہیں ، اور کسی چینل کو درجہ بندی کے طور پر منظم کرنے کی سہولت مہیا کرتے ہیں</descrip>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="9dcb88e0137649590b755372b040afad188">
+      <termEntry id="4588e674d3f0faf985047d4c3f13ed0d1144">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-fr">utilisateur</term>
+            <descrip type="definition">Une personne utilisant la plateforme d'apprentissage Kolibri. Le plus souvent, chaque utilisateur a son propre compte. Cependant plusieurs utilisateurs peuvent partager le même compte ou bien utiliser Kolibri anonymement. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="9dcb88e0137649590b755372b040afad188-en">user type</term>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-en">user</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A person who uses the Kolibri learning platform. Often, every user will have their own account. However, multiple users may sometimes share an account, or they may use Kolibri anonymously.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-fa">کاربر</term>
+            <descrip type="definition">شخصی که از بستر یادگیری کلیبری استفاده می کند. اغلب ، هر کاربر حساب کاربری خود را خواهد داشت. با این وجود ، ممکن است چندین کاربر یک حساب را به اشتراک بگذارند ، یا ممکن است از کلیبری ناشناس استفاده کنند</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="vi">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-vi">người dùng</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-la">usuario</term>
+            <descrip type="definition">Persona que utiliza la plataforma de aprendizaje de Kolibri. A menudo, cada usuario tendrá su propia cuenta. Sin embargo, varios usuarios a veces pueden compartir una cuenta, o pueden usar Kolibri anónimamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-es-ES">usuario</term>
+            <descrip type="definition">Una persona que utiliza la plataforma de aprendizaje de Kolibri. A menudo, cada usuario tendrá su propia cuenta. Sin embargo, a veces varios usuarios pueden compartir una cuenta, o pueden usar Kolibri de forma anónima.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-qu">usuario</term>
+            <descrip type="definition">Persona que utiliza la plataforma de aprendizaje de Kolibri. A menudo, cada usuario tendrá su propia cuenta. Sin embargo, varios usuarios a veces pueden compartir una cuenta, o pueden usar Kolibri anónimamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-pt-BR">usuário</term>
+            <descrip type="definition">Uma pessoa que utiliza a plataforma de aprendizagem do Kolibri. Muitas vezes, cada usuário terá a sua própria conta. Entretanto, diversos usuários podem às vezes compartilhar uma conta ou usar o Kolibri anonimamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="4588e674d3f0faf985047d4c3f13ed0d1144-ur-PK">صارف</term>
+            <descrip type="definition">ایک ایسا شخص جو کولیبری سیکھنے کا پلیٹ فارم استعمال کرتا ہے۔ اکثر، ہر صارف کا اپنا اکاؤنٹ ہوگا۔ تاہم، متعدد صارفین بعض اوقات ایک اکاؤنٹ کا اشتراک کرسکتے ہیں، یا وہ نامعلوم رہ کر کولیبری استعمال کرسکتے ہیں۔</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="8a3363abe792db2d8761d6403605aeb71146">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-fr">type d'utilisateur</term>
+            <descrip type="definition">Peut être utilisé en lieu et place de "rôle". Défini si le compte est un super-administrateur, administrateur, éducateur, éducateur d'établissement ou apprenant.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-en">user type</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">Used interchangeably with role. Refers to whether an account is a super admin, admin, coach, facility coach, or learner.</descrip>
           </tig>
         </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-fa">نوع کاربر</term>
+            <descrip type="definition">ارتباط مستقیم با نقش دارد. به اینكه آیا حساب کاربری مدیر ارشد ، مدیر ، مربی ، مربی تسهیلات یا یادگیرنده است اشاره دارد.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-la">tipo de usuario</term>
+            <descrip type="definition">Se usa indistintamente para referirse al 'rol' de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-es-ES">tipo de usuario</term>
+            <descrip type="definition">Se usa indistintamente para referirse al 'rol' de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro, o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-qu">tipo de usuario</term>
+            <descrip type="definition">Se usa indistintamente para referirse al 'rol' de usuario. Designa si una cuenta es de tipo superadministrador, administrador, tutor, tutor del centro o estudiante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-pt-BR">tipo de usuário</term>
+            <descrip type="definition">Utilizado de maneira intercambiável com perfil. Refere-se a se uma conta é super admin, administrador, professor, professor de centro educativo ou estudante.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="8a3363abe792db2d8761d6403605aeb71146-ur-PK">صارف کی قسم</term>
+            <descrip type="definition">کردار کے ساتھ تبادلہ استعمال کیا جاتا ہے۔ حوالہ دیتا ہے کہ آیا اکاؤنٹ ایکاعلیٰ منتظم، منتظم، کوچ، سہولت کوچ، یا سیکھنے والا ہے۔</descrip>
+          </tig>
+        </langSet>
       </termEntry>
-      <termEntry id="cfecdb276f634854f3ef915e2e980c31190">
+      <termEntry id="df0aab058ce179e4f7ab135ed4e641a91148">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-fr">nom d'utilisateur</term>
+            <descrip type="definition">Un nom unique identifiant un compte au sein d'un établissement d'enseignement.</descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="cfecdb276f634854f3ef915e2e980c31190-en">username</term>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-en">username</term>
+            <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A name that uniquely identifies an account within a facility.</descrip>
           </tig>
         </langSet>
-      </termEntry>
-      <termEntry id="58a2fc6ed39fd083f55d4182bf88826d192">
-        <langSet xml:lang="en">
+        <langSet xml:lang="fa">
           <tig>
-            <term id="58a2fc6ed39fd083f55d4182bf88826d192-en">test</term>
-            <termNote type="partOfSpeech">noun</termNote>
-            <descrip type="definition">test 22222</descrip>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-fa">نام کاربری</term>
+            <descrip type="definition">نامی که یک حساب کاربری را در یک مرکز مشخص می کند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-la">nombre de usuario</term>
+            <descrip type="definition">Un nombre que identifica de manera exclusiva una cuenta de usuario del centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-es-ES">nombre de usuario</term>
+            <descrip type="definition">Un nombre que identifica de manera exclusiva una cuenta de usuario del centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-qu">nombre de usuario</term>
+            <descrip type="definition">Un nombre que identifica de manera exclusiva una cuenta de usuario del centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-pt-BR">nome de usuário</term>
+            <descrip type="definition">Um nome que identifica de maneira única uma conta em um centro educativo.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-ur-PK">صارف کا نام</term>
+            <descrip type="definition">ایک ایسا نام جو سہولت کے اندر کسی اکاؤنٹ کی الگ الگ شناخت کرتا ہے۔</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="df0aab058ce179e4f7ab135ed4e641a91148-fv">Innde kuutiniroowo</term>
           </tig>
         </langSet>
       </termEntry>
-      <termEntry id="a597e50502f5ff68e3e25b9114205d4a194">
+      <termEntry id="2b38c2df6a49b97f706ec9148ce48d861150">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-fr">chaînes non répertoriées</term>
+            <descrip type="definition">Une chaîne non disponible publiquement via Kolibri Studio. Elle doit être importée en utilisant un jeton de chaîne. </descrip>
+          </tig>
+        </langSet>
         <langSet xml:lang="en">
           <tig>
-            <term id="a597e50502f5ff68e3e25b9114205d4a194-en">unlisted channel</term>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-en">unlisted channel</term>
             <termNote type="partOfSpeech">noun</termNote>
             <descrip type="definition">A channel that is not available publicly through Kolibri Studio. It must be imported using a channel token.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-fa">کانال ثبت نشده</term>
+            <descrip type="definition">کانالی که از طریق استودیو کلیبری به صورت عمومی در دسترس نیست. باید با استفاده از نشانه کانال وارد شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-la">canal privado</term>
+            <descrip type="definition">Un canal que no está disponible públicamente a través de Kolibri Studio. Debe ser importado usando un token de canal.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-es-ES">canal privado</term>
+            <descrip type="definition">Un canal que no está disponible públicamente a través de Kolibri Studio. Debe ser importado usando un token de canal.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-qu">canal privado</term>
+            <descrip type="definition">Un canal que no está disponible públicamente a través de Kolibri Studio. Debe ser importado usando un token de canal.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-pt-BR">canal privado</term>
+            <descrip type="definition">Um canal que não está disponível publicamente no Kolibri Studio. Deve ser importado usando o token do canal.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="2b38c2df6a49b97f706ec9148ce48d861150-ur-PK">غیر مندرج چینل</term>
+            <descrip type="definition">ایسا چینل جو کولبری اسٹوڈیو کے توسط سے عوامی طور پر دستیاب نہیں ہے۔ اسے چینل ٹوکن کا استعمال کرتے ہوئے درآمد کرنا ضروری ہے۔
+</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="45f31d16b1058d586fc3be7207b580531152">
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-fr">apprenant</term>
+            <descrip type="definition">Type de compte avec des permissions limitées. Les apprenants peuvent être inscrits à des classes, assignés à des ressources ou quiz via des leçons et naviguer parmi les chaînes directement. Nous avons intentionnellement omis le mot "élève" pour inclure les contextes n'étant pas formellement éducatifs. </descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="en">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-en">learner</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">An account type that has limited permissions. Learners can be enrolled in classes, get assigned resources through lessons and quizzes, and navigate channels directly. We intentionally did not use the term "student" to be more inclusive of non-formal educational contexts.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-fa">یادگیرنده</term>
+            <descrip type="definition">یک نوع حساب که دارای مجوزهای محدود است. یادگیرنده ها می توانند در کلاسها ثبت نام کنند، به منابع اختصاص داده شده دسترسی داشته باشند از طریق دروس و آزمونها، و مستقیماً در کانالها حرکت کنند. ما عمداً از اصطلاح "دانشجو" استفاده نکردیم تا در بین آموزش غیر رسمی قرارگرفته شود.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-la">estudiante</term>
+            <descrip type="definition">Un tipo de cuenta que tiene permisos limitados. Los estudiantes pueden inscribirse en clases, obtener recursos asignados a través de lecciones y cuestionarios, y navegar por canales directamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-es-ES">estudiante</term>
+            <descrip type="definition">Un tipo de cuenta que tiene permisos limitados. Los estudiantes pueden ser inscritos a las clases, tener recursos asignados a través de lecciones y pruebas, y navegar por canales directamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-qu">estudiante</term>
+            <descrip type="definition">Un tipo de cuenta que tiene permisos limitados. Los estudiantes pueden inscribirse en clases, obtener recursos asignados a través de lecciones y cuestionarios, y navegar por canales directamente.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-pt-BR">estudante</term>
+            <descrip type="definition">Um tipo de conta que tem permissões limitadas. Estudantes podem ser inscritos em classes, ter conteúdos atribuídos por meio de lições e testes e navegar por canais diretamente. Não empregamos o termo "aluno" intencionalmente, para sermos mais inclusivos com contextos de educação informal.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="45f31d16b1058d586fc3be7207b580531152-ur-PK">سیکھنے والا</term>
+            <descrip type="definition">محدود اجازت ناموں کے ساتھ اکاؤنٹ کی ایک قسم ہے۔ سیکھنے والوں کو کلاسوں میں داخلہ دیا جاسکتا ہے، اسباق اور سوالناموں کے ذریعہ مقرر کردہ وسائل حاصل کیے جا سکتے ہیں، اور چینلز کو براہ راست استعمال كرسکتے ہیں۔ ہم نے جان بوجھ کر "طالب علم" کی اصطلاح استعمال نہیں کی تا کہ ہمم غیر رسمی تعلیمی سیاق و سباق  کا حصہ بن سکیں</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="e8b1cbd05f6e6a358a81dee52493dd061154">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-en">account</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A set of data associated with a particular user, including their name, username, password, and logs of their interactions with resources. Most users will have an account in order to track their progress as a learner, manage Kolibri as an admin, or manage their classes as a coach.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-fr">compte</term>
+            <descrip type="definition">Un ensemble de données associées à un utilisateur particulier, incluant leur nom, nom d'utilisateur, mot de passe et logs de leurs interaction avec les ressources. La plupart des utilisateurs ont un compte afin de suivre leur progrès en tant qu'apprenant, gérer Kolibri en tant qu'admin ou bien gérer leurs classes en tant que éducateur.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-fa">حساب</term>
+            <descrip type="definition">مجموعه ای از داده های مرتبط با یک کاربر خاص ، از جمله نام ، نام کاربری ، رمز عبور و گزارش های مربوط به تعامل آنها با منابع. اکثر کاربران برای پیگیری پیشرفت خود به عنوان یادگیرنده ، مدیریت کليبری به عنوان سرپرست یا مدیریت کلاسهای خود به عنوان مربی ، دارای یک حساب کاربری هستند.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="vi">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-vi">tài khoản</term>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-la">cuenta</term>
+            <descrip type="definition">Un conjunto de datos asociados con un usuario en particular, incluyendo su nombre, nombre de usuario, contraseña, y registros de sus interacciones con los recursos. La mayoría de los usuarios tendrán una cuenta para que se pueda seguir su progreso como estudiante, gestionar Kolibri como administrador, o gestionar grupos como tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-es-ES">cuenta</term>
+            <descrip type="definition">Un conjunto de datos asociados con un usuario en particular, incluyendo su nombre, nombre de usuario, contraseña, y registros de sus interacciones con los recursos. La mayoría de los usuarios tendrán una cuenta para que se pueda seguir su progreso como estudiante, gestionar Kolibri como administrador, o gestionar grupos como tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="qu">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-qu">cuenta</term>
+            <descrip type="definition">Un conjunto de datos asociados con un usuario en particular, incluyendo su nombre, nombre de usuario, contraseña, y registros de sus interacciones con los recursos. La mayoría de los usuarios tendrán una cuenta para que se pueda seguir su progreso como estudiante, gestionar Kolibri como administrador, o gestionar grupos como tutor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-pt-BR">conta</term>
+            <descrip type="definition">Um conjunto de dados associados a um determinado usuário, incluindo seu nome, nome de usuário, senha e registros de suas interações com conteúdos. A maioria dos usuários terá uma conta para acompanhar seu progresso como estudante, gerenciar o Kolibri como administrador ou gerenciar suas aulas como professor.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="ur-PK">
+          <tig>
+            <term id="e8b1cbd05f6e6a358a81dee52493dd061154-ur-PK">اکاؤنٹ</term>
+            <descrip type="definition">کسی خاص صارف کے ساتھ وابستہ اعداد و شمار کا ایک مجموعہ، جس میں ان کا نام، صارف نام، پاس ورڈ اور وسائل کے ساتھ ان کے باہمی تعامل کے لاگز شامل ہیں۔ سیکھنے والے کی حیثیت سے اپنی پیشرفت کو ٹریک کرنے، بطور ایڈمنسٹریٹر کولبیری کا انتظام کرنے، یا بطور کوچ اپنی کلاسوں کا انتظام کرنے کیلئے زیادہ تر صارفین کے پاس ایک اکاؤنٹ ہوگا۔
+</descrip>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="16e6a3326dd7d868cbc926602a61e4d01159">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-en">facility</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">A facility is a concept within Kolibri that connects a set of accounts, classes, and their associated data. The same facility can be shared and synced across multiple devices, and there can also be multiple facilities on a single device.
+
+Examples of facilities could include physical schools, temporary learning hubs, organizations distributing devices across multiple locations, parent or family programs, and other types of learning environments featuring continuity between learners' activities.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="es-ES">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-es-ES">centro educativo</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Un conjunto de cuentas de usuario, clases y sus datos asociados. Ejemplos de centros educativos podrían incluir escuelas físicas, centros de aprendizaje temporales, organizaciones que distribuyen dispositivos a través de múltiples ubicaciones, programas organizados por padres o familiares, y otros tipos de entornos de aprendizaje que ofrecen continuidad entre las actividades de los estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="la">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-la">centro educativo</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Un conjunto de cuentas de usuario, grupos y sus datos asociados. Ejemplos de centros educativos podrían incluir escuelas físicas, centros de aprendizaje temporales, organizaciones que distribuyen dispositivos a través de múltiples ubicaciones, programas organizados por padres o familiares, y otros tipos de entornos de aprendizaje que ofrecen continuidad entre las actividades de los estudiantes.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="pt-BR">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-pt-BR">centro educativo</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Um conjunto de contas, classes e seus respectivos dados. Exemplos de centros educativos podem incluir escolas físicas, centros de aprendizagem temporários, organizações distribuindo dispositivos em diversas localidades, programas de pais ou familiares e outros tipos de ambiente com continuidade entre as atividades dos estudantes.	</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fr">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-fr">établissement</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">Un ensemble de comptes, classes et les données qui leurs sont associées. Des exemples d'établissements pourraient inclure des établissements scolaires physiques, des hubs d'enseignement temporaires, des organisations distribuant des appareils à de multiples endroits, des programmes pour parents et familles, et tout autre type d'environnement offrant une continuité entre les activités des apprenants.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fa">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-fa">امکانات</term>
+            <termNote type="partOfSpeech">noun</termNote>
+            <descrip type="definition">مجموعه ای از حساب ها، کلاس ها و داده های مرتبط با آنها. نمونه هایی از این امکانات می تواند شامل مدارس فیزیکی، مراکز یادگیری موقت، سازمانهایی باشد که دستگاهها را در چندین مکان توزیع می کنند ، برنامه های والدین یا خانواده و سایر انواع محیط های یادگیری شامل تداوم فعالیت های یادگیرنده ها.</descrip>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="16e6a3326dd7d868cbc926602a61e4d01159-fv">wuro bote</term>
+            <termNote type="partOfSpeech">noun</termNote>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="38ca89564b2259401518960f7a06f94b1161">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="38ca89564b2259401518960f7a06f94b1161-en">minute</term>
+            <termNote type="partOfSpeech">noun</termNote>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="38ca89564b2259401518960f7a06f94b1161-fv">minti</term>
+          </tig>
+        </langSet>
+      </termEntry>
+      <termEntry id="6e7d2da6d3953058db75714ac400b5841163">
+        <langSet xml:lang="en">
+          <tig>
+            <term id="6e7d2da6d3953058db75714ac400b5841163-en">hour</term>
+            <termNote type="partOfSpeech">noun</termNote>
+          </tig>
+        </langSet>
+        <langSet xml:lang="fv">
+          <tig>
+            <term id="6e7d2da6d3953058db75714ac400b5841163-fv">awa</term>
           </tig>
         </langSet>
       </termEntry>


### PR DESCRIPTION

## Summary

Pulls latest glossary from crowdin using `make i18n-download-glossary`

## References

refs:

* https://github.com/learningequality/kolibri-design-system/issues/274
* https://github.com/learningequality/kolibri-design-system/pull/277
* https://github.com/learningequality/kolibri/pull/6019

## Reviewer guidance

We should probably remove the glossary from Kolibri and use the Design System as the sole "crowdin backup" location

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
