### PR TITLE
Restore Show resources header.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -103,6 +103,9 @@
         v-if="Object.keys(resourcesNeededList).length"
         class="section"
       >
+        <h2 class="title">
+          {{ coreString('showResources') }}
+        </h2>
         <div
           v-for="(val, activity) in resourcesNeededList"
 


### PR DESCRIPTION
## Summary
* Adds show resources header back in that seems to have got lost along the way

## References
Fixes #8762

## Reviewer guidance
Is the display consistent with the other headers in the side panel?
![Screenshot from 2021-11-22 14-19-06](https://user-images.githubusercontent.com/1680573/142943797-640a6435-e1ea-4e10-ac56-0a644d931a45.png)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
