### PR TITLE
If leaving LessonPlaylistPage for non-content, unset lesson in vuex

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -45,12 +45,13 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapMutations, mapState } from 'vuex';
   import sumBy from 'lodash/sumBy';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
   import genContentLink from '../../utils/genContentLink';
+  import { PageNames } from '../../constants';
   import HybridLearningCardGrid from './../HybridLearningCardGrid';
 
   export default {
@@ -84,7 +85,15 @@
         return undefined;
       },
     },
+    beforeDestroy() {
+      /* If we are going anywhere except for content we unset the lesson */
+
+      if (this.$route.name !== PageNames.TOPICS_CONTENT) {
+        this.SET_CURRENT_LESSON({});
+      }
+    },
     methods: {
+      ...mapMutations('lessonPlaylist', ['SET_CURRENT_LESSON']),
       getContentNodeThumbnail,
       genContentLink,
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The "Also in this" panel (and anywhere else) was stuck with the last viewed lesson's state even when no longer viewing a lesson.

The best solution I can find is in `LessonPlaylistPage#beforeDestroy` unset the lesson in Vuex whenever the user navigates anywhere except to a piece of content.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8721

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to a Lesson and view content. You should see the icon "View lesson resources" which opens the side panel and shows lesson resources.

Go to Bookmarks or Library page, view some content, the icon should now say "View folder resources" and show folder siblings in the side panel when clicked (previously, this would have had the same content list and label as the lesson you viewed).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
