### PR TITLE
Fix some issues in search

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -117,7 +117,7 @@
       },
       getContentNodeThumbnail: {
         type: Function,
-        default: () => ({}),
+        default: () => '',
         required: false,
       },
       footerIcons: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -145,7 +145,7 @@
       v-if="!windowIsLarge && sidePanelIsOpen"
       alignment="left"
       class="full-screen-side-panel"
-      closeButtonHidden="true"
+      :closeButtonHidden="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth + 64}px`"
       @closePanel="toggleSidePanelVisibility"
     >
@@ -172,6 +172,8 @@
         :width="`${sidePanelOverlayWidth}px`"
         :availableLabels="labels"
         position="overlay"
+        :activeActivityButtons="activeActivityButtons"
+        :activeCategories="activeCategories"
         @currentCategory="handleShowSearchModal"
       />
       <CategorySearchModal


### PR DESCRIPTION
## Summary
* Fixes issue where default thumbnail was returning an empty object not an empty string
* Fixes props passing for mobile views of the search panel

## References
Follow up to https://github.com/learningequality/kolibri/pull/8646#issuecomment-966321839
Follow up to https://github.com/learningequality/kolibri/pull/8548

## Reviewer guidance
When viewing in mobile view with 'list' cards, does it avoid returning a weird 404 URL when a content node doesn't have a thumbnail?
In mobile view, can you open and use the search side panel?

![mobilesearch](https://user-images.githubusercontent.com/1680573/141326047-d1960026-fb73-42f1-b953-724ec4d28261.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
