### PR TITLE
Allow going back before importing the first user

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/machines/lodImportMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/lodImportMachine.js
@@ -105,20 +105,20 @@ export const lodImportMachine = createMachine({
       },
     },
     syncAdminUser: {
-      meta: { step: '2', component: MultipleUsers },
+      meta: { step: '3', component: MultipleUsers },
       on: {
         CONTINUE: { target: 'selectUsers' },
       },
     },
     selectUsers: {
-      meta: { step: '2', component: MultipleUsers },
+      meta: { step: '3', component: MultipleUsers },
       on: {
         CONTINUE: { target: 'importingSingleUser', actions: importUser },
         BACK: 'userCredentials',
       },
     },
     importingSingleUser: {
-      meta: { step: '3', component: LoadingTaskPage },
+      meta: { step: '4', component: LoadingTaskPage },
       on: {
         BACK: { target: 'selectUsers' },
       },

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -77,7 +77,7 @@
       },
       removeNavIcon() {
         // TODO disable backwards navigation at the router level
-        return this.currentStep > 1;
+        return this.currentStep > 2 || this.state.context.users.length > 0;
       },
       users() {
         return this.state.context.users;
@@ -127,7 +127,8 @@
     },
     methods: {
       previousStep() {
-        if (this.state.matches('selectFacility')) this.wizardService.send('BACK');
+        if (this.state.matches('selectFacility') || this.state.matches('userCredentials'))
+          this.wizardService.send('BACK');
         else this.service.send('BACK');
       },
       redirectToChannels() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -5,7 +5,9 @@
     :description="formDescription"
     :submitText="coreString('importAction')"
     :disabled="checkFormDisabled"
+    :finishButton="users.length !== 0"
     @submit="handleSubmit"
+    @click_finish="redirectToChannels"
   >
     <p class="facility-name">
       {{ formatNameAndId(facility.name, facility.id) }}
@@ -88,7 +90,11 @@
   import { DemographicConstants, ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import OnboardingForm from '../onboarding-forms/OnboardingForm';
-  import { FacilityImportResource, SetupSoUDTasksResource } from '../../api';
+  import {
+    FacilityImportResource,
+    FinishSoUDSyncingResource,
+    SetupSoUDTasksResource,
+  } from '../../api';
 
   export default {
     name: 'ImportIndividualUserForm',
@@ -117,6 +123,9 @@
       },
       facility() {
         return this.state.value.facility;
+      },
+      users() {
+        return this.state.value.users;
       },
       checkFormDisabled() {
         return (
@@ -226,6 +235,9 @@
               this.error = true;
             } else this.$store.dispatch('handleApiError', error);
           });
+      },
+      redirectToChannels() {
+        FinishSoUDSyncingResource.finish();
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -22,13 +22,22 @@
       </div>
 
       <slot name="buttons">
-        <KButton
-          class="onboarding-form-submit"
-          :primary="true"
-          type="submit"
-          :text="submitText || coreString('continueAction')"
-          :disabled="$attrs.disabled"
-        />
+        <KButtonGroup>
+          <KButton
+            class="onboarding-form-submit"
+            :primary="true"
+            type="submit"
+            :text="submitText || coreString('continueAction')"
+            :disabled="$attrs.disabled"
+          />
+
+          <KButton
+            v-if="finishButton"
+            primary
+            :text="coreString('finishAction')"
+            @click="$emit('click_finish')"
+          />
+        </KButtonGroup>
       </slot>
     </form>
   </div>
@@ -55,6 +64,10 @@
       submitText: {
         type: String,
         default: null,
+      },
+      finishButton: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -33,7 +33,6 @@
 
           <KButton
             v-if="finishButton"
-            primary
             :text="coreString('finishAction')"
             @click="$emit('click_finish')"
           />


### PR DESCRIPTION
## Summary
In the Setup Wizard, allows going back before any user has been synced


![Peek 23-11-2021 18-26](https://user-images.githubusercontent.com/1008178/143074149-54491354-235b-4803-a0f7-89b77cd9665b.gif)


## References
Closes: #8377 

## Reviewer guidance
Start the setup wizard to provision one new device. Check that after selecting the option to import from a new device it's possible to go back before importing any user.
After an user import has begun , there's no way back as the device is setup as a Learner Only Device.



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
