### PR TITLE
Number of coach contents fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -53,9 +53,9 @@
       />
       <div class="footer-icons">
         <CoachContentLabel
-          v-if="isUserLoggedIn && !isLearner && content.numCoachContents"
+          v-if="isUserLoggedIn && !isLearner && content.num_coach_contents"
           class="coach-content-label"
-          :value="content.numCoachContents"
+          :value="content.num_coach_contents"
           :isTopic="isTopic"
         />
         <KIconButton
@@ -150,8 +150,8 @@
         return (
           1 +
           this.content.is_leaf +
-          (this.isUserLoggedIn && !this.isLearner && this.content.numCoachContents) +
-          (this.content.numCoachContents > 0) +
+          (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
+          (this.content.num_coach_contents > 0) +
           (this.content.copies_count > 1) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR fixes case typos and also the problem with the info icon overlapping the progress bar that was caused by `footerLength` not being a number since the typo resulted in having `undefined` value in its calculation:

| Before | After |
| --------- | ------ |
| ![Screenshot from 2021-11-22 17-49-17](https://user-images.githubusercontent.com/13509191/142902682-6deeda15-7ed0-4f8a-8700-7aae44aac52c.png) | ![Screenshot from 2021-11-22 17-47-21](https://user-images.githubusercontent.com/13509191/142902702-0b05dffa-b8e7-4339-9880-29dbfbc0c4e7.png) |

After applying these fixes, as you can see on the "After" screenshot above, the resource title truncation doesn't work anymore again as expected (should truncate to 5 lines). I don't think that these updates are causing regression but rather reveal some new layout or styling conditions that also played role in #8667 and maybe @indirectlylit reported the issue under different conditions from when I tried to reproduce it. I'm reopening  #8667 and will look into it again.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
