### PR TITLE
update numCols to null, rather than 1, so page renders correctly

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -29,7 +29,7 @@
         v-if="contentNodes.length"
         currentPage="lessonPage"
         cardViewStyle="list"
-        :numCols="1"
+        :numCols="null"
         :getContentNodeThumbnail="getContentNodeThumbnail"
         :genContentLink="genContentLink"
         :contents="contentNodes"


### PR DESCRIPTION
## Summary
Updates the value of `numCols` on the lessons page from 1 to `null`, which now ensures the cards render

## References
Potentially fixes some or all of #8828 (but need more investigation before we should close this, I think)

## Reviewer guidance
Do the cards display when running the local server?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
