### PR TITLE
Bookmark font size

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/card.scss
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/card.scss
@@ -1,6 +1,6 @@
 $ratio: 16 / 9;
 
-$thumb-height-desktop-hybrid-learning: 160px;
+$thumb-height-desktop-hybrid-learning: 120px;
 $thumb-width-desktop-hybrid-learning: round($thumb-height-desktop-hybrid-learning * $ratio);
 
 $thumb-height-mobile-hybrid-learning: 185px;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -268,7 +268,7 @@
     position: absolute;
     bottom: 0;
     width: 100%;
-    padding: $margin 24px;
+    padding: 16px 24px;
   }
 
   .metadata-info-footer {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -275,7 +275,7 @@
     flex: auto;
     align-self: center;
     margin: 0;
-    font-size: 14px;
+    font-size: 13px;
   }
 
   .footer-elements {
@@ -307,7 +307,6 @@
   .thumbnail {
     display: inline-block;
     width: 240px;
-    height: 100px;
     margin-top: 8px;
     margin-right: 24px;
     margin-left: 24px;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -69,18 +69,20 @@
         />
       </span>
     </router-link>
-    <KFixedGrid :numCols="10" class="footer">
-      <KFixedGridItem span="3" class="footer-elements">
-        <p
-          v-if="isBookmarksPage"
-          class="metadata-info-footer"
-          :style="{ color: $themePalette.grey.v_700 }"
-        >
-          {{ bookmarkCreated }}
-        </p>
-        <ProgressBar :contentNode="content" />
-      </KFixedGridItem>
-      <KFixedGridItem span="10" alignment="right" class="footer-elements footer-icons">
+    <div class="footer">
+      <div class="footer-elements">
+        <div class="footer-progress">
+          <p
+            v-if="isBookmarksPage"
+            class="metadata-info-footer"
+            :style="{ color: $themePalette.grey.v_700 }"
+          >
+            {{ bookmarkCreated }}
+          </p>
+          <ProgressBar :contentNode="content" />
+        </div>
+      </div>
+      <div class="footer-elements footer-icons">
         <KIconButton
           v-for="(value, key) in footerIcons"
           :key="key"
@@ -91,8 +93,8 @@
           :tooltip="coreString(value)"
           @click="$emit(value)"
         />
-      </KFixedGridItem>
-    </KFixedGrid>
+      </div>
+    </div>
   </div>
 
 </template>
@@ -198,8 +200,6 @@
   @import '~kolibri-design-system/lib/styles/definitions';
   @import './ContentCard/card';
 
-  $margin: 16px;
-
   .drop-shadow {
     @extend %dropshadow-1dp;
     &:hover {
@@ -278,13 +278,18 @@
 
   .footer-elements {
     position: relative;
-    display: inline-block;
+    display: block;
+  }
+
+  .footer-progress {
+    width: 240px;
   }
 
   .footer-icons {
     // this override fixes an existing KDS bug with
     // the hover state circle being squished
     // and can be removed upon that hover state fix
+    float: right;
     .button {
       width: 32px !important;
       height: 32px !important;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -70,7 +70,7 @@
       </span>
     </router-link>
     <KFixedGrid :numCols="10" class="footer">
-      <KFixedGridItem span="6" class="footer-elements">
+      <KFixedGridItem span="3" class="footer-elements">
         <p
           v-if="isBookmarksPage"
           class="metadata-info-footer"
@@ -80,7 +80,7 @@
         </p>
         <ProgressBar :contentNode="content" />
       </KFixedGridItem>
-      <KFixedGridItem span="3" alignment="right" class="footer-elements footer-icons">
+      <KFixedGridItem span="10" alignment="right" class="footer-elements footer-icons">
         <KIconButton
           v-for="(value, key) in footerIcons"
           :key="key"
@@ -198,7 +198,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
   @import './ContentCard/card';
 
-  $margin: 24px;
+  $margin: 16px;
 
   .drop-shadow {
     @extend %dropshadow-1dp;
@@ -268,24 +268,20 @@
     position: absolute;
     bottom: 0;
     width: 100%;
-    padding: $margin;
+    padding: $margin 24px;
   }
 
   .metadata-info-footer {
-    flex: auto;
-    align-self: center;
     margin: 0;
     font-size: 13px;
   }
 
   .footer-elements {
-    position: absolute;
-    bottom: 16px;
-    display: inline;
+    position: relative;
+    display: inline-block;
   }
 
   .footer-icons {
-    right: 16px;
     // this override fixes an existing KDS bug with
     // the hover state circle being squished
     // and can be removed upon that hover state fix


### PR DESCRIPTION
## Summary
Some UI updates to make the bookmark cards more closely aligned to [spec in Figma](https://www.figma.com/file/uiZuCIqh2KYvBUfbCiJyyA/Hybrid-Learning?node-id=76%3A6747).
- Moved the right icons into their own separate row, per spec
- Updated size of thumbnail
- Updated margins for card

<img width="1507" alt="Screen Shot 2021-12-08 at 12 05 04 PM" src="https://user-images.githubusercontent.com/13563002/145278111-45917923-d515-40fc-a0d1-46a118fe1a18.png">

## References
Fixes #8844 

## Reviewer guidance

- [ ] Check to see if bookmarked cards now more closely match the specs
- [ ] Check to see if there is brittleness in CSS that should be fixed
- [ ] Check for regressions

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
