### PR TITLE
Reinstate ids on attempt log viewset.

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -918,6 +918,7 @@ class AttemptLogViewSet(ReadOnlyValuesViewset):
     ordering = ("end_timestamp",)
 
     values = (
+        "id",
         "item",
         "start_timestamp",
         "end_timestamp",

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -68,10 +68,7 @@
                   <KRouterLink
                     v-if="showLink(tableRow)"
                     :text="tableRow.title"
-                    :to="classRoute(
-                      'ReportsLearnerReportLessonExercisePage',
-                      { exerciseId: tableRow.content_id }
-                    )"
+                    :to="tableRow.link"
                   />
                   <template v-else>
                     {{ tableRow.title }}
@@ -99,6 +96,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { PageNames } from '../../constants';
   import commonCoach from '../common';
   import CSVExporter from '../../csv/exporter';
   import * as csvFields from '../../csv/fields';
@@ -125,6 +123,10 @@
         return contentArray.map(content => {
           const tableRow = {
             statusObj: this.getContentStatusObjForLearner(content.content_id, this.learner.id),
+            link: this.classRoute(PageNames.REPORTS_LEARNER_REPORT_LESSON_EXERCISE_PAGE_ROOT, {
+              exerciseId: content.content_id,
+              learnerId: this.learner.id,
+            }),
           };
           Object.assign(tableRow, content);
           return tableRow;


### PR DESCRIPTION
## Summary
* Migration to values viewset failed to add "id" to the serialized data
* This rectifies that and fixes coach reports as a result

## References
Fixes #8869

## Reviewer guidance
Use the database from #8869 and navigate to the lesson report for an exercise, confirm it renders properly.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
