### PR TITLE
Add safeguards against too many fds through http server

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -8,13 +8,13 @@ from diskcache import Cache
 
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.conf import OPTIONS
+from kolibri.utils.options import CACHE_SHARDS
 
 cache_options = OPTIONS["Cache"]
 
 pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
 
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
-CACHE_SHARDS = 8
 
 
 def recreate_diskcache():

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -14,6 +14,7 @@ cache_options = OPTIONS["Cache"]
 pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
 
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
+CACHE_SHARDS = 8
 
 
 def recreate_diskcache():
@@ -47,6 +48,7 @@ default_cache = {
 process_cache = {
     "BACKEND": "diskcache.DjangoCache",
     "LOCATION": diskcache_location,
+    "SHARDS": CACHE_SHARDS,
     "OPTIONS": {
         "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],
         # Pin pickle protocol for Python 2 compatibility

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -63,6 +63,7 @@ def calculate_thread_pool():
 
 ALL_LANGUAGES = "kolibri-all"
 SUPPORTED_LANGUAGES = "kolibri-supported"
+DEFAULT_THREAD_POOL_SIZE = calculate_thread_pool()
 
 
 def _process_language_string(value):
@@ -301,7 +302,7 @@ base_option_spec = {
         },
         "CHERRYPY_THREAD_POOL": {
             "type": "integer",
-            "default": calculate_thread_pool(),
+            "default": DEFAULT_THREAD_POOL_SIZE,
             "description": "How many threads the Kolibri server should use to serve requests",
         },
         "CHERRYPY_SOCKET_TIMEOUT": {

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -29,12 +29,13 @@ except NotImplementedError:
 from kolibri.utils.i18n import KOLIBRI_LANGUAGE_INFO
 from kolibri.utils.i18n import KOLIBRI_SUPPORTED_LANGUAGES
 from kolibri.plugins.utils.options import extend_config_spec
-from kolibri.deployment.default.cache import CACHE_SHARDS
 from kolibri.deployment.default.sqlite_db_names import (
     ADDITIONAL_SQLITE_DATABASES,
 )
 from kolibri.utils.system import get_fd_limit
 
+
+CACHE_SHARDS = 8
 
 # file descriptors per thread
 FD_PER_THREAD = sum(

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -29,41 +29,60 @@ except NotImplementedError:
 from kolibri.utils.i18n import KOLIBRI_LANGUAGE_INFO
 from kolibri.utils.i18n import KOLIBRI_SUPPORTED_LANGUAGES
 from kolibri.plugins.utils.options import extend_config_spec
+from kolibri.deployment.default.cache import CACHE_SHARDS
+from kolibri.deployment.default.sqlite_db_names import (
+    ADDITIONAL_SQLITE_DATABASES,
+)
+from kolibri.utils.system import get_fd_limit
+
+
+# file descriptors per thread
+FD_PER_THREAD = sum(
+    (
+        5,  # minimum allowance
+        1 + len(ADDITIONAL_SQLITE_DATABASES),  # DBs assuming SQLite
+        CACHE_SHARDS,  # assuming diskcache
+    )
+)
 
 
 def calculate_thread_pool():
     """
     Returns the default value for CherryPY thread_pool:
     - calculated based on the best values obtained in several partners installations
-    - value must be between 10 (default CherryPy value) and 200
     - servers with more memory can deal with more threads
     - calculations are done for servers with more than 2 Gb of RAM
+    - restricts value to avoid exceeding file descriptor limit
     """
     MIN_POOL = 50
     MAX_POOL = 150
+
+    pool_size = MIN_POOL
     if psutil:
         MIN_MEM = 2
         MAX_MEM = 6
         total_memory = psutil.virtual_memory().total / pow(2, 30)  # in Gb
         # if it's in the range, scale thread count linearly with available memory
         if MIN_MEM < total_memory < MAX_MEM:
-            return MIN_POOL + int(
+            pool_size = MIN_POOL + int(
                 (MAX_POOL - MIN_POOL)
                 * float(total_memory - MIN_MEM)
                 / (MAX_MEM - MIN_MEM)
             )
-        # otherwise return either the min or max amount
-        return MAX_POOL if total_memory >= MAX_MEM else MIN_POOL
+        elif total_memory >= MAX_MEM:
+            pool_size = MAX_POOL
     elif sys.platform.startswith(
         "darwin"
     ):  # Considering MacOS has at least 4 Gb of RAM
-        return MAX_POOL
-    return MIN_POOL
+        pool_size = MAX_POOL
+
+    # ensure (number of threads) x (open file descriptors) < (fd limit)
+    max_threads = get_fd_limit() // FD_PER_THREAD
+    return min(pool_size, max_threads)
 
 
 ALL_LANGUAGES = "kolibri-all"
 SUPPORTED_LANGUAGES = "kolibri-supported"
-DEFAULT_THREAD_POOL_SIZE = calculate_thread_pool()
 
 
 def _process_language_string(value):
@@ -302,7 +321,7 @@ base_option_spec = {
         },
         "CHERRYPY_THREAD_POOL": {
             "type": "integer",
-            "default": DEFAULT_THREAD_POOL_SIZE,
+            "default": calculate_thread_pool(),
             "description": "How many threads the Kolibri server should use to serve requests",
         },
         "CHERRYPY_SOCKET_TIMEOUT": {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -26,6 +26,7 @@ from zeroconf import InterfaceChoice
 
 import kolibri
 from .system import become_daemon
+from .system import get_fd_limit
 from .system import pid_exists
 from kolibri.utils import conf
 from kolibri.utils.android import on_android
@@ -698,9 +699,39 @@ class KolibriProcessBus(ProcessBus):
         if self.serve_http:
             from kolibri.deployment.default.wsgi import application
             from kolibri.deployment.default.alt_wsgi import alt_application
+            from kolibri.utils.options import DEFAULT_THREAD_POOL_SIZE
+
+            # min file descriptor allowance per thread
+            per_thread_fd_allowance = 5
+
+            # using sqlite, include number of databases in fd count
+            if conf.OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
+                from kolibri.deployment.default.sqlite_db_names import (
+                    ADDITIONAL_SQLITE_DATABASES,
+                )
+
+                per_thread_fd_allowance += 1 + len(ADDITIONAL_SQLITE_DATABASES)
+
+            # using diskcache, count number of shards (number of cache files)
+            if conf.OPTIONS["Cache"]["CACHE_BACKEND"] != "redis":
+                from kolibri.deployment.default.cache import CACHE_SHARDS
+
+                per_thread_fd_allowance += CACHE_SHARDS
+
+            # determine if number of threads can exceed fd limit
+            num_threads = conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"]
+            max_threads = int(get_fd_limit() / per_thread_fd_allowance)
+            if num_threads > max_threads:
+                if num_threads == DEFAULT_THREAD_POOL_SIZE:
+                    logger.info(
+                        "Lowering CHERRYPY_THREAD_POOL to {}".format(max_threads)
+                    )
+                    num_threads = max_threads
+                else:
+                    logger.warning("Problematic CHERRYPY_THREAD_POOL setting detected")
 
             server_config = {
-                "numthreads": conf.OPTIONS["Server"]["CHERRYPY_THREAD_POOL"],
+                "numthreads": num_threads,
                 "request_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],
                 "timeout": conf.OPTIONS["Server"]["CHERRYPY_SOCKET_TIMEOUT"],
                 "accepted_queue_size": conf.OPTIONS["Server"]["CHERRYPY_QUEUE_SIZE"],

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import resource
 import sys
 
 import six
@@ -183,10 +184,23 @@ def become_daemon(**kwargs):
     _become_daemon_function(**kwargs)
 
 
-# Utility functions for pinging or killing PIDs
+def _posix_get_fd_limit():
+    fd_soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
+    return fd_soft_limit
+
+
+def _windows_get_fd_limit():
+    import ctypes
+
+    return ctypes.cdll._getmaxstdio()
+
+
+# Utility functions
 if os.name == "posix":
     pid_exists = _posix_pid_exists
+    get_fd_limit = _posix_get_fd_limit
     _become_daemon_function = _posix_become_daemon
 else:
     pid_exists = _windows_pid_exists
+    get_fd_limit = _windows_get_fd_limit
     _become_daemon_function = _windows_become_daemon

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -199,9 +199,8 @@ def _windows_get_fd_limit():
     Determines the File Descriptor (FD) limit
     :return: int
     """
-    import ctypes
-
-    return ctypes.cdll.stdio._getmaxstdio()
+    # TODO: "determine" it
+    return 512
 
 
 # Utility functions

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -184,6 +184,10 @@ def become_daemon(**kwargs):
 
 
 def _posix_get_fd_limit():
+    """
+    Determines the File Descriptor (FD) limit
+    :return: int
+    """
     import resource
 
     fd_soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -191,9 +195,13 @@ def _posix_get_fd_limit():
 
 
 def _windows_get_fd_limit():
+    """
+    Determines the File Descriptor (FD) limit
+    :return: int
+    """
     import ctypes
 
-    return ctypes.cdll._getmaxstdio()
+    return ctypes.cdll.stdio._getmaxstdio()
 
 
 # Utility functions

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import resource
 import sys
 
 import six
@@ -185,6 +184,8 @@ def become_daemon(**kwargs):
 
 
 def _posix_get_fd_limit():
+    import resource
+
     fd_soft_limit, _ = resource.getrlimit(resource.RLIMIT_NOFILE)
     return fd_soft_limit
 

--- a/kolibri/utils/tests/test_system.py
+++ b/kolibri/utils/tests/test_system.py
@@ -1,0 +1,7 @@
+from kolibri.utils.system import get_fd_limit
+
+
+def test_get_fd_limit():
+    limit = get_fd_limit()
+    assert limit is not None
+    assert limit > 0


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates thread calculation to take file descriptor (fd) limit into account
- Hard codes limit at 512 for Windows for now
- Adds constant for shard quantity, which was using default value of 8

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/8618

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
