### PR TITLE
Conditionally display 'over x results' when more to show.

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1036,6 +1036,17 @@ const noneOfTheAboveTranslator = createTranslator('PerseusInternalMessages', {
   'None of the above': 'None of the above',
 });
 
+// We forgot another string, so we are using one from the EPubRenderer SearchSideBar namespace
+// do not do this, do as I say, not as I do, etc. etc.
+// TODO: 0.16 - remove this and put a proper string in place
+const overResultsTranslator = createTranslator('SearchSideBar', {
+  overCertainNumberOfSearchResults: {
+    message: 'Over {num, number, integer} {num, plural, one {result} other {results}}',
+    context:
+      'Refers to number of search results when there are over a specified amount. Only translate "over", "result" and "results".\n',
+  },
+});
+
 /**
  * An object mapping ad hoc keys (like those to be passed to coreString()) which do not
  * conform to the expectations. Examples:
@@ -1090,6 +1101,10 @@ export default {
     coreString(key, args) {
       if (key === 'None of the above' || key === METADATA.NoCategories) {
         return noneOfTheAboveTranslator.$tr('None of the above', args);
+      }
+
+      if (key === 'overCertainNumberOfSearchResults') {
+        return overResultsTranslator.$tr(key, args);
       }
 
       const metadataKey = get(MetadataLookup, key, null);

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -70,16 +70,11 @@
       <!-- for interacting or updating the results   -->
       <div v-else-if="!searchLoading">
         <h2 class="results-title">
-          {{ $tr('results', { results: results.length }) }}
+          {{ more ?
+            coreString('overCertainNumberOfSearchResults', { num: results.length }) :
+            $tr('results', { results: results.length })
+          }}
         </h2>
-        <KButton
-          v-if="more"
-          :text="coreString('viewMoreAction')"
-          appearance="basic-link"
-          :disabled="moreLoading"
-          class="filter-action-button"
-          @click="searchMore"
-        />
         <div v-if="!(windowBreakpoint < 1) && results.length" class="toggle-view-buttons">
           <KIconButton
             icon="menu"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -209,16 +209,11 @@
           </div>
           <div v-else-if="!searchLoading">
             <h2 class="results-title">
-              {{ translator.$tr('results', { results: results.length }) }}
+              {{ more ?
+                coreString('overCertainNumberOfSearchResults', { num: results.length }) :
+                translator.$tr('results', { results: results.length })
+              }}
             </h2>
-            <KButton
-              v-if="more"
-              :text="coreString('viewMoreAction')"
-              appearance="basic-link"
-              :disabled="moreLoading"
-              class="filter-action-button"
-              @click="searchMore"
-            />
             <SearchChips
               :searchTerms="searchTerms"
               @removeItem="removeFilterTag"


### PR DESCRIPTION
## Summary
* Digs out a string from the EPub Renderer to show 'Over X results' when there are more results to display
* Removes view more button at top if search results

## References
Fixes #8832

## Reviewer guidance
![Screenshot from 2021-12-07 13-16-45](https://user-images.githubusercontent.com/1680573/145112298-0d22ead1-b445-4086-8c75-5729e471a38c.png)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
