### PR TITLE
Fix `KTextbox` in form vertical shift

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -146,4 +146,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  /deep/ .ui-textbox-feedback {
+    display: block !important;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -149,6 +149,7 @@
 <style lang="scss" scoped>
 
   /deep/ .ui-textbox-feedback {
+    // Add to fix vertical shifting of textboxes
     display: block !important;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -693,4 +693,8 @@
     margin-left: 15rem;
   }
 
+  /deep/ .ui-textbox-feedback {
+    display: block !important;
+  }
+
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -694,6 +694,7 @@
   }
 
   /deep/ .ui-textbox-feedback {
+    // Add to fix vertical shifting of textboxes
     display: block !important;
   }
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -286,4 +286,8 @@
     color: red;
   }
 
+  /deep/ .ui-textbox-feedback {
+    display: block !important;
+  }
+
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -287,6 +287,7 @@
   }
 
   /deep/ .ui-textbox-feedback {
+    // Add to fix vertical shifting of textboxes
     display: block !important;
   }
 

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -578,10 +578,12 @@
   }
 
   /deep/ .ui-textbox-feedback {
+    // Add to fix vertical shifting of textboxes
     display: block !important;
   }
 
   /deep/ .ui-textbox {
+    // Add to fix spacing for https://github.com/learningequality/kolibri/issues/8675
     margin-bottom: 0;
   }
 

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -577,4 +577,12 @@
     list-style-type: none;
   }
 
+  /deep/ .ui-textbox-feedback {
+    display: block !important;
+  }
+
+  /deep/ .ui-textbox {
+    margin-bottom: 0;
+  }
+
 </style>


### PR DESCRIPTION
## Summary
Fixes the shifting HTML elements in the following views:
- Setup wizard
- Creating a quiz page
- And the two below:

|View|Initial|Change|
|--|--|--|
|User sign-in page|![2021-11-12 09 15 22](https://user-images.githubusercontent.com/2367265/141481020-2a682481-35f9-43da-ac0f-635ebb045162.gif)|![2021-11-18 21 22 54](https://user-images.githubusercontent.com/13563002/142569770-64bdb5ed-9792-449d-beb9-68bcfbb57bb9.gif)|
|Password box in the user creation page|![2021-11-18 20 46 16](https://user-images.githubusercontent.com/13563002/142569124-aacbef1c-7754-4c9c-be0d-841850eff026.gif)|![2021-11-18 20 48 31](https://user-images.githubusercontent.com/13563002/142569135-53b23fe6-a453-4a86-8624-b00fdfcabe62.gif)|

## References
#8675

**Important!** To fix the issue, KDS also needs to be updated in Kolibri. See https://github.com/learningequality/kolibri-design-system/pull/279

## Reviewer guidance
Please review manually in the following components:
- User accounts
- `CreateExamPage`
- `ImportIndividualUserForm` in setup wizard
- `SignInPage`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
