### PR TITLE
Fixes for buttons on resource cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -108,7 +108,7 @@
     },
     computed: {
       footerIcons() {
-        return { info: 'viewInformation', close: 'removeFromBookmarks' };
+        return { infoOutline: 'viewInformation', close: 'removeFromBookmarks' };
       },
       currentPage() {
         return PageNames.BOOKMARKS;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -65,7 +65,7 @@
             :key="key"
             :icon="key"
             size="mini"
-            :color="$themePalette.grey.v_400"
+            :color="$themePalette.grey.v_600"
             :ariaLabel="coreString(value)"
             :tooltip="coreString(value)"
             class="icon-fix"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -144,6 +144,9 @@
       isBookmarksPage() {
         return this.currentPage === PageNames.BOOKMARKS;
       },
+      isLibraryPage() {
+        return this.currentPage === PageNames.LIBRARY;
+      },
       ceilingDate() {
         if (this.createdDate > this.now) {
           return this.now;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -8,12 +8,7 @@
     >
       <KFixedGrid numCols="4">
         <KFixedGridItem :span="isMobile ? 4 : 1" class="thumb-area">
-          <CardThumbnail
-            :kind="content.kind"
-            v-bind="{ thumbnail }"
-            :activityLength="content.duration"
-            :contentNode="content"
-          />
+          <CardThumbnail :contentNode="content" />
           <p
             v-if="isBookmarksPage && !isMobile"
             class="created-info"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -327,7 +327,7 @@
         return PageNames.LIBRARY;
       },
       footerIcons() {
-        return { info: 'viewInformation' };
+        return { infoOutline: 'viewInformation' };
       },
       sidePanelWidth() {
         if (this.windowIsSmall || this.windowIsMedium) {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -105,6 +105,7 @@
           :cardViewStyle="currentViewStyle"
           :genContentLink="genContentLink"
           :contents="results"
+          :currentPage="currentPage"
           @toggleInfoPanel="toggleInfoPanel"
         />
         <!-- conditionally displayed button if there are additional results -->

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -105,6 +105,7 @@
           :cardViewStyle="currentViewStyle"
           :genContentLink="genContentLink"
           :contents="results"
+          :footerIcons="footerIcons"
           :currentPage="currentPage"
           @toggleInfoPanel="toggleInfoPanel"
         />


### PR DESCRIPTION
## Summary

- Removes obsolete properties from `CardThumbnail`
- Fixes missing copies/locations button on resource cards in the list view on the Library default and search pages
- Fixes missing info icon button on resource cards in the list view on the Library search page
- Aligns footer icons style on resource cards on the Bookmarks and Library pages with designs making them consistent with other cards used in Library. This also improves icons visibility.

| | Before | After |
| ----- | --------- | ------- |
| Library default page - cards list view | ![library-default-list-before](https://user-images.githubusercontent.com/13509191/152496239-faf2bfa1-f942-4684-9d2b-8d35ab3da434.png) | ![library-default-list-after](https://user-images.githubusercontent.com/13509191/152496235-016dba0e-8e7a-4d57-a506-a57e511fa2e8.png) |
| Library search page - cards list view | ![library-search-list-before](https://user-images.githubusercontent.com/13509191/152496243-c228004a-912b-46a4-961b-2fb624eacc1c.png) | ![library-search-list-after](https://user-images.githubusercontent.com/13509191/152496241-02f69c19-72f6-4815-9bb8-435eb99d3f47.png) |
| Bookmarks | ![bookmarks-before](https://user-images.githubusercontent.com/13509191/152353569-35380667-d075-4651-b2bd-0205f0d8f453.png) | ![bookmarks-after](https://user-images.githubusercontent.com/13509191/152353597-d6662a08-4cb7-4664-8b92-42c061af5bb2.png) |

## References

Resolves #9075

## Reviewer guidance

Please check buttons on cards on Library default and search pages as well as on the Bookmarks page for various resolutions and for resources that have more copies (locations). When previewing cards in Library, make sure to preview resource cards in both grid and list views. You can also check for regressions on resource cards on topic and lesson pages since some the components I've updated are used there.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md