### PR TITLE
Remove unnecessary cruft from Bookmark.infer_dataset

### DIFF
--- a/kolibri/core/bookmarks/models.py
+++ b/kolibri/core/bookmarks/models.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from morango.models import UUIDField
 
 from kolibri.core.auth.models import AbstractFacilityDataModel
-from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.general import IsOwn
 
@@ -24,21 +23,7 @@ class Bookmark(AbstractFacilityDataModel):
     permissions = IsOwn()
 
     def infer_dataset(self, *args, **kwargs):
-        if self.user_id:
-            return self.cached_related_dataset_lookup("user")
-        elif self.dataset_id:
-            # confirm that there exists a facility with that dataset_id
-            try:
-                return Facility.objects.get(dataset_id=self.dataset_id).dataset_id
-            except Facility.DoesNotExist:
-                pass
-        # if no user or matching facility, infer dataset from the default facility
-        facility = Facility.get_default_facility()
-        if not facility:
-            raise AssertionError(
-                "Before you can save bookmarks, you must have a facility"
-            )
-        return facility.dataset_id
+        return self.cached_related_dataset_lookup("user")
 
     def calculate_partition(self):
         return "{dataset_id}:user-rw:{user_id}".format(


### PR DESCRIPTION
Quick flyby cleanup: it looks as if the code here was copied from the logger models, but we can keep it simpler here. The logs can be anonymous (no user), so we need to jump through more hoops to decide on a facility to associate them with, whereas bookmarks require that the user be specified.