### PR TITLE
Side Panel freezing fix

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -187,9 +187,9 @@
       <div v-for="location in locationsInChannel" :key="location.id">
         <div>
           <KRouterLink
-            :to="genContentLink((location.ancestors.splice(-1)[0] || {}).id, false)"
+            :to="genContentLink(lastAncestor(location).id, false)"
           >
-            {{ (location.ancestors.splice(-1)[0] || {}).title }}
+            {{ lastAncestor(location).title }}
           </KRouterLink>
         </div>
       </div>
@@ -305,9 +305,12 @@
         // Retreives any topics in this same channel
         ContentNodeResource.fetchCollection({
           getParams: { content_id: this.content.content_id, channel_id: this.content.channel_id },
-        }).then(
-          locations => (this.locationsInChannel = locations && locations.length ? locations : null)
-        );
+        }).then((locations = []) => {
+          locations = locations.filter(loc => loc.id !== this.content.id);
+          if (locations && locations.length) {
+            this.locationsInChannel = locations;
+          }
+        });
       }
 
       this.metadataStrings = crossComponentTranslator(SidePanelResourceMetadata);
@@ -315,6 +318,10 @@
     },
     methods: {
       genContentLink,
+      lastAncestor(location) {
+        const lastAncestor = location.ancestors[location.ancestors.length - 1];
+        return lastAncestor;
+      },
       toggleShowMoreOrLess() {
         if (this.showMoreOrLess === 'Show More') {
           this.showMoreOrLess = 'Show Less';


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Vue rerenders when its data changes - so you cannot use splice on anything (or its children) that would cause a rerender because it will constantly be changing itself forever and ever.

Much gratitude to @indirectlylit for the help working this out!

Now the side panel only consumes it's proper allotment of CPU.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8611 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->


1) Go to Library page
2) Go to a Channel where you know a piece of content lives in two places in that same channel (try early math KA-en or something)
3) Click the (i) on the card when browsing that channel.
4) See a list of topic names as links at the bottom of the side panel which link you to the same content in a different folder (but NOT one to the currently viewed folder).
5) Also nothing freezes and everything goes perfectly yayyyy (if you're running in dev mode, check the console error log to see if anything complains about an infinite loop).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
