### PR TITLE
Make non-kolibri servers unavailable to be imported

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -262,7 +262,7 @@
           .filter(
             address =>
               address.available &&
-              (this.$route.path == '/content' || address.application === 'kolibri')
+              (this.$route.path === '/content' || address.application === 'kolibri')
           )
           .map(address => address.id);
         if (!this.availableAddressIds.includes(this.selectedAddressId)) {

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/SelectAddressForm.vue
@@ -259,7 +259,11 @@
       },
       combinedAddresses(addrs) {
         this.availableAddressIds = addrs
-          .filter(address => address.available)
+          .filter(
+            address =>
+              address.available &&
+              (this.$route.path == '/content' || address.application === 'kolibri')
+          )
           .map(address => address.id);
         if (!this.availableAddressIds.includes(this.selectedAddressId)) {
           this.selectedAddressId = '';

--- a/kolibri/core/discovery/serializers.py
+++ b/kolibri/core/discovery/serializers.py
@@ -51,6 +51,7 @@ class NetworkLocationSerializer(serializers.ModelSerializer):
                 ),
                 code=e.code,
             )
+        data["base_url"] = client.base_url
         info = {k: v for (k, v) in client.info.items() if v is not None}
         data.update(info)
         return super(NetworkLocationSerializer, self).validate(data)

--- a/kolibri/core/discovery/serializers.py
+++ b/kolibri/core/discovery/serializers.py
@@ -41,12 +41,16 @@ class NetworkLocationSerializer(serializers.ModelSerializer):
             "subset_of_users_device",
         )
 
-    def validate_base_url(self, value):
+    def validate(self, data):
         try:
-            client = NetworkClient(address=value)
+            client = NetworkClient(address=data["base_url"])
         except errors.NetworkError as e:
             raise ValidationError(
-                "Error with address {} ({})".format(value, e.__class__.__name__),
+                "Error with address {} ({})".format(
+                    data["base_url"], e.__class__.__name__
+                ),
                 code=e.code,
             )
-        return client.base_url
+        info = {k: v for (k, v) in client.info.items() if v is not None}
+        data.update(info)
+        return super(NetworkLocationSerializer, self).validate(data)


### PR DESCRIPTION
## Summary
When manually adding servers, their info was not completely stored in the NetworkLocation table, so it was impossible to distinguish kolibri servers from others as Studio. This PR saves the complete information and filter the servers to make them available or not depending on the context.
![image](https://user-images.githubusercontent.com/1008178/145858264-bc019654-dd03-444e-a284-9834544fbecc.png)



## References
Closes: #7785 

## Reviewer guidance

Adding manually one server when either in : 
- Setup wizard
- Importing a facility
- Importing content
should enable or not the servers depending on the context.

Example of three servers: one not available due to a network issue (hotfix), another is a kolibri server (demo) and the third is a studio server(studio)
When importing a facility:
![image](https://user-images.githubusercontent.com/1008178/145858672-048c4f91-ffd2-4bf4-9bde-5db00d654a45.png)
When importing content:
![image](https://user-images.githubusercontent.com/1008178/145858782-df10ba61-5d5b-4dd2-95ff-aae5cc36d4a2.png)



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
