### PR TITLE
Always provide port to zeroconf

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -734,7 +734,7 @@ class KolibriProcessBus(ProcessBus):
     def run(self):
         self.graceful()
         if not self.serve_http:
-            self.publish("SERVING", None)
+            self.publish("SERVING", self.port)
 
         self.block()
 


### PR DESCRIPTION
## Summary
zeroconf should provide info on the port to be used by kolibri, even if the server mechanism is not the cointained server but an external one as nginx.

With the previous setup, if `CHERRYPY_START` is set to `False` in options.ini, the port info is not provided, thus other kolibri servers try to use 8080 (default, when port is None) in https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/discovery/models.py#L55 to check if the server is available . If the server runs in 8080 nothing is noticed but if the server is running on a different port, it's not accesible, thus marked as unavailable for others to sync.

## References

Commented on slack

## Reviewer guidance

Do any test fail?
is there any secondary effect to announce the port always?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
