### PR TITLE
Check that a channel exists locally before trying to import content

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -10,6 +10,7 @@ from ...utils import annotation
 from ...utils import paths
 from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
+from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.content.utils.import_export_content import compare_checksums
@@ -453,6 +454,16 @@ class Command(AsyncCommand):
         return FILE_TRANSFERRED, data_transferred
 
     def handle_async(self, *args, **options):
+        try:
+            ChannelMetadata.objects.get(id=options["channel_id"])
+        except ValueError:
+            raise CommandError(
+                "{} is not a valid channel_id".format(options["channel_id"])
+            )
+        except ChannelMetadata.DoesNotExist:
+            raise CommandError(
+                "Must import a channel with importchannel before importing content."
+            )
         if options["command"] == "network":
             self.download_content(
                 options["channel_id"],


### PR DESCRIPTION
## Summary
* Adds some simple validation to the importchannel command

## References
Fixes #7506

## Reviewer guidance
Does importcontent still work as expected?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
