### PR TITLE
Toggle mark learner complete based on content metadata.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -71,6 +71,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import get from 'lodash/get';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
@@ -182,9 +183,7 @@
         return this.content ? this.content.title : '';
       },
       allowMarkComplete() {
-        // TODO: This should be determined by some other means. Content metadata?
-        const DEV_ONLY = process.env.NODE_ENV !== 'production';
-        return DEV_ONLY;
+        return get(this, ['content', 'options', 'completion_criteria', 'learner_managed'], false);
       },
       mappedLearningActivities() {
         let learningActivities = [];


### PR DESCRIPTION
## Summary
* Allows content to be marked as complete if metadata allows it

## References
Fixes #8666

## Reviewer guidance
This matches up to the planned structure that @bjester will be implementing for saving/publishing this on Studio.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
