### PR TITLE
Removes search box from top navbar when user is in library

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -132,6 +132,9 @@
       currentPage() {
         return pageNameToComponentMap[this.pageName] || null;
       },
+      pageName() {
+        return this.$route.name;
+      },
       currentPageIsTopic() {
         return [
           pageNameToComponentMap[PageNames.TOPICS_TOPIC],
@@ -249,7 +252,7 @@
         };
       },
       showSearch() {
-        return this.canAccessUnassignedContent;
+        return this.canAccessUnassignedContent && this.pageName !== PageNames.LIBRARY;
       },
       topNavIsVisible() {
         return (

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -16,9 +16,6 @@
     authorizedRole="registeredUser"
     v-bind="immersivePageProps"
   >
-    <template #app-bar-actions>
-      <ActionBarSearchBox v-if="showSearch" />
-    </template>
 
     <template #sub-nav>
       <LearnTopNav />
@@ -73,7 +70,6 @@
   import ClassAssignmentsPage from './classes/ClassAssignmentsPage';
   import LessonPlaylistPage from './classes/LessonPlaylistPage';
   import LessonResourceViewer from './classes/LessonResourceViewer';
-  import ActionBarSearchBox from './ActionBarSearchBox';
   import LearnTopNav from './LearnTopNav';
   import { ASSESSMENT_FOOTER, QUIZ_FOOTER } from './footers.js';
   import BookmarkPage from './BookmarkPage.vue';
@@ -96,7 +92,6 @@
   export default {
     name: 'LearnIndex',
     components: {
-      ActionBarSearchBox,
       Breadcrumbs,
       CoreBase,
       LearnTopNav,
@@ -111,7 +106,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'canAccessUnassignedContent']),
+      ...mapGetters(['isUserLoggedIn']),
       ...mapState('lessonPlaylist/resource', {
         lessonContent: 'content',
       }),
@@ -131,9 +126,6 @@
       },
       currentPage() {
         return pageNameToComponentMap[this.pageName] || null;
-      },
-      pageName() {
-        return this.$route.name;
       },
       currentPageIsTopic() {
         return [
@@ -250,9 +242,6 @@
           appBarTitle: this.learnString('learnLabel'),
           immersivePage: false,
         };
-      },
-      showSearch() {
-        return this.canAccessUnassignedContent && this.pageName !== PageNames.LIBRARY;
       },
       topNavIsVisible() {
         return (


### PR DESCRIPTION
## Summary
![2021-12-07 15 49 33](https://user-images.githubusercontent.com/13563002/145123566-80c1be63-90ca-4bd3-9fdb-3c6815e302c5.gif)


## References
Addresses #8838 

## Reviewer guidance
Check to see that the top search box is removed when a user is in the library, and that it still works as intended on other pages.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
