### PR TITLE
Use importlib.resources to access local file resources rather than relative path resolution

### DIFF
--- a/kolibri/core/auth/constants/facility_presets.py
+++ b/kolibri/core/auth/constants/facility_presets.py
@@ -1,14 +1,13 @@
 from __future__ import unicode_literals
 
-import io
 import json
-import os
 
-presets_file = os.path.join(
-    os.path.dirname(__file__), "./facility_configuration_presets.json"
+from importlib_resources import files
+
+ref = files("kolibri.core.auth.constants").joinpath(
+    "facility_configuration_presets.json"
 )
-with io.open(presets_file, mode="r", encoding="utf-8") as f:
-    presets = json.load(f)
+presets = json.loads(ref.read_text())
 
 choices = [(key, key) for key in presets]
 

--- a/kolibri/core/content/__init__.py
+++ b/kolibri/core/content/__init__.py
@@ -1,5 +1,6 @@
 import mimetypes
-import os
+
+import importlib_resources
 
 
 default_app_config = "kolibri.core.content.apps.KolibriContentConfig"
@@ -7,4 +8,5 @@ default_app_config = "kolibri.core.content.apps.KolibriContentConfig"
 
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
 # https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
-mimetypes.init([os.path.join(os.path.dirname(__file__), "constants", "mime.types")])
+ref = importlib_resources.files("kolibri.core.content.constants") / "mime.types"
+mimetypes.init([ref.read_text()])

--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -19,16 +19,24 @@ from sqlalchemy.orm import sessionmaker
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
 from kolibri.core.content.constants.schema_versions import CURRENT_SCHEMA_VERSION
+from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_MODULE_NAME
+from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_PATH
 from kolibri.core.content.utils.sqlalchemybridge import (
     coerce_version_name_to_valid_module_path,
 )
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import prepare_base
 from kolibri.core.content.utils.sqlalchemybridge import SharingPool
-from kolibri.core.content.utils.sqlalchemybridge import SQLALCHEMY_CLASSES_PATH_TEMPLATE
 
 DATA_PATH_TEMPLATE = os.path.join(
     os.path.dirname(__file__), "../../fixtures/{name}_content_data.json"
+)
+
+SQLALCHEMY_CLASSES_PATH_TEMPLATE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    *(__SQLALCHEMY_CLASSES_PATH + (__SQLALCHEMY_CLASSES_MODULE_NAME + ".py",))
 )
 
 

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -1,7 +1,7 @@
-import io
 import os
 import re
 
+import importlib_resources
 from django.conf import settings
 from django.utils.http import urlencode
 from six.moves.urllib.parse import urljoin
@@ -293,12 +293,12 @@ HASHI_FILENAME = None
 def get_hashi_html_filename():
     global HASHI_FILENAME
     if HASHI_FILENAME is None or getattr(settings, "DEVELOPER_MODE", None):
-        with io.open(
-            os.path.join(os.path.dirname(__file__), "../build/hashi_filename"),
-            mode="r",
-            encoding="utf-8",
-        ) as f:
-            HASHI_FILENAME = f.read().strip()
+        ref = (
+            importlib_resources.files("kolibri.core.content")
+            / "build"
+            / "hashi_filename"
+        )
+        HASHI_FILENAME = ref.read_text().strip()
     return HASHI_FILENAME
 
 

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -165,12 +165,6 @@ __SQLALCHEMY_CLASSES_PATH = ("contentschema", "versions")
 
 __SQLALCHEMY_CLASSES_MODULE_NAME = "content_schema_{name}"
 
-SQLALCHEMY_CLASSES_PATH_TEMPLATE = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    *(__SQLALCHEMY_CLASSES_PATH + (__SQLALCHEMY_CLASSES_MODULE_NAME + ".py",))
-)
-
 SQLALCHEMY_CLASSES_MODULE_PATH_TEMPLATE = ".".join(
     tuple(__name__.split(".")[:-2])
     + __SQLALCHEMY_CLASSES_PATH

--- a/kolibri/core/content/utils/stopwords.py
+++ b/kolibri/core/content/utils/stopwords.py
@@ -1,13 +1,10 @@
-import io
 import json
-import os
 
-# load stopwords file
-stopwords_path = os.path.join(
-    os.path.dirname(__file__), os.path.pardir, "constants", "stopwords-all.json"
-)
-with io.open(stopwords_path, mode="r", encoding="utf-8") as f:
-    stopwords = json.load(f)
+from importlib_resources import files
+
+# stopwords file
+ref = files("kolibri.core.content.constants").joinpath("stopwords-all.json")
+stopwords = json.loads(ref.read_text())
 
 # load into a set
 stopwords_set = set()

--- a/kolibri/core/logger/management/commands/generateuserdata.py
+++ b/kolibri/core/logger/management/commands/generateuserdata.py
@@ -3,11 +3,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import csv
-import io
 import logging
-import os
 import random
 
+import importlib_resources
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -112,8 +111,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # Load in the user data from the csv file to give a predictable source of user data
-        data_path = os.path.join(os.path.dirname(__file__), "user_data.csv")
-        with io.open(data_path, mode="r", encoding="utf-8") as f:
+        ref = importlib_resources.files(".") / "user_data.csv"
+        with ref.open("r", encoding="utf-8") as f:
             user_data = [data for data in csv.DictReader(f)]
 
         n_seed = options["seed"]

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
-import importlib
-import io
 import json
-import os
 
-import kolibri
+from importlib_resources import files
 
 
 def get_installed_app_locale_path(appname):
@@ -14,11 +11,10 @@ def get_installed_app_locale_path(appname):
     Note that the module is imported to determine its location.
     """
     try:
-        m = importlib.import_module(appname)
-        module_path = os.path.dirname(m.__file__)
-        module_locale_path = os.path.join(module_path, "locale")
+        m = files(appname)
+        module_locale_path = m / "locale"
 
-        if os.path.isdir(module_locale_path):
+        if module_locale_path.is_dir():
             return module_locale_path
     except ImportError:
         pass
@@ -26,15 +22,12 @@ def get_installed_app_locale_path(appname):
 
 
 def _get_language_info():
-    file_path = os.path.join(
-        os.path.dirname(kolibri.__file__), "locale", "language_info.json"
-    )
-    with io.open(file_path, encoding="utf-8") as f:
-        languages = json.load(f)
-        output = {}
-        for language in languages:
-            output[language["intl_code"]] = language
-        return output
+    ref = files("kolibri") / "locale" / "language_info.json"
+    languages = json.loads(ref.read_text())
+    output = {}
+    for language in languages:
+        output[language["intl_code"]] = language
+    return output
 
 
 # Kolibri format

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import shutil
 import sys
 from sqlite3 import DatabaseError as SQLite3DatabaseError
 
@@ -15,6 +14,7 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import handle_default_options
 from django.db.utils import DatabaseError
+from importlib_resources import files
 
 import kolibri
 from kolibri.core.device.utils import device_provisioned
@@ -168,20 +168,17 @@ def _copy_preseeded_db(db_name, target=None):
     target = os.path.join(KOLIBRI_HOME, target)
     if not os.path.exists(target):
         try:
-            import kolibri.dist
+            db_file = files("kolibri.dist") / "home" / "{}.sqlite3".format(db_name)
+            with open(target, "wb") as f:
+                f.write(db_file.read_bytes())
 
-            db_path = os.path.join(
-                os.path.dirname(kolibri.dist.__file__),
-                "home/{}.sqlite3".format(db_name),
-            )
-            shutil.copy(db_path, target)
             logger.info(
-                "Copied preseeded database from {} to {}".format(db_path, target)
+                "Copied preseeded database from {} to {}".format(db_name, target)
             )
         except (ImportError, IOError, OSError):
             logger.warning(
                 "Unable to copy pre-migrated database from {} to {}".format(
-                    db_path, target
+                    db_name, target
                 )
             )
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,3 +29,4 @@ ifcfg==0.21
 Click==7.0
 whitenoise==4.1.4
 idna==2.8
+importlib_resources==3.3.1


### PR DESCRIPTION
## Summary
* Updates our loading of local file resources to use importlib.resources using the `importlib_resources` [backport](https://importlib-resources.readthedocs.io/en/latest/)
* This allows more flexibility in how we package Kolibri, as it does not need an explicit local file system available at the time that the resources are requested
* This is important for PyInstaller packaging in kolibri-app

Targeting this to 0.15, so that we have a chance of using the updated kolibri-app to produce a mac installer for the 0.15.x series.
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
