### PR TITLE
Lesson completion modal

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -509,8 +509,8 @@
   }
 
   .loader {
-    margin-top: 16px;
-    margin-bottom: 16px;
+    margin-top: 56px;
+    margin-bottom: 56px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -53,6 +53,7 @@
       v-if="progress >= 1 && wasIncomplete"
       :isUserLoggedIn="isUserLoggedIn"
       :contentNodeId="content.id"
+      :lessonId="lessonId"
       @close="markAsComplete"
     />
   </div>

--- a/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
@@ -30,6 +30,7 @@ function makeWrapper({ propsData, data } = {}) {
     methods: {
       loadNextContent: jest.fn(),
       loadRecommendedContent: jest.fn(),
+      loadNextLessonContent: jest.fn(),
     },
   });
 }

--- a/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
@@ -1,4 +1,4 @@
-import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
+import { createLocalVue, mount } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 
 import CompletionModal from '../../src/views/CompletionModal';
@@ -28,21 +28,16 @@ function makeWrapper({ propsData, data } = {}) {
     propsData,
     data,
     methods: {
-      loadNextContent: jest.fn(),
-      loadRecommendedContent: jest.fn(),
-      loadNextLessonContent: jest.fn(),
+      loadNextContent: jest.fn().mockResolvedValue(null),
+      loadRecommendedContent: jest.fn().mockResolvedValue([]),
+      loadNextLessonContent: jest.fn().mockResolvedValue(null),
     },
   });
 }
 
 describe('CompletionModal', () => {
   it('smoke test', () => {
-    const wrapper = shallowMount(CompletionModal, {
-      methods: {
-        loadNextContent: jest.fn(),
-        loadRecommendedContent: jest.fn(),
-      },
-    });
+    const wrapper = makeWrapper();
 
     expect(wrapper.exists()).toBe(true);
   });
@@ -101,15 +96,16 @@ describe('CompletionModal', () => {
     });
   });
 
-  it("displays 'Stay and practice' section with 'Stay here' button", () => {
+  it("displays 'Stay and practice' section with 'Stay here' button", async () => {
     const wrapper = makeWrapper();
-
+    await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain('Stay and practice');
     expect(getStayHereButton(wrapper).exists()).toBe(true);
   });
 
-  it("emits `close` even on 'Stay here' button click", () => {
+  it("emits `close` even on 'Stay here' button click", async () => {
     const wrapper = makeWrapper();
+    await wrapper.vm.$nextTick();
     getStayHereButton(wrapper).trigger('click');
 
     expect(wrapper.emitted().close).toBeTruthy();

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -49,6 +49,49 @@ class LearnStateView(APIView):
         )
 
 
+def _consolidate_lessons_data(request, lessons):
+    lesson_contentnode_ids = set()
+    for lesson in lessons:
+        lesson_contentnode_ids |= {
+            resource["contentnode_id"] for resource in lesson["resources"]
+        }
+
+    contentnode_progress = (
+        contentnode_progress_viewset.serialize_list(
+            request, {"ids": lesson_contentnode_ids}
+        )
+        if lesson_contentnode_ids
+        else []
+    )
+
+    contentnodes = (
+        contentnode_viewset.serialize_list(request, {"ids": lesson_contentnode_ids})
+        if lesson_contentnode_ids
+        else []
+    )
+
+    progress_map = {l["content_id"]: l["progress"] for l in contentnode_progress}
+
+    contentnode_map = {c["id"]: c for c in contentnodes}
+
+    for lesson in lessons:
+        lesson["progress"] = {
+            "resource_progress": sum(
+                (
+                    progress_map[resource["content_id"]]
+                    for resource in lesson["resources"]
+                    if resource["content_id"] in progress_map
+                )
+            ),
+            "total_resources": len(lesson["resources"]),
+        }
+        for resource in lesson["resources"]:
+            resource["progress"] = progress_map.get(resource["content_id"], 0)
+            resource["contentnode"] = contentnode_map.get(
+                resource["contentnode_id"], None
+            )
+
+
 class LearnerClassroomViewset(ReadOnlyValuesViewset):
     """
     Returns all Classrooms for which the requesting User is a member,
@@ -79,48 +122,7 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                 "description", "id", "is_active", "title", "resources", "collection"
             )
         )
-        lesson_contentnode_ids = set()
-        for lesson in lessons:
-            lesson_contentnode_ids |= {
-                resource["contentnode_id"] for resource in lesson["resources"]
-            }
-
-        contentnode_progress = (
-            contentnode_progress_viewset.serialize_list(
-                self.request, {"ids": lesson_contentnode_ids}
-            )
-            if lesson_contentnode_ids
-            else []
-        )
-
-        contentnodes = (
-            contentnode_viewset.serialize_list(
-                self.request, {"ids": lesson_contentnode_ids}
-            )
-            if lesson_contentnode_ids
-            else []
-        )
-
-        progress_map = {l["content_id"]: l["progress"] for l in contentnode_progress}
-
-        contentnode_map = {c["id"]: c for c in contentnodes}
-
-        for lesson in lessons:
-            lesson["progress"] = {
-                "resource_progress": sum(
-                    (
-                        progress_map[resource["content_id"]]
-                        for resource in lesson["resources"]
-                        if resource["content_id"] in progress_map
-                    )
-                ),
-                "total_resources": len(lesson["resources"]),
-            }
-            for resource in lesson["resources"]:
-                resource["progress"] = progress_map.get(resource["content_id"], 0)
-                resource["contentnode"] = contentnode_map.get(
-                    resource["contentnode_id"], None
-                )
+        _consolidate_lessons_data(self.request, lessons)
 
         user_masterylog_content_ids = MasteryLog.objects.filter(
             user=self.request.user
@@ -280,3 +282,11 @@ class LearnerLessonViewset(ReadOnlyValuesViewset):
             lesson_assignments__collection__membership__user=self.request.user,
             is_active=True,
         )
+
+    def consolidate(self, items, queryset):
+        if not items:
+            return items
+
+        _consolidate_lessons_data(self.request, items)
+
+        return items


### PR DESCRIPTION
## Summary
* Updates completion modal to be context aware with a lesson prop
* Tweaks the lesson learner viewset in Learn to match the data returned by the learner classroom viewset
* Adds a fetchLesson method to the useLearnerResources composable and matches the behaviour there for reusing content node and progress data returned
* Conditionally loads either the next content if not in a lesson or the next content in a lesson if in a lesson
* Adds restrictions based on the no unassigned content device setting to prevent display of non-lesson next content and recommended content if the device setting is active
* Adds loading a loading state to the completion modal
* Updates data loading for the LearnImmersiveLayout component that is used by the AlsoInThis component to use the new fetchLesson composable method


## References
Fixes #8749

## Reviewer guidance
If engaging with a resource in a lesson, does the move on section take you to the next resource in a lesson?
![lessonmoveon](https://user-images.githubusercontent.com/1680573/143063723-f26858c0-5c21-494f-8680-a2c37978e2df.gif)

If engaging with a resource in a lesson, and learners cannot engage with unassigned content, does it not show the recommended content section?
![nounassignedmoveon](https://user-images.githubusercontent.com/1680573/143063857-6957bf61-aae5-4b5d-80a2-f9ca89b158d3.gif)

If using a slow connection (e.g. switching to Slow 3G on the network tab before completing the resource) does a loading state display?
![completionmodalloading](https://user-images.githubusercontent.com/1680573/143065579-9949a383-0021-4b30-8130-bcaa1386b3f8.gif)

Do the contents of the lesson properly display in the also in this side panel? (note that some links in there may still be broken, pending merge of #8754)
![alsointhislesson](https://user-images.githubusercontent.com/1680573/143067020-31dfa8da-9c65-4205-abe4-e58a13401687.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
