### PR TITLE
Fake labels for testing

### DIFF
--- a/kolibri/core/content/management/commands/labeltestdata.py
+++ b/kolibri/core/content/management/commands/labeltestdata.py
@@ -1,0 +1,93 @@
+import logging
+import random
+
+from django.core.management.base import BaseCommand
+from le_utils.constants import content_kinds
+from le_utils.constants.labels.accessibility_categories import (
+    ACCESSIBILITYCATEGORIESLIST,
+)
+from le_utils.constants.labels.learning_activities import LEARNINGACTIVITIESLIST
+from le_utils.constants.labels.levels import LEVELSLIST
+from le_utils.constants.labels.needs import NEEDSLIST
+from le_utils.constants.labels.subjects import SUBJECTSLIST
+
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.utils.search import annotate_label_bitmasks
+from kolibri.core.device.models import ContentCacheKey
+
+logger = logging.getLogger(__name__)
+
+
+def choices(sequence, k):
+    return [random.choice(sequence) for _ in range(0, k)]
+
+
+class Command(BaseCommand):
+    """
+    This command will try to fix the content tables in the database,
+    reviewing the availability of all the existing files, to recover
+    content that's not visible in Kolibri.
+    """
+
+    help = "Scan content and databases in Kolibri folder and updates the database to show if available"
+
+    def add_arguments(self, parser):
+
+        channels_help_text = """
+        Constrain the label generation to a particular set of channels. Other channels will not be affected.
+        Separate multiple channel IDs with commas.
+        """
+        parser.add_argument(
+            "--channels",
+            # Split the comma separated string we get, into a list of strings
+            type=lambda x: x.split(","),
+            default=None,
+            required=False,
+            dest="channels",
+            help=channels_help_text,
+        )
+
+    def _handle_channel(self, channel):
+        logger.info("Adding fake metadata labels to channel: {}".format(channel.name))
+        channel_resource_nodes = channel.root.get_descendants().exclude(
+            kind=content_kinds.TOPIC
+        )
+        for node in channel_resource_nodes:
+            random.seed(node.id)
+            node.learning_activities = ",".join(
+                set(choices(LEARNINGACTIVITIESLIST, k=random.randint(1, 3)))
+            )
+            node.accessibility_labels = ",".join(
+                set(choices(ACCESSIBILITYCATEGORIESLIST, k=random.randint(1, 3)))
+            )
+            node.grade_levels = ",".join(
+                set(choices(LEVELSLIST, k=random.randint(1, 2)))
+            )
+            node.categories = ",".join(
+                set(choices(SUBJECTSLIST, k=random.randint(1, 10)))
+            )
+            node.learner_needs = ",".join(
+                set(choices(NEEDSLIST, k=random.randint(1, 5)))
+            )
+            node.save()
+        annotate_label_bitmasks(channel_resource_nodes)
+        logger.info("Added fake metadata labels to channel: {}".format(channel.name))
+
+    def handle(self, *args, **options):
+        channels = ChannelMetadata.objects.all()
+        if options["channels"]:
+            channels.filter(id__in=options["channels"])
+
+        logger.info(
+            "Adding fake metadata labels to channels: {}".format(
+                ", ".join(channels.values_list("name", flat=True))
+            )
+        )
+        for channel in channels:
+            self._handle_channel(channel)
+        ContentCacheKey.update_cache_key()
+        logger.info(
+            "Successfully added fake metadata labels to {} channels".format(
+                len(channels)
+            )
+        )

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -187,7 +187,11 @@ class ContentNode(base_models.ContentNode):
 
     # Use this to annotate ancestor information directly onto the ContentNode, as it can be a
     # costly lookup
-    ancestors = JSONField(default=[], null=True, blank=True)
+    # Don't use strict loading as the titles used to construct the ancestors can contain
+    # control characters, which will fail strict loading.
+    ancestors = JSONField(
+        default=[], null=True, blank=True, load_kwargs={"strict": False}
+    )
 
     objects = ContentNodeManager()
 

--- a/kolibri/core/fields.py
+++ b/kolibri/core/fields.py
@@ -103,7 +103,7 @@ class JSONField(JSONFieldBase):
     def from_db_value(self, value, expression, connection, context):
         if isinstance(value, string_types):
             try:
-                return json.loads(value)
+                return json.loads(value, **self.load_kwargs)
             except ValueError:
                 pass
 
@@ -112,7 +112,7 @@ class JSONField(JSONFieldBase):
     def to_python(self, value):
         if isinstance(value, string_types):
             try:
-                return json.loads(value)
+                return json.loads(value, **self.load_kwargs)
             except ValueError:
                 pass
 

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -100,7 +100,7 @@
         class="section"
       />
       <div
-        v-if="value.learner_needs && value.learner_needs.length"
+        v-if="Object.keys(resourcesNeededList).length"
         class="section"
       >
         <div


### PR DESCRIPTION
## Summary
* Fixes bug with ancestor JSON by allowing non-strict loading of JSON from ancestors (was getting broken by control characters like `\t`)
* Adds management command to generate fake labels for channels in the local database for testing purposes

## Reviewer guidance
Run:
```
kolibri manage labeltestdata
```

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
