### PR TITLE
PDF renderer completion fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -354,6 +354,13 @@ describe('useProgressTracking composable', () => {
       expect(get(progress_delta)).toEqual(0.1);
       expect(client).not.toHaveBeenCalled();
     });
+    it('should increment progress_delta if progress is updated twice', async () => {
+      const { updateContentSession, progress_delta } = await initStore();
+      await updateContentSession({ progress: 0.6 });
+      await updateContentSession({ progress: 0.7 });
+      expect(get(progress_delta)).toEqual(0.2);
+      expect(client).not.toHaveBeenCalled();
+    });
     it('should update progress and store progress_delta if progress is updated over threshold', async () => {
       const { updateContentSession, progress } = await initStore();
       await updateContentSession({ progress: 1 });

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -65,7 +65,7 @@ export default function useProgressTracking(store) {
   store = store || getCurrentInstance().proxy.$store;
   const complete = ref(null);
   const progress_state = ref(null);
-  const progress_delta = ref(null);
+  const progress_delta = ref(0);
   const time_spent = ref(null);
   const time_spent_delta = ref(null);
   const session_id = ref(null);
@@ -350,7 +350,9 @@ export default function useProgressTracking(store) {
       progress = _zeroToOne(progress);
       progress = threeDecimalPlaceRoundup(progress);
       if (get(progress_state) < progress) {
-        set(progress_delta, threeDecimalPlaceRoundup(progress - get(progress_state)));
+        const newProgressDelta =
+          get(progress_delta) + threeDecimalPlaceRoundup(progress - get(progress_state));
+        set(progress_delta, newProgressDelta);
         set(progress_state, progress);
       }
     }

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -325,8 +325,9 @@
           // TODO: there is a miscalculation that causes a wrong position change on scale
           this.savePosition(this.calculatePosition());
 
-          // determine how many pages user has viewed/visited
-          let currentPage = parseInt(this.currentLocation * this.totalPages) + 1;
+          // determine how many pages user has viewed/visited; fix edge case of 2 pages
+          let currentPage =
+            this.totalPages === 2 ? 2 : parseInt(this.currentLocation * this.totalPages) + 1;
           this.storeVisitedPage(currentPage);
           this.updateProgress();
           this.updateContentState();

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -260,6 +260,8 @@
         }
         this.$emit('startTracking');
         this.updateContentStateInterval = setInterval(this.updateProgress, 30000);
+        // Even if user does not pause while scrolling on first page, we store that as visited
+        this.storeVisitedPage(1);
       });
     },
     beforeDestroy() {


### PR DESCRIPTION
## Summary
- Fix edge case of 2-page pdfs
- Add visit to 1st pdf page for all pdfs
- Fix progress tracking from PDF to content card

![2021-12-15 16 19 06](https://user-images.githubusercontent.com/13563002/146285425-765612c1-a52d-4c5c-87ee-2fdebbcbb34a.gif)

## References
Fixes #8868 

## Reviewer guidance
1. Sign in as learner
2. Go to the library and choose the 2-pg PDF in the QA channel
3. Read through the PDF; check to see that it gets completed and that the completed icon shows up in the app bar
4. Go back to the library and check to see that the progress on that content card is now complete
5. Repeat for PDFs of other lengths, but also periodically check to see that the progress on the content card shows accurate progress while you're reading through the PDF

## Testing checklist
- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
