### PR TITLE
Don't package core node_modules dir

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,23 +6,20 @@ include README.md
 include kolibri/VERSION
 recursive-include kolibri/locale *.mo
 recursive-include kolibri/locale *.json
-recursive-include kolibri/auth *
-recursive-include kolibri/content *
 recursive-include kolibri/core *
 recursive-include kolibri/deployment *
 recursive-include kolibri/dist *
-recursive-include kolibri/logger *
 recursive-include kolibri/plugins *
-recursive-include kolibri/test *
 recursive-include kolibri/utils *
-recursive-include kolibri/tasks *
 recursive-include kolibri/*/static *.*
 recursive-include kolibri/*/build/ *.json
 recursive-include kolibri/plugins/*/build *.json
 include kolibri/plugins/*/content_types.json
 
 recursive-exclude kolibri/* *pyc
+recursive-exclude kolibri/* *pyo
 recursive-exclude kolibri/core/assets *
+recursive-exclude kolibri/core/node_modules *
 recursive-exclude kolibri/plugins/*/assets *
 recursive-exclude kolibri/plugins/*/node_modules *
 exclude kolibri/*/buildConfig.js


### PR DESCRIPTION
## Summary
* Cleans up outdated references in MANIFEST.in
* Adds exclude for the node_modules directory in kolibri/core which is never needed in production

## Reviewer guidance
This is a low risk change as it is removing references to folders that don't exist or adding an exclude for a directory that has never been used in production.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
