### PR TITLE
Export size bug

### DIFF
--- a/kolibri/core/content/management/commands/exportchannel.py
+++ b/kolibri/core/content/management/commands/exportchannel.py
@@ -39,8 +39,4 @@ class Command(AsyncCommand):
                     pass
 
                 if self.is_cancelled():
-                    try:
-                        os.remove(dest)
-                    except IOError:
-                        pass
                     self.cancel()

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 
 class Command(AsyncCommand):
+    exported_size = 0
+    total_resources = 0
+
     def add_arguments(self, parser):
         node_ids_help_text = """
         Specify one or more node IDs to import. Only the files associated to those node IDs will be imported.
@@ -86,7 +89,6 @@ class Command(AsyncCommand):
         with self.start_progress(
             total=total_bytes_to_transfer
         ) as overall_progress_update:
-
             for f in files:
 
                 if self.is_cancelled():
@@ -97,14 +99,10 @@ class Command(AsyncCommand):
                     exported_files.append(dest)
 
             if self.is_cancelled():
-                # Cancelled, clean up any already downloading files.
-                for dest in exported_files:
-                    os.remove(dest)
                 self.cancel()
 
     def export_file(self, f, data_dir, overall_progress_update):
         filename = get_content_file_name(f)
-
         try:
             srcpath = paths.get_content_storage_file_path(filename)
             dest = paths.get_content_storage_file_path(filename, datafolder=data_dir)
@@ -117,17 +115,21 @@ class Command(AsyncCommand):
         if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
             overall_progress_update(f["file_size"])
             return
-
         copy = transfer.FileCopy(srcpath, dest, cancel_check=self.is_cancelled)
-
         with copy, self.start_progress(
             total=copy.total_size
         ) as file_cp_progress_update:
             try:
                 for chunk in copy:
                     length = len(chunk)
+                    self.exported_size = self.exported_size + length
                     overall_progress_update(length)
                     file_cp_progress_update(length)
             except transfer.TransferCanceled:
+                job = get_current_job()
+                if job:
+                    job.extra_metadata["file_size"] = self.exported_size
+                    job.extra_metadata["total_resources"] = 0
+                    job.save_meta()
                 return
         return dest

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1220,7 +1220,7 @@ class ExportChannelTestCase(TestCase):
             local_src_path, local_dest_path, cancel_check=is_cancelled_mock
         )
         cancel_mock.assert_called_with()
-        self.assertFalse(os.path.exists(local_dest_path))
+        self.assertTrue(os.path.exists(local_dest_path))
 
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -170,7 +170,6 @@ def get_import_export_data(  # noqa: C901
             )
 
         count_content_ids = nodes_segment.count()
-
         # Only bother with this query if there were any resources returned above.
         if count_content_ids:
             number_of_resources = number_of_resources + count_content_ids

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -55,7 +55,7 @@
           />
         </template>
       </div>
-      <template v-if="!taskIsCompleted && !taskIsCanceled">
+      <template v-if="!taskIsCompleted">
         <p v-if="sizeText" class="details-size">
           {{ sizeText }}
         </p>
@@ -192,6 +192,10 @@
             numResources: total_resources,
             bytesText: bytesForHumans(file_size),
           });
+        } else if (file_size) {
+          return this.$tr('cancelSize', {
+            bytesText: bytesForHumans(file_size),
+          });
         }
         return '';
       },
@@ -261,6 +265,11 @@
           '{numResources} {numResources, plural, one {resource} other {resources}} ({bytesText})',
         context: 'Indicates the number of resources and their size.',
       },
+      cancelSize: {
+        message: 'Exported size: ({bytesText})',
+        context: 'Indicates the number of resources and their size.',
+      },
+
       statusInProgress: {
         message: 'In-progress',
         context: 'Label indicating that a task is in progress.',

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
@@ -15,7 +15,9 @@ exports[`TaskPanel renders correctly when it is a canceled DISKCONTENTEXPORT tas
       Export resources from 'Canceled disk export channel test'
     </h2>
     <!---->
-    <!---->
+    <p class="details-size">
+      500 resources (5 KB)
+    </p>
     <p class="details-startedby" style="color: rgb(97, 97, 97);">
       Started by 'Tester'
     </p>
@@ -42,7 +44,9 @@ exports[`TaskPanel renders correctly when it is a canceled DISKEXPORT task (bulk
       Export 'Canceled disk export channel test'
     </h2>
     <!---->
-    <!---->
+    <p class="details-size">
+      500 resources (5 KB)
+    </p>
     <p class="details-startedby" style="color: rgb(97, 97, 97);">
       Started by 'Tester'
     </p>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Now when we are exporting first we get a bar with progress and total amount of bytes and total number of resources. When we press cancel now at the end it will be show the total amount of bytes. 

## References
Fixes https://github.com/learningequality/kolibri/issues/7625

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
