### PR TITLE
Update button on library page to also read 'filter'

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -8,7 +8,7 @@
       <div v-if="!windowIsLarge">
         <KButton
           icon="filter"
-          :text="coreString('searchLabel')"
+          :text="translator.$tr('filter')"
           :primary="false"
           @click="toggleSidePanelVisibility"
         />
@@ -239,6 +239,8 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import FullScreenSidePanel from 'kolibri.coreVue.components.FullScreenSidePanel';
+  import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import genContentLink from '../utils/genContentLink';
   import { PageNames } from '../constants';
   import useSearch from '../composables/useSearch';
@@ -374,6 +376,7 @@
     },
     created() {
       this.search();
+      this.translator = crossComponentTranslator(FilterTextbox);
     },
     methods: {
       genContentLink,


### PR DESCRIPTION

## Summary
Uses the same cross component translator code that is used in TopicsPage to update button to read 'filter' for consistency across pages and to spec

## References

No issue 


<img width="767" alt="Screen Shot 2021-12-17 at 1 31 45 PM" src="https://user-images.githubusercontent.com/17235236/146591566-3e0fa024-21a2-4c9a-a348-a72da7f60ac2.png">




## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->



----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
