### PR TITLE
Fix rtl alignment issues 

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -81,13 +81,6 @@
         type: Boolean,
         default: false,
       },
-      alignment: {
-        type: String,
-        default: 'right',
-        validator(val) {
-          return ['right', 'left'].includes(val);
-        },
-      },
       // to customize the width of the side panel in different scenarios
       sidePanelOverrideWidth: {
         type: String,
@@ -98,6 +91,9 @@
     computed: {
       isMobile() {
         return this.windowBreakpoint == 0;
+      },
+      alignment() {
+        return this.isRtl ? 'left' : 'right';
       },
     },
     /* this is the easiest way I could think to avoid having dual scroll bars */

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -3,7 +3,7 @@
   <div>
     <main
       class="main-grid"
-      :style="{ marginLeft: `${(sidePanelWidth + 24)}px` }"
+      :style="gridOffset"
     >
       <div v-if="!windowIsLarge">
         <!-- TO DO Marcella swap out new icon after KDS update -->
@@ -143,7 +143,6 @@
     <!-- FullScreen is a container component, and then the EmbeddedSidePanel sits within -->
     <FullScreenSidePanel
       v-if="!windowIsLarge && sidePanelIsOpen"
-      alignment="left"
       class="full-screen-side-panel"
       closeButtonHidden="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth + 64}px`"
@@ -331,6 +330,11 @@
       },
       activeCategories() {
         return this.searchTerms.categories;
+      },
+      gridOffset() {
+        return this.isRtl
+          ? { marginRight: `${this.sidePanelWidth + 24}px` }
+          : { marginLeft: `${this.sidePanelWidth + 24}px` };
       },
     },
     created() {

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -113,6 +113,7 @@
             color: this.$themeTokens.annotation,
           },
           color: this.$themeTokens.text,
+          textAlign: this.isRtl ? 'right' : '',
         };
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -117,7 +117,7 @@
 
       <main
         class="main-content-grid"
-        :style="{ marginLeft: `${(sidePanelWidth + 24)}px` }"
+        :style="gridOffset"
       >
         <div
           class="card-grid"
@@ -272,7 +272,6 @@
       <!-- FullScreen is a container component, and then the EmbeddedSidePanel sits within -->
       <FullScreenSidePanel
         v-if="!windowIsLarge && sidePanelIsOpen"
-        alignment="left"
         class="full-screen-side-panel"
         :closeButtonHidden="true"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth + 64}px`"
@@ -583,6 +582,11 @@
         } else {
           return 346;
         }
+      },
+      gridOffset() {
+        return this.isRtl
+          ? { marginRight: `${this.sidePanelWidth + 24}px` }
+          : { marginLeft: `${this.sidePanelWidth + 24}px` };
       },
       sidePanelOverlayWidth() {
         return 300;


### PR DESCRIPTION
Should address the following scenarios: 

- Fix card and search panel alignment in the library page
- Fix card and search panel alignment in the topics page
- When opening informational side panel within the content renderer, the side panel should open under the icon that was used to open it - left for RTL languages, and right for LTR languages 
- placeholder text in the search bar should be correctly aligned for RTL languages 

Fixes #8593 

Library and search placeholder 
<img width="1434" alt="Screen Shot 2021-11-10 at 5 26 27 PM" src="https://user-images.githubusercontent.com/17235236/141204001-b76e7b7d-923e-47d0-98ad-15289eae7408.png">

Topics
<img width="1434" alt="Screen Shot 2021-11-10 at 5 27 11 PM" src="https://user-images.githubusercontent.com/17235236/141203996-a15384be-8376-4cc2-86a5-72cd91a4d718.png">

Content Renderer
<img width="1433" alt="Screen Shot 2021-11-10 at 5 26 39 PM" src="https://user-images.githubusercontent.com/17235236/141204000-a96798e3-88b8-4a31-9195-929c5867e79c.png">

