### PR TITLE
Display completion modal when completing quiz.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -86,11 +86,11 @@
 
               <CompletionModalSection
                 ref="staySection"
-                icon="restart"
+                :icon="isQuiz ? 'reports' : 'restart'"
                 :class="sectionClass"
-                :title="$tr('stayTitle')"
-                :description="$tr('stayDescription')"
-                :buttonLabel="$tr('stayButtonLabel')"
+                :title="isQuiz ? $tr('reviewQuizTitle') : $tr('stayTitle')"
+                :description="isQuiz ? $tr('reviewQuizDescription') : $tr('stayDescription')"
+                :buttonLabel="isQuiz ? $tr('reviewQuizButtonLabel') : $tr('stayButtonLabel')"
                 @buttonClick="$emit('close')"
               />
 
@@ -201,6 +201,10 @@
       lessonId: {
         type: String,
         default: null,
+      },
+      isQuiz: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {
@@ -428,6 +432,18 @@
       stayButtonLabel: {
         message: 'Stay here',
         context: 'Label for a button used if learner decides to repeat the completed resource.',
+      },
+      reviewQuizTitle: {
+        message: 'Review quiz',
+        context: 'Message to the user to review a quiz after they completed it.',
+      },
+      reviewQuizDescription: {
+        message: 'Open the quiz report to review your answers',
+        context: 'After learner submitted a practice quiz, they can view the report page.',
+      },
+      reviewQuizButtonLabel: {
+        message: 'View report',
+        context: 'Label for a button used if learner decides to view the practice quiz report.',
       },
       helpfulResourcesTitle: {
         message: 'You may find helpful',

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -64,10 +64,11 @@
     <KCircularLoader v-else />
 
     <CompletionModal
-      v-if="progress >= 1 && wasIncomplete && !practiceQuiz"
+      v-if="progress >= 1 && wasIncomplete"
       :isUserLoggedIn="isUserLoggedIn"
       :contentNodeId="content.id"
       :lessonId="lessonId"
+      :isQuiz="practiceQuiz"
       @close="markAsComplete"
     />
   </div>


### PR DESCRIPTION
## Summary
* Reinstates completion modal after completing a quiz
* Adds quiz specific language to the completion modal.

## References
Fixes #8893

## Reviewer guidance
![completionmodalquiz](https://user-images.githubusercontent.com/1680573/145653039-964c6ae6-633a-4e7d-a52c-ee35167ce59d.gif)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
