### PR TITLE
Update coach bookmarks

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1216,7 +1216,6 @@ class BookmarkFilter(FilterSet):
         queryset = queryset.annotate(
             kind=Subquery(
                 models.ContentNode.objects.filter(
-                    available=True,
                     id=OuterRef("contentnode_id"),
                 ).values_list("kind", flat=True)[:1]
             )

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -126,6 +126,7 @@ export function showExamCreationTopicPage(store, params) {
     });
   });
 }
+
 export function showExamCreationBookmarksPage(store, params) {
   return store.dispatch('loading').then(() => {
     const { topicId } = params;
@@ -179,7 +180,7 @@ function getBookmarks() {
     });
 }
 
-export function showExamCreationPreviewPage(store, params, query = {}) {
+export function showExamCreationPreviewPage(store, params, fromRoute, query = {}) {
   const { classId, contentId } = params;
   return store.dispatch('loading').then(() => {
     return Promise.all([_prepExamContentPreview(store, classId, contentId)])
@@ -193,12 +194,16 @@ export function showExamCreationPreviewPage(store, params, query = {}) {
             },
             query: otherQueryParams,
           });
-        } else {
+        } else if (fromRoute && fromRoute.name === PageNames.EXAM_CREATION_TOPIC) {
           store.commit('SET_TOOLBAR_ROUTE', {
             name: PageNames.EXAM_CREATION_TOPIC,
             params: {
               topicId: contentNode.parent,
             },
+          });
+        } else {
+          store.commit('SET_TOOLBAR_ROUTE', {
+            name: PageNames.EXAM_CREATION_ROOT,
           });
         }
         store.dispatch('notLoading');
@@ -312,6 +317,8 @@ const creationPages = [
   PageNames.EXAM_CREATION_TOPIC,
   PageNames.EXAM_CREATION_PREVIEW,
   PageNames.EXAM_CREATION_SEARCH,
+  PageNames.EXAM_CREATION_BOOKMARKS,
+  PageNames.EXAM_CREATION_BOOKMARKS_MAIN,
 ];
 
 export function showExamCreationQuestionSelectionPage(store, toRoute, fromRoute) {

--- a/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planExamRoutes.js
@@ -110,8 +110,8 @@ export default [
     name: PageNames.EXAM_CREATION_PREVIEW,
     path: '/:classId/plan/quizzes/new/preview/',
     component: PlanQuizPreviewPage,
-    handler: toRoute => {
-      showExamCreationPreviewPage(store, toRoute.params);
+    handler: (toRoute, fromRoute) => {
+      showExamCreationPreviewPage(store, toRoute.params, fromRoute);
     },
   },
   {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -327,17 +327,7 @@
           const topicExercises = flatMap(topics, ({ exercises }) => exercises);
           return [...exercises, ...topicExercises];
         } else if (this.bookmarks) {
-          const bookmarkedTopics = this.bookmarks.filter(
-            ({ kind }) => kind === ContentNodeKinds.TOPIC
-          );
-          const bookmarkedExercises = this.bookmarks.filter(
-            ({ kind }) => kind === ContentNodeKinds.EXERCISE
-          );
-          const bookmarkedTopicExercises = flatMap(
-            bookmarkedTopics,
-            ({ bookmarkedExercises }) => bookmarkedExercises
-          );
-          return [...bookmarkedExercises, ...bookmarkedTopicExercises];
+          return this.bookmarks;
         }
         return [];
       },


### PR DESCRIPTION
## Summary

This PR updates some of the bookmark fetching in coach quiz creation, by adding a filterset to display only exercises, simplify getting the count, and update some of the routing to fix problems with navigating through the full quiz creation when selecting bookmarks.

## References
Fixes #8723 and other related problems

## Reviewer guidance
- Can a user create a quiz using bookmarked exercises? 
- can the user select some or all from the bookmarks selection page?
- does the user only see exercises within the bookmarks, with an accurate count of how many exercise?
- can the user navigate backwards to the main page from previewing a bookmarked resource?
- can the user navigate back to the correct channel folder display after previewing a non-bookmarked resource accessed be browsing through channels?
- can the user use the browser back button without error or missing content?

**Quiz creation from bookmarks **
![select-all-quiz-creation](https://user-images.githubusercontent.com/17235236/144944854-1fd6c176-e985-449a-b835-7bc1e31d3046.gif)

**Back following content preview - bookmarks**
![bookmark-preview-back](https://user-images.githubusercontent.com/17235236/144944849-ef98cb81-2962-4fac-99a6-beebc1e7d931.gif)

**Back following content preview - channel content**
![channel-preview-back](https://user-images.githubusercontent.com/17235236/144944851-ed43155a-e1f5-44bc-b2f5-01fab5c59d6a.gif)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
