### PR TITLE
Fix height on content cards with folders

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -135,7 +135,6 @@
       },
       footerLength() {
         return (
-          1 +
           this.content.is_leaf +
           (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
           (this.content.num_coach_contents > 0) +
@@ -211,8 +210,8 @@
   .folder-header-text {
     display: inline-block;
     padding: 0;
-    margin: 0;
-    font-size: 16px;
+    margin: 7px 0;
+    font-size: 13px;
   }
 
   .k-labeled-icon {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -192,6 +192,7 @@
   .header-bar {
     display: flex;
     justify-content: space-between;
+    height: 48px;
     padding: 8px 16px;
     font-size: 13px;
     .channel-logo {
@@ -210,7 +211,7 @@
   .folder-header-text {
     display: inline-block;
     padding: 0;
-    margin: 7px 0;
+    margin: 0;
     font-size: 13px;
   }
 


### PR DESCRIPTION
## Summary
Update CSS to fix the height and text size on content cards with folders so that it matches the text size and height of the other content cards.

|Before|After|
|--|--|
|<img width="674" alt="Screen Shot 2021-12-06 at 1 33 10 PM" src="https://user-images.githubusercontent.com/13563002/144926066-9b3bcfd3-5e58-4cce-a621-2c73b5131e00.png">|![Screen Shot 2021-12-07 at 1 48 42 PM](https://user-images.githubusercontent.com/13563002/145111413-27470a76-480a-4e2d-b33b-9ee8d60ba938.png)|
## References
Addresses #8809

## Reviewer guidance
Double check that the heights now match that of the content cards with activities:
1. Log in as a learner
2. Click on "Library" tab
3. On left sidebar, go to Category > "None of the above" to view everything (including folders)
4. See that cards with folders are the same height as other cards.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
