### PR TITLE
Adjust search-chip spacing to enforce 8px minimum separation.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchChips.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchChips.vue
@@ -111,7 +111,7 @@
 
   .filter-chip {
     display: inline-block;
-    margin: 2px;
+    margin-left: 8px;
     font-size: 14px;
     vertical-align: top;
     background-color: #dedede;


### PR DESCRIPTION
## Summary
* Sets `margin-left` on search chips to 8px

## References
Fixes #8668

## Reviewer guidance
Before:
![Screenshot from 2021-12-06 21-51-15](https://user-images.githubusercontent.com/1680573/144974007-09fef060-868c-482a-953b-5b5d4c05a964.png)

After:
![Screenshot from 2021-12-06 21-50-53](https://user-images.githubusercontent.com/1680573/144974018-94c1832a-5ee6-4bd8-9c67-cbf0b3628b0c.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
