### PR TITLE
Update content import flow for channel upgrades

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -2,7 +2,7 @@
 
   <div v-if="!loadingChannel">
 
-    <section v-if="isUpdatingChannel">
+    <section v-if="!isUpdatingChannel">
       <h1>
         {{ $tr('updateChannelAction') }}
       </h1>
@@ -109,7 +109,7 @@
 
     <BottomAppBar>
       <KButton
-        v-if="!channelIsUpdated"
+        v-if="channelIsUpdated"
         :text="$tr('updateChannelAction')"
         appearance="raised-button"
         :primary="true"
@@ -246,7 +246,7 @@
     },
     methods: {
       handleSubmit() {
-        this.disableModal = true;
+        this.showModal = false;
         const updateParams = {
           sourcetype: 'remote',
           channel_id: this.params.channelId,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -244,7 +244,9 @@
                 }
               });
             } else {
-              this.$router.push(this.$router.getRoute(PageNames.MANAGE_TASKS));
+              this.$router.push({
+                ...this.$router.getRoute(PageNames.SELECT_CONTENT),
+              });
             }
           })
           .catch(error => {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -136,13 +136,20 @@
         type: Object,
         required: true,
       },
+      nextStep: {
+        type: Boolean,
+        required: false,
+      },
     },
     computed: {
       buttonLabel() {
-        if (this.taskIsClearable) {
+        if (this.taskIsClearable && !this.nextStep) {
           return this.coreString('clearAction');
+        } else if (this.taskIsClearable && this.nextStep) {
+          return this.coreString('continueAction');
+        } else {
+          return this.coreString('cancelAction');
         }
-        return this.coreString('cancelAction');
       },
       taskIsRunning() {
         return this.task.status === TaskStatuses.RUNNING;

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -65,7 +65,7 @@
       objectType="resource"
       actionType="import"
       :resourceCounts="{ count: transferResourceCount, fileSize: transferFileSize }"
-      :disabled="disableBottomBar || newVersionAvailable || transferFileSize > availableSpace"
+      :disabled="disableBottomBar || transferFileSize > availableSpace"
       @clickconfirm="handleClickConfirm"
     />
   </div>

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -7,16 +7,6 @@
     />
 
     <template v-else>
-      <TaskPanel
-        v-for="task in sortedTaskList"
-        :key="task.id"
-        :task="task"
-        class="task-panel"
-        :style="{ borderBottomColor: $themePalette.grey.v_200 }"
-        @clickclear="handleClickClear(task)"
-        @clickcancel="handleClickCancel(task)"
-      />
-
       <template v-if="onDeviceInfoIsReady">
         <section
           v-if="transferredChannel && onDeviceInfoIsReady"
@@ -81,12 +71,10 @@
   import { mapState, mapActions, mapMutations, mapGetters } from 'vuex';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import isEmpty from 'lodash/isEmpty';
-  import reverse from 'lodash/fp/reverse';
   import find from 'lodash/find';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import TaskPanel from '../ManageTasksPage/TaskPanel';
   import { ContentWizardErrors, TaskTypes, PageNames } from '../../constants';
   import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
   import taskNotificationMixin from '../taskNotificationMixin';
@@ -112,7 +100,6 @@
       ContentWizardUiAlert,
       NewChannelVersionBanner,
       SelectionBottomBar,
-      TaskPanel,
       UiAlert,
     },
     mixins: [responsiveWindowMixin, taskNotificationMixin],
@@ -126,7 +113,7 @@
       };
     },
     computed: {
-      ...mapGetters('manageContent', ['channelIsOnDevice', 'managedTasks']),
+      ...mapGetters('manageContent', ['channelIsOnDevice']),
       ...mapState('manageContent', ['taskList']),
       ...mapGetters('manageContent/wizard', [
         'inLocalImportMode',
@@ -148,9 +135,6 @@
       },
       onDeviceInfoIsReady() {
         return !isEmpty(this.currentTopicNode);
-      },
-      sortedTaskList() {
-        return reverse(this.managedTasks);
       },
       metadataDownloadTask() {
         return find(this.taskList, ({ type, channel_id }) => {
@@ -296,14 +280,6 @@
             this.disableBottomBar = false;
             this.createTaskFailedSnackbar();
           });
-      },
-      handleClickClear(task) {
-        TaskResource.deleteFinishedTask(task.id).catch(() => {
-          // error silently
-        });
-      },
-      handleClickCancel(task) {
-        TaskResource.cancelTask(task.id);
       },
       startImportTask,
       handleClickViewNewVersion() {

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -55,7 +55,6 @@
           {{ spaceTranslator.$tr('notEnoughSpaceForChannelsWarning') }}
         </UiAlert>
         <ContentTreeViewer
-          v-if="!newVersionAvailable"
           class="block-item"
           :class="{ small: windowIsSmall }"
           :style="{ borderBottomColor: $themeTokens.fineLine }"
@@ -63,7 +62,6 @@
       </template>
     </template>
     <SelectionBottomBar
-      v-if="!newVersionAvailable"
       objectType="resource"
       actionType="import"
       :resourceCounts="{ count: transferResourceCount, fileSize: transferFileSize }"

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -7,11 +7,14 @@
     />
 
     <template v-else>
-      <TaskProgress
-        :show="!onDeviceInfoIsReady"
-        type="DOWNLOADING_CHANNEL_CONTENTS"
-        :showButtons="false"
-        status="RUNNING"
+      <TaskPanel
+        v-for="task in sortedTaskList"
+        :key="task.id"
+        :task="task"
+        class="task-panel"
+        :style="{ borderBottomColor: $themePalette.grey.v_200 }"
+        @clickclear="handleClickClear(task)"
+        @clickcancel="handleClickCancel(task)"
       />
 
       <template v-if="onDeviceInfoIsReady">
@@ -78,11 +81,12 @@
   import { mapState, mapActions, mapMutations, mapGetters } from 'vuex';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import isEmpty from 'lodash/isEmpty';
+  import reverse from 'lodash/fp/reverse';
   import find from 'lodash/find';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import TaskProgress from '../ManageContentPage/TaskProgress';
+  import TaskPanel from '../ManageTasksPage/TaskPanel';
   import { ContentWizardErrors, TaskTypes, PageNames } from '../../constants';
   import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
   import taskNotificationMixin from '../taskNotificationMixin';
@@ -108,7 +112,7 @@
       ContentWizardUiAlert,
       NewChannelVersionBanner,
       SelectionBottomBar,
-      TaskProgress,
+      TaskPanel,
       UiAlert,
     },
     mixins: [responsiveWindowMixin, taskNotificationMixin],
@@ -122,7 +126,7 @@
       };
     },
     computed: {
-      ...mapGetters('manageContent', ['channelIsOnDevice']),
+      ...mapGetters('manageContent', ['channelIsOnDevice', 'managedTasks']),
       ...mapState('manageContent', ['taskList']),
       ...mapGetters('manageContent/wizard', [
         'inLocalImportMode',
@@ -144,6 +148,9 @@
       },
       onDeviceInfoIsReady() {
         return !isEmpty(this.currentTopicNode);
+      },
+      sortedTaskList() {
+        return reverse(this.managedTasks);
       },
       metadataDownloadTask() {
         return find(this.taskList, ({ type, channel_id }) => {
@@ -289,6 +296,14 @@
             this.disableBottomBar = false;
             this.createTaskFailedSnackbar();
           });
+      },
+      handleClickClear(task) {
+        TaskResource.deleteFinishedTask(task.id).catch(() => {
+          // error silently
+        });
+      },
+      handleClickCancel(task) {
+        TaskResource.cancelTask(task.id);
       },
       startImportTask,
       handleClickViewNewVersion() {


### PR DESCRIPTION
## Summary

This is a PR with very few code changes but some significant differences to the UX. It adjusts the channel upgrade flow when importing additional resources. We had tagged this on `0.15.1` as Devon thought it may have been a regression (thus, more important to fix promptly) but after some [investigating](https://learningequality.slack.com/archives/CB37UM23A/p1643988582256619), it seems as though this is just an improvement, rather than a bug fix. So, I am open to suggestions about if this should go into 15 or into develop.

1. The content tree view is now always visible, even if there is an upgrade available
2. After upgrade, the user is returned to the page they were on ("Import More") rather than being returned to the main channel page

## References

Fixes #8826 

| Description | Before  |  After |
|---|---|---|
| Content tree view  | ![old-version-import (1)](https://user-images.githubusercontent.com/17235236/153067822-d8fafbc9-b376-4ba7-ba46-b510f0098469.gif)  | ![new-content-tree-view](https://user-images.githubusercontent.com/17235236/153068107-b9ed04f9-0aa3-4fa0-b22c-c0b73df62453.gif) |
| Redirecting after upgrade |  ![old-redirect-import-flow](https://user-images.githubusercontent.com/17235236/153072449-363b2947-49bc-454c-a46f-7444d13bd567.gif)  | ![new-upgrade-channel-redirect](https://user-images.githubusercontent.com/17235236/153067839-33a3388a-9e2d-40ed-98c1-c1368377cee2.gif) |

## Reviewer guidance
- Does this sufficiently address the issue? 
- Would adding some kind of "feedback" or loading state between the "upgrade channel" and being returned back to the original page be helpful (cc @jtamiace) 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
