### PR TITLE
Update || to && for conditions for toggling card styles

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -2,7 +2,7 @@
 
   <div class="content-grid">
     <KFixedGrid
-      v-if="numCols !== null && (cardViewStyle === 'card' || !windowIsSmall)"
+      v-if="numCols !== null && cardViewStyle === 'card' && !windowIsSmall"
       :numCols="numCols"
       gutter="24"
     >


### PR DESCRIPTION
## Summary

**Before**
![toggle-before](https://user-images.githubusercontent.com/17235236/145228942-6b920cf8-37ff-4c1f-81ab-ca912b4d7f5d.gif)

**Fixed**
![toggle-fixed](https://user-images.githubusercontent.com/17235236/145228943-88c8df63-c01e-43cc-9cd9-a7a0d3eb54cd.gif)

Updates the condition from `||` to `&&` to accurately display cards v. lists

## References
 
Fixes #8831 

## Reviewer guidance
- Does the toggle work? 
- Do the correct cards still display correctly at all screen sizes on each page? 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
