### PR TITLE
upgrade to KDS v1.2.1 with textbox shifting update

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "^0.1.34",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.0",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "^0.1.34",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.0",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8838,9 +8838,9 @@ kolibri-constants@^0.1.34:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.34.tgz#06d1cdb04ded4e4ce785437f3e4bd87801168fae"
   integrity sha512-nArDgIwIPYJMacVaqHazptLRpIjSTS6LNr4FWtL/7D6Ek+z7DVcWtFYL74hH/wdebGykWywmkOa5qnfcy1JQ+A==
 
-"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.2.0":
-  version "1.2.0"
-  resolved "git://github.com/learningequality/kolibri-design-system#718831f11eb327b4fc5929a9e62231c6ce42b072"
+"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.2.1":
+  version "1.2.1"
+  resolved "git://github.com/learningequality/kolibri-design-system#fe3ab268a8ed0470d1ac74e23c56b0a8c8e5f9e0"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION

## Summary

Upgrades KDS to tagged release v1.2.1: https://github.com/learningequality/kolibri-design-system/releases/tag/v1.2.1

## References

* Includes change from https://github.com/learningequality/kolibri-design-system/pull/279
* Fixes https://github.com/learningequality/kolibri/issues/8675

## Reviewer guidance

I forgot this update when I tagged v1.2.0, so this is a new patch v1.2.1

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
