### PR TITLE
Add back context for navigating back to search pages.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -132,8 +132,10 @@
       uniqueId: null,
     }),
     computed: {
-      ...mapState(['pageName']),
       ...mapState('lessonPlaylist', ['currentLesson']),
+      pageName() {
+        return this.$route.name;
+      },
       isBookmarksPage() {
         return this.pageName === PageNames.BOOKMARKS;
       },
@@ -141,12 +143,12 @@
         return this.pageName === PageNames.LIBRARY;
       },
       context() {
-        let context = {};
+        const context = {};
         if (this.currentLesson && this.currentLesson.classroom) {
-          context = {
-            lessonId: this.currentLesson.id,
-            classId: this.currentLesson.classroom.id,
-          };
+          context.lessonId = this.currentLesson.id;
+          context.classId = this.currentLesson.classroom.id;
+        } else if (this.isLibraryPage || this.pageName === PageNames.TOPICS_TOPIC_SEARCH) {
+          Object.assign(context, this.$route.query);
         }
         return context;
       },

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -283,6 +283,9 @@
         // extract the key pieces of routing from immersive page props, but since we don't need
         // them all, just create two alternative route paths for return/'back' navigation
         let route = {};
+        const query = { ...this.$route.query };
+        delete query.last;
+        delete query.topicId;
         if (
           this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH ||
           this.$route.query.last === PageNames.TOPICS_TOPIC
@@ -292,16 +295,19 @@
             : this.topicsTreeContent.parent;
           const lastPage = this.$route.query.last;
           // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(lastPage, {
-            id: lastId,
-          });
+          route = this.$router.getRoute(
+            lastPage,
+            {
+              id: lastId,
+            },
+            query
+          );
+        } else if (this.$route.query && this.$route.query.last === PageNames.LIBRARY) {
+          const lastPage = this.$route.query.last;
+          route = this.$router.getRoute(lastPage, {}, query);
         } else if (this.$route.query && this.$route.query.last) {
           const last = this.$route.query.last;
-          route = this.$router.getRoute(last);
-          if (this.$route.query) {
-            const params = this.$route.query;
-            route = { ...route, params };
-          }
+          route = this.$router.getRoute(last, query);
         } else {
           route = this.$router.getRoute(PageNames.HOME);
         }


### PR DESCRIPTION
## Summary
* Adds in search context to query parameters when generating links from the LibraryPage and the TOPICS_TOPICS_SEARCH route
* Uses to navigate back to search pages using the back button

## References
Fixes #8612

## Reviewer guidance
Can you use the back arrow in the immersive view to return to search pages?
Do other uses of the back button still work?

GIF of Library
![searchlibraryback](https://user-images.githubusercontent.com/1680573/142042032-f1b5ba8b-5430-4d17-a5ea-941ff085bf36.gif)

GIF of Topics
![searchbacktopics](https://user-images.githubusercontent.com/1680573/142042060-2ff99003-566c-42d2-af48-719a262e1bb2.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
