### PR TITLE
IE is not a modern browser

### DIFF
--- a/kolibri/core/assets/src/utils/setupAndLoadFonts.js
+++ b/kolibri/core/assets/src/utils/setupAndLoadFonts.js
@@ -30,6 +30,9 @@ const modernFontBrowsers = {
     major: 11,
     minor: 4,
   },
+  IE: {
+    major: 100, // specify impossible IE version, forcing passesRequirements to fail
+  },
 };
 
 function loadFullFonts() {


### PR DESCRIPTION
## Summary

The `passesRequirements` function was returning `true` because IE was not included in the requirements.

## References

fixes https://github.com/learningequality/kolibri/issues/5939

## Reviewer guidance

The behavior of `passesRequirements` was surprising at first, but it makes sense.

That said, the solution feels like a hack. Is there a better way?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
