### PR TITLE
Do not show the bookmark button if the user is not logged in

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -17,6 +17,7 @@
       :contentProgress="contentProgress"
       :allowMarkComplete="allowMarkComplete"
       :contentKind="content.kind"
+      :showBookmark="isUserLoggedIn"
       data-test="learningActivityBar"
       @navigateBack="navigateBack"
       @toggleBookmark="toggleBookmark"
@@ -192,7 +193,7 @@
       };
     },
     computed: {
-      ...mapGetters(['currentUserId']),
+      ...mapGetters(['currentUserId', 'isUserLoggedIn']),
       ...mapState({
         contentProgress: state => state.core.logging.progress,
         error: state => state.core.error,

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -199,6 +199,15 @@
         required: false,
         default: null,
       },
+      /**
+      A Boolean check whether we should show the Bookmark Icon
+      what should not happen if the user is not logged in
+      */
+      showBookmark: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
     },
     data() {
       return {
@@ -218,7 +227,9 @@
             event: 'viewResourceList',
             dataTest: this.isLessonContext ? 'viewLessonPlanButton' : 'viewTopicResourcesButton',
           },
-          {
+        ];
+        if (this.showBookmark) {
+          actions.push({
             id: 'bookmark',
             icon: this.isBookmarked ? 'bookmark' : 'bookmarkEmpty',
             label: this.isBookmarked
@@ -227,8 +238,8 @@
             event: 'toggleBookmark',
             disabled: this.isBookmarked === null,
             dataTest: this.isBookmarked ? 'removeBookmarkButton' : 'addBookmarkButton',
-          },
-        ];
+          });
+        }
         if (this.allowMarkComplete) {
           actions.push({
             id: 'mark-complete',
@@ -255,7 +266,8 @@
           actions.push(this.allActions.find(action => action.id === 'view-resource-list'));
         }
         if (this.windowBreakpoint >= 2) {
-          actions.push(this.allActions.find(action => action.id === 'bookmark'));
+          if (this.showBookmark)
+            actions.push(this.allActions.find(action => action.id === 'bookmark'));
           // if a resource doesn’t have the option for learners to manually mark as complete,
           // the 'More options' bar icon button changes to the 'View information' bar icon button
           if (!this.allowMarkComplete) {

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -115,6 +115,23 @@ describe('LearningActivityBar', () => {
       });
     });
 
+    describe('when a bookmark icon is not shown', () => {
+      let wrapper;
+
+      beforeEach(() => {
+        wrapper = makeWrapper({
+          propsData: {
+            showBookmark: false,
+            learningActivities: [LearningActivities.WATCH],
+          },
+        });
+      });
+
+      it("doesn't show the add bookmark button in the bar", () => {
+        expect(wrapper.find("[data-test='bar_addBookmarkButton']").exists()).toBeFalsy();
+      });
+    });
+
     describe('when a resource is bookmarked', () => {
       let wrapper;
 


### PR DESCRIPTION
## Summary
Users exploring the library without being logged in should not see the bookmark button
![image](https://user-images.githubusercontent.com/1008178/144659250-d4b094a8-c652-406e-9041-efb13317298c.png)

## References
Closes: #8750 

## Reviewer guidance
Does it hide the bookmark button when not logged in?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
