### PR TITLE
Perseus in Coach full width - some coach alignment fixes

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -203,6 +203,7 @@
 
   .coach-content-label {
     display: inline-block;
+    width: auto; // keeps on same line as question
     margin-top: -4px;
     margin-left: 8px;
     vertical-align: middle;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseHeader.vue
@@ -3,7 +3,7 @@
   <div>
 
     <section>
-      <HeaderWithOptions>
+      <HeaderWithOptions style="position: relative; top: 24px">
         <template #header>
           <BackLink
             :to="classRoute('ReportsLessonReportPage')"
@@ -66,6 +66,14 @@
 
   .stats {
     margin-right: 16px;
+  }
+
+  /deep/ .pad-button {
+    // TODO revisit how HeaderWithOptions is styled - this ensures the backlink is aligned with
+    // the preview button. Changing it in HeaderWithOptions to fix this breaks elsewhere and this
+    // seems isolated to two places right now
+    padding-top: 0 !important;
+    padding-bottom: 16px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -13,9 +13,7 @@
 
     <KPageContainer>
       <section>
-        <HeaderWithOptions
-          style="padding-top:24px;"
-        >
+        <HeaderWithOptions style="position: relative; top: 24px">
           <template #header>
             <BackLink
               :to="classRoute('ReportsLessonReportPage', {})"
@@ -312,6 +310,14 @@
 
   .group-title {
     margin-bottom: 24px;
+  }
+
+  /deep/ .pad-button {
+    // TODO revisit how HeaderWithOptions is styled - this ensures the backlink is aligned with
+    // the preview button. Changing it in HeaderWithOptions to fix this breaks elsewhere and this
+    // seems isolated to two places right now
+    padding-top: 0 !important;
+    padding-bottom: 16px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -13,7 +13,9 @@
 
     <KPageContainer>
       <section>
-        <HeaderWithOptions>
+        <HeaderWithOptions
+          style="padding-top:24px;"
+        >
           <template #header>
             <BackLink
               :to="classRoute('ReportsLessonReportPage', {})"

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -18,8 +18,9 @@
           <!-- Layout notes
             - Layout12 span8 -> ~66% width on windowIsLarge
             - No other layout definitions means span will be 100%
+            - When not interactive, this should be full width
           -->
-          <KGridItem :layout12="{ span: 6 }">
+          <KGridItem :layout12="{ span: interactive ? 6 : 12 }">
             <div
               id="problem-area"
               class="problem-area"
@@ -29,7 +30,14 @@
             </div>
           </KGridItem>
 
-          <KGridItem :layout12="{ span: 6 }">
+          <!--
+              - Only show the hints section at all if in interactive mode
+                Initially done to hide it in Coach reports after recent improvements to
+                the styles here for Learners.
+              - It is a v-show because seems without the proper anchors in place
+                it will fail to properly mount the react component
+          -->
+          <KGridItem v-show="interactive" :layout12="{ span: 6 }">
             <div v-if="hinted" id="hintlabel" class="hintlabel" :dir="contentDirection">
               {{ $tr("hintLabel") }}
             </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When *not* in interactive mode, the Perseus renderer was unnecessarily showing the hints KFixedGridItem, causing the actual quiz content to be half-width. This hides it with `v-show` so that the content renders properly and the grid spans are adjusted accordingly.

*(っ◔◡◔)っ ♥ Bonus fixes ♥*

1) Coach content icon was defaulting too 100% width making it drop to a newline - a `width: auto` style took care of that business.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/6356129/145458035-1978737c-9796-42bd-bb9e-1a814ef07065.png) | ![image](https://user-images.githubusercontent.com/6356129/145458081-0a691e61-9f85-4777-8d12-4cc5f56b0fd6.png) |

2) **(hacky)** The backlink was hugging the top on a couple reports and misaligned with the Preview button so I put some `/deep/` CSS and a TODO in there. HeaderWithOptions needs refactor and I can do it but wanted to get the fix in for the deadline. I can do a more robust fix next week or over the Holidays depending on priorities.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/6356129/145458738-a2390d6d-b1d6-418a-9c2d-c001c65de624.png) | !![image](https://user-images.githubusercontent.com/6356129/145458761-446e5784-90a6-4604-949a-93b8e810b3d7.png) |



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8834

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go look at Quiz reports and make sure questions are full width. Then go make a quiz and verify the same.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
