### PR TITLE
Android and UI responsive updates

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -5,9 +5,21 @@
       {{ $tr('answerHistoryLabel') }}
     </h3>
 
+    <KSelect
+      v-if="isMobile"
+      class="history-select"
+      :value="selected"
+      label=""
+      :options="options"
+      :disabled="$attrs.disabled"
+      @change="handleDropdownChange($event.value)"
+    />
+
     <ul
+      v-else
       ref="attemptList"
       class="history-list"
+      :class="isMobile ? 'mobile-list' : ''"
       role="listbox"
       @keydown.home="setSelectedAttemptLog(0)"
       @keydown.end="setSelectedAttemptLog(attemptLogs.length - 1)"
@@ -64,15 +76,10 @@
               icon="hint"
             />
             <p class="item">
-              {{
-                windowIsLarge ?
-                  coreString(
-                    'questionNumberLabel',
-                    { questionNumber: attemptLog.questionNumber }
-                  )
-                  :
-                  // Add non-breaking space to preserve vertical centering
-                  "&nbsp;"
+              {{ coreString(
+                'questionNumberLabel',
+                { questionNumber: attemptLog.questionNumber }
+              )
               }}
             </p>
             <CoachContentLabel
@@ -107,6 +114,10 @@
         type: Array,
         required: true,
       },
+      isMobile: {
+        type: Boolean,
+        required: false,
+      },
       selectedQuestionNumber: {
         type: Number,
         required: true,
@@ -123,6 +134,21 @@
           };
         }
       },
+      selected() {
+        return this.options.find(o => o.value === this.selectedQuestionNumber + 1) || {};
+      },
+      options() {
+        let label = '';
+        return this.attemptLogs.map(attemptLog => {
+          label = this.coreString('questionNumberLabel', {
+            questionNumber: attemptLog.questionNumber,
+          });
+          return {
+            value: attemptLog.questionNumber,
+            label: label,
+          };
+        });
+      },
     },
     mounted() {
       this.$nextTick(() => {
@@ -130,6 +156,9 @@
       });
     },
     methods: {
+      handleDropdownChange(value) {
+        this.$emit('select', value - 1);
+      },
       setSelectedAttemptLog(questionNumber) {
         const listOption = this.$refs.attemptListOption[questionNumber];
         listOption.focus();
@@ -141,7 +170,10 @@
         return Number(this.selectedQuestionNumber) === questionNumber;
       },
       scrollToSelectedAttemptLog(questionNumber) {
-        const selectedElement = this.$refs.attemptList.children[questionNumber];
+        let selectedElement;
+        if (this.$refs.attemptListOption && this.$refs.attemptList.children) {
+          selectedElement = this.$refs.attemptList.children[questionNumber];
+        }
         if (selectedElement) {
           const parent = this.$el.parentElement;
           parent.scrollTop =
@@ -188,6 +220,12 @@
     padding-left: 0;
     margin: 0;
     list-style-type: none;
+  }
+
+  .history-select {
+    max-width: 90%;
+    padding-top: 16px;
+    margin: auto;
   }
 
   .item {

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div :style="{ backgroundColor: $themeTokens.surface }">
-    <h3 class="header" :style="iconStyle">
+    <h3 id="answer-history-label" class="header" :style="iconStyle">
       {{ $tr('answerHistoryLabel') }}
     </h3>
 
@@ -9,7 +9,7 @@
       v-if="isMobile"
       class="history-select"
       :value="selected"
-      label=""
+      aria-labelledby="answer-history-label"
       :options="options"
       :disabled="$attrs.disabled"
       @change="handleDropdownChange($event.value)"

--- a/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
+++ b/kolibri/core/assets/src/views/ExamReport/PageStatus.vue
@@ -10,6 +10,17 @@
         <h1 class="title">
           <KLabeledIcon icon="person" :label="userName" />
         </h1>
+        <div v-if="windowIsSmall" class="completion-status">
+          <ProgressIcon class="svg-icon" :progress="progress" />
+          <span class="completion-component">
+            <strong>
+              {{ progressIconLabel }}
+            </strong>
+            <div v-if="completed">
+              <ElapsedTime :date="completionTimestamp" class="completion-component" />
+            </div>
+          </span>
+        </div>
         <KLabeledIcon icon="quiz" :label="contentName" />
       </div>
 
@@ -36,7 +47,7 @@
         </tr>
       </table>
     </KFixedGridItem>
-    <KFixedGridItem span="1" alignment="right">
+    <KFixedGridItem v-if="!windowIsSmall" span="1" alignment="right">
       <div>
         <ProgressIcon class="svg-icon" :progress="progress" />
         <strong>
@@ -57,6 +68,7 @@
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import ElapsedTime from 'kolibri.coreVue.components.ElapsedTime';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
 
   export default {
     name: 'PageStatus',
@@ -64,7 +76,7 @@
       ProgressIcon,
       ElapsedTime,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
       userName: {
         type: String,
@@ -168,6 +180,12 @@
 
   .title {
     margin-top: 0;
+  }
+
+  .completion-component {
+    display: inline-block;
+    margin-bottom: 16px;
+    vertical-align: top;
   }
 
   .scores {

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -11,7 +11,7 @@
       />
     </template>
 
-    <template #aside>
+    <template v-if="!windowIsSmall" #aside>
       <AttemptLogList
         :attemptLogs="attemptLogs"
         :selectedQuestionNumber="questionNumber"
@@ -20,9 +20,18 @@
     </template>
 
     <template #main>
+      <AttemptLogList
+        v-if="windowIsSmall"
+        :isMobile="windowIsSmall"
+        :class="windowIsSmall ? 'mobile-attempt-log-list' : ''"
+        :attemptLogs="attemptLogs"
+        :selectedQuestionNumber="questionNumber"
+        @select="handleNavigateToQuestion"
+      />
       <div
         v-if="exercise"
         class="exercise-container"
+        :class="windowIsSmall ? 'mobile-exercise-container' : ''"
         :style="{ backgroundColor: $themeTokens.surface }"
       >
         <h3>{{ coreString('questionNumberLabel', { questionNumber: questionNumber + 1 }) }}</h3>
@@ -69,6 +78,7 @@
   import find from 'lodash/find';
   import MultiPaneLayout from 'kolibri.coreVue.components.MultiPaneLayout';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import PageStatus from './PageStatus';
 
   export default {
@@ -79,7 +89,7 @@
       InteractionList,
       MultiPaneLayout,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
       examAttempts: {
         type: Array,
@@ -176,6 +186,7 @@
     },
     methods: {
       handleNavigateToQuestion(questionNumber) {
+        console.log(questionNumber);
         this.navigateToQuestion(questionNumber);
         this.$refs.multiPaneLayout.scrollMainToTop();
         this.showCorrectAnswer = false;
@@ -201,6 +212,14 @@
 
   .exercise-container {
     padding: 8px;
+  }
+
+  .mobile-exercise-container {
+    margin-top: 16px;
+  }
+
+  .mobile-attempt-log-list {
+    margin-top: 16px;
   }
 
   h3 {

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -186,7 +186,6 @@
     },
     methods: {
       handleNavigateToQuestion(questionNumber) {
-        console.log(questionNumber);
         this.navigateToQuestion(questionNumber);
         this.$refs.multiPaneLayout.scrollMainToTop();
         this.showCorrectAnswer = false;

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -13,8 +13,8 @@
         :style="{
           color: $themeTokens.text,
           backgroundColor: $themeTokens.surface,
-          right: (alignment === 'right' ? 0 : ''),
-          left: (alignment === 'left' ? 0 : ''),
+          right: (alignment === 'left' ? 0 : ''),
+          left: (alignment === 'right' ? 0 : ''),
           width: (sidePanelOverrideWidth ? sidePanelOverrideWidth : '')
         }"
       >
@@ -139,7 +139,6 @@
     bottom: 0;
     // Must be <= 12 z-index so that KDropdownMenu shows over
     z-index: 12;
-    width: 472px;
     height: 100vh;
     padding: 32px;
     overflow: auto;

--- a/kolibri/core/assets/src/views/KeenUiToolbar.vue
+++ b/kolibri/core/assets/src/views/KeenUiToolbar.vue
@@ -17,15 +17,6 @@
     white-space: nowrap;
   }
 
-  /deep/ .ui-toolbar__right {
-    // Improves UI on smaller screen where long
-    // text in some languages (ie, the hint string in bg-bg)
-    // would push the width of the screen rightward. Now the
-    // content of this section will wrap internally instead of
-    // expanding the parent container
-    flex-shrink: 1;
-  }
-
   /deep/ .ui-toolbar__left {
     margin-left: 16px;
   }

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
@@ -7,9 +7,7 @@
         class="requirements"
         :text="overallStatusStrings.$tr('goal', { count: requiredCorrectAnswers })"
       />
-      <span
-        :style="[ { flexShrink: '0' }, isRtl ? { marginRight: 'auto' } : { marginLeft: 'auto' }]"
-      >
+      <span>
         <slot name="hint"></slot>
       </span>
     </div>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -2,7 +2,7 @@
 
   <div class="content-grid">
     <KFixedGrid
-      v-if="(cardViewStyle === 'card' && !!numCols)"
+      v-if="(cardViewStyle === 'card' && !!numCols) || !windowIsSmall"
       :numCols="numCols"
       gutter="24"
     >

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -378,11 +378,6 @@
     align-items: center;
   }
 
-  /deep/ .ui-toolbar__right {
-    // never shrink controls on the right side of the toolbar
-    flex-shrink: 0;
-  }
-
   /deep/ .progress-icon .ui-icon {
     margin-top: -2px;
     margin-left: 16px;

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -148,8 +148,9 @@
     <FullScreenSidePanel
       v-if="!windowIsLarge && sidePanelIsOpen"
       class="full-screen-side-panel"
+      alignment="left"
       :closeButtonHidden="true"
-      :sidePanelOverrideWidth="`${sidePanelOverlayWidth + 64}px`"
+      :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
       @closePanel="toggleSidePanelVisibility"
     >
       <KIconButton
@@ -172,7 +173,7 @@
       <EmbeddedSidePanel
         v-if="!currentCategory"
         v-model="searchTerms"
-        :width="`${sidePanelOverlayWidth}px`"
+        :width="`${sidePanelOverlayWidth - 64}px`"
         :availableLabels="labels"
         position="overlay"
         :activeActivityButtons="activeActivityButtons"
@@ -320,13 +321,18 @@
         }
       },
       sidePanelOverlayWidth() {
-        return 300;
+        if (!this.windowIsSmall) {
+          return 364;
+        }
+        return null;
       },
       numCols() {
-        if (this.windowIsSmall) {
+        if (this.windowIsMedium) {
           return 2;
-        } else {
+        } else if (!this.windowIsSmall) {
           return 3;
+        } else {
+          return null;
         }
       },
       activeActivityButtons() {
@@ -419,6 +425,7 @@
 
   .full-screen-side-panel {
     position: relative;
+    width: 100vw;
   }
   .overlay-close-button {
     position: absolute;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -124,6 +124,7 @@
         class="main-content-grid"
         :style="gridOffset"
       >
+        <slot v-if="windowIsSmall" name="breadcrumbs" class="breadcrumbs"></slot>
         <div
           class="card-grid"
         >
@@ -285,7 +286,7 @@
         v-if="!windowIsLarge && sidePanelIsOpen"
         class="full-screen-side-panel"
         :closeButtonHidden="true"
-        :sidePanelOverrideWidth="`${sidePanelOverlayWidth + 64}px`"
+        :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="$router.push(currentLink)"
       >
         <KIconButton
@@ -314,7 +315,7 @@
           :topicsLoading="topicMoreLoading"
           :more="topicMore"
           :genContentLink="genContentLink"
-          :width="`${sidePanelOverlayWidth}px`"
+          :width="`${sidePanelOverlayWidth - 64}px`"
           :availableLabels="labels"
           :activeActivityButtons="activeActivityButtons"
           :activeCategories="activeCategories"
@@ -462,7 +463,7 @@
       foldersLink() {
         if (this.topic) {
           const query = {};
-          if (this.windowIsSmall || this.windowIsMedium) {
+          if (this.windowIsSmall) {
             query.sidePanel = String(
               this.$route.name === PageNames.TOPICS_TOPIC ? !this.sidePanelIsOpen : true
             );
@@ -605,13 +606,13 @@
         return 300;
       },
       numCols() {
-        if (this.windowBreakpoint < 2) {
+        if (this.windowBreakpoint > 1 && this.windowBreakpoint < 2) {
           return 2;
-        } else if (this.windowBreakpoint <= 4) {
+        } else if (this.windowBreakpoint >= 2 && this.windowBreakpoint <= 4) {
           return 3;
-        } else {
+        } else if (this.windowBreakpoint > 4) {
           return 4;
-        }
+        } else return null;
       },
       // calls handleScroll no more than every 17ms
       throttledHandleScroll() {
@@ -816,6 +817,7 @@
     top: 0;
     bottom: 0;
     z-index: 12;
+    width: 100vw;
   }
 
   .mobile-header {


### PR DESCRIPTION
## Summary

Updates to Android UI mobile responsiveness issues (pt. 1) 
Perseus renderer issues are documented/addressed in a separate issue. 

## References


| Issue | Screenshot  |
|---|---|
| Improves layout and usability of quiz renderer on mobile |  <img width="301" alt="Screen Shot 2021-12-03 at 11 31 03 AM" src="https://user-images.githubusercontent.com/17235236/144647749-48d38671-bee9-4054-830a-110d2aed4efd.png"> |
| Reverts toolbar spacing/stacking changes  | <img width="241" alt="Screen Shot 2021-12-03 at 11 31 39 AM" src="https://user-images.githubusercontent.com/17235236/144647987-b95230c0-85fc-4cfa-b6da-8bf047a4670c.png"> |
| Fixes side panel screen fit and alignment regressions  |  <img width="543" alt="Screen Shot 2021-12-03 at 11 33 02 AM" src="https://user-images.githubusercontent.com/17235236/144648033-2d29f06c-80cd-49dd-8793-dabcd5de34b2.png"> |
| Fixes mobile single-card view  | <img width="407" alt="Screen Shot 2021-12-03 at 11 33 32 AM" src="https://user-images.githubusercontent.com/17235236/144648097-2e374af4-f637-4ad0-87f9-647117f8f7b8.png"> |
| Adds mobile breadcrumbs in topic browsing | <img width="304" alt="Screen Shot 2021-12-03 at 11 34 22 AM" src="https://user-images.githubusercontent.com/17235236/144648159-80318de4-58b9-4d5a-be9b-8d3f78f6a4a9.png"> |




## Reviewer guidance

Fixes #8722 aside from the completion modal spacing, which I cannot yet wrap my head around, and will file a follow up PR for as soon as I sort it out. 

I have done browser dev tools and browserstack testing, but since I don't have a physical android device, some of these fixes are educated guesses that _appear_ to be working. Please be patient with me @radinamatic and @pcenov if there are still some tweaks to be made 😄 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
