### PR TITLE
Fix slow-closing submit modal

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -379,9 +379,9 @@ export default function useProgressTracking(store) {
         Math.min(threeDecimalPlaceRoundup(get(progress_state) + progressDelta), 1)
       );
     }
-    if (get(progress_state) >= 1) {
-      set(complete, true);
-    }
+    // if (get(progress_state) >= 1) {
+    //   set(complete, true);
+    // }
     if (!isUndefined(contentState)) {
       if (!isPlainObject(contentState)) {
         throw TypeError('contentState must be an object');

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -379,9 +379,6 @@ export default function useProgressTracking(store) {
         Math.min(threeDecimalPlaceRoundup(get(progress_state) + progressDelta), 1)
       );
     }
-    // if (get(progress_state) >= 1) {
-    //   set(complete, true);
-    // }
     if (!isUndefined(contentState)) {
       if (!isPlainObject(contentState)) {
         throw TypeError('contentState must be an object');

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -384,6 +384,12 @@
         if ($coreSnackbar && $coreSnackbar.contains(target)) {
           return;
         }
+        // If there is an open KModal, the base case allows us to avoid
+        // the infinite recursion caused by trying to focus trap the KModal
+        const $coreModal = document.getElementById('modal-window');
+        if ($coreModal && $coreModal.contains(target)) {
+          return;
+        }
         // focus has escaped the modal - put it back!
         if (!this.$refs.modal.contains(target)) {
           this.focusModal();

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -38,6 +38,7 @@
         :mastered="complete"
         :masteryLevel="masteryLevel"
         :updateContentSession="wrappedUpdateContentSession"
+        :hideSubmitModal="progress >= 1 && wasIncomplete"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateInteraction="updateInteraction"

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -38,7 +38,6 @@
         :mastered="complete"
         :masteryLevel="masteryLevel"
         :updateContentSession="wrappedUpdateContentSession"
-        :hideSubmitModal="progress >= 1 && wasIncomplete"
         @startTracking="startTracking"
         @stopTracking="stopTracking"
         @updateInteraction="updateInteraction"

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -203,6 +203,10 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
+      hideSubmitModal: {
+        type: Boolean,
+        default: false,
+      },
       content: {
         type: Object,
         required: true,
@@ -335,6 +339,12 @@
       },
     },
     watch: {
+      hideSubmitModal(newVal, oldVal) {
+        if (newVal === true) {
+          this.submitModalOpen = false;
+        }
+        console.log(oldVal);
+      },
       itemId(newVal, oldVal) {
         // HACK: manually dismiss the perseus renderer message when moving
         // to a different item (fixes #3853)

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -203,10 +203,6 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
-      hideSubmitModal: {
-        type: Boolean,
-        default: false,
-      },
       content: {
         type: Object,
         required: true,
@@ -339,12 +335,6 @@
       },
     },
     watch: {
-      hideSubmitModal(newVal, oldVal) {
-        if (newVal === true) {
-          this.submitModalOpen = false;
-        }
-        console.log(oldVal);
-      },
       itemId(newVal, oldVal) {
         // HACK: manually dismiss the perseus renderer message when moving
         // to a different item (fixes #3853)
@@ -382,6 +372,9 @@
 
         if (close) {
           data.progress = 1;
+          data.force = true;
+          data.immediate = true;
+          this.submitting = true;
         } else {
           // We don't set progress to 1 until the quiz is submitted, so we max out here.
           // If any interaction has happened, we set a peppercorn progress so that it shows
@@ -393,9 +386,6 @@
               0.99
             )
           );
-        }
-        if (close) {
-          this.submitting = true;
         }
         return this.updateContentSession(data).then(() => {
           if (close) {


### PR DESCRIPTION
## Summary
1. Fixes infinite loop error in `CompletionModal`
2. Fixes "submit" modal not disappearing after `CompletionModal` is closed by adding `force` and `immediate` to the `QuizRenderer` when saving the exam attempt log and closing the submit modal for `updateContentSession`

What you should see now:
![2021-12-29 14 39 12](https://user-images.githubusercontent.com/13563002/147708640-bc759a04-f87d-473d-9da3-cd0bdc97fbc8.gif)

## References
Fixes #8893 - in particular, this error: https://github.com/learningequality/kolibri/issues/8893#issuecomment-994130168

## Reviewer guidance
1. Sign in as learner (open console in browser)
2. Find a practice quiz that has other resources lined up after the practice quiz
3. Take and submit the practice quiz
4. Immediate click on the "x" on the upper right hand corner to close the `CompletionModal`
5. You should not see any RangeErrors in the console and you should not see the practice quiz submit modal at all

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
