### PR TITLE
Completion labels

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -19,7 +19,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-constants": "^0.1.34",
+    "kolibri-constants": "0.1.36",
     "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -5,9 +5,12 @@
 
 import { computed } from 'kolibri.lib.vueCompositionApi';
 import { get } from '@vueuse/core';
+import CompletionCriteria from 'kolibri-constants/CompletionCriteria';
 import lodashGet from 'lodash/get';
 import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import coreStrings from 'kolibri.utils.coreStrings';
+
+const DURATION_THRESHOLD = 60 * 30; // 30 minutes in seconds
 
 export default function useLearningActivities(contentNode) {
   const ReferenceLabel = coreStrings.$tr('readReference');
@@ -52,7 +55,10 @@ export default function useLearningActivities(contentNode) {
    *                   set to reference.
    */
   const isReference = computed(() => {
-    return lodashGet(contentNode, ['options', 'completion_criteria', 'model']) === 'reference';
+    return (
+      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
+      CompletionCriteria.REFERENCE
+    );
   });
 
   /**
@@ -65,14 +71,30 @@ export default function useLearningActivities(contentNode) {
   /**
    * Should we display precise time duration for the content node?
    *
-   * @returns {Boolean} `true` when the content node has exactly one learning activity
-   *                    associated and that activity is watching or listening
+   * @returns {Boolean} `true` when the content node has a duration and the time
+   *                    completion criterion.
    */
   const displayPreciseDuration = computed(() => {
     return (
       contentNode &&
       contentNode.duration &&
-      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) === 'time'
+      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
+        CompletionCriteria.TIME
+    );
+  });
+
+  /**
+   * Should we display an estimated duration for the content node?
+   *
+   * @returns {Boolean} `true` when the content node has a duration and the approx_time
+   *                    completion criterion.
+   */
+  const displayEstimatedDuration = computed(() => {
+    return (
+      contentNode &&
+      contentNode.duration &&
+      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
+        CompletionCriteria.APPROX_TIME
     );
   });
 
@@ -85,13 +107,14 @@ export default function useLearningActivities(contentNode) {
 
   /**
    * @returns {String} Returns the translated 'Short activity' label when duration is less
-   *                   than 30 minutes. Otherwise returns the translated 'Long activity' label.
+   *                   than or equal to 30 minutes.
+   *                   Otherwise returns the translated 'Long activity' label.
    */
   const durationEstimation = computed(() => {
     if (!get(hasDuration)) {
       return '';
     }
-    return contentNode.duration < 1800
+    return contentNode.duration <= DURATION_THRESHOLD
       ? coreStrings.$tr('shortActivity')
       : coreStrings.$tr('longActivity');
   });
@@ -111,6 +134,7 @@ export default function useLearningActivities(contentNode) {
     isReference,
     hasDuration,
     displayPreciseDuration,
+    displayEstimatedDuration,
     durationInSeconds,
     durationEstimation,
     getLearningActivityLabel,

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -5,6 +5,7 @@
 
 import { computed } from 'kolibri.lib.vueCompositionApi';
 import { get } from '@vueuse/core';
+import lodashGet from 'lodash/get';
 import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import coreStrings from 'kolibri.utils.coreStrings';
 
@@ -47,11 +48,11 @@ export default function useLearningActivities(contentNode) {
   });
 
   /**
-   * @returns {Boolean} `true` if the content node has exactly one learning
-   *                    activity associated and that activity is reading
+   * @returns {Boolean} `true` if the content node has completion criterion
+   *                   set to reference.
    */
   const isReference = computed(() => {
-    return get(hasSingleActivity) && get(firstActivity) === LearningActivities.READ;
+    return lodashGet(contentNode, ['options', 'completion_criteria', 'model']) === 'reference';
   });
 
   /**
@@ -71,8 +72,7 @@ export default function useLearningActivities(contentNode) {
     return (
       contentNode &&
       contentNode.duration &&
-      get(hasSingleActivity) &&
-      [LearningActivities.WATCH, LearningActivities.LISTEN].includes(get(firstActivity))
+      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) === 'time'
     );
   });
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/__tests__/index.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/__tests__/index.spec.js
@@ -1,6 +1,6 @@
 import { shallowMount, mount } from '@vue/test-utils';
+import CompletionCriteria from 'kolibri-constants/CompletionCriteria';
 
-import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import LearningActivityDuration from '../index';
 
 jest.mock('kolibri.utils.coreStrings', () => {
@@ -26,84 +26,59 @@ describe(`LearningActivityDuration`, () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it.each([LearningActivities.LISTEN, LearningActivities.WATCH])(
-    `displays time duration for '%s' activity`,
-    activity => {
-      const wrapper = makeWrapper({
-        contentNode: {
-          duration: 322,
-          learning_activities: [activity],
+  it('displays time duration for exact time', () => {
+    const wrapper = makeWrapper({
+      contentNode: {
+        duration: 322,
+        options: {
+          completion_criteria: {
+            model: CompletionCriteria.TIME,
+          },
         },
-      });
-      expect(wrapper.text()).toBe('5 minutes');
-    }
-  );
+      },
+    });
+    expect(wrapper.text()).toBe('5 minutes');
+  });
 
-  it.each([
-    LearningActivities.CREATE,
-    LearningActivities.REFLECT,
-    LearningActivities.PRACTICE,
-    LearningActivities.EXPLORE,
-  ])(
-    `displays 'Short activity' as duration for '%s' activity
-    when estimated time is less than 30 minutes`,
-    activity => {
-      const wrapper = makeWrapper({
-        contentNode: {
-          duration: 322,
-          learning_activities: [activity],
-        },
-      });
-      expect(wrapper.text()).toBe('Short activity');
-    }
-  );
-
-  it.each([
-    LearningActivities.CREATE,
-    LearningActivities.REFLECT,
-    LearningActivities.PRACTICE,
-    LearningActivities.EXPLORE,
-  ])(
-    `displays 'Long activity' as duration for '%s' activity
-    when estimated time is more than 30 minutes`,
-    activity => {
-      const wrapper = makeWrapper({
-        contentNode: {
-          duration: 1800 + 322,
-          learning_activities: [activity],
-        },
-      });
-      expect(wrapper.text()).toBe('Long activity');
-    }
-  );
-
-  it(`displays 'Short activity' as duration for multiple activities
+  it(`displays 'Short activity' as duration for approximate time
     when estimated time is less than 30 minutes`, () => {
     const wrapper = makeWrapper({
       contentNode: {
         duration: 322,
-        learning_activities: [LearningActivities.WATCH, LearningActivities.EXPLORE],
+        options: {
+          completion_criteria: {
+            model: CompletionCriteria.APPROX_TIME,
+          },
+        },
       },
     });
     expect(wrapper.text()).toBe('Short activity');
   });
 
-  it(`displays 'Long activity' as duration for multiple activities
+  it(`displays 'Long activity' as duration for approximate time
     when estimated time is more than 30 minutes`, () => {
     const wrapper = makeWrapper({
       contentNode: {
         duration: 1800 + 322,
-        learning_activities: [LearningActivities.WATCH, LearningActivities.EXPLORE],
+        options: {
+          completion_criteria: {
+            model: CompletionCriteria.APPROX_TIME,
+          },
+        },
       },
     });
     expect(wrapper.text()).toBe('Long activity');
   });
 
-  it(`displays 'Reference' and no time duration for 'read' activity`, () => {
+  it(`displays 'Reference' and no time duration for reference`, () => {
     const wrapper = makeWrapper({
       contentNode: {
         duration: 322,
-        learning_activities: [LearningActivities.READ],
+        options: {
+          completion_criteria: {
+            model: CompletionCriteria.REFERENCE,
+          },
+        },
       },
     });
     expect(wrapper.text()).toBe('Reference');

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span
-    v-if="isReference || hasDuration"
+    v-if="isReference || displayPreciseDuration || displayEstimatedDuration"
     :class="[ appearance === 'chip' ? 'chip' : '']"
     :style="[ appearance === 'chip' ? { color: $themeTokens.textInverted } : {}]"
   >
@@ -12,7 +12,7 @@
       v-else-if="displayPreciseDuration"
       :seconds="durationInSeconds"
     />
-    <template v-else>
+    <template v-else-if="displayEstimatedDuration">
       {{ durationEstimation }}
     </template>
   </span>
@@ -44,8 +44,8 @@
       const {
         ReferenceLabel,
         isReference,
-        hasDuration,
         displayPreciseDuration,
+        displayEstimatedDuration,
         durationInSeconds,
         durationEstimation,
       } = useLearningActivities(props.contentNode);
@@ -53,8 +53,8 @@
       return {
         ReferenceLabel,
         isReference,
-        hasDuration,
         displayPreciseDuration,
+        displayEstimatedDuration,
         durationInSeconds,
         durationEstimation,
       };

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -22,7 +22,7 @@
     "hammerjs": "^2.0.8",
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
-    "kolibri-constants": "^0.1.34",
+    "kolibri-constants": "0.1.36",
     "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8833,10 +8833,10 @@ knuth-shuffle-seeded@^1.0.6:
   dependencies:
     seed-random "~2.2.0"
 
-kolibri-constants@^0.1.34:
-  version "0.1.34"
-  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.34.tgz#06d1cdb04ded4e4ce785437f3e4bd87801168fae"
-  integrity sha512-nArDgIwIPYJMacVaqHazptLRpIjSTS6LNr4FWtL/7D6Ek+z7DVcWtFYL74hH/wdebGykWywmkOa5qnfcy1JQ+A==
+kolibri-constants@0.1.36:
+  version "0.1.36"
+  resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.36.tgz#c9ab07305dc6e052547b830a91e61a58757bb1ee"
+  integrity sha512-61FoLBFjOXoBu7lsAKFltkZCwwzVO/Cwmgq+wBqkoTmLw92ma6shLP/ZYaNrzYNhuEn4gHfCC6zWZoLoC1hp/w==
 
 "kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## Summary
* Sets Learning Activity duration labels via metadata

## References
Fixes #8767

## Reviewer guidance
Do tests satisfy the specification linked in #8767 ?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
