### PR TITLE
AlsoInThis side panel follow-up

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -177,7 +177,6 @@
         const progress = {
           progress: this.contentNodeProgressMap[node.content_id] || 0,
         };
-        console.log({ ...node, ...progress });
         return { ...node, ...progress };
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -43,12 +43,12 @@
           </div>
           <div class="progress">
             <KIcon
-              v-if="content.progress === 1"
+              v-if="withProgress(content).progress === 1"
               icon="star"
               class="mastered-icon"
               :style="{ fill: $themeTokens.mastered }"
             />
-            <ProgressBar v-else :contentNode="content" class="bar" />
+            <ProgressBar v-else :contentNode="withProgress(content)" class="bar" />
           </div>
         </div>
 
@@ -87,6 +87,7 @@
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import SidePanelResourcesList from '../../../../../../kolibri/core/assets/src/views/FullScreenSidePanel/SidePanelResourcesList';
+  import useContentNodeProgress from '../composables/useContentNodeProgress';
   import genContentLink from '../utils/genContentLink';
   import LearningActivityIcon from './LearningActivityIcon.vue';
   import ProgressBar from './ProgressBar';
@@ -102,6 +103,10 @@
       TimeDuration,
     },
     mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { contentNodeProgressMap } = useContentNodeProgress();
+      return { contentNodeProgressMap };
+    },
     props: {
       /**
        * contentNodes - The contentNode objects to be displayed. Each
@@ -166,7 +171,16 @@
         return context;
       },
     },
-    methods: { genContentLink },
+    methods: {
+      genContentLink,
+      withProgress(node) {
+        const progress = {
+          progress: this.contentNodeProgressMap[node.content_id] || 0,
+        };
+        console.log({ ...node, ...progress });
+        return { ...node, ...progress };
+      },
+    },
   };
 
 </script>

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -24,31 +24,34 @@
           :kind="content.learning_activities"
         />
         <KIcon v-else class="topic-icon" icon="topic" />
-        <div class="content-meta" :style="{ top: (content.duration ? '-8px' : '8px') }">
-          <TextTruncator
-            :text="content.title"
-            :maxHeight="24"
-            :style="{ marginTop: (content.duration ? '8px' : '0px') }"
-          />
-          <TimeDuration
-            v-if="content.duration"
-            :style="{
-              color: $themeTokens.annotation,
-              top: '16px',
-              position: 'relative'
-            }"
-            :seconds="content.duration"
-          />
+
+        <div class="content-meta">
+          <div class="text-and-time">
+            <TextTruncator
+              class="content-title"
+              :text="content.title"
+              :maxHeight="72"
+            />
+            <TimeDuration
+              v-if="content.duration"
+              class="time-duration"
+              :style="{
+                color: $themeTokens.annotation,
+              }"
+              :seconds="content.duration"
+            />
+          </div>
+          <div class="progress">
+            <KIcon
+              v-if="content.progress === 1"
+              icon="star"
+              class="mastered-icon"
+              :style="{ fill: $themeTokens.mastered }"
+            />
+            <ProgressBar v-else :contentNode="content" class="bar" />
+          </div>
         </div>
-        <div class="progress">
-          <KIcon
-            v-if="content.progress === 1"
-            icon="star"
-            class="mastered-icon"
-            :style="{ fill: $themeTokens.mastered }"
-          />
-          <ProgressBar v-else :contentNode="content" class="bar" />
-        </div>
+
       </KRouterLink>
     </div>
 
@@ -176,7 +179,6 @@
   $parent-padding: 32px; // The SidePanel
   $icon-size: 32px;
   $progress-width: 48px;
-  $item-padding-x: 8px;
   $top-bar-height: 40px;
   $next-content-link-height: 100px;
 
@@ -186,6 +188,15 @@
 
     /* Avoids overflow issues, aligns bottom bit */
     height: calc(100% - 16px);
+  }
+
+  .top-bar {
+    position: relative;
+    top: 0;
+    right: 0;
+    left: 0;
+    height: $top-bar-height;
+    background-color: #ffffff;
   }
 
   .content-list {
@@ -198,8 +209,95 @@
     margin-right: -32px;
     overflow-y: scroll;
 
+    /* When there is nothing to link to in the next-content-link */
     &.no-bottom-link {
       height: calc(100% - #{$top-bar-height});
+    }
+  }
+
+  .item {
+    position: relative;
+    display: block;
+    width: 100%;
+    min-height: 72px;
+    margin-top: 24px;
+  }
+
+  .activity-icon,
+  .next-label,
+  .topic-icon {
+    position: absolute;
+    left: 0;
+    display: inline-block;
+    width: $icon-size;
+    height: $icon-size;
+  }
+
+  .activity-icon,
+  .topic-icon {
+    top: 0;
+  }
+
+  .content-meta {
+    position: relative;
+    left: calc(#{$icon-size} + 16px);
+    display: inline-block;
+    width: calc(100% - #{$icon-size});
+  }
+
+  .text-and-time {
+    display: inline-block;
+    width: calc(100% - #{$icon-size} - #{$progress-width});
+  }
+
+  .progress {
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    .bar {
+      width: $progress-width;
+      margin-right: 4px; // puts mastery star aligned center with bars
+    }
+  }
+  .mastered-icon {
+    top: 0;
+    right: 16px;
+    width: 24px;
+    height: 24px;
+  }
+
+  /** Styles overriding the above when windowIsSmall **/
+  .small {
+    &.item {
+      // Differentiate between items a bit better
+      margin-bottom: 32px;
+    }
+    // Without the progress on the same line, don't incl it in calcs
+    .content-meta {
+      width: calc(100% - #{$icon-size});
+    }
+    .time-duration {
+      display: block;
+      width: 100%;
+      margin-top: 8px;
+    }
+    .text-and-time {
+      display: block;
+      width: 100%;
+    }
+    // The progress section neds to become block & have some of its
+    // spacing tweaked when it is on a small screen - under the text
+    .progress {
+      position: relative;
+      display: block;
+      width: 100%;
+      margin-top: 8px;
+    }
+    .mastered-icon {
+      right: auto;
+      bottom: 0;
+      left: 0;
     }
   }
 
@@ -239,91 +337,6 @@
       right: $parent-padding;
       width: $icon-size;
       height: $icon-size;
-    }
-  }
-
-  .item {
-    position: relative;
-    display: block;
-    width: 100%;
-    height: 56px;
-    padding: 16px $item-padding-x;
-    margin-top: 24px;
-  }
-
-  .activity-icon,
-  .next-label,
-  .topic-icon {
-    position: absolute;
-    left: $item-padding-x;
-    display: inline-block;
-    width: $icon-size;
-    height: $icon-size;
-  }
-
-  .activity-icon,
-  .topic-icon {
-    top: 0;
-  }
-
-  .content-meta {
-    position: absolute;
-    left: calc(#{$icon-size} + #{$item-padding-x});
-    display: inline-block;
-    width: calc(100% - #{$icon-size} - #{$progress-width} - #{$item-padding-x * 2});
-    height: 56px;
-    padding: 0 16px;
-  }
-
-  .progress {
-    position: absolute;
-    top: 0;
-    right: 0;
-
-    .bar {
-      width: $progress-width;
-      margin-top: 16px;
-    }
-  }
-  .mastered-icon {
-    top: 0;
-    right: 16px;
-    width: 24px;
-    height: 24px;
-  }
-
-  .top-bar {
-    position: relative;
-    top: 0;
-    right: 0;
-    left: 0;
-    height: $top-bar-height;
-    background-color: #ffffff;
-  }
-
-  /** Styles overriding the above when windowIsSmall **/
-  .small {
-    &.item {
-      // Differentiate between items a bit better
-      margin-bottom: 32px;
-    }
-    // Without the progress on the same line, don't incl it in calcs
-    .content-meta {
-      width: calc(100% - #{$icon-size} - #{$item-padding-x});
-    }
-    // The progress section neds to become block & have some of its
-    // spacing tweaked when it is on a small screen - under the text
-    .progress {
-      top: auto;
-      bottom: -8px;
-      left: 56px;
-      display: block;
-    }
-    .mastered-icon {
-      top: 8px;
-      right: auto;
-      bottom: 0;
-      left: 0;
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -43,12 +43,12 @@
           </div>
           <div class="progress">
             <KIcon
-              v-if="withProgress(content).progress === 1"
+              v-if="progressFor(content) === 1"
               icon="star"
               class="mastered-icon"
               :style="{ fill: $themeTokens.mastered }"
             />
-            <ProgressBar v-else :contentNode="withProgress(content)" class="bar" />
+            <ProgressBar v-else :contentNode="content" class="bar" />
           </div>
         </div>
 
@@ -173,11 +173,8 @@
     },
     methods: {
       genContentLink,
-      withProgress(node) {
-        const progress = {
-          progress: this.contentNodeProgressMap[node.content_id] || 0,
-        };
-        return { ...node, ...progress };
+      progressFor(node) {
+        return this.contentNodeProgressMap[node.content_id] || 0;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
@@ -56,11 +56,7 @@
     },
     computed: {
       progress() {
-        return (
-          this.contentNode.progress ||
-          this.contentNodeProgressMap[this.contentNode && this.contentNode.content_id] ||
-          0
-        );
+        return this.contentNodeProgressMap[this.contentNode && this.contentNode.content_id] || 0;
       },
       completed() {
         return this.progress >= 1;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

https://user-images.githubusercontent.com/6356129/141417838-65d424dd-5263-43b6-9848-07d0c8e73450.mp4

- Title can now be 2 lines @jtamiace 
- Less `position:absolute`, refactored layout a bit for simpler approach to accommodate the 2-line request
- CSS cleaned up quite a bit
- Use `useContentNodeProgress` various tools to build and use a shared store (:heart_eyes:) 
- General clean up, improved comments, etc

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

I don't see an issue to fix, but this is follow up on #8651 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The above is what I intended to do here. There was discussion around routing that should be handled in a separate follow-up PR. 

Copy-pasted from #8651 - all should still work:

It ended up being more complicated than I had anticipated but it should be good to go :)

Mainly be sure that you can get the

General

Progress indicator on content where there is progress. Just a star if completed
Scrollbar appears in largely populated folders and all items are visible when scrolled down
The content you're viewing doesn't get listed in the side bar
Content which has a duration will show the time under the title
A channel with lots of folders, if you view a content a level or two deep, then you should be guaranteed to see the link on the bottom of the sidebar linking to the folder.
Lesson context

The contents listed should be from within the same lesson, not from siblings of that content in it's other locations (in channels in the library).
Links should remain in Lesson context - so you should always see the "view lesson resources" icon as you click through side panel "next in lesson" resources
Mobile

The progress / completed icon appears underneath the title (and optionally the duration if present)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
