### PR TITLE
Prevent unnecessary fetches on the library page.

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -6,7 +6,7 @@ import { deduplicateResources } from '../utils/contentNode';
 import { normalizeContentNode } from '../modules/coreLearn/utils';
 import useContentNodeProgress from './useContentNodeProgress';
 
-const searchKeys = [
+export const searchKeys = [
   'learning_activities',
   'categories',
   'learner_needs',

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -4,17 +4,15 @@ import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import { PageNames } from '../../constants';
 import useChannels from '../../composables/useChannels';
-import useContentNodeProgress from '../../composables/useContentNodeProgress';
 import useLearnerResources from '../../composables/useLearnerResources';
+import { searchKeys } from '../../composables/useSearch';
 import { _collectionState } from '../coreLearn/utils';
 
 const { channels } = useChannels();
 
-const { fetchContentNodeProgress } = useContentNodeProgress();
-
 const { fetchResumableContentNodes } = useLearnerResources();
 
-export function showLibrary(store) {
+export function showLibrary(store, query) {
   if (!get(channels).length) {
     return;
   }
@@ -24,41 +22,45 @@ export function showLibrary(store) {
     store.commit('CORE_SET_PAGE_LOADING', true);
   }
 
-  const promises = [
-    ContentNodeResource.fetchCollection({
-      getParams: {
-        parent__isnull: true,
-        include_coach_content:
-          store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
-      },
-    }),
-  ];
+  const promises = [];
 
-  if (store.getters.isUserLoggedIn) {
-    fetchContentNodeProgress({ resume: true });
-    promises.push(fetchResumableContentNodes());
+  if (!searchKeys.some(key => query[key])) {
+    promises.push(
+      ContentNodeResource.fetchCollection({
+        getParams: {
+          parent__isnull: true,
+          include_coach_content:
+            store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+        },
+      })
+    );
+    if (store.getters.isUserLoggedIn) {
+      promises.push(fetchResumableContentNodes());
+    }
   }
 
   return ConditionalPromise.all(promises).only(
     samePageCheckGenerator(store),
     ([channelCollection]) => {
-      // we want them to be in the same order as the channels list
-      const rootNodes = get(channels)
-        .map(channel => {
-          const node = _collectionState(channelCollection).find(n => n.channel_id === channel.id);
-          if (node) {
-            // The `channel` comes with additional data that is
-            // not returned from the ContentNodeResource.
-            // Namely thumbnail, description and tagline (so far)
-            node.title = channel.name || node.title;
-            node.thumbnail = channel.thumbnail;
-            node.description = channel.tagline || channel.description;
-            return node;
-          }
-        })
-        .filter(Boolean);
+      if (channelCollection && channelCollection.length) {
+        // we want them to be in the same order as the channels list
+        const rootNodes = get(channels)
+          .map(channel => {
+            const node = _collectionState(channelCollection).find(n => n.channel_id === channel.id);
+            if (node) {
+              // The `channel` comes with additional data that is
+              // not returned from the ContentNodeResource.
+              // Namely thumbnail, description and tagline (so far)
+              node.title = channel.name || node.title;
+              node.thumbnail = channel.thumbnail;
+              node.description = channel.tagline || channel.description;
+              return node;
+            }
+          })
+          .filter(Boolean);
 
-      store.commit('SET_ROOT_NODES', rootNodes);
+        store.commit('SET_ROOT_NODES', rootNodes);
+      }
 
       store.commit('CORE_SET_PAGE_LOADING', false);
       store.commit('CORE_SET_ERROR', null);

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -25,6 +25,7 @@ export function showLibrary(store, query) {
   const promises = [];
 
   if (!searchKeys.some(key => query[key])) {
+    // If not currently on a route with search terms
     promises.push(
       ContentNodeResource.fetchCollection({
         getParams: {

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -84,11 +84,11 @@ export default [
   {
     name: PageNames.LIBRARY,
     path: '/library',
-    handler: () => {
+    handler: to => {
       if (unassignedContentGuard()) {
         return unassignedContentGuard();
       }
-      showLibrary(store);
+      showLibrary(store, to.query);
     },
     component: LibraryPage,
   },


### PR DESCRIPTION
## Summary
* Conditionalizes data loading on the Library page depending on whether a search is currently under way or not

## Reviewer guidance
Should prevent repeated fetches of the root node data (less of a problem as they hit browser cache) and resume + resume contentnode progress

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
