### PR TITLE
Fix category search modal focus

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
@@ -10,6 +10,7 @@
       @cancel="$emit('cancel')"
     >
       <CategorySearchOptions
+        ref="searchOptions"
         :selectedCategory="selectedCategory"
         :availableLabels="availableLabels"
         v-on="$listeners"
@@ -18,6 +19,7 @@
     <div v-else>
       <h2>{{ $tr('title') }}</h2>
       <CategorySearchOptions
+        ref="searchOptions"
         :selectedCategory="selectedCategory"
         :availableLabels="availableLabels"
         v-on="$listeners"
@@ -115,6 +117,16 @@
         type: Object,
         required: false,
         default: null,
+      },
+    },
+    methods: {
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap depending on content
+       * rendered in the search modal.
+       */
+      focusFirstEl() {
+        this.$refs.searchOptions.$el.querySelector('.filter-list-title > h2 > a').focus();
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -175,6 +175,7 @@
       />
       <CategorySearchModal
         v-if="currentCategory && (windowIsSmall || windowIsMedium)"
+        ref="searchModal"
         :selectedCategory="currentCategory"
         :numCols="numCols"
         :availableLabels="labels"
@@ -425,8 +426,10 @@
       findFirstEl() {
         if (this.$refs.embeddedPanel) {
           this.$refs.embeddedPanel.focusFirstEl();
-        } else {
+        } else if (this.$refs.resourcePanel) {
           this.$refs.resourcePanel.focusFirstEl();
+        } else {
+          this.$refs.searchModal.focusFirstEl();
         }
       },
     },


### PR DESCRIPTION
## Summary
Fixed category search modal focus in full screen side panel.

## References
From a bug that was discovered while reviewing a PR

## Reviewer guidance
1. Use the keyboard to navigate through Learn's full screen side panel
2. Must come after this PR: https://github.com/learningequality/kolibri/pull/9080 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
