### PR TITLE
Move close button logic to `FullScreenSidePanel`

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -22,10 +22,19 @@
         </div>
 
         <KIconButton
-          v-if="!closeButtonHidden"
+          v-if="!fullScreenSidePanelCloseButton"
           icon="close"
           class="close-button"
           :style="closeButtonStyles"
+          :ariaLabel="coreString('closeAction')"
+          :tooltip="coreString('closeAction')"
+          @click="closePanel"
+        />
+        <KIconButton
+          v-else
+          icon="close"
+          class="close-button"
+          :style="closeButtonFullScreenSidePanelStyles"
           :ariaLabel="coreString('closeAction')"
           :tooltip="coreString('closeAction')"
           @click="closePanel"
@@ -62,9 +71,7 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
-      /* Hides the (X) icon button to close the side panel. In this case, clicking off of the
-         panel or hitting the ESC keys are the only way to close the panel */
-      closeButtonHidden: {
+      fullScreenSidePanelCloseButton: {
         type: Boolean,
         default: false,
       },
@@ -151,6 +158,13 @@
       closeButtonStyles() {
         return {
           top: `calc((${this.fixedHeaderHeight} - 40px) / 2)`,
+        };
+      },
+      closeButtonFullScreenSidePanelStyles() {
+        return {
+          position: 'absolute',
+          top: '8px',
+          right: '8px',
         };
       },
     },

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -22,10 +22,10 @@
         </div>
 
         <KIconButton
-          v-if="!fullScreenSidePanelCloseButton"
+          v-if="fullScreenSidePanelCloseButton"
           icon="close"
           class="close-button"
-          :style="closeButtonStyles"
+          :style="closeButtonFullScreenSidePanelStyles"
           :ariaLabel="coreString('closeAction')"
           :tooltip="coreString('closeAction')"
           @click="closePanel"
@@ -34,7 +34,7 @@
           v-else
           icon="close"
           class="close-button"
-          :style="closeButtonFullScreenSidePanelStyles"
+          :style="closeButtonStyles"
           :ariaLabel="coreString('closeAction')"
           :tooltip="coreString('closeAction')"
           @click="closePanel"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -147,19 +147,10 @@
       v-if="!windowIsLarge && sidePanelIsOpen"
       class="full-screen-side-panel"
       alignment="left"
-      :closeButtonHidden="true"
+      :fullScreenSidePanelCloseButton="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
       @closePanel="toggleSidePanelVisibility"
     >
-      <KIconButton
-        v-if="windowIsSmall && !currentCategory"
-        class="overlay-close-button"
-        icon="close"
-        :ariaLabel="coreString('closeAction')"
-        :color="$themeTokens.text"
-        :tooltip="coreString('closeAction')"
-        @click="toggleSidePanelVisibility"
-      />
       <KIconButton
         v-if="windowIsSmall && currentCategory"
         icon="back"
@@ -460,11 +451,6 @@
   .full-screen-side-panel {
     position: relative;
     width: 100vw;
-  }
-  .overlay-close-button {
-    position: absolute;
-    top: 8px;
-    right: 8px;
   }
 
   .results-title {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -259,19 +259,10 @@
         v-if="!windowIsLarge && sidePanelIsOpen"
         class="full-screen-side-panel"
         alignment="left"
-        :closeButtonHidden="true"
+        :fullScreenSidePanelCloseButton="true"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="toggleFolderSearchSidePanel"
       >
-        <KIconButton
-          v-if="windowIsSmall && !currentCategory"
-          class="overlay-close-button"
-          icon="close"
-          :ariaLabel="coreString('closeAction')"
-          :color="$themeTokens.text"
-          :tooltip="coreString('closeAction')"
-          @click="toggleFolderSearchSidePanel"
-        />
         <KIconButton
           v-if="windowIsSmall && currentCategory"
           icon="back"
@@ -854,11 +845,6 @@
     top: 16px;
     right: 16px;
     max-height: 40px;
-  }
-  .overlay-close-button {
-    position: absolute;
-    top: 8px;
-    right: 24px;
   }
 
   .more-after-grid {


### PR DESCRIPTION
## Summary
The close button in the `FullScreenSidePanel` originally lived in both the `LibraryPage` and `TopicsPage`. I moved it into the `FullScreenSidePanel` so that this component now takes care of all `close` actions associated with it.

It should look like this. In my example, I've highlighted the background color pink so we can see that this component is controlled by the `FullScreenSidePanel`, as the original code in the `TopicsPage` and `LibraryPage` has now been deleted.

![2022-01-20 16 27 49](https://user-images.githubusercontent.com/13563002/150443792-d4bfd70d-7a51-42ac-bb59-f7baedb48137.gif)

## References
This was mentioned in the following issue and pull request, and this fix will help resolve both:
- https://github.com/learningequality/kolibri/issues/8992
- https://github.com/learningequality/kolibri/pull/8986

## Reviewer guidance
**Library Page**
1. On mobile/responsive view, sign in as a learner and go to the Library tab
2. Click on the "filter" button to access the `FullScreenSidePanel` component that comes out from the left side
3. Check to make sure that the "x"/close icon is fully functional (note, tabbing and focus for the side panel is not fixed in this PR, so focus on whether or not you can close using the "x" icon)

**Topics Page**
1. From the Library page, click on a channel (Kolibri QA is a good one to use, but any channel with multiple channels will work)
2. Once in the channel, click on the "filter" button and repeat step 3 from above.
3. Click on the "folders" button, and repeat step 3 from above.
4. Click on the "i"/information icon on any folder (in a content card) in the channel, and make sure that when that side panel opens (from the right), the "x" button still works.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
