### PR TITLE
Fix the side panel not taking the full height on a page with no content when browsing a channel 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -760,9 +760,11 @@
 <style lang="scss" scoped>
 
   $header-height: 324px;
+  $toolbar-height: 70px;
 
   .page {
     position: relative;
+    min-height: calc(100vh - #{$toolbar-height});
     overflow-x: hidden;
   }
 


### PR DESCRIPTION
## Summary

Allows the side panel to take the full height by setting min-height on the page container so the panel can vertically spread even though there are no cards. Toolbar height needs to be taken into account when calculating min-height, otherwise the page would be higher than it needs to be and a vertical bar would appear for the main area when there is no content present.

| Before | After |
| -------- | ------- |
| ![before](https://user-images.githubusercontent.com/13509191/153203263-890c1f87-b0e7-441c-a4ab-75cc5f6d5bd5.png) | ![after](https://user-images.githubusercontent.com/13509191/153203342-d4828388-8305-411a-ab77-5ad6773ff3db.png) |
| ![before](https://user-images.githubusercontent.com/13509191/153204329-9b74de41-590f-4564-bfb5-a8b5864e1177.png) | ![after](https://user-images.githubusercontent.com/13509191/153204344-0b956590-6c47-4f28-91d7-f555f035f209.png) |

## References

Fixes https://github.com/learningequality/kolibri/issues/9010

## Reviewer guidance

- [ ] Please check that #9010 has been fixed by following its steps to reproduce:

> 1. Install the official 0.15 build of Kolibri
> 2. Import the QA Channel (nakav-mafak) and go to Learn>Library
> 3. Filter by language - Espanol - and click the Spanish folder in the Search results

- [ ] and that there are no layout regressions on the page when it has some cards
- [ ] and that there is no regression with the stickiness of the side panel when scrolling the page

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
