### PR TITLE
Handle no xAPI statements existing.

### DIFF
--- a/packages/hashi/src/xAPI/xAPIInterface.js
+++ b/packages/hashi/src/xAPI/xAPIInterface.js
@@ -79,7 +79,7 @@ export default class xAPI extends BaseShim {
       return 1;
     }
     // If there has been any interaction return some progress, otherwise null.
-    return Object.keys(this.data[STATEMENT]).length ? 0.01 : null;
+    return Object.keys(this.data[STATEMENT] || {}).length ? 0.01 : null;
   }
 
   createAgent() {


### PR DESCRIPTION
## Summary
* Fixes unreported bug where xAPI progress calculation would error when no statements had been recorded.

## Reviewer guidance
Ensure that entering an HTML5 app (not H5P) does not produce an error in the console like this:
```
xAPIInterface.js:82 Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at xAPI.__calculateProgress (xAPIInterface.js:82)
    at MainClient.getProgress (mainClient.js:146)
    at Sub.recordProgress (Html5AppRendererIndex.vue:188)
    at Html5AppRendererIndex.vue:198
```

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
