### PR TITLE
Content API: Change default ordering to "lft"

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -555,14 +555,11 @@ class BaseContentNodeMixin(object):
 
 
 class OptionalPagination(ValuesViewsetCursorPagination):
-    ordering = "id"
+    ordering = ("lft", "id")
     page_size_query_param = "max_results"
 
 
 class OptionalContentNodePagination(OptionalPagination):
-    ordering = "id"
-    page_size_query_param = "max_results"
-
     def paginate_queryset(self, queryset, request, view=None):
         # Record the queryset for use in returning available filters
         self.queryset = queryset


### PR DESCRIPTION
The API should return the nodes ordered in the same way as they where
authored in Kolibri Studio.

## Reviewer guidance
Create a custom presentation for a channel. Then check that the ordering is the same as the default Kolibri presentation. Which at the same time should be the same ordering as in Kolibri Studio. Here are before/after screenshots:

Before:
![regression-before](https://user-images.githubusercontent.com/83944/149942780-ee10c52e-87fb-42c6-ae70-94d85a6eacae.png)

After:
![regression-after](https://user-images.githubusercontent.com/83944/149942810-2181bbe4-5cbf-4438-a0c9-673a278522df.png)

And default (matches after):
![regression-default](https://user-images.githubusercontent.com/83944/149942833-114a80d3-f2d8-448b-a237-b54c26c4a3c7.png)


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
