### PR TITLE
Learning activity bar truncation and alignment fixes

### DIFF
--- a/kolibri/core/assets/src/views/TextTruncatorCss.vue
+++ b/kolibri/core/assets/src/views/TextTruncatorCss.vue
@@ -1,24 +1,28 @@
 <template>
 
   <!--
-    Text is wrapped in two `div`s to allow parent components adding
+    Text is wrapped in two `spans`s to allow parent components adding
     padding style directly on `<TextTruncatorCss>` component no matter
     of what truncating technique is used. Otherwise adding padding directly
     would break when using technique (B) since text that should be truncated
     would show in padding area.
 
-    Attributes are inherited by the inner `div` to emulate the same behavior
+    Attributes are inherited by the inner `span` to emulate the same behavior
     like if only one element would wrap the text to allow attributes be applied
     as close as possible to the text element.
+
+    Some width information need to be provided to `<span>s` to allow `text-overflow`
+    calculate properly when ellipsis should be added.
   -->
-  <div>
-    <div
+  <span :style="{ display: 'inline-block', maxWidth: '100%' }">
+    <span
       v-bind="$attrs"
+      :style="{ display: 'inline-block', maxWidth: '100%' }"
       :class="$computedClass(truncate)"
     >
       {{ text }}
-    </div>
-  </div>
+    </span>
+  </span>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -361,6 +361,20 @@
     transform: translateY(16px);
   }
 
+  /*
+    Make truncation via text ellipsis work well in UIToolbar's body flex item:
+    By default, `min-width` is `auto`  for a flex item which means it
+    cannot be smaller than the size of its content which causes the whole
+    title being visible even in cases when it should be already truncated.
+    Overriding it to `0` allows the title to be shrinked and then truncated
+    properly. Labeled icon wrapper needs to have this set too for its parent
+    flex item to shrink.
+  */
+  /deep/ .ui-toolbar__body,
+  /deep/ .labeled-icon-wrapper {
+    min-width: 0;
+  }
+
   /deep/ .progress-icon .ui-icon {
     margin-top: -2px;
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -378,6 +378,11 @@
     align-items: center;
   }
 
+  /deep/ .ui-toolbar__right {
+    // never shrink controls on the right side of the toolbar
+    flex-shrink: 0;
+  }
+
   /deep/ .progress-icon .ui-icon {
     margin-top: -2px;
     margin-left: 16px;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -17,10 +17,8 @@
         :text="resourceTitle"
         :maxLines="1"
       />
-      <template #iconAfter>
-        <ProgressIcon :progress="contentProgress" class="progress-icon" />
-      </template>
     </KLabeledIcon>
+    <ProgressIcon :progress="contentProgress" class="progress-icon" />
 
     <template #icon>
       <KIconButton
@@ -375,8 +373,13 @@
     min-width: 0;
   }
 
+  /deep/ .ui-toolbar__body {
+    align-items: center;
+  }
+
   /deep/ .progress-icon .ui-icon {
     margin-top: -2px;
+    margin-left: 16px;
 
     svg {
       width: 18px;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -13,9 +13,9 @@
           :shaded="true"
         />
       </template>
-      <TextTruncator
+      <TextTruncatorCss
         :text="resourceTitle"
-        :maxHeight="26"
+        :maxLines="1"
       />
       <template #iconAfter>
         <ProgressIcon :progress="contentProgress" class="progress-icon" />
@@ -107,7 +107,7 @@
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import { validateLearningActivity } from 'kolibri.utils.validators';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import LearningActivityIcon from './LearningActivityIcon.vue';
@@ -120,7 +120,7 @@
       CoachContentLabel,
       CoreMenu,
       CoreMenuOption,
-      TextTruncator,
+      TextTruncatorCss,
       LearningActivityIcon,
       MarkAsCompleteModal,
       ProgressIcon,

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -5,7 +5,7 @@
       :value="isCoachContent"
       style="margin-top: 8px; width: auto;"
     />
-    <KLabeledIcon :style="{ 'margin-top': '8px', 'width': 'auto' }">
+    <KLabeledIcon :style="{ 'margin-top': '8px' }">
       <template #icon>
         <LearningActivityIcon
           data-test="learningActivityIcon"
@@ -374,6 +374,7 @@
   }
 
   /deep/ .ui-toolbar__body {
+    flex-grow: 0; // make sure that the completion icon is right next to the title
     align-items: center;
   }
 


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes a couple of truncation and alignment problems in the learning activity bar.

(1) Replaces `TextTruncator` with `TextTruncatorCss` on this opportunity to avoid investigating issues in the environment using a component that may soon be obsolete as we agreed to move towards `TextTruncatorCss` everywhere.
(2) Fixes ellipsis not being applied when it should and being applied when it shouldn't. Some issues occurred in all browsers, some were IE specific. See commit messages and code comments for details.
(3) Fixes an issue with overflowing controls on the right side of the bar when a resource title is very long:

![rect122-3-7](https://user-images.githubusercontent.com/13509191/142604587-4e73ddb5-6f9b-4944-91dd-5d11f632f1c9.png)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8678

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

![Peek 2021-11-19 11-11](https://user-images.githubusercontent.com/13509191/142605491-bf012c9a-5e62-4768-9abd-a3b695093848.gif)

In all browsers

- [ ] all icons, buttons, and a resource title are aligned properly
- [ ] a resource title truncation works well

Please double-check in Internet Explorer. Note that some icons may not be visible all the time, e.g. the progress and completion icons become visible only after a resource has been started.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
