### PR TITLE
Ensure nodes are ordered by bookmark creation

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1198,15 +1198,19 @@ class ContentNodeBookmarksViewset(
 
     def consolidate(self, items, queryset):
         items = super(ContentNodeBookmarksViewset, self).consolidate(items, queryset)
+        sorted_items = []
         if items:
-            bookmark_lookup = {}
+            item_lookup = {item["id"]: item for item in items}
+
+            # now loop through ordered bookmark queryset to order nodes returned by same order
             for bookmark in self.bookmark_queryset.values(
                 "id", "contentnode_id", "created"
             ):
-                bookmark_lookup[bookmark["contentnode_id"]] = bookmark
-            for item in items:
-                item["bookmark"] = bookmark_lookup[item["id"]]
-        return items
+                item = item_lookup.pop(bookmark["contentnode_id"], None)
+                if item:
+                    item["bookmark"] = bookmark
+                    sorted_items.append(item)
+        return sorted_items
 
 
 def get_cache_key(*args, **kwargs):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Sorts content nodes by results in bookmarking queryset to maintain bookmark ordering

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/8617

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
