### PR TITLE
Update sync/register interface

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -28,17 +28,49 @@
             <td class="button-col">
               <KButtonGroup style="margin-top: 8px; overflow: visible">
                 <KButton
+                  v-if="!theFacility.dataset.registered"
                   appearance="raised-button"
                   :text="$tr('register')"
-                  :disabled="Boolean(syncTaskId) || theFacility.dataset.registered"
                   @click="displayModal(Modals.REGISTER_FACILITY)"
                 />
                 <KButton
+                  v-else-if="!Boolean(syncTaskId)"
                   appearance="raised-button"
                   :text="$tr('sync')"
-                  :disabled="Boolean(syncTaskId)"
                   @click="displayModal(Modals.SYNC_FACILITY)"
                 />
+                <KIconButton
+                  ref="moreOptionsButton"
+                  data-test="moreOptionsButton"
+                  icon="optionsHorizontal"
+                  :tooltip="coreString('optionsLabel')"
+                  :ariaLabel="coreString('optionsLabel')"
+                  @click="toggleMenu"
+                />
+                <CoreMenu
+                  v-show="isMenuOpen"
+                  ref="menu"
+                  class="menu"
+                  :raised="true"
+                  :isOpen="isMenuOpen"
+                  :containFocus="true"
+                  @close="closeMenu"
+                >
+                  <template #options>
+                    <CoreMenuOption
+                      v-if="theFacility.dataset.registered"
+                      :style="{ 'cursor': 'pointer', textAlign: 'left' }"
+                      :label="$tr('register')"
+                      @select="displayModal(Modals.REGISTER_FACILITY)"
+                    />
+                    <CoreMenuOption
+                      v-else
+                      :style="{ 'cursor': 'pointer', textAlign: 'left' }"
+                      :label="$tr('sync')"
+                      @select="displayModal(Modals.SYNC_FACILITY)"
+                    />
+                  </template>
+                </CoreMenu>
               </KButtonGroup>
             </td>
           </tr>
@@ -89,6 +121,9 @@
   } from 'kolibri.coreVue.componentSets.sync';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { FacilityTaskResource, FacilityResource } from 'kolibri.resources';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
+  import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import { TaskStatuses } from '../../../constants';
   import PrivacyModal from './PrivacyModal';
 
@@ -108,8 +143,10 @@
       RegisterFacilityModal,
       ConfirmationRegisterModal,
       SyncFacilityModalGroup,
+      CoreMenu,
+      CoreMenuOption,
     },
-    mixins: [commonSyncElements],
+    mixins: [commonSyncElements, commonCoreStrings],
     data() {
       return {
         theFacility: null,
@@ -119,6 +156,7 @@
         isSyncing: false,
         syncHasFailed: false,
         Modals,
+        isMenuOpen: false,
       };
     },
     beforeMount() {
@@ -177,6 +215,24 @@
       handleSyncFacilityFailure() {
         this.syncHasFailed = true;
         this.closeModal();
+      },
+      closeMenu({ focusMoreOptionsButton = true } = {}) {
+        this.isMenuOpen = false;
+        if (!focusMoreOptionsButton) {
+          return;
+        }
+        this.$nextTick(() => {
+          this.$refs.moreOptionsButton.$el.focus();
+        });
+      },
+      toggleMenu() {
+        this.isMenuOpen = !this.isMenuOpen;
+        if (!this.isMenuOpen) {
+          return;
+        }
+        this.$nextTick(() => {
+          this.$refs.menu.$el.focus();
+        });
       },
     },
     $trs: {


### PR DESCRIPTION


## Summary

Rather than having a visible but disabled "Register" button for registered facilities, the option to register facilities is now in a kebab menu, with the sync button more prominent. Inversely, for non-registered facilities, the register button is prominent, with the sync button in a kebab menu.

**Not already registered**
<img width="1026" alt="Screen Shot 2021-11-19 at 1 04 00 PM" src="https://user-images.githubusercontent.com/17235236/142671679-0cb8066a-34fa-4d3d-b72c-ffcf23fb9912.png">

**Already registered**
<img width="1016" alt="Screen Shot 2021-11-19 at 1 16 35 PM" src="https://user-images.githubusercontent.com/17235236/142671775-3e2cd81e-c7fa-4a04-a501-012a6882ffd1.png">


## References
Fixed #7672 

## Reviewer guidance

I am not actually sure if this is a sufficient change to account for all of the conditions @jamalex described? Any other considerations I should account for?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
