### PR TITLE
Show that a facility is registered immediately upon registering.

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -204,6 +204,7 @@
       },
       handleConfirmationSuccess(payload) {
         this.$store.commit('manageCSV/SET_REGISTERED', payload);
+        this.theFacility.dataset.registered = true;
         this.closeModal();
       },
       handleSyncFacilitySuccess(taskId) {


### PR DESCRIPTION
## Summary
* Does minimal fix to ensure that a facility displays as registered immediately upon registering to KDP in the Facility plugin

## References
Fixes #8801

## Reviewer guidance
I deliberately kept it simple, in parallel to the behaviour in the Device plugin:
![registered](https://user-images.githubusercontent.com/1680573/146466846-679c4f38-3959-4012-875e-b0f526e8092b.gif)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
