### PR TITLE
'basic link' button and inline with number in Coach

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -38,6 +38,7 @@
               :text="$tr('viewLearners')"
               appearance="basic-link"
               :to="classLearnersListRoute"
+              style="margin-left: 24 px;"
             />
           </template>
         </template>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -33,17 +33,13 @@
         </template>
         <template #value>
           {{ $formatNumber(learnerNames.length) }}
-        </template>
-      </HeaderTableRow>
-      <HeaderTableRow v-if="learnerNames.length > 0">
-        <template #key>
-        </template>
-        <template #value>
-          <KRouterLink
-            :text="$tr('viewLearners')"
-            appearance="raised-button"
-            :to="classLearnersListRoute"
-          />
+          <template v-if="learnerNames.length > 0">
+            <KRouterLink
+              :text="$tr('viewLearners')"
+              appearance="basic-link"
+              :to="classLearnersListRoute"
+            />
+          </template>
         </template>
       </HeaderTableRow>
     </HeaderTable>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Fixes #8629 
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
view learners' button in Coach has incorrect styling
Button is a 'basic link' and inline with number, not on next line
![image](https://user-images.githubusercontent.com/10187395/142198367-4c9b2075-e3cc-494a-9994-6d742396fd19.png)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/8629

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
is it okay? Do I need modify more?
![image](https://user-images.githubusercontent.com/10187395/142198676-816970af-040f-465d-a0db-7242562529c0.png)


----

## Testing checklist

- [-] Contributor has fully tested the PR manually
- [-] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [-] PR has the correct target branch and milestone
- [-] PR has 'needs review' or 'work-in-progress'   ##label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
