### PR TITLE
When running the Python devserver, watch the plugins.json and options.ini to autorestart when plugins are updated 

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -655,8 +655,8 @@ class KolibriProcessBus(ProcessBus):
 
         if getattr(settings, "DEVELOPER_MODE", False):
             autoreloader = Autoreloader(self)
-            plugins=os.path.join(conf.KOLIBRI_HOME, "plugins.json")
-            options=os.path.join(conf.KOLIBRI_HOME, "options.ini")
+            plugins = os.path.join(conf.KOLIBRI_HOME, "plugins.json")
+            options = os.path.join(conf.KOLIBRI_HOME, "options.ini")
             autoreloader.files.add(plugins)
             autoreloader.files.add(options)
             autoreloader.subscribe()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -655,6 +655,10 @@ class KolibriProcessBus(ProcessBus):
 
         if getattr(settings, "DEVELOPER_MODE", False):
             autoreloader = Autoreloader(self)
+            plugins=os.path.join(conf.KOLIBRI_HOME, "plugins.json")
+            options=os.path.join(conf.KOLIBRI_HOME, "options.ini")
+            autoreloader.files.add(plugins)
+            autoreloader.files.add(options)
             autoreloader.subscribe()
 
         reload_plugin = ProcessControlPlugin(self)


### PR DESCRIPTION

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Autoreload when the options.ini and plugins.json files in the KOLIBRI_HOME (defined here: https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/utils/conf.py#L31) change too.
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
#8603
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
Please test the changes I have made @rtibbles 
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
