### PR TITLE
Misc Perseus renderer style fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -601,4 +601,34 @@ oriented data synchronization.
     margin: 0;
   }
 
+  .hint-btn-container {
+    display: flex;
+    align-items: center;
+    padding-right: 8px !important;
+    font-size: medium;
+
+    // Ensures the tooltip is visible on the screen in RTL and LTR
+    /deep/ &.rtl {
+      /deep/ .k-tooltip {
+        right: auto !important;
+        left: 0 !important;
+      }
+    }
+
+    /deep/ .k-tooltip {
+      right: 0 !important;
+      left: auto !important;
+      transform: translate3d(0, 23px, 0) !important;
+    }
+  }
+
+  .hint-btn {
+    padding: 0 4px; // Space from btn in RTL and LTR
+    vertical-align: text-bottom;
+
+    /deep/ .link-text {
+      text-align: right;
+    }
+  }
+
 </style>

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -15,7 +15,11 @@
           />
         </div>
         <KGrid>
-          <KGridItem :layout="{ span: 4 }">
+          <!-- Layout notes
+            - Layout12 span8 -> 75% width on windowIsLarge
+            - No other layout definitions means span will be 100%
+          -->
+          <KGridItem :layout12="{ span: 9 }">
             <div
               id="problem-area"
               class="problem-area"
@@ -25,7 +29,7 @@
             </div>
           </KGridItem>
 
-          <KGridItem :layout="{ span: 4 }">
+          <KGridItem :layout12="{ span: 9 }">
             <div v-if="hinted" id="hintlabel" class="hintlabel" :dir="contentDirection">
               {{ $tr("hintLabel") }}
             </div>
@@ -615,34 +619,6 @@
 
   .hintsarea {
     padding-right: 16px;
-  }
-
-  /deep/ .hint-btn-container {
-    display: flex;
-    align-items: center;
-    padding-right: 8px !important;
-    font-size: medium;
-
-    &.rtl {
-      /deep/ .k-tooltip {
-        right: auto !important;
-        left: 0 !important;
-      }
-    }
-
-    /deep/ .k-tooltip {
-      right: 0 !important;
-      left: auto !important;
-      transform: translate3d(0, 23px, 0) !important;
-    }
-  }
-
-  .hint-btn {
-    vertical-align: text-bottom;
-
-    /deep/ .link-text {
-      text-align: right;
-    }
   }
 
   .info-icon {

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -19,7 +19,7 @@
             - Layout12 span8 -> ~66% width on windowIsLarge
             - No other layout definitions means span will be 100%
           -->
-          <KGridItem :layout12="{ span: 9 }">
+          <KGridItem :layout12="{ span: 6 }">
             <div
               id="problem-area"
               class="problem-area"
@@ -29,7 +29,7 @@
             </div>
           </KGridItem>
 
-          <KGridItem :layout12="{ span: 9 }">
+          <KGridItem :layout12="{ span: 6 }">
             <div v-if="hinted" id="hintlabel" class="hintlabel" :dir="contentDirection">
               {{ $tr("hintLabel") }}
             </div>

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -15,7 +15,7 @@
           />
         </div>
         <KGrid>
-          <KGridItem :layout="{ span: 8 }">
+          <KGridItem :layout="{ span: 4 }">
             <div
               id="problem-area"
               class="problem-area"
@@ -603,7 +603,9 @@
   }
 
   .solutionarea {
+    max-width: 100%;
     padding: 0 !important;
+    margin: 0 !important;
     border-bottom-style: none !important;
   }
 
@@ -615,9 +617,10 @@
     padding-right: 16px;
   }
 
-  .hint-btn-container {
+  /deep/ .hint-btn-container {
     display: flex;
     align-items: center;
+    padding-right: 8px !important;
     font-size: medium;
 
     &.rtl {
@@ -652,7 +655,7 @@
   }
 
   .problem-area {
-    padding: 0 16px 16px;
+    padding: 0 16px;
   }
 
   /* Perseus Hacks */
@@ -693,6 +696,11 @@
 
   /deep/ .perseus-renderer {
     padding: 16px;
+  }
+
+  /deep/ .pure-g {
+    // Overrides Perseus smushing the letter spacing on mobile
+    letter-spacing: inherit;
   }
 
 </style>

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -634,6 +634,18 @@
     padding: 0 16px;
   }
 
+  .perseus-mobile {
+    .perseus {
+      padding: 16px;
+    }
+    .problem-area {
+      padding: 0;
+    }
+    /deep/ .perseus-renderer {
+      padding: 0;
+    }
+  }
+
   /* Perseus Hacks */
 
   /* The rest in this <style> block are mostly styles that

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -16,7 +16,7 @@
         </div>
         <KGrid>
           <!-- Layout notes
-            - Layout12 span8 -> 75% width on windowIsLarge
+            - Layout12 span8 -> ~66% width on windowIsLarge
             - No other layout definitions means span will be 100%
           -->
           <KGridItem :layout12="{ span: 9 }">


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Fix error indicated by KFixedGridItem re: too-big span (the red error rectangle)
- CSS was left behind when the LearningActivityBar was moved to AssessmentWrapper - bringing it over fixes the hint tooltip going off screen and aligns the tooltip
- Fix `letter-spacing` being set to some silly number by Perseus, resulting in smushed letters
- #solutionarea is 100% width now to avoid horizontal overflow (it would be larger for no apparent reason)
- Some unnecessary vertical padding removed from .problem-area

BEFORE

https://user-images.githubusercontent.com/6356129/142080682-ae837517-0a54-4c06-80df-9e2c3225a152.mp4


AFTER 

https://user-images.githubusercontent.com/6356129/142080212-a5e52590-13f7-4d32-b4f7-2688abc74dd7.mp4


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

No related issues (that I know of or have seen) - but spurred by notes in Slack from @radinamatic 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

How does it look? Are there any kinds of exercise that I should review specifically? Some of these issues only affect those which have a grid of options and I saw no other issues with the fill-in-the-blank or drag and drop ones I have locally. 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
