### PR TITLE
Allow facility forking and recreation

### DIFF
--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -1,64 +1,22 @@
 import logging
 from contextlib import contextmanager
 
-from django.contrib.admin.models import LogEntry
 from django.core.management.base import CommandError
 from django.db import transaction
-from django.db.models import Q
-from morango.models import Buffer
-from morango.models import Certificate
-from morango.models import DatabaseMaxCounter
-from morango.models import RecordMaxCounter
-from morango.models import RecordMaxCounterBuffer
-from morango.models import Store
-from morango.models import SyncSession
-from morango.models import TransferSession
 
-from kolibri.core.analytics.models import PingbackNotificationDismissed
-from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.management.utils import get_facility
-from kolibri.core.auth.management.utils import GroupDeletion
-from kolibri.core.auth.models import AdHocGroup
-from kolibri.core.auth.models import Classroom
-from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import dataset_cache
-from kolibri.core.auth.models import FacilityDataset
-from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.models import LearnerGroup
-from kolibri.core.auth.models import Membership
-from kolibri.core.auth.models import Role
-from kolibri.core.auth.utils import confirm_or_exit
-from kolibri.core.device.models import DevicePermissions
-from kolibri.core.exams.models import Exam
-from kolibri.core.exams.models import ExamAssignment
-from kolibri.core.lessons.models import Lesson
-from kolibri.core.lessons.models import LessonAssignment
-from kolibri.core.logger.models import AttemptLog
-from kolibri.core.logger.models import ContentSessionLog
-from kolibri.core.logger.models import ContentSummaryLog
-from kolibri.core.logger.models import ExamAttemptLog
-from kolibri.core.logger.models import ExamLog
-from kolibri.core.logger.models import MasteryLog
-from kolibri.core.logger.models import UserSessionLog
+from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
+from kolibri.core.auth.utils.delete import get_delete_group_for_facility
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
 
 logger = logging.getLogger(__name__)
 
 
-def chunk(things, size):
-    """
-    Chunk generator
-
-    :type things: list
-    :type size: int
-    """
-    for i in range(0, len(things), size):
-        yield things[i : i + size]
-
-
 class Command(AsyncCommand):
-    help = "This command initiates the deletion process for a facility and all of it's related data."
+    help = "This command initiates the deletion process for a facility and all of its related data."
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -95,17 +53,7 @@ class Command(AsyncCommand):
                 "ARE YOU SURE? If you do this, there is no way to recover the facility data on this device."
             )
 
-        # everything should get cascade deleted from the facility, but we'll check anyway
-        delete_group = GroupDeletion(
-            "Main",
-            groups=[
-                self._get_morango_models(dataset_id),
-                self._get_log_models(dataset_id),
-                self._get_class_models(dataset_id),
-                self._get_users(dataset_id),
-                self._get_facility_dataset(dataset_id),
-            ],
-        )
+        delete_group = get_delete_group_for_facility(facility)
 
         logger.info(
             "Proceeding with facility deletion. Deleting all data for facility <{}>".format(
@@ -147,110 +95,3 @@ class Command(AsyncCommand):
     def _delete_context(self):
         with DisablePostDeleteSignal(), transaction.atomic():
             yield
-
-    def _get_facility_dataset(self, dataset_id):
-        return FacilityDataset.objects.filter(id=dataset_id)
-
-    def _get_certificates(self, dataset_id):
-        return (
-            Certificate.objects.filter(id=dataset_id)
-            .get_descendants(include_self=True)
-            .exclude(_private_key=None)
-        )
-
-    def _get_users(self, dataset_id):
-        user_id_filter = Q(
-            user_id__in=FacilityUser.objects.filter(dataset_id=dataset_id).values_list(
-                "pk", flat=True
-            )
-        )
-        dataset_id_filter = Q(dataset_id=dataset_id)
-
-        return GroupDeletion(
-            "User models",
-            querysets=[
-                LogEntry.objects.filter(user_id_filter),
-                DevicePermissions.objects.filter(user_id_filter),
-                PingbackNotificationDismissed.objects.filter(user_id_filter),
-                Collection.objects.filter(
-                    Q(parent_id__isnull=True) & dataset_id_filter
-                ),
-                Role.objects.filter(dataset_id_filter),
-                Membership.objects.filter(dataset_id_filter),
-                FacilityUser.objects.filter(dataset_id_filter),
-            ],
-        )
-
-    def _get_class_models(self, dataset_id):
-        dataset_id_filter = Q(dataset_id=dataset_id)
-        return GroupDeletion(
-            "Class models",
-            querysets=[
-                ExamAssignment.objects.filter(dataset_id_filter),
-                Exam.objects.filter(dataset_id_filter),
-                LessonAssignment.objects.filter(dataset_id_filter),
-                Lesson.objects.filter(dataset_id_filter),
-                AdHocGroup.objects.filter(dataset_id_filter),
-                LearnerGroup.objects.filter(dataset_id_filter),
-                Classroom.objects.filter(dataset_id_filter),
-            ],
-        )
-
-    def _get_log_models(self, dataset_id):
-        dataset_id_filter = Q(dataset_id=dataset_id)
-        return GroupDeletion(
-            "Log models",
-            querysets=[
-                ContentSessionLog.objects.filter(dataset_id_filter),
-                ContentSummaryLog.objects.filter(dataset_id_filter),
-                AttemptLog.objects.filter(dataset_id_filter),
-                ExamAttemptLog.objects.filter(dataset_id_filter),
-                ExamLog.objects.filter(dataset_id_filter),
-                MasteryLog.objects.filter(dataset_id_filter),
-                UserSessionLog.objects.filter(dataset_id_filter),
-            ],
-        )
-
-    def _get_morango_models(self, dataset_id):
-        querysets = [
-            DatabaseMaxCounter.objects.filter(partition__startswith=dataset_id)
-        ]
-
-        stores = Store.objects.filter(partition__startswith=dataset_id)
-        store_ids = stores.values_list("pk", flat=True)
-
-        for store_ids_chunk in chunk(list(store_ids), 300):
-            querysets.append(
-                RecordMaxCounter.objects.filter(store_model_id__in=store_ids_chunk)
-            )
-
-        # append after RecordMaxCounter
-        querysets.append(stores)
-
-        certificates = self._get_certificates(dataset_id)
-        certificate_ids = certificates.distinct().values_list("pk", flat=True)
-
-        for certificate_id_chunk in chunk(certificate_ids, 300):
-            sync_sessions = SyncSession.objects.filter(
-                Q(client_certificate_id__in=certificate_id_chunk)
-                | Q(server_certificate_id__in=certificate_id_chunk)
-            )
-            sync_session_ids = sync_sessions.distinct().values_list("pk", flat=True)
-            transfer_sessions = TransferSession.objects.filter(
-                sync_session_id__in=sync_session_ids
-            )
-            transfer_session_filter = Q(
-                transfer_session_id__in=transfer_sessions.values_list("pk", flat=True)
-            )
-
-            querysets.extend(
-                [
-                    RecordMaxCounterBuffer.objects.filter(transfer_session_filter),
-                    Buffer.objects.filter(transfer_session_filter),
-                    transfer_sessions,
-                    sync_sessions,
-                    certificates,
-                ]
-            )
-
-        return GroupDeletion("Morango models", groups=querysets)

--- a/kolibri/core/auth/management/commands/deletefacility.py
+++ b/kolibri/core/auth/management/commands/deletefacility.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.management.utils import get_facility
 from kolibri.core.auth.models import dataset_cache
+from kolibri.core.auth.utils.delete import clean_up_legacy_counters
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.auth.utils.delete import get_delete_group_for_facility
 from kolibri.core.tasks.management.commands.base import AsyncCommand
@@ -78,6 +79,8 @@ class Command(AsyncCommand):
                 total_deleted += count
                 # clear related cache
                 dataset_cache.clear()
+
+            clean_up_legacy_counters()
 
             # if count doesn't match, something doesn't seem right
             if total_count != total_deleted:

--- a/kolibri/core/auth/management/commands/deleteuser.py
+++ b/kolibri/core/auth/management/commands/deleteuser.py
@@ -1,8 +1,8 @@
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 
+from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.utils import confirm_or_exit
 
 
 class Command(BaseCommand):

--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -7,10 +7,10 @@ from morango.models import DatabaseIDModel
 from morango.models import DeletedModels
 from morango.models import Store
 
-from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.utils import confirm_or_exit
+from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.logger.models import AttemptLog

--- a/kolibri/core/auth/management/commands/flushsyncsessions.py
+++ b/kolibri/core/auth/management/commands/flushsyncsessions.py
@@ -9,8 +9,8 @@ from morango.models import RecordMaxCounterBuffer
 from morango.models import SyncSession
 from morango.models import TransferSession
 
-from kolibri.core.auth.management.utils import GroupDeletion
-from kolibri.core.auth.utils import confirm_or_exit
+from kolibri.core.auth.management.utils import confirm_or_exit
+from kolibri.core.auth.utils.delete import GroupDeletion
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 
 

--- a/kolibri/core/auth/management/commands/recreatefacility.py
+++ b/kolibri/core/auth/management/commands/recreatefacility.py
@@ -1,0 +1,55 @@
+import logging
+
+from django.db import transaction
+
+from kolibri.core.auth.management.utils import confirm_or_exit
+from kolibri.core.auth.management.utils import get_facility
+from kolibri.core.auth.utils.migrate import migrate_facility
+from kolibri.core.tasks.management.commands.base import AsyncCommand
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(AsyncCommand):
+    help = "This command initiates the recreation process for a facility and all of its related data."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--facility",
+            action="store",
+            type=str,
+            help="The ID of the facility to recreate",
+        )
+        parser.add_argument("--noninteractive", action="store_true")
+
+    def handle_async(self, *args, **options):
+        noninteractive = options["noninteractive"]
+        facility = get_facility(
+            facility_id=options["facility"], noninteractive=noninteractive
+        )
+        dataset_id = facility.dataset_id
+
+        logger.info(
+            "Found facility {} <{}> for recreation".format(facility.id, dataset_id)
+        )
+
+        if not noninteractive:
+            # ensure the user REALLY wants to do this!
+            confirm_or_exit(
+                "Are you sure you wish to permanently recreate this facility? This will TRANSFER ALL FACILITY DATA TO A NEW FACILITY."
+            )
+            confirm_or_exit(
+                "ARE YOU SURE? If you do this, there is no way to recover the original facility data."
+            )
+
+        logger.info(
+            "Proceeding with facility recreation. Recreating all data for facility <{}>".format(
+                dataset_id
+            )
+        )
+
+        with transaction.atomic():
+            migrate_facility(facility)
+
+        logger.info("Recreation complete.")

--- a/kolibri/core/auth/management/commands/registerfacility.py
+++ b/kolibri/core/auth/management/commands/registerfacility.py
@@ -5,8 +5,8 @@ from morango.models import Certificate
 from requests import exceptions
 
 from kolibri.core import error_constants
+from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.management.utils import get_facility
-from kolibri.core.auth.utils import confirm_or_exit
 from kolibri.core.utils.portal import registerfacility
 
 

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -5,13 +5,12 @@ import getpass
 import json
 import logging
 import math
-import time
+import sys
 from contextlib import contextmanager
 from functools import wraps
 
 import requests
 from django.core.management.base import CommandError
-from django.db.models.signals import post_delete
 from django.urls import reverse
 from django.utils.six.moves import input
 from morango.models import Certificate
@@ -45,19 +44,13 @@ from kolibri.utils.data import bytes_for_humans
 logger = logging.getLogger(__name__)
 
 
-class DisablePostDeleteSignal(object):
-    """
-    Helper that disables the post_delete signal temporarily when deleting, so Morango doesn't
-    create DeletedModels objects for what we're deleting
-    """
-
-    def __enter__(self):
-        self.receivers = post_delete.receivers
-        post_delete.receivers = []
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        post_delete.receivers = self.receivers
-        self.receivers = None
+def confirm_or_exit(message):
+    answer = ""
+    while answer not in ["yes", "n", "no"]:
+        answer = input("{} [Type 'yes' or 'no'.] ".format(message)).lower()
+    if answer != "yes":
+        print("Canceled! Exiting without touching the database.")
+        sys.exit(1)
 
 
 def _interactive_client_facility_selection():
@@ -382,89 +375,6 @@ def run_once(f):
 
     wrapper.has_run = False
     return wrapper
-
-
-class GroupDeletion(object):
-    """
-    Helper to manage deleting many models, or groups of models
-    """
-
-    def __init__(self, name, groups=None, querysets=None, sleep=None):
-        """
-        :type groups: GroupDeletion[]
-        :type querysets: QuerySet[]
-        :type sleep: int
-        """
-        self.name = name
-        groups = [] if groups is None else groups
-        if querysets is not None:
-            groups.extend(querysets)
-        self.groups = groups
-        self.sleep = sleep
-
-    def count(self, progress_updater):
-        """
-        :type progress_updater: function
-        :rtype: int
-        """
-        sum = 0
-        for qs in self.groups:
-            if isinstance(qs, GroupDeletion):
-                count = qs.count(progress_updater)
-                logger.debug("Counted {} in group `{}`".format(count, qs.name))
-            else:
-                count = qs.count()
-                progress_updater(increment=1)
-                logger.debug(
-                    "Counted {} of `{}`".format(count, qs.model._meta.model_name)
-                )
-
-            sum += count
-
-        return sum
-
-    def group_count(self):
-        """
-        :rtype: int
-        """
-        return sum(
-            [
-                qs.group_count() if isinstance(qs, GroupDeletion) else 1
-                for qs in self.groups
-            ]
-        )
-
-    def delete(self, progress_updater, sleep=None):
-        """
-        :type progress_updater: function
-        :type sleep: int
-        :rtype: tuple(int, dict)
-        """
-        total_count = 0
-        all_deletions = {}
-        sleep = self.sleep if sleep is None else sleep
-
-        for qs in self.groups:
-            if isinstance(qs, GroupDeletion):
-                count, deletions = qs.delete(progress_updater)
-                debug_msg = "Deleted {} of `{}` in group `{}`"
-                name = qs.name
-            else:
-                count, deletions = qs.delete()
-                debug_msg = "Deleted {} of `{}` with model `{}`"
-                name = qs.model._meta.model_name
-
-            total_count += count
-            progress_updater(increment=count)
-
-            for obj_name, count in deletions.items():
-                if not isinstance(qs, GroupDeletion):
-                    logger.debug(debug_msg.format(count, obj_name, name))
-                all_deletions.update({obj_name: all_deletions.get(obj_name, 0) + count})
-            if self.sleep is not None:
-                time.sleep(sleep)
-
-        return total_count, all_deletions
 
 
 class MorangoSyncCommand(AsyncCommand):

--- a/kolibri/core/auth/test/test_delete_user.py
+++ b/kolibri/core/auth/test/test_delete_user.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from .. import utils
+from kolibri.core.auth.management import utils
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -21,8 +21,8 @@ from kolibri.core.auth.test.test_api import ClassroomFactory
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.auth.test.test_api import FacilityUserFactory
 from kolibri.core.auth.test.test_api import LearnerGroupFactory
-from kolibri.core.auth.utils import fork_facility
-from kolibri.core.auth.utils import merge_users
+from kolibri.core.auth.utils.migrate import fork_facility
+from kolibri.core.auth.utils.migrate import merge_users
 from kolibri.core.logger import models as log_models
 
 

--- a/kolibri/core/auth/test/test_utils.py
+++ b/kolibri/core/auth/test/test_utils.py
@@ -195,6 +195,9 @@ class TeleportUserTestCase(TestCase):
                 masterylog__summarylog__content_id=log.masterylog.summarylog.content_id,
             ).exists()
         )
+        for attempt_log in log_models.AttemptLog.objects.filter(user=self.user_2):
+            for json_field in ("answer", "interaction_history"):
+                self.assertNotIsInstance(getattr(attempt_log, json_field), (str,))
 
     def test_contentsessionlogs(self):
         self.assertEqual(

--- a/kolibri/core/auth/utils/delete.py
+++ b/kolibri/core/auth/utils/delete.py
@@ -1,0 +1,305 @@
+import logging
+import time
+
+from django.contrib.admin.models import LogEntry
+from django.db import transaction
+from django.db.models import Q
+from django.db.models.signals import post_delete
+from morango.models import Buffer
+from morango.models import Certificate
+from morango.models import DatabaseMaxCounter
+from morango.models import DeletedModels
+from morango.models import RecordMaxCounter
+from morango.models import RecordMaxCounterBuffer
+from morango.models import Store
+from morango.models import SyncSession
+from morango.models import TransferSession
+
+from kolibri.core.analytics.models import PingbackNotificationDismissed
+from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.models import Classroom
+from kolibri.core.auth.models import Collection
+from kolibri.core.auth.models import dataset_cache
+from kolibri.core.auth.models import FacilityDataset
+from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.models import Membership
+from kolibri.core.auth.models import Role
+from kolibri.core.bookmarks.models import Bookmark
+from kolibri.core.device.models import DevicePermissions
+from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import ExamAttemptLog
+from kolibri.core.logger.models import ExamLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.models import UserSessionLog
+
+
+logger = logging.getLogger(__name__)
+
+
+class DisablePostDeleteSignal(object):
+    """
+    Helper that disables the post_delete signal temporarily when deleting, so Morango doesn't
+    create DeletedModels objects for what we're deleting
+    """
+
+    def __enter__(self):
+        self.receivers = post_delete.receivers
+        post_delete.receivers = []
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        post_delete.receivers = self.receivers
+        self.receivers = None
+
+
+class GroupDeletion(object):
+    """
+    Helper to manage deleting many models, or groups of models
+    """
+
+    def __init__(self, name, groups=None, querysets=None, sleep=None):
+        """
+        :type groups: GroupDeletion[]
+        :type querysets: QuerySet[]
+        :type sleep: int
+        """
+        self.name = name
+        groups = [] if groups is None else groups
+        if querysets is not None:
+            groups.extend(querysets)
+        self.groups = groups
+        self.sleep = sleep
+
+    def count(self, progress_updater=None):
+        """
+        :type progress_updater: function
+        :rtype: int
+        """
+        sum = 0
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count = qs.count(progress_updater)
+                logger.debug("Counted {} in group `{}`".format(count, qs.name))
+            else:
+                count = qs.count()
+                if progress_updater:
+                    progress_updater(increment=1)
+                logger.debug(
+                    "Counted {} of `{}`".format(count, qs.model._meta.model_name)
+                )
+
+            sum += count
+
+        return sum
+
+    def group_count(self):
+        """
+        :rtype: int
+        """
+        return sum(
+            [
+                qs.group_count() if isinstance(qs, GroupDeletion) else 1
+                for qs in self.groups
+            ]
+        )
+
+    def delete(self, progress_updater=None, sleep=None):
+        """
+        :type progress_updater: function
+        :type sleep: int
+        :rtype: tuple(int, dict)
+        """
+        total_count = 0
+        all_deletions = {}
+        sleep = self.sleep if sleep is None else sleep
+
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                count, deletions = qs.delete(progress_updater)
+                debug_msg = "Deleted {} of `{}` in group `{}`"
+                name = qs.name
+            else:
+                count, deletions = qs.delete()
+                debug_msg = "Deleted {} of `{}` with model `{}`"
+                name = qs.model._meta.model_name
+
+            total_count += count
+            if progress_updater:
+                progress_updater(increment=count)
+
+            for obj_name, count in deletions.items():
+                if not isinstance(qs, GroupDeletion):
+                    logger.debug(debug_msg.format(count, obj_name, name))
+                all_deletions.update({obj_name: all_deletions.get(obj_name, 0) + count})
+            if self.sleep is not None:
+                time.sleep(sleep)
+
+        return total_count, all_deletions
+
+
+def chunk(things, size):
+    """
+    Chunk generator
+
+    :type things: list
+    :type size: int
+    """
+    for i in range(0, len(things), size):
+        yield things[i : i + size]
+
+
+def _get_facility_dataset(dataset_id):
+    return FacilityDataset.objects.filter(id=dataset_id)
+
+
+def _get_certificates(dataset_id):
+    return (
+        Certificate.objects.filter(id=dataset_id)
+        .get_descendants(include_self=True)
+        .exclude(_private_key=None)
+    )
+
+
+def _get_users(dataset_id):
+    user_id_filter = Q(
+        user_id__in=FacilityUser.objects.filter(dataset_id=dataset_id).values_list(
+            "pk", flat=True
+        )
+    )
+    dataset_id_filter = Q(dataset_id=dataset_id)
+
+    return GroupDeletion(
+        "User models",
+        querysets=[
+            LogEntry.objects.filter(user_id_filter),
+            DevicePermissions.objects.filter(user_id_filter),
+            PingbackNotificationDismissed.objects.filter(user_id_filter),
+            Collection.objects.filter(Q(parent_id__isnull=True) & dataset_id_filter),
+            Role.objects.filter(dataset_id_filter),
+            Membership.objects.filter(dataset_id_filter),
+            Bookmark.objects.filter(dataset_id_filter),
+            FacilityUser.objects.filter(dataset_id_filter),
+        ],
+    )
+
+
+def _get_class_models(dataset_id):
+    dataset_id_filter = Q(dataset_id=dataset_id)
+    return GroupDeletion(
+        "Class models",
+        querysets=[
+            ExamAssignment.objects.filter(dataset_id_filter),
+            Exam.objects.filter(dataset_id_filter),
+            LessonAssignment.objects.filter(dataset_id_filter),
+            Lesson.objects.filter(dataset_id_filter),
+            AdHocGroup.objects.filter(dataset_id_filter),
+            LearnerGroup.objects.filter(dataset_id_filter),
+            Classroom.objects.filter(dataset_id_filter),
+        ],
+    )
+
+
+def _get_log_models(dataset_id):
+    dataset_id_filter = Q(dataset_id=dataset_id)
+    return GroupDeletion(
+        "Log models",
+        querysets=[
+            ContentSessionLog.objects.filter(dataset_id_filter),
+            ContentSummaryLog.objects.filter(dataset_id_filter),
+            AttemptLog.objects.filter(dataset_id_filter),
+            ExamAttemptLog.objects.filter(dataset_id_filter),
+            ExamLog.objects.filter(dataset_id_filter),
+            MasteryLog.objects.filter(dataset_id_filter),
+            UserSessionLog.objects.filter(dataset_id_filter),
+        ],
+    )
+
+
+def _get_morango_models(dataset_id):
+    querysets = [DatabaseMaxCounter.objects.filter(partition__startswith=dataset_id)]
+
+    stores = Store.objects.filter(partition__startswith=dataset_id)
+    store_ids = stores.values_list("pk", flat=True)
+
+    for store_ids_chunk in chunk(list(store_ids), 300):
+        querysets.append(
+            RecordMaxCounter.objects.filter(store_model_id__in=store_ids_chunk)
+        )
+        querysets.append(DeletedModels.objects.filter(id__in=store_ids_chunk))
+
+    # append after RecordMaxCounter
+    querysets.append(stores)
+
+    certificates = _get_certificates(dataset_id)
+    certificate_ids = certificates.distinct().values_list("pk", flat=True)
+
+    for certificate_id_chunk in chunk(certificate_ids, 300):
+        sync_sessions = SyncSession.objects.filter(
+            Q(client_certificate_id__in=certificate_id_chunk)
+            | Q(server_certificate_id__in=certificate_id_chunk)
+        )
+        sync_session_ids = sync_sessions.distinct().values_list("pk", flat=True)
+        transfer_sessions = TransferSession.objects.filter(
+            sync_session_id__in=sync_session_ids
+        )
+        transfer_session_filter = Q(
+            transfer_session_id__in=transfer_sessions.values_list("pk", flat=True)
+        )
+
+        querysets.extend(
+            [
+                RecordMaxCounterBuffer.objects.filter(transfer_session_filter),
+                Buffer.objects.filter(transfer_session_filter),
+                transfer_sessions,
+                sync_sessions,
+                certificates,
+            ]
+        )
+
+    return GroupDeletion("Morango models", groups=querysets)
+
+
+def get_delete_group_for_facility(facility):
+    dataset_id = facility.dataset_id
+    # everything should get cascade deleted from the facility, but we'll check anyway
+    return GroupDeletion(
+        "Main",
+        groups=[
+            _get_morango_models(dataset_id),
+            _get_log_models(dataset_id),
+            _get_class_models(dataset_id),
+            _get_users(dataset_id),
+            _get_facility_dataset(dataset_id),
+        ],
+    )
+
+
+def delete_facility(facility):
+    logger.info("Deleting facility {}".format(facility.name))
+    delete_group = get_delete_group_for_facility(facility)
+    total_to_delete = delete_group.count()
+    logger.info(
+        "Deleting {} database records for facility {}".format(
+            total_to_delete, facility.name
+        )
+    )
+    with DisablePostDeleteSignal(), transaction.atomic():
+        count, _ = delete_group.delete()
+        dataset_cache.clear()
+    if count == total_to_delete:
+        logger.info(
+            "Deleted {} database records for facility {}".format(count, facility.name)
+        )
+    else:
+        logger.warn(
+            "Deleted {} database records but expected to delete {} records for facility {}".format(
+                count, total_to_delete, facility.name
+            )
+        )
+    logger.info("Deleted facility {}".format(facility.name))

--- a/kolibri/core/auth/utils/delete.py
+++ b/kolibri/core/auth/utils/delete.py
@@ -20,6 +20,7 @@ from kolibri.core.auth.models import AdHocGroup
 from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import dataset_cache
+from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
@@ -29,6 +30,8 @@ from kolibri.core.bookmarks.models import Bookmark
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.exams.models import IndividualSyncableExam
+from kolibri.core.lessons.models import IndividualSyncableLesson
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
 from kolibri.core.logger.models import AttemptLog
@@ -75,6 +78,16 @@ class GroupDeletion(object):
             groups.extend(querysets)
         self.groups = groups
         self.sleep = sleep
+
+    def get_querysets(self):
+        querysets = []
+        for qs in self.groups:
+            if isinstance(qs, GroupDeletion):
+                querysets.extend(qs.get_querysets())
+            else:
+                querysets.append(qs)
+
+        return querysets
 
     def count(self, progress_updater=None):
         """
@@ -185,6 +198,7 @@ def _get_users(dataset_id):
             Membership.objects.filter(dataset_id_filter),
             Bookmark.objects.filter(dataset_id_filter),
             FacilityUser.objects.filter(dataset_id_filter),
+            Facility.objects.filter(dataset_id_filter),
         ],
     )
 
@@ -196,8 +210,10 @@ def _get_class_models(dataset_id):
         querysets=[
             ExamAssignment.objects.filter(dataset_id_filter),
             Exam.objects.filter(dataset_id_filter),
+            IndividualSyncableExam.objects.filter(dataset_id_filter),
             LessonAssignment.objects.filter(dataset_id_filter),
             Lesson.objects.filter(dataset_id_filter),
+            IndividualSyncableLesson.objects.filter(dataset_id_filter),
             AdHocGroup.objects.filter(dataset_id_filter),
             LearnerGroup.objects.filter(dataset_id_filter),
             Classroom.objects.filter(dataset_id_filter),

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -1,0 +1,9 @@
+from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.models import Membership
+
+
+def create_adhoc_group_for_learners(classroom, learners):
+    adhoc_group = AdHocGroup.objects.create(name="Ad hoc", parent=classroom)
+    for learner in learners:
+        Membership.objects.create(user=learner, collection=adhoc_group)
+    return adhoc_group

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -31,6 +31,7 @@ no_default_value = object()
 
 def get_device_setting(setting, default=no_default_value):
     from .models import DeviceSettings
+    from kolibri.core.auth.models import Facility
 
     try:
         device_settings = DeviceSettings.objects.get()
@@ -41,6 +42,8 @@ def get_device_setting(setting, default=no_default_value):
         if default is not no_default_value:
             return default
         raise DeviceNotProvisioned
+    except Facility.DoesNotExist:
+        return None
 
 
 def device_provisioned():

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -14,7 +14,7 @@ from kolibri.core.auth.constants.collection_kinds import ADHOCLEARNERSGROUP
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Membership
-from kolibri.core.auth.utils import create_adhoc_group_for_learners
+from kolibri.core.auth.utils.users import create_adhoc_group_for_learners
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
 from kolibri.core.serializers import DateTimeTzField

--- a/kolibri/core/exams/single_user_assignment_utils.py
+++ b/kolibri/core/exams/single_user_assignment_utils.py
@@ -1,6 +1,6 @@
 from .models import ExamAssignment
 from .models import IndividualSyncableExam
-from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 
 
 def update_individual_syncable_exams_from_assignments(user_id):

--- a/kolibri/core/lessons/serializers.py
+++ b/kolibri/core/lessons/serializers.py
@@ -14,7 +14,7 @@ from kolibri.core.auth.constants.collection_kinds import ADHOCLEARNERSGROUP
 from kolibri.core.auth.models import Collection
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import Membership
-from kolibri.core.auth.utils import create_adhoc_group_for_learners
+from kolibri.core.auth.utils.users import create_adhoc_group_for_learners
 
 
 class ResourceSerializer(Serializer):

--- a/kolibri/core/lessons/single_user_assignment_utils.py
+++ b/kolibri/core/lessons/single_user_assignment_utils.py
@@ -1,6 +1,6 @@
 from .models import IndividualSyncableLesson
 from .models import LessonAssignment
-from kolibri.core.auth.management.utils import DisablePostDeleteSignal
+from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
 
 
 def update_individual_syncable_lessons_from_assignments(user_id):

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,4 +6,5 @@ sphinx-intl==2.0.1
 sphinx-rtd-theme==0.5.2
 sphinx-autobuild==0.7.1
 m2r==0.2.1
+mistune<2.0.0
 sphinx-notfound-page==0.6


### PR DESCRIPTION
## Summary
* Fixes a possible bug in user merging, by ensuring that serialized data is passed through db_to_value
* Adds a utility for cloning a facility and all its data
* Refactors some auth app utils into separate modules by function
* Updates the deletefacility command to delete the morango `DeletedModels` model and the new `Bookmark` model
* Uses the cloning facility and the updated delete facility functions to add a migrate_facility function and recreatefacility management command to allow the migration of a facility to a fresh start

## References
Fixes all but the automated parts of: #8091
Fixes #8435

## Reviewer guidance
Anything I have failed to copy?
Any morango subtleties I might have missed?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
