### PR TITLE
Update results displayed to be 3 per row

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -376,9 +376,6 @@
   import LibraryPage from './LibraryPage';
   import plugin_data from 'plugin_data';
 
-  const carouselLimit = 4;
-  const mobileCarouselLimit = 3;
-
   export default {
     name: 'TopicsPage',
     metaInfo() {
@@ -449,6 +446,7 @@
         expandedTopics: {},
         subTopicLoading: null,
         topicMoreLoading: false,
+        childrenToDisplay: 3,
       };
     },
     computed: {
@@ -619,9 +617,6 @@
       },
       activeCategories() {
         return this.searchTerms.categories;
-      },
-      childrenToDisplay() {
-        return this.windowIsLarge ? carouselLimit : mobileCarouselLimit;
       },
       topicMore() {
         return this.topic.children && this.topic.children.more;


### PR DESCRIPTION
## Summary
Remove difference in carousel limit for mobile and desktop, and set value to be 3.

<img width="1115" alt="Screen Shot 2021-12-08 at 4 18 38 PM" src="https://user-images.githubusercontent.com/13563002/145311721-5ea91127-881d-479c-a6b3-c68b9cd1fa1a.png">

## References
Fixes #8846 

## Reviewer guidance
Check to see that the update fixes the original issue so that only 3 card results show up when a user clicks into a folder.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
