### PR TITLE
Sort data to prevent flaky postgres tests.

### DIFF
--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -356,7 +356,9 @@ class ContentNodeAPITestCase(APITestCase):
         )
 
     def _assert_nodes(self, data, nodes):
-        for actual, expected in zip(data, nodes):
+        for actual, expected in zip(
+            sorted(data, key=lambda x: x["id"]), sorted(nodes, key=lambda x: x.id)
+        ):
             self._assert_node(actual, expected)
 
     def test_contentnode_list(self):


### PR DESCRIPTION
## Summary
* Attempt to fix flaky postgres test by explicitly ordering before comparison

## References
Attempts to fix one element of #8255 

## Reviewer guidance
Do all tests still pass?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
