### PR TITLE
First part of the fix for the info side panel not displayed in Internet Explorer

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -171,7 +171,7 @@
       },
       closeButtonStyles() {
         return {
-          top: `calc((${this.fixedHeaderHeight} - 40px) / 2)`,
+          top: `${(this.fixedHeaderHeight - 40) / 2}px`,
         };
       },
       closeButtonFullScreenSidePanelStyles() {


### PR DESCRIPTION
Fixes the info side panel not displayed in IE after clicking the info button (https://github.com/learningequality/kolibri/issues/9100). See the commit message for an explanation.

However, I tested this fix on the bookmarks page only, and even though the side panel appears now in Internet Explorer as expected for me, there still needs to be some work done. It seems that over time we somehow updated styles related to positioning the close button in the full-screen side panel and after fixing the calculation in this PR, the button seems to be off now in ALL browsers:

**(1) When there are some learning activities**
![Screenshot from 2022-02-14 14-00-26](https://user-images.githubusercontent.com/13509191/153870735-508c8bd8-80c4-4a0f-aafe-f9566b52abca.png)

**(2) No learning activities or when the header slot is empty**
Not sure if it happens with production data but in any case `FullScreenSidePanel` should be ready for this situation since the header slot is optional or when learning activities would be missing.

![Screenshot from 2022-02-14 14-01-35](https://user-images.githubusercontent.com/13509191/153870781-81dda9c4-df7f-4c1e-afb7-2dc1c663dd1c.png)

I might have also overlooked something and so far was debugging on Browserstack where things were getting quite stuck. Since #9100 seems to be a blocker to the release, I'm opening a draft PR if someone would like to finish this sooner, before I can get to it again.
