### PR TITLE
Add padding to <th> and <td> elements on device permission page table

### DIFF
--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -259,6 +259,10 @@
   }
   th {
     min-width: 112px;
+    padding-right: 4px;
+  }
+  td {
+    padding-left: 4px;
   }
 
   .super-admin-checkbox {


### PR DESCRIPTION
## Summary
Adds a small amount of padding to the table cell elements on the device permissions page, so that when there are long strings in separate cells, they do not touch.

| Screen size  |  Before  |  After  |
|---|---|---|
| xs screen  | <img width="450" alt="Screen Shot 2022-02-08 at 4 52 51 PM" src="https://user-images.githubusercontent.com/17235236/153082254-db051d3c-67b7-437f-9ca3-f557b444fb58.png"> | <img width="483" alt="Screen Shot 2022-02-08 at 4 48 15 PM" src="https://user-images.githubusercontent.com/17235236/153082320-18cde764-5705-4f03-acf4-13946cca1b21.png"> |
| sm screen  | <img width="525" alt="Screen Shot 2022-02-08 at 4 52 42 PM" src="https://user-images.githubusercontent.com/17235236/153082365-3cf6891a-159d-4695-a608-ae601fae7788.png">  | <img width="585" alt="Screen Shot 2022-02-08 at 4 48 24 PM" src="https://user-images.githubusercontent.com/17235236/153082350-650b3020-3473-45f9-9551-a71a8611610b.png"> |


## References
Fixes #8948 

## Reviewer guidance
- With language settings on German and on a mobile size display: Device > Permissions > Edit Permissions 
- This does not take into consideration text wrapping, just the spacing issue. Is that sufficient to consider this done?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
