### PR TITLE
Progress update fix

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -250,7 +250,7 @@ class Job(object):
                     "storage is not defined on this job, cannot update progress"
                 )
             self.progress = progress
-            self.total_progress = progress
+            self.total_progress = total_progress
             self.storage.update_job_progress(self.job_id, progress, total_progress)
 
     def check_for_cancel(self):
@@ -270,7 +270,7 @@ class Job(object):
             raise ReferenceError(
                 "storage is not defined on this job, cannot save as cancellable"
             )
-        self.job.cancellable = cancellable
+        self.cancellable = cancellable
         self.storage.save_job_as_cancellable(self.job_id, cancellable=cancellable)
 
     @property

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -270,6 +270,7 @@ class Job(object):
             raise ReferenceError(
                 "storage is not defined on this job, cannot save as cancellable"
             )
+        self.job.cancellable = cancellable
         self.storage.save_job_as_cancellable(self.job_id, cancellable=cancellable)
 
     @property

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -249,6 +249,8 @@ class Job(object):
                 raise ReferenceError(
                     "storage is not defined on this job, cannot update progress"
                 )
+            self.progress = progress
+            self.total_progress = progress
             self.storage.update_job_progress(self.job_id, progress, total_progress)
 
     def check_for_cancel(self):

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -7,7 +7,7 @@ from kolibri.core.tasks.job import RegisteredJob
 
 class JobTest(TestCase):
     def setUp(self):
-        self.job = Job(id)
+        self.job = Job(id, track_progress=True)
         self.job.storage = mock.MagicMock()
 
     def test_job_save_as_cancellable(self):
@@ -17,6 +17,23 @@ class JobTest(TestCase):
         self.job.storage.save_job_as_cancellable.assert_called_once_with(
             self.job.job_id, cancellable=cancellable
         )
+
+    def test_job_save_as_cancellable_sets_cancellable(self):
+        cancellable = not self.job.cancellable
+
+        self.job.save_as_cancellable(cancellable=cancellable)
+        self.assertEqual(self.job.cancellable, cancellable)
+
+    def test_job_update_progress_saves_progress_to_storage(self):
+        self.job.update_progress(0.5, 1.5)
+        self.job.storage.update_job_progress.assert_called_once_with(
+            self.job.job_id, 0.5, 1.5
+        )
+
+    def test_job_update_progress_sets_progress(self):
+        self.job.update_progress(0.5, 1.5)
+        self.assertEqual(self.job.progress, 0.5)
+        self.assertEqual(self.job.total_progress, 1.5)
 
     def test_job_save_as_cancellable__skip(self):
         cancellable = self.job.cancellable


### PR DESCRIPTION
## Summary
* Fixes bug in the task tracking machinery where calling `save_meta` on a Job object would overwrite previously set attributes like `progress`, `total_progress`, and `cancellable` because it resaves the entire job state.
* Does this by explicitly setting the updated attributes onto the job object as well as persisting them to the backend

## References
Fixes #6712

## Reviewer guidance
Are the correct attributes being set? Do all the attributes being set correspond to the attribute being set in the method? Do they all correspond to attributes being set during the Job `__init__` method?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
