### PR TITLE
Make sure to preload facility config on the user profile page.

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -3,16 +3,23 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 
+function preload(next) {
+  store.commit('CORE_SET_PAGE_LOADING', true);
+  store.dispatch('getFacilityConfig').then(() => {
+    store.commit('CORE_SET_PAGE_LOADING', false);
+    next();
+  });
+}
+
 export default [
   {
     path: '/',
     component: ProfilePage,
     beforeEnter(to, from, next) {
-      store.commit('CORE_SET_PAGE_LOADING', false);
       if (!store.getters.isUserLoggedIn) {
         redirectBrowser();
       } else {
-        next();
+        preload(next);
       }
     },
   },
@@ -20,11 +27,10 @@ export default [
     path: '/edit',
     component: ProfileEditPage,
     beforeEnter(to, from, next) {
-      store.commit('CORE_SET_PAGE_LOADING', false);
       if (!store.getters.isUserLoggedIn) {
         redirectBrowser();
       } else {
-        next();
+        preload(next);
       }
     },
   },

--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -97,11 +97,10 @@
     },
     mixins: [commonCoreStrings],
     data() {
-      const { username, full_name } = this.$store.state.core.session;
       return {
-        fullName: full_name,
+        fullName: '',
         fullNameValid: false,
-        username: username,
+        username: '',
         usernameValid: false,
         birthYear: '',
         gender: '',
@@ -148,6 +147,8 @@
           facilityUser => {
             this.birthYear = facilityUser.birth_year;
             this.gender = facilityUser.gender;
+            this.fullName = facilityUser.full_name;
+            this.username = facilityUser.username;
             this.userCopy = { ...facilityUser };
           }
         );

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -78,12 +78,12 @@
 
         <tr>
           <th>{{ coreString('fullNameLabel') }}</th>
-          <td>{{ session.full_name }}</td>
+          <td>{{ currentUser.full_name }}</td>
         </tr>
 
         <tr>
           <th>{{ coreString('usernameLabel') }}</th>
-          <td>{{ session.username }}</td>
+          <td>{{ currentUser.username }}</td>
         </tr>
 
         <tr>
@@ -126,7 +126,7 @@
 <script>
 
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
-  import { mapState, mapGetters } from 'vuex';
+  import { mapGetters } from 'vuex';
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import find from 'lodash/find';
   import pickBy from 'lodash/pickBy';
@@ -177,9 +177,6 @@
         'totalPoints',
         'userHasPermissions',
       ]),
-      ...mapState({
-        session: state => state.core.session,
-      }),
       profileEditRoute() {
         return this.$router.getRoute(ComponentMap.PROFILE_EDIT);
       },


### PR DESCRIPTION
## Summary
* Loads facility dataset before opening any profile pages to ensure settings are available

## References
Fixes #8689
Fixes #8688

## Reviewer guidance
Can you edit full name, username, and password, when appropriate facility settings are set?

![Screenshot from 2021-11-15 09-11-12](https://user-images.githubusercontent.com/1680573/141824564-df771db9-2846-4139-8ad8-76b00997eeb6.png)

![Screenshot from 2021-11-15 09-11-03](https://user-images.githubusercontent.com/1680573/141824549-12105022-cf2a-425c-a771-0abf083bbc21.png)----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
