### PR TITLE
Do an extra check to stop an unclean shutdown from breaking kolibri.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -607,7 +607,14 @@ class KolibriProcessBus(ProcessBus):
         # If there are, then we need to stop users from starting kolibri again.
         pid, _, _, status = _read_pid_file(self.pid_file)
 
-        if status in IS_RUNNING and pid_exists(pid):
+        if (
+            status in IS_RUNNING
+            and pid_exists(pid)
+            and (
+                not self.serve_http
+                or check_port_availability(self.listen_address, self.port)
+            )
+        ):
             logger.error(
                 "There is another Kolibri server running. "
                 "Please use `kolibri stop` and try again."

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -116,7 +116,7 @@ class Server(BaseServer):
         return logger.log(level, msg)
 
 
-def check_port_availability(host, port):
+def port_is_available_on_host(host, port):
     """
     Make sure the port is available for the server to start.
     """
@@ -152,7 +152,7 @@ class PortCache:
                     if not self.values[p] and p not in self.occupied_ports
                 )
                 if port:
-                    if check_port_availability(host, port):
+                    if port_is_available_on_host(host, port):
                         self.values[port] = True
                         return port
             except StopIteration:
@@ -612,7 +612,7 @@ class KolibriProcessBus(ProcessBus):
             and pid_exists(pid)
             and (
                 not self.serve_http
-                or check_port_availability(self.listen_address, self.port)
+                or not port_is_available_on_host(self.listen_address, self.port)
             )
         ):
             logger.error(
@@ -679,7 +679,7 @@ class KolibriProcessBus(ProcessBus):
         if (
             not os.environ.get("LISTEN_PID", None)
             and port
-            and not check_port_availability(self.listen_address, port)
+            and not port_is_available_on_host(self.listen_address, port)
         ):
             # Port is occupied
             logger.error(

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -288,11 +288,15 @@ class ServerInitializationTestCase(TestCase):
             run_mock.assert_called()
 
     @mock.patch("kolibri.utils.server.pid_exists")
-    def test_server_running(self, pid_exists_mock, read_pid_file_mock):
+    @mock.patch("kolibri.utils.server.wait_for_free_port")
+    def test_server_running(
+        self, wait_for_port_mock, pid_exists_mock, read_pid_file_mock
+    ):
+        wait_for_port_mock.side_effect = OSError
         pid_exists_mock.return_value = True
         read_pid_file_mock.return_value = (1000, 8000, 8001, server.STATUS_RUNNING)
         with self.assertRaises(SystemExit):
-            server.start()
+            server.start(port=8000)
 
 
 class ServerSignalHandlerTestCase(TestCase):


### PR DESCRIPTION
## Summary
* Reinstates a port check for starting kolibri in the case that it is serving http, and the pid file and a pid exists check indicate that the server might still be running

## References
Fixes #8853 , #8841

## Reviewer guidance
Does the app still start as expected? Does Windows properly startup?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
