### PR TITLE
Fix learning activity label style on bookmarks cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -32,7 +32,11 @@
           class="metadata-info"
           :style="{ color: $themePalette.grey.v_700 }"
         >
-          <LearningActivityLabel :contentNode="content" class="learning-activity-label" />
+          <LearningActivityLabel
+            :contentNode="content"
+            labelAfter
+            condensed
+          />
         </div>
         <h3 class="title">
           <TextTruncator
@@ -265,13 +269,6 @@
     bottom: 0;
     width: 100%;
     padding: $margin;
-  }
-
-  .learning-activity-label {
-    width: 100px;
-    /deep/ .learning-activity {
-      justify-content: flex-start;
-    }
   }
 
   .metadata-info-footer {

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
@@ -1,10 +1,10 @@
 <template>
 
-  <div v-if="contentNode">
+  <div v-if="contentNode" :class="[ condensed ? 'condensed' : '']">
     <div class="learning-activity">
       <span
         v-if="!labelAfter"
-        class="label"
+        class="label-before"
         data-test="label"
       >
         {{ label }}
@@ -17,15 +17,18 @@
           :kind="learningActivity"
           :style="{ fontSize: '18px' }"
         />
-        <span
-          v-if="labelAfter"
-          class="label"
-          data-test="label"
-        >
-          {{ label }}
-        </span>
       </template>
+      <span
+        v-if="labelAfter"
+        class="label-after"
+        data-test="label"
+      >
+        {{ label }}
+      </span>
     </div>
+
+    <span v-if="condensed" class="separator">|</span>
+
     <div
       v-if="!hideDuration"
       class="duration"
@@ -79,6 +82,12 @@
       },
       // allows for switching the order of the label and the icon
       labelAfter: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      // show the label and duration on one row separated by a vertical line
+      condensed: {
         type: Boolean,
         required: false,
         default: false,
@@ -168,23 +177,40 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+  }
 
-    .label {
-      padding-right: 4px;
-      padding-left: 4px;
-    }
+  .label-before {
+    padding-right: 4px;
+  }
 
-    .icon {
-      // override KIcon's `position: relative` to allow
-      // for precise vertical centering of label and icon
-      position: static;
-      padding-left: 2px;
-    }
+  .label-after {
+    padding-left: 4px;
+  }
+
+  .icon {
+    // override KIcon's `position: relative` to allow
+    // for precise vertical centering of label and icon
+    position: static;
   }
 
   .duration {
     margin-top: 8px;
     text-align: right;
+  }
+
+  .condensed {
+    display: flex;
+    align-items: center;
+
+    .duration {
+      margin-top: 0;
+      text-align: left;
+    }
+
+    .separator {
+      padding-right: 4px;
+      padding-left: 4px;
+    }
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/LearningActivityLabel.vue
@@ -27,7 +27,7 @@
       </span>
     </div>
 
-    <span v-if="condensed" class="separator">|</span>
+    <span v-if="displaySeparator" class="separator">|</span>
 
     <div
       v-if="!hideDuration"
@@ -164,6 +164,11 @@
           return '';
         }
         return this.LearningActivityToLabelMap[this.contentNode.learning_activities[0]];
+      },
+      displaySeparator() {
+        return (
+          this.condensed && !this.hideDuration && (this.durationEstimation || this.displayMinutes)
+        );
       },
     },
   };


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes learning activity labels on cards on the bookmarks page so that learning activity label, icon, and duration show on one line as specced [in Figma designs](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=130%3A11706). For that purpose, `condensed` prop has been added to `LearningActivityLabel` component.

| Before | After |
| -------- | ------- |
| ![Screenshot from 2021-12-02 11-05-22](https://user-images.githubusercontent.com/13509191/144410847-cdcef769-652b-4b8a-bbad-41a299941b33.png) | ![Screenshot from 2021-12-02 11-04-57](https://user-images.githubusercontent.com/13509191/144410866-dcc9abe4-effd-41db-92cd-13be9a10ab03.png) |

## References

Closes #8725

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check cards on the bookmarks page for various resolutions, learning activities, content kinds, and their durations.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
