### PR TITLE
Info level logs in env.py only for kolibri start command

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -99,7 +99,7 @@ def prepend_cext_path(dist_path):
         # add it + the matching noarch (OpenSSL) modules to sys.path
         sys.path = [str(dirname), str(noarch_dir)] + sys.path
     else:
-        logger.info("No C extensions are available for this platform")
+        logger.debug("No C extensions are available for this platform")
 
 
 def check_python_versions():


### PR DESCRIPTION
## Summary
1. Fix for issue: https://github.com/learningequality/kolibri/issues/7972
2. Approach tried before to set WARNING logging level for env.py from any other file does not work since it gets reset due to this configuration: https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/utils/env.py#L6
3. Currently, I have restricted logging to only 'kolibri start' command, which fixes the issue for a lot of other commands too. If this is not safe, we can also skip printing the log line for just 'kolibri plugins list' command 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
