### PR TITLE
Various UI fixes and improvements

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -357,7 +357,7 @@
         }
         return {
           top: this.fixedAppBar ? `${this.appbarHeight}px` : 0,
-          padding: `${this.windowIsSmall ? 16 : 32}px`,
+          padding: `32px ${this.windowIsSmall ? 16 : 32}px`,
         };
       },
       mainStyles() {

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -18,6 +18,7 @@
 
       <FocusTrap
         ref="focusTrap"
+        class="ui-menu-options"
         :disabled="!containFocus"
         :firstEl="firstFocusableEl"
         :lastEl="lastFocusableEl"
@@ -113,11 +114,17 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
+
   .ui-menu-header {
     padding: 1rem 1rem 1rem 1.2rem;
     font-size: 0.9375rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   }
+
+  .ui-menu-options {
+    padding-top: 4px; // make enough space for the keyboard focus ring
+  }
+
   .ui-menu-footer {
     padding: 1rem 1rem 0 1.2rem;
     border-top: 1px solid rgba(0, 0, 0, 0.08);

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -366,7 +366,7 @@
     position: fixed;
     bottom: 0;
     left: 0;
-    padding-top: 8px;
+    padding-top: 4px;
     overflow: auto;
   }
 

--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="password-textbox">
     <KTextbox
       ref="password"
       :value="value"
@@ -146,4 +146,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .password-textbox {
+    padding-top: 8px; // make enough space for the keyboard focus ring
+  }
+
+</style>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -26,10 +26,18 @@
       </div>
 
       <KFixedGrid numCols="4">
-        <KFixedGridItem span="1" class="version">
-          <p>{{ $tr('version', { version: versionNumber }) }}</p>
+        <KFixedGridItem
+          :span="windowIsSmall ? 4 : 1"
+          class="version"
+        >
+          <p :style="[windowIsSmall ? { marginBottom: 0 } : {}]">
+            {{ $tr('version', { version: versionNumber }) }}
+          </p>
         </KFixedGridItem>
-        <KFixedGridItem span="3" alignment="right">
+        <KFixedGridItem
+          :span="windowIsSmall ? 4 : 3"
+          :alignment="windowIsSmall ? 'left' : 'right'"
+        >
           <p><slot></slot></p>
         </KFixedGridItem>
       </KFixedGrid>
@@ -77,6 +85,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import DeviceInfoPage from '../DeviceInfoPage.vue';
 
   export default {
@@ -84,7 +93,7 @@
     components: {
       TextTruncatorCss,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, KResponsiveWindowMixin],
     props: {
       channel: {
         type: Object,

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -12,7 +12,7 @@
           {{ $tr('unlistedChannelTooltip') }}
         </KTooltip>
         <h1>
-          <KLabeledIcon icon="channel" :label="channel.name">
+          <KLabeledIcon icon="channel">
             <template #iconAfter>
               <KIcon
                 v-if="channel.public === false"
@@ -20,6 +20,7 @@
                 icon="unlistedchannel"
               />
             </template>
+            <TextTruncatorCss :text="channel.name" />
           </KLabeledIcon>
         </h1>
       </div>
@@ -74,11 +75,15 @@
 
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import DeviceInfoPage from '../DeviceInfoPage.vue';
 
   export default {
     name: 'ChannelContentsSummary',
+    components: {
+      TextTruncatorCss,
+    },
     mixins: [commonCoreStrings],
     props: {
       channel: {
@@ -151,11 +156,6 @@
 
 
 <style lang="scss" scoped>
-
-  .labeled-icon-wrapper {
-    width: auto;
-    white-space: nowrap;
-  }
 
   .channel-header {
     margin-top: 16px;


### PR DESCRIPTION
## Summary

Introduces several UI fixes and improvements in the whole app:

### (1) More vertical space in the content area of a page to account for the case when the horizontal scrollbar gets displayed in the top navigation bar

| Before | After |
| -------- | ------- |
| ![learn-home-before](https://user-images.githubusercontent.com/13509191/147932633-7804c0cb-5d77-473b-aa78-fb11aa3233b2.png) | ![learn-home-after](https://user-images.githubusercontent.com/13509191/147932631-087486f4-fb1c-4cfc-87a4-785cb4409be8.png) |


### (2) Mobile responsiveness improvements in "Device" on the page for selecting resources for import from a channel 

| Before | After |
| -------- | ------- |
| ![import-resources-before](https://user-images.githubusercontent.com/13509191/147933594-6cc28b67-aedf-47ba-af77-e24ec0345366.png) | ![import-resources-after](https://user-images.githubusercontent.com/13509191/147933590-e5c8b58a-8318-4dba-bee3-48683fe3faf9.png) |

### (3) "New version" information mobile responsiveness in "Device" on the page for managing a channel

| Before | After |
| -------- | ------- |
| ![manage-before](https://user-images.githubusercontent.com/13509191/147933982-2c1b1e5a-1ceb-423a-b4b4-b643d934bdb1.png) | ![manage-after](https://user-images.githubusercontent.com/13509191/147933980-e27f556a-b2e0-41c4-bd59-d2c3b8664dc8.png) |

### (4) Fixes the keyboard focus ring in the side menu

| Before | After |
| -------- | ------- |
| ![ring-menu-before](https://user-images.githubusercontent.com/13509191/147949182-c666b343-3d32-4b55-8995-07a442968d0c.png) | ![ring-menu-after](https://user-images.githubusercontent.com/13509191/147949181-0a2f8984-4657-4565-8425-f4070da3da12.png) |

### (5) Fixes the keyboard focus ring on the password change modal

| Before | After |
| -------- | ------- |
| ![ring-pw-before](https://user-images.githubusercontent.com/13509191/147949254-9b286956-711c-4561-a2ff-e4f4ca7ccb8c.png) | ![ring-pw-after](https://user-images.githubusercontent.com/13509191/147949252-f9620ce6-356c-4d80-914b-5e1ed27566e0.png) |

## Reviewer guidance

Can you see any regressions in the updated places?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
