### PR TITLE
Updates to developer 'getting started' docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # can be used to pass in a pre-build pex file or fixtures for tests
 docker/mnt/
 
+# other docker files
+docker-whl.cid
+docker-whl.iid
+
 # C extensions
 *.so
 

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -43,4 +43,3 @@ If the `KOLIBRI_PROVISIONDEVICE_FACILITY` environment variable is set, the entry
 * `KOLIBRI_PROVISIONDEVICE_PRESET`: defaults to `formal`, with the other options being `nonformal` and `informal`
 * `KOLIBRI_PROVISIONDEVICE_SUPERUSERNAME`: default `devowner`
 * `KOLIBRI_PROVISIONDEVICE_SUPERUSERPASSWORD`: default `admin123`
-

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,46 @@
+# Docker-related files
+
+This directory contains docker files and startup scripts for various tasks. See also the `docker-*` `make` commands in the _Makefile_  in the root directory.
+
+## env.list
+
+Docker environment variables
+
+## base.dockerfile
+
+Base layer that installs JavaScript and Python dependencies
+
+## build_whl.dockerfile
+
+Generates a `.whl`, `tar.gz`, and `.pex` files in `dist/`
+
+## build_windows.dockerfile
+
+Generate the Windows installer
+
+## dev.dockerfile
+
+Gull development setup with running devserver
+
+## demoserver.dockerfile
+
+Runs the pex from `KOLIBRI_PEX_URL` with production setup
+
+## entrypoint.py
+
+Startup script that configures Kolibri based on ENV variables:
+
+* `KOLIBRI_PEX_URL`: Download URL or the string ``default``
+* `DOCKERMNT_PEX_PATH`: Local path such as ``/docker/mnt/nameof.pex``
+* `KOLIBRI_RUN_MODE`: set in Dockerfile
+* `KOLIBRI_HOME`: default `/kolibrihome`
+* `KOLIBRI_HTTP_PORT`: default `8080`
+* `KOLIBRI_LANG`: default `en`
+* `CHANNELS_TO_IMPORT`: comma-separated list of channel IDs (not set by default)
+
+If the `KOLIBRI_PROVISIONDEVICE_FACILITY` environment variable is set, the entrypoint script will set up a facility with this name. The `KOLIBRI_LANG` environment variable and the following other environment variables will be used in the process:
+
+* `KOLIBRI_PROVISIONDEVICE_PRESET`: defaults to `formal`, with the other options being `nonformal` and `informal`
+* `KOLIBRI_PROVISIONDEVICE_SUPERUSERNAME`: default `devowner`
+* `KOLIBRI_PROVISIONDEVICE_SUPERUSERPASSWORD`: default `admin123`
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -470,59 +470,39 @@ Learn more about our :ref:`dev_workflow` and :ref:`release_process`
 Development using Docker
 ------------------------
 
-.. note::
-  The Docker workflows below have not been fully tested
+Engineers who are familiar with Docker can start a Kolibri instance without setting up the full JavaScript and Python development environments on the host machine.
 
-Users who are familiar with Docker can spin up a Kolibri instance quickly without setting up
-the full JavaScript and Python development environments. We provide docker images that contain
-all the necessary prerequisites for running Kolibri.
+For more information, see the *docker* directory and the ``docker-*`` commands in the *Makefile*.
 
-The ``docker/`` directory contains the docker files and startup scripts needed for various tasks.
 
- * ``docker/base.dockerfile``: the base layer that installs JavaScript and Python dependencies (image tag ``learningequality/kolibri``).
- * ``docker/build_whl.dockerfile``: generates a ``.whl``, ``tar.gz``, and ``.pex`` files in ``dist/``
- * ``docker/build_windows.dockerfile``: used to generate the Windows installer.
- * ``docker/dev.dockerfile``: container with full development setup, running devserver.
- * ``docker/demoserver.dockerfile``: runs the pex from ``KOLIBRI_PEX_URL`` with production setup.
- * ``docker/entrypoint.py``: startup script that configures Kolibri based on ENV variables:
+Development server
+~~~~~~~~~~~~~~~~~~
 
-    * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run latest pex from Kolibri download page
-    * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
-    * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
-    * ``KOLIBRI_RUN_MODE``: set in Dockerfile
-    * ``KOLIBRI_PROVISIONDEVICE_FACILITY``: if this environment variable is set
-      the entrypoint script will run the provision device an setup a facility
-      with this name. The ``KOLIBRI_LANG`` environment variable and the following
-      other environment variables will be used in the process:
+Start the Kolibri devserver running inside a container:
 
-        * ``KOLIBRI_PROVISIONDEVICE_PRESET``: defaults to ``formal``, with the other options being ``nonformal`` and ``informal``
-        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERNAME``: default ``devowner``
-        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERPASSWORD``: default ``admin123``
+.. code-block:: bash
 
-    * ``KOLIBRI_HOME``: default ``/kolibrihome``
-    * ``KOLIBRI_HTTP_PORT``: default ``8080``
-    * ``KOLIBRI_LANG``: default ``en``
-    * ``CHANNELS_TO_IMPORT``: comma-separated list of channel IDs (not set by default)
+  # only needed first time
+  make docker-build-base
+
+  # takes a few mins to run pip install -e + webpack build
+  make docker-devserver
 
 
 Building a pex file
 ~~~~~~~~~~~~~~~~~~~
 
-When simply testing things out or reviewing a pull request, the easiest way to
-obtain a pex file is to get the link from the buildkite assets link that is present
-for every git branch and every pull request. This is the approach we recommend in
-combination with the ``demoserver`` approach for running described in the next section.
+.. note::
+  The easiest way to obtain a pex file is to submit a Github PR and download the built assets from buildkite.
 
-However, if you want to build and run a pex from the Kolibri code in your current
-local source files without relying on the github and the buildkite integration,
-you can run the following commands to build a pex file:
+If you want to build and run a pex from the Kolibri code in your current local source files without relying on the github and the buildkite integration, you can run the following commands to build a pex file:
 
 .. code-block:: bash
 
   make docker-whl
 
 The pex file will be generated in the ``dist/`` directory. You can run this pex
-file using the ``demoserver`` approach described below.
+file using the production server approach described below.
 
 
 Production server
@@ -533,23 +513,15 @@ environment variables in your local copy of `docker/env.list` then running the c
 
 .. code-block:: bash
 
-  make docker-build-base      # only needed first time
+  # only needed first time
+  make docker-build-base
+
+  # run demo server
   make docker-demoserver
 
 The choice of pex file can be controlled by setting environment variables in the
-file ``docker/env.list``:
+file *./docker/env.list*:
 
- * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run the latest pex from Kolibri download page
- * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
- * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
+ * ``KOLIBRI_PEX_URL``: Download URL or the string ``default``
+ * ``DOCKERMNT_PEX_PATH``: Local path such as ``/docker/mnt/nameof.pex``
 
-
-
-Development server
-~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-  # start the Kolibri devserver running inside a container
-  make docker-build-base  # only needed first time
-  make docker-devserver   # takes a few mins to run pip install -e + webpack build

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -524,4 +524,3 @@ file *./docker/env.list*:
 
  * ``KOLIBRI_PEX_URL``: Download URL or the string ``default``
  * ``DOCKERMNT_PEX_PATH``: Local path such as ``/docker/mnt/nameof.pex``
-

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -269,93 +269,6 @@ In production, content is served through CherryPy. Static assets must be pre-bui
 Now you should be able to access the server at ``http://127.0.0.1:8080/``.
 
 
-
-
-Developing on Kolibri inside Docker
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. note::
-  The Docker workflows below have not been fully tested
-
-Users who are familiar with Docker can spin up a Kolibri instance quickly without setting up
-the full JavaScript and Python development environments. We provide docker images that contain
-all the necessary prerequisites for running Kolibri.
-
-The ``docker/`` directory contains the docker files and startup scripts needed for various tasks.
-
- * ``docker/base.dockerfile``: the base layer that installs JavaScript and Python dependencies (image tag ``learningequality/kolibri``).
- * ``docker/build_whl.dockerfile``: generates a ``.whl``, ``tar.gz``, and ``.pex`` files in ``dist/``
- * ``docker/build_windows.dockerfile``: used to generate the Windows installer.
- * ``docker/dev.dockerfile``: container with full development setup, running devserver.
- * ``docker/demoserver.dockerfile``: runs the pex from ``KOLIBRI_PEX_URL`` with production setup.
- * ``docker/entrypoint.py``: startup script that configures Kolibri based on ENV variables:
-
-    * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run latest pex from Kolibri download page
-    * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
-    * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
-    * ``KOLIBRI_RUN_MODE``: set in Dockerfile
-    * ``KOLIBRI_PROVISIONDEVICE_FACILITY``: if this environment variable is set
-      the entrypoint script will run the provision device an setup a facility
-      with this name. The ``KOLIBRI_LANG`` environment variable and the following
-      other environment variables will be used in the process:
-
-        * ``KOLIBRI_PROVISIONDEVICE_PRESET``: defaults to ``formal``, with the other options being ``nonformal`` and ``informal``
-        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERNAME``: default ``devowner``
-        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERPASSWORD``: default ``admin123``
-
-    * ``KOLIBRI_HOME``: default ``/kolibrihome``
-    * ``KOLIBRI_HTTP_PORT``: default ``8080``
-    * ``KOLIBRI_LANG``: default ``en``
-    * ``CHANNELS_TO_IMPORT``: comma-separated list of channel IDs (not set by default)
-
-
-**Building a pex file:**
-
-When simply testing things out or reviewing a pull request, the easiest way to
-obtain a pex file is to get the link from the buildkite assets link that is present
-for every git branch and every pull request. This is the approach we recommend in
-combination with the ``demoserver`` approach for running described in the next section.
-
-However, if you want to build and run a pex from the Kolibri code in your current
-local source files without relying on the github and the buildkite integration,
-you can run the following commands to build a pex file:
-
-.. code-block:: bash
-
-  make docker-whl
-
-The pex file will be generated in the ``dist/`` directory. You can run this pex
-file using the ``demoserver`` approach described below.
-
-
-**Starting a demo server:**
-
-You can start a Kolibri instance running any pex file by setting the appropriate
-environment variables in your local copy of `docker/env.list` then running the commands:
-
-.. code-block:: bash
-
-  make docker-build-base      # only needed first time
-  make docker-demoserver
-
-The choice of pex file can be controlled by setting environment variables in the
-file ``docker/env.list``:
-
- * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run the latest pex from Kolibri download page
- * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
- * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
-
-
-
-**Starting a devserver:**
-
-.. code-block:: bash
-
-  # start the Kolibri devserver running inside a container
-  make docker-build-base  # only needed first time
-  make docker-devserver   # takes a few mins to run pip install -e + webpack build
-
-
 Additional Recommended Setup
 ----------------------------
 
@@ -545,3 +458,93 @@ Go to Kolibri's `GitHub page <https://github.com/learningequality/kolibri>`__, a
 Another member of the team will review your code, and either ask for updates on your part or merge your PR to Kolibri codebase. Until the PR is merged you can push new commits to your branch and add updates to it.
 
 Learn more about our :ref:`dev_workflow` and :ref:`release_process`
+
+
+
+
+Development using Docker
+------------------------
+
+.. note::
+  The Docker workflows below have not been fully tested
+
+Users who are familiar with Docker can spin up a Kolibri instance quickly without setting up
+the full JavaScript and Python development environments. We provide docker images that contain
+all the necessary prerequisites for running Kolibri.
+
+The ``docker/`` directory contains the docker files and startup scripts needed for various tasks.
+
+ * ``docker/base.dockerfile``: the base layer that installs JavaScript and Python dependencies (image tag ``learningequality/kolibri``).
+ * ``docker/build_whl.dockerfile``: generates a ``.whl``, ``tar.gz``, and ``.pex`` files in ``dist/``
+ * ``docker/build_windows.dockerfile``: used to generate the Windows installer.
+ * ``docker/dev.dockerfile``: container with full development setup, running devserver.
+ * ``docker/demoserver.dockerfile``: runs the pex from ``KOLIBRI_PEX_URL`` with production setup.
+ * ``docker/entrypoint.py``: startup script that configures Kolibri based on ENV variables:
+
+    * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run latest pex from Kolibri download page
+    * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
+    * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
+    * ``KOLIBRI_RUN_MODE``: set in Dockerfile
+    * ``KOLIBRI_PROVISIONDEVICE_FACILITY``: if this environment variable is set
+      the entrypoint script will run the provision device an setup a facility
+      with this name. The ``KOLIBRI_LANG`` environment variable and the following
+      other environment variables will be used in the process:
+
+        * ``KOLIBRI_PROVISIONDEVICE_PRESET``: defaults to ``formal``, with the other options being ``nonformal`` and ``informal``
+        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERNAME``: default ``devowner``
+        * ``KOLIBRI_PROVISIONDEVICE_SUPERUSERPASSWORD``: default ``admin123``
+
+    * ``KOLIBRI_HOME``: default ``/kolibrihome``
+    * ``KOLIBRI_HTTP_PORT``: default ``8080``
+    * ``KOLIBRI_LANG``: default ``en``
+    * ``CHANNELS_TO_IMPORT``: comma-separated list of channel IDs (not set by default)
+
+
+Building a pex file
+~~~~~~~~~~~~~~~~~~~
+
+When simply testing things out or reviewing a pull request, the easiest way to
+obtain a pex file is to get the link from the buildkite assets link that is present
+for every git branch and every pull request. This is the approach we recommend in
+combination with the ``demoserver`` approach for running described in the next section.
+
+However, if you want to build and run a pex from the Kolibri code in your current
+local source files without relying on the github and the buildkite integration,
+you can run the following commands to build a pex file:
+
+.. code-block:: bash
+
+  make docker-whl
+
+The pex file will be generated in the ``dist/`` directory. You can run this pex
+file using the ``demoserver`` approach described below.
+
+
+Production server
+~~~~~~~~~~~~~~~~~
+
+You can start a Kolibri instance running any pex file by setting the appropriate
+environment variables in your local copy of `docker/env.list` then running the commands:
+
+.. code-block:: bash
+
+  make docker-build-base      # only needed first time
+  make docker-demoserver
+
+The choice of pex file can be controlled by setting environment variables in the
+file ``docker/env.list``:
+
+ * Set ``KOLIBRI_PEX_URL`` to string ``default`` to run the latest pex from Kolibri download page
+ * Set ``KOLIBRI_PEX_URL`` to something like ``http://host.org/nameof.pex``
+ * Set ``DOCKERMNT_PEX_PATH`` to something like ``/docker/mnt/nameof.pex``
+
+
+
+Development server
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+  # start the Kolibri devserver running inside a container
+  make docker-build-base  # only needed first time
+  make docker-devserver   # takes a few mins to run pip install -e + webpack build

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -275,8 +275,8 @@ Vue development tools
 To ensure a more efficient workflow, install appropriate editor plugins for Vue.js, ESLint, and stylelint.
 
 
-Sample data for development
----------------------------
+Sample resources and data
+-------------------------
 
 Once you have the server running, proceed to import some channels and resources. To quickly import all available and supported Kolibri resource types, use the token ``nakav-mafak`` for the `Kolibri QA channel <https://kolibri-beta.learningequality.org/en/learn/#/topics/95a52b386f2c485cb97dd60901674a98>`__ (~350MB).
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -5,8 +5,8 @@ Getting started
 
 First of all, thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference. The instructions below should get you up and running the code in no time!
 
-Setting up Kolibri for development
-----------------------------------
+Prerequisites
+-------------
 
 Most of the steps below require entering commands into your Terminal, so you should expect to become comfortable with this if you're not already.
 
@@ -170,11 +170,6 @@ The Python project-specific dependencies installed above will install ``nodeenv`
   yarn install
 
 
-Running the Kolibri server
---------------------------
-
-.. _devserver:
-
 Database setup
 ~~~~~~~~~~~~~~
 
@@ -183,6 +178,12 @@ To initialize the database run the following command:
 .. code-block:: bash
 
   kolibri manage migrate
+
+
+Running the server
+------------------
+
+.. _devserver:
 
 
 Development server
@@ -202,121 +203,113 @@ Alternatively, you can run the devserver with `hot reload <https://vue-loader.vu
 
   yarn run devserver-hot
 
-Note that the default devserver commands above will automatically watch your source files for changes as you edit them, and do formatting and linting fixes on them. If you would prefer to do these on demand (such as with IDE linting tools or using a tool like pre-commit), then it is best to use the following commands, whereby linting and formatting errors will generate warnings, but not be fixed on the fly:
+Note that the default devserver commands above will automatically watch your source files for changes as you edit them, and do formatting and linting fixes on them.
 
-.. code-block:: bash
+For more information, including instructions on disabling auto-formatting, see the :ref:`linting` section below.
 
-  yarn run devserver-warn
-
-Or:
-
-.. code-block:: bash
-
-  yarn run devserver-hot-warn
+For a complete reference of the commands that can be run and what they do, inspect the ``scripts`` section of the root *./package.json* file.
 
 .. warning::
 
   Some functionality, such as right-to-left language support, is broken when hot-reload is enabled
 
-
-Development server - advanced
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The commands above will start multiple concurrent processes: One for the Django web server, and at least one more for the webpack devserver. If you'd like to start these processes separately, you can do it in two separate terminal windows.
-
-In the first terminal you can start the django development server with this command:
-
-.. code-block:: bash
-
-  yarn run python-devserver
-
-In the second terminal, you can start the webpack build process for frontend assets in 'watch' mode – meaning they will be automatically rebuilt if you modify them – with this command:
-
-.. code-block:: bash
-
-  yarn run watch
-
-If you need to make the development server available through the LAN, you need to do a production build of the assets; so use the following commands:
-
-.. code-block:: bash
-
-  # first build the assets
-  yarn run build
-  # now, run the Django devserver
-  yarn run python-devserver
-
-Now you can simply use your server's IP from another device in the local network through the port 8000, for example ``http://192.168.1.38:8000/``.
-
-
 .. tip::
 
   If you get an error similar to "Node Sass could not find a binding for your current environment", try running ``npm rebuild node-sass``
 
+Production server
+~~~~~~~~~~~~~~~~~
 
-
-Production
-~~~~~~~~~~
-
-In production, content is served through CherryPy. Static assets must be pre-built:
+In production, content is served through CherryPy. Frontend static assets are pre-built:
 
 .. code-block:: bash
 
   # first build the assets
   yarn run build
+
   # now, run the Django production server
   kolibri start
 
 Now you should be able to access the server at ``http://127.0.0.1:8080/``.
 
 
-Additional Recommended Setup
-----------------------------
+Separate servers
+~~~~~~~~~~~~~~~~
 
-If you're planning on contributing code to the project, there are a few additional steps you should consider taking.
+If you are working mainly on backend code, you can build the front-end assets once and then just run the Python devserver. This may also help with multi-device testing over a LAN.
+
+.. code-block:: bash
+
+  # first build the front-end assets
+  yarn run build
+
+  # now, run the Django devserver
+  yarn run python-devserver
+
+You can also run the Django development server and webpack devserver independently in separate terminal windows. In the first terminal you can start the django development server:
+
+.. code-block:: bash
+
+  yarn run python-devserver
+
+and in the second terminal, start the webpack build process for frontend assets:
+
+.. code-block:: bash
+
+  yarn run frontend-devserver
 
 
-Editor config
-~~~~~~~~~~~~~
+Editor configuration
+--------------------
 
 We have a project-level *.editorconfig* file to help you configure your text editor or IDE to use our internal conventions.
 
 `Check your editor <http://editorconfig.org/#download>`__ to see if it supports EditorConfig out-of-the-box, or if a plugin is available.
 
 
-Frontend dev tools
-~~~~~~~~~~~~~~~~~~
+Vue development tools
+---------------------
 
 `Vue.js devtools <https://github.com/vuejs/vue-devtools>`__ is a browser plugin that is very helpful when working with Vue.js components and Vuex.
 
 To ensure a more efficient workflow, install appropriate editor plugins for Vue.js, ESLint, and stylelint.
 
 
-Import channels and resources
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sample data for development
+---------------------------
 
 Once you have the server running, proceed to import some channels and resources. To quickly import all available and supported Kolibri resource types, use the token ``nakav-mafak`` for the `Kolibri QA channel <https://kolibri-beta.learningequality.org/en/learn/#/topics/95a52b386f2c485cb97dd60901674a98>`__ (~350MB).
 
 
+Now you can create users, classes, lessons, etc manually. To auto-generate some sample user data you can also run:
 
-.. _workflow_intro:
+.. code-block:: bash
 
-Development workflows
----------------------
+  kolibri manage generateuserdata
 
-Design system
-~~~~~~~~~~~~~
-
-We have a large number of reusable patterns, conventions, and components built into the application. Review the `Kolibri Design System <https://design-system.learningequality.org/>`__ to get a sense for the tools at your disposal, and to ensure that new changes stay consistent with established UI patterns.
 
 
 Linting and auto-formatting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
+
+.. _linting:
+
+Manual linting and formatting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Linting and code auto-formatting provided by Prettier and Black are run in the background automatically by ``yarn run devserver`` (see :ref:`devserver`). You can monitor for linting errors and warnings in the terminal outputs of the dev server while it is running.
 
-A full set of linting and auto-formatting can also be applied by pre-commit hooks (instructions below). The pre-commit hooks are identical to the automated build check by Travis CI in Pull Requests.
+If you would prefer to do these on demand (such as with IDE linting tools or using a tool like pre-commit) then you can run the development server in "warning only" mode. For example:
 
-.. tip:: As a convenience, many developers install linting and formatting plugins in their code editor (IDE). Installing ESLint, Prettier, Black, and Flake8 plugins in your editor will catch most (but not all) code-quality checks.
+.. code-block:: bash
+
+  yarn run devserver-warn
+
+or with hot reload:
+
+.. code-block:: bash
+
+  yarn run devserver-hot-warn
 
 You can manually run the auto-formatters using:
 
@@ -332,6 +325,12 @@ Or to check the formatting without writing changes, run:
   yarn run lint-frontend
   yarn run fmt-backend:check
 
+
+Pre-commit hooks
+~~~~~~~~~~~~~~~~
+
+A full set of linting and auto-formatting can also be applied by pre-commit hooks. The pre-commit hooks are identical to the automated build check by Travis CI in Pull Requests.
+
 `pre-commit <http://pre-commit.com/>`__ is used to apply a full set of checks and formatting automatically each time that ``git commit`` runs. If there are errors, the Git commit is aborted and you are asked to fix the error and run ``git commit`` again.
 
 Pre-commit is already installed as a development dependency, but you also need to enable it:
@@ -340,13 +339,45 @@ Pre-commit is already installed as a development dependency, but you also need t
 
   pre-commit install
 
-.. note:: Pre-commit can have issues running from alternative Git clients like GitUp. If you encounter problems while committing changes, run ``pre-commit uninstall`` to disable pre-commit.
+.. tip:: As a convenience, many developers install linting and formatting plugins in their code editor (IDE). Installing ESLint, Prettier, Black, and Flake8 plugins in your editor will catch most (but not all) code-quality checks.
+
+.. tip:: Pre-commit can have issues running from alternative Git clients like GitUp. If you encounter problems while committing changes, run ``pre-commit uninstall`` to disable pre-commit.
 
 .. warning:: If you do not use any linting tools, your code is likely fail our server-side checks and you will need to update the PR in order to get it merged.
 
 
+Design system
+-------------
+
+We have a large number of reusable patterns, conventions, and components built into the application. Review the `Kolibri Design System <https://design-system.learningequality.org/>`__ to get a sense for the tools at your disposal, and to ensure that new changes stay consistent with established UI patterns.
+
+
+Updating documentation
+----------------------
+
+First, install some additional dependencies related to building documentation output:
+
+.. code-block:: bash
+
+  pip install -r requirements/docs.txt
+  pip install -r requirements/build.txt
+
+To make changes to documentation, edit the ``rst`` files in the ``kolibri/docs`` directory and then run:
+
+.. code-block:: bash
+
+  make docs
+
+You can also run the auto-build for faster editing from the ``docs`` directory:
+
+.. code-block:: bash
+
+  cd docs
+  sphinx-autobuild --port 8888 . _build
+
+
 Automated testing
-~~~~~~~~~~~~~~~~~
+-----------------
 
 
 Kolibri comes with a Javascript test suite based on `Jest <https://jestjs.io/>`__. To run all front-end tests:
@@ -392,32 +423,8 @@ To run Python tests for all environments, use simply ``tox``. This simulates wha
   ``tox`` reuses its environment when it is run again. If you add anything to the requirements, you will want to either delete the `.tox` directory, or run ``tox`` with the ``-r`` argument to recreate the environment
 
 
-Updating documentation
-~~~~~~~~~~~~~~~~~~~~~~
-
-First, install some additional dependencies related to building documentation output:
-
-.. code-block:: bash
-
-  pip install -r requirements/docs.txt
-  pip install -r requirements/build.txt
-
-To make changes to documentation, edit the ``rst`` files in the ``kolibri/docs`` directory and then run:
-
-.. code-block:: bash
-
-  make docs
-
-You can also run the auto-build for faster editing from the ``docs`` directory:
-
-.. code-block:: bash
-
-  cd docs
-  sphinx-autobuild --port 8888 . _build
-
-
 Manual testing
-~~~~~~~~~~~~~~
+--------------
 
 All changes should be thoroughly tested and vetted before being merged in. Our primary considerations are:
 
@@ -458,8 +465,6 @@ Go to Kolibri's `GitHub page <https://github.com/learningequality/kolibri>`__, a
 Another member of the team will review your code, and either ask for updates on your part or merge your PR to Kolibri codebase. Until the PR is merged you can push new commits to your branch and add updates to it.
 
 Learn more about our :ref:`dev_workflow` and :ref:`release_process`
-
-
 
 
 Development using Docker


### PR DESCRIPTION
## Summary

A number of updates to the 'getting started' page to help new contributors.

* Reorganized sections to make reading flow from start-to-end more natural for a first-time contributor
* Moved Docker-related instructions to end of file, and moved information about implementation details to _./docker/readme.md_
* Flattened nested header structure a bit to make scanning the left-hand navigation easier
* Clarified instructions related to running servers and linting

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/2367265/142773142-554b3cf4-3dd8-44be-987f-78d6533865ef.png) | ![image](https://user-images.githubusercontent.com/2367265/142773251-20d7e06c-0d18-44ed-805b-1b57a3f64935.png) |


## Reviewer guidance

To test docs locally, run `sphinx-autobuild --port 8888 . _build`

Note that due to reorganization of sections, the git diffs are not particularly helpful. It may be more useful to load up the final state and browse through it alongside the current state.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
