### PR TITLE
Make KSelect label prop optional to match KeenUI Select.

### DIFF
--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -82,7 +82,7 @@
        */
       label: {
         type: String,
-        required: true,
+        default: null,
       },
       /**
        * Whether disabled or not


### PR DESCRIPTION
## Summary
* A recent use of KSelect did not need a label, so it doesn't have one (https://github.com/learningequality/kolibri/pull/8802)
* This caused a prop validation error
* On further investigation KeenUI Select does not need a label, so I made KSelect not need one either!


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
