### PR TITLE
Expand media player to use more of viewport in ImmersiveLayout

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -2,10 +2,10 @@
 
   <MediaPlayerFullscreen
     ref="fullscreen"
-    class="fill-space"
+    class="fill-space fullscreen-wrapper"
     :style="{
       'border-color': $themeTokens.fineLine,
-      padding: '32px 24px',
+      padding: fullscreenWrapperPadding,
     }"
     @changeFullscreen="isFullscreen = $event"
   >
@@ -17,7 +17,7 @@
           'keyboard-modality': $inputModality === 'keyboard',
           'video-loading': loading,
           'transcript-visible': transcriptVisible,
-          'transcript-wrap': windowIsPortrait || (!isFullscreen && windowIsSmall),
+          'transcript-wrap': transcriptWrap,
         },
         $computedClass(progressStyle)
       ]"
@@ -193,6 +193,16 @@
         return this.player.duration();
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
+      transcriptWrap() {
+        return this.windowIsPortrait || (!this.isFullscreen && this.windowIsSmall);
+      },
+      fullscreenWrapperPadding() {
+        if (this.isFullscreen) {
+          return 0;
+        }
+
+        return this.transcriptWrap ? '16px' : '32px 24px';
+      },
     },
     watch: {
       isFullscreen() {
@@ -566,16 +576,20 @@
   @import './videojs-style/videojs-font/css/videojs-icons.css';
   @import './videojs-style/variables';
   @import '~kolibri-design-system/lib/styles/definitions';
-  $transcript-wrap-height: 250px;
   $transcript-wrap-fill-height: 100% * 9 / 16;
   $video-height: 100% * 9 / 16;
+  // basically (100% of height) - (video height) - (app bar + padding)
+  $transcript-wrap-height: #{$video-player-max-height} - #{(100% - $video-height) / 100% * 100vw} - 72px;
+  .fullscreen-wrapper {
+    box-sizing: border-box;
+  }
   .wrapper {
     box-sizing: content-box;
     max-width: 100%;
     max-height: $video-player-max-height;
   }
   .wrapper.transcript-visible.transcript-wrap {
-    padding-bottom: $transcript-wrap-height;
+    padding-bottom: calc(#{$transcript-wrap-height});
   }
   .wrapper.video-loading video {
     position: absolute;
@@ -625,7 +639,7 @@
   }
   .wrapper.transcript-wrap .media-player-transcript {
     left: 0;
-    height: $transcript-wrap-height;
+    height: calc(#{$transcript-wrap-height});
     /deep/ .loading-space {
       padding-top: 90px;
     }

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -576,17 +576,14 @@
   @import './videojs-style/videojs-font/css/videojs-icons.css';
   @import './videojs-style/variables';
   @import '~kolibri-design-system/lib/styles/definitions';
-  $transcript-wrap-fill-height: 100% * 9 / 16;
-  $video-height: 100% * 9 / 16;
-  // basically (100% of height) - (video height) - (app bar + padding)
-  $transcript-wrap-height: #{$video-player-max-height} - #{(100% - $video-height) / 100% * 100vw} - 72px;
+
   .fullscreen-wrapper {
     box-sizing: border-box;
   }
   .wrapper {
     box-sizing: content-box;
     max-width: 100%;
-    max-height: $video-player-max-height;
+    max-height: calc(#{$video-player-max-vh});
   }
   .wrapper.transcript-visible.transcript-wrap {
     padding-bottom: calc(#{$transcript-wrap-height});
@@ -608,7 +605,7 @@
   .loading-space,
   /deep/ .loading-space {
     box-sizing: border-box;
-    padding-top: #{$video-height};
+    padding-top: #{$video-player-height-by-width};
   }
   /deep/ .loader {
     position: absolute;
@@ -659,11 +656,11 @@
     .wrapper.transcript-visible.transcript-wrap .media-player-transcript {
       top: 0;
       height: auto;
-      margin-top: #{$video-height};
+      margin-top: #{$video-player-height-by-width};
     }
     .wrapper.transcript-visible.transcript-wrap .video-js.vjs-fill {
       height: auto;
-      padding-top: #{$video-height};
+      padding-top: #{$video-player-height-by-width};
     }
   }
 

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerLanguages/LanguagesMenu.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerLanguages/LanguagesMenu.vue
@@ -30,7 +30,8 @@
   .vjs-menu {
     left: -8em;
     width: 16em;
-    max-height: calc(#{$video-player-max-height} - #{$video-player-control-height});
+    // minus 32px max immersive layout padding
+    max-height: calc(#{$video-player-height-vw} - #{$video-player-control-height} - 32px);
     overflow-y: auto;
   }
 

--- a/kolibri/plugins/media_player/assets/src/views/videojs-style/variables.scss
+++ b/kolibri/plugins/media_player/assets/src/views/videojs-style/variables.scss
@@ -9,4 +9,4 @@ $video-player-control-height: 3.25em;
 $video-player-font-color: white;
 
 $video-player-font-size: 12px;
-$video-player-max-height: 562px;
+$video-player-max-height: 85vh;

--- a/kolibri/plugins/media_player/assets/src/views/videojs-style/variables.scss
+++ b/kolibri/plugins/media_player/assets/src/views/videojs-style/variables.scss
@@ -5,8 +5,20 @@ $video-player-color-2: tint($video-player-color, 7%);
 $video-player-color-3: tint($video-player-color, 15%);
 
 $video-player-control-height: 3.25em;
-
 $video-player-font-color: white;
-
 $video-player-font-size: 12px;
-$video-player-max-height: 85vh;
+
+// 16:9 video aspect ratio
+$video-player-aspect: 9 / 16;
+
+// max height, minus appbar and padding
+$video-player-max-vh: 100vh - #{132px};
+
+// height based off width
+$video-player-height-by-width: 100% * $video-player-aspect;
+
+// height based off vw (viewport width)
+$video-player-height-vw: $video-player-aspect * 100vw;
+
+// (100% of allowable height) - (video height)
+$transcript-wrap-height: $video-player-max-vh - #{$video-player-height-vw};


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Increases maximum height of player to be % of height instead of fixed pixels
- Fixes issues with padding in fullscreen
- Increases transcript space in responsive wrapped view

| Before | After |
| --- | --- |
| ![Screenshot from 2021-11-24 15-57-53](https://user-images.githubusercontent.com/819838/143327090-a19a5c23-6754-4f37-b90e-bc961466fb6f.png) | ![Screenshot from 2021-11-24 15-45-54](https://user-images.githubusercontent.com/819838/143327099-310977a9-f549-4549-84aa-a968fe396505.png) |
| ![Screenshot from 2021-11-24 15-57-35](https://user-images.githubusercontent.com/819838/143327112-c166ef0a-1934-4441-a1b5-38d9bd87093c.png) | ![Screenshot from 2021-11-24 15-47-30](https://user-images.githubusercontent.com/819838/143327118-de6d671d-a14f-43f1-8fa3-f525d85de97f.png) |
| ![Screenshot from 2021-11-24 15-57-12](https://user-images.githubusercontent.com/819838/143327135-763d0012-1eef-40fa-8ba2-bc7bf01687a0.png) | ![Screenshot from 2021-11-24 15-47-54](https://user-images.githubusercontent.com/819838/143327149-9e29a059-7bc7-4227-b0f2-f9b703999a71.png) |






## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/8616


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
