### PR TITLE
Tweak Resource search drop down UX

### DIFF
--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -938,8 +938,6 @@
       .ui-select-display {
         color: $ui-input-text-color--disabled;
         cursor: default;
-        border-bottom-style: $ui-input-border-style--disabled;
-        border-bottom-width: $ui-input-border-width--active;
       }
 
       .ui-select-dropdown-button,

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -482,7 +482,7 @@
         return {};
       },
       clearableState() {
-        return this.clearable && this.value && Object.keys(this.value).length;
+        return this.clearable && this.value && Object.keys(this.value).length && !this.disabled;
       },
     },
 

--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -161,6 +161,8 @@
 
 <style lang="scss" scoped>
 
+  @import 'kolibri-design-system/lib/keen/styles/imports';
+
   .k-select-inline {
     display: inline-block;
     width: 150px;
@@ -171,6 +173,15 @@
   .k-select-disabled /deep/ .ui-select__label-text.is-inline {
     cursor: default;
   }
+
+  /* stylelint-disable csstree/validator */
+
+  .k-select-disabled {
+    border-bottom-style: $ui-input-border-style--disabled;
+    border-bottom-width: $ui-input-border-width--active;
+  }
+
+  /* stylelint-enable */
 
   /deep/ .ui-select__display-value {
     line-height: 1.3;

--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -179,6 +179,7 @@
   /* stylelint-disable csstree/validator */
 
   .k-select-disabled {
+    border-bottom-color: $ui-input-text-color--disabled;
     border-bottom-style: $ui-input-border-style--disabled;
     border-bottom-width: $ui-input-border-width--active;
   }

--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -146,7 +146,9 @@
       },
       selection(newSelection) {
         /* Emits new selection.*/
-        this.$emit('change', newSelection);
+        if (!this.disabled) {
+          this.$emit('change', newSelection);
+        }
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
@@ -4,6 +4,7 @@
     <KSelect
       v-if="languageOptionsList.length"
       :options="languageOptionsList"
+      :disabled="!langId && enabledLanguageOptions.length < 2"
       class="selector"
       :clearable="true"
       :value="selectedLanguage"
@@ -14,6 +15,7 @@
     <KSelect
       v-if="contentLevelsList.length"
       :options="contentLevelsList"
+      :disabled="!levelId && enabledContentLevels.length < 2"
       class="selector"
       :clearable="true"
       :value="selectedLevel"
@@ -24,6 +26,7 @@
     <KSelect
       v-if="showChannels && channelOptionsList.length"
       :options="channelOptionsList"
+      :disabled="!channelId && enabledChannelOptions.length < 2"
       class="selector"
       :clearable="true"
       :value="selectedChannel"
@@ -34,6 +37,7 @@
     <KSelect
       v-if="accessibilityOptionsList.length"
       :options="accessibilityOptionsList"
+      :disabled="!accessId && enabledAccessibilityOptions.length < 2"
       class="selector"
       :clearable="true"
       :value="selectedAccessibilityFilter"
@@ -99,6 +103,9 @@
           };
         });
       },
+      enabledLanguageOptions() {
+        return this.languageOptionsList.filter(l => !l.disabled);
+      },
       accessibilityOptionsList() {
         return accessibilityOptionsList.map(key => {
           const value = AccessibilityCategories[key];
@@ -109,6 +116,9 @@
             label: this.coreString(camelCase(key)),
           };
         });
+      },
+      enabledAccessibilityOptions() {
+        return this.accessibilityOptionsList.filter(a => !a.disabled);
       },
       contentLevelsList() {
         return contentLevelsList.map(key => {
@@ -130,6 +140,9 @@
           };
         });
       },
+      enabledContentLevels() {
+        return this.contentLevelsList.filter(c => !c.disabled);
+      },
       channelOptionsList() {
         return plugin_data.channels.map(channel => ({
           value: channel.id,
@@ -138,21 +151,44 @@
           label: channel.name,
         }));
       },
+      enabledChannelOptions() {
+        return this.channelOptionsList.filter(c => !c.disabled);
+      },
+      langId() {
+        return Object.keys(this.value.languages)[0];
+      },
       selectedLanguage() {
-        const langId = Object.keys(this.value.languages)[0];
-        return this.languageOptionsList.find(o => o.value === langId) || {};
+        if (!this.langId && this.enabledLanguageOptions.length === 1) {
+          return this.enabledLanguageOptions[0];
+        }
+        return this.languageOptionsList.find(o => o.value === this.langId) || {};
+      },
+      accessId() {
+        return Object.keys(this.value.accessibility_labels)[0];
       },
       selectedAccessibilityFilter() {
-        const accessId = Object.keys(this.value.accessibility_labels)[0];
-        return this.accessibilityOptionsList.find(o => o.value === accessId) || {};
+        if (!this.accessId && this.enabledAccessibilityOptions.length === 1) {
+          return this.enabledAccessibilityOptions[0];
+        }
+        return this.accessibilityOptionsList.find(o => o.value === this.accessId) || {};
+      },
+      levelId() {
+        return Object.keys(this.value.grade_levels)[0];
       },
       selectedLevel() {
-        const levelId = Object.keys(this.value.grade_levels)[0];
-        return this.contentLevelsList.find(o => o.value === levelId) || {};
+        if (!this.levelId && this.enabledContentLevels.length === 1) {
+          return this.enabledContentLevels[0];
+        }
+        return this.contentLevelsList.find(o => o.value === this.levelId) || {};
+      },
+      channelId() {
+        return Object.keys(this.value.channels)[0];
       },
       selectedChannel() {
-        const channelId = Object.keys(this.value.channels)[0];
-        return this.channelOptionsList.find(o => o.value === channelId) || {};
+        if (!this.channelId && this.enabledChannelOptions.length === 1) {
+          return this.enabledChannelOptions[0];
+        }
+        return this.channelOptionsList.find(o => o.value === this.channelId) || {};
       },
     },
     methods: {


### PR DESCRIPTION
## Summary
* Updates the search dropdown selectors to be disabled when no options in them are available to filter by
* Updates the search dropdown selectors to be disabled when there is only one option in them available to filter by and displays that option
* To achieve this also does these updates to KSelect:
  * Fixes the disabled state styling to properly show the dotted line at the bottom of the select box
  * Prevents the 'clearable' state from being displayed when the KSelect is disabled
  * Prevents KSelect from emitting change events when it is disabled (this allows the easy display of the single value case)

## Reviewer guidance
Does filtering by the dropdown options still work as expected?
Does the new flow make sense?

![dropdown](https://user-images.githubusercontent.com/1680573/142891102-2e92e4c9-6b48-469a-93dd-d9af2ba493a0.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
