### PR TITLE
Updates "View learner devices" link to appear in all reports pages

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -4,7 +4,7 @@
     <slot></slot>
     <div class="report-controls-buttons">
       <KRouterLink
-        v-if="isQuizTab"
+        v-if="isMainReport"
         :text="$tr('viewLearners')"
         appearance="basic-link"
         :to="classLearnersListRoute"
@@ -63,8 +63,13 @@
         // Always disable in app mode until we add the ability to download files.
         return isEmbeddedWebView || this.disableExport;
       },
-      isQuizTab() {
-        return this.$route.name === 'ReportsQuizListPage';
+      isMainReport() {
+        return (
+          this.$route.name === 'ReportsQuizListPage' ||
+          this.$route.name === 'ReportsGroupListPage' ||
+          this.$route.name === 'ReportsLearnerListPage' ||
+          this.$route.name === 'ReportsLessonListPage'
+        );
       },
       classLearnersListRoute() {
         const { query } = this.$route;


### PR DESCRIPTION
## Summary
This PR makes it so that the "View learner devices link" is available for:
- Reports > Lessons
- Reports > Quizzes
- Reports > Groups
- Reports > Learners

![2021-11-16 15 48 14](https://user-images.githubusercontent.com/13563002/142084163-bbed8a05-67ca-45ae-bcc8-ff75f6ae0f2f.gif)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Addresses #8475

## Reviewer guidance
- Double-check to see that no other pages with this `ReportControls` component is showing this link.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
