### PR TITLE
Filter bookmarks by available nodes.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1246,11 +1246,12 @@ class BookmarkFilter(FilterSet):
         queryset = queryset.annotate(
             available=Subquery(
                 models.ContentNode.objects.filter(
-                    available=True,
                     id=OuterRef("contentnode_id"),
                 ).values_list("available", flat=True)[:1]
             )
         )
+
+        return queryset.filter(available=value)
 
 
 class ContentNodeBookmarksViewset(

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -427,7 +427,7 @@
     },
     created() {
       ContentNodeResource.fetchBookmarks({
-        params: { limit: 25, kind: ContentNodeKinds.EXERCISE },
+        params: { limit: 25, kind: ContentNodeKinds.EXERCISE, available: true },
       }).then(data => {
         this.more = data.more;
         this.bookmarks = data.results;

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -92,7 +92,7 @@
       },
     },
     created() {
-      ContentNodeResource.fetchBookmarks({ params: { limit: 25 } }).then(data => {
+      ContentNodeResource.fetchBookmarks({ params: { limit: 25, available: true } }).then(data => {
         this.more = data.more;
         this.bookmarks = data.results ? data.results.map(normalizeContentNode) : [];
         this.loading = false;


### PR DESCRIPTION
## Summary
* Only return available bookmarks to the user to avoid confusion

## References
Fixes #8823

## Reviewer guidance
Bookmark a content node, then delete that content node from your device. Check that it no longer shows up in your bookmarks.

Before deleting node:
![Screenshot from 2021-12-14 12-26-00](https://user-images.githubusercontent.com/1680573/146074452-fe4e7227-a628-425f-a9d3-d4f605c65a7a.png)

After deleting the top node from the device (marked as unavailable):
![Screenshot from 2021-12-14 12-27-01](https://user-images.githubusercontent.com/1680573/146074510-de1e95c8-a099-448b-87c3-802f865fac8e.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
