### PR TITLE
Fix alignment and improve visibility of navigation buttons in a quiz

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -47,68 +47,40 @@
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
             <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
-              <UiIconButton
-                v-if="windowBreakpoint === 0"
-                :aria-label="$tr('nextQuestion')"
-                size="large"
-                type="secondary"
-                class="footer-button"
-                :disabled="questionNumber === exam.question_count - 1"
-                @click="goToQuestion(questionNumber + 1)"
-              >
-                <KIcon
-                  icon="forward"
-                  :color="$themeTokens.primary"
-                />
-              </UiIconButton>
               <KButton
-                v-else
                 :disabled="questionNumber === exam.question_count - 1"
                 :primary="true"
-                class="footer-button"
                 :dir="layoutDirReset"
+                :aria-label="$tr('nextQuestion')"
+                :appearanceOverrides="navigationButtonStyle"
                 @click="goToQuestion(questionNumber + 1)"
               >
-                {{ $tr('nextQuestion') }}
+                <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
                 <template #iconAfter>
                   <KIcon
                     icon="forward"
                     :color="$themeTokens.textInverted"
-                    class="forward-icon"
+                    :style="navigationIconStyleNext"
                   />
                 </template>
               </KButton>
-              <UiIconButton
-                v-if="windowBreakpoint === 0"
-                :aria-label="$tr('previousQuestion')"
-                size="large"
-                type="secondary"
-                class="footer-button left-align"
-                :disabled="questionNumber === 0"
-                @click="goToQuestion(questionNumber - 1)"
-              >
-                <KIcon
-                  icon="back"
-                  :color="$themeTokens.primary"
-                />
-              </UiIconButton>
               <KButton
-                v-else
                 :disabled="questionNumber === 0"
                 :primary="true"
-                class="footer-button"
                 :dir="layoutDirReset"
+                :appearanceOverrides="navigationButtonStyle"
                 :class="{ 'left-align': windowIsSmall }"
+                :aria-label="$tr('previousQuestion')"
                 @click="goToQuestion(questionNumber - 1)"
               >
                 <template #icon>
                   <KIcon
                     icon="back"
                     :color="$themeTokens.textInverted"
-                    class="back-icon"
+                    :style="navigationIconStylePrevious"
                   />
                 </template>
-                {{ $tr('previousQuestion') }}
+                <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
               </KButton>
             </component>
 
@@ -308,6 +280,24 @@
         // Overrides bottomBarLayoutDirection reversal
         return this.isRtl ? 'rtl' : 'ltr';
       },
+      displayNavigationButtonLabel() {
+        return this.windowBreakpoint > 0;
+      },
+      navigationButtonStyle() {
+        return this.displayNavigationButtonLabel
+          ? {}
+          : { minWidth: '36px', width: '36px', padding: 0 };
+      },
+      navigationIconStyleNext() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '4px' }
+          : {};
+      },
+      navigationIconStylePrevious() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '-4px' }
+          : {};
+      },
     },
     watch: {
       attemptLogItemValue(newVal, oldVal) {
@@ -499,25 +489,9 @@
     text-align: center;
   }
 
-  .back-icon {
-    position: relative;
-    top: 3px;
-    left: -4px;
-  }
-
-  .forward-icon {
-    position: relative;
-    top: 3px;
-    left: 4px;
-  }
-
   .left-align {
     position: absolute;
     left: 16px;
-    display: inline-block;
-  }
-
-  .footer-button {
     display: inline-block;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -46,7 +46,7 @@
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
-            <KButtonGroup>
+            <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
               <UiIconButton
                 v-if="windowBreakpoint === 0"
                 :aria-label="$tr('nextQuestion')"
@@ -110,7 +110,7 @@
                 </template>
                 {{ $tr('previousQuestion') }}
               </KButton>
-            </KButtonGroup>
+            </component>
 
             <!-- below prev/next buttons in tab and DOM order, in footer -->
             <div


### PR DESCRIPTION
## Summary

Fixes vertical alignment of buttons on smaller screens and improves buttons visibility when they're displayed without "Previous"/"Next" labels:

| | Before | After |
| - | -------- | ------- |
| 0-480px | ![before_0-480](https://user-images.githubusercontent.com/13509191/152765613-2a535ed4-78cd-4102-ab93-d9f9c55ab6ae.png) | ![after_0-480](https://user-images.githubusercontent.com/13509191/152765606-ab24f15d-075f-481e-a19a-37c83a9010c1.png) |
| 480-600px | ![before_480-600](https://user-images.githubusercontent.com/13509191/152765615-bd61ab30-eb4c-4108-bf56-b63892e5e365.png) | ![after_480-600](https://user-images.githubusercontent.com/13509191/152765611-1e9c5479-0d8e-482e-b7c4-3c6bfd52c1c8.png) |

## References

Resolves https://github.com/learningequality/kolibri/issues/9052
Resolves https://github.com/learningequality/kolibri/issues/9053

## Reviewer guidance

Take a quiz as a learner for screen widths referenced above

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
