### PR TITLE
Allow superuser to be null in device provision API

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -40,7 +40,7 @@ class DeviceSerializerMixin(object):
 class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
     facility = FacilitySerializer()
     preset = serializers.ChoiceField(choices=choices)
-    superuser = NoFacilityFacilityUserSerializer()
+    superuser = NoFacilityFacilityUserSerializer(allow_null=True)
     language_id = serializers.CharField(max_length=15)
     device_name = serializers.CharField(max_length=50, allow_null=True)
     settings = serializers.JSONField()
@@ -78,12 +78,16 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
             facility.dataset.save()
 
             # Create superuser
-            superuser = FacilityUser.objects.create_superuser(
-                validated_data["superuser"]["username"],
-                validated_data["superuser"]["password"],
-                facility=facility,
-                full_name=validated_data["superuser"].get("full_name"),
-            )
+            superuser_data = validated_data.pop("superuser")
+            if superuser_data:
+                superuser = FacilityUser.objects.create_superuser(
+                    superuser_data["username"],
+                    superuser_data["password"],
+                    facility=facility,
+                    full_name=superuser_data.get("full_name"),
+                )
+            else:
+                superuser = None
 
             # Create device settings
             language_id = validated_data.pop("language_id")


### PR DESCRIPTION
## Summary

This change to Kolibri's device provision API makes it possible to provision the device without a superuser, which is consistent with the [`provisiondevice`](https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/device/management/commands/provisiondevice.py) management command.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
