### PR TITLE
Bug/soud cannot edit profile

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -1,6 +1,8 @@
 <template>
 
+  <!-- The v-if ensures the page isn't visible briefly before redirection -->
   <CoreBase
+    v-if="!isSubsetOfUsersDevice"
     :immersivePage="true"
     immersivePageIcon="close"
     :appBarTitle="$tr('editProfileHeader')"
@@ -69,6 +71,7 @@
 
   import every from 'lodash/every';
   import pickBy from 'lodash/pickBy';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import { mapGetters } from 'vuex';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import CatchErrors from 'kolibri.utils.CatchErrors';
@@ -80,6 +83,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoreBase from 'kolibri.coreVue.components.CoreBase';
   import { ComponentMap } from '../constants';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ProfileEditPage',
@@ -108,6 +112,7 @@
         formSubmitted: false,
         status: '',
         userCopy: {},
+        isSubsetOfUsersDevice: plugin_data['isSubsetOfUsersDevice'],
       };
     },
     computed: {
@@ -139,6 +144,13 @@
     },
     mounted() {
       this.setFacilityUser();
+    },
+    created() {
+      // Users cannot edit profiles on SoUD so redirect them if they get here which should
+      // only be possible by direct linking to the URL that leads here
+      if (plugin_data['isSubsetOfUsersDevice']) {
+        redirectBrowser();
+      }
     },
     methods: {
       // Have to query FacilityUser again since we don't put demographic info on the session

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -11,7 +11,8 @@
         <KGridItem sizes="100, 75, 75" percentage>
           <h1>{{ $tr('detailsHeader') }}</h1>
         </KGridItem>
-        <KGridItem sizes="100, 25, 25" percentage alignment="right">
+        <!-- Users cannot edit their profile if on a SoUD -->
+        <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
           <KRouterLink
             :text="$tr('editAction')"
             appearance="raised-button"
@@ -141,6 +142,7 @@
   import { ComponentMap } from '../../constants';
   import ChangeUserPasswordModal from './ChangeUserPasswordModal';
   import useCurrentUser from './useCurrentUser';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'ProfilePage',
@@ -162,8 +164,10 @@
     setup() {
       const showPasswordModal = ref(false);
       const { currentUser } = useCurrentUser();
+      const { isSubsetOfUsersDevice } = plugin_data;
       return {
         currentUser,
+        isSubsetOfUsersDevice,
         showPasswordModal,
       };
     },

--- a/kolibri/plugins/user_profile/kolibri_plugin.py
+++ b/kolibri/plugins/user_profile/kolibri_plugin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
@@ -19,6 +20,10 @@ class UserProfile(KolibriPluginBase):
 @register_hook
 class UserAuthAsset(webpack_hooks.WebpackBundleHook):
     bundle_id = "app"
+
+    @property
+    def plugin_data(self):
+        return {"isSubsetOfUsersDevice": get_device_setting("subset_of_users_device")}
 
 
 @register_hook


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Users shouldn't be able to edit their profile on SoUD this ensures:
- The "Edit" button is not present on the Profile page when on SoUD
- The Profile Edit page altogether is inaccessible by direct URL to be extra safe

Per @jamalex 's suggestion - if I can get my hands on the SoUD specs doc I'll do an audit to be sure things that aren't allowed aren't allowed.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8849  

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go into your database and in the `device_devicesettings` table make your `subset_of_users_device` setting is true.

Log in - try to edit your profile. Go to the profile and add "edit" to the URL and you should be redirected to your user's "home" - a super admin goes to device and a learner goes to learn, for example. A coach... probably to coach? In any case - this would only happen in the exact case you're testing (going directly to the URL) so it's an edge case altogether. 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
