### PR TITLE
Adds guards against non-locally available content.

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -117,6 +117,13 @@ export default new Resource({
       return response.data;
     });
   },
+  fetchLessonResources(lesson) {
+    const url = urls['kolibri:core:usercontentnode_list']();
+    return this.client({ url, params: { lesson } }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+  },
   cache: {},
   fetchModel({ id, getParams: params }) {
     if (this.cache[id]) {

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -119,6 +119,7 @@ export function fetchNodeDataAndConvertExam(exam) {
   return ContentNodeResource.fetchCollection({
     getParams: {
       ids: uniq(exam.question_sources.map(item => item.exercise_id)),
+      no_available_filtering: true,
     },
   }).then(contentNodes => {
     return {
@@ -160,6 +161,7 @@ export function getExamReport(examId, tryIndex = 0, questionNumber = 0, interact
           contentPromise = ContentNodeResource.fetchCollection({
             getParams: {
               ids: uniq(questionSources.map(item => item.exercise_id)),
+              no_available_filtering: true,
             },
           });
         } else {

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1041,6 +1041,18 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
       "Could also be translated as \"View information about providing identifier\"\n\nAll 'AriaLabel' type of messages are providing additional context to the screen-reader users. \n\nIn this case the screen-reader will announce the message to the user indicating that they can access more information and examples about the 'Identifier' through the 'i' icon.",
   },
 
+  // Missing resource strings
+  someResourcesMissingOrNotSupported: {
+    message: 'Some resources are missing or not supported',
+    context:
+      'Floating notification message that appears over the alert icon and indicates that there are missing resources',
+  },
+  resourceNotFoundOnDevice: {
+    message: 'Resource not found on device',
+    context:
+      'Error message that displays if a learning resource cannot be found on the device being used currently.',
+  },
+
   // Content activity
   notStartedLabel: {
     message: 'Not started',

--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -56,6 +56,12 @@
       :value="attemptLog.num_coach_contents || 0"
       :isTopic="false"
     />
+    <KIcon
+      v-if="attemptLog.missing_resource"
+      class="coach-content-label"
+      icon="warning"
+      :color="$themePalette.orange.v_400"
+    />
   </span>
 
 </template>

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -553,6 +553,8 @@ class BaseContentNodeMixin(object):
     }
 
     def get_queryset(self):
+        if self.request.GET.get("no_available_filtering", False):
+            return models.ContentNode.objects.all()
         return models.ContentNode.objects.filter(available=True)
 
     def get_related_data_maps(self, items, queryset):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1319,7 +1319,10 @@ class UserContentNodeFilter(ContentNodeFilter):
 
     def filter_by_lesson(self, queryset, name, value):
         try:
-            lesson = Lesson.objects.get(pk=value)
+            lesson = Lesson.objects.filter(
+                lesson_assignments__collection__membership__user=self.request.user,
+                is_active=True,
+            ).get(pk=value)
             node_ids = list(map(lambda x: x["contentnode_id"], lesson.resources))
             return queryset.filter(pk__in=node_ids)
         except Lesson.DoesNotExist:

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -248,6 +248,15 @@ export function title() {
   ];
 }
 
+export function questionTitle() {
+  return [
+    {
+      name: coachStrings.$tr('titleLabel'),
+      key: 'title',
+    },
+  ];
+}
+
 export function quizQuestionsAnswered(quiz) {
   return [
     {

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -243,7 +243,10 @@ export function showLessonSelectionContentPreview(store, params, query = {}) {
 
 function _prepLessonContentPreview(store, classId, lessonId, contentId) {
   const cache = store.state.lessonSummary.resourceCache || {};
-  return ContentNodeResource.fetchModel({ id: contentId }).then(
+  return ContentNodeResource.fetchModel({
+    id: contentId,
+    getParams: { no_available_filtering: true },
+  }).then(
     contentNode => {
       const contentMetadata = assessmentMetaDataState(contentNode);
       store.commit('lessonSummary/SET_STATE', {

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -43,14 +43,16 @@ export function getResourceCache(store, resourceIds) {
     return ContentNodeResource.fetchCollection({
       getParams: {
         ids: nonCachedResourceIds,
+        no_available_filtering: true,
       },
     }).then(contentNodes => {
-      contentNodes.forEach(contentNode =>
+      contentNodes.forEach(contentNode => {
+        const channel = store.getters.getChannelForNode(contentNode);
         store.commit('ADD_TO_RESOURCE_CACHE', {
           node: contentNode,
-          channelTitle: store.getters.getChannelForNode(contentNode).title,
-        })
-      );
+          channelTitle: channel ? channel.title : '',
+        });
+      });
       return { ...resourceCache };
     });
   } else {

--- a/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionList/actions.js
@@ -27,6 +27,7 @@ export function setItemStats(store, { classId, exerciseId, quizId, lessonId, gro
     resource = practiceQuiz ? PracticeQuizDifficulties : ExerciseDifficulties;
     itemPromise = ContentNodeResource.fetchModel({
       id: store.rootState.classSummary.contentMap[pk].node_id,
+      getParams: { no_available_filtering: true },
     });
   }
 

--- a/kolibri/plugins/coach/assets/src/modules/resourceDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/resourceDetail/handlers.js
@@ -23,7 +23,10 @@ function showResourceView({ resourceId, exerciseId } = {}) {
   // Passed in exerciseId is the content_id of the contentNode
   // Map this to the id of the content node to do this fetch
   const nodeId = store.state.classSummary.contentMap[resourceId || exerciseId].node_id;
-  return ContentNodeResource.fetchModel({ id: nodeId }).then(
+  return ContentNodeResource.fetchModel({
+    id: nodeId,
+    getParams: { no_available_filtering: true },
+  }).then(
     resource => {
       store.commit('resourceDetail/SET_STATE', {
         resource,

--- a/kolibri/plugins/coach/assets/src/views/common.js
+++ b/kolibri/plugins/coach/assets/src/views/common.js
@@ -1,4 +1,5 @@
 import { mapState, mapGetters } from 'vuex';
+import coreStrings from 'kolibri.utils.coreStrings';
 import CoreTable from 'kolibri.coreVue.components.CoreTable';
 import { ContentNodeKinds, CollectionKinds } from 'kolibri.coreVue.vuex.constants';
 import router from 'kolibri.coreVue.router';
@@ -232,6 +233,14 @@ export default {
     maxLastActivity(statuses) {
       const max = this._.maxBy(statuses, 'last_activity');
       return max && max.last_activity ? max.last_activity : null;
+    },
+    missingResourceObj(dummyId) {
+      return {
+        node_id: dummyId,
+        kind: 'warning',
+        title: coreStrings.$tr('resourceNotFoundOnDevice'),
+        missing: true,
+      };
     },
   },
 };

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerExerciseReport.vue
@@ -1,6 +1,7 @@
 <template>
 
   <KPageContainer :topMargin="0">
+    <MissingResourceAlert v-if="!exercise.available" :multiple="false" />
     <ExamReport
       :contentId="exercise.content_id"
       :title="exercise.title"
@@ -24,6 +25,7 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import commonCoach from '../common';
@@ -31,6 +33,7 @@
   export default {
     name: 'LearnerExerciseReport',
     components: {
+      MissingResourceAlert,
       ExamReport,
     },
     mixins: [commonCoach, commonCoreStrings],

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
@@ -15,9 +15,6 @@
       :navigateTo="navigateTo"
       :questions="questions"
     />
-    <div v-else>
-      {{ getMissingContentString('someResourcesMissingOrNotSupported') }}
-    </div>
   </KPageContainer>
 
 </template>

--- a/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LearnerQuizReport.vue
@@ -2,7 +2,6 @@
 
   <KPageContainer :topMargin="0">
     <ExamReport
-      v-if="exerciseContentNodes && exerciseContentNodes.length"
       :contentId="exam.id"
       :title="exam.title"
       :userName="learner.name"

--- a/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizLessonDetailsHeader.vue
@@ -30,6 +30,7 @@
         </div>
       </template>
     </HeaderWithOptions>
+    <MissingResourceAlert v-if="resource.missing_resource" />
 
   </KPageContainer>
 
@@ -39,6 +40,7 @@
 <script>
 
   import { mapState } from 'vuex';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import HeaderWithOptions from './HeaderWithOptions';
   import StatusElapsedTime from './StatusElapsedTime';
   import BackLink from './BackLink';
@@ -47,6 +49,7 @@
     name: 'QuizLessonDetailsHeader',
     components: {
       HeaderWithOptions,
+      MissingResourceAlert,
       StatusElapsedTime,
       BackLink,
     },

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -531,32 +531,6 @@ const coachStrings = createTranslator('CommonCoachStrings', {
 
 // Strings for the Missing Content modals, tooltips, alerts, etc.
 const MissingContentStrings = createTranslator('MissingContentStrings', {
-  someResourcesMissingOrNotSupported: {
-    message: 'Some resources are missing or not supported',
-    context:
-      'Floating notification message that appears over the alert icon and indicates that there are missing resources',
-  },
-  resourceNotFoundOnDevice: {
-    message: 'Resource not found on device',
-    context:
-      'Error message that displays if a learning resource cannot be found on the device being used currently.',
-  },
-  resourcesUnavailableTitle: {
-    message: 'Resources unavailable',
-    context: 'Title of the modal window',
-  },
-  resourcesUnavailableP1: {
-    message:
-      'Some report data is missing, either because there are resources that were not found on the device, or because they are not compatible with your version of Kolibri.',
-
-    context: 'First paragraph of the "Resources Unavailable - Learn More" modal',
-  },
-  resourcesUnavailableP2: {
-    message:
-      'Consult your administrator for guidance, or use an account with device permissions to manage channels and resources.',
-
-    context: 'Second paragraph of the "Resources Unavailable - Learn More" modal.',
-  },
   upgradeKolibriTitle: {
     message: 'Upgrade Kolibri to view resources',
     context: 'Title of the modal window',

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -15,10 +15,25 @@
       <KFixedGridItem :span="showTime ? 3 : 4">
         <div class="icon-spacer">
           <ContentIcon
+            v-if="contentIcon"
             class="content-icon"
             :kind="contentIcon"
             :showTooltip="false"
           />
+          <template v-else>
+            <KIcon
+              ref="warning"
+              icon="warning"
+              :color="$themePalette.orange.v_400"
+            />
+            <KTooltip
+              reference="warning"
+              placement="bottom"
+              :refs="$refs"
+            >
+              {{ getMissingContentString('resourceNotFoundOnDevice') }}
+            </KTooltip>
+          </template>
           <KRouterLink
             v-if="route"
             :text="linkText"
@@ -44,6 +59,7 @@
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
   import CoachStatusIcon from '../status/CoachStatusIcon';
+  import { coachStringsMixin } from '../commonCoachStrings';
   import {
     NotificationEvents,
     NotificationObjects,
@@ -65,6 +81,7 @@
       CoachStatusIcon,
       ElapsedTime,
     },
+    mixins: [coachStringsMixin],
     props: {
       notification: {
         type: Object,
@@ -94,9 +111,10 @@
           return 'exam';
         } else if (this.notification.object === NotificationObjects.LESSON) {
           return 'lesson';
-        } else {
+        } else if (this.notification.resource.type.length) {
           return this.notification.resource.type;
         }
+        return null;
       },
       context() {
         const contentContext = this.notification.assignment.name;
@@ -119,7 +137,7 @@
         return new Date(this.notification.timestamp);
       },
       linkText() {
-        return cardTextForNotification(this.notification);
+        return cardTextForNotification(this.notification, !this.notification.resource.type.length);
       },
       route() {
         const targetPage = notificationLink(this.notification);

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/NotificationCard.vue
@@ -31,7 +31,7 @@
               placement="bottom"
               :refs="$refs"
             >
-              {{ getMissingContentString('resourceNotFoundOnDevice') }}
+              {{ coreString('resourceNotFoundOnDevice') }}
             </KTooltip>
           </template>
           <KRouterLink
@@ -58,8 +58,8 @@
 
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoachStatusIcon from '../status/CoachStatusIcon';
-  import { coachStringsMixin } from '../commonCoachStrings';
   import {
     NotificationEvents,
     NotificationObjects,
@@ -81,7 +81,7 @@
       CoachStatusIcon,
       ElapsedTime,
     },
-    mixins: [coachStringsMixin],
+    mixins: [commonCoreStrings],
     props: {
       notification: {
         type: Object,
@@ -137,7 +137,7 @@
         return new Date(this.notification.timestamp);
       },
       linkText() {
-        return cardTextForNotification(this.notification, !this.notification.resource.type.length);
+        return cardTextForNotification(this.notification);
       },
       route() {
         const targetPage = notificationLink(this.notification);

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
@@ -19,53 +19,114 @@ const nStrings = createTranslator('NotificationStrings', {
   // started
   individualStarted: {
     message: `{learnerName} started '{itemName}'`,
-    context: 'Indicates that a learner has started a lesson.',
+    context: 'Indicates that a learner has started a lesson or resource.',
+  },
+  individualStartedMissing: {
+    message: `{learnerName} started a resource in this lesson`,
+    context: 'Indicates that a learner has started a resource but the title cannot be displayed.',
   },
   multipleStarted: {
     message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} started '{itemName}'`,
-    context: 'Indicates the learner name and how many other learners started a specific exercise.',
+    context:
+      'Indicates the learner name and how many other learners started a specific lesson or resource.',
+  },
+  multipleStartedMissing: {
+    message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} started a resource in this lesson`,
+    context:
+      'Indicates the learner name and how many other learners started a resource but the title cannot be displayed.',
   },
   wholeClassStarted: {
     message: `Everyone started '{itemName}'`,
-    context: 'Indicates that every learner in the class started an activity.',
+    context: 'Indicates that every learner in the class started a lesson or resource.',
+  },
+  wholeClassStartedMissing: {
+    message: `Everyone started a resource in this lesson`,
+    context:
+      'Indicates that every learner in the class started a resource but the title cannot be displayed.',
   },
   wholeGroupStarted: {
     message: `Everyone in '{groupName}' started '{itemName}'`,
-    context: 'Indicates that all the learners in a specific group started a lesson.',
+    context: 'Indicates that all the learners in a specific group started a lesson or resource.',
+  },
+  wholeGroupStartedMissing: {
+    message: `Everyone in '{groupName}' started a resource in this lesson`,
+    context:
+      'Indicates that all the learners in a specific group started a resource but the title cannot be displayed.',
   },
   everyoneStarted: {
     message: `Everyone started '{itemName}'`,
-    context: 'Indicates that every learner in the group or class started an activity.',
+    context: 'Indicates that every learner in the group or class started a lesson or resource.',
+  },
+  everyoneStartedMissing: {
+    message: `Everyone started a resource in this lesson`,
+    context:
+      'Indicates that every learner in the group or class started a resource but the title cannot be displayed.',
   },
 
   // completed
   individualCompleted: {
     message: `{learnerName} completed '{itemName}'`,
-    context: 'Indicates that a learner has completed an exercise.',
+    context: 'Indicates that a learner has completed a lesson or resource.',
+  },
+  individualCompletedMissing: {
+    message: `{learnerName} completed a resource in this lesson`,
+    context: 'Indicates that a learner has completed a resource but the title cannot be displayed.',
   },
   multipleCompleted: {
     message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} completed '{itemName}'`,
-    context: 'Indicates a learner and one other or others have completed an exercise.',
+    context: 'Indicates a learner and one other or others have completed a lesson or resource.',
+  },
+  multipleCompletedMissing: {
+    message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} completed a resource in this lesson`,
+    context:
+      'Indicates a learner and one other or others have completed a resource but the title cannot be displayed.',
   },
   wholeClassCompleted: {
     message: `Everyone completed '{itemName}'`,
-    context: 'Indicates that every learner in the class completed an activity.',
+    context: 'Indicates that every learner in the class completed a lesson or resource.',
+  },
+  wholeClassCompletedMissing: {
+    message: `Everyone completed a resource in this lesson`,
+    context:
+      'Indicates that every learner in the class completed a resource but the title cannot be displayed.',
   },
   wholeGroupCompleted: {
     message: `Everyone in '{groupName}' completed '{itemName}'`,
-    context: 'Indicates that all the learners in a specific group completed a lesson.',
+    context: 'Indicates that all the learners in a specific group completed a lesson or resource.',
+  },
+  wholeGroupCompletedMissing: {
+    message: `Everyone in '{groupName}' completed a resource in this lesson`,
+    context:
+      'Indicates that all the learners in a specific group completed a resource but the title cannot be displayed.',
   },
   everyoneCompleted: {
     message: `Everyone completed '{itemName}'`,
-    context: 'Indicates that every learner in the group or class completed an activity.',
+    context: 'Indicates that every learner in the group or class completed a lesson or resource.',
+  },
+  everyoneCompletedMissing: {
+    message: `Everyone completed a resource in this lesson`,
+    context:
+      'Indicates that every learner in the group or class completed a resource but the title cannot be displayed.',
   },
 
   // needs help
   individualNeedsHelp: {
     message: `{learnerName} needs help with '{itemName}'`,
-    context: 'Indicates that a learner needs help with a specific lesson.',
+    context: 'Indicates that a learner needs help with a specific exercise.',
   },
-  multipleNeedHelp: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} need help with '{itemName}'`,
+  individualNeedsHelpMissing: {
+    message: `{learnerName} needs help with a resource in this lesson`,
+    context: 'Indicates that a learner needs help a resource but the title cannot be displayed.',
+  },
+  multipleNeedHelp: {
+    message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} need help with '{itemName}'`,
+    context: 'Indicates a learner and one other or others need help with a specific exercise.',
+  },
+  multipleNeedHelpMissing: {
+    message: `{learnerName} and {numOthers, number} {numOthers, plural, one {other} other {others}} need help with a resource in this lesson`,
+    context:
+      'Indicates a learner and one other or others need help a resource but the title cannot be displayed.',
+  },
 });
 
 const nStringsMixin = {
@@ -79,7 +140,7 @@ const nStringsMixin = {
   },
 };
 
-function cardTextForNotification(notification) {
+function cardTextForNotification(notification, missing = false) {
   const { collection, resource, learnerSummary, object, event } = notification;
   let stringType;
   let stringDetails = {
@@ -125,6 +186,10 @@ function cardTextForNotification(notification) {
       stringType = 'multipleNeedHelp';
       stringDetails.numOthers = learnerSummary.total - 1;
     }
+  }
+
+  if (missing) {
+    stringType += 'Missing';
   }
 
   return nStrings.$tr(stringType, stringDetails);

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
@@ -140,7 +140,7 @@ const nStringsMixin = {
   },
 };
 
-function cardTextForNotification(notification, missing = false) {
+function cardTextForNotification(notification) {
   const { collection, resource, learnerSummary, object, event } = notification;
   let stringType;
   let stringDetails = {
@@ -188,7 +188,7 @@ function cardTextForNotification(notification, missing = false) {
     }
   }
 
-  if (missing) {
+  if (object === RESOURCE && !resource.type.length) {
     stringType += 'Missing';
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/AssessmentQuestionListItem.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/AssessmentQuestionListItem.vue
@@ -29,15 +29,6 @@
         :isTopic="false"
       />
     </a>
-    <KTooltip
-      v-if="!available"
-      reference="missing"
-      placement="bottom"
-      style="position: relative;"
-      :refs="$refs"
-    >
-      {{ getMissingContentString('someResourcesMissingOrNotSupported') }}
-    </KTooltip>
     <div v-if="draggable" class="handle">
       <DragSortWidget
         :isFirst="isFirst"
@@ -57,6 +48,7 @@
 
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import DragSortWidget from 'kolibri.coreVue.components.DragSortWidget';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { coachStringsMixin } from '../../common/commonCoachStrings';
 
   export default {
@@ -65,7 +57,7 @@
       CoachContentLabel,
       DragSortWidget,
     },
-    mixins: [coachStringsMixin],
+    mixins: [coachStringsMixin, commonCoreStrings],
     props: {
       draggable: {
         type: Boolean,
@@ -81,7 +73,7 @@
       },
       exerciseName: {
         type: String,
-        required: true,
+        default: null,
       },
       isCoachContent: {
         type: Boolean,
@@ -102,6 +94,9 @@
     },
     computed: {
       text() {
+        if (!this.exerciseName) {
+          return this.coreString('resourceNotFoundOnDevice');
+        }
         if (this.questionNumberOfExercise === undefined || this.questionNumberOfExercise === null) {
           return this.exerciseName;
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
@@ -67,11 +67,11 @@
       :layout8="{ span: 4 }"
       :layout12="{ span: 7 }"
     >
-      <h3 class="question-title">
+      <h3 v-if="content && content.available" class="question-title">
         {{ currentQuestion.title }}
       </h3>
       <KContentRenderer
-        v-if="content && questionId"
+        v-if="content && content.available && questionId"
         ref="contentRenderer"
         :kind="content.kind"
         :files="content.files"
@@ -152,6 +152,8 @@
           if (totals[question.exercise_id] > 1) {
             question.counterInExercise = counts[this.listKey(question)];
           }
+          const node = this.selectedExercises[question.exercise_id];
+          question.missing_resource = !node || !node.available;
           return question;
         });
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
@@ -98,7 +98,7 @@
   import DragContainer from 'kolibri.coreVue.components.DragContainer';
   import Draggable from 'kolibri.coreVue.components.Draggable';
   import DragHandle from 'kolibri.coreVue.components.DragHandle';
-  import { coachStringsMixin } from '../../common/commonCoachStrings';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AssessmentQuestionListItem from './AssessmentQuestionListItem';
 
   export default {
@@ -109,7 +109,7 @@
       DragContainer,
       DragHandle,
     },
-    mixins: [coachStringsMixin],
+    mixins: [commonCoreStrings],
     props: {
       // If set to true, question buttons will be draggable
       fixedOrder: {
@@ -165,7 +165,7 @@
         return this.currentQuestion.question_id;
       },
       resourceMissingText() {
-        return this.getMissingContentString('resourceNotFoundOnDevice');
+        return this.coreString('resourceNotFoundOnDevice');
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -5,6 +5,7 @@
       {{ header }}
     </h2>
     <KContentRenderer
+      v-if="content.available"
       :class="{ hof: isExercise }"
       :showCorrectAnswer="true"
       :itemId="selectedQuestion"
@@ -15,6 +16,7 @@
       :extraFields="content.extra_fields"
       :interactive="false"
     />
+    <MissingResourceAlert v-else :multiple="false" />
   </section>
 
 </template>
@@ -22,8 +24,13 @@
 
 <script>
 
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
+
   export default {
     name: 'ContentArea',
+    components: {
+      MissingResourceAlert,
+    },
     props: {
       content: {
         type: Object,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -217,7 +217,7 @@
         return '';
       },
       description() {
-        if (this.content) {
+        if (this.content && this.content.description) {
           const md = new markdownIt('zero', { breaks: true });
           return md.render(this.content.description);
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -89,7 +89,6 @@
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
-  import { coachStringsMixin } from '../../common/commonCoachStrings';
 
   // This is a simplified version of ResourceListTable that is supposed to work
   // outside of the LessonSummaryPage workflow.
@@ -103,7 +102,7 @@
       ContentIcon,
       CoachContentLabel,
     },
-    mixins: [coachStringsMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
     props: {
       // Array<{ contentnode_id, content_id, channel_id }>
       resources: {
@@ -155,7 +154,7 @@
         });
       },
       resourceMissingText() {
-        return this.getMissingContentString('resourceNotFoundOnDevice');
+        return this.coreString('resourceNotFoundOnDevice');
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/EditDetailsResourceListTable.vue
@@ -146,11 +146,10 @@
               num_coach_contents: match.num_coach_contents,
               channelTitle: this.resourceChannelTitle(contentnode_id),
             };
-          } else {
-            // Need to filter out objects not in the contentNodeMap.
-            // Hopefully the contentNodeMap is always updated.
-            return resource;
           }
+          // Need to filter out objects not in the contentNodeMap.
+          // Hopefully the contentNodeMap is always updated.
+          return resource;
         });
       },
       resourceMissingText() {
@@ -163,7 +162,11 @@
         this.$emit('update:resources', resources);
       },
       resourceChannelTitle(id) {
-        const match = this.$store.getters['getChannelObject'](this.contentNodeMap[id].channel_id);
+        const contentNode = this.contentNodeMap[id];
+        if (!contentNode) {
+          return '';
+        }
+        const match = this.$store.getters['getChannelObject'](contentNode.channel_id);
         return match ? match.title : '';
       },
       removeResource(resource) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -13,7 +13,7 @@
           <KFixedGrid
             class="row"
             :style="{ backgroundColor: $themeTokens.surface }"
-            numCols="8"
+            numCols="9"
           >
             <KFixedGridItem span="1" class="relative">
               <div class="move-handle">
@@ -27,8 +27,8 @@
                 />
               </div>
             </KFixedGridItem>
-            <KFixedGridItem span="4">
-              <template v-if="getCachedResource(resource.contentnode_id)">
+            <KFixedGridItem class="parent" span="4">
+              <div v-if="getCachedResource(resource.contentnode_id)" class="child">
                 <div class="resource-title">
                   <div class="content-icon">
                     <ContentIcon :kind="resourceKind(resource.contentnode_id)" />
@@ -41,7 +41,12 @@
                       )"
                     />
                   </div>
-                  <p dir="auto" class="channel-title" :style="{ color: $themeTokens.annotation }">
+                  <p
+                    v-if="resourceChannelTitle(resource.contentnode_id).length"
+                    dir="auto"
+                    class="channel-title"
+                    :style="{ color: $themeTokens.annotation }"
+                  >
                     <dfn class="visuallyhidden"> {{ $tr('parentChannelLabel') }} </dfn>
                     {{ resourceChannelTitle(resource.contentnode_id) }}
                   </p>
@@ -51,13 +56,18 @@
                   :value="getCachedResource(resource.contentnode_id).num_coach_contents"
                   :isTopic="false"
                 />
-              </template>
-              <template v-else>
-                <p>
-                  <KIcon icon="warning" :style=" { fill: $themePalette.orange.v_400 }" />
-                  {{ resourceMissingText }}
-                </p>
-              </template>
+              </div>
+              <div v-else class="child">
+                {{ resourceMissingText }}
+              </div>
+            </KFixedGridItem>
+            <KFixedGridItem span="1" :style="{ 'padding-top': '16px' }" alignment="right">
+              <KIcon
+                v-if="!getCachedResource(resource.contentnode_id) ||
+                  !getCachedResource(resource.contentnode_id).available"
+                icon="warning"
+                :style=" { fill: $themePalette.orange.v_400 }"
+              />
             </KFixedGridItem>
             <KFixedGridItem :style="{ 'padding-top': '16px' }" span="3" alignment="right">
               <KButton
@@ -311,6 +321,16 @@
   .content-link {
     display: inline-block;
     width: calc(100% - 16px);
+  }
+
+  .parent {
+    position: relative;
+  }
+
+  .child {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ResourceListTable.vue
@@ -85,7 +85,6 @@
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { coachStringsMixin } from '../../common/commonCoachStrings';
 
   const removalSnackbarTime = 5000;
 
@@ -99,7 +98,7 @@
       CoachContentLabel,
       ContentIcon,
     },
-    mixins: [commonCoreStrings, coachStringsMixin],
+    mixins: [commonCoreStrings],
     data() {
       return {
         workingResourcesBackup: [...this.$store.state.lessonSummary.workingResources],
@@ -121,7 +120,7 @@
         return this.workingResourcesBackup.length - this.workingResources.length;
       },
       resourceMissingText() {
-        return this.getMissingContentString('resourceNotFoundOnDevice');
+        return this.coreString('resourceNotFoundOnDevice');
       },
     },
     methods: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ExerciseQuestionListPageBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ExerciseQuestionListPageBase.vue
@@ -1,0 +1,158 @@
+<template>
+
+  <CoachAppBarPage
+    :authorized="userIsAuthorized"
+    authorizedRole="adminOrCoach"
+    :showSubNav="true"
+  >
+
+    <KPageContainer>
+
+      <ReportsResourceHeader
+        :resource="exercise"
+        @previewClick="onPreviewClick"
+      />
+
+      <ReportsControls @export="exportCSV" />
+
+      <CoreTable :emptyMessage="coachString('questionListEmptyState')">
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group
+            tag="tbody"
+            name="list"
+          >
+            <tr
+              v-for="tableRow in table"
+              :key="tableRow.question_id"
+            >
+              <td>
+                <KRouterLink
+                  v-if="exercise.available"
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.question_id)"
+                  icon="question"
+                />
+                <span v-else>
+                  <KIcon icon="question" />{{ tableRow.title }}
+                </span>
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
+                />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
+      </CoreTable>
+    </KPageContainer>
+  </CoachAppBarPage>
+
+</template>
+
+
+<script>
+
+  import { mapGetters, mapState } from 'vuex';
+  import commonCoach from '../common';
+  import CoachAppBarPage from '../CoachAppBarPage';
+  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
+  import CSVExporter from '../../csv/exporter';
+  import * as csvFields from '../../csv/fields';
+  import ReportsResourceHeader from './ReportsResourceHeader';
+  import ReportsControls from './ReportsControls';
+  import { PageNames } from './../../constants';
+
+  export default {
+    name: 'ExerciseQuestionListPageBase',
+    components: {
+      CoachAppBarPage,
+      ReportsResourceHeader,
+      ReportsControls,
+      LearnerProgressRatio,
+    },
+    mixins: [commonCoach],
+    computed: {
+      ...mapState('questionList', ['exercise']),
+      ...mapGetters('questionList', ['difficultQuestions']),
+      lesson() {
+        return this.lessonMap[this.$route.params.lessonId];
+      },
+      resource() {
+        return this.contentMap[this.$route.params.exerciseId];
+      },
+      group() {
+        return this.$route.params.groupId && this.groupMap[this.$route.params.groupId];
+      },
+      table() {
+        return this.difficultQuestions.map(question => {
+          const tableRow = {};
+          Object.assign(tableRow, question);
+          return tableRow;
+        });
+      },
+    },
+    methods: {
+      questionLink(questionId) {
+        return this.classRoute(
+          this.group
+            ? PageNames.REPORTS_GROUP_REPORT_LESSON_EXERCISE_QUESTION_PAGE_ROOT
+            : PageNames.REPORTS_LESSON_EXERCISE_QUESTION_PAGE_ROOT,
+          {
+            questionId,
+            exerciseId: this.$route.params.exerciseId,
+          }
+        );
+      },
+      exportCSV() {
+        const columns = [...csvFields.questionTitle(), ...csvFields.helpNeeded()];
+
+        const exporter = new CSVExporter(columns, this.className);
+        const names = {
+          lesson: this.lesson.title,
+          resource: this.resource.title,
+          difficultQuestions: this.coachString('difficultQuestionsLabel'),
+        };
+
+        if (this.group) {
+          names.group = this.group.name;
+        }
+
+        exporter.addNames(names);
+
+        exporter.export(this.table);
+      },
+      onPreviewClick() {
+        this.$router.push(
+          this.$router.getRoute(
+            'RESOURCE_CONTENT_PREVIEW',
+            {
+              contentId: this.exercise.id,
+            },
+            this.defaultBackLinkQuery
+          )
+        );
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '../common/print-table';
+
+  .stats {
+    margin-right: 16px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/QuizQuestionListPageBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/QuizQuestionListPageBase.vue
@@ -1,0 +1,119 @@
+<template>
+
+  <ReportsQuizBaseListPage @export="exportCSV">
+    <div>
+      <CoreTable :emptyMessage="coachString('questionListEmptyState')">
+        <template #headers>
+          <th>{{ coachString('questionLabel') }}</th>
+          <th>{{ coachString('helpNeededLabel') }}</th>
+        </template>
+        <template #tbody>
+          <transition-group tag="tbody" name="list">
+            <tr v-for="(tableRow, index) in table" :key="tableRow.item + index">
+              <td>
+                <span v-if="$isPrint">{{ tableRow.title }}</span>
+                <KRouterLink
+                  v-if="!exam.missing_resource"
+                  :text="tableRow.title"
+                  :to="questionLink(tableRow.item)"
+                  icon="question"
+                />
+                <span v-else>
+                  <KIcon icon="question" />{{ tableRow.title }}
+                </span>
+              </td>
+              <td>
+                <LearnerProgressRatio
+                  :verb="VERBS.needHelp"
+                  :icon="ICONS.help"
+                  :total="tableRow.total"
+                  :count="tableRow.total - tableRow.correct"
+                  :verbosity="1"
+                />
+              </td>
+            </tr>
+          </transition-group>
+        </template>
+      </CoreTable>
+    </div>
+  </ReportsQuizBaseListPage>
+
+</template>
+
+
+<script>
+
+  import { mapGetters } from 'vuex';
+  import commonCoach from '../common';
+  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
+  import CSVExporter from '../../csv/exporter';
+  import * as csvFields from '../../csv/fields';
+  import ReportsQuizBaseListPage from './ReportsQuizBaseListPage';
+  import { PageNames } from './../../constants';
+
+  export default {
+    name: 'QuizQuestionListPageBase',
+    components: {
+      LearnerProgressRatio,
+      ReportsQuizBaseListPage,
+    },
+    mixins: [commonCoach],
+    computed: {
+      ...mapGetters('questionList', ['difficultQuestions']),
+      exam() {
+        return this.examMap[this.$route.params.quizId];
+      },
+      group() {
+        return this.$route.params.groupId && this.groupMap[this.$route.params.groupId];
+      },
+      table() {
+        return this.difficultQuestions.map(question => {
+          const tableRow = {};
+          Object.assign(tableRow, question);
+          return tableRow;
+        });
+      },
+    },
+    methods: {
+      questionLink(questionId) {
+        return this.classRoute(
+          this.group
+            ? PageNames.REPORTS_GROUP_REPORT_QUIZ_QUESTION_PAGE_ROOT
+            : PageNames.REPORTS_QUIZ_QUESTION_PAGE_ROOT,
+          {
+            questionId,
+            quizId: this.$route.params.quizId,
+          }
+        );
+      },
+      exportCSV() {
+        const columns = [...csvFields.questionTitle(), ...csvFields.helpNeeded()];
+
+        const exporter = new CSVExporter(columns, this.className);
+        const names = {
+          resource: this.exam.title,
+          difficultQuestions: this.coachString('difficultQuestionsLabel'),
+        };
+
+        if (this.group) {
+          names.group = this.group.name;
+        }
+        exporter.addNames(names);
+
+        exporter.export(this.table);
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '../common/print-table';
+
+  .stats {
+    margin-right: 16px;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseQuestionListPage.vue
@@ -1,150 +1,19 @@
 <template>
 
-  <CoachAppBarPage
-    :authorized="userIsAuthorized"
-    authorizedRole="adminOrCoach"
-    :showSubNav="true"
-  >
-
-    <KPageContainer>
-
-      <ReportsResourceHeader
-        :resource="exercise"
-        @previewClick="onPreviewClick"
-      />
-
-      <ReportsControls @export="exportCSV" />
-
-      <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <template #headers>
-          <th>{{ coachString('questionLabel') }}</th>
-          <th>{{ coachString('helpNeededLabel') }}</th>
-        </template>
-        <template #tbody>
-          <transition-group
-            tag="tbody"
-            name="list"
-          >
-            <tr
-              v-for="tableRow in table"
-              :key="tableRow.question_id"
-            >
-              <td>
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.question_id)"
-                  icon="person"
-                />
-              </td>
-              <td>
-                <LearnerProgressRatio
-                  :verb="VERBS.needHelp"
-                  :icon="ICONS.help"
-                  :total="tableRow.total"
-                  :count="tableRow.total - tableRow.correct"
-                  :verbosity="1"
-                />
-              </td>
-            </tr>
-          </transition-group>
-        </template>
-      </CoreTable>
-    </KPageContainer>
-  </CoachAppBarPage>
+  <ExerciseQuestionListPageBase />
 
 </template>
 
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
-  import commonCoach from '../common';
-  import CoachAppBarPage from '../CoachAppBarPage';
-  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
-  import CSVExporter from '../../csv/exporter';
-  import * as csvFields from '../../csv/fields';
-  import ReportsResourceHeader from './ReportsResourceHeader';
-  import ReportsControls from './ReportsControls';
-  import { PageNames } from './../../constants';
+  import ExerciseQuestionListPageBase from './ExerciseQuestionListPageBase';
 
   export default {
     name: 'ReportsGroupReportLessonExerciseQuestionListPage',
     components: {
-      CoachAppBarPage,
-      ReportsResourceHeader,
-      ReportsControls,
-      LearnerProgressRatio,
-    },
-    mixins: [commonCoach],
-    computed: {
-      ...mapState('questionList', ['exercise']),
-      ...mapGetters('questionList', ['difficultQuestions']),
-      lesson() {
-        return this.lessonMap[this.$route.params.lessonId];
-      },
-      resource() {
-        return this.contentMap[this.$route.params.exerciseId];
-      },
-      group() {
-        return this.groupMap[this.$route.params.groupId];
-      },
-      table() {
-        return this.difficultQuestions.map(question => {
-          const tableRow = {};
-          Object.assign(tableRow, question);
-          return tableRow;
-        });
-      },
-    },
-    methods: {
-      questionLink(questionId) {
-        return this.classRoute(PageNames.REPORTS_GROUP_REPORT_LESSON_EXERCISE_QUESTION_PAGE_ROOT, {
-          questionId,
-          exerciseId: this.$route.params.exerciseId,
-        });
-      },
-      exportCSV() {
-        const columns = [
-          {
-            name: this.coachString('questionLabel'),
-            key: 'title',
-          },
-          ...csvFields.helpNeeded(),
-        ];
-
-        const exporter = new CSVExporter(columns, this.className);
-        exporter.addNames({
-          group: this.group.name,
-          lesson: this.lesson.title,
-          resource: this.resource.title,
-          difficultQuestions: this.coachString('difficultQuestionsLabel'),
-        });
-
-        exporter.export(this.table);
-      },
-      onPreviewClick() {
-        this.$router.push(
-          this.$router.getRoute(
-            'RESOURCE_CONTENT_PREVIEW',
-            {
-              contentId: this.exercise.id,
-            },
-            this.defaultBackLinkQuery
-          )
-        );
-      },
+      ExerciseQuestionListPageBase,
     },
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '../common/print-table';
-
-  .stats {
-    margin-right: 16px;
-  }
-
-</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizQuestionListPage.vue
@@ -1,109 +1,19 @@
 <template>
 
-  <ReportsQuizBaseListPage @export="exportCSV">
-    <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-      <template #headers>
-        <th>{{ coachString('questionLabel') }}</th>
-        <th>{{ coachString('helpNeededLabel') }}</th>
-      </template>
-      <template #tbody>
-        <transition-group tag="tbody" name="list">
-          <tr v-for="tableRow in table" :key="tableRow.question_id">
-            <td>
-              <KRouterLink
-                :text="tableRow.title"
-                :to="questionLink(tableRow.question_id)"
-                icon="question"
-              />
-            </td>
-            <td>
-              <LearnerProgressRatio
-                :verb="VERBS.needHelp"
-                :icon="ICONS.help"
-                :total="tableRow.total"
-                :count="tableRow.total - tableRow.correct"
-                :verbosity="1"
-              />
-            </td>
-          </tr>
-        </transition-group>
-      </template>
-    </CoreTable>
-  </ReportsQuizBaseListPage>
+  <QuizQuestionListPageBase />
 
 </template>
 
 
 <script>
 
-  import { mapGetters } from 'vuex';
-  import commonCoach from '../common';
-  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
-  import CSVExporter from '../../csv/exporter';
-  import * as csvFields from '../../csv/fields';
-  import ReportsQuizBaseListPage from './ReportsQuizBaseListPage';
-  import { PageNames } from './../../constants';
+  import QuizQuestionListPageBase from './QuizQuestionListPageBase';
 
   export default {
     name: 'ReportsGroupReportQuizQuestionListPage',
     components: {
-      ReportsQuizBaseListPage,
-      LearnerProgressRatio,
-    },
-    mixins: [commonCoach],
-    computed: {
-      ...mapGetters('questionList', ['difficultQuestions']),
-      exam() {
-        return this.examMap[this.$route.params.quizId];
-      },
-      group() {
-        return this.groupMap[this.$route.params.groupId];
-      },
-      table() {
-        return this.difficultQuestions.map(question => {
-          const tableRow = {};
-          Object.assign(tableRow, question);
-          return tableRow;
-        });
-      },
-    },
-    methods: {
-      questionLink(questionId) {
-        return this.classRoute(PageNames.REPORTS_GROUP_REPORT_QUIZ_QUESTION_PAGE_ROOT, {
-          questionId,
-          quizId: this.$route.params.quizId,
-        });
-      },
-      exportCSV() {
-        const columns = [
-          {
-            name: this.coachString('questionLabel'),
-            key: 'title',
-          },
-          ...csvFields.helpNeeded(),
-        ];
-
-        const exporter = new CSVExporter(columns, this.className);
-        exporter.addNames({
-          group: this.group.name,
-          resource: this.exam.title,
-          difficultQuestions: this.coachString('difficultQuestionsLabel'),
-        });
-
-        exporter.export(this.table);
-      },
+      QuizQuestionListPageBase,
     },
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '../common/print-table';
-
-  .stats {
-    margin-right: 16px;
-  }
-
-</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -77,10 +77,12 @@
                 </KLabeledIcon>
               </td>
               <td>
-                <StatusSimple :status="tableRow.statusObj.status" />
+                <StatusSimple v-if="tableRow.statusObj" :status="tableRow.statusObj.status" />
+                <KEmptyPlaceholder v-else />
               </td>
               <td>
-                <TimeDuration :seconds="showTime(tableRow)" />
+                <TimeDuration v-if="tableRow.statusObj" :seconds="showTime(tableRow)" />
+                <KEmptyPlaceholder v-else />
               </td>
             </tr>
           </transition-group>
@@ -121,7 +123,10 @@
       },
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
-        return contentArray.map(content => {
+        return contentArray.map((content, index) => {
+          if (!content) {
+            return this.missingResourceObj(index);
+          }
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
             link: this.classRoute(PageNames.REPORTS_LEARNER_REPORT_LESSON_EXERCISE_PAGE_ROOT, {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -112,7 +112,10 @@
       },
       contentTable() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
-        return contentArray.map(content => {
+        return contentArray.map((content, index) => {
+          if (!content) {
+            return this.missingResourceObj(index);
+          }
           const tally = this.getContentStatusTally(content.content_id, this.recipients);
           const tableRow = {
             avgTimeSpent: this.getContentAvgTimeSpent(content.content_id, this.recipients),

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseQuestionListPage.vue
@@ -1,140 +1,19 @@
 <template>
 
-  <CoachAppBarPage
-    :authorized="userIsAuthorized"
-    authorizedRole="adminOrCoach"
-    :showSubNav="true"
-  >
-
-    <KPageContainer>
-
-      <ReportsResourceHeader
-        :resource="exercise"
-        @previewClick="onPreviewClick"
-      />
-
-      <ReportsControls @export="exportCSV" />
-
-      <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <template #headers>
-          <th>{{ coachString('questionLabel') }}</th>
-          <th>{{ coachString('helpNeededLabel') }}</th>
-        </template>
-        <template #tbody>
-          <transition-group
-            tag="tbody"
-            name="list"
-          >
-            <tr
-              v-for="tableRow in table"
-              :key="tableRow.question_id"
-            >
-              <td>
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.question_id)"
-                />
-              </td>
-              <td>
-                <LearnerProgressRatio
-                  :verb="VERBS.needHelp"
-                  :icon="ICONS.help"
-                  :total="tableRow.total"
-                  :count="tableRow.total - tableRow.correct"
-                  :verbosity="1"
-                />
-              </td>
-            </tr>
-          </transition-group>
-        </template>
-      </CoreTable>
-    </KPageContainer>
-  </CoachAppBarPage>
+  <ExerciseQuestionListPageBase />
 
 </template>
 
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
-  import commonCoach from '../common';
-  import CoachAppBarPage from '../CoachAppBarPage';
-  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
-  import { LastPages } from '../../constants/lastPagesConstants';
-  import CSVExporter from '../../csv/exporter';
-  import * as csvFields from '../../csv/fields';
-  import ReportsResourceHeader from './ReportsResourceHeader';
-  import ReportsControls from './ReportsControls';
-  import { PageNames } from './../../constants';
+  import ExerciseQuestionListPageBase from './ExerciseQuestionListPageBase';
 
   export default {
     name: 'ReportsLessonExerciseQuestionListPage',
     components: {
-      CoachAppBarPage,
-      ReportsResourceHeader,
-      ReportsControls,
-      LearnerProgressRatio,
-    },
-    mixins: [commonCoach],
-    computed: {
-      ...mapGetters('questionList', ['difficultQuestions']),
-      ...mapState('questionList', ['exercise']),
-      lesson() {
-        return this.lessonMap[this.$route.params.lessonId];
-      },
-      table() {
-        return this.difficultQuestions.map(question => {
-          const tableRow = {};
-          Object.assign(tableRow, question);
-          return tableRow;
-        });
-      },
-    },
-    methods: {
-      questionLink(questionId) {
-        return this.classRoute(PageNames.REPORTS_LESSON_EXERCISE_QUESTION_PAGE_ROOT, {
-          questionId,
-          exerciseId: this.$route.params.exerciseId,
-        });
-      },
-      onPreviewClick() {
-        this.$router.push(
-          this.$router.getRoute(
-            'RESOURCE_CONTENT_PREVIEW',
-            {
-              contentId: this.exercise.id,
-            },
-            {
-              last: LastPages.EXERCISE_QUESTION_LIST,
-              exerciseId: this.exercise.content_id,
-            }
-          )
-        );
-      },
-      exportCSV() {
-        const columns = [...csvFields.title(), ...csvFields.helpNeeded()];
-
-        const exporter = new CSVExporter(columns, this.className);
-        exporter.addNames({
-          lesson: this.lesson.title,
-          resource: this.exercise.title,
-          difficultQuestions: this.coachString('difficultQuestionsLabel'),
-        });
-
-        exporter.export(this.table);
-      },
+      ExerciseQuestionListPageBase,
     },
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '../common/print-table';
-
-  .stats {
-    margin-right: 16px;
-  }
-
-</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerBase.vue
@@ -28,6 +28,8 @@
 
       <ReportsControls @export="exportCSV" />
 
+      <MissingResourceAlert v-if="lesson.missing_resource" />
+
       <CoreTable :emptyMessage="coachString('activityListEmptyState')">
         <template #headers>
           <th>{{ coachString('titleLabel') }}</th>
@@ -56,10 +58,12 @@
                 </KLabeledIcon>
               </td>
               <td>
-                <StatusSimple :status="tableRow.statusObj.status" />
+                <StatusSimple v-if="tableRow.statusObj" :status="tableRow.statusObj.status" />
+                <KEmptyPlaceholder v-else />
               </td>
               <td>
-                <TimeDuration :seconds="showTimeDuration(tableRow)" />
+                <TimeDuration v-if="tableRow.statusObj" :seconds="showTimeDuration(tableRow)" />
+                <KEmptyPlaceholder v-else />
               </td>
             </tr>
           </transition-group>
@@ -74,6 +78,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import CSVExporter from '../../csv/exporter';
@@ -86,6 +91,7 @@
     name: 'ReportsLessonLearnerBase',
     components: {
       CoachAppBarPage,
+      MissingResourceAlert,
       ReportsControls,
       ReportsResourcesStats,
     },
@@ -102,7 +108,10 @@
       },
       table() {
         const contentArray = this.lesson.node_ids.map(node_id => this.contentNodeMap[node_id]);
-        return contentArray.map(content => {
+        return contentArray.map((content, index) => {
+          if (!content) {
+            return this.missingResourceObj(index);
+          }
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
           };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourcesList.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourcesList.vue
@@ -23,12 +23,15 @@
           </td>
           <td>
             <StatusSummary
+              v-if="tableRow.tally"
               :tally="tableRow.tally"
               :verbose="true"
             />
+            <KEmptyPlaceholder v-else />
           </td>
           <td>
-            <TimeDuration :seconds="tableRow.avgTimeSpent" />
+            <TimeDuration v-if="tableRow.tally" :seconds="tableRow.avgTimeSpent" />
+            <KEmptyPlaceholder v-else />
           </td>
         </tr>
       </transition-group>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizQuestionListPage.vue
@@ -1,102 +1,19 @@
 <template>
 
-  <ReportsQuizBaseListPage @export="exportCSV">
-    <div>
-      <CoreTable :emptyMessage="coachString('questionListEmptyState')">
-        <template #headers>
-          <th>{{ coachString('questionLabel') }}</th>
-          <th>{{ coachString('helpNeededLabel') }}</th>
-        </template>
-        <template #tbody>
-          <transition-group tag="tbody" name="list">
-            <tr v-for="(tableRow, index) in table" :key="tableRow.item + index">
-              <td>
-                <span v-if="$isPrint">{{ tableRow.title }}</span>
-                <KRouterLink
-                  :text="tableRow.title"
-                  :to="questionLink(tableRow.item)"
-                  icon="question"
-                />
-              </td>
-              <td>
-                <LearnerProgressRatio
-                  :verb="VERBS.needHelp"
-                  :icon="ICONS.help"
-                  :total="tableRow.total"
-                  :count="tableRow.total - tableRow.correct"
-                  :verbosity="1"
-                />
-              </td>
-            </tr>
-          </transition-group>
-        </template>
-      </CoreTable>
-    </div>
-  </ReportsQuizBaseListPage>
+  <QuizQuestionListPageBase />
 
 </template>
 
 
 <script>
 
-  import { mapGetters } from 'vuex';
-  import commonCoach from '../common';
-  import LearnerProgressRatio from '../common/status/LearnerProgressRatio';
-  import CSVExporter from '../../csv/exporter';
-  import * as csvFields from '../../csv/fields';
-  import ReportsQuizBaseListPage from './ReportsQuizBaseListPage';
-  import { PageNames } from './../../constants';
+  import QuizQuestionListPageBase from './QuizQuestionListPageBase';
 
   export default {
     name: 'ReportsQuizQuestionListPage',
     components: {
-      LearnerProgressRatio,
-      ReportsQuizBaseListPage,
-    },
-    mixins: [commonCoach],
-    computed: {
-      ...mapGetters('questionList', ['difficultQuestions']),
-      exam() {
-        return this.examMap[this.$route.params.quizId];
-      },
-      table() {
-        return this.difficultQuestions.map(question => {
-          const tableRow = {};
-          Object.assign(tableRow, question);
-          return tableRow;
-        });
-      },
-    },
-    methods: {
-      questionLink(questionId) {
-        return this.classRoute(PageNames.REPORTS_QUIZ_QUESTION_PAGE_ROOT, {
-          questionId,
-          quizId: this.$route.params.quizId,
-        });
-      },
-      exportCSV() {
-        const columns = [...csvFields.title(), ...csvFields.helpNeeded()];
-
-        const exporter = new CSVExporter(columns, this.className);
-        exporter.addNames({
-          resource: this.exam.title,
-          difficultQuestions: this.coachString('difficultQuestionsLabel'),
-        });
-
-        exporter.export(this.table);
-      },
+      QuizQuestionListPageBase,
     },
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '../common/print-table';
-
-  .stats {
-    margin-right: 16px;
-  }
-
-</style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceHeader.vue
@@ -23,6 +23,7 @@
           />
         </template>
       </HeaderWithOptions>
+      <MissingResourceAlert v-if="!$isPrint && !resource.available" :multiple="false" />
       <h1>
         <KLabeledIcon :icon="resource.kind" :label="resource.title" />
       </h1>
@@ -129,6 +130,7 @@
   import InfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import SlotTruncator from 'kolibri.coreVue.components.SlotTruncator';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import {
     licenseLongName,
     licenseDescriptionForConsumer,
@@ -140,6 +142,7 @@
   export default {
     name: 'ReportsResourceHeader',
     components: {
+      MissingResourceAlert,
       HeaderWithOptions,
       InfoIcon,
       SlotTruncator,

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -274,6 +274,9 @@ def serialize_lessons(queryset):
 
 def _map_exam(item):
     item["assignments"] = item.pop("exam_assignments")
+    item["node_ids"] = list(
+        {question["exercise_id"] for question in item.get("question_sources")}
+    )
     return item
 
 
@@ -331,6 +334,16 @@ class ClassSummaryViewSet(viewsets.ViewSet):
         lesson_data = serialize_lessons(query_lesson)
         exam_data = serialize_exams(query_exams)
 
+        all_node_ids = set()
+        for lesson in lesson_data:
+            all_node_ids |= set(lesson.get("node_ids"))
+        for exam in exam_data:
+            all_node_ids |= set(exam.get("node_ids"))
+
+        query_content = ContentNode.objects.filter_by_uuids(all_node_ids)
+        # final list of available nodes
+        set_of_ids = {node.id for node in query_content}
+
         individual_learners_group_ids = AdHocGroup.objects.filter(
             parent=classroom
         ).values_list("id", flat=True)
@@ -342,6 +355,10 @@ class ClassSummaryViewSet(viewsets.ViewSet):
                 for g in exam["assignments"]
                 if g != pk and g not in individual_learners_group_ids
             ]
+            # determine if any resources are missing locally for the quiz
+            exam["missing_resource"] = any(
+                node_id not in set_of_ids for node_id in exam["node_ids"]
+            )
 
         # filter classes out of lesson assignments
         for lesson in lesson_data:
@@ -350,41 +367,10 @@ class ClassSummaryViewSet(viewsets.ViewSet):
                 for g in lesson["assignments"]
                 if g != pk and g not in individual_learners_group_ids
             ]
-
-        all_node_ids = set()
-        for lesson in lesson_data:
-            all_node_ids |= set(lesson.get("node_ids"))
-        for exam in exam_data:
-            exam_node_ids = [
-                question["exercise_id"] for question in exam.get("question_sources")
-            ]
-            all_node_ids |= set(exam_node_ids)
-
-        # map node ids => content_ids so we can replace missing nodes, if another matching content_id node exists
-        content_id_map = {
-            resource["contentnode_id"]: resource["content_id"]
-            for lesson in lesson_data
-            for resource in (lesson.pop("resources") or [])
-        }
-        query_content = ContentNode.objects.filter_by_uuids(all_node_ids)
-        # final list of available nodes
-        list_of_ids = [node.id for node in query_content]
-        # determine a new list of node_ids for each lesson, removing/replacing missing content items
-        for lesson in lesson_data:
-            node_ids = []
-            for node_id in lesson["node_ids"]:
-                # if resource exists, add to node_ids
-                if node_id in list_of_ids:
-                    node_ids.append(node_id)
-                else:
-                    # if resource does not exist, check if another resource with same content_id exists
-                    nodes = ContentNode.objects.filter(
-                        content_id=content_id_map[node_id]
-                    )
-                    if nodes:
-                        node_ids.append(nodes[0].id)
-            # point to new list of node ids
-            lesson["node_ids"] = node_ids
+            # determine if any resources are missing locally for the lesson
+            lesson["missing_resource"] = any(
+                node_id not in set_of_ids for node_id in lesson["node_ids"]
+            )
 
         learners_data = serialize_users(query_learners)
 

--- a/kolibri/plugins/coach/test/test_class_summary.py
+++ b/kolibri/plugins/coach/test/test_class_summary.py
@@ -81,7 +81,7 @@ class ClassSummaryTestCase(EvaluationMixin, APITestCase):
         cls.basename = "kolibri:kolibri.plugins.coach:classsummary"
         cls.detail_name = cls.basename + "-detail"
 
-    def test_non_existent_nodes_dont_show_up_in_lessons(self):
+    def test_non_existent_nodes_do_show_up_in_lessons(self):
         node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).first()
         last_node = ContentNode.objects.exclude(kind=content_kinds.TOPIC).last()
         real_data = {
@@ -108,11 +108,13 @@ class ClassSummaryTestCase(EvaluationMixin, APITestCase):
         response = self.client.get(
             reverse(self.detail_name, kwargs={"pk": self.classroom.id})
         )
-        node_ids = response.data["lessons"][0]["node_ids"]
+        lesson = response.data["lessons"][0]
+        node_ids = lesson["node_ids"]
         self.assertIn(real_data["contentnode_id"], node_ids)
         # swapped data
-        self.assertIn(last_node.id, node_ids)
-        self.assertNotIn(fake_data["contentnode_id"], node_ids)
+        self.assertNotIn(last_node.id, node_ids)
+        self.assertIn(fake_data["contentnode_id"], node_ids)
+        self.assertTrue(lesson["missing_resource"])
 
     def test_anon_user_cannot_access_detail(self):
         response = self.client.get(

--- a/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
@@ -123,7 +123,7 @@ export default function useLearnerResources() {
    */
   const resumableClassesResources = computed(() => {
     return get(_classesResources).filter(resource => {
-      return resource.progress && resource.progress < 1;
+      return resource.progress && resource.progress < 1 && resource.contentNode;
     });
   });
 

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -77,6 +77,10 @@ export function showExam(store, params, alreadyOnQuiz) {
                   contentNodeMap[node.id] = node;
                 }
 
+                for (const question of questions) {
+                  question.missing = !contentNodeMap[question.exercise_id];
+                }
+
                 store.commit('examViewer/SET_STATE', {
                   contentNodeMap,
                   exam,

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
@@ -12,27 +12,22 @@ export function showLessonPlaylist(store, { lessonId }) {
     if (store.getters.isUserLoggedIn) {
       fetchContentNodeProgress({ lesson: lessonId });
     }
+    const contentNodePromise = ContentNodeResource.fetchLessonResources(lessonId);
     return LearnerLessonResource.fetchModel({ id: lessonId })
       .then(lesson => {
         store.commit('SET_PAGE_NAME', ClassesPageNames.LESSON_PLAYLIST);
         store.commit('lessonPlaylist/SET_CURRENT_LESSON', lesson);
         if (lesson.resources.length) {
-          return ContentNodeResource.fetchCollection({
-            getParams: {
-              ids: lesson.resources.map(resource => resource.contentnode_id),
-            },
-          });
+          return contentNodePromise;
         }
         return Promise.resolve([]);
       })
       .then(contentNodes => {
-        const sortedContentNodes = contentNodes.sort((a, b) => {
-          const lesson = store.state.lessonPlaylist.currentLesson;
-          const aKey = lesson.resources.findIndex(resource => resource.contentnode_id === a.id);
-          const bKey = lesson.resources.findIndex(resource => resource.contentnode_id === b.id);
-          return aKey - bKey;
-        });
-        store.commit('lessonPlaylist/SET_LESSON_CONTENTNODES', sortedContentNodes);
+        const contentNodesMap = {};
+        for (let node of contentNodes) {
+          contentNodesMap[node.id] = node;
+        }
+        store.commit('lessonPlaylist/SET_LESSON_CONTENTNODES', contentNodesMap);
         store.dispatch('notLoading');
       })
       .catch(error => {

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/index.js
@@ -2,13 +2,13 @@ export default {
   namespaced: true,
   state() {
     return {
-      contentNodes: [],
+      contentNodesMap: {},
       currentLesson: {},
     };
   },
   mutations: {
     SET_LESSON_CONTENTNODES(state, contentNodes) {
-      state.contentNodes = [...contentNodes];
+      state.contentNodesMap = { ...contentNodes };
     },
     SET_CURRENT_LESSON(state, lesson) {
       state.currentLesson = { ...lesson };

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -1,6 +1,7 @@
 <template>
 
   <div class="wrapper">
+    <MissingResourceAlert v-if="missingLessonResources" />
     <div
       v-if="contentNodes.length"
       class="content-list"
@@ -96,6 +97,7 @@
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import useContentLink from '../composables/useContentLink';
   import SidePanelResourcesList from './SidePanelModal/SidePanelResourcesList';
@@ -111,6 +113,7 @@
       ProgressBar,
       TextTruncator,
       TimeDuration,
+      MissingResourceAlert,
     },
     mixins: [KResponsiveWindowMixin],
     setup() {
@@ -152,6 +155,10 @@
       currentResourceID: {
         type: String,
         required: true,
+      },
+      missingLessonResources: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -15,6 +15,13 @@
           @click="$emit('goToQuestion', index)"
         >
           <KIcon
+            v-if="question.missing"
+            class="dot"
+            icon="warning"
+            :color="$themePalette.orange.v_400"
+          />
+          <KIcon
+            v-else
             class="dot"
             icon="notStarted"
             :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -46,6 +46,7 @@
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
         <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
           <KPageContainer>
+            <MissingResourceAlert v-if="missingResources" />
             <h1>
               {{ $tr('question', { num: questionNumber + 1, total: exam.question_count }) }}
             </h1>
@@ -178,6 +179,7 @@
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import useProgressTracking from '../../composables/useProgressTracking';
   import { PageNames, ClassesPageNames } from '../../constants';
   import { LearnerClassroomResource } from '../../apiResources';
@@ -199,6 +201,7 @@
       TimeDuration,
       SuggestedTime,
       ImmersivePage,
+      MissingResourceAlert,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     setup() {
@@ -278,6 +281,9 @@
       },
       nodeId() {
         return this.currentQuestion ? this.currentQuestion.exercise_id : null;
+      },
+      missingResources() {
+        return this.questions.some(q => !this.contentNodeMap[q.exercise_id]);
       },
       itemId() {
         return this.currentQuestion ? this.currentQuestion.question_id : null;

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -46,7 +46,7 @@
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
         <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
           <KPageContainer>
-            <MissingResourceAlert v-if="missingResources" />
+
             <h1>
               {{ $tr('question', { num: questionNumber + 1, total: exam.question_count }) }}
             </h1>
@@ -63,9 +63,7 @@
               :answerState="currentAttempt.answer"
               @interaction="saveAnswer"
             />
-            <UiAlert v-else :dismissible="false" type="error">
-              {{ $tr('noItemId') }}
-            </UiAlert>
+            <MissingResourceAlert v-else :multiple="false" />
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
@@ -113,15 +111,19 @@
               :dir="layoutDirReset"
               class="left-align"
             >
-              <div class="answered">
+              <div v-if="!missingResources" class="answered">
                 {{ answeredText }}
               </div>
               <KButton
+                v-if="!missingResources"
                 :text="$tr('submitExam')"
                 :primary="false"
                 appearance="flat-button"
                 @click="toggleModal"
               />
+              <div v-if="missingResources" class="nosubmit">
+                {{ $tr('unableToSubmit') }}
+              </div>
             </div>
 
           </BottomAppBar>
@@ -132,15 +134,19 @@
               class="bottom-block"
               :class="{ windowIsSmall }"
             >
-              <div class="answered">
+              <div v-if="!missingResources" class="answered">
                 {{ answeredText }}
               </div>
               <KButton
+                v-if="!missingResources"
                 :text="$tr('submitExam')"
                 :primary="false"
                 appearance="flat-button"
                 @click="toggleModal"
               />
+              <div v-if="missingResources" class="nosubmit">
+                {{ $tr('unableToSubmit') }}
+              </div>
             </div>
           </KPageContainer>
         </main>
@@ -487,15 +493,15 @@
 
         context: 'Indicates how many questions the learner has not answered.',
       },
-      noItemId: {
-        message: 'This question has an error, please move on to the next question',
-        context:
-          'Message they may appear to the learner if there is a question missing in a quiz. The question may have been deleted accidentally, for example.',
-      },
       question: {
         message: 'Question {num, number, integer} of {total, number, integer}',
         context:
           'Indicates which question the user is working on currently and the total number of questions in a quiz.\n\nFor example: "Question 2 of 10".',
+      },
+      unableToSubmit: {
+        message: 'Unable to submit quiz because some resources are missing or not supported',
+        context:
+          'Indicates that a learner cannot submit the quiz because they are not able to see all the questions.',
       },
     },
   };
@@ -510,6 +516,13 @@
     margin-right: 8px;
     margin-left: 8px;
     white-space: nowrap;
+  }
+
+  .nosubmit {
+    display: inline-block;
+    margin-top: 8px;
+    margin-right: 8px;
+    margin-left: 8px;
   }
 
   .column-pane {

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -5,6 +5,7 @@
     :loading="loading"
   >
     <div v-if="!loading" id="main" role="main">
+      <MissingResourceAlert v-if="missingResources" />
       <YourClasses
         v-if="displayClasses"
         class="section"
@@ -58,6 +59,7 @@
 
   import { computed } from 'kolibri.lib.vueCompositionApi';
   import { get } from '@vueuse/core';
+  import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import useChannels from '../../composables/useChannels';
   import useDeviceSettings from '../../composables/useDeviceSettings';
   import useLearnerResources from '../../composables/useLearnerResources';
@@ -85,6 +87,7 @@
       ContinueLearning,
       ExploreChannels,
       LearnAppBarPage,
+      MissingResourceAlert,
     },
     mixins: [commonLearnStrings],
     setup() {
@@ -141,6 +144,13 @@
         return get(isUserLoggedIn) && (get(classes).length || !get(canAccessUnassignedContent));
       });
 
+      const missingResources = computed(() => {
+        return (
+          get(activeClassesLessons).some(l => l.missing_resource) ||
+          get(activeClassesQuizzes).some(q => q.missing_resource)
+        );
+      });
+
       return {
         isUserLoggedIn,
         channels,
@@ -153,6 +163,7 @@
         continueLearning,
         displayExploreChannels,
         displayClasses,
+        missingResources,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -127,6 +127,7 @@
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
         :currentResourceID="currentResourceID"
+        :missingLessonResources="missingLessonResources"
       />
     </SidePanelModal>
 
@@ -246,6 +247,7 @@
         resourcesSidePanelFetched: false,
         resourcesSidePanelLoading: false,
         contentPageMounted: false,
+        lesson: null,
       };
     },
     computed: {
@@ -300,6 +302,9 @@
       },
       currentResourceID() {
         return this.content ? this.content.content_id : '';
+      },
+      missingLessonResources() {
+        return this.lesson && this.lesson.resources.some(c => !c.contentnode);
       },
     },
     watch: {
@@ -371,8 +376,9 @@
         // Get the lesson and then assign its resources to this.viewResourcesContents
         // fetchLesson also handles fetching the progress data for this lesson and
         // the content node data for the resources
-        this.fetchLesson({ lessonId: this.lessonId }).then(lesson => {
+        return this.fetchLesson({ lessonId: this.lessonId }).then(lesson => {
           // Filter out this.content
+          this.lesson = lesson;
           this.viewResourcesContents = lesson.resources
             .filter(n => n.contentnode)
             .map(n => n.contentnode);

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -14,6 +14,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.content.api import ContentNodeProgressViewset
 from kolibri.core.content.api import ContentNodeViewset
 from kolibri.core.content.api import UserContentNodeViewset
+from kolibri.core.content.models import ContentNode
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.logger.models import AttemptLog
@@ -84,11 +85,14 @@ def _consolidate_lessons_data(request, lessons):
             ),
             "total_resources": len(lesson["resources"]),
         }
+        missing_resource = False
         for resource in lesson["resources"]:
             resource["progress"] = progress_map.get(resource["content_id"], 0)
             resource["contentnode"] = contentnode_map.get(
                 resource["contentnode_id"], None
             )
+            missing_resource = missing_resource or not resource["contentnode"]
+        lesson["missing_resource"] = missing_resource
 
 
 class LearnerClassroomViewset(ReadOnlyValuesViewset):
@@ -174,6 +178,18 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                 "closed",
                 "answer_count",
                 "score",
+                "question_sources",
+            )
+        )
+        exam_node_ids = set()
+        for exam in exams:
+            exam_node_ids |= {
+                question["exercise_id"] for question in exam.get("question_sources")
+            }
+
+        available_exam_ids = set(
+            ContentNode.objects.filter_by_uuids(exam_node_ids).values_list(
+                "id", flat=True
             )
         )
 
@@ -195,6 +211,10 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                     "closed": None,
                     "started": False,
                 }
+            exam["missing_resource"] = any(
+                question["exercise_id"] not in available_exam_ids
+                for question in exam.get("question_sources")
+            )
         out_items = []
         for item in items:
             item["assignments"] = {

--- a/packages/kolibri-common/components/MissingResourceAlert.vue
+++ b/packages/kolibri-common/components/MissingResourceAlert.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div :style="{ marginBottom: '8px' }">
     <UiAlert
       :dismissible="false"
       :removeIcon="true"

--- a/packages/kolibri-common/components/MissingResourceAlert.vue
+++ b/packages/kolibri-common/components/MissingResourceAlert.vue
@@ -1,0 +1,81 @@
+<template>
+
+  <div>
+    <UiAlert
+      :dismissible="false"
+      :removeIcon="true"
+      type="warning"
+      :style="{ marginBottom: 0, marginTop: '8px' }"
+    >
+      <span>
+        {{ coreString(
+          multiple ? 'someResourcesMissingOrNotSupported' :
+          'resourceNotFoundOnDevice'
+        ) }}
+      </span>
+              &nbsp;
+      <KButton appearance="basic-link" @click="open = true">
+        {{ $tr('learnMore') }}
+      </KButton>
+    </UiAlert>
+    <KModal
+      v-if="open"
+      :title="$tr('resourcesUnavailableTitle')"
+      :cancelText="coreString('closeAction')"
+      @cancel="open = false"
+    >
+      <p>{{ $tr('resourcesUnavailableP1') }}</p>
+      <p>{{ $tr('resourcesUnavailableP2') }}</p>
+    </KModal>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'MissingResourceAlert',
+    components: {
+      UiAlert,
+    },
+    mixins: [commonCoreStrings],
+    props: {
+      multiple: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    data() {
+      return { open: false };
+    },
+    $trs: {
+      resourcesUnavailableTitle: {
+        message: 'Resources unavailable',
+        context: 'Title of the modal window',
+      },
+      resourcesUnavailableP1: {
+        message:
+          'Some resources are missing, either because they were not found on the device, or because they are not compatible with your version of Kolibri.',
+
+        context: 'First paragraph of the "Resources Unavailable - Learn More" modal',
+      },
+      resourcesUnavailableP2: {
+        message:
+          'Consult your administrator for guidance, or use an account with device permissions to manage channels and resources.',
+
+        context: 'Second paragraph of the "Resources Unavailable - Learn More" modal.',
+      },
+      learnMore: {
+        message: 'Learn more',
+        context:
+          'A clickable link to open a modal with more information about how to remedy missing or incompatible resource issues.',
+      },
+    },
+  };
+
+</script>


### PR DESCRIPTION
## Summary
* Consolidates report components with repetitive boilerplate across group/non-group to prevent deviations
* Adds MissingResourceAlert component to show consistent messages to end users about missing resources
* Updates all reports to prevent missing resources from disrupting display, while ensuring the maximal available information is displayed to the end user where possible.
* Adds fetching of metadata that is available, but where the resource is unavailable to maximize the contextual information provided to coaches.
* Updates learn lesson playlist and quiz interfaces to display warnings
* Updates learn lesson also in this to display warnings

## References
Fixes #6563
Fixes #7325

## Reviewer guidance
Create quizzes and lessons assigned to both classes and groups.
Interact with them with learner accounts, but do not complete them.
Delete 1 or more of the resources required by the quizzes and lessons.
Review all reports and revisit the plan page for each quiz and lesson. View the reports for both non-group and group reports.
Return to the lessons and quizzes as a learner.

Learner quiz
![Screenshot from 2023-02-13 17-34-53](https://user-images.githubusercontent.com/1680573/218618604-fe98ba2a-f455-4fdd-b025-2f7f31711ef1.png)

Learner Lesson playlist
![Screenshot from 2023-02-13 17-40-37](https://user-images.githubusercontent.com/1680573/218618878-7b5a126d-38f6-4803-b9bf-976bab4ed09d.png)

Learner lesson 'also in this'
file:///home/richard/Pictures/Screenshots/Screenshot%20from%202023-02-13%2017-52-08.png

Coach notifications
![Screenshot from 2023-02-13 17-35-22](https://user-images.githubusercontent.com/1680573/218618928-5f75b75d-7776-4f5b-8d3d-e68e332b1df5.png)

Coach lesson report
![Screenshot from 2023-02-13 17-35-37](https://user-images.githubusercontent.com/1680573/218618957-00bc024e-8bb9-40dc-aba3-3618035cbc4e.png)

Coach lesson resource detail report
![Screenshot from 2023-02-13 17-35-43](https://user-images.githubusercontent.com/1680573/218618983-d96c7807-5aec-452e-af82-739e298a2a0b.png)

Coach lesson report preview
![Screenshot from 2023-02-13 17-35-47](https://user-images.githubusercontent.com/1680573/218619003-355ce1a7-6b77-4421-96d8-44ee1f95d27c.png)

Coach quiz report
![Screenshot from 2023-02-13 17-36-05](https://user-images.githubusercontent.com/1680573/218619025-2c90a0f5-062d-45f0-a7a4-f13cabfffecf.png)

Coach quiz difficult questions report
![Screenshot from 2023-02-13 17-36-11](https://user-images.githubusercontent.com/1680573/218619099-826fab69-9dc9-4712-a0ea-5534a44e6ea3.png)

Coach lesson plan (at the moment this is mostly unchanged, showing resources not available across the board - should I update to showing available metadata parallel to the reports?)
![Screenshot from 2023-02-13 17-39-34](https://user-images.githubusercontent.com/1680573/218619233-de7cc732-569f-42e1-92ac-4b3ccc4f6372.png)

Coach quiz plan preview
![Screenshot from 2023-02-13 17-40-03](https://user-images.githubusercontent.com/1680573/218619253-a7ff9497-98c2-488e-a5dd-4882d47dd67d.png)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
