### PR TITLE
API: Add query context to the pagination object

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -163,12 +163,14 @@
           },
         })
           .then(contentNodes => {
+            const { more, results } = contentNodes;
+
             return createReturnMsg({
               message,
               data: {
                 maxResults: options.maxResults ? options.maxResults : 50,
-                more: contentNodes.more,
-                results: contentNodes.results,
+                more,
+                results,
               },
             });
           })
@@ -184,18 +186,17 @@
         const { options } = message;
 
         return ContentNodeResource.fetchCollection({
-          getParams: {
-            cursor: options.cursor,
-            max_results: options.maxResults ? options.maxResults : 50,
-          },
+          getParams: options,
         })
           .then(contentNodes => {
+            const { more, results } = contentNodes;
+
             return createReturnMsg({
               message,
               data: {
-                maxResults: options.maxResults ? options.maxResults : 50,
-                more: contentNodes.more,
-                results: contentNodes.results,
+                maxResults: options.max_results ? options.max_results : 50,
+                more,
+                results,
               },
             });
           })

--- a/packages/hashi/src/kolibri.js
+++ b/packages/hashi/src/kolibri.js
@@ -137,9 +137,7 @@ export default class Kolibri extends BaseShim {
       /*
        * Method to query next page of contentnodes from Kolibri and return
        * an array
-       * @param {Object} options - The different options to filter by
-       * @param {string} options.cursor - the cursor pagination
-       * @param {number} [options.maxResults=50] - the maximum number of nodes per request
+       * @param {MoreObject} options - A more object returned in a call to getContentByFilter
        * @return {Promise<PageResult>} - a Promise that resolves to an array of ContentNodes
        */
       getContentPage(options) {


### PR DESCRIPTION
## Summary
This patch adds the getParams to the pagination object so any call to the getContentPage has the same filter parameters than the initial query call, making the pagination consistent and simpler.