### PR TITLE
Fix upgrade startup errors

### DIFF
--- a/kolibri/core/tasks/upgrade.py
+++ b/kolibri/core/tasks/upgrade.py
@@ -4,6 +4,7 @@ A file to contain specific logic to handle version upgrades in Kolibri.
 import logging
 
 from kolibri.core.tasks.main import job_storage
+from kolibri.core.tasks.main import scheduler
 from kolibri.core.upgrade import version_upgrade
 
 logger = logging.getLogger(__name__)
@@ -20,3 +21,4 @@ def drop_old_iceqube_tables():
     and let iceqube reinitialize the tables from scratch.
     """
     job_storage.recreate_tables()
+    scheduler.recreate_tables()

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -1,10 +1,6 @@
 import copy
 import os
-import shutil
 import sys
-from sqlite3 import DatabaseError
-
-from diskcache import Cache
 
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.conf import OPTIONS
@@ -15,23 +11,6 @@ cache_options = OPTIONS["Cache"]
 pickle_protocol = OPTIONS["Python"]["PICKLE_PROTOCOL"]
 
 diskcache_location = os.path.join(KOLIBRI_HOME, "process_cache")
-
-
-def recreate_diskcache():
-    if cache_options["CACHE_BACKEND"] != "redis":
-        try:
-            diskcache_cache = Cache(
-                diskcache_location, disk_pickle_protocol=pickle_protocol
-            )
-        except DatabaseError:
-            shutil.rmtree(diskcache_location, ignore_errors=True)
-            os.mkdir(diskcache_location)
-            diskcache_cache = Cache(
-                diskcache_location, disk_pickle_protocol=pickle_protocol
-            )
-        diskcache_cache.clear()
-        diskcache_cache.close()
-
 
 # Default to LocMemCache, as it has the simplest configuration
 default_cache = {
@@ -48,6 +27,7 @@ default_cache = {
 process_cache = {
     "BACKEND": "diskcache.DjangoCache",
     "LOCATION": diskcache_location,
+    "TIMEOUT": cache_options["CACHE_TIMEOUT"],
     "SHARDS": CACHE_SHARDS,
     "OPTIONS": {
         "MAX_ENTRIES": cache_options["CACHE_MAX_ENTRIES"],

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -238,11 +238,6 @@ class ServicesPlugin(SimplePlugin):
         self.bus = bus
         self.workers = None
 
-    def ENTER(self):
-        from kolibri.deployment.default.cache import recreate_diskcache
-
-        recreate_diskcache()
-
     def START(self):
         from kolibri.core.tasks.main import initialize_workers
         from kolibri.core.tasks.main import scheduler


### PR DESCRIPTION
## Summary
* Moves disk cache integrity check to before any upgrades are run, ensures that it catches all fanout shards by using full Django cache
* Adds scheduler storage table recreation to upgrade task

## References
Fixes #8781 - fixes both errors reported therein, which are reproducible with the zip file.

## Reviewer guidance
Does running with the kolibri home dir in the issue upgrade without any issues?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
