### PR TITLE
Add fixed header to FullScreenSidePanel

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -2,34 +2,46 @@
 
   <div
     ref="sidePanel"
-    class="side-panel-wrapper"
     :class="{ 'is-rtl': isRtl, 'is-mobile': isMobile }"
-    tabindex="0"
     @keyup.esc="closePanel"
   >
     <transition name="side-panel">
       <div
         class="side-panel"
-        :style="{
-          color: $themeTokens.text,
-          backgroundColor: $themeTokens.surface,
-          right: (rtlAlignment === 'right' ? 0 : ''),
-          left: (rtlAlignment === 'left' ? 0 : ''),
-          width: sidePanelOverrideWidth,
-        }"
+        :style="sidePanelStyles"
       >
-        <KIconButton
-          v-if="!closeButtonHidden"
-          icon="close"
-          class="close-button"
-          :ariaLabel="coreString('closeAction')"
-          :tooltip="coreString('closeAction')"
-          @click="closePanel"
-        />
 
-        <slot></slot>
+        <!-- Fixed header with optional close button -->
+        <div class="fixed-header" :style="fixedHeaderStyles">
+
+          <div ref="fixedHeader" class="header-content" tabindex="0">
+            <slot name="header">
+            </slot>
+          </div>
+
+          <KIconButton
+            v-if="!closeButtonHidden"
+            icon="close"
+            class="close-button"
+            :ariaLabel="coreString('closeAction')"
+            :tooltip="coreString('closeAction')"
+            @click="closePanel"
+          />
+
+        </div>
+
+        <!-- Default slot for inserting content which will scroll on overflow -->
+        <div
+          class="side-panel-content"
+          :style="contentStyles"
+          :class="$computedClass({ 'height': `calc(100vh - ${fixedHeaderHeight})` })"
+        >
+          <slot></slot>
+        </div>
+
       </div>
     </transition>
+
     <Backdrop
       :transitions="true"
       class="backdrop"
@@ -53,19 +65,19 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
+      /* Hides the (X) icon button to close the side panel. In this case, clicking off of the
+         panel or hitting the ESC keys are the only way to close the panel */
       closeButtonHidden: {
         type: Boolean,
         default: false,
       },
-      // to customize the width of the side panel in different scenarios
-      sidePanelOverrideWidth: {
+      /* Optionally override the default width of the side panel with valid CSS value */
+      sidePanelWidth: {
         type: String,
         required: false,
-        default: null,
+        default: '436px',
       },
-      // to which side of the screen should the panel be fixed?
-      // set alignment based on LTR languages
-      // rtl is handled as appropriate through computed props
+      /* Which side of the screen should the panel be fixed? Reverses the value when isRtl */
       alignment: {
         type: String,
         required: true,
@@ -74,10 +86,18 @@
         },
       },
     },
+    data() {
+      return {
+        /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
+        fixedHeaderHeight: null,
+      };
+    },
     computed: {
       isMobile() {
         return this.windowBreakpoint == 0;
       },
+      /* Returns an object with properties left or right set to the appropriate value
+         depending on isRtl and this.alignment */
       rtlAlignment() {
         if (this.isRtl && this.alignment === 'left') {
           return 'right';
@@ -87,11 +107,60 @@
           return this.alignment;
         }
       },
+      /* Returns an object with this.rtlAlignment set to 0 */
+      langDirStyles() {
+        return {
+          [this.rtlAlignment]: 0,
+        };
+      },
+      responsiveWidth() {
+        return this.isMobile ? '100vw' : this.sidePanelWidth;
+      },
+      /** Styling Properties */
+      fixedHeaderStyles() {
+        return {
+          ...this.langDirStyles,
+          width: this.responsiveWidth,
+          position: 'fixed',
+          top: 0,
+          backgroundColor: this.$themeTokens.surface,
+          'border-bottom': `1px solid ${this.$themePalette.grey.v_500}`,
+          padding: '24px 32px',
+          // Header border stays over content with this, but under any tooltips
+          'z-index': 16,
+          // Ensure the content doesn't overlap the close button when present, accounts for RTL
+          [`padding-${this.rtlAlignment}`]: this.closeButtonHidden ? 0 : '80px',
+        };
+      },
+      sidePanelStyles() {
+        return {
+          ...this.langDirStyles,
+          width: this.responsiveWidth,
+          top: 0,
+          position: 'fixed',
+          color: this.$themeTokens.text,
+          backgroundColor: this.$themeTokens.surface,
+          'z-index': 12,
+        };
+      },
+      contentStyles() {
+        return {
+          'margin-top': this.fixedHeaderHeight,
+          padding: '24px 32px 16px',
+          'overflow-y': 'scroll',
+        };
+      },
     },
     /* this is the easiest way I could think to avoid having dual scroll bars */
     mounted() {
       const htmlTag = window.document.getElementsByTagName('html')[0];
       htmlTag.style['overflow-y'] = 'hidden';
+
+      // Gets the height of the fixed header - adds 40 to account for padding
+      this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 40 + 'px';
+
+      // Ensures user starts at top header with keyboard focus
+      this.$refs.fixedHeader.focus();
     },
     beforeDestroy() {
       const htmlTag = window.document.getElementsByTagName('html')[0];
@@ -118,31 +187,8 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .side-panel-wrapper {
-    overflow-x: hidden;
-  }
-
-  .side-panel {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    // Must be <= 12 z-index so that KDropdownMenu shows over
-    z-index: 12;
-    width: 436px;
-    height: 100vh;
-    padding: 24px 32px 32px;
-    overflow: auto;
-    font-size: 14px;
-
-    .is-mobile & {
-      width: 100vw;
-    }
-  }
-
-  .title {
-    max-width: 70vw;
-    margin-left: 32px;
+  .header-content {
+    width: 100%;
   }
 
   .close-button {
@@ -150,16 +196,6 @@
     top: 24px;
     right: 32px;
     z-index: 24; // Always above everything
-  }
-
-  .next-resource-footer {
-    position: fixed;
-    bottom: 0;
-    height: 100px;
-  }
-
-  .backdrop {
-    color: rgba(0, 0, 0, 0.7);
   }
 
   /** Need to be sure a KDropdownMenu shows up on the Side Panel */

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -12,30 +12,27 @@
       >
 
         <!-- Fixed header with optional close button -->
-        <div class="fixed-header" :style="fixedHeaderStyles">
+        <div v-if="$slots.header" ref="fixedHeader" class="fixed-header" :style="fixedHeaderStyles">
 
-          <div ref="fixedHeader" class="header-content" tabindex="0">
+          <div class="header-content" tabindex="0">
             <slot name="header">
             </slot>
           </div>
 
-          <KIconButton
-            v-if="!closeButtonHidden"
-            icon="close"
-            class="close-button"
-            :ariaLabel="coreString('closeAction')"
-            :tooltip="coreString('closeAction')"
-            @click="closePanel"
-          />
-
         </div>
 
+        <KIconButton
+          v-if="!closeButtonHidden"
+          icon="close"
+          class="close-button"
+          :style="closeButtonStyles"
+          :ariaLabel="coreString('closeAction')"
+          :tooltip="coreString('closeAction')"
+          @click="closePanel"
+        />
+
         <!-- Default slot for inserting content which will scroll on overflow -->
-        <div
-          class="side-panel-content"
-          :style="contentStyles"
-          :class="$computedClass({ 'height': `calc(100vh - ${fixedHeaderHeight})` })"
-        >
+        <div class="side-panel-content" :style="contentStyles">
           <slot></slot>
         </div>
 
@@ -148,6 +145,12 @@
           'margin-top': this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
+          height: `calc((100vh - ${this.fixedHeaderHeight}))`,
+        };
+      },
+      closeButtonStyles() {
+        return {
+          top: `calc((${this.fixedHeaderHeight} - 40px) / 2)`,
         };
       },
     },
@@ -157,7 +160,7 @@
       htmlTag.style['overflow-y'] = 'hidden';
 
       // Gets the height of the fixed header - adds 40 to account for padding
-      this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 40 + 'px';
+      this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 'px';
 
       // Ensures user starts at top header with keyboard focus
       this.$refs.fixedHeader.focus();
@@ -193,9 +196,8 @@
 
   .close-button {
     position: fixed;
-    top: 24px;
     right: 32px;
-    z-index: 24; // Always above everything
+    z-index: 24;
   }
 
   /** Need to be sure a KDropdownMenu shows up on the Side Panel */

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -1,14 +1,10 @@
 <template>
 
   <div class="wrapper">
-    <div class="top-bar">
-      <h2>{{ title }}</h2>
-    </div>
-
     <div
       v-if="contentNodes.length"
       class="content-list"
-      :class="nextContent ? '' : 'no-bottom-link'"
+      :class="nextContent ? 'bottom-link' : ''"
     >
       <KRouterLink
         v-for="content in contentNodes"
@@ -118,11 +114,6 @@
         required: true,
         default: () => [],
       },
-      /** Title text for the component. */
-      title: {
-        type: String,
-        required: true,
-      },
       /** Content node with the following properties: id, is_leaf, title */
       nextContent: {
         type: Object, // or falsy
@@ -190,6 +181,11 @@
   $top-bar-height: 40px;
   $next-content-link-height: 100px;
 
+  .content-list.bottom-link {
+    // Ensure all items are visible when bottom link visible
+    padding-bottom: $next-content-link-height;
+  }
+
   .wrapper {
     position: relative;
     width: 100%;
@@ -205,22 +201,6 @@
     left: 0;
     height: $top-bar-height;
     background-color: #ffffff;
-  }
-
-  .content-list {
-    height: calc(100% - #{$top-bar-height} - #{$next-content-link-height});
-    padding-right: 32px;
-
-    /** margin <> padding offset keeps content aligned the same way
-     *  whether the scrollbar is there or not and pushes the scrollbar
-     *  agains the side of the screen, while being as tall as the scroll */
-    margin-right: -32px;
-    overflow-y: scroll;
-
-    /* When there is nothing to link to in the next-content-link */
-    &.no-bottom-link {
-      height: calc(100% - #{$top-bar-height});
-    }
   }
 
   .item {
@@ -311,12 +291,13 @@
 
   /** Most of the styles for the footer piece */
   .next-content-link {
-    position: absolute;
-    right: -32px;
+    position: fixed;
     bottom: 0;
-    left: -32px;
+    width: 436px;
     height: $next-content-link-height;
     padding: 12px 32px 8px;
+    margin-right: -32px;
+    margin-left: -32px;
     background: white;
 
     .next-label {

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -30,12 +30,33 @@
       :delay="false"
     />
 
+    <!-- Side panel for showing the information of selected content with a link to view it -->
     <FullScreenSidePanel
       v-if="sidePanelContent"
       alignment="right"
       @closePanel="sidePanelContent = null"
     >
-      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />
+      <template #header>
+        <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
+            multiple chips - not a common thing but just in case -->
+        <div
+          v-for="activity in sidePanelContent.learning_activities"
+          :key="activity"
+          class="side-panel-chips"
+          :class="$computedClass({ '::after': {
+            content: '',
+            flex: 'auto'
+          } })"
+        >
+          <LearningActivityChip
+            class="chip"
+            style="margin-left: 8px; margin-bottom: 8px;"
+            :kind="activity"
+          />
+        </div>
+      </template>
+
+      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
     </FullScreenSidePanel>
   </div>
 
@@ -55,6 +76,7 @@
   import { PageNames } from '../constants';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
+  import LearningActivityChip from './LearningActivityChip';
   import HybridLearningCardGrid from './HybridLearningCardGrid';
   import BrowseResourceMetadata from './BrowseResourceMetadata';
 
@@ -68,6 +90,7 @@
     components: {
       BrowseResourceMetadata,
       FullScreenSidePanel,
+      LearningActivityChip,
       HybridLearningCardGrid,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
@@ -147,3 +170,20 @@
   };
 
 </script>
+
+
+<style scoped lang="scss">
+
+  .side-panel-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-bottom: -8px;
+    margin-left: -8px;
+  }
+  .chip {
+    margin-bottom: 8px;
+    margin-left: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -2,17 +2,7 @@
 
   <section class="metadata">
 
-    <div class="chips section">
-      <div v-for="activity in content.learning_activities" :key="activity">
-        <LearningActivityChip
-          :kind="activity"
-        />
-      </div>
-    </div>
-
     <div class="flex section">
-      <!-- Wrapping each flex child content in the plain div keeps them flex-spaced
-        properly even when one isn't there -->
       <div>
         <span
           v-if="forBeginners"
@@ -214,7 +204,6 @@
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import { ContentNodeResource } from 'kolibri.resources';
   import genContentLink from '../utils/genContentLink';
-  import LearningActivityChip from './LearningActivityChip';
   import LearningActivityIcon from './LearningActivityIcon';
   import ContentNodeThumbnail from './thumbnails/ContentNodeThumbnail';
   import SidePanelResourceMetadata from './SidePanelResourceMetadata';
@@ -222,7 +211,6 @@
   export default {
     name: 'BrowseResourceMetadata',
     components: {
-      LearningActivityChip,
       LearningActivityIcon,
       TimeDuration,
       ContentNodeThumbnail,
@@ -409,15 +397,6 @@
     &.title {
       font-size: 1.25em;
       font-weight: bold;
-    }
-
-    &.chips {
-      display: flex;
-      flex-wrap: wrap;
-      max-width: 426px;
-      // Ensures space on line w/ closing X icon whether
-      // chips are visible or not
-      min-height: 40px;
     }
 
     &.flex {

--- a/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
@@ -2,14 +2,6 @@
 
   <section v-if="content" class="metadata">
 
-    <div class="chips section">
-      <div v-for="activity in content.learning_activities" :key="activity">
-        <LearningActivityChip
-          :kind="activity"
-        />
-      </div>
-    </div>
-
     <div>
       <span
         v-if="forBeginners"
@@ -157,7 +149,6 @@
     licenseDescriptionForConsumer,
   } from 'kolibri.utils.licenseTranslations';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import LearningActivityChip from './LearningActivityChip';
   import ContentNodeThumbnail from './thumbnails/ContentNodeThumbnail';
   import SidePanelResourceMetadata from './SidePanelResourceMetadata';
 
@@ -165,7 +156,6 @@
     name: 'CurrentlyViewedResourceMetadata',
     components: {
       DownloadButton,
-      LearningActivityChip,
       ContentNodeThumbnail,
       TimeDuration,
     },
@@ -312,15 +302,6 @@
     &.title {
       font-size: 1.25em;
       font-weight: bold;
-    }
-
-    &.chips {
-      display: flex;
-      flex-wrap: wrap;
-      max-width: 426px;
-      // Ensures space on line w/ closing X icon whether
-      // chips are visible or not
-      min-height: 40px;
     }
 
     .label {

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -64,6 +64,25 @@
       alignment="right"
       @closePanel="sidePanelContent = null"
     >
+      <template #header>
+        <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
+            multiple chips - not a common thing but just in case -->
+        <div
+          v-for="activity in sidePanelContent.learning_activities"
+          :key="activity"
+          class="side-panel-chips"
+          :class="$computedClass({ '::after': {
+            content: '',
+            flex: 'auto'
+          } })"
+        >
+          <LearningActivityChip
+            class="chip"
+            style="margin-left: 8px; margin-bottom: 8px;"
+            :kind="activity"
+          />
+        </div>
+      </template>
       <CurrentlyViewedResourceMetadata
         :content="sidePanelContent"
         :canDownloadContent="canDownload"
@@ -77,10 +96,15 @@
       alignment="right"
       @closePanel="showViewResourcesSidePanel = false"
     >
+      <template #header>
+        <h2 style="margin: 0;">
+          {{ viewResourcesTitle }}
+        </h2>
+      </template>
       <AlsoInThis
+        style="margin-top: 8px"
         :contentNodes="viewResourcesContents"
         :nextContent="nextContent"
-        :title="viewResourcesTitle"
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
       />
@@ -110,6 +134,7 @@
   import useCoreLearn from '../composables/useCoreLearn';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import useLearnerResources from '../composables/useLearnerResources';
+  import LearningActivityChip from './LearningActivityChip';
   import LessonResourceViewer from './classes/LessonResourceViewer';
   import CurrentlyViewedResourceMetadata from './CurrentlyViewedResourceMetadata';
   import ContentPage from './ContentPage';
@@ -145,6 +170,7 @@
       FullScreenSidePanel,
       GlobalSnackbar,
       LearningActivityBar,
+      LearningActivityChip,
       CurrentlyViewedResourceMetadata,
       SkipNavigationLink,
     },
@@ -441,6 +467,18 @@
     /deep/ .side-panel {
       padding-bottom: 0;
     }
+  }
+
+  .side-panel-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-bottom: -8px;
+    margin-left: -8px;
+  }
+  .chip {
+    margin-bottom: 8px;
+    margin-left: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -205,7 +205,27 @@
       alignment="right"
       @closePanel="sidePanelContent = null"
     >
-      <BrowseResourceMetadata :content="sidePanelContent" :canDownloadContent="true" />
+      <template #header>
+        <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
+            multiple chips - not a common thing but just in case -->
+        <div
+          v-for="activity in sidePanelContent.learning_activities"
+          :key="activity"
+          class="side-panel-chips"
+          :class="$computedClass({ '::after': {
+            content: '',
+            flex: 'auto'
+          } })"
+        >
+          <LearningActivityChip
+            class="chip"
+            style="margin-left: 8px; margin-bottom: 8px;"
+            :kind="activity"
+          />
+        </div>
+      </template>
+
+      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
     </FullScreenSidePanel>
   </div>
 
@@ -226,6 +246,7 @@
   import BrowseResourceMetadata from './BrowseResourceMetadata';
   import commonLearnStrings from './commonLearnStrings';
   import ChannelCardGroupGrid from './ChannelCardGroupGrid';
+  import LearningActivityChip from './LearningActivityChip';
   import HybridLearningCardGrid from './HybridLearningCardGrid';
   import EmbeddedSidePanel from './EmbeddedSidePanel';
   import CategorySearchModal from './CategorySearchModal';
@@ -244,6 +265,7 @@
     components: {
       HybridLearningCardGrid,
       ChannelCardGroupGrid,
+      LearningActivityChip,
       EmbeddedSidePanel,
       FullScreenSidePanel,
       CategorySearchModal,
@@ -448,6 +470,18 @@
   .filter-action-button {
     display: inline-block;
     margin: 4px;
+    margin-left: 8px;
+  }
+
+  .side-panel-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-bottom: -8px;
+    margin-left: -8px;
+  }
+  .chip {
+    margin-bottom: 8px;
     margin-left: 8px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -856,6 +856,7 @@
     margin-top: 16px;
     text-align: center;
   }
+
   .side-panel-chips {
     display: flex;
     flex-wrap: wrap;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -321,11 +321,33 @@
       />
 
     </div>
+
+    <!-- Side panel for showing the information of selected content with a link to view it -->
     <FullScreenSidePanel
       v-if="sidePanelContent"
       alignment="right"
       @closePanel="sidePanelContent = null"
     >
+      <template #header>
+        <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
+            multiple chips - not a common thing but just in case -->
+        <div
+          v-for="activity in sidePanelContent.learning_activities"
+          :key="activity"
+          class="side-panel-chips"
+          :class="$computedClass({ '::after': {
+            content: '',
+            flex: 'auto'
+          } })"
+        >
+          <LearningActivityChip
+            class="chip"
+            style="margin-left: 8px; margin-bottom: 8px;"
+            :kind="activity"
+          />
+        </div>
+      </template>
+
       <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
     </FullScreenSidePanel>
   </div>
@@ -355,6 +377,7 @@
   import HybridLearningCardGrid from './HybridLearningCardGrid';
   import EmbeddedSidePanel from './EmbeddedSidePanel';
   import BrowseResourceMetadata from './BrowseResourceMetadata';
+  import LearningActivityChip from './LearningActivityChip';
   import CustomContentRenderer from './ChannelRenderer/CustomContentRenderer';
   import CardThumbnail from './ContentCard/CardThumbnail';
   import CategorySearchModal from './CategorySearchModal';
@@ -386,6 +409,7 @@
       CategorySearchModal,
       EmbeddedSidePanel,
       FullScreenSidePanel,
+      LearningActivityChip,
       BrowseResourceMetadata,
       SearchChips,
       TextTruncator,
@@ -831,6 +855,17 @@
     width: 100%;
     margin-top: 16px;
     text-align: center;
+  }
+  .side-panel-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    margin-bottom: -8px;
+    margin-left: -8px;
+  }
+  .chip {
+    margin-bottom: 8px;
+    margin-left: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
@@ -9,7 +9,6 @@ import ResourceTypes from 'kolibri-constants/labels/ResourceType';
 import Subjects from 'kolibri-constants/labels/Subjects';
 import LearningActivities from 'kolibri-constants/labels/LearningActivities';
 import ContentNodeThumbnail from '../../src/views/thumbnails/ContentNodeThumbnail';
-import LearningActivityChip from '../../src/views/LearningActivityChip';
 import BrowseResourceMetadata from '../../src/views/BrowseResourceMetadata';
 import genContentLink from '../../src/utils/genContentLink';
 import routes from '../../src/routes/index.js';
@@ -102,10 +101,6 @@ describe('BrowseResourceMetadata', () => {
   describe('metadata is displayed when present on given content', () => {
     beforeAll(() => (wrapper = makeWrapper()));
 
-    it('shows properly translated learning activities as LearningActivityChip', () => {
-      expect(wrapper.findComponent(LearningActivityChip).exists()).toBeTruthy();
-    });
-
     it('shows the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeTruthy();
     });
@@ -170,10 +165,6 @@ describe('BrowseResourceMetadata', () => {
           license_owner: null,
         }))
     );
-
-    it('does not show properly translated learning activities as LearningActivityChip', () => {
-      expect(wrapper.findComponent(LearningActivityChip).exists()).toBeFalsy();
-    });
 
     it('does not show the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeFalsy();

--- a/kolibri/plugins/learn/assets/test/views/currently-viewed-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/currently-viewed-resource-metadata.spec.js
@@ -5,7 +5,6 @@ import GradeLevels from 'kolibri-constants/labels/Levels';
 import ResourceTypes from 'kolibri-constants/labels/ResourceType';
 import Subjects from 'kolibri-constants/labels/Subjects';
 import LearningActivities from 'kolibri-constants/labels/LearningActivities';
-import LearningActivityChip from '../../src/views/LearningActivityChip';
 import CurrentlyViewedResourceMetadata from '../../src/views/CurrentlyViewedResourceMetadata';
 
 const baseContentNode = {
@@ -79,10 +78,6 @@ describe('CurrentlyViewedResourceMetadata', () => {
       expect(wrapper.find("[data-test='download-button']").exists()).toBeTruthy();
     });
 
-    it('shows properly translated learning activities as LearningActivityChip', () => {
-      expect(wrapper.findComponent(LearningActivityChip).exists()).toBeTruthy();
-    });
-
     it('shows the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       expect(wrapper.find("[data-test='beginners-chip']").exists()).toBeTruthy();
     });
@@ -137,10 +132,6 @@ describe('CurrentlyViewedResourceMetadata', () => {
           { propsData: { canDownloadContent: false } }
         ))
     );
-
-    it('does not show properly translated learning activities as LearningActivityChip', () => {
-      expect(wrapper.findComponent(LearningActivityChip).exists()).toBeFalsy();
-    });
 
     it('does not show the forBeginners chip when one of LearnerNeeds is FOR_BEGINNERS', () => {
       console.log(wrapper.vm.forBeginners);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Add's a slot `#header` to FullScreenSidePanel where the content at the top, aligned with the (optional) close icon, will live without scrolling. The header overlays the content of the sidepanel as it scrolls up underneath.


https://user-images.githubusercontent.com/6356129/146099414-2331ba28-f974-4718-85a2-2ebd428ddbd5.mp4

Video:

- Side panel while in library. Note that scroll section extends as Show more / License data expands
- Side panel while viewing content for the content being viewed
- "Also in this" folder for that same content
- (The H5P part) - Side panel while viewing content "Also in this" which has a "next folder" link in it
- Side panel while viewing "Also in this" lesson

Additionally:
 
- Focus is started on the header once the panel is open

Known issues:

- The scroll bar visually goes underneath the "Next folder" section which is odd but I couldn't get it lined up correctly. There is padding ensuring that all content is visible and nothing gets hidden behind it (you should double check that if you're testing though).

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8551 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Test a11y, keyboard navigation if you can please
- Test on mobile where possible
- Check the search filters in the library which use this component, but not the thing that I added in this PR

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
