### PR TITLE
Update the content cache key after annotating

### DIFF
--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -29,6 +29,7 @@ from kolibri.core.content.utils.search import annotate_label_bitmasks
 from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
 from kolibri.core.content.utils.sqlalchemybridge import Bridge
 from kolibri.core.content.utils.tree import get_channel_node_depth
+from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.upgrade import version_upgrade
 
 
@@ -307,3 +308,4 @@ def metadata_annotation_update():
 
     for channel_id in ChannelMetadata.objects.values_list("id", flat=True):
         set_channel_ancestors(channel_id)
+    ContentCacheKey.update_cache_key()


### PR DESCRIPTION
## Summary
* Fixes possible bug for upgrade scenarios where new annotations would not be present due to caching

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
