### PR TITLE
Allow untranslated headers in csv + correct serialization into json

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -471,7 +471,8 @@ class Command(AsyncCommand):
             header = next(csv.reader(f, strict=True))
             has_header = False
             self.header_translation = {
-                lbl.partition("(")[2].partition(")")[0]: lbl for lbl in header
+                lbl if "(" not in lbl else lbl.partition("(")[2].partition(")")[0]: lbl
+                for lbl in header
             }
             neutral_header = self.header_translation.keys()
             # If every item in the first row matches an item in the fieldnames, consider it a header row
@@ -760,14 +761,16 @@ class Command(AsyncCommand):
         if self.overall_error:
             classes_report = {"created": 0, "updated": 0, "cleared": 0}
             users_report = {"created": 0, "updated": 0, "deleted": 0}
+            # force translation to str type, to be serialized into json:
+            overall_error = [str(msg) for msg in self.overall_error]
             if self.job:
-                self.job.extra_metadata["overall_error"] = self.overall_error
+                self.job.extra_metadata["overall_error"] = overall_error
                 self.job.extra_metadata["per_line_errors"] = 0
                 self.job.extra_metadata["classes"] = classes_report
                 self.job.extra_metadata["users"] = users_report
                 self.job.extra_metadata["filename"] = ""
                 self.job.save_meta()
-            raise CommandError("File errors: {}".format(str(self.overall_error)))
+            raise CommandError("File errors: {}".format(overall_error))
         return
 
     def remove_memberships(self, users, enrolled, assigned):

--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -683,7 +683,7 @@ class Command(AsyncCommand):
 
     def get_number_lines(self, filepath):
         try:
-            with open(filepath) as f:
+            with open_csv_for_reading(filepath) as f:
                 number_lines = len(f.readlines())
         except (ValueError, FileNotFoundError, csv.Error) as e:
             number_lines = None


### PR DESCRIPTION
## Summary
This PR fixes three different problems found when importing users using a csv file from kolibri:

1. Changes in 0.15.x required json for the job serialization and some error messages from the importer where not json serializable
2. The importer always requires () in the header field names. This was done to allow translation of columns but didn't make sense if the language of the user is English
3. Force the use of utf-8 when opening the csv to count the lines to avoid charset problems in Windows

## References
Fixes: #9032 , #9034, #9060 

## Reviewer guidance
* In Facility->Data import a csv with errors, the errors list should be correctly visible in the browser
* Import a valid csv file without parenthesis in the colums, as this one, and it should be correctly imported:
[bec-list-test.csv](https://github.com/learningequality/kolibri/files/7935807/bec-list-test.csv)
* Import a valid csv with some columns translated as this one, and it should be correctly imported:
[bec2.csv](https://github.com/learningequality/kolibri/files/7935818/bec2.csv)



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
