### PR TITLE
[DO NOT MERGE] Introduce KDS breadcrumbs fixes

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.36",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
+    "kolibri-design-system": "git://github.com/MisRob/kolibri-design-system#f8c095f151f9cc33a2dea117940d8b48b2cac0cf",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8838,6 +8838,20 @@ kolibri-constants@0.1.36:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.36.tgz#c9ab07305dc6e052547b830a91e61a58757bb1ee"
   integrity sha512-61FoLBFjOXoBu7lsAKFltkZCwwzVO/Cwmgq+wBqkoTmLw92ma6shLP/ZYaNrzYNhuEn4gHfCC6zWZoLoC1hp/w==
 
+"kolibri-design-system@git://github.com/MisRob/kolibri-design-system#f8c095f151f9cc33a2dea117940d8b48b2cac0cf":
+  version "1.2.1"
+  resolved "git://github.com/MisRob/kolibri-design-system#f8c095f151f9cc33a2dea117940d8b48b2cac0cf"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
 "kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.2.1":
   version "1.2.1"
   resolved "git://github.com/learningequality/kolibri-design-system#fe3ab268a8ed0470d1ac74e23c56b0a8c8e5f9e0"


### PR DESCRIPTION
## Summary

Pins KDS to https://github.com/learningequality/kolibri-design-system/pull/292.

Do not merge. The temporary commit will be replaced by the new KDS release tag as soon as the first reviews are completed.

## References

Resolves https://github.com/learningequality/kolibri/issues/6918

## Reviewer guidance

See testing instructions in https://github.com/learningequality/kolibri-design-system/pull/292.

There's no need to use `yarn link` locally to test KDS updates in Kolibri since this PR contains a commit that temporarily pins the corresponding KDS commit for testing. You only need to run `yarn install` to update dependencies after checking out this PR's branch.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
