### PR TITLE
Store all currently displayed locations, not just the start location for EPUB progress

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -101,7 +101,16 @@
         <div
           class="column epubjs-navigation"
         >
+          <NextButton
+            v-if="contentIsRtl"
+            v-show="!isAtEnd"
+            :color="navigationButtonColor"
+            :isRtl="contentIsRtl"
+            :style="{ backgroundColor }"
+            @goToNextPage="goToNextPage"
+          />
           <PreviousButton
+            v-else
             v-show="!isAtStart"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"
@@ -118,7 +127,16 @@
         <div
           class="column epubjs-navigation"
         >
+          <PreviousButton
+            v-if="contentIsRtl"
+            v-show="!isAtStart"
+            :color="navigationButtonColor"
+            :isRtl="contentIsRtl"
+            :style="{ backgroundColor }"
+            @goToPreviousPage="goToPreviousPage"
+          />
           <NextButton
+            v-else
             v-show="!isAtEnd"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -493,9 +493,11 @@
         }
       },
       storeVisitedPage(currentLocation) {
-        let visited = this.savedVisitedPages;
-        visited[currentLocation] = true;
-        this.savedVisitedPages = visited;
+        if (currentLocation) {
+          let visited = this.savedVisitedPages;
+          visited[currentLocation] = true;
+          this.savedVisitedPages = visited;
+        }
       },
       handleReadyRendition() {
         this.updateRenditionTheme(this.themeStyle);
@@ -706,7 +708,6 @@
         this.currentSection = this.getCurrentSection(currentLocationStart);
       },
       relocatedHandler(location) {
-        //console.log(location);
         // Ensures that when we're on the last page, we set the slider value to 100
         // otherwise, we show the slider % using the start
         if (location.atEnd) {
@@ -716,7 +717,13 @@
         }
         this.updateCurrentSection(location.start);
         this.currentLocation = location.start.cfi;
-        this.storeVisitedPage(this.currentLocation);
+        for (
+          let locationIndex = location.start.location;
+          locationIndex <= location.end.location;
+          locationIndex++
+        ) {
+          this.storeVisitedPage(this.locations[locationIndex]);
+        }
         this.updateProgress();
         this.updateContentState();
       },


### PR DESCRIPTION
## Summary
* Stores all the locations currently being displayed on the screen, rather than just the starting location
* This means that all displayed locations count as visited
* Allows EPUBs to be completed
* Fixes display of Next and Previous buttons for RTL books

## References
Fixes #8309

## Reviewer guidance
If you read every page of an EPUB does it get marked as complete?

RTL reading still seems not to work, but I can't narrow down if it is due to our implementation of EPUB.js or the library itself.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
