### PR TITLE
Add support for topics to `ResourceCard`

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -149,14 +149,14 @@ describe(`HomePage`, () => {
                 lessonId: 'class-1-lesson',
                 classId: 'class-1',
                 progress: 0.5,
-                contentNode: { id: 'class-resource-1', title: 'Class resource 1' },
+                contentNode: { id: 'class-resource-1', title: 'Class resource 1', is_leaf: true },
               },
               {
                 contentNodeId: 'class-resource-2',
                 lessonId: 'class-2-lesson',
                 classId: 'class-2',
                 progress: 0.5,
-                contentNode: { id: 'class-resource-2', title: 'Class resource 2' },
+                contentNode: { id: 'class-resource-2', title: 'Class resource 2', is_leaf: true },
               },
             ],
             getClassQuizLink() {
@@ -299,8 +299,8 @@ describe(`HomePage`, () => {
           useLearnerResourcesMock({
             learnerFinishedAllClasses: true,
             resumableContentNodes: [
-              { id: 'non-class-resource-1', title: 'Non-class resource 1' },
-              { id: 'non-class-resource-2', title: 'Non-class resource 2' },
+              { id: 'non-class-resource-1', title: 'Non-class resource 1', is_leaf: true },
+              { id: 'non-class-resource-2', title: 'Non-class resource 2', is_leaf: true },
             ],
             getTopicContentNodeLink() {
               return { path: '/topic-resource' };

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -34,7 +34,7 @@
         >
           <LearningActivityLabel
             :contentNode="content"
-            labelAfter
+            :labelAfter="true"
             condensed
           />
         </div>

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -61,6 +61,10 @@
       icon() {
         let icon;
 
+        if (this.kind === undefined || this.kind === null) {
+          return null;
+        }
+
         if (Array.isArray(this.kind)) {
           if (this.kind.length === 0) {
             return null;

--- a/kolibri/plugins/learn/assets/src/views/cards/BaseCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/BaseCard.vue
@@ -13,7 +13,7 @@
         <KFixedGridItem span="1">
           <slot name="topLeft"></slot>
         </KFixedGridItem>
-        <KFixedGridItem span="1">
+        <KFixedGridItem span="1" alignment="right">
           <slot name="topRight"></slot>
         </KFixedGridItem>
       </KFixedGrid>

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
@@ -1,30 +1,40 @@
 <template>
 
-  <BaseCard
+  <div
     v-if="contentNode"
-    v-bind="{ to, title, collectionTitle }"
+    class="resource-card-outer"
   >
-    <template #topLeft>
-      <ContentNodeThumbnail
-        :contentNode="contentNode"
-        rounded
-      />
-    </template>
-    <template #topRight>
-      <LearningActivityLabel :contentNode="contentNode" />
-      <KButton
-        v-if="contentNode.copies"
-        appearance="basic-link"
-        class="copies"
-        :text="coreString('copies', { num: contentNode.copies.length })"
-        @click.prevent="$emit('openCopiesModal', contentNode.copies)"
-      />
-    </template>
+    <div
+      v-if="!contentNode.is_leaf"
+      class="topic-bar"
+      :style="{ backgroundColor: $themeTokens.text }"
+    ></div>
+    <BaseCard
+      v-bind="{ to, title, collectionTitle }"
+      class="resource-card"
+    >
+      <template #topLeft>
+        <ContentNodeThumbnail
+          :contentNode="contentNode"
+          rounded
+        />
+      </template>
+      <template #topRight>
+        <LearningActivityLabel :contentNode="contentNode" />
+        <KButton
+          v-if="contentNode.copies"
+          appearance="basic-link"
+          class="copies"
+          :text="coreString('copies', { num: contentNode.copies.length })"
+          @click.prevent="$emit('openCopiesModal', contentNode.copies)"
+        />
+      </template>
 
-    <template #progress>
-      <ProgressBar :contentNode="contentNode" />
-    </template>
-  </BaseCard>
+      <template #progress>
+        <ProgressBar :contentNode="contentNode" />
+      </template>
+    </BaseCard>
+  </div>
 
 </template>
 
@@ -78,6 +88,23 @@
 
   .copies {
     float: right;
+  }
+
+  .resource-card-outer {
+    position: relative;
+  }
+
+  .topic-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 10px;
+    border-radius: 8px 8px 0 0;
+  }
+
+  .resource-card {
+    padding-top: 26px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/ResourceCard/index.vue
@@ -20,7 +20,15 @@
         />
       </template>
       <template #topRight>
-        <LearningActivityLabel :contentNode="contentNode" />
+        <LearningActivityLabel
+          v-if="contentNode.is_leaf"
+          :contentNode="contentNode"
+        />
+        <KLabeledIcon
+          v-else
+          iconAfter="topic"
+          :label="coreString('folder')"
+        />
         <KButton
           v-if="contentNode.copies"
           appearance="basic-link"


### PR DESCRIPTION
## Summary

When browsing a channel on smaller resolutions, a different card component, `ResourceCard`, is used than the card used for larger resolutions. However, `ResourceCard` didn't have support for topic resources implemented. This adds the logic that's needed to display topic nodes.

| Before | After |
| -------- | ------- |
![before](https://user-images.githubusercontent.com/13509191/145549882-0a938891-c000-46ec-8f12-ac1d510ab516.png) |   ![after](https://user-images.githubusercontent.com/13509191/145549907-d40ecf35-0eab-4808-afb4-4ce7656723fd.png) |

## References

Fixes #8833

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Go to "Library"
2. Click on a channel that has some folders in it, e.g. Kolibri QA Channel
3. Preview cards on the channel page in small resolution 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
