### PR TITLE
Correct answered question count

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -302,7 +302,14 @@
         return this.itemIdArray[this.questionNumber];
       },
       questionsAnswered() {
-        return this.pastattempts.reduce((count, attempt) => count + (attempt.answer ? 1 : 0), 0);
+        return Object.keys(
+          this.pastattempts.reduce((map, attempt) => {
+            if (attempt.answer) {
+              map[attempt.item] = true;
+            }
+            return map;
+          }, {})
+        ).length;
       },
       questionsUnanswered() {
         return this.questionsTotal - this.questionsAnswered;


### PR DESCRIPTION
## Summary
* Count number of answered questions by number of questions with an answer, not number of attempt logs
* Catches edge cases where for some reason there are duplicate attempt logs for a specific question which can lead to an overcount

## References
Fixes the Practice Quiz manifestation of #8922

## Reviewer guidance
Answer a channel based quiz on 0.15 as an exercise multiple times.
Switch to develop, engage with it as a practice quiz, confirm that it never displays answered questions in excess of the total number of questions.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
