### PR TITLE
Fix upgrade issue

### DIFF
--- a/kolibri/plugins/registry.py
+++ b/kolibri/plugins/registry.py
@@ -50,6 +50,9 @@ from kolibri.plugins.utils import PluginLoadsApp
 logger = logging.getLogger(__name__)
 
 
+__initialized = False
+
+
 class PluginExistsInApp(Exception):
     """
     This exception is raise when a plugin is initialized inside a Django app and
@@ -163,6 +166,7 @@ def __initialize():
     """
     Called once to register hook callbacks.
     """
+    global __initialized
     registry = Registry()
     logger.debug("Loading kolibri plugin registry...")
     was_configured = settings.configured
@@ -171,7 +175,12 @@ def __initialize():
             "Django settings already configured when plugin registry initialized"
         )
     registry.register_plugins(config.ACTIVE_PLUGINS)
+    __initialized = True
     return registry
 
 
 registered_plugins = SimpleLazyObject(__initialize)
+
+
+def is_initialized():
+    return __initialized

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -392,6 +392,11 @@ def autoremove_unavailable_plugins():
     configured by the user or some other kind of hard dependency that should
     make execution stop if not loadable.
     """
+    from kolibri.plugins.registry import is_initialized
+
+    if is_initialized():
+        # TODO: Turn this into a Runtime error
+        logger.warning("Attempted to updated plugins when registry is initialized")
     changed = False
     # Iterate over a copy of the set so that it is not modified during the loop
     for module_path in config["INSTALLED_PLUGINS"].copy():
@@ -415,6 +420,11 @@ def enable_new_default_plugins():
     default plugins that have been explicitly disabled by a user,
     in versions prior to the implementation of a plugin blacklist.
     """
+    from kolibri.plugins.registry import is_initialized
+
+    if is_initialized():
+        # TODO: Turn this into a Runtime error
+        logger.warning("Attempted to updated plugins when registry is initialized")
     changed = False
     for module_path in DEFAULT_PLUGINS:
         if module_path not in config["INSTALLED_PLUGINS"]:

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -2,8 +2,6 @@ import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
 
-from . import conf
-
 
 GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
@@ -105,11 +103,14 @@ class FalseFilter(logging.Filter):
         return False
 
 
-class RequireDebugTrue(logging.Filter):
-    """A copy from Django to avoid loading Django's settings stack"""
+def get_require_debug_true(debug):
+    class RequireDebugTrue(logging.Filter):
+        """A copy from Django to avoid loading Django's settings stack"""
 
-    def filter(self, record):
-        return conf.OPTIONS["Server"]["DEBUG"]
+        def filter(self, record):
+            return debug
+
+    return RequireDebugTrue
 
 
 def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
@@ -227,7 +228,7 @@ def get_base_logging_config(LOG_ROOT, debug=False, debug_database=False):
     config = get_default_logging_config(
         LOG_ROOT, debug=debug, debug_database=debug_database
     )
-    config["filters"]["require_debug_true"] = {"()": RequireDebugTrue}
+    config["filters"]["require_debug_true"] = {"()": get_require_debug_true(debug)}
 
     return config
 

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -190,11 +190,20 @@ def _upgrades_before_django_setup(updated, version):
     if version and updated:
         check_plugin_config_file_location(version)
 
+    # Do this here so that we can fix any issues with our configuration file before
+    # we attempt to set up django.
+    autoremove_unavailable_plugins()
+
     if updated:
         # Reset the enabled plugins to the defaults
         # This needs to be run before dbbackup because
         # dbbackup relies on settings.INSTALLED_APPS
         enable_new_default_plugins()
+
+    # Ensure that we have done all manipulations of our plugins registry before
+    # we do the check for options.ini as that will invoke our plugin registry.
+    # Check if there is an options.ini file exist inside the KOLIBRI_HOME folder
+    check_default_options_exist()
 
     if OPTIONS["Database"]["DATABASE_ENGINE"] == "sqlite":
         # If we are using sqlite,
@@ -255,13 +264,6 @@ def initialize(
     default_options = DefaultDjangoOptions(settings, pythonpath)
 
     handle_default_options(default_options)
-
-    # Do this here so that we can fix any issues with our configuration file before
-    # we attempt to set up django.
-    autoremove_unavailable_plugins()
-
-    # Check if there is an options.ini file exist inside the KOLIBRI_HOME folder
-    check_default_options_exist()
 
     version = get_version()
 


### PR DESCRIPTION
## Summary
* Do all plugin changes before checking options
* Prevent logging from accessing the options and hence initializing the registry while the plugin configuration is still being cleaned up

## References
Fixes unresolved issue first noted here: https://github.com/learningequality/kolibri/pull/8895#issuecomment-995616965

## Reviewer guidance
Do the upgrade from 0.14.7 to 0.15.0 does everything work as expected? Specifically, can you see Perseus exercises anywhere in the UI?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
