### PR TITLE
Adds auto alignment to channel card grids to ensure proper description display for RTL

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -36,7 +36,7 @@
           :showContentIcon="false"
         />
       </KFixedGridItem>
-      <KFixedGridItem span="3">
+      <KFixedGridItem span="3" alignment="auto">
         <TextTruncator
           :text="tagline"
           :maxHeight="taglineHeight"

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -4,7 +4,7 @@
     <KGridItem
       v-for="content in contents"
       :key="content.id"
-      :layout="{ span: cardColumnSpan }"
+      :layout="{ span: cardColumnSpan, alignment: 'auto' }"
     >
       <ChannelCard
         :isMobile="windowIsSmall"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -6,7 +6,7 @@
       :numCols="numCols"
       gutter="24"
     >
-      <KFixedGridItem v-for="content in contents" :key="content.id" span="1">
+      <KFixedGridItem v-for="content in contents" :key="content.id" span="1" alignment="auto">
         <HybridLearningContentCard
           class="card-grid-item"
           :isMobile="windowIsSmall"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -26,9 +26,9 @@
             <KBreadcrumbs v-if="breadcrumbs.length" :items="breadcrumbs" />
           </KGridItem>
           <KGridItem
-            :layout4="{ span: 4 }"
-            :layout8="{ span: 8 }"
-            :layout12="{ span: 12 }"
+            :layout4="{ span: 4, alignment: 'auto' }"
+            :layout8="{ span: 8, alignment: 'auto' }"
+            :layout12="{ span: 12, alignment: 'auto' }"
           >
             <h1 class="title">
               <TextTruncator
@@ -59,9 +59,9 @@
           <KGridItem
             v-if="topic.description"
             class="text"
-            :layout4="{ span: topic.thumbnail ? 3 : 4 }"
-            :layout8="{ span: topic.thumbnail ? 6 : 8 }"
-            :layout12="{ span: topic.thumbnail ? 10 : 12 }"
+            :layout4="{ span: topic.thumbnail ? 3 : 4, alignment: 'auto' }"
+            :layout8="{ span: topic.thumbnail ? 6 : 8, alignment: 'auto' }"
+            :layout12="{ span: topic.thumbnail ? 10 : 12, alignment: 'auto' }"
           >
             <TextTruncator
               :text="topic.description"


### PR DESCRIPTION
## Summary
* Adds two `auto` alignment props to KGrid items to ensure proper display of descriptions

## References
Fixes #7650

## Reviewer guidance
Before:
![image](https://user-images.githubusercontent.com/1680573/153978788-98f711d7-ac6c-4872-a611-e8f50578067d.png)

After:
![Screenshot from 2022-02-14 18-02-42](https://user-images.githubusercontent.com/1680573/153978798-b72660b9-c244-4eef-9f2a-e874d9cf2143.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
