### PR TITLE
Use TextTruncatorCss for cards on library page and truncate resource titles to five lines

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -39,9 +39,9 @@
       />
       <div class="text" :style="{ color: $themeTokens.text }">
         <h3 class="title" dir="auto">
-          <TextTruncator
+          <TextTruncatorCss
             :text="content.title"
-            :maxHeight="maxTitleHeight"
+            :maxLines="5"
           />
         </h3>
       </div>
@@ -86,7 +86,7 @@
   import { mapGetters } from 'vuex';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ProgressBar from '../ProgressBar';
   import LearningActivityLabel from '../cards/ResourceCard/LearningActivityLabel';
@@ -98,7 +98,7 @@
     components: {
       CardThumbnail,
       CoachContentLabel,
-      TextTruncator,
+      TextTruncatorCss,
       LearningActivityLabel,
       ProgressBar,
     },
@@ -137,14 +137,6 @@
           };
         }
         return styles;
-      },
-      maxTitleHeight() {
-        if (this.footerLength && this.subtitle) {
-          return 20;
-        } else if (this.footerLength || this.subtitle) {
-          return 40;
-        }
-        return 120;
       },
       footerLength() {
         return (


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes a bug when the resource title was truncated to one line instead of five lines on the library page and in line with #8532 removes `TextTruncator` in favor of `TextTruncatorCss` on that opportunity.

| Before | After |
| --------- | ------ |
| ![before](https://user-images.githubusercontent.com/13509191/142989015-eb6c0390-475a-4e6b-92b1-b65eac04f0f7.png) | ![after](https://user-images.githubusercontent.com/13509191/142989033-9b5aa279-b82e-4a1d-b90e-8cb8d359167b.png) |

## References

Fixes #8667

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check cards on the library page in regards to text truncation

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
