### PR TITLE
Finalize H5P Integration

### DIFF
--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -125,6 +125,9 @@
         return 300;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
+      entry() {
+        return (this.options && this.options.entry) || 'index.html';
+      },
     },
     watch: {
       userData(newValue) {
@@ -155,7 +158,7 @@
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData,
         this.defaultFile.extension === 'zip'
-          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension, 'index.html')
+          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension, this.entry)
           : this.defaultFile.storage_url,
         this.defaultFile.checksum
       );

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -128,6 +128,9 @@
       entry() {
         return (this.options && this.options.entry) || 'index.html';
       },
+      isH5P() {
+        return this.defaultFile.extension === 'h5p';
+      },
     },
     watch: {
       userData(newValue) {
@@ -140,6 +143,10 @@
       this.hashi = new Hashi({ iframe: this.$refs.iframe, now });
       this.hashi.onStateUpdate(data => {
         this.$emit('updateContentState', data);
+        const hashiProgress = this.hashi.getProgress();
+        if (hashiProgress !== null && !this.forceDurationBasedProgress) {
+          this.$emit('updateProgress', hashiProgress);
+        }
       });
       this.hashi.on('navigateTo', message => {
         this.$emit('navigateTo', message);
@@ -157,13 +164,15 @@
       this.hashi.initialize(
         (this.extraFields && this.extraFields.contentState) || {},
         this.userData,
-        this.defaultFile.extension === 'zip'
-          ? urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension, this.entry)
-          : this.defaultFile.storage_url,
+        this.isH5P
+          ? this.defaultFile.storage_url
+          : urls.zipContentUrl(this.defaultFile.checksum, this.defaultFile.extension, this.entry),
         this.defaultFile.checksum
       );
       this.$emit('startTracking');
-      this.pollProgress();
+      if (!this.isH5P) {
+        this.pollProgress();
+      }
     },
     beforeDestroy() {
       if (this.timeout) {
@@ -173,17 +182,21 @@
     },
     methods: {
       recordProgress() {
-        const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
-        this.$emit(
-          'updateProgress',
-          hashiProgress === null ? this.durationBasedProgress : hashiProgress
-        );
+        if (this.forceDurationBasedProgress) {
+          this.$emit('updateProgress', this.durationBasedProgress);
+        } else {
+          const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
+          this.$emit(
+            'updateProgress',
+            hashiProgress === null ? this.durationBasedProgress : hashiProgress
+          );
+        }
         this.pollProgress();
       },
       pollProgress() {
         this.timeout = setTimeout(() => {
           this.recordProgress();
-        }, 15000);
+        }, 5000);
       },
     },
     $trs: {

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -82,6 +82,7 @@ export default class SandboxEnvironment {
         this.xAPI.iframeInitialize(this.iframe.contentWindow);
         patchIndexedDB(this.contentNamespace, this.iframe.contentWindow);
       } catch (e) {
+        console.debug(e);
         console.log('Shimming storage APIs failed, data will not persist'); // eslint-disable-line no-console
       }
     }

--- a/packages/hashi/src/iframeClient.js
+++ b/packages/hashi/src/iframeClient.js
@@ -81,11 +81,6 @@ export default class SandboxEnvironment {
         this.H5P.iframeInitialize(this.iframe.contentWindow);
         this.xAPI.iframeInitialize(this.iframe.contentWindow);
         patchIndexedDB(this.contentNamespace, this.iframe.contentWindow);
-        this.mutationObserver.observe(this.iframe.contentDocument, {
-          attributes: true,
-          childList: true,
-          subtree: true,
-        });
       } catch (e) {
         console.log('Shimming storage APIs failed, data will not persist'); // eslint-disable-line no-console
       }
@@ -93,9 +88,6 @@ export default class SandboxEnvironment {
   }
 
   clearIframe() {
-    try {
-      this.mutationObserver.disconnect();
-    } catch (e) {} // eslint-disable-line no-empty
     try {
       document.body.removeChild(this.iframe);
     } catch (e) {} // eslint-disable-line no-empty

--- a/packages/hashi/src/xAPI/xAPIInterface.js
+++ b/packages/hashi/src/xAPI/xAPIInterface.js
@@ -178,6 +178,8 @@ export default class xAPI extends BaseShim {
       // not directly from the data 'statements' property, so reversing in place is safe
       statements.reverse();
     }
+    // Only return statements that we have not flagged as errored.
+    statements = statements.filter(s => !s.error);
     if (limit && isNumber(limit)) {
       statements = statements.slice(0, limit);
     }
@@ -275,7 +277,7 @@ export default class xAPI extends BaseShim {
        * @return {Promise} a Promise that resolves when the statement has been successfully stored
        */
       sendStatement(statement, compress = false) {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
           return import(
             /* webpackChunkName: "xAPISchema", webpackPrefetch: true */ './xAPISchema'
           ).then(({ Statement }) => {
@@ -283,8 +285,8 @@ export default class xAPI extends BaseShim {
             try {
               statement = Statement.clean(statement);
             } catch (e) {
-              reject(e);
-              return;
+              console.debug('Statement: ', statement, 'gave the following error: ', e);
+              statement.error = e.message;
             }
             if (compress) {
               // If we are compressing, then remove things that we

--- a/packages/hashi/src/xAPI/xAPIInterface.js
+++ b/packages/hashi/src/xAPI/xAPIInterface.js
@@ -67,35 +67,18 @@ export default class xAPI extends BaseShim {
    * be calculated.
    */
   __calculateProgress() {
-    if (
-      find(
-        this.data[STATEMENT],
-        s =>
-          s.verb.id === XAPIVerbMap.mastered ||
-          s.verb.id === XAPIVerbMap.passed ||
-          s.verb.id === XAPIVerbMap.completed ||
-          (s.result && s.result.success)
-      )
-    ) {
-      return 1;
-    }
-    const scoreStatement = find(
+    const successStatement = find(
       this.data[STATEMENT],
       s =>
-        s.result &&
-        s.result.score &&
-        (s.result.score.scaled || (s.result.score.min && s.result.score.max && s.result.score.raw))
+        s.verb.id === XAPIVerbMap.mastered ||
+        s.verb.id === XAPIVerbMap.passed ||
+        s.verb.id === XAPIVerbMap.completed
     );
-    if (scoreStatement) {
-      if (scoreStatement.result.score.scaled) {
-        return scoreStatement.result.score.scaled;
-      }
-      return (
-        (scoreStatement.result.score.raw - scoreStatement.result.score.min) /
-        (scoreStatement.result.score.max - scoreStatement.result.score.min)
-      );
+    if (successStatement) {
+      return 1;
     }
-    return null;
+    // If there has been any interaction return some progress, otherwise null.
+    return Object.keys(this.data[STATEMENT]).length ? 0.01 : null;
   }
 
   createAgent() {

--- a/packages/hashi/src/xAPI/xAPIInterface.js
+++ b/packages/hashi/src/xAPI/xAPIInterface.js
@@ -70,9 +70,10 @@ export default class xAPI extends BaseShim {
     const successStatement = find(
       this.data[STATEMENT],
       s =>
-        s.verb.id === XAPIVerbMap.mastered ||
-        s.verb.id === XAPIVerbMap.passed ||
-        s.verb.id === XAPIVerbMap.completed
+        !s.error &&
+        (s.verb.id === XAPIVerbMap.mastered ||
+          s.verb.id === XAPIVerbMap.passed ||
+          s.verb.id === XAPIVerbMap.completed)
     );
     if (successStatement) {
       return 1;


### PR DESCRIPTION
## Summary
-  Disable time based progress tracking for H5P files in the HTML5 viewer
-  Log all logged xAPI statements even when they fail validation, but mark them as such
-  Add logic in the score calculation logic to handle invalid statements and other statement handling logic
- Prevent H5P from returning statements that imply completion when they are only about subContentIds within the main content (seemingly contrary to the CMI5 spec https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#verbs_completed)
- Clean up old mutation observer/resizing code that is no longer used but was causing an unreported error that was preventing data from being saved

## References
Fixes #8927

## Reviewer guidance
Engage with H5P content in the Kolibri QA channel.
Engage with the H5P node here: `birid-riziv`

Ensure in both instances that the content is not completed too soon at the very least (possible that it will never be marked as complete, but there's only so much we can do).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
