### PR TITLE
Fix undefined string. Add tooltip and aria label for button.

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -22,6 +22,8 @@
           <KIconButton
             icon="close"
             class="close-button"
+            :ariaLabel="coreString('close')"
+            :tooltip="coreString('close')"
             @click="closePanel"
           />
         </div>
@@ -65,6 +67,7 @@
 <script>
 
   import Backdrop from 'kolibri.coreVue.components.Backdrop';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   //import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   //import SidePanelResourcesList from './SidePanelResourcesList';
@@ -75,7 +78,7 @@
       Backdrop,
       //SidePanelResourcesList,
     },
-    mixins: [responsiveWindowMixin],
+    mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
       closeButtonHidden: {
         type: Boolean,

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -160,9 +160,9 @@
       <KIconButton
         v-if="windowIsSmall && currentCategory"
         icon="back"
-        :ariaLabel="coreString('back')"
+        :ariaLabel="coreString('goBackAction')"
         :color="$themeTokens.text"
-        :tooltip="coreString('back')"
+        :tooltip="coreString('goBackAction')"
         @click="closeCategoryModal"
       />
       <EmbeddedSidePanel


### PR DESCRIPTION
## Summary
* Changes referent for string to `goBackAction` from `back`
* Adds tooltip and aria label for close button

## References
Fixes #8707

## Reviewer guidance

Tooltip displaying properly:
![Screenshot from 2021-11-16 17-37-09](https://user-images.githubusercontent.com/1680573/142093311-d7346292-df61-4adb-b599-df2fa1e55399.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
