### PR TITLE
Deprecation warnings for Python 3.4 and 3.5

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -4,9 +4,18 @@ import platform
 import sys
 from warnings import warn
 
-from colorlog import ColoredFormatter
-from colorlog import getLogger
-from colorlog import StreamHandler
+try:
+    # Do this to allow this to be accessed
+    # during build, when dependencies are not
+    # installed.
+    # TODO: Move version tools to build tools, so we don't have to do this
+    from colorlog import ColoredFormatter
+    from colorlog import getLogger
+    from colorlog import StreamHandler
+except ImportError:
+    StreamHandler = None
+    getLogger = None
+    ColoredFormatter = None
 
 from .logger import LOG_COLORS
 
@@ -14,14 +23,17 @@ from .logger import LOG_COLORS
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
 
-handler = StreamHandler()
-handler.setFormatter(
-    ColoredFormatter(
-        fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
+if StreamHandler and getLogger and ColoredFormatter:
+    handler = StreamHandler()
+    handler.setFormatter(
+        ColoredFormatter(
+            fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
+        )
     )
-)
-logger = getLogger("env")
-logger.addHandler(handler)
+    logger = getLogger("env")
+    logger.addHandler(handler)
+else:
+    logger = logging.getLogger("env")
 
 
 def settings_module():

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -3,8 +3,24 @@ import os
 import platform
 import sys
 
+from colorlog import ColoredFormatter
+from colorlog import getLogger
+from colorlog import StreamHandler
+
+from .logger import LOG_COLORS
+
+
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
+
+handler = StreamHandler()
+handler.setFormatter(
+    ColoredFormatter(
+        fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
+    )
+)
+logger = getLogger("env")
+logger.addHandler(handler)
 
 
 def settings_module():
@@ -68,7 +84,7 @@ def prepend_cext_path(dist_path):
         # add it + the matching noarch (OpenSSL) modules to sys.path
         sys.path = [str(dirname), str(noarch_dir)] + sys.path
     else:
-        logging.info("No C extensions are available for this platform")
+        logger.info("No C extensions are available for this platform")
 
 
 def set_env():

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import sys
+from warnings import warn
 
 from colorlog import ColoredFormatter
 from colorlog import getLogger
@@ -87,6 +88,15 @@ def prepend_cext_path(dist_path):
         logger.info("No C extensions are available for this platform")
 
 
+def check_python_versions():
+    if sys.version_info.major == 3 and (
+        sys.version_info.minor == 4 or sys.version_info.minor == 5
+    ):
+        warning_text = "Python 3.4 and 3.5 support will be dropped in Kolibri 0.16, please upgrade your Python version"
+        logger.warn(warning_text)
+        warn(warning_text, DeprecationWarning)
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -97,6 +107,8 @@ def set_env():
     else.
     """
     from kolibri import dist as kolibri_dist  # noqa
+
+    check_python_versions()
 
     sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -8,6 +8,14 @@ DO_ROLLOVER = "doRollover"
 
 NO_FILE_BASED_LOGGING = os.environ.get("KOLIBRI_NO_FILE_BASED_LOGGING", False)
 
+LOG_COLORS = {
+    "DEBUG": "blue",
+    "INFO": "white",
+    "WARNING": "yellow",
+    "ERROR": "red",
+    "CRITICAL": "bold_red",
+}
+
 
 class KolibriTimedRotatingFileHandler(TimedRotatingFileHandler):
     """
@@ -143,13 +151,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             "color": {
                 "()": "colorlog.ColoredFormatter",
                 "format": "%(log_color)s%(levelname)-8s %(message)s",
-                "log_colors": {
-                    "DEBUG": "blue",
-                    "INFO": "white",
-                    "WARNING": "yellow",
-                    "ERROR": "red",
-                    "CRITICAL": "bold_red",
-                },
+                "log_colors": LOG_COLORS,
             },
         },
         "handlers": {


### PR DESCRIPTION
## Summary
* Sets up a logger with pretty colors for our env.py file (using the same color config as our regular logger)
* Adds a deprecation warning for Python versions 3.4 and 3.5 which gets logged as a warning and emitted as a Python warning

## Reviewer guidance
Run kolibri with Python 3.4 and 3.5, confirm that a warning appears on the terminal.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
