### PR TITLE
Don't show home page for guest users.

### DIFF
--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -46,7 +46,10 @@ export default [
     name: PageNames.ROOT,
     path: '/',
     handler: () => {
-      return router.replace({ name: PageNames.HOME });
+      if (get(isUserLoggedIn)) {
+        return router.replace({ name: PageNames.HOME });
+      }
+      return router.replace({ name: PageNames.LIBRARY });
     },
   },
   {
@@ -58,15 +61,16 @@ export default [
         router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
         return;
       }
-      const promises = [];
-      // force fetch classes and resumable content nodes to make sure that the home
-      // page is up-to-date when navigating to other 'Learn' pages and then back
-      // to the home page
-      if (get(isUserLoggedIn)) {
-        promises.push(hydrateHomePage());
+
+      if (!get(isUserLoggedIn)) {
+        router.replace({ name: PageNames.LIBRARY });
+        return;
       }
       return store.dispatch('loading').then(() => {
-        return Promise.all(promises)
+        // force fetch classes and resumable content nodes to make sure that the home
+        // page is up-to-date when navigating to other 'Learn' pages and then back
+        // to the home page
+        return hydrateHomePage()
           .then(() => {
             store.commit('SET_PAGE_NAME', PageNames.HOME);
             store.dispatch('notLoading');

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -2,6 +2,7 @@
 
   <Navbar>
     <NavbarLink
+      v-if="isUserLoggedIn"
       :title="coreString('homeLabel')"
       :link="homePageLink"
     >

--- a/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-index.spec.js
@@ -106,9 +106,8 @@ describe('learn plugin index page', () => {
       setSessionUserKind('anonymous');
       setMemberships([]);
       const wrapper = makeWrapper({ store });
-      const { tabLinks, homeLink, libraryLink } = getElements(wrapper);
-      expect(tabLinks().length).toEqual(2);
-      expect(homeLink().element.tagName).toBe('A');
+      const { tabLinks, libraryLink } = getElements(wrapper);
+      expect(tabLinks().length).toEqual(1);
       expect(libraryLink().element.tagName).toBe('A');
     });
 
@@ -128,7 +127,7 @@ describe('learn plugin index page', () => {
       setMemberships([]);
       const wrapper = makeWrapper({ store });
       const { classesLink, tabLinks } = getElements(wrapper);
-      expect(tabLinks().length).toEqual(2);
+      expect(tabLinks().length).toEqual(1);
       expect(!classesLink().exists()).toEqual(true);
     });
 
@@ -147,13 +146,12 @@ describe('learn plugin index page', () => {
       setCanAccessUnassignedContent(false);
     });
 
-    it('only the home tab is available when not signed-in', () => {
+    it('no tab is available when not signed-in', () => {
       setSessionUserKind('anonymous');
       setMemberships([]);
       const wrapper = makeWrapper({ store });
-      const { tabLinks, homeLink } = getElements(wrapper);
-      expect(tabLinks().length).toEqual(1);
-      expect(homeLink().element.tagName).toBe('A');
+      const { tabLinks } = getElements(wrapper);
+      expect(tabLinks().length).toEqual(0);
     });
 
     it('the home and classes tab is available if signed in', () => {


### PR DESCRIPTION
## Summary
* Hides Home page if user is not logged in
* Redirects from root to Library if user is not logged in
* Redirects from home to Library if user is not logged in

## References
Gives guest access directly to the library rather than the more limited guest home page

## Reviewer guidance
![Screenshot from 2021-11-17 12-58-16](https://user-images.githubusercontent.com/1680573/142281552-0e6deb98-ce04-443e-9c13-befca67dda5c.png)

![guestlearn](https://user-images.githubusercontent.com/1680573/142281565-dc9b5a38-6b77-44ad-a7cc-9ede5441aa57.gif)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
