### PR TITLE
Reinstate BaseLogFilter for collection based filtering of logs.

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -6,6 +6,7 @@ from random import randint
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import OuterRef
+from django.db.models import Q
 from django.db.models import Subquery
 from django.db.models import Sum
 from django.http import Http404
@@ -847,7 +848,26 @@ class TotalContentProgressViewSet(viewsets.GenericViewSet):
         )
 
 
-class MasteryFilter(FilterSet):
+class BaseLogFilter(FilterSet):
+    facility = UUIDFilter(method="filter_facility")
+    classroom = UUIDFilter(method="filter_classroom")
+    learner_group = UUIDFilter(method="filter_learner_group")
+
+    # Only a superuser can filter by facilities
+    def filter_facility(self, queryset, name, value):
+        return queryset.filter(user__facility=value)
+
+    def filter_classroom(self, queryset, name, value):
+        return queryset.filter(
+            Q(user__memberships__collection_id=value)
+            | Q(user__memberships__collection__parent_id=value)
+        )
+
+    def filter_learner_group(self, queryset, name, value):
+        return queryset.filter(user__memberships__collection_id=value)
+
+
+class MasteryFilter(BaseLogFilter):
     content = UUIDFilter(name="summarylog__content_id")
 
     class Meta:
@@ -873,7 +893,7 @@ class MasteryLogViewSet(ReadOnlyValuesViewset):
     )
 
 
-class AttemptFilter(FilterSet):
+class AttemptFilter(BaseLogFilter):
     content = CharFilter(method="filter_content")
 
     def filter_content(self, queryset, name, value):


### PR DESCRIPTION
## Summary
* Reinstates erroneously deleted BaseLogFilter
* Adds it to MasteryLog and AttemptLog in case any coach reports are filtering by those (the difficult questions interface in Coach reports filters AttemptLog by `classroom` and `group`)

## References
Follow up from #8525

## Reviewer guidance
This should be harmless and reinstate the required functionality using a slightly more performant UUIDFilter than ModelChoice (which performs a lookup).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
