### PR TITLE
Responsivity improvements of the mastery bar on an exercise page

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -78,6 +78,7 @@ import DragContainer from '../views/sortable/DragContainer';
 import DragSortWidget from '../views/sortable/DragSortWidget';
 import FocusTrap from '../views/FocusTrap';
 import BottomAppBar from '../views/BottomAppBar';
+import BaseToolbar from '../views/BaseToolbar';
 import GenderSelect from '../views/userAccounts/GenderSelect';
 import BirthYearSelect from '../views/userAccounts/BirthYearSelect';
 import FullNameTextbox from '../views/userAccounts/FullNameTextbox';
@@ -184,6 +185,7 @@ export default {
       DragSortWidget,
       FocusTrap,
       BottomAppBar,
+      BaseToolbar,
       GenderSelect,
       GenderDisplayText,
       BirthYearSelect,

--- a/kolibri/core/assets/src/views/BaseToolbar.vue
+++ b/kolibri/core/assets/src/views/BaseToolbar.vue
@@ -1,0 +1,43 @@
+<template>
+
+  <div
+    class="base-toolbar"
+    :style="{ color: $themeTokens.text }"
+  >
+    <slot></slot>
+  </div>
+
+</template>
+
+
+<script>
+
+  /**
+   * A simple toolbar with appearance derived from UiToolbar.
+   * It behaves like a container that doesn't provide any implementation
+   * of its internal content layout. Insted, its content area is expected
+   * to be fully controlled from components that use this toolbar.
+   * It is suitable for toolbar layouts that don't conform to typical UiToolbar
+   * use-cases or when using UiToolbar may be possible but is complicated
+   * and requires many /deep/ overrides and fixes.
+   */
+  export default {
+    name: 'BaseToolbar',
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .base-toolbar {
+    position: relative;
+    min-height: 3.5rem;
+    padding-right: 24px;
+    padding-left: 24px;
+    font-size: 1.125rem;
+    background-color: white;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
@@ -5,7 +5,7 @@
     <div class="container" :style="{ flexWrap: windowBreakpoint > 0 ? 'nowrap' : 'wrap' }">
       <TextTruncatorCss
         class="requirements"
-        :text="overallStatusStrings.$tr('goal', { count: totalCorrectRequiredM })"
+        :text="overallStatusStrings.$tr('goal', { count: requiredCorrectAnswers })"
       />
       <span class="hint">
         <slot name="hint"></slot>
@@ -18,8 +18,6 @@
 
 <script>
 
-  import { mapState } from 'vuex';
-  import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BaseToolbar from 'kolibri.coreVue.components.BaseToolbar';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
@@ -36,25 +34,17 @@
       TextTruncatorCss,
     },
     mixins: [KResponsiveWindowMixin, commonCoreStrings],
+    props: {
+      // typically this would be "m" from "m of n" mastery model
+      requiredCorrectAnswers: {
+        type: Number,
+        required: true,
+      },
+    },
     data() {
       return {
         overallStatusStrings,
       };
-    },
-    computed: {
-      ...mapState('topicsTree', ['content']),
-      masteryModel() {
-        return this.content.masteryModel;
-      },
-      mOfNMasteryModel() {
-        return MasteryModelGenerators[this.masteryModel.type](
-          this.content.assessmentIds,
-          this.masteryModel
-        );
-      },
-      totalCorrectRequiredM() {
-        return this.mOfNMasteryModel.m;
-      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
@@ -1,32 +1,82 @@
 <template>
 
   <!-- z-index 7 - one beneath top menu bar for nested elevations -->
-  <UiToolbar style="z-index: 7;">
-    <template #icon>
-      <OverallStatus />
-    </template>
-
-    <template #actions>
-      <slot name="hint"></slot>
-    </template>
-  </UiToolbar>
+  <BaseToolbar style="z-index: 7;">
+    <div class="container" :style="{ flexWrap: windowBreakpoint > 0 ? 'nowrap' : 'wrap' }">
+      <TextTruncatorCss
+        class="requirements"
+        :text="overallStatusStrings.$tr('goal', { count: totalCorrectRequiredM })"
+      />
+      <span class="hint">
+        <slot name="hint"></slot>
+      </span>
+    </div>
+  </BaseToolbar>
 
 </template>
 
 
 <script>
 
+  import { mapState } from 'vuex';
+  import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BaseToolbar from 'kolibri.coreVue.components.BaseToolbar';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
-  import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import OverallStatus from './OverallStatus.vue';
+
+  const overallStatusStrings = crossComponentTranslator(OverallStatus);
 
   export default {
     name: 'LessonMasteryBar',
     components: {
-      UiToolbar,
-      OverallStatus,
+      BaseToolbar,
+      TextTruncatorCss,
     },
-    mixins: [KResponsiveWindowMixin],
+    mixins: [KResponsiveWindowMixin, commonCoreStrings],
+    data() {
+      return {
+        overallStatusStrings,
+      };
+    },
+    computed: {
+      ...mapState('topicsTree', ['content']),
+      masteryModel() {
+        return this.content.masteryModel;
+      },
+      mOfNMasteryModel() {
+        return MasteryModelGenerators[this.masteryModel.type](
+          this.content.assessmentIds,
+          this.masteryModel
+        );
+      },
+      totalCorrectRequiredM() {
+        return this.mOfNMasteryModel.m;
+      },
+    },
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .container {
+    display: flex;
+    justify-content: space-between;
+    padding-top: 16px;
+    padding-bottom: 8px;
+  }
+
+  .requirements {
+    min-width: 0; // allow text to be shrinked and truncated
+    margin-right: 8px;
+  }
+
+  .hint {
+    flex-shrink: 0;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
@@ -7,7 +7,9 @@
         class="requirements"
         :text="overallStatusStrings.$tr('goal', { count: requiredCorrectAnswers })"
       />
-      <span class="hint">
+      <span
+        :style="[ { flexShrink: '0' }, isRtl ? { marginRight: 'auto' } : { marginLeft: 'auto' }]"
+      >
         <slot name="hint"></slot>
       </span>
     </div>
@@ -63,10 +65,6 @@
   .requirements {
     min-width: 0; // allow text to be shrinked and truncated
     margin-right: 8px;
-  }
-
-  .hint {
-    flex-shrink: 0;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/OverallStatus.vue
@@ -14,6 +14,7 @@
   export default {
     name: 'OverallStatus',
     $trs: {
+      // eslint-disable-next-line kolibri/vue-no-unused-translations
       goal: {
         message: 'Get {count, number, integer} {count, plural, other {correct}}',
         context:

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/OverallStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/OverallStatus.vue
@@ -1,11 +1,9 @@
 <template>
 
-  <div class="overall-container" :style="{ color: $themeTokens.text }">
-    <div class="overall-status">
-      <span>
-        {{ $tr('goal', { count: totalCorrectRequiredM }) }}
-      </span>
-    </div>
+  <div>
+    <!-- TODO Delete this component, the strings should live in different
+    namespaces in the next release - this is here to be crossComponentTranslated
+    until the next batch of translations -->
   </div>
 
 </template>
@@ -13,31 +11,8 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import { mapState } from 'vuex';
-  import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-
   export default {
     name: 'OverallStatus',
-    mixins: [responsiveWindowMixin, commonCoreStrings],
-
-    computed: {
-      ...mapState('topicsTree', ['content']),
-      masteryModel() {
-        return this.content.masteryModel;
-      },
-      mOfNMasteryModel() {
-        return MasteryModelGenerators[this.masteryModel.type](
-          this.content.assessmentIds,
-          this.masteryModel
-        );
-      },
-      totalCorrectRequiredM() {
-        return this.mOfNMasteryModel.m;
-      },
-    },
-
     $trs: {
       goal: {
         message: 'Get {count, number, integer} {count, plural, other {correct}}',
@@ -48,15 +23,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  @import '~kolibri-design-system/lib/styles/definitions';
-
-  .overall-status {
-    display: inline-block;
-    margin: 8px;
-  }
-
-</style>

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -604,7 +604,6 @@ oriented data synchronization.
   .hint-btn-container {
     display: flex;
     align-items: center;
-    padding-right: 8px !important;
     font-size: medium;
 
     // Ensures the tooltip is visible on the screen in RTL and LTR

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -13,6 +13,7 @@ oriented data synchronization.
     <LessonMasteryBar
       data-test="lessonMasteryBar"
       :availableHintsMessage="hint$tr('hint', { hintsLeft: availableHints })"
+      :requiredCorrectAnswers="totalCorrectRequiredM"
       @takeHint="takeHint"
     >
       <template #hint>

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -10,12 +10,7 @@ oriented data synchronization.
 <template v-if="ready">
 
   <div>
-    <LessonMasteryBar
-      data-test="lessonMasteryBar"
-      :availableHintsMessage="hint$tr('hint', { hintsLeft: availableHints })"
-      :requiredCorrectAnswers="totalCorrectRequiredM"
-      @takeHint="takeHint"
-    >
+    <LessonMasteryBar :requiredCorrectAnswers="totalCorrectRequiredM">
       <template #hint>
         <div
           v-if="totalHints > 0"


### PR DESCRIPTION
## Summary

- Fixes x-overflow problems with hints button on small mobile screens by moving the button below the requirements text
- Fixes the bottom bar not being sticky on small mobile screens
- Introduces `BaseToolbar` component as it was simpler than overriding `UiToolbar`. See `BaseToolbar`'s docstring for more information.
- Components, styles, and data flow simplifications in related components

| Before | After |
| --------- | ------ |
| ![before](https://user-images.githubusercontent.com/13509191/143829063-4db644d3-23e4-4f11-8b68-2c51906f8dd4.gif) | ![after](https://user-images.githubusercontent.com/13509191/143829081-aa2c6e4e-9c3c-410d-ba82-34c991385a0d.gif) |

(the noise is caused by bad conversion to gif)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8727

## Reviewer guidance

Navigate to the "Recognize fractions" exercise in the "Kolibri QA channel" > "Exercises" > "Channel based quizzes" and see the mastery bar for different screen sizes.

As for #8727, reproducing was possible only under quite specific conditions so when testing the bottom bar stickiness, please use the following conditions as well:
- switch Kolibri language to Spanish
- test on your real device or a BrowserStack real device
- test for a question that is higher than the screen so that you can scroll up and down

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
