### PR TITLE
Assign an h5p learning activity kind

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -1,5 +1,4 @@
 import invert from 'lodash/invert';
-import LearningActivities from 'kolibri-constants/labels/LearningActivities';
 import Subjects from 'kolibri-constants/labels/Subjects';
 // coach-facing
 export { default as ContentNodeResourceType } from 'kolibri-constants/labels/ResourceType';
@@ -40,15 +39,6 @@ export const ContentNodeKinds = {
   ACTIVITY: 'ACTIVITY',
   SLIDESHOW: 'slideshow',
   BOOKMARK: 'bookmark',
-};
-
-export const ContentKindsToLearningActivitiesMap = {
-  audio: LearningActivities.LISTEN,
-  document: LearningActivities.READ,
-  exercise: LearningActivities.PRACTICE,
-  html5: LearningActivities.EXPLORE,
-  video: LearningActivities.WATCH,
-  topic: 'folder',
 };
 
 export const CategoriesLookup = invert(Subjects);

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -351,6 +351,11 @@ export default {
         // convert dates
         status.last_activity = status.last_activity ? new Date(status.last_activity) : null;
       });
+      const patchedSummaryContent = summary.content.map(item => {
+        const obj = Object.assign({}, item);
+        obj['kind'] = obj['kind'] == 'h5p' ? 'html5' : obj['kind'];
+        return obj;
+      });
       Object.assign(state, {
         id: summary.id,
         facility_id: summary.facility_id,
@@ -361,8 +366,8 @@ export default {
         adHocGroupsMap: _itemMap(summary.adhoclearners, 'id'),
         examMap,
         examLearnerStatusMap: _statusMap(summary.exam_learner_status, 'exam_id'),
-        contentMap: _itemMap(summary.content, 'content_id'),
-        contentNodeMap: _itemMap(summary.content, 'node_id'),
+        contentMap: _itemMap(patchedSummaryContent, 'content_id'),
+        contentNodeMap: _itemMap(patchedSummaryContent, 'node_id'),
         contentLearnerStatusMap: _statusMap(summary.content_learner_status, 'content_id'),
         lessonMap,
       });

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -10,7 +10,7 @@
     <SkipNavigationLink />
     <LearningActivityBar
       :resourceTitle="resourceTitle"
-      :learningActivities="mappedLearningActivities"
+      :learningActivities="content.learning_activities"
       :isLessonContext="lessonContext"
       :isBookmarked="bookmark ? true : bookmark"
       :isCoachContent="isCoachContent"
@@ -98,10 +98,6 @@
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import FullScreenSidePanel from 'kolibri.coreVue.components.FullScreenSidePanel';
-  import {
-    LearningActivities,
-    ContentKindsToLearningActivitiesMap,
-  } from 'kolibri.coreVue.vuex.constants';
   import { ContentNodeResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import client from 'kolibri.client';
@@ -220,18 +216,6 @@
       },
       allowMarkComplete() {
         return get(this, ['content', 'options', 'completion_criteria', 'learner_managed'], false);
-      },
-      mappedLearningActivities() {
-        let learningActivities = [];
-        if (this.content && this.content.kind) {
-          if (Object.values(LearningActivities).includes(this.content.kind)) {
-            learningActivities.push(this.content.kind);
-          } else {
-            // otherwise reassign the old content types to the new metadata
-            learningActivities.push(ContentKindsToLearningActivitiesMap[this.content.kind]);
-          }
-        }
-        return learningActivities;
       },
       lessonContext() {
         return Boolean(this.lessonId);


### PR DESCRIPTION
## Summary

h5p activities have not a defined icon to be shown. This PR solves it assigning a html5 icon to this content kind

The real fix should be done in kolibri-design-system to assing an icon to h5p at https://github.com/learningequality/kolibri-design-system/blob/main/lib/KIcon/iconDefinitions.js#L95

This PR also solves a problem in the Learn plugin to ensure the right icon is shown.

## References
Closes: #8882 

## Reviewer guidance
Browse the content library , and select an h5p resource, an icon should be shown 
![image](https://user-images.githubusercontent.com/1008178/145463322-d4f8e6bf-701c-45d4-b701-8afdd8a15a01.png)
![image](https://user-images.githubusercontent.com/1008178/145463362-739e0d8e-217e-49f7-851c-a32b4a84f44b.png)
Go to the Coach reports in a lesson with h5p content, the icon should be the same as with html5:
![image](https://user-images.githubusercontent.com/1008178/145472885-5587618a-71a3-4ff4-b240-75a1919579f8.png)
![image](https://user-images.githubusercontent.com/1008178/145472991-aaa429f3-4588-4f46-96cb-930a8c46a8c1.png)


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
