### PR TITLE
Update bookmarks handler to reference lessonId

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -164,10 +164,11 @@ export function showLessonResourceBookmarks(store, params) {
     });
   });
 }
-export function showLessonResourceBookmarksMain(store) {
+export function showLessonResourceBookmarksMain(store, params) {
   return store.dispatch('loading').then(() => {
     getBookmarks().then(bookmarks => {
       return showResourceSelectionPage(store, {
+        lessonId: params.lessonId,
         bookmarksList: bookmarks[0],
       });
     });

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -388,7 +388,8 @@
         }
       },
       addToSelectedResources(content) {
-        const list = this.contentList.length ? this.contentList : this.bookmarksList;
+        const list =
+          this.contentList && this.contentList.length ? this.contentList : this.bookmarksList;
         this.addToResourceCache({
           node: list.find(n => n.id === content.id),
         });


### PR DESCRIPTION
## Summary
This PR fixes the problem @pcenov reported where adding a bookmarked resource to a lesson causes and error and doesn't allow the user to close. The problem was that the lessonId was required, but it was not added in the handler. Now with that value accessible, there is no 400 error.

It also adds and extra conditional check to ensure the correct list (contentList vs. bookmarksList) is referenced.

## References
Fixes #8724

![add-bookmarked-resources](https://user-images.githubusercontent.com/17235236/144119568-f1ad095e-c31c-4851-986a-44ba477ca568.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
