### PR TITLE
upgrade caniuse-lite

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4007,25 +4007,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001061:
-  version "1.0.30001066"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001066.tgz#0a8a58a10108f2b9bf38e7b65c237b12fd9c5f04"
-  integrity sha512-Gfj/WAastBtfxLws0RCh2sDbTK/8rJuSeZMecrSkNGYxPcv7EzblmDGfWQCFEQcSqYE2BRgQiJh8HOD07N5hIw==
-
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
-  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
-
-caniuse-lite@^1.0.30001166:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
-
-caniuse-lite@^1.0.30001181:
-  version "1.0.30001208"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz#a999014a35cebd4f98c405930a057a0d75352eb9"
-  integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001061, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001166, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001219:
+  version "1.0.30001282"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz"
+  integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION

## Summary

Upgrades `caniuse-lite` by running `npx browserslist@latest --update-db`:

```bash
❯ npx browserslist@latest --update-db
npx: installed 6 in 2.596s
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001282
Installed versions: 1.0.30001066, 1.0.30001208, 1.0.30001237, 1.0.30001239
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ yarn add -W caniuse-lite

warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > hashi > eslint-plugin-compat@3.9.0" has unmet peer dependency "eslint@^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > hashi > html-webpack-plugin@4.5.2" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > @vue/test-utils@1.0.3" has unmet peer dependency "vue@2.x".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > eslint-config-vue@2.0.2" has incorrect peer dependency "eslint@^2.0.0 || ^3.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > eslint-config-vue@2.0.2" has incorrect peer dependency "eslint-plugin-vue@^1.0.0 || ^2.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > postcss-loader@4.3.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > vue-jest@2.6.0" has unmet peer dependency "vue@^2.x".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-document-epub-render-plugin > vue-focus-lock@1.4.0" has unmet peer dependency "vue@^2.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-document-pdf-render-plugin > vue-virtual-scroller@0.12.0" has unmet peer dependency "vue@^2.5.2".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-perseus-viewer > string-replace-loader@3.0.3" has unmet peer dependency "webpack@^5".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > stylelint-config-recess-order > stylelint-order@4.0.0" has incorrect peer dependency "stylelint@^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-document-pdf-render-plugin > pdfjs-dist > worker-loader@1.1.1" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-document-pdf-render-plugin > vue-virtual-scroller > vue-resize@0.4.5" has unmet peer dependency "vue@^2.3.0".
warning "workspace-aggregator-001fc789-540f-4de3-afeb-c05930fafd6d > kolibri-tools > eslint-plugin-jest > @typescript-eslint/experimental-utils > @typescript-eslint/typescript-estree > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
Cleaning package.json dependencies from caniuse-lite
$ yarn remove -W caniuse-lite
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > hashi > eslint-plugin-compat@3.9.0" has unmet peer dependency "eslint@^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > hashi > html-webpack-plugin@4.5.2" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > @vue/test-utils@1.0.3" has unmet peer dependency "vue@2.x".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > eslint-config-vue@2.0.2" has incorrect peer dependency "eslint@^2.0.0 || ^3.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > eslint-config-vue@2.0.2" has incorrect peer dependency "eslint-plugin-vue@^1.0.0 || ^2.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > postcss-loader@4.3.0" has unmet peer dependency "postcss@^7.0.0 || ^8.0.1".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > vue-jest@2.6.0" has unmet peer dependency "vue@^2.x".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-document-epub-render-plugin > vue-focus-lock@1.4.0" has unmet peer dependency "vue@^2.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-document-pdf-render-plugin > vue-virtual-scroller@0.12.0" has unmet peer dependency "vue@^2.5.2".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-perseus-viewer > string-replace-loader@3.0.3" has unmet peer dependency "webpack@^5".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > stylelint-config-recess-order > stylelint-order@4.0.0" has incorrect peer dependency "stylelint@^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-document-pdf-render-plugin > pdfjs-dist > worker-loader@1.1.1" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-document-pdf-render-plugin > vue-virtual-scroller > vue-resize@0.4.5" has unmet peer dependency "vue@^2.3.0".
warning "workspace-aggregator-47b66845-e996-4110-ba27-4d4198469016 > kolibri-tools > eslint-plugin-jest > @typescript-eslint/experimental-utils > @typescript-eslint/typescript-estree > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
caniuse-lite has been successfully updated
```

Target browser changes:

```diff
- and_chr 89
+ and_chr 95
- and_ff 86
+ and_ff 92
- android 89
+ android 95
+ chrome 96
+ chrome 95
+ chrome 94
+ chrome 93
+ chrome 92
+ chrome 91
+ chrome 90
+ edge 95
+ edge 94
+ edge 93
+ edge 92
+ edge 91
+ edge 90
+ firefox 94
+ firefox 93
+ firefox 92
+ firefox 91
+ firefox 90
+ firefox 89
+ firefox 88
- ios_saf 14.0-14.5
- ios_saf 12.2-12.4
+ ios_saf 15
+ ios_saf 14.5-14.8
+ ios_saf 14.0-14.4
+ ios_saf 12.2-12.5
+ opera 81
+ opera 80
+ opera 79
+ opera 78
+ opera 77
+ opera 76
+ opera 75
+ opera 74
+ safari 15.1
+ safari 15
+ safari 14.1
+ samsung 15.0
+ samsung 14.0
```


## References

fixes #8728 

## Reviewer guidance

Updating did not seem to require any package.json changes after all, which is probably a good thing.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
