### PR TITLE
Hide search panel in mobile when search is selected

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -2,7 +2,7 @@
 
   <div class="content-grid">
     <KFixedGrid
-      v-if="(cardViewStyle === 'card' && !!numCols) || !windowIsSmall"
+      v-if="numCols !== null && (cardViewStyle === 'card' || !windowIsSmall)"
       :numCols="numCols"
       gutter="24"
     >

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -347,6 +347,11 @@
           : { marginLeft: `${this.sidePanelWidth + 24}px` };
       },
     },
+    watch: {
+      searchTerms() {
+        this.sidePanelIsOpen = false;
+      },
+    },
     created() {
       this.search();
     },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -359,6 +359,7 @@
 <script>
 
   import { mapActions, mapState } from 'vuex';
+  import isEqual from 'lodash/isEqual';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
@@ -644,6 +645,11 @@
       subTopicId(newValue, oldValue) {
         if (newValue && newValue !== oldValue) {
           this.handleLoadMoreinSubtopic(newValue);
+        }
+      },
+      searchTerms(newVal, oldVal) {
+        if (!isEqual(newVal, oldVal) && this.displayingSearchResults) {
+          this.$router.push({ ...this.searchLink, sidePanel: false });
         }
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -235,7 +235,7 @@
             />
             <div v-if="more" class="end-button-block">
               <KButton
-                v-if="moreLoading"
+                v-if="!moreLoading"
                 :text="coreString('viewMoreAction')"
                 appearance="basic-link"
                 :disabled="moreLoading"


### PR DESCRIPTION
## Summary
* Hides search panel in library page in mobile when search updates
* Hides search panel in topics page in mobile when search updates
* Prevents numCols being null errors
* Properly displays view more button at bottom of topics search results instead of loader

## References
Fixes #8817

## Reviewer guidance
![mobilepanel](https://user-images.githubusercontent.com/1680573/144978843-c2a56b99-77ea-41da-94fb-8f4ba2f26727.gif)

![tpoicsearch](https://user-images.githubusercontent.com/1680573/144978854-488af07f-9b3d-4729-bc34-342b8c6d2347.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
