### PR TITLE
Schnittstellenfehler - Visual bugs in German

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <section>
-      <h1 style="word-break: break-all">
+      <h1>
         {{ $tr('pageHeader') }}
       </h1>
       <p>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -2,7 +2,7 @@
 
   <div>
     <section>
-      <h1>
+      <h1 style="word-break: break-all">
         {{ $tr('pageHeader') }}
       </h1>
       <p>

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -3,14 +3,17 @@
   <div>
     <HeaderWithOptions :headerText="coreString('facilitiesLabel')">
       <template #options>
+        <!-- Margins to and bottom adds space when buttons are vertically stacked -->
         <KButtonGroup>
           <KButton
             :text="$tr('syncAllAction')"
+            style="margin-top: 16px; margin-bottom: -16px;"
             @click="showSyncAllModal = true"
           />
           <KButton
             :text="$tr('importFacilityAction')"
             primary
+            style="margin-top: 16px; margin-bottom: -16px;"
             @click="showImportModal = true"
           />
         </KButtonGroup>
@@ -29,7 +32,43 @@
         <th>{{ coreString('facilityLabel') }}</th>
       </template>
       <template #tbody>
-        <tbody>
+        <!-- On mobile, put buttons on a row of their own -->
+        <tbody v-if="windowIsSmall">
+          <template v-for="(facility, idx) in facilities">
+            <tr :key="idx" style="border: none!important">
+              <td>
+                <FacilityNameAndSyncStatus
+                  :facility="facility"
+                  :isSyncing="facilityIsSyncing(facility)"
+                  :isDeleting="facilityIsDeleting(facility)"
+                  :syncHasFailed="facility.syncHasFailed"
+                />
+              </td>
+            </tr>
+            <!-- May cause error on device with > 10000 facilities... -->
+            <tr :key="idx + 10000">
+              <td style="padding: 0 0 16px 0;">
+                <!-- Gives most space possible to buttons and aligns them with text -->
+                <KButtonGroup style="margin-left: -16px; margin-right: -16px; max-width: 100%">
+                  <KButton
+                    :text="coreString('syncAction')"
+                    appearance="flat-button"
+                    @click="facilityForSync = facility"
+                  />
+                  <KDropdownMenu
+                    :text="coreString('optionsLabel')"
+                    :options="facilityOptions(facility)"
+                    appearance="flat-button"
+                    @select="handleOptionSelect($event.value, facility)"
+                  />
+                </KButtonGroup>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+
+        <!-- Non-mobile -->
+        <tbody v-else>
           <tr v-for="(facility, idx) in facilities" :key="idx">
             <td>
               <FacilityNameAndSyncStatus
@@ -112,6 +151,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import { FacilityResource } from 'kolibri.resources';
@@ -153,7 +193,7 @@
       SyncAllFacilitiesModal,
       TasksBar,
     },
-    mixins: [commonCoreStrings, commonSyncElements, facilityTaskQueue],
+    mixins: [commonCoreStrings, commonSyncElements, facilityTaskQueue, responsiveWindowMixin],
     data() {
       return {
         showSyncAllModal: false,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -6,17 +6,20 @@
       <HeaderWithOptions :headerText="coreString('channelsLabel')">
         <template #options>
           <KButtonGroup>
+            <!-- Margins to and bottom adds space when buttons are vertically stacked -->
             <KDropdownMenu
               v-if="channelsAreInstalled"
               appearance="raised-button"
               :text="coreString('optionsLabel')"
               position="bottom left"
               :options="dropdownOptions"
+              style="margin-top: 16px; margin-bottom: -16px;"
               class="options-btn"
               @select="handleSelect"
             />
             <KButton
               :text="$tr('import')"
+              style="margin-top: 16px; margin-bottom: -16px;"
               :primary="true"
               @click="startImportWorkflow()"
             />

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
@@ -3,7 +3,9 @@
   <div>
 
     <div class="description">
-      <h1>{{ coreString('devicePermissionsLabel') }}</h1>
+      <h1>
+        {{ coreString('devicePermissionsLabel') }}
+      </h1>
       <p>{{ $tr('devicePermissionsDescription') }}</p>
     </div>
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/OnboardingForm.vue
@@ -109,4 +109,9 @@
     margin-top: 24px;
   }
 
+  /deep/ .truncate-text {
+    // Ensure long text (like German) wrap and stay on screen
+    white-space: normal;
+  }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Addressing some visual issues in #7337 and finding that some no longer exist:

In order as they appear in #7337 

1) "N Channels selected [Import]" where text flows atop the button *not fixed here*

2) Facilites list table - buttons being cut off. (Also adding space between the KButtonGroup buttons when stacked)

https://user-images.githubusercontent.com/6356129/146487986-c0fd3a8f-4969-451a-b4a8-669b7169859c.mp4

3) Options and Import button hugging when stacked - added some space there:

![image](https://user-images.githubusercontent.com/6356129/146491252-b5cfc6b3-485f-4ff2-a4ea-e8acfd3c8473.png)

4) Device > Channels > Import 
4a) Table items misaligned - already improved by other work it seems. 
4b) Bottom app bar button & text like (1) above *not fixed here*

5) Stacked flat and primary buttons weird left-alignment - *not an issue the designs have changed* (although KButtonGroup should be refactored to accommodate more flexible designs)

6) Device permissions title overflow - I added `word-break: break-all` to that title. Not sure if this is the best way to handle this for all languages (or any languges for that matter @radinamatic) - now it just does this:

![image](https://user-images.githubusercontent.com/6356129/146488358-0a43a6d4-9aad-4863-a7ac-9be622a132ef.png)
 
7) Device > Info table URL cut off - *not fixed here* 

8) Probably not fixable except by wrapping the text within the button (gross and more work than it's worth to avoid regressions probably)

9) Device > Settings title overflowing - *not fixed here* but with feedback on (6) can apply it here if we don't undo the other similar word-break fix.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Partially fixes #7337 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Check it out - did I miss anything? Does it look okay in other non-German and non-English languages? How about RTL languages?

KButtonGroup could use some tweaks I think if we want to have it work so that it stacks. I think that IE11-safe flexbox might suit it well because we don't need anything from flex aside from basic flow-direction and content justification. 

Should the CoreTable in FacilitesPage just be a KGrid? Also I just thought maybe I could have used a colspan attr or something but if this works then it works :) 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
