### PR TITLE
Perseus to only show hints when allowHints or interactive is true 

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -18,9 +18,10 @@
           <!-- Layout notes
             - Layout12 span8 -> ~66% width on windowIsLarge
             - No other layout definitions means span will be 100%
-            - When not interactive, this should be full width
+            - If we're not allowingHints, then it should be 100% because
+              they're the reason we'd go smaller at all
           -->
-          <KGridItem :layout12="{ span: interactive ? 6 : 12 }">
+          <KGridItem :layout12="{ span: allowHints && interactive ? 6 : 12 }">
             <div
               id="problem-area"
               class="problem-area"
@@ -31,13 +32,11 @@
           </KGridItem>
 
           <!--
-              - Only show the hints section at all if in interactive mode
-                Initially done to hide it in Coach reports after recent improvements to
-                the styles here for Learners.
+              - Hide when not allowing hints
               - It is a v-show because seems without the proper anchors in place
                 it will fail to properly mount the react component
           -->
-          <KGridItem v-show="interactive" :layout12="{ span: 6 }">
+          <KGridItem v-show="interactive && allowHints" :layout12="{ span: 6 }">
             <div v-if="hinted" id="hintlabel" class="hintlabel" :dir="contentDirection">
               {{ $tr("hintLabel") }}
             </div>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Cherry picking [this commit ](https://github.com/learningequality/kolibri/pull/8884/commits/d69c7653bb81d6dd35f3638cb8d6245afd26255d) which was merged to develop previously.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9050 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Read #9050 and see that it is fixed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
