### PR TITLE
Handle duplicate resources

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useLearnerResources.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useLearnerResources.spec.js
@@ -32,14 +32,42 @@ jest.mock('../useContentNodeProgress');
 
 const TEST_RESUMABLE_CONTENT_NODES = [
   // the following resources are used in classess
-  { id: 'resource-1-in-progress', title: 'Resource 1 (In Progress)' },
-  { id: 'resource-3-in-progress', title: 'Resource 3 (In Progress)' },
-  { id: 'resource-5-in-progress', title: 'Resource 5 (In Progress)' },
-  { id: 'resource-6-in-progress', title: 'Resource 6 (In Progress)' },
-  { id: 'resource-8-in-progress', title: 'Resource 8 (In Progress)' },
+  {
+    id: 'resource-1-in-progress',
+    title: 'Resource 1 (In Progress)',
+    content_id: 'resource-1-in-progress',
+  },
+  {
+    id: 'resource-3-in-progress',
+    title: 'Resource 3 (In Progress)',
+    content_id: 'resource-3-in-progress',
+  },
+  {
+    id: 'resource-5-in-progress',
+    title: 'Resource 5 (In Progress)',
+    content_id: 'resource-5-in-progress',
+  },
+  {
+    id: 'resource-6-in-progress',
+    title: 'Resource 6 (In Progress)',
+    content_id: 'resource-6-in-progress',
+  },
+  {
+    id: 'resource-8-in-progress',
+    title: 'Resource 8 (In Progress)',
+    content_id: 'resource-8-in-progress',
+  },
   // the following resources are not used in classses
-  { id: 'resource-9-in-progress', title: 'Resource 9 (In Progress)' },
-  { id: 'resource-10-in-progress', title: 'Resource 10 (In Progress)' },
+  {
+    id: 'resource-9-in-progress',
+    title: 'Resource 9 (In Progress)',
+    content_id: 'resource-9-in-progress',
+  },
+  {
+    id: 'resource-10-in-progress',
+    title: 'Resource 10 (In Progress)',
+    content_id: 'resource-10-in-progress',
+  },
 ];
 
 const TEST_CLASSES = [

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useSearch.spec.js
@@ -376,7 +376,7 @@ describe(`useSearch`, () => {
       expect(ContentNodeResource.fetchCollection).toHaveBeenCalledWith({ getParams: moreExpected });
     });
     it('should set results, more and labels', async () => {
-      const { labels, more, results, searchMore } = prep({
+      const { labels, more, results, searchMore, search } = prep({
         categories: `test1,test2,${NoCategories}`,
       });
       const expectedLabels = {
@@ -385,7 +385,18 @@ describe(`useSearch`, () => {
       const expectedMore = {
         cursor: 'adalskdjsadlkjsadlkjsalkd',
       };
-      const expectedResults = [{ id: 'node-id1' }];
+      const originalResults = [{ id: 'originalId', content_id: 'first' }];
+      ContentNodeResource.fetchCollection = jest.fn();
+      ContentNodeResource.fetchCollection.mockReturnValue(
+        Promise.resolve({
+          labels: expectedLabels,
+          results: originalResults,
+          more: expectedMore,
+        })
+      );
+      search();
+      await Vue.nextTick();
+      const expectedResults = [{ id: 'node-id1', content_id: 'second' }];
       ContentNodeResource.fetchCollection = jest.fn();
       ContentNodeResource.fetchCollection.mockReturnValue(
         Promise.resolve({
@@ -395,13 +406,11 @@ describe(`useSearch`, () => {
         })
       );
       set(more, {});
-      const originalResults = [{ id: 'originalId' }];
-      set(results, originalResults);
       searchMore();
       await Vue.nextTick();
       expect(get(labels)).toEqual(expectedLabels);
       expect(get(results)).toEqual(
-        originalResults.concat(expectedResults.map(normalizeContentNode))
+        originalResults.concat(expectedResults).map(normalizeContentNode)
       );
       expect(get(more)).toEqual(expectedMore);
     });

--- a/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
@@ -11,6 +11,7 @@ import flatMap from 'lodash/flatMap';
 import flatMapDepth from 'lodash/flatMapDepth';
 
 import { ContentNodeResource } from 'kolibri.resources';
+import { deduplicateResources } from '../utils/contentNode';
 import genContentLink from '../utils/genContentLink';
 import { LearnerClassroomResource } from '../apiResources';
 import { PageNames, ClassesPageNames } from '../constants';
@@ -18,19 +19,19 @@ import { normalizeContentNode } from '../modules/coreLearn/utils';
 import useContentNodeProgress, { setContentNodeProgress } from './useContentNodeProgress';
 
 // The refs are defined in the outer scope so they can be used as a shared store
-const resumableContentNodes = ref([]);
+const _resumableContentNodes = ref([]);
 const moreResumableContentNodes = ref(null);
 const classes = ref([]);
 const { fetchContentNodeProgress } = useContentNodeProgress();
 
 export function setResumableContentNodes(nodes, more = null) {
-  set(resumableContentNodes, nodes.map(normalizeContentNode));
+  set(_resumableContentNodes, nodes.map(normalizeContentNode));
   set(moreResumableContentNodes, more);
   ContentNodeResource.cacheData(nodes);
 }
 
 function addResumableContentNodes(nodes, more = null) {
-  set(resumableContentNodes, [...get(resumableContentNodes), ...nodes.map(normalizeContentNode)]);
+  set(_resumableContentNodes, [...get(_resumableContentNodes), ...nodes.map(normalizeContentNode)]);
   set(moreResumableContentNodes, more);
   ContentNodeResource.cacheData(nodes);
 }
@@ -341,6 +342,10 @@ export default function useLearnerResources() {
       return results;
     });
   }
+
+  const resumableContentNodes = computed(() => {
+    return deduplicateResources(get(_resumableContentNodes));
+  });
 
   return {
     classes,

--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -2,6 +2,7 @@ import { get, set } from '@vueuse/core';
 import { computed, getCurrentInstance, ref, watch } from 'kolibri.lib.vueCompositionApi';
 import { ContentNodeResource } from 'kolibri.resources';
 import { AllCategories, NoCategories } from 'kolibri.coreVue.vuex.constants';
+import { deduplicateResources } from '../utils/contentNode';
 import { normalizeContentNode } from '../modules/coreLearn/utils';
 import useContentNodeProgress from './useContentNodeProgress';
 
@@ -27,7 +28,7 @@ export default function useSearch(store, router) {
 
   const searchLoading = ref(false);
   const moreLoading = ref(false);
-  const results = ref([]);
+  const _results = ref([]);
   const more = ref(null);
   const labels = ref(null);
 
@@ -123,7 +124,7 @@ export default function useSearch(store, router) {
         fetchContentNodeProgress(getParams);
       }
       ContentNodeResource.fetchCollection({ getParams }).then(data => {
-        set(results, (data.results || []).map(normalizeContentNode));
+        set(_results, (data.results || []).map(normalizeContentNode));
         set(more, data.more);
         set(labels, data.labels);
         set(searchLoading, false);
@@ -149,7 +150,7 @@ export default function useSearch(store, router) {
         fetchContentNodeProgress(get(more));
       }
       return ContentNodeResource.fetchCollection({ getParams: get(more) }).then(data => {
-        set(results, [...get(results), ...(data.results || []).map(normalizeContentNode)]);
+        set(_results, [...get(_results), ...(data.results || []).map(normalizeContentNode)]);
         set(more, data.more);
         set(labels, data.labels);
         set(moreLoading, false);
@@ -182,6 +183,10 @@ export default function useSearch(store, router) {
   }
 
   watch(searchTerms, search);
+
+  const results = computed(() => {
+    return deduplicateResources(get(_results));
+  });
 
   return {
     searchTerms,

--- a/kolibri/plugins/learn/assets/src/utils/contentNode.js
+++ b/kolibri/plugins/learn/assets/src/utils/contentNode.js
@@ -1,0 +1,30 @@
+import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
+import { currentLanguage } from 'kolibri.utils.i18n';
+
+export function deduplicateResources(contentNodes) {
+  const grouped = groupBy(contentNodes, 'content_id');
+  return Object.keys(grouped).map(key => {
+    const groupedNodes = grouped[key];
+    if (groupedNodes.length === 1) {
+      return groupedNodes[0];
+    }
+    const langCode = currentLanguage.split('-')[0];
+    const sortedNodes = sortBy(groupedNodes, n => {
+      if (n.lang && n.lang.id === currentLanguage) {
+        // Best language match return 0 to sort first
+        return 0;
+      }
+      if (n.lang && n.lang.lang_code === langCode) {
+        // lang_code match, so next best
+        return 1;
+      }
+      // Everything else
+      return 2;
+    });
+    const primaryNode = sortedNodes[0];
+    // Include self in copies
+    primaryNode.copies = sortedNodes;
+    return primaryNode;
+  });
+}

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -16,17 +16,9 @@
         :numCoachContents="content.num_coach_contents"
         :link="genChannelLink(content.id, content.is_leaf)"
         :contentId="content.content_id"
-        :copiesCount="content.copies_count"
-        @openCopiesModal="openCopiesModal"
       />
     </KGridItem>
 
-    <CopiesModal
-      v-if="modalIsOpen"
-      :uniqueId="uniqueId"
-      :sharedContentId="sharedContentId"
-      @submit="modalIsOpen = false"
-    />
   </KGrid>
 
 </template>
@@ -37,13 +29,11 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { PageNames } from '../constants';
   import ChannelCard from './ChannelCard';
-  import CopiesModal from './CopiesModal';
 
   export default {
     name: 'ChannelCardGroupGrid',
     components: {
       ChannelCard,
-      CopiesModal,
     },
     mixins: [responsiveWindowMixin],
     props: {
@@ -52,11 +42,6 @@
         required: true,
       },
     },
-    data: () => ({
-      modalIsOpen: false,
-      sharedContentId: null,
-      uniqueId: null,
-    }),
     computed: {
       cardColumnSpan() {
         if (this.windowBreakpoint <= 2) return 4;
@@ -71,11 +56,6 @@
           name: PageNames.TOPICS_TOPIC,
           params: { id },
         };
-      },
-      openCopiesModal(contentId) {
-        this.sharedContentId = contentId;
-        this.uniqueId = this.contents.find(content => content.content_id === contentId).id;
-        this.modalIsOpen = true;
       },
       getTagLine(content) {
         return content.tagline || content.description;

--- a/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
+++ b/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
@@ -19,16 +19,16 @@
         >
           <div class="title">
             <KRouterLink
-              :text="copy[copy.length - 1].title"
-              :to="generateCopyLink(copy[copy.length - 1].id)"
+              :text="copy.title"
+              :to="genContentLink(copy)"
             />
           </div>
           <ol>
             <li
-              v-for="(ancestor, index2) in copy.slice(0, -1)"
+              v-for="(ancestor, index2) in copy.ancestors"
               :key="index2"
               class="ancestor"
-              :class="{ 'arrow': index2 < copy.slice(0, -1).length - 1 }"
+              :class="{ 'arrow': index2 < copy.ancestors.length - 1 }"
             >
               {{ ancestor.title }}
             </li>
@@ -43,51 +43,19 @@
 
 <script>
 
-  import toArray from 'lodash/toArray';
-  import { mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import sortBy from 'lodash/sortBy';
-  import { PageNames } from '../constants';
 
   export default {
     name: 'CopiesModal',
     mixins: [commonCoreStrings],
     props: {
-      uniqueId: {
-        type: String,
+      copies: {
+        type: Array,
         required: true,
       },
-      sharedContentId: {
-        type: String,
+      genContentLink: {
+        type: Function,
         required: true,
-      },
-    },
-    data() {
-      return {
-        loading: true,
-        copies: [],
-      };
-    },
-    created() {
-      this.getCopies(this.sharedContentId).then(copies => {
-        // transform the copies objects from Array<Object> to Array<Array>
-        const arrayedCopies = copies.map(copy => {
-          return toArray(copy);
-        });
-        this.copies = sortBy(arrayedCopies, copy => copy[copy.length - 1].id !== this.uniqueId);
-        this.loading = false;
-      });
-    },
-    methods: {
-      ...mapActions(['getCopies']),
-      generateCopyLink(id) {
-        return {
-          name: PageNames.TOPICS_CONTENT,
-          params: { id },
-          query: {
-            searchTerm: this.$route.query.searchTerm || '',
-          },
-        };
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
+++ b/kolibri/plugins/learn/assets/src/views/CopiesModal.vue
@@ -6,12 +6,7 @@
     @submit="$emit('submit')"
   >
     <transition mode="out-in">
-
-      <KCircularLoader
-        v-if="loading"
-        :delay="false"
-      />
-      <ul v-else>
+      <ul>
         <li
           v-for="(copy, index) in copies"
           :key="index"

--- a/kolibri/plugins/learn/assets/src/views/HomePage/ContinueLearning.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/ContinueLearning.vue
@@ -33,16 +33,24 @@
           :contentNode="contentNode"
           :to="getTopicContentNodeLink(contentNode.id)"
           :collectionTitle="getContentNodeTopicName(contentNode)"
+          @openCopiesModal="openCopiesModal"
         />
-        <KButton
-          v-if="moreResumableContentNodes"
-          appearance="basic-link"
-          @click="fetchMoreResumableContentNodes"
-        >
-          {{ coreString('viewMoreAction') }}
-        </KButton>
       </template>
     </CardGrid>
+    <KButton
+      v-if="moreResumableContentNodes"
+      style="margin-top: 16px;"
+      appearance="basic-link"
+      @click="fetchMoreResumableContentNodes"
+    >
+      {{ coreString('viewMoreAction') }}
+    </KButton>
+    <CopiesModal
+      v-if="displayedCopies.length"
+      :copies="displayedCopies"
+      :genContentLink="contentNode => getTopicContentNodeLink(contentNode.id)"
+      @submit="displayedCopies = []"
+    />
   </section>
 
 </template>
@@ -58,6 +66,7 @@
   import CardGrid from '../cards/CardGrid';
   import QuizCard from '../cards/QuizCard';
   import ResourceCard from '../cards/ResourceCard';
+  import CopiesModal from '../CopiesModal';
   import useLearnerResources from '../../composables/useLearnerResources';
 
   /**
@@ -69,6 +78,7 @@
       CardGrid,
       ResourceCard,
       QuizCard,
+      CopiesModal,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -134,11 +144,21 @@
         default: false,
       },
     },
+    data() {
+      return {
+        displayedCopies: [],
+      };
+    },
     computed: {
       header() {
         return this.fromClasses
           ? this.$tr('continueLearningFromClassesHeader')
           : this.$tr('continueLearningOnYourOwnHeader');
+      },
+    },
+    methods: {
+      openCopiesModal(copies) {
+        this.displayedCopies = copies;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -12,7 +12,7 @@
           :isMobile="windowIsSmall"
           :content="content"
           :thumbnail="content.thumbnail"
-          :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
+          :link="genContentLink(content)"
           @openCopiesModal="openCopiesModal"
           @toggleInfoPanel="$emit('toggleInfoPanel', content)"
         />
@@ -26,7 +26,7 @@
         :thumbnail="content.thumbnail || getContentNodeThumbnail(content)"
         class="card-grid-item"
         :isMobile="windowIsSmall"
-        :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
+        :link="genContentLink(content)"
       />
     </div>
     <CardGrid
@@ -37,7 +37,7 @@
 
         :key="`resource-${idx}`"
         :contentNode="content"
-        :to="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
+        :to="genContentLink(content)"
       />
     </CardGrid>
 
@@ -50,7 +50,7 @@
       :currentPage="currentPage"
       class="card-grid-item"
       :isMobile="windowIsSmall"
-      :link="genContentLink(content.id, topicId, content.is_leaf, backRoute, context)"
+      :link="genContentLink(content)"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
       @openCopiesModal="openCopiesModal"
@@ -58,10 +58,10 @@
       @removeFromBookmarks="removeFromBookmarks(content, contents)"
     />
     <CopiesModal
-      v-if="modalIsOpen"
-      :uniqueId="uniqueId"
-      :sharedContentId="sharedContentId"
-      @submit="modalIsOpen = false"
+      v-if="displayedCopies.length"
+      :copies="displayedCopies"
+      :genContentLink="genContentLink"
+      @submit="displayedCopies = []"
     />
   </div>
 
@@ -127,9 +127,7 @@
       },
     },
     data: () => ({
-      modalIsOpen: false,
-      sharedContentId: null,
-      uniqueId: null,
+      displayedCopies: [],
     }),
     computed: {
       ...mapState(['pageName']),
@@ -165,11 +163,17 @@
       },
     },
     methods: {
-      genContentLink,
-      openCopiesModal(contentId) {
-        this.sharedContentId = contentId;
-        this.uniqueId = this.contents.find(content => content.content_id === contentId).id;
-        this.modalIsOpen = true;
+      genContentLink(content) {
+        return genContentLink(
+          content.id,
+          this.topicId,
+          content.is_leaf,
+          this.backRoute,
+          this.context
+        );
+      },
+      openCopiesModal(copies) {
+        this.displayedCopies = copies;
       },
       removeFromBookmarks(content, contents) {
         return this.$emit('removeFromBookmarks', content.bookmark, contents.indexOf(content));

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -68,11 +68,10 @@
           @click="$emit('toggleInfoPanel')"
         />
         <KButton
-          v-if="content.copies_count > 1"
+          v-if="content.copies"
           appearance="basic-link"
-          class="copies"
-          :text="coreString('copies', { num: content.copies_count })"
-          @click.prevent="$emit('openCopiesModal', contentId)"
+          :text="coreString('copies', { num: content.copies.length })"
+          @click.prevent="$emit('openCopiesModal', content.copies)"
         />
         <slot name="actions"></slot>
       </div>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -58,12 +58,12 @@
           class="channel-logo"
         >
         <KButton
-          v-if="!isMobile && isLibraryPage && content.copies_count && (content.copies_count > 0)"
+          v-if="!isMobile && isLibraryPage && content.copies"
           appearance="basic-link"
           class="copies"
           :style="{ color: $themeTokens.text }"
-          :text="coreString('copies', { num: content.copies_count })"
-          @click.prevent="$emit('openCopiesModal', contentId)"
+          :text="coreString('copies', { num: content.copies.length })"
+          @click.prevent="$emit('openCopiesModal', content.copies)"
         />
       </span>
     </router-link>
@@ -136,10 +136,6 @@
       isMobile: {
         type: Boolean,
         default: false,
-      },
-      contentId: {
-        type: String,
-        default: null,
       },
       currentPage: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
@@ -12,6 +12,13 @@
     </template>
     <template #topRight>
       <LearningActivityLabel :contentNode="contentNode" />
+      <KButton
+        v-if="contentNode.copies"
+        appearance="basic-link"
+        class="copies"
+        :text="coreString('copies', { num: contentNode.copies.length })"
+        @click.prevent="$emit('openCopiesModal', contentNode.copies)"
+      />
     </template>
 
     <template #progress>
@@ -24,6 +31,7 @@
 
 <script>
 
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ContentNodeThumbnail from '../../thumbnails/ContentNodeThumbnail';
   import ProgressBar from '../../ProgressBar';
   import BaseCard from '../BaseCard';
@@ -37,6 +45,7 @@
       LearningActivityLabel,
       ProgressBar,
     },
+    mixins: [commonCoreStrings],
     props: {
       contentNode: {
         type: Object,
@@ -63,3 +72,12 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .copies {
+    float: right;
+  }
+
+</style>


### PR DESCRIPTION
## Summary
* Adds utility function for deduplicating arrays of ContentNodes by content_id
* Groups together and then adds a `copies` property to the ContentNodes with all of the nodes therein
* Uses currently activated language code in an attempt to surface the most relevant node to the user out of the duplicates
* Uses this in both search results and resumable content node display

## References
Fixes #8700
Fixes #8498

## Reviewer guidance
Does the styling and placement of everything look correct?

Flagging that this does produce slightly unpredictable counts of search results due to the deduplication, but I think it is still preferable to displaying the duplicates, especially in restricted searches.

Resume duplicates
![resumeduplicate](https://user-images.githubusercontent.com/1680573/142088760-1e8ea05c-d8b4-440a-b540-4c98f4f55a47.gif)

Search duplicates (failure to render is because I don't actually have the exercise imported locally)
![searchduplicates](https://user-images.githubusercontent.com/1680573/142088791-c2c505ad-f26c-4983-91b4-d0179ce804c8.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
