### PR TITLE
Last minute bug fixes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -561,6 +561,8 @@
 
 <style lang="scss" scoped>
 
+  @import '~kolibri-design-system/lib/styles/definitions';
+
   .search-filters {
     margin-top: 24px;
   }

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
@@ -7,6 +7,7 @@
     <KButton
       appearance="flat-button"
       :appearanceOverrides="customActivityStyles"
+      :disabled="activeKeys.length === 0"
       @click="$emit('input', null)"
     >
       <KIcon icon="allActivities" class="activity-icon" />

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -314,14 +314,18 @@
         this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
       },
       handleActivity(activity) {
-        let learning_activities;
-        if (this.value.learning_activities[activity]) {
-          learning_activities = {};
+        if (activity === null) {
+          const learning_activities = {};
           this.$emit('input', { ...this.value, learning_activities });
-        } else if (activity || !this.value.learning_activities[activity]) {
-          learning_activities = {
+        } else if (activity && !this.value.learning_activities[activity]) {
+          const learning_activities = {
             [activity]: true,
+            ...this.value.learning_activities,
           };
+          this.$emit('input', { ...this.value, learning_activities });
+        } else if (activity && this.value.learning_activities[activity]) {
+          const learning_activities = { ...this.value.learning_activities };
+          delete learning_activities[activity];
           this.$emit('input', { ...this.value, learning_activities });
         }
       },


### PR DESCRIPTION
## Summary
* Fixes reference to design system variable that did not have the proper import to make it defined.
* Fixes handling of learning activity selection.

## Reviewer guidance
Run build without this PR. Gives big error on coach plugin because of missing variable.

Use `all` button on Learning Activities without this PR, results in selection of `learning_activities=null` which is not what is intended. This updates it to clear any existing learning activities.

Previously:
![before](https://user-images.githubusercontent.com/1680573/146716448-7dc68336-ab58-41f9-a9ac-66b47b5c617b.gif)

Now:
![learning_activities](https://user-images.githubusercontent.com/1680573/146716240-19e25e21-a058-477f-b767-6073bad1f386.gif)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
