### PR TITLE
Bump zeroconf and remove separate plugin tracking of addresses

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -274,7 +274,6 @@ class ServicesPlugin(SimplePlugin):
 
 class ZeroConfPlugin(Monitor):
     def __init__(self, bus, port):
-        self.addresses = set()
         self.port = port
         Monitor.__init__(self, bus, self.run, frequency=5)
         self.bus.subscribe("SERVING", self.SERVING)
@@ -305,9 +304,6 @@ class ZeroConfPlugin(Monitor):
         else:
             self.broadcast.update_broadcast(instance=instance)
 
-        # cache the list of addresses active right now, so we can detect changes
-        self.addresses = get_all_addresses()
-
     def UPDATE_ZEROCONF(self):
         self.SERVING(self.port)
 
@@ -322,13 +318,12 @@ class ZeroConfPlugin(Monitor):
         # If set of addresses that were present at the last time zeroconf updated its broadcast list
         # don't match the current set of all addresses for this device, then we should reinitialize
         # zeroconf, the listener, and the broadcast kolibri service.
-        current_addresses = get_all_addresses()
-        if self.addresses != current_addresses:
+        current_addresses = set(get_all_addresses())
+        if self.broadcast is not None and self.broadcast.addresses != current_addresses:
             logger.info(
                 "List of local addresses has changed since zeroconf was last initialized, updating now"
             )
             self.broadcast.update_broadcast(interfaces=InterfaceChoice.All)
-            self.addresses = current_addresses
 
 
 status_map = {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -319,7 +319,11 @@ class ZeroConfPlugin(Monitor):
         # don't match the current set of all addresses for this device, then we should reinitialize
         # zeroconf, the listener, and the broadcast kolibri service.
         current_addresses = set(get_all_addresses())
-        if self.broadcast is not None and self.broadcast.addresses != current_addresses:
+        if (
+            self.broadcast is not None
+            and self.broadcast.is_broadcasting
+            and self.broadcast.addresses != current_addresses
+        ):
             logger.info(
                 "List of local addresses has changed since zeroconf was last initialized, updating now"
             )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ semver==2.8.1
 django-redis-cache==2.0.0
 redis==3.2.1
 html5lib==1.0.1
-zeroconf-py2compat==0.19.14
+zeroconf-py2compat==0.19.15
 ifcfg==0.21
 Click==7.0
 whitenoise==4.1.4


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates Zeroconf to track interfaces separately from those which it successfully attached to
- Allows Kolibri to retain a single source of truth for Zeroconf interface addresses, initialized through Kolibri's internal zeroconf API

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Follow up to: https://github.com/learningequality/kolibri/pull/8865

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I'm unable to test this behavior on Windows

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
