### PR TITLE
Coach view: hide dropdown when there are no practice quizzes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -148,12 +148,11 @@
 
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-  import { ContentNodeResource, ExamResource } from 'kolibri.resources';
-  import { mapGetters } from 'vuex';
+  import { ExamResource } from 'kolibri.resources';
   import { PageNames } from '../../../constants';
   import commonCoach from '../../common';
   import PlanHeader from '../../plan/PlanHeader';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'CoachExamsPage',
@@ -175,13 +174,14 @@
         // },
         showOpenConfirmationModal: false,
         showCloseConfirmationModal: false,
-        practiceQuizzesExist: true,
       };
     },
     computed: {
-      ...mapGetters(['getChannels']),
       sortedExams() {
         return this._.orderBy(this.exams, ['date_created'], ['desc']);
+      },
+      practiceQuizzesExist() {
+        return plugin_data.practice_quizzes_exist;
       },
       // Hidden temporarily per https://github.com/learningequality/kolibri/issues/6174
       // Uncomment this once we use the filters again.
@@ -227,34 +227,6 @@
           { label: this.$tr('selectQuiz'), value: 'SELECT_QUIZ' },
         ];
       },
-    },
-    mounted() {
-      this.$nextTick(() => {
-        let channelIds = this.getChannels.map(channel => channel.id);
-        let array = [];
-
-        let results = channelIds.map(id => {
-          return ContentNodeResource.fetchCollection({
-            getParams: {
-              parent: id,
-              kind_in: [ContentNodeKinds.TOPIC, ContentNodeKinds.EXERCISE],
-              contains_quiz: true,
-            },
-          }).then(results => {
-            if (results.length !== 0) {
-              array.push(results);
-            }
-          });
-        });
-
-        Promise.all(results)
-          .then(() => {
-            if (array.length === 0) {
-              this.practiceQuizzesExist = false;
-            }
-          })
-          .catch(err => console.log(err));
-      });
     },
     methods: {
       handleOpenQuiz(quizId) {

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -43,3 +43,14 @@ class CoachNavItem(NavigationHook):
 @register_hook
 class CoachAsset(webpack_hooks.WebpackBundleHook):
     bundle_id = "app"
+
+    @property
+    def plugin_data(self):
+        from kolibri.core.content.models import ContentNode
+
+        practice_quizzes_exist = ContentNode.objects.filter(
+            available=True, options__contains='"modality": "QUIZ"'
+        ).exists()
+        return {
+            "practice_quizzes_exist": practice_quizzes_exist,
+        }


### PR DESCRIPTION
## Summary
|Frame|Description of expected behavior|
|--|--|
|<img width="953" alt="Screen Shot 2021-11-12 at 3 25 25 PM" src="https://user-images.githubusercontent.com/13563002/141594810-124bb897-a598-40ae-8524-b457e45c8232.png">| Coach user has access to channels with folders that have practice quizzes (channel quizzes) - dropdown menu with option to select a practice quiz is visible |
|<img width="953" alt="Screen Shot 2021-11-12 at 3 25 57 PM" src="https://user-images.githubusercontent.com/13563002/141594855-069d090b-8904-474b-9104-57a7e376a33f.png"> | Coach user does not have access to channels that have folders with practice quizzes - normal `KRouterLink` to create a new quiz is visible |

## References
Addresses #8632

## Reviewer guidance

For manual testing:

**Frame 1: Coach user with practice quizzes on device**
1. Sign in as super admin
2. Make sure there is a channel with a practice quiz on the device
3. Go to Coach in the sidenav
4. In Coach, click on Plan tab > Quizzes subtab
5. Check to see that the "New quiz" button is a dropdown (has a triangle) and that "Select a channel quiz" is an option (for the moment, it is "channel quiz" but when the strings are merged, this will become "practice quiz")

**Frame 2: Coach user with NO practice quizzes in any channel on device**
1. Sign in as super admin
2. Make sure there are NO channels with practice quizzes on the device
3. Go to Coach in the sidenav
4. In Coach, click on Plan tab > Quizzes subtab
5. Check to see that the "New quiz" button is not a dropdown (without a triangle) and that you are directed to creating a new quiz when you click on this button

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
