### PR TITLE
Fixes and tests for metadata labels

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -135,13 +135,36 @@ class ChannelMetadataFilter(FilterSet):
 
 
 @method_decorator(cache_forever, name="dispatch")
-class ChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
-    serializer_class = serializers.ChannelMetadataSerializer
+class ChannelMetadataViewSet(ReadOnlyValuesViewset):
     filter_backends = (DjangoFilterBackend,)
     filter_class = ChannelMetadataFilter
 
+    values = (
+        "author",
+        "description",
+        "tagline",
+        "id",
+        "last_updated",
+        "root__lang__lang_code",
+        "root__lang__lang_name",
+        "name",
+        "root",
+        "thumbnail",
+        "version",
+        "root__available",
+        "root__num_coach_contents",
+        "public",
+    )
+
+    field_map = {
+        "num_coach_contents": "root__num_coach_contents",
+        "available": "root__available",
+        "lang_code": "root__lang__lang_code",
+        "lang_name": "root__lang__lang_name",
+    }
+
     def get_queryset(self):
-        return models.ChannelMetadata.objects.all().select_related("root__lang")
+        return models.ChannelMetadata.objects.all()
 
 
 class IdFilter(FilterSet):

--- a/kolibri/core/content/test/test_search.py
+++ b/kolibri/core/content/test/test_search.py
@@ -1,20 +1,150 @@
+from uuid import uuid4
+
 from django.test import TestCase
+from le_utils.constants import content_kinds
+from parameterized import parameterized
 
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.test.test_channel_upgrade import ChannelBuilder
 from kolibri.core.content.utils.search import annotate_label_bitmasks
+from kolibri.core.content.utils.search import get_available_metadata_labels
 from kolibri.core.content.utils.search import metadata_lookup
 
 
-class BitMaskTestCase(TestCase):
-    def test_ancestors(self):
+class RandomBitMaskTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
         builder = ChannelBuilder()
         builder.insert_into_default_db()
         annotate_label_bitmasks(ContentNode.objects.all())
-        for field, LIST in metadata_lookup.items():
-            for label in LIST:
-                self.assertEqual(
-                    ContentNode.objects.filter(**{field + "__contains": label}).count(),
-                    ContentNode.objects.has_all_labels(field, [label]).count(),
-                    "{} {}".format(field, label),
+
+    @parameterized.expand(
+        (field, label)
+        for field in metadata_lookup.keys()
+        for label in metadata_lookup[field]
+    )
+    def test_bitmasks(self, field, label):
+        self.assertEqual(
+            ContentNode.objects.filter(**{field + "__contains": label}).count(),
+            ContentNode.objects.has_all_labels(field, [label]).count(),
+            "{} {}".format(field, label),
+        )
+
+
+class ConstrainedBitMaskTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        for field in metadata_lookup.keys():
+            for label in metadata_lookup[field]:
+                ContentNode.objects.create(
+                    content_id=uuid4().hex,
+                    channel_id=uuid4().hex,
+                    description="Blah blah blah",
+                    id=uuid4().hex,
+                    license_name="GNU",
+                    license_owner="",
+                    license_description=None,
+                    lang_id=None,
+                    author="",
+                    title="Test{}_{}".format(field, label),
+                    parent_id=None,
+                    kind=content_kinds.VIDEO,
+                    coach_content=False,
+                    available=False,
+                    **{field: label}
                 )
+        annotate_label_bitmasks(ContentNode.objects.all())
+
+    @parameterized.expand(
+        (field, label)
+        for field in metadata_lookup.keys()
+        for label in metadata_lookup[field]
+    )
+    def test_bitmasks(self, field, label):
+        self.assertEqual(
+            ContentNode.objects.filter(**{field + "__contains": label}).count(),
+            ContentNode.objects.has_all_labels(field, [label]).count(),
+            "{} {}".format(field, label),
+        )
+
+
+class RandomMetadataLabelsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        builder = ChannelBuilder()
+        builder.insert_into_default_db()
+        annotate_label_bitmasks(ContentNode.objects.all())
+
+    def _run_test_for_qs(self, queryset):
+        metadata_labels = get_available_metadata_labels(queryset)
+        for field, LIST in metadata_labels.items():
+            if field != "channels" and field != "languages":
+                all_labels = metadata_lookup[field]
+                for label in all_labels:
+                    if label in LIST:
+                        self.assertTrue(
+                            queryset.filter(**{field + "__contains": label}).exists(),
+                            "{} {}".format(field, label),
+                        )
+                    else:
+                        self.assertFalse(
+                            queryset.filter(**{field + "__contains": label}).exists(),
+                            "{} {}".format(field, label),
+                        )
+
+    def test_all(self):
+        self._run_test_for_qs(ContentNode.objects.all())
+
+    @parameterized.expand(content_kinds.choices)
+    def test_filtered_kind(self, kind, kind_name):
+        self._run_test_for_qs(ContentNode.objects.filter(kind=kind))
+
+    @parameterized.expand(
+        (field, label)
+        for field in metadata_lookup.keys()
+        for label in metadata_lookup[field]
+    )
+    def test_labels(self, field, label):
+        self._run_test_for_qs(ContentNode.objects.has_all_labels(field, [label]))
+
+
+class ConstrainedMetadataLabelsTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        for field in metadata_lookup.keys():
+            for label in metadata_lookup[field]:
+                ContentNode.objects.create(
+                    content_id=uuid4().hex,
+                    channel_id=uuid4().hex,
+                    description="Blah blah blah",
+                    id=uuid4().hex,
+                    license_name="GNU",
+                    license_owner="",
+                    license_description=None,
+                    lang_id=None,
+                    author="",
+                    title="Test{}_{}".format(field, label),
+                    parent_id=None,
+                    kind=content_kinds.VIDEO,
+                    coach_content=False,
+                    available=False,
+                    **{field: label}
+                )
+        annotate_label_bitmasks(ContentNode.objects.all())
+
+    @parameterized.expand(
+        (field, label)
+        for field in metadata_lookup.keys()
+        for label in metadata_lookup[field]
+    )
+    def test_labels(self, field, label):
+        metadata_labels = get_available_metadata_labels(
+            ContentNode.objects.filter(**{field: label})
+        )
+        split_labels = label.split(".")
+        expected = [
+            ".".join(split_labels[0:i]) for i in range(1, len(split_labels) + 1)
+        ]
+        self.assertEqual(
+            set(metadata_labels[field]), set(expected), "{} {}".format(field, label)
+        )

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -60,30 +60,14 @@ for key, labels in metadata_lookup.items():
 
 
 def _get_available_languages(base_queryset):
-    from kolibri.core.content.models import Language
-
     lang_ids = (
-        base_queryset.exclude(lang=None)
-        .order_by("lang_id")
-        .values_list("lang_id", flat=True)
+        base_queryset.exclude(lang=None).values_list("lang_id", flat=True).distinct()
     )
-    return list(
-        Language.objects.filter(id__in=lang_ids)
-        .order_by("id")
-        .values("id", "lang_name")
-    )
+    return list(lang_ids)
 
 
 def _get_available_channels(base_queryset):
-    from kolibri.core.content.models import ChannelMetadata
-
-    return list(
-        ChannelMetadata.objects.filter(
-            id__in=base_queryset.values_list("channel_id", flat=True)
-        )
-        .order_by()
-        .values("id", "name")
-    )
+    return list(base_queryset.values_list("channel_id", flat=True).distinct())
 
 
 class SQLiteBitwiseORAggregate(Aggregate):

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -101,7 +101,7 @@ def get_available_metadata_labels(base_queryset):
         aggregates = {}
         for field in bitmask_fieldnames:
             field_agg = field + "_agg"
-            if connections[base_queryset.db].vendor == "sqlite":
+            if connections[base_queryset.db].vendor == "sqlite" or BitOr is None:
                 aggregates[field_agg] = SQLiteBitwiseORAggregate(
                     field, num_bits=len(bitmask_fieldnames[field])
                 )

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -4,10 +4,17 @@ that should not initiate the Django app registry.
 """
 import hashlib
 
+try:
+    from django.contrib.postgres.aggregates import BitOr
+except ImportError:
+    BitOr = None
+
+from django.db import connections
+from django.db.models import Aggregate
 from django.db.models import Case
-from django.db.models import Exists
 from django.db.models import Value
 from django.db.models import When
+from django.db.models.fields import IntegerField
 from le_utils.constants.labels.accessibility_categories import (
     ACCESSIBILITYCATEGORIESLIST,
 )
@@ -80,7 +87,25 @@ def _get_available_channels(base_queryset):
     )
 
 
-def get_available_metadata_labels(base_queryset, limit_to_known_fields=True):
+class SQLiteBitwiseORAggregate(Aggregate):
+    name = "BitwiseOR"
+
+    def __init__(self, expression, num_bits=None, **extra):
+        if not num_bits:
+            raise ValueError("num_bits must be a positive integer")
+        self.num_bits = num_bits
+        super(SQLiteBitwiseORAggregate, self).__init__(
+            expression, output_field=IntegerField(), **extra
+        )
+
+    @property
+    def template(self):
+        return " + ".join(
+            "max(%(expressions)s&{})".format(2 ** i) for i in range(0, self.num_bits)
+        )
+
+
+def get_available_metadata_labels(base_queryset):
     from kolibri.core.device.models import ContentCacheKey
 
     content_cache_key = ContentCacheKey.get_cache_key()
@@ -89,27 +114,25 @@ def get_available_metadata_labels(base_queryset, limit_to_known_fields=True):
         hashlib.md5(str(base_queryset.query).encode("utf8")).hexdigest(),
     )
     if cache_key not in cache:
-        base_queryset = base_queryset.values("id").order_by()
-        queryset = base_queryset
-        all_values = []
-        if limit_to_known_fields:
-            lookup = get_all_contentnode_label_metadata()
-            lookup.pop("channels")
-            lookup.pop("languages")
-        else:
-            lookup = metadata_lookup
-        for field, values in lookup.items():
-            queryset = queryset.annotate(
-                **{
-                    value: Exists(base_queryset.has_all_labels(field, [value]))
-                    for value in values
-                }
-            )
-            all_values += values
-        result = queryset.values(*all_values).first()
+        base_queryset = base_queryset.order_by()
+        aggregates = {}
+        for field in bitmask_fieldnames:
+            field_agg = field + "_agg"
+            if connections[base_queryset.db].vendor == "sqlite":
+                aggregates[field_agg] = SQLiteBitwiseORAggregate(
+                    field, num_bits=len(bitmask_fieldnames[field])
+                )
+            elif connections[base_queryset.db].vendor == "postgresql":
+                aggregates[field_agg] = BitOr(field)
         output = {}
-        for field, values in lookup.items():
-            output[field] = [v for v in values if result and result.get(v)]
+        agg = base_queryset.aggregate(**aggregates)
+        for field, values in bitmask_fieldnames.items():
+            bit_value = agg[field + "_agg"]
+            for value in values:
+                if value["field_name"] not in output:
+                    output[value["field_name"]] = []
+                if bit_value is not None and bit_value & value["bits"]:
+                    output[value["field_name"]].append(value["label"])
         output["languages"] = _get_available_languages(base_queryset)
         output["channels"] = _get_available_channels(base_queryset)
         cache.set(cache_key, output, timeout=None)
@@ -119,9 +142,7 @@ def get_available_metadata_labels(base_queryset, limit_to_known_fields=True):
 def get_all_contentnode_label_metadata():
     from kolibri.core.content.models import ContentNode
 
-    return get_available_metadata_labels(
-        ContentNode.objects.filter(available=True), limit_to_known_fields=False
-    )
+    return get_available_metadata_labels(ContentNode.objects.filter(available=True))
 
 
 def annotate_label_bitmasks(queryset):

--- a/kolibri/core/content/utils/search.py
+++ b/kolibri/core/content/utils/search.py
@@ -69,7 +69,6 @@ def _get_available_languages(base_queryset):
     )
     return list(
         Language.objects.filter(id__in=lang_ids)
-        .distinct()
         .order_by("id")
         .values("id", "lang_name")
     )
@@ -80,10 +79,10 @@ def _get_available_channels(base_queryset):
 
     return list(
         ChannelMetadata.objects.filter(
-            id__in=base_queryset.values_list("channel_id", flat=True).distinct()
+            id__in=base_queryset.values_list("channel_id", flat=True)
         )
-        .order_by("order")
-        .values("id", "name", "thumbnail")
+        .order_by()
+        .values("id", "name")
     )
 
 

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/SelectGroup.vue
@@ -92,9 +92,7 @@
         return plugin_data.languages.map(language => {
           return {
             value: language.id,
-            disabled:
-              this.availableLabels &&
-              !this.availableLabels.languages.find(l => l.id === language.id),
+            disabled: this.availableLabels && !this.availableLabels.languages.includes(language.id),
             label: language.lang_name,
           };
         });
@@ -133,8 +131,7 @@
       channelOptionsList() {
         return plugin_data.channels.map(channel => ({
           value: channel.id,
-          disabled:
-            this.availableLabels && !this.availableLabels.channels.find(c => c.id === channel.id),
+          disabled: this.availableLabels && !this.availableLabels.channels.includes(channel.id),
           label: channel.name,
         }));
       },

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.auth.constants.user_kinds import LEARNER
 from kolibri.core.content.hooks import ContentNodeDisplayHook
-from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
 from kolibri.core.device.utils import allow_learner_unassigned_resource_access
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import is_landing_page
@@ -52,6 +51,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 
     @property
     def plugin_data(self):
+        from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
         from kolibri.core.content.models import ChannelMetadata
 
         channels = list(

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.db.models import F
 from django.urls import reverse
 
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
@@ -52,32 +51,12 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
     @property
     def plugin_data(self):
         from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
-        from kolibri.core.content.models import ChannelMetadata
+        from kolibri.core.content.api import ChannelMetadataViewSet
 
-        channels = list(
-            ChannelMetadata.objects.filter(root__available=True)
-            .annotate(
-                lang_code=F("root__lang__lang_code"),
-                lang_name=F("root__lang__lang_name"),
-                available=F("root__available"),
-                num_coach_contents=F("root__num_coach_contents"),
-            )
-            .values(
-                "author",
-                "description",
-                "tagline",
-                "id",
-                "last_updated",
-                "lang_code",
-                "lang_name",
-                "name",
-                "root",
-                "thumbnail",
-                "version",
-                "available",
-                "num_coach_contents",
-                "public",
-            )
+        channel_viewset = ChannelMetadataViewSet()
+
+        channels = channel_viewset.serialize(
+            channel_viewset.get_queryset().filter(root__available=True)
         )
         label_metadata = get_all_contentnode_label_metadata()
         return {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -52,6 +52,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
     def plugin_data(self):
         from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
         from kolibri.core.content.api import ChannelMetadataViewSet
+        from kolibri.core.content.models import Language
 
         channel_viewset = ChannelMetadataViewSet()
 
@@ -59,6 +60,11 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             channel_viewset.get_queryset().filter(root__available=True)
         )
         label_metadata = get_all_contentnode_label_metadata()
+        languages = list(
+            Language.objects.filter(id__in=label_metadata["languages"]).values(
+                "id", "lang_name"
+            )
+        )
         return {
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
@@ -70,7 +76,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             ),
             "categories": label_metadata["categories"],
             "learningActivities": label_metadata["learning_activities"],
-            "languages": label_metadata["languages"],
+            "languages": languages,
             "channels": channels,
             "gradeLevels": label_metadata["grade_levels"],
             "accessibilityLabels": label_metadata["accessibility_labels"],

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,3 +11,4 @@ pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-pythonpath==0.7.2
 attrs==20.3.0
+parameterized==0.8.1


### PR DESCRIPTION
## Summary
* Adds extensive testing for searching by metadata labels and the available labels generation code
* This showed that the available metadata labels code was not quite doing what it ought
* Changes how the available metadata labels code produces the available metadata labels to make the tests pass and also improve performance
* Uses a Bit wise OR in Postgres to determine which labels are present
* Implements a Bit wise OR shim for SQLite that functions identically to the postgres Bit wise OR, except that the maximum size of bits must be specified in advance
* Uses a bit wise OR to do the label aggregation in a single query without subqueries, which significantly improves the performance, and gives full test compliance
* Limits the data returned for Channels and Languages in the available label metadata to just the ids (reduces query times for these two specific items by roughly 100x for each)
* Bootstraps full language data into the learn page explicitly to compensate for only the ids (to compensate for the full data no longer coming from the available labels)

Fixes #8737

## Reviewer guidance
Does filtering seem to produce the correct remaining labels?
When testing I changed this line to `if True:` https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/content/utils/search.py#L91 to repeatably execute the queries that are being optimized here.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
