### PR TITLE
Defer and parallelize loading of data for the also in this panel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -13,7 +13,7 @@
       <KRouterLink
         v-for="content in contentNodes"
         :key="content.id"
-        :to="genContentLink(content.id, content.is_leaf, backRoute, context)"
+        :to="genContentLink(content.id, null, content.is_leaf, null, context)"
         class="item"
         :class="windowIsSmall && 'small'"
         :style="linkStyles"
@@ -63,7 +63,7 @@
 
     <KRouterLink
       v-if="nextContent"
-      :to="genContentLink(nextContent.id, nextContent.is_leaf, backRoute, context)"
+      :to="genContentLink(nextContent.id, null, nextContent.is_leaf, null, context)"
       class="next-content-link"
       :style="{ borderTop: '1px solid ' + $themeTokens.fineLine, ...linkStyles }"
     >
@@ -83,7 +83,6 @@
 
 <script>
 
-  import { mapState } from 'vuex';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
@@ -147,8 +146,6 @@
       },
     },
     computed: {
-      ...mapState(['pageName']),
-      ...mapState('lessonPlaylist', ['currentLesson']),
       /** Overrides some default styles in KRouterLink */
       linkStyles() {
         return {
@@ -163,18 +160,8 @@
           : sidePanelStrings.$tr('noOtherTopicResources');
         /* eslint-enable */
       },
-      backRoute() {
-        return this.pageName;
-      },
       context() {
-        let context = {
-          id: this.$route.params.id,
-        };
-        if (this.currentLesson && this.currentLesson.classroom) {
-          context['lessonId'] = this.currentLesson.id;
-          context['classId'] = this.currentLesson.classroom.id;
-        }
-        return context;
+        return this.$route.query;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -55,6 +55,8 @@
       </KRouterLink>
     </div>
 
+    <KCircularLoader v-else-if="loading" />
+
     <div v-else>
       {{ emptyMessage }}
     </div>
@@ -136,6 +138,10 @@
         },
       },
       isLesson: {
+        type: Boolean,
+        default: false,
+      },
+      loading: {
         type: Boolean,
         default: false,
       },


### PR DESCRIPTION
## Summary
* Switches the eager loading of data for the AlsoInThis side panel to be lazy upon the side panel opening
* Parallelizes some of the data loading to minimizes round trip chains
* Fixes link generation in the Also In this side panel, and defers to the current context rather than duplicating

## Reviewer guidance
Does data get loaded right? Does it get cleared properly when navigating directly to a new content item?

Can you navigate properly to different items in the Also In this panel?

All changes:
![fullspeedalsointhis](https://user-images.githubusercontent.com/1680573/142690610-99e7e6f8-d956-4409-8b3a-9528cf0f3342.gif)

Using throttled connection to show loading state:
![alsointhisloadingstate](https://user-images.githubusercontent.com/1680573/142690658-e322863a-ed44-4bd7-a712-f860b1b12399.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
