### PR TITLE
Ignore duplicate attempts at questions when counting.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -272,7 +272,14 @@
         return `${this.nodeId}:${this.itemId}`;
       },
       questionsAnswered() {
-        return this.pastattempts.reduce((count, attempt) => count + (attempt.answer ? 1 : 0), 0);
+        return Object.keys(
+          this.pastattempts.reduce((map, attempt) => {
+            if (attempt.answer) {
+              map[attempt.item] = true;
+            }
+            return map;
+          }, {})
+        ).length;
       },
       questionsUnanswered() {
         return this.exam.question_count - this.questionsAnswered;


### PR DESCRIPTION
## Summary
* Duplicate attempts at a question in a quiz can sometimes occur
* This can then result in a confusing user experience
* We already account for this in the backend when doing summarization and aggregation, but not in the learner UI
* This fixes that by doing a count of attempts made unique by item

## References
Fixes #8922

## Reviewer guidance
This bug is hard to reproduce, so I'd suggest doing an inspection of the code and ensuring this introduces no regressions.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
