### PR TITLE
fixed view-as-grid and as-list button active state

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -29,6 +29,7 @@
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsList')"
             @click="toggleCardView('list')"
+            :disabled="currentViewStyle === 'list'"
           />
           <KIconButton
             icon="channel"
@@ -36,6 +37,7 @@
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsGrid')"
             @click="toggleCardView('card')"
+            :disabled="currentViewStyle === 'card'"
           />
         </div>
         <h2 v-if="resumableContentNodes.length">
@@ -82,6 +84,7 @@
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsList')"
             @click="toggleCardView('list')"
+            :disabled="currentViewStyle === 'list'"
           />
           <KIconButton
             icon="channel"
@@ -89,6 +92,7 @@
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsGrid')"
             @click="toggleCardView('card')"
+            :disabled="currentViewStyle === 'card'"
           />
         </div>
         <SearchChips

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -28,16 +28,16 @@
             :ariaLabel="$tr('viewAsList')"
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsList')"
-            @click="toggleCardView('list')"
             :disabled="currentViewStyle === 'list'"
+            @click="toggleCardView('list')"
           />
           <KIconButton
             icon="channel"
             :ariaLabel="$tr('viewAsGrid')"
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsGrid')"
-            @click="toggleCardView('card')"
             :disabled="currentViewStyle === 'card'"
+            @click="toggleCardView('card')"
           />
         </div>
         <h2 v-if="resumableContentNodes.length">
@@ -83,16 +83,16 @@
             :ariaLabel="$tr('viewAsList')"
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsList')"
+            :disabled="currentViewStyle === 'list'"
             @click="toggleCardView('list')"
-            :disabled="currentViewStyle === 'list'" 
           />
           <KIconButton
             icon="channel"
             :ariaLabel="$tr('viewAsGrid')"
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsGrid')"
-            @click="toggleCardView('card')"
             :disabled="currentViewStyle === 'card'"
+            @click="toggleCardView('card')"
           />
         </div>
         <SearchChips

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -84,7 +84,7 @@
             :color="$themeTokens.text"
             :tooltip="$tr('viewAsList')"
             @click="toggleCardView('list')"
-            :disabled="currentViewStyle === 'list'"
+            :disabled="currentViewStyle === 'list'" 
           />
           <KIconButton
             icon="channel"


### PR DESCRIPTION
## Summary

* Added conditions to disable view-as-grid and view-as-list button 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

* closes #8669

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

You can check the buttons at learn

![screenrecording](https://user-images.githubusercontent.com/53405133/141775100-6596a97c-3380-4768-ad5b-501fc32ea2e8.gif)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
