### PR TITLE
Make display of attempts parallel between mobile and non-mobile display

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -1,0 +1,97 @@
+<template>
+
+  <span>
+    <KIcon
+      v-if="attemptLog.noattempt"
+      class="item svg-item"
+      icon="notStarted"
+    />
+    <KIcon
+      v-else-if="attemptLog.correct"
+      class="item svg-item"
+      :style="{ fill: $themeTokens.correct }"
+      icon="correct"
+    />
+    <KIcon
+      v-else-if="attemptLog.error"
+      class="svg-item"
+      :style=" { fill: $themeTokens.annotation }"
+      icon="helpNeeded"
+    />
+    <KIcon
+      v-else-if="!attemptLog.correct"
+      class="item svg-item"
+      :style="{ fill: $themeTokens.incorrect }"
+      icon="incorrect"
+    />
+    <KIcon
+      v-else-if="attemptLog.hinted"
+      class="item svg-item"
+      :style=" { fill: $themeTokens.annotation }"
+      icon="hint"
+    />
+    <component :is="displayTag" class="item">
+      {{ coreString(
+        'questionNumberLabel',
+        { questionNumber: attemptLog.questionNumber }
+      )
+      }}
+    </component>
+    <CoachContentLabel
+      class="coach-content-label"
+      :value="attemptLog.num_coach_contents || 0"
+      :isTopic="false"
+    />
+  </span>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
+
+  export default {
+    name: 'AttemptLogItem',
+    components: {
+      CoachContentLabel,
+    },
+    mixins: [commonCoreStrings],
+    props: {
+      attemptLog: {
+        type: Object,
+        required: true,
+      },
+      displayTag: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .coach-content-label {
+    display: inline-block;
+    width: auto; // keeps on same line as question
+    margin-top: -4px;
+    margin-left: 8px;
+    vertical-align: middle;
+  }
+
+  .item {
+    display: inline-block;
+    height: 100%;
+  }
+
+  .svg-item {
+    margin-right: 12px;
+    margin-bottom: -4px;
+    font-size: 24px;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -77,7 +77,7 @@
 
   .coach-content-label {
     display: inline-block;
-    width: auto; // keeps on same line as question
+    max-width: 0.5vw; // keeps on same line as question
     margin-top: -4px;
     margin-left: 8px;
     vertical-align: middle;

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -13,7 +13,14 @@
       :options="options"
       :disabled="$attrs.disabled"
       @change="handleDropdownChange($event.value)"
-    />
+    >
+      <template #display>
+        <AttemptLogItem :attemptLog="attemptLogs[selectedQuestionNumber]" displayTag="span" />
+      </template>
+      <template #option="{ index }">
+        <AttemptLogItem :attemptLog="attemptLogs[index]" displayTag="span" />
+      </template>
+    </KSelect>
 
     <ul
       v-else
@@ -46,48 +53,7 @@
             @keydown.enter="setSelectedAttemptLog(index)"
             @keydown.space.prevent="setSelectedAttemptLog(index)"
           >
-            <KIcon
-              v-if="attemptLog.noattempt"
-              class="item svg-item"
-              icon="notStarted"
-            />
-            <KIcon
-              v-else-if="attemptLog.correct"
-              class="item svg-item"
-              :style="{ fill: $themeTokens.correct }"
-              icon="correct"
-            />
-            <KIcon
-              v-else-if="attemptLog.error"
-              class="svg-item"
-              :style=" { fill: $themeTokens.annotation }"
-              icon="helpNeeded"
-            />
-            <KIcon
-              v-else-if="!attemptLog.correct"
-              class="item svg-item"
-              :style="{ fill: $themeTokens.incorrect }"
-              icon="incorrect"
-            />
-            <KIcon
-              v-else-if="attemptLog.hinted"
-              class="item svg-item"
-              :style=" { fill: $themeTokens.annotation }"
-              icon="hint"
-            />
-            <p class="item">
-              {{ coreString(
-                'questionNumberLabel',
-                { questionNumber: attemptLog.questionNumber }
-              )
-              }}
-            </p>
-            <CoachContentLabel
-              v-if="windowIsLarge"
-              class="coach-content-label"
-              :value="attemptLog.num_coach_contents || 0"
-              :isTopic="false"
-            />
+            <AttemptLogItem :attemptLog="attemptLog" displayTag="p" />
           </a>
         </li>
       </template>
@@ -100,13 +66,13 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import AttemptLogItem from './AttemptLogItem';
 
   export default {
     name: 'AttemptLogList',
     components: {
-      CoachContentLabel,
+      AttemptLogItem,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {
@@ -171,7 +137,11 @@
       },
       scrollToSelectedAttemptLog(questionNumber) {
         let selectedElement;
-        if (this.$refs.attemptListOption && this.$refs.attemptList.children) {
+        if (
+          this.$refs.attemptListOption &&
+          this.$refs.attemptList &&
+          this.$refs.attemptList.children
+        ) {
           selectedElement = this.$refs.attemptList.children[questionNumber];
         }
         if (selectedElement) {
@@ -201,14 +171,6 @@
 
 <style lang="scss" scoped>
 
-  .coach-content-label {
-    display: inline-block;
-    width: auto; // keeps on same line as question
-    margin-top: -4px;
-    margin-left: 8px;
-    vertical-align: middle;
-  }
-
   .header {
     padding-top: 10px;
     padding-bottom: 10px;
@@ -227,17 +189,6 @@
     max-width: 90%;
     padding-top: 16px;
     margin: auto;
-  }
-
-  .item {
-    display: inline-block;
-    height: 24px;
-  }
-
-  .svg-item {
-    margin-right: 12px;
-    margin-bottom: -4px;
-    font-size: 24px;
   }
 
   .attempt-item {

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -26,7 +26,6 @@
       v-else
       ref="attemptList"
       class="history-list"
-      :class="isMobile ? 'mobile-list' : ''"
       role="listbox"
       @keydown.home="setSelectedAttemptLog(0)"
       @keydown.end="setSelectedAttemptLog(attemptLogs.length - 1)"
@@ -90,16 +89,6 @@
       },
     },
     computed: {
-      iconStyle() {
-        if (this.windowIsLarge) {
-          return {};
-        } else {
-          return {
-            textAlign: 'center',
-            padding: 0,
-          };
-        }
-      },
       selected() {
         return this.options.find(o => o.value === this.selectedQuestionNumber + 1) || {};
       },
@@ -180,8 +169,10 @@
 
   .history-list {
     max-height: inherit;
+    padding-right: 0;
     padding-left: 0;
     margin: 0;
+    text-align: justify;
     list-style-type: none;
   }
 
@@ -199,7 +190,8 @@
 
   .attempt-item > a {
     display: block;
-    padding-left: 20px;
+    padding-right: 1vw;
+    padding-left: 1vw;
     cursor: pointer;
   }
 

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -22,8 +22,8 @@
     <template #main>
       <AttemptLogList
         v-if="windowIsSmall"
-        :isMobile="windowIsSmall"
-        :class="windowIsSmall ? 'mobile-attempt-log-list' : ''"
+        class="mobile-attempt-log-list"
+        :isMobile="true"
         :attemptLogs="attemptLogs"
         :selectedQuestionNumber="questionNumber"
         @select="handleNavigateToQuestion"

--- a/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
+++ b/kolibri/core/assets/src/views/KSelect/KeenUiSelect.vue
@@ -55,8 +55,10 @@
             class="ui-select-display-value"
             :class="{ 'is-placeholder': !hasDisplayText }"
           >
-            {{ hasDisplayText ? displayText : (
-              hasFloatingLabel && isLabelInline) ? null : placeholder }}
+            <slot name="display">
+              {{ hasDisplayText ? displayText : (
+                hasFloatingLabel && isLabelInline) ? null : placeholder }}
+            </slot>
           </div>
 
           <UiIcon v-if="!clearableState" class="ui-select-dropdown-button">

--- a/kolibri/core/assets/src/views/KSelect/index.vue
+++ b/kolibri/core/assets/src/views/KSelect/index.vue
@@ -18,7 +18,21 @@
     :placeholder="placeholder"
     @change="handleChange"
     @blur="$emit('blur')"
-  />
+  >
+    <template #display>
+      <slot name="display"></slot>
+    </template>
+    <template #option="{ highlighted, index, option, selected }">
+      <slot
+        name="option"
+        :highlighted="highlighted"
+        :index="index"
+        :option="option"
+        :selected="selected"
+      >
+      </slot>
+    </template>
+  </UiSelect>
 
 </template>
 


### PR DESCRIPTION
## Summary
* Follow up from #8802 to use the same iconography and display for mobile and non-mobile attempt log list display
* Allows KSelect to take slots for option and display customization
* Uses this customization to display the dropdown and the selected value with styling consistent with the non-dropdown display
* Displays using a `<span>` in mobile and `<p>` in non-mobile view to use space more efficiently.
* Removes conditional display of the coach content icon.

## References
Fixes #8888

## Reviewer guidance
Any UI weirdness as a result?
Non-mobile:
![nonmobile](https://user-images.githubusercontent.com/1680573/145507824-87e7df53-5098-4a13-acf9-9846bcfbb722.gif)

Mobile:
![mobile](https://user-images.githubusercontent.com/1680573/145507830-a63ebc38-c4ee-45b3-9401-b09a876d66a7.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
