### PR TITLE
Remove text transformation on category search strings

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -263,9 +263,9 @@
           color: this.$themeTokens.text,
           width: '100%',
           border: '2px solid transparent',
-          'text-transform': 'capitalize',
           'text-align': 'left',
           'font-weight': 'normal',
+          'text-transform': 'none',
           position: 'relative',
           transition: 'none',
           ':hover': {


### PR DESCRIPTION
## Summary

Removes text transformation from category buttons that was making them capitalized. Now uses existing sentence case from string references


## References

Fixes #8469

<img width="1126" alt="Screen Shot 2021-11-30 at 9 29 17 AM" src="https://user-images.githubusercontent.com/17235236/144075153-87a83004-15b8-47cd-9f93-ebf641c9fc97.png">
<img width="1092" alt="Screen Shot 2021-11-30 at 9 29 31 AM" src="https://user-images.githubusercontent.com/17235236/144075156-70e42845-1c0a-42a4-afeb-4b3aeba822a6.png">

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
