### PR TITLE
Home page fixes

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -22,8 +22,8 @@
           <KIconButton
             icon="close"
             class="close-button"
-            :ariaLabel="coreString('close')"
-            :tooltip="coreString('close')"
+            :ariaLabel="coreString('closeAction')"
+            :tooltip="coreString('closeAction')"
             @click="closePanel"
           />
         </div>

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -151,9 +151,6 @@ export default [
     name: PageNames.TOPICS_CONTENT,
     path: '/topics/c/:id',
     handler: toRoute => {
-      if (unassignedContentGuard()) {
-        return unassignedContentGuard();
-      }
       showTopicsContent(store, toRoute.params.id);
     },
   },

--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -86,9 +86,21 @@ describe(`HomePage`, () => {
     });
 
     it(`the section is not displayed for a signed in user with no classes`, () => {
+      useDeviceSettings.mockImplementation(() =>
+        useDeviceSettingsMock({ canAccessUnassignedContent: true })
+      );
       useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
       const wrapper = makeWrapper();
       expect(getClassesSection(wrapper).exists()).toBe(false);
+    });
+
+    it(`the section is displayed for a signed in user with no classes who cannot access unassigned content`, () => {
+      useDeviceSettings.mockImplementation(() =>
+        useDeviceSettingsMock({ canAccessUnassignedContent: false })
+      );
+      useUser.mockImplementation(() => useUserMock({ isUserLoggedIn: true }));
+      const wrapper = makeWrapper();
+      expect(getClassesSection(wrapper).exists()).toBe(true);
     });
 
     it(`classes are displayed for a signed in user who is enrolled in some classes`, () => {

--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -85,7 +85,7 @@ describe(`HomePage`, () => {
       expect(getClassesSection(wrapper).exists()).toBe(false);
     });
 
-    it(`the section is not displayed for a signed in user with no classes`, () => {
+    it(`the section is not displayed for a signed in user who has no classes and can access unassigned content`, () => {
       useDeviceSettings.mockImplementation(() =>
         useDeviceSettingsMock({ canAccessUnassignedContent: true })
       );

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <YourClasses
-      v-if="isUserLoggedIn && classes.length"
+      v-if="displayClasses"
       class="section"
       :classes="classes"
       data-test="classes"
@@ -118,6 +118,10 @@
         );
       });
 
+      const displayClasses = computed(() => {
+        return get(isUserLoggedIn) && (get(classes).length || !get(canAccessUnassignedContent));
+      });
+
       return {
         isUserLoggedIn,
         channels,
@@ -129,6 +133,7 @@
         continueLearningFromClasses,
         continueLearningOnYourOwn,
         displayExploreChannels,
+        displayClasses,
       };
     },
   };

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -85,12 +85,20 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                 resource["contentnode_id"] for resource in lesson["resources"]
             }
 
-        contentnode_progress = contentnode_progress_viewset.serialize_list(
-            self.request, {"ids": lesson_contentnode_ids}
+        contentnode_progress = (
+            contentnode_progress_viewset.serialize_list(
+                self.request, {"ids": lesson_contentnode_ids}
+            )
+            if lesson_contentnode_ids
+            else []
         )
 
-        contentnodes = contentnode_viewset.serialize_list(
-            self.request, {"ids": lesson_contentnode_ids}
+        contentnodes = (
+            contentnode_viewset.serialize_list(
+                self.request, {"ids": lesson_contentnode_ids}
+            )
+            if lesson_contentnode_ids
+            else []
         )
 
         progress_map = {l["content_id"]: l["progress"] for l in contentnode_progress}

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -214,7 +214,7 @@ def _resumable_resources(classrooms):
     for classroom in classrooms:
         for lesson in classroom["assignments"]["lessons"]:
             for resource in lesson["resources"]:
-                yield resource["progress"] > 0
+                yield 0 < resource["progress"] < 1
 
 
 class LearnHomePageHydrationView(APIView):


### PR DESCRIPTION
## Summary
* Fixes issue for learner classroom viewset where there were no contentnodes to query, would query all contentnodes
* Show classes section to learners who cannot see unassigned content but who are not in any classes
* Remove the unassigned content guard from the content page route so that learners can access content when they are only allowed to access assigned content
* Fixes an erroneous string reference (that I thought I fixed before?) in the side panel close button
* Fixes a resumable resource check in the backend to check for progress greater than 0 and less than 1

## References
Fixes #8729
Fixes #8730
Fixes #8732

## Reviewer guidance
If a learner is assigned to a classroom but has no lessons or quizzes, does the homepage still load quickly?
Confirm fixes for the three above.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
