### PR TITLE
Refactor hybrid learning card grid

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -8,15 +8,18 @@
       {{ $tr('noBookmarks') }}
     </p>
 
-    <HybridLearningCardGrid
-      v-if="bookmarks.length"
-      :contents="bookmarks"
-      :currentPage="currentPage"
-      :genContentLink="genContentLink"
-      :cardViewStyle="windowIsSmall ? 'card' : 'list'"
+    <HybridLearningContentCardListView
+      v-for="content in bookmarks"
+      v-else
+      :key="content.id"
+      :content="content"
+      class="card-grid-item"
+      :isMobile="windowIsSmall"
+      :link="genContentLink(content)"
       :footerIcons="footerIcons"
-      @removeFromBookmarks="removeFromBookmarks"
-      @toggleInfoPanel="toggleInfoPanel"
+      :createdDate="content.bookmark ? content.bookmark.created : null"
+      @viewInformation="toggleInfoPanel(content)"
+      @removeFromBookmarks="removeFromBookmarks(content.bookmark)"
     />
 
     <KButton
@@ -78,11 +81,11 @@
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
   import genContentLink from '../utils/genContentLink';
-  import { PageNames } from '../constants';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import LearningActivityChip from './LearningActivityChip';
-  import HybridLearningCardGrid from './HybridLearningCardGrid';
+  import HybridLearningContentCardListView from './HybridLearningContentCardListView';
+
   import BrowseResourceMetadata from './BrowseResourceMetadata';
 
   export default {
@@ -96,7 +99,7 @@
       BrowseResourceMetadata,
       FullScreenSidePanel,
       LearningActivityChip,
-      HybridLearningCardGrid,
+      HybridLearningContentCardListView,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     setup() {
@@ -115,8 +118,8 @@
       footerIcons() {
         return { infoOutline: 'viewInformation', close: 'removeFromBookmarks' };
       },
-      currentPage() {
-        return PageNames.BOOKMARKS;
+      backRoute() {
+        return this.$route.name;
       },
     },
     created() {
@@ -129,7 +132,15 @@
     },
     methods: {
       ...mapActions(['createSnackbar']),
-      genContentLink,
+      genContentLink(content) {
+        return genContentLink(
+          content.id,
+          this.topicId,
+          content.is_leaf,
+          this.backRoute,
+          this.context
+        );
+      },
       loadMore() {
         if (!this.loading) {
           this.loading = true;

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -6,7 +6,7 @@
       <ResourceCard
         v-for="(content, idx) in contents"
         :key="`resource-${idx}`"
-        data-test="resource-card"
+        :data-test="'resource-card-' + idx"
         :contentNode="content"
         :to="genContentLink(content)"
         @openCopiesModal="$emit('openCopiesModal', content.copies)"
@@ -22,7 +22,7 @@
         v-for="(content, idx) in contents"
         :key="`resource-${idx}`"
         class="card-grid-item"
-        data-test="content-card"
+        :data-test="'content-card-' + idx"
         :isMobile="windowIsSmall"
         :content="content"
         :link="genContentLink(content)"
@@ -37,7 +37,7 @@
       :key="content.id"
       :content="content"
       class="card-grid-item"
-      data-test="card-list-view"
+      :data-test="'card-list-view-' + idx"
       :link="genContentLink(content)"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"
@@ -85,6 +85,9 @@
           return ['card', 'list'].includes(value);
         },
       },
+      // Used to define the "type" (number of columns) for <CardGrid />
+      // Currently only either `1` or `2`
+      // See props in CardGrid.vue for more details on # of cards per level
       gridType: {
         type: Number,
         required: true,

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -22,7 +22,7 @@
         v-for="(content, idx) in contents"
         :key="`resource-${idx}`"
         class="card-grid-item"
-        data-test="hybrid-learning-content-card"
+        data-test="content-card"
         :isMobile="windowIsSmall"
         :content="content"
         :link="genContentLink(content)"
@@ -33,12 +33,11 @@
     <!-- large displays, list view -->
     <HybridLearningContentCardListView
       v-for="content in contents"
-      v-else
+      v-else-if="!windowIsSmall && currentCardViewStyle === 'list'"
       :key="content.id"
       :content="content"
       class="card-grid-item"
-      data-test="hybrid-learning-content-card-list-view"
-      :isMobile="windowIsSmall"
+      data-test="card-list-view"
       :link="genContentLink(content)"
       :footerIcons="footerIcons"
       :createdDate="content.bookmark ? content.bookmark.created : null"

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -1,0 +1,118 @@
+<template>
+
+  <div>
+    <!-- small and xs displays -->
+    <CardGrid v-if="windowIsSmall" data-test="mobile-card-grid">
+      <ResourceCard
+        v-for="(content, idx) in contents"
+        :key="`resource-${idx}`"
+        data-test="resource-card"
+        :contentNode="content"
+        :to="genContentLink(content)"
+        @openCopiesModal="$emit('openCopiesModal', content.copies)"
+      />
+    </CardGrid>
+    <!-- large displays, card view -->
+    <CardGrid
+      v-else-if="!windowIsSmall && currentCardViewStyle === 'card'"
+      :gridType="gridType"
+      data-test="non-mobile-card-grid"
+    >
+      <HybridLearningContentCard
+        v-for="(content, idx) in contents"
+        :key="`resource-${idx}`"
+        class="card-grid-item"
+        data-test="hybrid-learning-content-card"
+        :isMobile="windowIsSmall"
+        :content="content"
+        :link="genContentLink(content)"
+        @openCopiesModal="$emit('openCopiesModal', content.copies)"
+        @toggleInfoPanel="$emit('toggleInfoPanel', content)"
+      />
+    </CardGrid>
+    <!-- large displays, list view -->
+    <HybridLearningContentCardListView
+      v-for="content in contents"
+      v-else
+      :key="content.id"
+      :content="content"
+      class="card-grid-item"
+      data-test="hybrid-learning-content-card-list-view"
+      :isMobile="windowIsSmall"
+      :link="genContentLink(content)"
+      :footerIcons="footerIcons"
+      :createdDate="content.bookmark ? content.bookmark.created : null"
+      @openCopiesModal="$emit('openCopiesModal', content.copies)"
+      @viewInformation="$emit('toggleInfoPanel', content)"
+      @removeFromBookmarks="$emit('removeFromBookmarks',content, contents)"
+    />
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import genContentLink from '../utils/genContentLink';
+  import CardGrid from './cards/CardGrid';
+  import ResourceCard from './cards/ResourceCard';
+
+  import HybridLearningContentCard from './HybridLearningContentCard';
+  import HybridLearningContentCardListView from './HybridLearningContentCardListView';
+
+  export default {
+    name: 'LibraryAndChannelBrowserMainContent',
+
+    components: {
+      CardGrid,
+      HybridLearningContentCard,
+      HybridLearningContentCardListView,
+      ResourceCard,
+    },
+
+    mixins: [responsiveWindowMixin],
+
+    props: {
+      contents: {
+        type: Array,
+        required: true,
+      },
+      currentCardViewStyle: {
+        type: String,
+        required: true,
+        default: 'card',
+        validator(value) {
+          return ['card', 'list'].includes(value);
+        },
+      },
+      gridType: {
+        type: Number,
+        required: true,
+        default: 1,
+      },
+    },
+
+    computed: {
+      footerIcons() {
+        return { info: 'viewInformation' };
+      },
+      backRoute() {
+        return this.$route.name;
+      },
+    },
+
+    methods: {
+      genContentLink(content) {
+        return genContentLink(
+          content.id,
+          this.topicId,
+          content.is_leaf,
+          this.backRoute,
+          this.context
+        );
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -99,7 +99,7 @@
         />
         <!-- Grid of search results  -->
         <LibraryAndChannelBrowserMainContent
-          :contents="resumableContentNodes"
+          :contents="results"
           :currentCardViewStyle="currentCardViewStyle"
           :gridType="1"
           @openCopiesModal="openCopiesModal"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -156,12 +156,11 @@
                 </KRouterLink>
               </h2>
               <!-- card grid of items in folder -->
-              <HybridLearningCardGrid
+              <LibraryAndChannelBrowserMainContent
                 v-if="t.children && t.children.length"
                 :contents="t.children"
-                :numCols="numCols"
-                :genContentLink="genContentLink"
-                cardViewStyle="card"
+                currentCardViewStyle="card"
+                :gridType="2"
                 @toggleInfoPanel="toggleInfoPanel"
               />
               <KButton
@@ -397,6 +396,7 @@
   import CategorySearchModal from './CategorySearchModal';
   import SearchChips from './SearchChips';
   import LibraryPage from './LibraryPage';
+  import LibraryAndChannelBrowserMainContent from './LibraryAndChannelBrowserMainContent';
   import plugin_data from 'plugin_data';
 
   export default {
@@ -419,6 +419,7 @@
       KBreadcrumbs,
       CardThumbnail,
       HybridLearningCardGrid,
+      LibraryAndChannelBrowserMainContent,
       CustomContentRenderer,
       CategorySearchModal,
       EmbeddedSidePanel,

--- a/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
@@ -1,0 +1,66 @@
+import { shallowMount } from '@vue/test-utils';
+import LibraryAndChannelBrowserMainContent from '../../src/views/LibraryAndChannelBrowserMainContent';
+
+describe('Library and Channel Browser Main Content', () => {
+  const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+    computed: { windowIsLarge: () => true, backRoute: 'test' },
+    propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
+  });
+
+  it('smoke test', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+  describe('When the user has a medium or large screen', () => {
+    describe('When `currentCardViewStyle` is a card', () => {
+      const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+        computed: { windowIsSmall: () => false, backRoute: 'test' },
+        propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
+      });
+      it('displays a `CardGrid`, and within the grid, a `HybridLearningContentCard` for each content node', () => {
+        expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeTruthy();
+        expect(wrapper.find('[data-test="content-card"]').element).toBeTruthy();
+      });
+      it('does not display a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
+        expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeFalsy();
+        expect(wrapper.find('[data-test="resource-card"]').element).toBeFalsy();
+      });
+      it('does not display a `HybridLearningContentCardListView` for each content node', () => {
+        expect(wrapper.find('[data-test="card-list-view"]').element).toBeFalsy();
+      });
+    });
+    describe('When `currentCardViewStyle` is a list', () => {
+      const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+        computed: { windowIsSmall: () => false, backRoute: 'test' },
+        propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'list' },
+      });
+      it('displays a `HybridLearningContentCardListView` for each content node, in a single, full-width column', () => {
+        expect(wrapper.find('[data-test="card-list-view"]').element).toBeTruthy();
+      });
+      it('does not display a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
+        expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeFalsy();
+        expect(wrapper.find('[data-test="resource-card"]').element).toBeFalsy();
+      });
+      it('does not display a `CardGrid` with `HybridLearningContentCard`s in columns', () => {
+        expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeFalsy();
+        expect(wrapper.find('[data-test="content-card"]').element).toBeFalsy();
+      });
+    });
+  });
+  describe('When the user is on a mobile device', () => {
+    const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+      computed: { windowIsSmall: () => true, backRoute: 'test' },
+      propsData: { contents: [{ node: 1 }] },
+    });
+    it('displays a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
+      expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeTruthy();
+      expect(wrapper.find('[data-test="resource-card"]').element).toBeTruthy();
+    });
+    it('does not display a `CardGrid` with `HybridLearningContentCard`s in columns', () => {
+      expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeFalsy();
+      expect(wrapper.find('[data-test="content-card"]').element).toBeFalsy();
+    });
+    it('does not display a `HybridLearningContentCardListView` for each content node', () => {
+      expect(wrapper.find('[data-test="card-list-view"]').element).toBeFalsy();
+    });
+  });
+});

--- a/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
@@ -6,9 +6,13 @@ describe('Library and Channel Browser Main Content', () => {
   beforeEach(() => {
     wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
       computed: { windowIsSmall: () => false, backRoute: 'test' },
-      propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
+      propsData: {
+        contents: [{ node: 1 }, { node: 2 }, { node: 3 }],
+        currentCardViewStyle: 'card',
+      },
     });
   });
+
   it('smoke test', () => {
     expect(wrapper.exists()).toBe(true);
   });
@@ -16,7 +20,9 @@ describe('Library and Channel Browser Main Content', () => {
     describe('When `currentCardViewStyle` is a card', () => {
       it('displays a `CardGrid`, and within the grid, a `HybridLearningContentCard` for each content node', () => {
         expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeTruthy();
-        expect(wrapper.find('[data-test="content-card"]').element).toBeTruthy();
+        it.each([{ node: 1 }, { node: 2 }, { node: 3 }], 'displays a card for each node n', n => {
+          expect(wrapper.find(`[data-test="content-card-"${n}]`).element).toBeTruthy();
+        });
       });
       it('does not display a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
         expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeFalsy();
@@ -34,7 +40,9 @@ describe('Library and Channel Browser Main Content', () => {
         });
       });
       it('displays a `HybridLearningContentCardListView` for each content node, in a single, full-width column', () => {
-        expect(wrapper.find('[data-test="card-list-view"]').element).toBeTruthy();
+        it.each([{ node: 1 }, { node: 2 }, { node: 3 }], 'displays a card for each node n', n => {
+          expect(wrapper.find(`[data-test="card-list-view-"${n}]`).element).toBeTruthy();
+        });
       });
       it('does not display a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
         expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeFalsy();
@@ -55,7 +63,13 @@ describe('Library and Channel Browser Main Content', () => {
     });
     it('displays a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
       expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeTruthy();
-      expect(wrapper.find('[data-test="resource-card"]').element).toBeTruthy();
+      it.each(
+        [{ node: 1 }, { node: 2 }, { node: 3 }],
+        'displays a `ResourceCard` for each node n',
+        n => {
+          expect(wrapper.find(`[data-test="resource-card-"${n}]`).element).toBeTruthy();
+        }
+      );
     });
     it('does not display a `CardGrid` with `HybridLearningContentCard`s in columns', () => {
       expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeFalsy();

--- a/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-and-channel-browser-main-content-grid.spec.js
@@ -2,20 +2,18 @@ import { shallowMount } from '@vue/test-utils';
 import LibraryAndChannelBrowserMainContent from '../../src/views/LibraryAndChannelBrowserMainContent';
 
 describe('Library and Channel Browser Main Content', () => {
-  const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
-    computed: { windowIsLarge: () => true, backRoute: 'test' },
-    propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+      computed: { windowIsSmall: () => false, backRoute: 'test' },
+      propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
+    });
   });
-
   it('smoke test', () => {
     expect(wrapper.exists()).toBe(true);
   });
   describe('When the user has a medium or large screen', () => {
     describe('When `currentCardViewStyle` is a card', () => {
-      const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
-        computed: { windowIsSmall: () => false, backRoute: 'test' },
-        propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'card' },
-      });
       it('displays a `CardGrid`, and within the grid, a `HybridLearningContentCard` for each content node', () => {
         expect(wrapper.find('[data-test="non-mobile-card-grid"]').element).toBeTruthy();
         expect(wrapper.find('[data-test="content-card"]').element).toBeTruthy();
@@ -29,9 +27,11 @@ describe('Library and Channel Browser Main Content', () => {
       });
     });
     describe('When `currentCardViewStyle` is a list', () => {
-      const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
-        computed: { windowIsSmall: () => false, backRoute: 'test' },
-        propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'list' },
+      beforeEach(() => {
+        wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+          computed: { windowIsSmall: () => false, backRoute: 'test' },
+          propsData: { contents: [{ node: 1 }], currentCardViewStyle: 'list' },
+        });
       });
       it('displays a `HybridLearningContentCardListView` for each content node, in a single, full-width column', () => {
         expect(wrapper.find('[data-test="card-list-view"]').element).toBeTruthy();
@@ -47,9 +47,11 @@ describe('Library and Channel Browser Main Content', () => {
     });
   });
   describe('When the user is on a mobile device', () => {
-    const wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
-      computed: { windowIsSmall: () => true, backRoute: 'test' },
-      propsData: { contents: [{ node: 1 }] },
+    beforeEach(() => {
+      wrapper = shallowMount(LibraryAndChannelBrowserMainContent, {
+        computed: { windowIsSmall: () => true, backRoute: 'test' },
+        propsData: { contents: [{ node: 1 }] },
+      });
     });
     it('displays a `CardGrid` with a `ResourceCard` for each content node in a single, full-width column', () => {
       expect(wrapper.find('[data-test="mobile-card-grid"]').element).toBeTruthy();


### PR DESCRIPTION
## Summary

Removes `HybridLearningCardGrid`
Fixes #9004
Fixes #8983 

`HybridLearningCardGrid` was clearly doing too much, and not doing any of it especially well. I approached refactoring by "unabstracting" to hopefully make things simpler. 

**For the Library and Topics pages**, which continued to have very similar layouts and variation only in the number of columns, I created a new component called `LibraryAndChannelBrowserMainContent` with just the elements from `HybridLearningCardGrid` that were needed for these two pages.  This new component uses the existing `CardGrid` component for grid displays as needed. It also has associated tests 🎉  
(Separately, I've gotten extremely reasonable/helpful feedback from @sairina that the mismatch between channel cards and `TopicsPage` is confusing. This is a first step in moving towards more consistent naming.) 

**For the Bookmarks page and lessons playlist page**, there was no need for grids at all, as the content is displayed in "list" style cards. The relevant cards were added directly to their pages. 

This approach I think remedies my previous poor decision of `HybridLearningCardGrid` having to keep track of which page it was on, to know what to display, and overall makes the card displays less brittle. It also reduces the number of levels which props and events need to traverse on some pages, which is nice! I do not think this makes the code any _shorter_, but hopefully this is a step in the right direction towards readability and maintainability. 

**Suggestions for other improvements, and whether they are blocking or follow-up, would be welcome and helpful!**

…


## Reviewer guidance
Because this refactor touched a lot of the learn pages, I have done my best to layout what would need to be reviewed for manual QA. 

**Lesson page**
(Home Page > Your Classes > Your lessons > [Lesson]
- [ ] list of lesson resources should display 
- [ ] clicking on the lesson should open the resource 
- [ ] using the "back" arrow within the content renderer should return the user to the lesson page 

**Library Page**
- [ ] list of resent resources should display when there are recent resources 
- [ ] list of search results should display when there are search results
- [ ] users should be able to toggle between list and grid view 
- [ ] users should be able to open the info panel with the "i" button on each card 
- [ ] users should be able to open the copies modal on resources that have multiple copies
- [ ] clicking on the content should open the resource 
- [ ] using the "back" arrow within the content renderer should return the user to the library page

**Topics/Channel Browsing Page**
- [ ] list of folders should display when there are folders
- [ ] list of content items within a folder should display when at that level within a folder
- [ ] list of search results should display when there are search results
- [ ] users should be able to open the info panel with the "i" button on each card 
- [ ] clicking on the content should open the resource 
- [ ] using the "back" arrow within the content renderer should return the user to the topics page

**Bookmarks page**
- [ ] list of bookmarks should display when there are bookmarks
- [ ] users should be able to open the info panel with the "i" button on each card 
- [ ] users should be able to remove the bookmark with the "x" button on each card 
- [ ] removing the bookmark should remove the bookmark from it's "current place in line" 
- [ ] clicking on the content should open the resource 
- [ ] using the "back" arrow within the content renderer should return the user to the bookmarks page

**Overall**
- [ ] for library and topic/channel pages, the grid should update the number of columns on resize to medium and small screen widths
- [ ] for all mobile devices, a single column of cards should display (never that weird bug with two columns of very narrow skinny cards that was popping up)

**tl;dr --manual QA should elicit a response somewhat like "Why has Marcella spent several days on this code? nothing is different??"**

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
