### PR TITLE
Truncate uncompressed files when packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ clean: clean-build clean-pyc clean-assets clean-staticdeps
 
 clean-assets:
 	yarn run clean
+	rm -fr kolibri/core/content/static/hashi/
 
 clean-build:
 	rm -f kolibri/VERSION

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -26,9 +26,7 @@ from kolibri.plugins.utils import plugin_url
 
 @define_hook
 class NavigationHook(WebpackBundleHook):
-
-    # Set this to True so that the resulting frontend code will be rendered inline.
-    inline = True
+    pass
 
 
 @define_hook

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -164,7 +164,6 @@ class FrontendHeadAssetsHook(WebpackBundleHook):
     """
 
     bundle_id = "frontend_head_assets"
-    inline = True
 
     def render_to_page_load_sync_html(self):
         """

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -69,10 +69,6 @@ class WebpackBundleHook(hooks.KolibriHook):
     def bundle_id(self):
         pass
 
-    # : When being included for synchronous loading, should the source files
-    # : for this be inlined?
-    inline = False
-
     # : A mapping of key to JSON serializable value.
     # : This plugin_data will be bootstrapped into a global object on window
     # : with a key of the unique_id as a Javascript object
@@ -211,37 +207,12 @@ class WebpackBundleHook(hooks.KolibriHook):
     def js_and_css_tags(self):
         js_tag = '<script type="text/javascript" src="{url}"></script>'
         css_tag = '<link type="text/css" href="{url}" rel="stylesheet"/>'
-        inline_js_tag = '<script type="text/javascript">{src}</script>'
-        inline_css_tag = "<style>{src}</style>"
         # Sorted to load css before js
         for chunk in self.sorted_chunks():
-            src = None
             if chunk["name"].endswith(".js"):
-                if self.inline:
-                    # During development, we do not write built files to disk
-                    # Because of this, this call might return None
-                    src = self.get_filecontent(chunk["url"])
-                if src is not None:
-                    # If it is not None, then we can inline it
-                    yield inline_js_tag.format(src=src)
-                else:
-                    # If src is None, either this is not something we should be inlining
-                    # or we are in development mode and need to fetch the file from the
-                    # development server, not the disk
-                    yield js_tag.format(url=chunk["url"])
+                yield js_tag.format(url=chunk["url"])
             elif chunk["name"].endswith(".css"):
-                if self.inline:
-                    # During development, we do not write built files to disk
-                    # Because of this, this call might return None
-                    src = self.get_filecontent(chunk["url"])
-                if src is not None:
-                    # If it is not None, then we can inline it
-                    yield inline_css_tag.format(src=src)
-                else:
-                    # If src is None, either this is not something we should be inlining
-                    # or we are in development mode and need to fetch the file from the
-                    # development server, not the disk
-                    yield css_tag.format(url=chunk["url"])
+                yield css_tag.format(url=chunk["url"])
 
     def frontend_message_tag(self):
         if self.frontend_messages():

--- a/kolibri/plugins/hooks.py
+++ b/kolibri/plugins/hooks.py
@@ -110,9 +110,7 @@ Here is the definition of the abstract NavigatonHook in kolibri.core.hooks:
 
     @define_hook
     class NavigationHook(WebpackBundleHook):
-
-        # Set this to True so that the resulting frontend code will be rendered inline.
-        inline = True
+        pass
 
 As can be seen from above, to define an abstract hook, instead of using the ``@register_hook``
 decorator, the ``@define_hook`` decorator is used instead, to signal that this instance of

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
     "hashi-build": "yarn workspace hashi run build",
-    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{js,css,ico,svg,map,eot,woff,ttf,woff2}'"
+    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{html,js,css,ico,svg,map,eot,woff,ttf,woff2}'"
   },
   "repository": {
     "type": "git",

--- a/packages/kolibri-tools/lib/compress.js
+++ b/packages/kolibri-tools/lib/compress.js
@@ -1,6 +1,6 @@
 const { constants, createGzip } = require('zlib');
 const { pipeline } = require('stream');
-const { createReadStream, createWriteStream } = require('fs');
+const { createReadStream, createWriteStream, truncate } = require('fs');
 const logger = require('./logging');
 
 const logging = logger.getLogger('Kolibri Compressor');
@@ -16,10 +16,16 @@ function compressFile(input) {
       if (err) {
         logging.error('An error occurred compressing file: ', input);
         logging.error(err);
+        resolve();
       } else {
-        logging.info('Successfully compressed: ', input);
+        truncate(input, err => {
+          if (err) {
+            logging.error('An error occurred truncating original file: ', input);
+          }
+          logging.info('Successfully compressed: ', input);
+          resolve();
+        });
       }
-      resolve();
     });
   });
 }


### PR DESCRIPTION
## Summary
* Truncates compressed files after successful compression so that we save space in our whl file.
* Removes capability to inline JS and CSS assets - this seems OK, as it shifts a lot of assets that are shared across multiple SPA pages out of HTML, and should on the whole improve the load time. It also interacted badly with the truncated assets, as it would just inline those!

## References
Follow up to https://github.com/learningequality/kolibri/pull/7797 which introduced the pre-compression of static files, but did not remove uncompressed files.

## Reviewer guidance
This is a higher risk change than the other packaging PRs but seems to produce the most dramatic results on the final whl size.

In terms of impact on users, if the files are served as gzipped only, this should not impact users as this is supported by nearly all browsers: https://caniuse.com/sr_content-encoding-gzip

However, it is possible there may be quirks in the static file serving that cause it to not work as expected when the original files are missing.

As long as static assets load as expected from the built asset, this should be safe.

New WHL size: 87MB

**The main consideration here is that if a device explicitly requests the `identity` `Accept-Encoding` header it will return an empty file instead of the actual file. The other alternative is to return a 406 status code if the identity header is passed for one of these files, but this seems to be [explicitly disallowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding).**

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
