### PR TITLE
Add copies link on hybrid learning content cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -34,10 +34,10 @@
     >
       <ResourceCard
         v-for="(content, idx) in contents"
-
         :key="`resource-${idx}`"
         :contentNode="content"
         :to="genContentLink(content)"
+        @openCopiesModal="openCopiesModal"
       />
     </CardGrid>
 

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -44,6 +44,13 @@
             :maxLines="5"
           />
         </h3>
+        <KButton
+          v-if="content.copies"
+          appearance="basic-link"
+          class="copies"
+          :text="coreString('copies', { num: content.copies.length })"
+          @click.prevent="$emit('openCopiesModal', content.copies)"
+        />
       </div>
     </router-link>
     <div class="footer">
@@ -138,7 +145,7 @@
           this.content.is_leaf +
           (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
           (this.content.num_coach_contents > 0) +
-          (this.content.copies_count > 1) +
+          (this.content.copies > 1) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );
       },
@@ -187,6 +194,13 @@
 
   .card-link {
     text-decoration: none;
+  }
+
+  .copies {
+    display: inline-block;
+    font-size: 13px;
+    text-decoration: none;
+    vertical-align: top;
   }
 
   .header-bar {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -45,7 +45,7 @@
           />
         </h3>
         <KButton
-          v-if="content.copies"
+          v-if="content.copies && content.copies.length"
           appearance="basic-link"
           class="copies"
           :text="coreString('copies', { num: content.copies.length })"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -145,7 +145,7 @@
           this.content.is_leaf +
           (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
           (this.content.num_coach_contents > 0) +
-          (this.content.copies > 1) +
+          (this.content.copies && this.content.copies.length > 1) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );
       },

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -60,7 +60,7 @@
           class="channel-logo"
         >
         <KButton
-          v-if="!isMobile && content.copies.length"
+          v-if="!isMobile && content.copies && content.copies.length"
           appearance="basic-link"
           class="copies"
           :style="{ color: $themeTokens.text }"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -60,7 +60,7 @@
           class="channel-logo"
         >
         <KButton
-          v-if="!isMobile && isLibraryPage && content.copies"
+          v-if="!isMobile && content.copies"
           appearance="basic-link"
           class="copies"
           :style="{ color: $themeTokens.text }"
@@ -170,9 +170,6 @@
         } else {
           return null;
         }
-      },
-      isLibraryPage() {
-        return this.currentPage === PageNames.LIBRARY;
       },
       isBookmarksPage() {
         return this.currentPage === PageNames.BOOKMARKS;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -60,7 +60,7 @@
           class="channel-logo"
         >
         <KButton
-          v-if="!isMobile && content.copies"
+          v-if="!isMobile && content.copies.length"
           appearance="basic-link"
           class="copies"
           :style="{ color: $themeTokens.text }"


### PR DESCRIPTION
## Summary
Ensures copies count appears on the content card, not just on list/bookmarks view and resources card

## References
Fixes #8913

<img width="1425" alt="Screen Shot 2021-12-15 at 6 40 12 PM" src="https://user-images.githubusercontent.com/17235236/146282126-65ad8214-38ff-43b2-8d64-3c527e06d1e6.png">



----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
