### PR TITLE
Fix `isTopic` error on Topics page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -77,7 +77,7 @@
             v-if="isUserLoggedIn && !isLearner && content.num_coach_contents"
             class="coach-footer-icon"
             :value="content.num_coach_contents"
-            :isTopic="isTopic"
+            :isTopic="content.num_coach_contents >= 1"
           />
           <KIconButton
             v-for="(value, key) in footerIcons"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -77,7 +77,7 @@
             v-if="isUserLoggedIn && !isLearner && content.num_coach_contents"
             class="coach-footer-icon"
             :value="content.num_coach_contents"
-            :isTopic="content.num_coach_contents >= 1"
+            :isTopic="!content.is_leaf"
           />
           <KIconButton
             v-for="(value, key) in footerIcons"


### PR DESCRIPTION
## Summary
Add method to check whether resource returns boolean for the `isTopic` prop to be passed into `CoachContentLabel`.

## References
Errors from before:
<img width="1512" alt="Screen Shot 2022-01-13 at 2 41 00 PM" src="https://user-images.githubusercontent.com/13563002/149421811-6399b532-44c6-4aa6-9b03-02215a6e2a15.png">

## Reviewer guidance
Check to see that there are no more errors in the console when in the Topics page, and that nothing else is broken as a result of this change (`HybridLearningCardGrid`, is used in Library, Topics, Bookmarks, and Lesson playlist pages)

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
