### PR TITLE
Do not show user sync tasks in the Channels tasks

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -106,6 +106,7 @@ export default {
             TaskTypes.REMOTECHANNELIMPORT,
             TaskTypes.DISKCHANNELIMPORT,
             TaskTypes.CHANNELDIFFSTATS,
+            TaskTypes.SYNCLOD,
           ].includes(task.type)
       );
     },


### PR DESCRIPTION
## Summary
In a Learner Only Device, the syncing of users tasks were appearing in the channels importing tasks, showing an ugly `TaskPanel.undefined` message

This PR filters this kind of tasks to avoid their appearance in this window

![image](https://user-images.githubusercontent.com/1008178/142057896-99a21799-ce6d-42f1-b550-a9db599fcbd8.png)

## References

Closes: #8393 


## Reviewer guidance

After creating a LOD, check that no odd tasks message appear in the Channels tab when the users are synced in the background 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
