### PR TITLE
Back navigation

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
@@ -251,7 +251,7 @@ export default function useLearnerResources() {
     if (lessonResourceIdx === undefined) {
       return undefined;
     }
-    return genContentLink(resource.contentNodeId, true, undefined, {
+    return genContentLink(resource.contentNodeId, null, true, undefined, {
       lessonId: resource.lessonId,
       classId: resource.classId,
     });

--- a/kolibri/plugins/learn/assets/src/utils/genContentLink.js
+++ b/kolibri/plugins/learn/assets/src/utils/genContentLink.js
@@ -3,7 +3,13 @@ import { PageNames } from '../constants';
 // previous context allows to pass in ids or params from the last route
 // topic id is passed to account for variability in topic search
 // and parent/ancestor id navigation
-export default function genContentLink(id, topicId, isLeaf, last, prevContext = {}) {
+export default function genContentLink(
+  id,
+  topicId = null,
+  isLeaf = false,
+  last = null,
+  prevContext = {}
+) {
   const query = { ...prevContext };
   if (last) {
     query.last = last;

--- a/kolibri/plugins/learn/assets/src/utils/genContentLink.js
+++ b/kolibri/plugins/learn/assets/src/utils/genContentLink.js
@@ -1,10 +1,15 @@
 import { PageNames } from '../constants';
 
 // previous context allows to pass in ids or params from the last route
-export default function genContentLink(id, isLeaf, last, prevContext = {}) {
+// topic id is passed to account for variability in topic search
+// and parent/ancestor id navigation
+export default function genContentLink(id, topicId, isLeaf, last, prevContext = {}) {
   const query = { ...prevContext };
   if (last) {
     query.last = last;
+  }
+  if (topicId) {
+    query.topicId = topicId;
   }
   return {
     name: isLeaf ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -29,7 +29,7 @@
           :text="metadataStrings.$tr('viewResource')"
           appearance="raised-button"
           :primary="false"
-          :to="genContentLink(content.id, content.is_leaf)"
+          :to="genContentLink(content.id, null, content.is_leaf, null, {})"
           data-test="view-resource-link"
         />
       </div>
@@ -165,7 +165,7 @@
           :key="related.title"
           class="list-item"
         >
-          <KRouterLink :to="genContentLink(related.id, related.is_leaf)">
+          <KRouterLink :to="genContentLink(related.id, null, related.is_leaf, null, {})">
             <KLabeledIcon>
               <template #icon>
                 <LearningActivityIcon :kind="related.learning_activities" />
@@ -187,7 +187,7 @@
       <div v-for="location in locationsInChannel" :key="location.id">
         <div>
           <KRouterLink
-            :to="genContentLink(lastAncestor(location).id, false)"
+            :to="genContentLink(lastAncestor(location).id, null, false, null, {})"
           >
             {{ lastAncestor(location).title }}
           </KRouterLink>

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -114,6 +114,7 @@
                     :contentNode="contentNode"
                     :contentNodeRoute="genContentLink(
                       contentNode.id,
+                      null,
                       contentNode.is_leaf,
                       $route.query.last,
                       $route.query
@@ -261,6 +262,7 @@
       nextContentNodeRoute() {
         return this.genContentLink(
           this.nextContentNode.id,
+          null,
           this.nextContentNode.is_leaf,
           this.$route.query.last,
           this.$route.query

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -162,7 +162,7 @@
         let id = message.nodeId;
         return ContentNodeResource.fetchModel({ id })
           .then(contentNode => {
-            router.push(this.genContentLink(contentNode.id, contentNode.is_leaf));
+            router.push(this.genContentLink(contentNode.id, null, contentNode.is_leaf, null, {}));
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -12,7 +12,7 @@
           :isMobile="windowIsSmall"
           :content="content"
           :thumbnail="content.thumbnail"
-          :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
+          :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
           @openCopiesModal="openCopiesModal"
           @toggleInfoPanel="$emit('toggleInfoPanel', content)"
         />
@@ -26,7 +26,7 @@
         :thumbnail="content.thumbnail || getContentNodeThumbnail(content)"
         class="card-grid-item"
         :isMobile="windowIsSmall"
-        :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
+        :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
       />
     </div>
     <CardGrid
@@ -37,7 +37,7 @@
 
         :key="`resource-${idx}`"
         :contentNode="content"
-        :to="genContentLink(content.id, content.is_leaf, backRoute, context)"
+        :to="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
       />
     </CardGrid>
 
@@ -50,7 +50,7 @@
       :currentPage="currentPage"
       class="card-grid-item"
       :isMobile="windowIsSmall"
-      :link="genContentLink(content.id, content.is_leaf, backRoute, context)"
+      :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
@@ -149,6 +149,16 @@
           };
         }
         return context;
+      },
+      topicId() {
+        if (
+          this.pageName === PageNames.TOPICS_TOPIC ||
+          this.pageName === PageNames.TOPICS_TOPIC_SEARCH
+        ) {
+          return this.$route.params.id;
+        } else {
+          return null;
+        }
       },
       backRoute() {
         return this.pageName;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -34,7 +34,8 @@
       </div>
       <CardThumbnail
         class="thumbnail"
-        v-bind="{ thumbnail, kind, isMobile }"
+        :kind="content.kind"
+        v-bind="{ thumbnail, isMobile }"
       />
       <div class="text" :style="{ color: $themeTokens.text }">
         <h3 class="title" dir="auto">
@@ -84,7 +85,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
+  import { validateLinkObject } from 'kolibri.utils.validators';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -107,11 +108,6 @@
       thumbnail: {
         type: String,
         default: null,
-      },
-      kind: {
-        type: String,
-        required: true,
-        validator: validateContentNodeKind,
       },
       link: {
         type: Object,

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -283,15 +283,17 @@
         // extract the key pieces of routing from immersive page props, but since we don't need
         // them all, just create two alternative route paths for return/'back' navigation
         let route = {};
-        if (this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH) {
+        if (
+          this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH ||
+          this.$route.query.last === PageNames.TOPICS_TOPIC
+        ) {
+          const lastId = this.$route.query.topicId
+            ? this.$route.query.topicId
+            : this.topicsTreeContent.parent;
+          const lastPage = this.$route.query.last;
           // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(PageNames.TOPICS_TOPIC_SEARCH, {
-            id: this.topicsTreeContent.parent,
-          });
-        } else if (this.$route.query.last === PageNames.TOPICS_TOPIC) {
-          // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
-            id: this.topicsTreeContent.this.topicsTreeContent.parent,
+          route = this.$router.getRoute(lastPage, {
+            id: lastId,
           });
         } else if (this.$route.query && this.$route.query.last) {
           const last = this.$route.query.last;

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -285,8 +285,13 @@
         let route = {};
         if (this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH) {
           // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
+          route = this.$router.getRoute(PageNames.TOPICS_TOPIC_SEARCH, {
             id: this.topicsTreeContent.parent,
+          });
+        } else if (this.$route.query.last === PageNames.TOPICS_TOPIC) {
+          // Need to guard for parent being non-empty to avoid console errors
+          route = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
+            id: this.topicsTreeContent.this.topicsTreeContent.parent,
           });
         } else if (this.$route.query && this.$route.query.last) {
           const last = this.$route.query.last;

--- a/kolibri/plugins/learn/assets/test/util/gen-content-link.spec.js
+++ b/kolibri/plugins/learn/assets/test/util/gen-content-link.spec.js
@@ -2,8 +2,8 @@ import { validateLinkObject } from 'kolibri.utils.validators';
 import { PageNames } from '../../src/constants';
 import genContentLink from '../../src/utils/genContentLink';
 
-const topicLink = genContentLink(19, null, false);
-const contentLink = genContentLink(88, 1, true);
+const topicLink = genContentLink(19, null, false, null, {});
+const contentLink = genContentLink(88, 1, true, null, {});
 
 describe('genContentLink - generating for a topic (isLeaf != true)', () => {
   it('returns a valid link object', () => {

--- a/kolibri/plugins/learn/assets/test/util/gen-content-link.spec.js
+++ b/kolibri/plugins/learn/assets/test/util/gen-content-link.spec.js
@@ -2,8 +2,8 @@ import { validateLinkObject } from 'kolibri.utils.validators';
 import { PageNames } from '../../src/constants';
 import genContentLink from '../../src/utils/genContentLink';
 
-const topicLink = genContentLink(19, false);
-const contentLink = genContentLink(88, true);
+const topicLink = genContentLink(19, null, false);
+const contentLink = genContentLink(88, 1, true);
 
 describe('genContentLink - generating for a topic (isLeaf != true)', () => {
   it('returns a valid link object', () => {

--- a/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
@@ -96,7 +96,9 @@ describe('BrowseResourceMetadata', () => {
       const link = wrapper.findComponent(KRouterLink);
       expect(link.exists()).toBeTruthy();
       const to = link.props().to;
-      expect(to).toEqual(genContentLink(baseContentNode.id, baseContentNode.is_leaf));
+      expect(to).toEqual(
+        genContentLink(baseContentNode.id, null, baseContentNode.is_leaf, null, {})
+      );
     });
 
     it('displays a ContentNodeThumbnail', () => {


### PR DESCRIPTION
## Summary
Updates genContentLink to take a topicId, rather than conditionally referring to the parent in Topic/TopicSearch page 
Fixes the issue with topic page back button appearing to break, and also ensures that the back button takes the user to their previous view, not just the parent (which can be disorienting, due to nested folder display)


## References
Fixes #8614

![topics-back-button](https://user-images.githubusercontent.com/17235236/141349339-c6201076-d8de-4227-a4d6-01d4aaf50a17.gif)


…

## Reviewer guidance
Do all of the back links still work? 
Any edge cases not considered or potentially breaking?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
