### PR TITLE
API: Remove duplicates for tag filtering

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -299,7 +299,7 @@ class ContentNodeFilter(IdFilter):
         :return: content nodes that match the tags
         """
         tags = value.split(",")
-        return queryset.filter(tags__tag_name__in=tags).order_by("lft")
+        return queryset.filter(tags__tag_name__in=tags).order_by("lft").distinct()
 
     def filter_descendant_of(self, queryset, name, value):
         """


### PR DESCRIPTION
Add distinct to the tag filter query.

The filter `tags__tag_name__in` is doing two INNER JOIN in the query
when there are more than one tag to filter by. This is producing
duplicate results.

```
SELECT * FROM "content_contentnode"
INNER JOIN "content_contentnode_tags" ON ("content_contentnode"."id" = "content_contentnode_tags"."contentnode_id")
INNER JOIN "content_contenttag" ON ("content_contentnode_tags"."contenttag_id" = "content_contenttag"."id")
WHERE (
    "content_contentnode"."available" = True AND
    "content_contentnode"."channel_id" = 057f871caa405ec29d62ba0523c193d7 AND
    "content_contenttag"."tag_name"
    IN (level=all levels, level=beginner, type=class)
) ORDER BY "content_contentnode"."tree_id" ASC, "content_contentnode"."lft" ASC
```

The added distinct filter fixes the issue.