### PR TITLE
Hide Folders tab when no topics available on channel page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -8,7 +8,7 @@
     }"
     :class="position === 'embedded' ? 'side-panel' : ''"
   >
-    <div v-if="topics && topicsListDisplayed">
+    <div v-if="topics && topics.length && topicsListDisplayed">
       <div v-for="t in topics" :key="t.id">
         <KRouterLink
           :text="t.title"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -66,6 +66,7 @@
         <!-- larger screens -->
         <div class="tabs">
           <KRouterLink
+            v-if="topics && topics.length"
             ref="tab_button"
             :to="foldersLink"
             :text="coreString('folders')"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The Folders tab was showing because `[] == true` so I added some `.length` checks to the display logic there.

The issue reports that the problem was that the Folders tab had a worthless "View more" link shown, but I think that the pointless empty tab needed hidden as well. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8701 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do channels like the example one in #8701 have the Folders tab?

Do channels like Kolibri QA Channel (which has folders) show the tab properly?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
