### PR TITLE
Assign headers properly to prevent 500 when database is locked

### DIFF
--- a/kolibri/core/device/middleware.py
+++ b/kolibri/core/device/middleware.py
@@ -128,11 +128,12 @@ class DatabaseBusyErrorHandler(object):
             return None
         # Return a 503 response with a Retry-After of 10 seconds. In future we may be able to customize this value
         # based on what is currently happening on the server.
-        return HttpResponse(
+        response = HttpResponse(
             "Database is not available for write operations",
             status=503,
-            headers={"Retry-After": 10},
         )
+        response["Retry-After"] = 10
+        return response
 
     def __call__(self, request):
         return self.get_response(request)


### PR DESCRIPTION
## Summary
* To preempt issues from syncing happening while learners are engaging with content, a middleware was implemented to prompt retries when a database locked error was encountered during progress tracking.
* Unfortunately, @rtibbles failed to set the headers properly, and tried to pass them as a kwarg to the Django response object, rather than setting them via attribute assignment after instantiation.
* This resolves that and assigns headers to response object properly to prevent an exception during exception handling.

## References
Fixes #8866

## Reviewer guidance
Run kolibri as a learner only device, engage with content while syncing is happening. See a 503, but that Kolibri eventually does make a successful request.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
