### PR TITLE
html5_viewer: Allow fullscreen in iframe

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -37,6 +37,7 @@
         :style="{ backgroundColor: $themePalette.grey.v_100 }"
         frameBorder="0"
         :src="rooturl"
+        allow="fullscreen"
       >
       </iframe>
       <KCircularLoader


### PR DESCRIPTION
## Summary
The T2 games (unity games) that we've on the Endless Key have a fullscreen button that don't work without the `allow="fullscreen"`. Adding this option to the iframe fixes the issue.