### PR TITLE
Added missing pluralization

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1072,20 +1072,24 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
       'Label in the dropdown menu where one can choose an attempt from their five most recent attempts at a practice quiz',
   },
   practiceQuizReportFasterSuggestedLabel: {
-    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the suggested time',
+    message:
+      '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the suggested time',
     context: 'Indicates to the learner how many minutes faster they were than the suggested time',
   },
   practiceQuizReportSlowerSuggestedLabel: {
-    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the suggested time',
+    message:
+      '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the suggested time',
     context: 'Indicates to the learner how many minutes slower they were than the suggested time',
   },
   practiceQuizReportFasterTimeLabel: {
-    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the previous attempt',
+    message:
+      '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the previous attempt',
     context:
       'Indicates to the learner how much faster they were on this attempt compared to the previous one',
   },
   practiceQuizReportSlowerTimeLabel: {
-    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the previous attempt',
+    message:
+      '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the previous attempt',
     context:
       'Indicates to the learner how much slower they were on this attempt compared to the previous one',
   },

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1072,20 +1072,20 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
       'Label in the dropdown menu where one can choose an attempt from their five most recent attempts at a practice quiz',
   },
   practiceQuizReportFasterSuggestedLabel: {
-    message: '{value, number, integer} minutes faster than the suggested time',
+    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the suggested time',
     context: 'Indicates to the learner how many minutes faster they were than the suggested time',
   },
   practiceQuizReportSlowerSuggestedLabel: {
-    message: '{value, number, integer} minutes slower than the suggested time',
+    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the suggested time',
     context: 'Indicates to the learner how many minutes slower they were than the suggested time',
   },
   practiceQuizReportFasterTimeLabel: {
-    message: '{value, number, integer} minutes faster than the previous attempt',
+    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} faster than the previous attempt',
     context:
       'Indicates to the learner how much faster they were on this attempt compared to the previous one',
   },
   practiceQuizReportSlowerTimeLabel: {
-    message: '{value, number, integer} minutes slower than the previous attempt',
+    message: '{value, number, integer} {value, plural, one {minute} other {minutes}} slower than the previous attempt',
     context:
       'Indicates to the learner how much slower they were on this attempt compared to the previous one',
   },


### PR DESCRIPTION

## Summary
Four instances of missing pluralization discovered while translating the past papers strings on Crowdin

## References
…

## Reviewer guidance
Is the pluralization now correct?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
