### PR TITLE
Do permanent redirect from /user to /auth.

### DIFF
--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -80,7 +80,7 @@ class AllUrlsTest(APITransactionTestCase):
 
     # Allow codes that may indicate a poorly formed response
     # 412 is returned from endpoints that have required GET params when these are not supplied
-    allowed_http_codes = [200, 302, 400, 401, 403, 404, 405, 412]
+    allowed_http_codes = [200, 301, 302, 400, 401, 403, 404, 405, 412]
 
     def setUp(self):
         provision_device()

--- a/kolibri/plugins/user_auth/kolibri_plugin.py
+++ b/kolibri/plugins/user_auth/kolibri_plugin.py
@@ -16,6 +16,7 @@ from kolibri.plugins.hooks import register_hook
 
 class UserAuth(KolibriPluginBase):
     translated_view_urls = "urls"
+    root_view_urls = "root_urls"
 
     @property
     def url_slug(self):

--- a/kolibri/plugins/user_auth/root_urls.py
+++ b/kolibri/plugins/user_auth/root_urls.py
@@ -1,0 +1,20 @@
+"""
+This is here to enable redirects from the old /user endpoint to /auth
+"""
+from django.conf.urls import include
+from django.conf.urls import url
+from django.views.generic.base import RedirectView
+
+from kolibri.core.device.translation import i18n_patterns
+
+redirect_patterns = [
+    url(
+        r"^user/$",
+        RedirectView.as_view(
+            pattern_name="kolibri:kolibri.plugins.user_auth:user_auth", permanent=True
+        ),
+        name="redirect_user",
+    ),
+]
+
+urlpatterns = [url(r"", include(i18n_patterns(redirect_patterns)))]


### PR DESCRIPTION
## Summary
* Sets up a permanent redirect from /user to /auth

## References
Fixes #8662

## Reviewer guidance
Does loading /user redirect to /auth then /<lang>/auth?
Does loading /<lang>/user redirec to /<lang>/auth?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
