### PR TITLE
Sticky side navigation improvements

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -7,7 +7,7 @@
 
     <div v-else class="page">
       <!-- Header with thumbail and tagline -->
-      <div v-if="!windowIsSmall" class="header">
+      <div v-if="!windowIsSmall" ref="header" class="header">
         <KGrid>
           <KGridItem
             class="breadcrumbs"
@@ -237,6 +237,7 @@
         v-if="!!windowIsLarge"
         v-model="searchTerms"
         :topicsListDisplayed="!desktopSearchActive"
+        class="side-panel"
         topicPage="True"
         :topics="topics"
         :activeActivityButtons="activeActivityButtons"
@@ -248,10 +249,7 @@
         :availableLabels="labels"
         :showChannels="false"
         position="embedded"
-        :style="{ position: 'fixed',
-                  marginTop: stickyTop,
-                  paddingTop: '24px',
-                  paddingBottom: '200px' }"
+        :style="sidePanelStyleOverrides"
         @currentCategory="handleShowSearchModal"
         @loadMoreTopics="handleLoadMoreInTopic"
       />
@@ -427,7 +425,7 @@
     },
     data: function() {
       return {
-        stickyTop: '388px',
+        sidePanelStyleOverrides: {},
         currentViewStyle: 'card',
         currentCategory: null,
         showSearchModal: false,
@@ -659,21 +657,25 @@
         option == 'search' ? (this.mobileSearchActive = true) : (this.mobileSearchActive = false);
         this.sidePanelIsOpen = !this.sidePanelIsOpen;
       },
+      // Stick the side panel to top. That can be on the very top of the viewport
+      // or right under the 'Browse channel' toolbar, depending on whether the toolbar
+      // is visible or no (the toolbar hides on smaller resolutions when scrolling
+      // down and appears again when scrolling up).
+      // Takes effect only when the side panel is not displayed full-screen.
       stickyCalculation() {
-        let header = document.getElementsByClassName('header')[0];
-        let topbar = document.getElementsByClassName('ui-toolbar')[0];
-        if (header) {
-          let position = header.getBoundingClientRect();
-          let topbarPosition = topbar.getBoundingClientRect();
-          if (position.bottom >= 64) {
-            this.stickyTop = `${position.bottom}px`;
-          } else if (position.bottom < 0 && topbarPosition.bottom < 0) {
-            this.stickyTop = '0px';
-          } else {
-            this.stickyTop = '64px';
-          }
+        const header = this.$refs.header;
+        const topbar = document.querySelector('.scrolling-header');
+        const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
+        const topbarBottom = topbar ? topbar.getBoundingClientRect().bottom : 0;
+
+        if (headerBottom < Math.max(topbarBottom, 0)) {
+          this.sidePanelStyleOverrides = {
+            position: 'fixed',
+            top: `${Math.max(0, headerBottom, topbarBottom)}px`,
+            height: '100%',
+          };
         } else {
-          null;
+          this.sidePanelStyleOverrides = {};
         }
       },
       handleShowMore(topicId) {
@@ -721,6 +723,8 @@
 
 <style lang="scss" scoped>
 
+  $header-height: 324px;
+
   .page {
     position: relative;
     overflow-x: hidden;
@@ -729,7 +733,7 @@
   .header {
     position: relative;
     width: 100%;
-    height: 324px;
+    height: $header-height;
     padding-top: 32px;
     padding-bottom: 48px;
     padding-left: 32px;
@@ -754,6 +758,13 @@
     position: absolute;
     bottom: 0;
     margin-bottom: 0;
+  }
+
+  .side-panel {
+    position: absolute;
+    top: $header-height;
+    height: calc(100% - #{$header-height});
+    padding-top: 16px;
   }
 
   .main-content-grid {


### PR DESCRIPTION
## Summary

This was originally fix for #8627. However, it seem that due to recent changes, behavior of the whole page is now different in regards to what is displayed at certain breakpoints and the problematic constellation of elements might be gone for now. or I wasn't able to find new conditions to reproduce it. However, I thought it might be good to submit the work, since it accounts for more scenarios in regards to hidden/visible top bar and also helped with jumping side navigation due to previously frequent styles updates.

## Reviewer guidance

Go to Library, select a channel, and scroll the page - it should scroll at first but as soon as the header is not visible, the side navigation should stick to the top of the page so that it's whole area is visible. It shouldn't get stuck or jump. Please test for more screen resolutions.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
