### PR TITLE
Fix focus for mobile full screen side panel; update `CoreMenu`, `CompletionModal`, and `FocusTrap` API

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -71,6 +71,7 @@
             :showActive="false"
             :style="{ backgroundColor: $themeTokens.surface }"
             @close="handleCoreMenuClose"
+            @shouldFocusFirstEl="findFirstEl()"
           >
             <template v-if="isUserLoggedIn" #header>
               <div class="role">
@@ -278,6 +279,11 @@
         this.$emit('showLanguageModal');
         this.userMenuDropdownIsOpen = false;
         this.isPolling = false;
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.userMenuDropdown.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -56,10 +56,12 @@
     </ScrollingHeader>
 
     <SideNav
+      ref="sideNav"
       :navShown="navShown"
       :headerHeight="headerHeight"
       :width="navWidth"
       @toggleSideNav="navShown = !navShown"
+      @shouldFocusFirstEl="findFirstEl()"
     />
 
     <div
@@ -516,6 +518,11 @@
         if (this.scrollPosition > 0) {
           this.$nextTick().then(this.showHeader);
         }
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.sideNav.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -20,8 +20,8 @@
         ref="focusTrap"
         class="ui-menu-options"
         :disabled="!containFocus"
-        :firstEl="firstFocusableEl"
-        :lastEl="lastFocusableEl"
+        @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
+        @shouldFocusLastEl="focusLastEl"
       >
         <slot name="options"></slot>
       </FocusTrap>
@@ -77,12 +77,6 @@
         showActive: this.showActive,
       };
     },
-    data() {
-      return {
-        firstFocusableEl: null,
-        lastFocusableEl: null,
-      };
-    },
     computed: {
       classes() {
         return {
@@ -102,9 +96,25 @@
       // make sure that all child components have been mounted
       // before attempting to access their elements
       this.$nextTick(() => {
-        this.firstFocusableEl = this.$el.querySelector('.core-menu-option');
-        this.lastFocusableEl = last(this.$el.querySelectorAll('.core-menu-option'));
+        // this.$nextTick(this.$refs.modal.focus());
+        this.focusFirstEl();
       });
+    },
+    destroyed() {
+      window.setTimeout(() => this.lastFocus.focus());
+    },
+    methods: {
+      focusLastEl() {
+        last(this.$el.querySelectorAll('.core-menu-option')).focus();
+      },
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap depending on content
+       * rendered in CoreMenu.
+       */
+      focusFirstEl() {
+        this.$el.querySelector('.core-menu-option').focus();
+      },
     },
   };
 

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -92,11 +92,13 @@
         }
       },
     },
+    beforeMount() {
+      this.lastFocus = document.activeElement;
+    },
     mounted() {
       // make sure that all child components have been mounted
       // before attempting to access their elements
       this.$nextTick(() => {
-        // this.$nextTick(this.$refs.modal.focus());
         this.focusFirstEl();
       });
     },
@@ -104,7 +106,13 @@
       window.setTimeout(() => this.lastFocus.focus());
     },
     methods: {
+      /**
+       * @public
+       * Focuses on correct last element for FocusTrap depending on content
+       * rendered in CoreMenu.
+       */
       focusLastEl() {
+        this.$emit('shouldFocusLastEl');
         last(this.$el.querySelectorAll('.core-menu-option')).focus();
       },
       /**
@@ -113,7 +121,9 @@
        * rendered in CoreMenu.
        */
       focusFirstEl() {
-        this.$el.querySelector('.core-menu-option').focus();
+        if (this.$el.querySelector('.core-menu-option')) {
+          this.$el.querySelector('.core-menu-option').focus();
+        }
       },
     },
   };

--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -112,7 +112,6 @@
        * rendered in CoreMenu.
        */
       focusLastEl() {
-        this.$emit('shouldFocusLastEl');
         last(this.$el.querySelectorAll('.core-menu-option')).focus();
       },
       /**

--- a/kolibri/core/assets/src/views/FocusTrap.vue
+++ b/kolibri/core/assets/src/views/FocusTrap.vue
@@ -59,15 +59,27 @@
         e.stopPropagation();
         if (!this.isTrapActive) {
           // On first focus, redirect to first option, then activate trap
-          this.firstEl.focus();
+          this.focusFirstEl();
           this.isTrapActive = true;
         } else {
-          this.lastEl.focus();
+          this.focusLastEl();
         }
       },
       handleLastTrapFocus(e) {
         e.stopPropagation();
-        this.firstEl.focus();
+        this.focusFirstEl();
+      },
+      focusFirstEl() {
+        this.$emit('shouldFocusFirstEl');
+        if (this.firstEl) {
+          this.firstEl.focus();
+        }
+      },
+      focusLastEl() {
+        this.$emit('shouldFocusLastEl');
+        if (this.lastEl) {
+          this.lastEl.focus();
+        }
       },
       /**
        * @public

--- a/kolibri/core/assets/src/views/FocusTrap.vue
+++ b/kolibri/core/assets/src/views/FocusTrap.vue
@@ -33,16 +33,6 @@
   export default {
     name: 'FocusTrap',
     props: {
-      firstEl: {
-        type: HTMLElement,
-        required: false,
-        default: null,
-      },
-      lastEl: {
-        type: HTMLElement,
-        required: false,
-        default: null,
-      },
       disabled: {
         type: Boolean,
         required: false,
@@ -71,15 +61,9 @@
       },
       focusFirstEl() {
         this.$emit('shouldFocusFirstEl');
-        if (this.firstEl) {
-          this.firstEl.focus();
-        }
       },
       focusLastEl() {
         this.$emit('shouldFocusLastEl');
-        if (this.lastEl) {
-          this.lastEl.focus();
-        }
       },
       /**
        * @public

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -16,7 +16,7 @@
           :style="sidePanelStyles"
         >
 
-          <!-- Fixed header with optional close button -->
+          <!-- Fixed header -->
           <div
             v-show="$slots.header"
             ref="fixedHeader"

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -10,6 +10,8 @@
       <FocusTrap
         :firstEl="firstFocusableEl"
         :lastEl="lastFocusableEl"
+        @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
+        @shouldFocusLastEl="focusLastEl"
       >
         <div
           class="side-panel"
@@ -117,7 +119,7 @@
         return this.windowBreakpoint == 0;
       },
       /* Returns an object with properties left or right set to the appropriate value
-         depending on isRtl and this.alignment */
+           depending on isRtl and this.alignment */
       rtlAlignment() {
         if (this.isRtl && this.alignment === 'left') {
           return 'right';
@@ -193,9 +195,8 @@
       htmlTag.style['overflow-y'] = 'hidden';
       // Gets the height of the fixed header - adds 40 to account for padding
       this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 'px';
-
       this.$nextTick(() => {
-        this.setFocusTrap();
+        this.$emit('shouldFocusFirstEl');
       });
     },
     beforeDestroy() {
@@ -209,18 +210,8 @@
       closePanel() {
         this.$emit('closePanel');
       },
-      setFocusTrap() {
-        if (this.$refs.sidePanel && !this.$refs.sidePanel.contains(document.activeElement)) {
-          this.focusSidePanel();
-        }
-        this.firstFocusableEl =
-          this.$el.querySelector('input[id="searchfield"]') || // if `EmbeddedSidePanel` is for search/filter btn
-          this.$el.querySelector('.raised') || // if `EmbeddedSidePanel` is for info btn
-          this.$el.querySelector('.side-panel-folder-link'); // if `EmbeddedSidePanel` is for folders btn
-        this.lastFocusableEl = this.$refs.closeButton.$el;
-      },
-      focusSidePanel() {
-        this.$refs.sidePanel.focus();
+      focusLastEl() {
+        this.$el.querySelector('.close-button').focus();
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -214,7 +214,7 @@
           this.focusSidePanel();
         }
         this.firstFocusableEl =
-          this.$el.querySelector('.search-box') || // if `EmbeddedSidePanel` is for search/filter btn
+          this.$el.querySelector('input[id="searchfield"]') || // if `EmbeddedSidePanel` is for search/filter btn
           this.$el.querySelector('.raised') || // if `EmbeddedSidePanel` is for info btn
           this.$el.querySelector('.side-panel-folder-link'); // if `EmbeddedSidePanel` is for folders btn
         this.lastFocusableEl = this.$refs.closeButton.$el;

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -8,8 +8,6 @@
   >
     <transition name="side-panel">
       <FocusTrap
-        :firstEl="firstFocusableEl"
-        :lastEl="lastFocusableEl"
         @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
         @shouldFocusLastEl="focusLastEl"
       >
@@ -109,8 +107,6 @@
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
         fixedHeaderHeight: 0,
-        firstFocusableEl: null,
-        lastFocusableEl: null,
         lastFocus: null,
       };
     },

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -214,9 +214,9 @@
           this.focusSidePanel();
         }
         this.firstFocusableEl =
-          this.$el.querySelector('.search-box') ||
-          this.$el.querySelector('.raised') ||
-          this.$el.querySelector('.side-panel-folder-link');
+          this.$el.querySelector('.search-box') || // if `EmbeddedSidePanel` is for search/filter btn
+          this.$el.querySelector('.raised') || // if `EmbeddedSidePanel` is for info btn
+          this.$el.querySelector('.side-panel-folder-link'); // if `EmbeddedSidePanel` is for folders btn
         this.lastFocusableEl = this.$refs.closeButton.$el;
       },
       focusSidePanel() {

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -214,7 +214,9 @@
           this.focusSidePanel();
         }
         this.firstFocusableEl =
-          this.$el.querySelector('.search-box') || this.$el.querySelector('.raised');
+          this.$el.querySelector('.search-box') ||
+          this.$el.querySelector('.raised') ||
+          this.$el.querySelector('.side-panel-folder-link');
         this.lastFocusableEl = this.$refs.closeButton.$el;
       },
       focusSidePanel() {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -54,6 +54,7 @@
             role="navigation"
             :style="{ backgroundColor: $themeTokens.surface }"
             :aria-label="$tr('navigationLabel')"
+            @shouldFocusFirstEl="findFirstEl()"
           >
             <template #options>
               <component :is="component" v-for="component in menuOptions" :key="component.name" />
@@ -271,6 +272,11 @@
           this.$refs.coreMenu.$el.focus();
         }
         return event;
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.coreMenu.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -16,101 +16,110 @@
           backgroundColor: $themeTokens.surface,
         }"
       >
-        <div
-          class="side-nav-header"
-          :style="{
-            height: headerHeight + 'px',
-            width: `${width}px`, paddingTop: windowIsSmall ? '4px' : '8px',
-            backgroundColor: $themeTokens.appBar,
-          }"
+        <FocusTrap
+          @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
+          @shouldFocusLastEl="focusLastEl"
         >
-          <KIconButton
-            icon="close"
-            :color="$themeTokens.textInverted"
-            class="side-nav-header-icon"
-            :ariaLabel="$tr('closeNav')"
-            size="large"
-            @click="toggleNav"
-          />
-          <span
-            class="side-nav-header-name"
-            :style="{ color: $themeTokens.textInverted }"
-          >{{ sideNavTitleText }}</span>
-        </div>
 
-        <div
-          class="side-nav-scrollable-area"
-          :style="{ top: `${headerHeight}px`, width: `${width}px` }"
-        >
-          <img
-            v-if="themeConfig.sideNav.topLogo"
-            class="logo"
-            :src="themeConfig.sideNav.topLogo.src"
-            :alt="themeConfig.sideNav.topLogo.alt"
-            :style="themeConfig.sideNav.topLogo.style"
+
+          <div
+            class="side-nav-scrollable-area"
+            :style="{ top: `${headerHeight}px`, width: `${width}px` }"
           >
-          <CoreMenu
-            ref="coreMenu"
-            role="navigation"
-            :style="{ backgroundColor: $themeTokens.surface }"
-            :aria-label="$tr('navigationLabel')"
-            @shouldFocusFirstEl="findFirstEl()"
-          >
-            <template #options>
-              <component :is="component" v-for="component in menuOptions" :key="component.name" />
-              <SideNavDivider />
-            </template>
-          </CoreMenu>
+            <img
+              v-if="themeConfig.sideNav.topLogo"
+              class="logo"
+              :src="themeConfig.sideNav.topLogo.src"
+              :alt="themeConfig.sideNav.topLogo.alt"
+              :style="themeConfig.sideNav.topLogo.style"
+            >
+            <CoreMenu
+              ref="coreMenu"
+              role="navigation"
+              :style="{ backgroundColor: $themeTokens.surface }"
+              :aria-label="$tr('navigationLabel')"
+            >
+              <template #options>
+                <component :is="component" v-for="component in menuOptions" :key="component.name" />
+                <SideNavDivider />
+              </template>
+            </CoreMenu>
 
-          <div v-if="showSoudNotice" style="padding: 16px">
-            <LearnOnlyDeviceNotice />
-          </div>
+            <div v-if="showSoudNotice" style="padding: 16px">
+              <LearnOnlyDeviceNotice />
+            </div>
 
-          <div class="side-nav-scrollable-area-footer" :style="{ color: $themeTokens.annotation }">
-            <!-- custom branded footer logo + text -->
-            <template v-if="themeConfig.sideNav.brandedFooter">
-              <img
-                v-if="themeConfig.sideNav.brandedFooter.logo"
-                class="side-nav-scrollable-area-footer-logo"
-                :src="themeConfig.sideNav.brandedFooter.logo.src"
-                :alt="themeConfig.sideNav.brandedFooter.logo.alt"
-                :style="themeConfig.sideNav.brandedFooter.logo.style"
-              >
-              <div
-                v-if="themeConfig.sideNav.brandedFooter.paragraphArray
-                  && themeConfig.sideNav.brandedFooter.paragraphArray.length"
-                class="side-nav-scrollable-area-footer-info"
-              >
-                <p
-                  v-for="(line, index) in themeConfig.sideNav.brandedFooter.paragraphArray"
-                  :key="index"
+            <div
+              class="side-nav-scrollable-area-footer"
+              :style="{ color: $themeTokens.annotation }"
+            >
+              <!-- custom branded footer logo + text -->
+              <template v-if="themeConfig.sideNav.brandedFooter">
+                <img
+                  v-if="themeConfig.sideNav.brandedFooter.logo"
+                  class="side-nav-scrollable-area-footer-logo"
+                  :src="themeConfig.sideNav.brandedFooter.logo.src"
+                  :alt="themeConfig.sideNav.brandedFooter.logo.alt"
+                  :style="themeConfig.sideNav.brandedFooter.logo.style"
                 >
-                  {{ line }}
+                <div
+                  v-if="themeConfig.sideNav.brandedFooter.paragraphArray
+                    && themeConfig.sideNav.brandedFooter.paragraphArray.length"
+                  class="side-nav-scrollable-area-footer-info"
+                >
+                  <p
+                    v-for="(line, index) in themeConfig.sideNav.brandedFooter.paragraphArray"
+                    :key="index"
+                  >
+                    {{ line }}
+                  </p>
+                </div>
+              </template>
+              <!-- Kolibri footer logo -->
+              <CoreLogo
+                v-if="themeConfig.sideNav.showKolibriFooterLogo"
+                class="side-nav-scrollable-area-footer-logo"
+              />
+              <div class="side-nav-scrollable-area-footer-info">
+                <p>{{ footerMsg }}</p>
+                <!-- Not translated -->
+                <p>© {{ copyrightYear }} Learning Equality</p>
+                <p>
+                  <KButton
+                    ref="privacyLink"
+                    :text="coreString('usageAndPrivacyLabel')"
+                    class="privacy-link"
+                    appearance="basic-link"
+                    @click="handleClickPrivacyLink"
+                  />
                 </p>
               </div>
-            </template>
-            <!-- Kolibri footer logo -->
-            <CoreLogo
-              v-if="themeConfig.sideNav.showKolibriFooterLogo"
-              class="side-nav-scrollable-area-footer-logo"
-            />
-            <div class="side-nav-scrollable-area-footer-info">
-              <p>{{ footerMsg }}</p>
-              <!-- Not translated -->
-              <p>© {{ copyrightYear }} Learning Equality</p>
-              <p>
-                <KButton
-                  ref="privacyLink"
-                  :text="coreString('usageAndPrivacyLabel')"
-                  class="privacy-link"
-                  appearance="basic-link"
-                  @click="handleClickPrivacyLink"
-                />
-              </p>
             </div>
           </div>
-        </div>
-
+          <div
+            class="side-nav-header"
+            :style="{
+              height: headerHeight + 'px',
+              width: `${width}px`, paddingTop: windowIsSmall ? '4px' : '8px',
+              backgroundColor: $themeTokens.appBar,
+            }"
+          >
+            <KIconButton
+              ref="closeButton"
+              tabindex="0"
+              icon="close"
+              :color="$themeTokens.textInverted"
+              class="side-nav-header-icon"
+              :ariaLabel="$tr('closeNav')"
+              size="large"
+              @click="toggleNav"
+            />
+            <span
+              class="side-nav-header-name"
+              :style="{ color: $themeTokens.textInverted }"
+            >{{ sideNavTitleText }}</span>
+          </div>
+        </FocusTrap>
       </div>
     </transition>
 
@@ -149,6 +158,7 @@
   import navComponentsMixin from '../mixins/nav-components';
   import logout from './LogoutSideNavEntry';
   import SideNavDivider from './SideNavDivider';
+  import FocusTrap from './FocusTrap.vue';
   import plugin_data from 'plugin_data';
 
   // Explicit ordered list of roles for nav item sorting
@@ -170,6 +180,7 @@
       LearnOnlyDeviceNotice,
       SideNavDivider,
       PrivacyInfoModal,
+      FocusTrap,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin, responsiveElementMixin, navComponentsMixin],
     setup() {
@@ -191,7 +202,6 @@
     },
     data() {
       return {
-        previouslyFocusedElement: null,
         // __copyrightYear is injected by Webpack DefinePlugin
         copyrightYear: __copyrightYear,
         privacyModalVisible: false,
@@ -228,15 +238,15 @@
       navShown(isShown) {
         this.$nextTick(() => {
           if (isShown) {
-            window.addEventListener('focus', this.containFocus, true);
-            this.previouslyFocusedElement = document.activeElement;
-            this.$refs.sideNav && this.$refs.sideNav.focus();
-          } else {
-            window.removeEventListener('focus', this.containFocus, true);
-            this.previouslyFocusedElement.focus();
+            this.focusFirstEl();
           }
         });
       },
+    },
+    mounted() {
+      this.$nextTick(() => {
+        this.$emit('shouldFocusFirstEl');
+      });
     },
     methods: {
       toggleNav() {
@@ -264,19 +274,17 @@
         // There is no difference!
         return 0;
       },
-      containFocus(event) {
-        if (event.target === window) {
-          return event;
-        }
-        if (!this.$refs.sideNav.contains(event.target)) {
-          this.$refs.coreMenu.$el.focus();
-        }
-        return event;
-      },
-      findFirstEl() {
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap.
+       */
+      focusFirstEl() {
         this.$nextTick(() => {
           this.$refs.coreMenu.focusFirstEl();
         });
+      },
+      focusLastEl() {
+        this.$refs.closeButton.$el.focus();
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -55,6 +55,7 @@
                   :isOpen="isMenuOpen"
                   :containFocus="true"
                   @close="closeMenu"
+                  @shouldFocusFirstEl="findFirstEl()"
                 >
                   <template #options>
                     <CoreMenuOption
@@ -233,6 +234,11 @@
         }
         this.$nextTick(() => {
           this.$refs.menu.$el.focus();
+        });
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.menu.focusFirstEl();
         });
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -35,6 +35,7 @@
       v-if="sidePanelContent"
       alignment="right"
       @closePanel="sidePanelContent = null"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <template #header>
         <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
@@ -56,7 +57,11 @@
         </div>
       </template>
 
-      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
+      <BrowseResourceMetadata
+        ref="resourcePanel"
+        :content="sidePanelContent"
+        :showLocationsInChannel="true"
+      />
     </FullScreenSidePanel>
   </div>
 
@@ -149,6 +154,9 @@
       },
       toggleInfoPanel(content) {
         this.sidePanelContent = content;
+      },
+      findFirstEl() {
+        this.$refs.resourcePanel.focusFirstEl();
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -16,6 +16,7 @@
 
       <div>
         <KRouterLink
+          ref="resourceButton"
           :text="metadataStrings.$tr('viewResource')"
           appearance="raised-button"
           :primary="false"
@@ -327,6 +328,13 @@
         if (this.$refs.description && this.$refs.description.scrollHeight > 175) {
           this.descriptionOverflow = true;
         }
+      },
+      /**
+       * @public
+       * Determines and calls first focusable element for FocusTrap
+       */
+      focusFirstEl() {
+        this.$refs.resourceButton.$el.focus();
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -292,7 +292,7 @@
       }
       Promise.all(promises).then(() => {
         this.loading = false;
-        this.$nextTick(this.focusFirstEl);
+        this.$nextTick(this.$refs.modal.focus());
       });
     },
     beforeMount() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -55,10 +55,12 @@
 
     <CompletionModal
       v-if="progress >= 1 && wasIncomplete"
+      ref="completionModal"
       :isUserLoggedIn="isUserLoggedIn"
       :contentNodeId="content.id"
       :lessonId="lessonId"
       @close="markAsComplete"
+      @shouldFocusFirstEl="findFirstEl()"
     />
   </div>
 
@@ -194,6 +196,11 @@
       },
       onError(error) {
         this.$store.dispatch('handleApiError', error);
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.completionModal.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -11,7 +11,7 @@
     <div v-if="topics && topics.length && topicsListDisplayed">
       <div v-for="t in topics" :key="t.id">
         <KRouterLink
-          ref="routerLink"
+          ref="folders"
           :text="t.title"
           class="side-panel-folder-link"
           :appearanceOverrides="{ color: $themeTokens.text }"
@@ -349,11 +349,15 @@
       },
       /**
        * @public
-       * Determines first focusable element for FocusTrap depending on content rendered in
-       * EmbeddedSidePanel.
+       * Focuses on correct first element for FocusTrap depending on content
+       * rendered in EmbeddedSidePanel.
        */
       focusFirstEl() {
-        this.$refs.searchBox.focusSearchBox();
+        if (this.$refs.searchBox) {
+          this.$refs.searchBox.focusSearchBox();
+        } else if (this.$refs.folders) {
+          this.$refs.folders[0].$el.focus();
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -34,7 +34,6 @@
       <SearchBox
         key="channel-search"
         placeholder="findSomethingToLearn"
-        :tabindex="0"
         :value="value.keywords || ''"
         @change="val => $emit('input', { ...value, keywords: val })"
       />

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -355,7 +355,7 @@
       focusFirstEl() {
         if (this.$refs.searchBox) {
           this.$refs.searchBox.focusSearchBox();
-        } else if (this.$refs.folders) {
+        } else if (this.$refs.folders && this.$refs.folders.length > 0) {
           this.$refs.folders[0].$el.focus();
         }
       },

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -34,6 +34,7 @@
       <SearchBox
         key="channel-search"
         placeholder="findSomethingToLearn"
+        :tabindex="0"
         :value="value.keywords || ''"
         @change="val => $emit('input', { ...value, keywords: val })"
       />

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -11,6 +11,7 @@
     <div v-if="topics && topics.length && topicsListDisplayed">
       <div v-for="t in topics" :key="t.id">
         <KRouterLink
+          ref="routerLink"
           :text="t.title"
           class="side-panel-folder-link"
           :appearanceOverrides="{ color: $themeTokens.text }"
@@ -33,6 +34,7 @@
       </h2>
       <SearchBox
         key="channel-search"
+        ref="searchBox"
         placeholder="findSomethingToLearn"
         :value="value.keywords || ''"
         @change="val => $emit('input', { ...value, keywords: val })"
@@ -344,6 +346,14 @@
             learner_needs: { ...this.value.learner_needs, [need]: true },
           });
         }
+      },
+      /**
+       * @public
+       * Determines first focusable element for FocusTrap depending on content rendered in
+       * EmbeddedSidePanel.
+       */
+      focusFirstEl() {
+        this.$refs.searchBox.focusSearchBox();
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -62,6 +62,7 @@
           :isOpen="isMenuOpen"
           :containFocus="true"
           @close="closeMenu"
+          @shouldFocusFirstEl="findFirstEl()"
         >
           <template #options>
             <CoreMenuOption
@@ -332,6 +333,11 @@
         ) {
           this.closeMenu({ focusMoreOptionsButton: false });
         }
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.menu.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -150,6 +150,7 @@
       :fullScreenSidePanelCloseButton="true"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
       @closePanel="toggleSidePanelVisibility"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <KIconButton
         v-if="windowIsSmall && currentCategory"
@@ -161,6 +162,7 @@
       />
       <EmbeddedSidePanel
         v-if="!currentCategory"
+        ref="embeddedPanel"
         v-model="searchTerms"
         :width="`${sidePanelOverlayWidth - 64}px`"
         :availableLabels="labels"
@@ -397,6 +399,11 @@
       handleCategory(category) {
         this.setCategory(category);
         this.currentCategory = null;
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.embeddedPanel.focusFirstEl();
+        });
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -198,6 +198,7 @@
       v-if="sidePanelContent"
       alignment="right"
       @closePanel="sidePanelContent = null"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <template #header>
         <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
@@ -219,7 +220,11 @@
         </div>
       </template>
 
-      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
+      <BrowseResourceMetadata
+        ref="resourcePanel"
+        :content="sidePanelContent"
+        :showLocationsInChannel="true"
+      />
     </FullScreenSidePanel>
   </div>
 
@@ -408,9 +413,11 @@
         this.currentCategory = null;
       },
       findFirstEl() {
-        this.$nextTick(() => {
+        if (this.$refs.embeddedPanel) {
           this.$refs.embeddedPanel.focusFirstEl();
-        });
+        } else {
+          this.$refs.resourcePanel.focusFirstEl();
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -372,6 +372,13 @@
       searchTerms() {
         this.sidePanelIsOpen = false;
       },
+      sidePanelIsOpen() {
+        if (this.sidePanelIsOpen) {
+          document.documentElement.style.position = 'fixed';
+          return;
+        }
+        document.documentElement.style.position = '';
+      },
     },
     created() {
       this.search();

--- a/kolibri/plugins/learn/assets/src/views/SearchBox.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchBox.vue
@@ -123,6 +123,12 @@
       },
     },
     methods: {
+      /**
+       * @public
+       */
+      focusSearchBox() {
+        this.$refs.searchInput.focus();
+      },
       clearInput() {
         this.searchInputValue = '';
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -318,6 +318,7 @@
       v-if="sidePanelContent"
       alignment="right"
       @closePanel="sidePanelContent = null"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <template #header>
         <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
@@ -339,7 +340,11 @@
         </div>
       </template>
 
-      <BrowseResourceMetadata :content="sidePanelContent" :showLocationsInChannel="true" />
+      <BrowseResourceMetadata
+        ref="resourcePanel"
+        :content="sidePanelContent"
+        :showLocationsInChannel="true"
+      />
     </FullScreenSidePanel>
   </div>
 
@@ -717,9 +722,11 @@
         });
       },
       findFirstEl() {
-        this.$nextTick(() => {
+        if (this.$refs.embeddedPanel) {
           this.$refs.embeddedPanel.focusFirstEl();
-        });
+        } else {
+          this.$refs.resourcePanel.focusFirstEl();
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -646,6 +646,13 @@
           this.sidePanelIsOpen = false;
         }
       },
+      sidePanelContent() {
+        if (this.sidePanelContent) {
+          document.documentElement.style.position = 'fixed';
+          return;
+        }
+        document.documentElement.style.position = '';
+      },
     },
     beforeDestroy() {
       window.removeEventListener('scroll', this.throttledHandleScroll);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -262,6 +262,7 @@
         :fullScreenSidePanelCloseButton="true"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="toggleFolderSearchSidePanel"
+        @shouldFocusFirstEl="findFirstEl()"
       >
         <KIconButton
           v-if="windowIsSmall && currentCategory"
@@ -273,6 +274,7 @@
         />
         <EmbeddedSidePanel
           v-if="!currentCategory"
+          ref="embeddedPanel"
           v-model="searchTerms"
           :topicsListDisplayed="!mobileSearchActive"
           topicPage="True"
@@ -712,6 +714,11 @@
         this.topicMoreLoading = true;
         this.loadMoreTopics().then(() => {
           this.topicMoreLoading = false;
+        });
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.embeddedPanel.focusFirstEl();
         });
       },
     },

--- a/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
@@ -94,22 +94,25 @@ describe('CompletionModal', () => {
     it('displays obtained points', () => {
       expect(wrapper.text()).toContain('+ 500 points');
     });
-  });
 
-  it("displays 'Stay and practice' section with 'Stay here' button", async () => {
-    const wrapper = makeWrapper();
-    await wrapper.vm.$nextTick();
-    expect(wrapper.text()).toContain('Stay and practice');
-    expect(getStayHereButton(wrapper).exists()).toBe(true);
-  });
+    it("displays 'Stay and practice' section with 'Stay here' button", async () => {
+      const wrapper = makeWrapper();
+      await wrapper.setProps({ isUserLoggedIn: true });
+      await wrapper.vm.$nextTick();
 
-  it("emits `close` even on 'Stay here' button click", async () => {
-    const wrapper = makeWrapper();
-    await wrapper.vm.$nextTick();
-    getStayHereButton(wrapper).trigger('click');
+      expect(wrapper.text()).toContain('Stay and practice');
+      expect(getStayHereButton(wrapper).exists()).toBe(true);
+    });
 
-    expect(wrapper.emitted().close).toBeTruthy();
-    expect(wrapper.emitted().close.length).toBe(1);
+    it("emits `close` even on 'Stay here' button click", async () => {
+      const wrapper = makeWrapper();
+      await wrapper.setProps({ isUserLoggedIn: true });
+      await wrapper.vm.$nextTick();
+      getStayHereButton(wrapper).trigger('click');
+
+      expect(wrapper.emitted().close).toBeTruthy();
+      expect(wrapper.emitted().close.length).toBe(1);
+    });
   });
 
   describe("when a resource doesn't have a next resource", () => {


### PR DESCRIPTION
## Summary
- Fixes missing focus on side panels that are opened on mobile.
- Add `FocusTrap` component in `FullScreenSidePanel`
- Updates `FocusTrap` API to emit events rather than pass props
- Updates existing implementation of components that use `FocusTrap` to emit events
  - `CoreMenu` in `AppBar`
  - `CoreMenu` in `SideNav`
  - `CoreMenu` in `LearningActivityBar`
  - `CoreMenu` in `SyncInterface` (gif not provided)
  - `CompletionModal`

|Library: filter/search|Library: info panel|
|--|--|
|![2022-01-21 15 28 52](https://user-images.githubusercontent.com/13563002/150613117-c1ed496a-0993-495e-81d8-b9c99438091a.gif)|![2022-02-09 22 21 41](https://user-images.githubusercontent.com/13563002/153358746-a1b40e12-d994-4a08-b901-e0796b09b09a.gif)|

|Topics: folders|Topics: info panel|
|--|--|
|![2022-01-21 15 29 25](https://user-images.githubusercontent.com/13563002/150613109-a394e1f6-dfb0-49c2-b147-5b30b1b1cc6f.gif)|![2022-01-21 15 29 44](https://user-images.githubusercontent.com/13563002/150613103-5cb7569f-57a7-4883-80ce-68bff57d6d0b.gif)|

|Completion modal|
|--|
|![2022-02-09 23 32 57](https://user-images.githubusercontent.com/13563002/153359358-6fa8f05b-b573-4c52-9440-4cedc464e2c1.gif)|

|Core menu in side nav and app bar|
|--|
|![2022-02-09 23 18 31](https://user-images.githubusercontent.com/13563002/153358464-aa5db48a-8cd7-4f1e-ab89-15657eb19e22.gif)|

|Learning activity bar - core menu in mobile|
|--|
|![2022-02-09 23 16 22](https://user-images.githubusercontent.com/13563002/153358247-2789cb3b-e872-4aca-ae9c-d0a98a500176.gif)|

## References
Fixes #8992

## Reviewer guidance
Please check any uses of the `FullScreenSidePanel`.
1. Log in as learner and make sure you are on a responsive/mobile screen
2. Click in the library tab

### Library Page
**Filter button**
1. Using the keyboard, navigate to the "filter" button
2. Once it opens, use tab to navigate through all the clickable elements
3. Make sure that the focus is "trapped" in the side panel and loops back to the first element after getting to the last element (the "x"/close icon)
4. Make sure that the "x"/close icon works via keyboard. 

### Topics Page
1. Click into a channel via the content card

**Filter button** (see above)
**Folders button**
1. Using the keyboard, navigate to the "folders" button
2. Once it opens, use tab to navigate through all the folders links
3. Make sure that the focus is "trapped" in the side panel and loops back to the first element after getting to the last element (the "x"/close icon)
4. Make sure that the "x"/close icon works via keyboard

**Info button on content card**
1. Using the keyboard, navigate to a content card, and then to the "i"/info icon
2. Once it opens, use tab to navigate through the clickable elements
3. Make sure that the focus is "trapped" in the side panel and loops back to the first element after getting to the last element (the "x"/close icon)
4. Make sure that the "x"/close icon works via keyboard

### Completion modal
1. As a learner, complete any activity
2. When the completion modal appears, make sure that a user can navigate through it using the keyboard

### Core menu in side nav and app bar
1. Sign in as a learner
2. Navigate with the keyboard to the user menu button on the righthand side of the app bar
3. Enter and make sure you can navigate through all options with the keyboard
4. ESC to exit and navigate to the hamburger menu on the left to open the side nav
5. Enter and make sure you can navigate through all options with the keyboard

### Learning activity bar - core menu in mobile
1. In mobile view, open an activity
2. In the Learning Activity Bar at the top of the activity, use the keyboard to navigate to the three dots horizontal icon
3. When you press enter, make sure that the focus can navigate through all options

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
