### PR TITLE
Use os.path.abspath to ensure path resolution.

### DIFF
--- a/kolibri/core/auth/constants/facility_presets.py
+++ b/kolibri/core/auth/constants/facility_presets.py
@@ -4,8 +4,8 @@ import io
 import json
 import os
 
-presets_file = os.path.join(
-    os.path.dirname(__file__), "./facility_configuration_presets.json"
+presets_file = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "./facility_configuration_presets.json")
 )
 with io.open(presets_file, mode="r", encoding="utf-8") as f:
     presets = json.load(f)

--- a/kolibri/core/content/__init__.py
+++ b/kolibri/core/content/__init__.py
@@ -7,4 +7,10 @@ default_app_config = "kolibri.core.content.apps.KolibriContentConfig"
 
 # Do this to prevent import of broken Windows filetype registry that makes guesstype not work.
 # https://www.thecodingforums.com/threads/mimetypes-guess_type-broken-in-windows-on-py2-7-and-python-3-x.952693/
-mimetypes.init([os.path.join(os.path.dirname(__file__), "constants", "mime.types")])
+mimetypes.init(
+    [
+        os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "constants", "mime.types")
+        )
+    ]
+)

--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -19,16 +19,24 @@ from sqlalchemy.orm import sessionmaker
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
 from kolibri.core.content.constants.schema_versions import CURRENT_SCHEMA_VERSION
+from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_MODULE_NAME
+from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_PATH
 from kolibri.core.content.utils.sqlalchemybridge import (
     coerce_version_name_to_valid_module_path,
 )
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import prepare_base
 from kolibri.core.content.utils.sqlalchemybridge import SharingPool
-from kolibri.core.content.utils.sqlalchemybridge import SQLALCHEMY_CLASSES_PATH_TEMPLATE
 
 DATA_PATH_TEMPLATE = os.path.join(
     os.path.dirname(__file__), "../../fixtures/{name}_content_data.json"
+)
+
+SQLALCHEMY_CLASSES_PATH_TEMPLATE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    *(__SQLALCHEMY_CLASSES_PATH + (__SQLALCHEMY_CLASSES_MODULE_NAME + ".py",))
 )
 
 

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -294,7 +294,9 @@ def get_hashi_html_filename():
     global HASHI_FILENAME
     if HASHI_FILENAME is None or getattr(settings, "DEVELOPER_MODE", None):
         with io.open(
-            os.path.join(os.path.dirname(__file__), "../build/hashi_filename"),
+            os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "../build/hashi_filename")
+            ),
             mode="r",
             encoding="utf-8",
         ) as f:

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -165,12 +165,6 @@ __SQLALCHEMY_CLASSES_PATH = ("contentschema", "versions")
 
 __SQLALCHEMY_CLASSES_MODULE_NAME = "content_schema_{name}"
 
-SQLALCHEMY_CLASSES_PATH_TEMPLATE = os.path.join(
-    os.path.dirname(__file__),
-    "..",
-    *(__SQLALCHEMY_CLASSES_PATH + (__SQLALCHEMY_CLASSES_MODULE_NAME + ".py",))
-)
-
 SQLALCHEMY_CLASSES_MODULE_PATH_TEMPLATE = ".".join(
     tuple(__name__.split(".")[:-2])
     + __SQLALCHEMY_CLASSES_PATH

--- a/kolibri/core/content/utils/stopwords.py
+++ b/kolibri/core/content/utils/stopwords.py
@@ -3,8 +3,10 @@ import json
 import os
 
 # load stopwords file
-stopwords_path = os.path.join(
-    os.path.dirname(__file__), os.path.pardir, "constants", "stopwords-all.json"
+stopwords_path = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), os.path.pardir, "constants", "stopwords-all.json"
+    )
 )
 with io.open(stopwords_path, mode="r", encoding="utf-8") as f:
     stopwords = json.load(f)

--- a/kolibri/core/logger/management/commands/generateuserdata.py
+++ b/kolibri/core/logger/management/commands/generateuserdata.py
@@ -112,7 +112,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # Load in the user data from the csv file to give a predictable source of user data
-        data_path = os.path.join(os.path.dirname(__file__), "user_data.csv")
+        data_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "user_data.csv")
+        )
         with io.open(data_path, mode="r", encoding="utf-8") as f:
             user_data = [data for data in csv.DictReader(f)]
 

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -173,16 +173,11 @@ class WebpackBundleHook(hooks.KolibriHook):
         An auto-generated path to where the build-time files are stored,
         containing information about the built bundles.
         """
-        return os.path.join(
-            self._build_path, "{plugin}_stats.json".format(plugin=self.unique_id)
+        return os.path.abspath(
+            os.path.join(
+                self._build_path, "{plugin}_stats.json".format(plugin=self.unique_id)
+            )
         )
-
-    @property
-    def _module_file_path(self):
-        """
-        Returns the path of the class inheriting this classmethod.
-        """
-        return os.path.dirname(self._build_path)
 
     def frontend_message_file(self, lang_code):
         message_file_name = "{name}-messages.json".format(name=self.unique_id)

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -16,7 +16,7 @@ def get_installed_app_locale_path(appname):
     try:
         m = importlib.import_module(appname)
         module_path = os.path.dirname(m.__file__)
-        module_locale_path = os.path.join(module_path, "locale")
+        module_locale_path = os.path.abspath(os.path.join(module_path, "locale"))
 
         if os.path.isdir(module_locale_path):
             return module_locale_path
@@ -26,8 +26,8 @@ def get_installed_app_locale_path(appname):
 
 
 def _get_language_info():
-    file_path = os.path.join(
-        os.path.dirname(kolibri.__file__), "locale", "language_info.json"
+    file_path = os.path.abspath(
+        os.path.join(os.path.dirname(kolibri.__file__), "locale", "language_info.json")
     )
     with io.open(file_path, encoding="utf-8") as f:
         languages = json.load(f)

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -170,9 +170,11 @@ def _copy_preseeded_db(db_name, target=None):
         try:
             import kolibri.dist
 
-            db_path = os.path.join(
-                os.path.dirname(kolibri.dist.__file__),
-                "home/{}.sqlite3".format(db_name),
+            db_path = os.path.abspath(
+                os.path.join(
+                    os.path.dirname(kolibri.dist.__file__),
+                    "home/{}.sqlite3".format(db_name),
+                )
             )
             shutil.copy(db_path, target)
             logger.info(


### PR DESCRIPTION
## Summary
* Wraps all resolutions of `__file__` used in production code with `os.path.abspath` as recommended by PyInstaller for operating in frozen environments: https://pyinstaller.readthedocs.io/en/stable/runtime-information.html#using-file

## References
Replaces #9024 with a solution compatible with all Python versions.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
