### PR TITLE
Fixes #8852: avoid constant zeroconf re-enumeration

### DIFF
--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -336,7 +336,7 @@ class KolibriBroadcast(object):
         # register our instance so we start broadcasting
         self.register()
 
-        # manually add our service browser to Zeroconf so its automatically cleaned up on close
+        # manually add our service browser to Zeroconf so it's automatically cleaned up on close
         self.zeroconf.browsers["bus"] = ServiceBrowser(
             self.zeroconf, SERVICE_TYPE, handlers=[self.events.publish_zeroconf_change]
         )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ semver==2.8.1
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-zeroconf-py2compat==0.19.13
+zeroconf-py2compat==0.19.14
 ifcfg==0.21
 Click==7.0
 whitenoise==4.1.4


### PR DESCRIPTION
## Summary

Fix #8852 by updating to the version of zeroconf to be released from https://github.com/learningequality/python-zeroconf-py2compat/pull/13 and changing the ZeroConfPlugin to have a local cache of the address list rather than relying on what zeroconf gives us (which may exclude some interfaces on which it couldn't successfully broadcast).

## References

Addresses https://github.com/learningequality/kolibri/issues/8852

Will not build until https://github.com/learningequality/python-zeroconf-py2compat/pull/13 has been merged and released.

## Reviewer guidance

To test, once we can get a build going, run this on a Windows device with some 169.254 addresses and check the logs to make sure it's not constantly saying that the list of addresses has changed.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
