### PR TITLE
CustomContent: Add withinDescendant parameter to API

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -159,6 +159,7 @@
             max_results: options.maxResults ? options.maxResults : 50,
             kind: kind,
             kind_in: kinds,
+            descendant_of: options.descendantOf,
           },
         })
           .then(contentNodes => {

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -114,6 +114,8 @@ export default class Kolibri extends BaseShim {
        * an array of matching metadata
        * @param {Object} options - The different options to filter by
        * @param {string=} options.parent - id of the parent node to filter by, or 'self'
+       * @param {string=} options.descendantOf - id of the root node to filter
+       * by, to show all descendants, not just direct children
        * @param {string[]} options.ids - an array of ids to filter by
        * @param {number} [options.maxResults=50] - the maximum number of nodes per request
        * @param {string[]} options.kinds - an array of kinds to filer by


### PR DESCRIPTION
## Summary

This patch adds a new optional parameter to the getContentByFilter API call to be able to retrieve all descendant nodes using the MPTT model fields.

With this new parameter it's possible to filter all the nodes below a specific topic node, useful when combining with other filters like kind or tags.