### PR TITLE
Fix side panel alignment

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -13,8 +13,8 @@
         :style="{
           color: $themeTokens.text,
           backgroundColor: $themeTokens.surface,
-          right: (alignment === 'right' ? 0 : ''),
-          left: (alignment === 'left' ? 0 : ''),
+          right: (rtlAlignment === 'right' ? 0 : ''),
+          left: (rtlAlignment === 'left' ? 0 : ''),
           width: (sidePanelOverrideWidth ? sidePanelOverrideWidth : '')
         }"
       >
@@ -28,30 +28,6 @@
           />
         </div>
         <slot></slot>
-
-      <!--
-        <h2 class="title">
-          {{ title }}
-          <span>
-            <KIconButton
-              icon="close"
-              class="close-button"
-              @click="togglePanel"
-            />
-          </span>
-        </h2>
-        <SidePanelResourceMetadata
-          v-if="panelType === 'resourceMetadata'"
-          :togglePanel="togglePanel"
-        />
-        <SidePanelResourcesList
-          v-if="panelType === 'resourcesList'"
-          :contents="siblingNodes"
-          :currentContent="content"
-          :togglePanel="togglePanel"
-          :nextTopic="nextTopic"
-        />
-      -->
       </div>
     </transition>
     <Backdrop
@@ -68,15 +44,12 @@
 
   import Backdrop from 'kolibri.coreVue.components.Backdrop';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  //import { mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  //import SidePanelResourcesList from './SidePanelResourcesList';
 
   export default {
     name: 'FullScreenSidePanel',
     components: {
       Backdrop,
-      //SidePanelResourcesList,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
@@ -90,13 +63,29 @@
         required: false,
         default: null,
       },
+      // to which side of the screen should the panel be fixed?
+      // set alignment based on LTR languages
+      // rtl is handled as appropriate through computed props
+      alignment: {
+        type: String,
+        required: true,
+        validator(value) {
+          return ['right', 'left'].includes(value);
+        },
+      },
     },
     computed: {
       isMobile() {
         return this.windowBreakpoint == 0;
       },
-      alignment() {
-        return this.isRtl ? 'left' : 'right';
+      rtlAlignment() {
+        if (this.isRtl && this.alignment === 'left') {
+          return 'right';
+        } else if (this.isRtl && this.alignment === 'right') {
+          return 'left';
+        } else {
+          return this.alignment;
+        }
       },
     },
     /* this is the easiest way I could think to avoid having dual scroll bars */
@@ -139,6 +128,7 @@
     bottom: 0;
     // Must be <= 12 z-index so that KDropdownMenu shows over
     z-index: 12;
+    width: 436px;
     height: 100vh;
     padding: 32px;
     overflow: auto;

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -15,18 +15,18 @@
           backgroundColor: $themeTokens.surface,
           right: (rtlAlignment === 'right' ? 0 : ''),
           left: (rtlAlignment === 'left' ? 0 : ''),
-          width: (sidePanelOverrideWidth ? sidePanelOverrideWidth : '')
+          width: sidePanelOverrideWidth,
         }"
       >
-        <div v-if="!closeButtonHidden">
-          <KIconButton
-            icon="close"
-            class="close-button"
-            :ariaLabel="coreString('closeAction')"
-            :tooltip="coreString('closeAction')"
-            @click="closePanel"
-          />
-        </div>
+        <KIconButton
+          v-if="!closeButtonHidden"
+          icon="close"
+          class="close-button"
+          :ariaLabel="coreString('closeAction')"
+          :tooltip="coreString('closeAction')"
+          @click="closePanel"
+        />
+
         <slot></slot>
       </div>
     </transition>
@@ -125,12 +125,13 @@
   .side-panel {
     position: fixed;
     top: 0;
+    right: 0;
     bottom: 0;
     // Must be <= 12 z-index so that KDropdownMenu shows over
     z-index: 12;
     width: 436px;
     height: 100vh;
-    padding: 32px;
+    padding: 24px 32px 32px;
     overflow: auto;
     font-size: 14px;
 
@@ -146,7 +147,7 @@
 
   .close-button {
     position: fixed;
-    top: 32px;
+    top: 24px;
     right: 32px;
     z-index: 24; // Always above everything
   }

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -13,8 +13,8 @@
         :style="{
           color: $themeTokens.text,
           backgroundColor: $themeTokens.surface,
-          right: (alignment === 'left' ? 0 : ''),
-          left: (alignment === 'right' ? 0 : ''),
+          right: (alignment === 'right' ? 0 : ''),
+          left: (alignment === 'left' ? 0 : ''),
           width: (sidePanelOverrideWidth ? sidePanelOverrideWidth : '')
         }"
       >

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -32,6 +32,7 @@
 
     <FullScreenSidePanel
       v-if="sidePanelContent"
+      alignment="right"
       @closePanel="sidePanelContent = null"
     >
       <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -61,6 +61,7 @@
     <!-- Side Panel for content metadata -->
     <FullScreenSidePanel
       v-if="sidePanelContent"
+      alignment="right"
       @closePanel="sidePanelContent = null"
     >
       <CurrentlyViewedResourceMetadata
@@ -73,6 +74,7 @@
     <FullScreenSidePanel
       v-if="showViewResourcesSidePanel"
       class="also-in-this-side-panel"
+      alignment="right"
       @closePanel="showViewResourcesSidePanel = false"
     >
       <AlsoInThis

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -6,7 +6,6 @@
       :style="gridOffset"
     >
       <div v-if="!windowIsLarge">
-        <!-- TO DO Marcella swap out new icon after KDS update -->
         <KButton
           icon="filter"
           :text="coreString('searchLabel')"
@@ -151,7 +150,7 @@
     <FullScreenSidePanel
       v-if="!windowIsLarge && sidePanelIsOpen"
       class="full-screen-side-panel"
-      alignment="right"
+      alignment="left"
       :closeButtonHidden="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
       @closePanel="toggleSidePanelVisibility"
@@ -208,6 +207,7 @@
 
     <FullScreenSidePanel
       v-if="sidePanelContent"
+      alignment="right"
       @closePanel="sidePanelContent = null"
     >
       <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -151,7 +151,7 @@
     <FullScreenSidePanel
       v-if="!windowIsLarge && sidePanelIsOpen"
       class="full-screen-side-panel"
-      alignment="left"
+      alignment="right"
       :closeButtonHidden="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
       @closePanel="toggleSidePanelVisibility"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -285,7 +285,7 @@
       <FullScreenSidePanel
         v-if="!windowIsLarge && sidePanelIsOpen"
         class="full-screen-side-panel"
-        alignment="right"
+        alignment="left"
         :closeButtonHidden="true"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="$router.push(currentLink)"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -285,6 +285,7 @@
       <FullScreenSidePanel
         v-if="!windowIsLarge && sidePanelIsOpen"
         class="full-screen-side-panel"
+        alignment="right"
         :closeButtonHidden="true"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="$router.push(currentLink)"
@@ -347,6 +348,7 @@
     </div>
     <FullScreenSidePanel
       v-if="sidePanelContent"
+      alignment="right"
       @closePanel="sidePanelContent = null"
     >
       <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The side panel now shows on the correct sides per designs - the right in LTR - for the AlsoInThis, BrowseMetadata and CurrentlyViewed metadata side panels.

**Does not include fixed headers** - this will require more substantial reworking than we should try to get in today - will be done - along with some a11y improvements, this week. 

Also note @marcellamaki did most of the work here I just finished up a few things and tested it. I was hoping to combine her work on this bug with the fixed header but time ran out.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8827 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check the side panels in RTL and LTR languages.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
