### PR TITLE
Fix no password learner logging in after passwords activated

### DIFF
--- a/kolibri/plugins/user_auth/assets/src/constants.js
+++ b/kolibri/plugins/user_auth/assets/src/constants.js
@@ -3,6 +3,7 @@ export const ComponentMap = {
   SIGN_UP: 'SignUpPage',
   AUTH_SELECT: 'AuthSelect',
   FACILITY_SELECT: 'FacilitySelect',
+  NEW_PASSWORD: 'NewPasswordPage',
 };
 
 export const pageNameToModuleMap = {

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -486,8 +486,6 @@
                   name: ComponentMap.NEW_PASSWORD,
                   query: sessionPayload,
                 });
-                // This error overrides the whole layout
-                this.loginError = err;
               } else {
                 // Otherwise, only show errors when we've submitted a password
                 this.usernameSubmittedWithoutPassword = !this.password;


### PR DESCRIPTION
## Summary
* Add missing component map that was preventing navigation.
* Remove redundant storage of error as data.

## References
Fixes #8687
Seems like something got lost in the refactor of this into a separate page, was just missing the appropriate reference to the component


## Reviewer guidance
Make a learner with facility setting "Require passwords for learners" off.
Set "Require passwords for learners" on.
Login with learner.
Be able to set password!

![nopassword](https://user-images.githubusercontent.com/1680573/141876824-9ff2d9f2-001e-4d38-ac60-9258cbf9c37e.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
