### PR TITLE
Sidepanel title as folder title

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -69,7 +69,7 @@
     >
       <KIcon class="folder-icon" icon="topic" />
       <div class="next-label">
-        Next folder
+        {{ nextFolderMessage }}
       </div>
       <div class="next-title">
         {{ nextContent.title }}
@@ -162,6 +162,11 @@
       },
       context() {
         return this.$route.query;
+      },
+      nextFolderMessage() {
+        /* eslint-disable kolibri/vue-no-undefined-string-uses */
+        return sidePanelStrings.$tr('nextFolder');
+        /* eslint-enable */
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -114,7 +114,6 @@
   import LearningActivityBar from './LearningActivityBar';
   import AlsoInThis from './AlsoInThis';
 
-  const sidepanelStrings = crossComponentTranslator(FullScreenSidePanel);
   const lessonStrings = crossComponentTranslator(LessonResourceViewer);
 
   export default {
@@ -227,7 +226,7 @@
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
         return this.lessonContext
           ? lessonStrings.$tr('nextInLesson')
-          : sidepanelStrings.$tr('topicHeader');
+          : this.content && this.content.ancestors.slice(-1)[0].title;
         /* eslint-enable */
       },
     },


### PR DESCRIPTION
Since no 'Also in this' string in crowdin, replaces with the folder title
also corrects the reference to the string for the 'nextLesson' footer