### PR TITLE
Add regression test for latest sync issue, and bump morango to 0.6.8

### DIFF
--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -1244,7 +1244,7 @@ class SingleUserSyncRegressionsTestCase(TestCase):
         )
 
     @multiple_kolibri_servers(3)
-    def test_new_morango_issue(self, servers):
+    def test_issue_fixed_in_morango_pull_146(self, servers):
 
         server1, server2, soud = servers
 

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -1242,3 +1242,43 @@ class SingleUserSyncRegressionsTestCase(TestCase):
             .filter(**base_log_params)
             .exists()
         )
+
+    @multiple_kolibri_servers(3)
+    def test_new_morango_issue(self, servers):
+
+        server1, server2, soud = servers
+
+        facility, learner, _ = server1.generate_base_data()
+
+        # create a log on server1
+        base_log_params = {
+            "channel_id": "725257a0570044acbd59f8cf6a68b2be",
+            "content_id": "9f9438fe6b0d42dd8e913d7d04cfb277",
+            "user_id": learner.id,
+        }
+        server1.create_model(
+            ContentSummaryLog,
+            start_timestamp=timezone.now(),
+            kind="audio",
+            **base_log_params
+        )
+
+        # do a full facility sync from the first server to the second server
+        server2.sync(server1, facility)
+
+        # verify that it was synced correctly
+        assert (
+            ContentSummaryLog.objects.using(server2.db_alias)
+            .filter(**base_log_params)
+            .exists()
+        )
+
+        # sync from the second server to the single-user device
+        soud.sync(server2, facility, user=learner)
+
+        # verify that the log has made it over to the single-user device as well
+        assert (
+            ContentSummaryLog.objects.using(soud.db_alias)
+            .filter(**base_log_params)
+            .exists()
+        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.1.37
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.8a0
+morango==0.6.8a1
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.1.37
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.8a1
+morango==0.6.8
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
## Summary

Adds a regression test for the case of data synced from one full-facility device to a second, and from there to a single-user device, and bumps the version of morango (not yet released) to address the test failure.

## References

Morango diff is here: https://github.com/learningequality/morango/pull/146 and https://github.com/learningequality/morango/pull/147 (this Kolibri PR will not build until the Morango PRs are merged and released)

## Reviewer guidance

Main test scenario will be:
- Create a facility on Device A, and User X
- Import the full facility to Device B
- Single-user sync User X from Device B to a new device C

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
