### PR TITLE
Include backRoute & context in content link on BrowseResourceMetadata

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -29,7 +29,7 @@
           :text="metadataStrings.$tr('viewResource')"
           appearance="raised-button"
           :primary="false"
-          :to="genContentLink(content.id, null, content.is_leaf, null, {})"
+          :to="genContentLink(content.id, null, content.is_leaf, $route.name, { ...$route.query })"
           data-test="view-resource-link"
         />
       </div>

--- a/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
@@ -1,4 +1,5 @@
-import { shallowMount } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import VueRouter from 'vue-router';
 import { ContentNodeResource } from 'kolibri.resources';
 import KRouterLink from 'kolibri-design-system/lib/buttons-and-links/KRouterLink';
 import LearnerNeeds from 'kolibri-constants/labels/Needs';
@@ -11,6 +12,21 @@ import ContentNodeThumbnail from '../../src/views/thumbnails/ContentNodeThumbnai
 import LearningActivityChip from '../../src/views/LearningActivityChip';
 import BrowseResourceMetadata from '../../src/views/BrowseResourceMetadata';
 import genContentLink from '../../src/utils/genContentLink';
+import routes from '../../src/routes/index.js';
+
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
+jest.mock('plugin_data', () => {
+  return {
+    __esModule: true,
+    default: {
+      accessibilityLabels: [],
+      gradeLevels: [],
+      learnerNeeds: [],
+    },
+  };
+});
 
 const promise = new Promise(() => []);
 
@@ -67,7 +83,9 @@ function makeWrapper(metadata = {}, options = {}) {
   const content = makeContentNode(metadata);
   const propsData = { content };
   return shallowMount(BrowseResourceMetadata, {
+    localVue,
     propsData,
+    router: new VueRouter(routes),
     ...options,
   });
 }
@@ -158,7 +176,6 @@ describe('BrowseResourceMetadata', () => {
     });
 
     it('does not show the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
-      console.log(wrapper.vm.forBeginners);
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeFalsy();
     });
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Two bugs fixed.

1. When accessing Bookmarked content from Bookmark's page's *side panel* the route of the content's back arrow would be the Learn Home page.
2. Also if a user would have search context and access the content via the side panel, then they'd have to click the back arrow twice and get sent to Learn Home

This change ensures correct context in both cases.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
--> 

Fixes #8830 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

First - confirm the two bugs above on release-0.15

This  is only when clicking view resource in the side panel when browsing content.

Try it in Bookmarks

Try it in the Library Page - with and without search criteria in place. It should always go back to the state you were in when you left.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
