### PR TITLE
Reset searchbox input value when search term is cleared

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -117,6 +117,11 @@
         };
       },
     },
+    watch: {
+      value(current) {
+        this.searchInputValue = current || '';
+      },
+    },
     methods: {
       clearInput() {
         this.searchInputValue = '';


### PR DESCRIPTION
## Summary
When search terms are cleared in the filters, the search input box must be cleared

## References
Closes: #8840 

## Reviewer guidance

1. Type some search term in the Keywords input box in the Learn-Library tab
2. Click on the "Clear all" link on the right or on the chip containing the written term
3. The Keywords input box should be cleared

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
