### PR TITLE
API: Fix random content query

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -581,7 +581,8 @@ class ContentNodeViewset(BaseContentNodeMixin, ReadOnlyValuesViewset):
     def random(self, request, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         max_results = int(self.request.query_params.get("max_results", 10))
-        queryset = queryset.order_by("?")[:max_results]
+        ids = list(queryset.order_by("?")[:max_results].values_list("id", flat=True))
+        queryset = models.ContentNode.objects.filter(id__in=ids)
         return Response(self.serialize(queryset))
 
     @list_route(methods=["get"])


### PR DESCRIPTION
## Summary

The queryset with random order does a query to the database for each access to the QuerySet object and the consolidate method does some manipulation with the queryset, so it's generating some inconsistence.

This patch gets the random list of ids as a fixed python List and then creates the QuerySet object with that list of ids, so every access to the queryset in the following serialization/consolidate methods will have the same nodes.

This affects for example to the serialized item related files, that are calculated during the serializing process and without this change any random result will have any related file even if the real content has related files.