### PR TITLE
DO NOT MERGE Update psycopg2 to latest Python 2 supported version.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,7 +14,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["**.py", "requirements/*.txt"]'
+          paths: '["**.py", "requirements/*.txt", ".github/workflows/tox.yml"]'
   unit_test:
     name: Python unit tests
     needs: pre_job

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -51,7 +51,7 @@ jobs:
       # Label used to access the service container
       postgres:
         # Docker Hub image
-        image: postgres
+        image: postgres:11.14
         # Provide the password for postgres
         env:
           POSTGRES_USER: postgres

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,2 +1,2 @@
 # Additional reqs for running kolibri with a postgres db layer
-psycopg2==2.7.5
+psycopg2==2.8.6


### PR DESCRIPTION
Running CI to sanity check Psycopg2 upgrade for 0.14.x