### PR TITLE
Update `pre-commit` config python version to 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v1.3.3
     hooks:
     -   id: reorder-python-imports
-        language_version: python2.7
+        language_version: python3.6
 -   repo: local
     hooks:
     -   id: lint-frontend

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v1.3.3
     hooks:
     -   id: reorder-python-imports
-        language_version: python3.6
+        language_version: python3
 -   repo: local
     hooks:
     -   id: lint-frontend

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -1,7 +1,7 @@
+import concurrent.futures
 import logging
 import os
 
-import concurrent.futures
 import requests
 from django.core.management.base import CommandError
 from le_utils.constants import content_kinds

--- a/kolibri/core/tasks/compat.py
+++ b/kolibri/core/tasks/compat.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import threading
-
 from concurrent import futures
 
 from kolibri.utils.conf import OPTIONS

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -1,6 +1,5 @@
 import logging
 import traceback
-
 from concurrent.futures import CancelledError
 
 from kolibri.core.tasks.compat import PoolExecutor

--- a/kolibri/utils/debian_check.py
+++ b/kolibri/utils/debian_check.py
@@ -1,9 +1,8 @@
 import getpass
 import os
 import sys
-from shutil import rmtree
-
 from builtins import input
+from shutil import rmtree
 
 from .conf import KOLIBRI_HOME
 from .server import installation_type

--- a/packages/kolibri-tools/lib/i18n/utils.py
+++ b/packages/kolibri-tools/lib/i18n/utils.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
+import configparser
 import functools
 import io
 import json
 import logging
 import os
 import sys
-
-import configparser
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
## Summary
Change the python `lang_version` from 2.7 to 3.6 for the pre-commit file. We already have python 2.7-specific tests that should catch any issues that arise from this, so hopefully reordering imports won't cause errors?

## Testing checklist
- [x] Contributor has fully tested the PR manually (as far as I know, I am now able to use the `pre-commit` hook)


## PR process
- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
