### PR TITLE
Update how we prevent orderer widget overflow.

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -682,10 +682,11 @@
   .framework-perseus {
     padding-bottom: 104px;
 
-    // Draggable box wrapper. Stops it from going off screen right
-    /deep/ .draggy-boxy-thing {
-      display: inline;
+    // Orderer widget wrapper. Stops it from going off screen right
+    /deep/ .orderer {
+      min-width: 0;
     }
+
     // Multiple choice table padding/margin fixes for clean appearance
     /deep/ .widget-block > div {
       padding: 0 !important;


### PR DESCRIPTION
## Summary
* Updates styling to continue to prevent overflow of orderer widget but prevent regression in drag and drop behaviour

## References
Fixes #8905

## Reviewer guidance
Load up a drag and drop exercise, use on a mobile screen.

Ensure that it doesn't overflow and scroll, and that the drag and drop functions correctly.

![draganddrop](https://user-images.githubusercontent.com/1680573/146088278-b53356d9-df75-4167-9907-ab22b5693c4b.gif)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
