### PR TITLE
Use url utilities to format urls

### DIFF
--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -3,6 +3,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
+from six.moves.urllib.parse import urljoin
 
 from .models import DynamicNetworkLocation
 from .models import NetworkLocation
@@ -45,9 +46,9 @@ class NetworkLocationFacilitiesView(viewsets.GenericViewSet):
             base_url = peer_device.base_url
 
             # Step 2: Make request to the /facility endpoint
-            response = requests.get("{}api/public/v1/facility".format(base_url))
+            response = requests.get(urljoin(base_url, "api/public/v1/facility"))
             response.raise_for_status()
-        except (Exception, NetworkLocation.DoesNotExist):
+        except (requests.RequestException, NetworkLocation.DoesNotExist):
             raise NotFound()
 
         # Step 3: Respond with the list of facilities, and append device info


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Resolves issue syncing with manual (static) network locations caused by invalid url formatting

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://community.learningequality.org/t/how-can-i-install-the-0-14-kolibri-version/2288

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
### New instance setup
1. Prepare a new Kolibri instance to sync with a separate, existing Kolibri instance
2. In the setup flow, choose to the advanced flow and import a facility from an existing instance
3. Manually add the location of the existing Kolibri instance when selecting the instance to import from
3. Verify you can complete the setup flow and the facility is synced

### Existing instance
1. Prepare an existing Kolibri instance to sync a new facility from a separate, existing Kolibri instance
2. From Device facilities page, choose to import a facility from an existing instance
3. Manually add the location of the existing Kolibri instance when selecting the instance to import from
3. Verify you can complete the sync process
----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
