### PR TITLE
Card heights

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -9,7 +9,7 @@
       short
     />
     <ContinueLearning
-      v-if="continueLearningFromClasses || continueLearningOnYourOwn"
+      v-if="continueLearning"
       class="section"
       :fromClasses="continueLearningFromClasses"
       :data-test="continueLearningFromClasses ?
@@ -37,7 +37,11 @@
       :channels="channels"
       class="section"
       data-test="exploreChannels"
-      short
+      :short="displayClasses ||
+        continueLearning ||
+        hasActiveClassesLessons ||
+        hasActiveClassesQuizzes
+      "
     />
   </div>
 
@@ -99,6 +103,11 @@
           get(canAccessUnassignedContent) &&
           get(resumableContentNodes).length > 0
       );
+
+      const continueLearning = computed(
+        () => get(continueLearningFromClasses) || get(continueLearningOnYourOwn)
+      );
+
       const hasActiveClassesLessons = computed(
         () =>
           get(isUserLoggedIn) && get(activeClassesLessons) && get(activeClassesLessons).length > 0
@@ -131,7 +140,7 @@
         hasActiveClassesLessons,
         hasActiveClassesQuizzes,
         continueLearningFromClasses,
-        continueLearningOnYourOwn,
+        continueLearning,
         displayExploreChannels,
         displayClasses,
       };

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -46,7 +46,7 @@
       :content="content"
       :currentPage="currentPage"
       class="card-grid-item"
-      :isMobile="windowIsSmall"
+      :isMobile="windowIsExtraSmall"
       :link="genContentLink(content)"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
@@ -154,6 +154,9 @@
       },
       backRoute() {
         return this.pageName;
+      },
+      windowIsExtraSmall() {
+        return this.windowBreakpoint === 0;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -1,17 +1,17 @@
 <template>
 
-  <div
-    class="card-thumbnail-wrapper"
-    :class="{ 'mobile-thumbnail': isMobile }"
-    :style="thumbnailBackground"
+  <ContentNodeThumbnail
+    :contentNode="contentNode"
   >
-    <LearningActivityDuration
-      v-if="!isMobile"
-      :contentNode="contentNode"
-      appearance="chip"
-      class="duration"
-    />
-  </div>
+    <template #labels>
+      <LearningActivityDuration
+        v-if="!isMobile"
+        :contentNode="contentNode"
+        appearance="chip"
+        class="duration"
+      />
+    </template>
+  </ContentNodeThumbnail>
 
 </template>
 
@@ -19,13 +19,14 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
+  import ContentNodeThumbnail from '../thumbnails/ContentNodeThumbnail.vue';
   import LearningActivityDuration from '../LearningActivityDuration';
 
   export default {
     name: 'CardThumbnail',
     components: {
       LearningActivityDuration,
+      ContentNodeThumbnail,
     },
     mixins: [commonCoreStrings],
     props: {
@@ -38,20 +39,6 @@
         required: true,
       },
     },
-    computed: {
-      thumbnail() {
-        if (!this.contentNode) {
-          return null;
-        }
-        return getContentNodeThumbnail(this.contentNode);
-      },
-      thumbnailBackground() {
-        return {
-          backgroundColor: this.$themePalette.grey.v_200,
-          backgroundImage: this.thumbnail ? `url('${this.thumbnail}')` : '',
-        };
-      },
-    },
   };
 
 </script>
@@ -59,45 +46,11 @@
 
 <style lang="scss" scoped>
 
-  @import './card';
-  .card-thumbnail-wrapper {
-    position: relative;
-    width: 100%;
-    height: $thumb-height-desktop-hybrid-learning;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-  }
-  .content-icon-wrapper {
-    position: absolute;
-    width: 56px;
-    height: 56px;
-  }
   .duration {
     position: absolute;
     bottom: 16px;
     left: 10px;
-  }
-
-  /* MOBILE OVERRIDES */
-  .mobile-thumbnail.card-thumbnail-wrapper {
-    width: 100%;
-    height: $thumb-height-mobile-hybrid-learning;
-  }
-  .mobile-thumbnail {
-    .type-icon {
-      transform: translate(-50%, -50%) scale(2);
-    }
-    .content-icon-wrapper {
-      width: 48px;
-      height: 48px;
-    }
-    .content-icon {
-      font-size: 18px;
-    }
-    .activity-length-chip {
-      bottom: 20px;
-    }
+    z-index: 2;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -57,7 +57,7 @@
       <ProgressBar
         class="progress-bar"
         :contentNode="content"
-        :style="{ maxWidth: `calc(100% - ${28 * footerLength}px)` }"
+        :style="{ maxWidth: `calc(100% - ${24 + 32 * footerLength}px)` }"
       />
       <div class="footer-icons">
         <CoachContentLabel
@@ -139,10 +139,8 @@
       },
       footerLength() {
         return (
-          this.content.is_leaf +
-          (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
-          (this.content.num_coach_contents > 0) +
-          (this.content.copies && this.content.copies.length ? 1 : 0) +
+          (this.content.is_leaf ? 1 : 0) +
+          (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents ? 1 : 0) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );
       },

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -41,7 +41,7 @@
         <h3 class="title" dir="auto">
           <TextTruncatorCss
             :text="content.title"
-            :maxLines="5"
+            :maxLines="3"
           />
         </h3>
         <KButton
@@ -55,8 +55,9 @@
     </router-link>
     <div class="footer">
       <ProgressBar
+        class="progress-bar"
         :contentNode="content"
-        :style="{ maxWidth: `calc(100% - ${32 * footerLength}px)` }"
+        :style="{ maxWidth: `calc(100% - ${28 * footerLength}px)` }"
       />
       <div class="footer-icons">
         <CoachContentLabel
@@ -141,7 +142,7 @@
           this.content.is_leaf +
           (this.isUserLoggedIn && !this.isLearner && this.content.num_coach_contents) +
           (this.content.num_coach_contents > 0) +
-          (this.content.copies && this.content.copies.length > 1) +
+          (this.content.copies && this.content.copies.length ? 1 : 0) +
           (this.$slots.actions ? this.$slots.actions.length : 0)
         );
       },
@@ -235,7 +236,7 @@
 
   .text {
     position: relative;
-    height: 190px;
+    height: 120px;
     padding: 0 $margin $margin $margin;
   }
 
@@ -245,6 +246,12 @@
     display: flex;
     width: 100%;
     padding: $margin;
+  }
+
+  .progress-bar {
+    position: absolute;
+    bottom: 12px;
+    left: $margin-thin;
   }
 
   .footer-icons {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -73,6 +73,12 @@
           </div>
         </div>
         <div class="footer-elements footer-icons">
+          <CoachContentLabel
+            v-if="isUserLoggedIn && !isLearner && content.num_coach_contents"
+            class="coach-footer-icon"
+            :value="content.num_coach_contents"
+            :isTopic="isTopic"
+          />
           <KIconButton
             v-for="(value, key) in footerIcons"
             :key="key"
@@ -93,10 +99,12 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import { validateLinkObject } from 'kolibri.utils.validators';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { now } from 'kolibri.utils.serverClock';
+  import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import { PageNames } from '../constants';
   import ProgressBar from './ProgressBar';
   import LearningActivityLabel from './LearningActivityLabel';
@@ -110,6 +118,7 @@
       TextTruncator,
       LearningActivityLabel,
       ProgressBar,
+      CoachContentLabel,
     },
     mixins: [commonLearnStrings, commonCoreStrings],
     props: {
@@ -143,6 +152,7 @@
       now: now(),
     }),
     computed: {
+      ...mapGetters(['isUserLoggedIn', 'isLearner']),
       maxTitleHeight() {
         return 40;
       },
@@ -248,7 +258,8 @@
     position: absolute;
     bottom: 0;
     width: 100%;
-    padding: 16px 24px;
+    height: 80px;
+    padding: 24px;
   }
 
   .metadata-info-footer {
@@ -258,7 +269,8 @@
 
   .footer-elements {
     position: relative;
-    display: block;
+    display: inline-block;
+    max-width: 240px;
   }
 
   .footer-progress {
@@ -269,7 +281,8 @@
     // this override fixes an existing KDS bug with
     // the hover state circle being squished
     // and can be removed upon that hover state fix
-    float: right;
+    position: absolute;
+    right: 16px;
     .button {
       width: 32px !important;
       height: 32px !important;
@@ -290,7 +303,7 @@
     width: 240px;
     margin-top: 8px;
     margin-right: 24px;
-    margin-left: 24px;
+    margin-left: 12px;
   }
 
   .mobile-card.card {
@@ -301,15 +314,27 @@
   .mobile-card {
     .thumbnail {
       position: absolute;
-      top: 24px;
-      width: calc(100% - 48px);
-      height: calc(100% - 24px);
-      margin-left: 24px;
+      width: 100%;
+      max-height: 240px;
+      margin-top: 0;
+      margin-left: 0;
+
+      /deep/ .image {
+        border-radius: 8px 8px 0 0;
+      }
+    }
+
+    .footer-progress {
+      max-width: 200px;
     }
     .details {
       max-width: 100%;
-      margin-top: 224px;
+      margin-top: 200px;
     }
+  }
+
+  .coach-footer-icon {
+    max-width: 24px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -312,10 +312,10 @@
   }
 
   .mobile-card {
+    max-height: 450px;
     .thumbnail {
       position: absolute;
       width: 100%;
-      max-height: 240px;
       margin-top: 0;
       margin-left: 0;
 
@@ -329,7 +329,7 @@
     }
     .details {
       max-width: 100%;
-      margin-top: 200px;
+      margin-top: 240px;
     }
   }
 

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -138,7 +138,7 @@
     width: 100%;
     padding-right: $margin;
     padding-left: $margin;
-    margin-top: 8px;
+    margin-top: $margin;
   }
 
   .learning-activity-label {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -51,6 +51,7 @@
           :numCols="numCols"
           :genContentLink="genContentLink"
           :contents="trimmedResume"
+          :footerIcons="footerIcons"
           :currentPage="currentPage"
           @toggleInfoPanel="toggleInfoPanel"
         />
@@ -332,6 +333,9 @@
       },
       currentPage() {
         return PageNames.LIBRARY;
+      },
+      footerIcons() {
+        return { info: 'viewInformation' };
       },
       sidePanelWidth() {
         if (this.windowIsSmall || this.windowIsMedium) {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -351,8 +351,10 @@
       numCols() {
         if (this.windowIsMedium) {
           return 2;
-        } else if (!this.windowIsSmall) {
+        } else if (this.windowBreakpoint < 7) {
           return 3;
+        } else if (this.windowBreakpoint >= 7) {
+          return 4;
         } else {
           return null;
         }

--- a/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/ProgressBar.vue
@@ -76,6 +76,7 @@
   }
 
   .k-linear-loader {
+    top: -8px;
     display: block;
     margin-bottom: 0;
   }

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -529,9 +529,10 @@
           .map(t => {
             let childrenToDisplay;
             const topicChildren = t.children ? t.children.results : [];
-            if (this.subTopicId) {
+            if (this.subTopicId || this.topics.length === 1) {
               // If we are in a subtopic display, we should only be displaying this topic
               // so don't bother checking if the ids match.
+              // Alternatively, if there is only one topic, we should display all of its children.
               childrenToDisplay = topicChildren.length;
             } else if (this.expandedTopics[t.id]) {
               // If topic is expanded show three times as many children.

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -458,12 +458,14 @@
         expandedTopics: {},
         subTopicLoading: null,
         topicMoreLoading: false,
-        childrenToDisplay: 3,
         mobileSearchActive: false,
       };
     },
     computed: {
       ...mapState('topicsTree', ['channel', 'contents', 'isRoot', 'topic']),
+      childrenToDisplay() {
+        return Math.max(this.numCols, 3);
+      },
       breadcrumbs() {
         if (!this.topic || !this.topic.ancestors) {
           return [];

--- a/kolibri/plugins/learn/assets/src/views/thumbnails/ContentNodeThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/thumbnails/ContentNodeThumbnail.vue
@@ -15,6 +15,10 @@
         :color="$themePalette.grey.v_500"
       />
     </template>
+
+    <template #labels>
+      <slot name="labels"></slot>
+    </template>
   </Thumbnail>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/views/thumbnails/Thumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/thumbnails/Thumbnail.vue
@@ -18,6 +18,7 @@
       :src="thumbnailUrl"
       alt=""
     >
+    <slot name="labels"></slot>
   </span>
 
 </template>


### PR DESCRIPTION
## Summary
* Uses ContentNodeThumbnail in the HybridLearningContentCard CardThumbnail implementation to give consistent empty thumbnail and sizing experience across the different hybrid learning card types
* Reduces the max lines for content node titles used in HybridLearningContentCard from 5 to 3 (as this should cover 99% of titles in the public library)
* Reduces the height of the text box below the thumbnail accordingly
* Fixes an uncaught bug in the progress bar width calculation
* Repositions the progress bar and completed label slightly to be better aligned with the other footer elements
* Updates LibraryPage and TopicsPage grids to have consistent numbers of columns across sections and pages
* Shows a subtopic's full children when it's the only one
* Shows all channels to a learner who has no other recommendations

## References
No precise issue.

## Reviewer guidance
The HybridLearningContentCard CardThumbnail implementation is only used in the HybridLearning* card components, so that's the only place that we'd need to double check for regressions.

Full channels for new learner:
![Screenshot from 2021-12-16 18-16-50](https://user-images.githubusercontent.com/1680573/146478670-6c4db9de-f205-45b6-b784-f729200c974f.png)

Consistent grid spacing on Library Page and fixes to progress bar width:
![Screenshot from 2021-12-16 18-23-51](https://user-images.githubusercontent.com/1680573/146478760-02e6d30a-5dd3-4cfb-b8ee-79320f3fccfc.png)

More consistent node thumbnails and reduced card white space:
![Screenshot from 2021-12-16 18-24-05](https://user-images.githubusercontent.com/1680573/146478776-8301674a-8ea7-4272-9220-4766d38a1d36.png)

No adverse effects on bookmarks?
![Screenshot from 2021-12-16 18-24-38](https://user-images.githubusercontent.com/1680573/146478835-c4bb6933-ae26-432e-8d56-2ccff33150dc.png)



----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
