### PR TITLE
fix crowdin capitalization

### DIFF
--- a/kolibri/locale/language_info.json
+++ b/kolibri/locale/language_info.json
@@ -161,7 +161,7 @@
     "default_font": "NotoSans"
   },
   {
-    "crowdin_code": "pt-MZ",
+    "crowdin_code": "pt-mz",
     "intl_code": "pt-mz",
     "language_name": "Português (Moçambique)",
     "english_name": "Portuguese (Mozambique)",


### PR DESCRIPTION
## Summary

This should fix https://github.com/learningequality/kolibri/issues/8915. My theory was wrong about state being left over between downloads. Instead, it was indeed a mac versus linux issue. Thank you @rtibbles for help debugging.

On crowdin, every other language uses a `lowercase-UPPERCASE` convention. However for some reason Mozambican PT uses `lowercase-lowercase`.

> ![image](https://user-images.githubusercontent.com/2367265/146463034-08936189-ca5a-4b0e-847f-b01a9e8e0d68.png)


> ![image](https://user-images.githubusercontent.com/2367265/146463009-a6a79f5c-541d-4b97-9738-1cc4abcacab2.png)


Mac's file system is case-insensitive so apparently it doesn't care about this discrepancy, while linux is case-sensitive.

## References

* https://github.com/learningequality/kolibri/pull/8911
* https://github.com/learningequality/kolibri/pull/8939

## Reviewer guidance

@radinamatic please try checking this out and running `make i18n-download`. Hopefully it won't delete your pt-mz files again.


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
