### PR TITLE
Ensure that we filter by subset_of_users_device on network location API

### DIFF
--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -18,7 +18,7 @@ class NetworkLocationViewSet(viewsets.ModelViewSet):
     serializer_class = NetworkLocationSerializer
     queryset = NetworkLocation.objects.all()
     filter_backends = [DjangoFilterBackend]
-    filterset_fields = [
+    filter_fields = [
         "subset_of_users_device",
     ]
 

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -105,3 +105,16 @@ class NetworkLocationAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_reading_network_location_list_filter_soud(self):
+        self.login(self.superuser)
+        models.NetworkLocation.objects.create(
+            base_url="https://kolibrihappyurl.qqq/",
+            subset_of_users_device=True,
+        )
+        response = self.client.get(
+            reverse("kolibri:core:staticnetworklocation-list"),
+            data={"subset_of_users_device": False},
+        )
+        for location in response.data:
+            self.assertFalse(location["subset_of_users_device"])


### PR DESCRIPTION
## Summary
* Fixes typo that was preventing filtering by subset of users devices
* Adds regression test

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
