### PR TITLE
Note which plugin has errors in webpack_json kolibri_plugin

### DIFF
--- a/packages/kolibri-tools/lib/webpack_json.py
+++ b/packages/kolibri-tools/lib/webpack_json.py
@@ -118,7 +118,7 @@ def plugin_data(module_path):
     # Python 3.7 raises a TypeError for an empty directory
     except (NotImplementedError, TypeError):
         pass
-    raise ImportError("No frontend build assets")
+    raise ImportError("No frontend build assets for plugin {}".format(module_path))
 
 
 def initialize_plugins(build_list):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Some outdated guidance RE: the VF plugin where I listed a bunch of plugins to put into `build_tools/build_plugins.txt` that included old names for Device and Facility threw an ambiguous "No frontend build assets" error. I was pretty confident I'd updated the `kolibri_instant_schools_plugin` properly - the change here made it clear that `kolibri.plugins.facility_management` was where it was failing... because that's not a plugin :facepalm:

Anyway - just adds some context to the error for the next person to run into the error.

