### PR TITLE
Make database preseeding sensitive to custom build options.

### DIFF
--- a/build_tools/preseed_home.py
+++ b/build_tools/preseed_home.py
@@ -9,6 +9,7 @@ from kolibri.main import initialize  # noqa E402
 from kolibri.deployment.default.sqlite_db_names import (  # noqa E402
     ADDITIONAL_SQLITE_DATABASES,
 )
+from django.conf import settings  # noqa E402
 from django.core.management import call_command  # noqa E402
 
 move_to = os.path.join(os.path.dirname(__file__), "..", "kolibri", "dist", "home")
@@ -22,10 +23,9 @@ call_command(
     "deprovision", "--destroy-all-user-data", "--permanent-irrevocable-data-loss"
 )
 
-shutil.move(os.path.join(temphome, "db.sqlite3"), move_to)
-
-for db_name in ADDITIONAL_SQLITE_DATABASES:
-    shutil.move(os.path.join(temphome, "{}.sqlite3".format(db_name)), move_to)
+for db_config in settings.DATABASES.values():
+    if db_config["ENGINE"] == "django.db.backends.sqlite3":
+        shutil.move(os.path.join(temphome, db_config["NAME"]), move_to)
 
 print("Moved all preseeded home data to {}".format(move_to))
 


### PR DESCRIPTION
## Summary
* SQLite database preseeding was introduced into mainline kolibri in 0.15
* It hardcoded database names, which meant that a custom build that changes these names could break
* Uses the actual database names from Django settings to enumerate the databases.

## Reviewer guidance
Does the build still build?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
