### PR TITLE
Fix morango 144: integrate new version of morango to address single-user syncing issue

### DIFF
--- a/kolibri/core/auth/test/test_sync_operations.py
+++ b/kolibri/core/auth/test/test_sync_operations.py
@@ -3,6 +3,7 @@ import json
 import mock
 from django.test import SimpleTestCase
 from morango.constants import transfer_statuses
+from morango.errors import MorangoSkipOperation
 from morango.sync.context import LocalSessionContext
 from morango.sync.context import SessionContext
 from morango.sync.operations import BaseOperation
@@ -186,7 +187,7 @@ class KolibriVersionedSyncOperationTestCase(SimpleTestCase):
 
     def test_handle__assert_version(self):
         self.operation.version = None
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(MorangoSkipOperation):
             self.operation.handle(self.context)
 
     def test_handle__server__upgrade_not_needed(self):
@@ -313,7 +314,7 @@ class KolibriSingleUserSyncOperationTestCase(SimpleTestCase):
     ):
         mock_is_local.return_value = False
         mock_is_remote.return_value = False
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(MorangoSkipOperation):
             self.assertFalse(self.operation.handle_initial(self.context))
         self.handle_local_user.assert_not_called()
         self.handle_remote_user.assert_not_called()

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.1.37
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.7
+morango==0.6.8a0
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
## Summary

This fixes a syncing issue around a SoUD syncing to a Full Facility device and from there to another Full Facility device. More details of the issue can be found at https://github.com/learningequality/morango/issues/144

## References

Fixes https://github.com/learningequality/morango/issues/144 through updating to Morango v0.6.8a0, which is based on the fixes in https://github.com/learningequality/morango/pull/145 (note: not yet merged/released, so this PR won't yet build).

## Reviewer guidance

We'll want to test a diverse range of syncing scenarios, to ensure everything is solid, with the specific one that was fixed here (and should probably be part of our standard manual testing workflows now too) being:
1. Setup device A with a new facility. Create user X.
2. Single-user sync user X to another device B.
3. Generate data for user X on device B.
4. Single-user sync B with A again, and ensure the data created on B has come across.
5. Full-facility sync A with another device C, and ensure that the data from B has made it onto device C as well.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
