### PR TITLE
Update KDS to v1.3.0

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.36",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.3.0",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.36",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.2.1",
+    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.3.0",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8838,9 +8838,9 @@ kolibri-constants@0.1.36:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.36.tgz#c9ab07305dc6e052547b830a91e61a58757bb1ee"
   integrity sha512-61FoLBFjOXoBu7lsAKFltkZCwwzVO/Cwmgq+wBqkoTmLw92ma6shLP/ZYaNrzYNhuEn4gHfCC6zWZoLoC1hp/w==
 
-"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.2.1":
-  version "1.2.1"
-  resolved "git://github.com/learningequality/kolibri-design-system#fe3ab268a8ed0470d1ac74e23c56b0a8c8e5f9e0"
+"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.3.0":
+  version "1.3.0"
+  resolved "git://github.com/learningequality/kolibri-design-system#c2acc3fd19cee52ccd2a17fa8d2b10cddb2b3d63"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary

Updates KDS to [version 1.3.0](https://github.com/learningequality/kolibri-design-system/blob/main/CHANGELOG.md#version-130). No updates are needed in the Kolibri codebase.

## References

- resolves #6918
- resolves #8786

## Reviewer guidance

You can reinstall dependencies with `yarn install` and see that the two issues referenced above have been indeed resolved.

Should be ready for merge since this work was reviewed in
- https://github.com/learningequality/kolibri-design-system/pull/291 + https://github.com/learningequality/kolibri/pull/8971
- https://github.com/learningequality/kolibri-design-system/pull/292 + https://github.com/learningequality/kolibri/pull/8972

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
