### PR TITLE
Don't generate notifications on single user devices

### DIFF
--- a/kolibri/core/notifications/kolibri_plugin.py
+++ b/kolibri/core/notifications/kolibri_plugin.py
@@ -29,7 +29,7 @@ class NotificationsSyncHook(FacilityDataSyncHook):
         "receiver" meaning we have received data
         """
         # if we've just received data on a single-user device, update the exams and assignments
-        if context.is_receiver:
+        if context.is_receiver and not local_is_single_user:
             batch_process_summarylogs(
                 context.transfer_session.get_touched_record_ids_for_model(
                     ContentSummaryLog


### PR DESCRIPTION
## Summary
* Don't generate notifications on a single user device

## Reviewer guidance
Is my logic correct?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
