### PR TITLE
Fix Library and Topics pages side panel scrolling

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -89,7 +89,7 @@
     data() {
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
-        fixedHeaderHeight: null,
+        fixedHeaderHeight: 0,
       };
     },
     computed: {
@@ -148,7 +148,7 @@
           'margin-top': this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
-          height: `calc((100vh - ${this.fixedHeaderHeight}))`,
+          height: `calc((100vh - ${this.fixedHeaderHeight}px))`,
         };
       },
       closeButtonStyles() {

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -12,13 +12,16 @@
       >
 
         <!-- Fixed header with optional close button -->
-        <div v-if="$slots.header" ref="fixedHeader" class="fixed-header" :style="fixedHeaderStyles">
-
+        <div
+          v-show="$slots.header"
+          ref="fixedHeader"
+          class="fixed-header"
+          :style="fixedHeaderStyles"
+        >
           <div class="header-content" tabindex="0">
             <slot name="header">
             </slot>
           </div>
-
         </div>
 
         <KIconButton
@@ -158,7 +161,6 @@
     mounted() {
       const htmlTag = window.document.getElementsByTagName('html')[0];
       htmlTag.style['overflow-y'] = 'hidden';
-
       // Gets the height of the fixed header - adds 40 to account for padding
       this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 'px';
 


### PR DESCRIPTION
## Summary
There seems to be 2 bugs in 0.15 for users in a mobile-responsive environment where the user cannot scroll vertically to access the rest of the content in the side panel overlay and the folders were not coming up on the Topics page correctly.

1. Scrolling: this seems to be due to the use of `v-if` instead `v-show` for the fixed header because `v-show` would allow the element to be rendered to the DOM so that it is accessible during the `mounted` hook.
2. Folders: this is because the `fixedHeaderHeight` was `null`, but needs to actually be set to `0`, as `calc` requires a number and a unit.

This was tested manually on the Library and Topics pages, but I'm not too familiar with the full spec so it would be helpful to see if this makes any other breaking changes in other parts of the code.

|Previous behavior (unable to scroll vertically)|Changed behavior (able to scroll)|
|--|--|
|![2022-01-10 20 19 15](https://user-images.githubusercontent.com/13563002/148880483-1cd61b28-7dec-44c9-b48b-9ddcb04b9626.gif)|![2022-01-10 20 18 35](https://user-images.githubusercontent.com/13563002/148880476-9dd70222-ac8d-4391-936b-930bbff15081.gif)|

|Previous behavior (folders)|Changed behavior (folders)|
|--|--|
|<img width="540" alt="Screen Shot 2022-01-13 at 10 07 52 AM" src="https://user-images.githubusercontent.com/13563002/149385169-a01352c3-1aa1-4d4d-8e79-18304af1cdfb.png">|<img width="540" alt="Screen Shot 2022-01-13 at 10 07 02 AM" src="https://user-images.githubusercontent.com/13563002/149385066-c1fb4d70-4e61-4286-9f55-30dc137dfdeb.png">|

## References
None

## Reviewer guidance
Check that this does not break any instances where `FullScreenSidePanel` is used (bookmark, library, topics pages) for a user on a responsive screen.

Additionally, @jtamiace, is this the correct behavior for scrolling for a side panel?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
