### PR TITLE
Answer history layout fix

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -8,7 +8,7 @@
       )
       }}
     </component>
-    <div v-if="!isSurvey" data-test="question-attempt-icons">
+    <template v-if="!isSurvey" data-test="question-attempt-icons">
       <AttemptIconDiff
         v-if="showDiff"
         class="diff-item item"
@@ -49,7 +49,7 @@
         :value="attemptLog.num_coach_contents || 0"
         :isTopic="false"
       />
-    </div>
+    </template>
   </span>
 
 </template>

--- a/kolibri/core/assets/src/views/AttemptLogItem.vue
+++ b/kolibri/core/assets/src/views/AttemptLogItem.vue
@@ -8,48 +8,54 @@
       )
       }}
     </component>
-    <template v-if="!isSurvey" data-test="question-attempt-icons">
+    <template v-if="!isSurvey">
       <AttemptIconDiff
         v-if="showDiff"
         class="diff-item item"
+        data-test="question-attempt-icons"
         :correct="attemptLog.correct"
         :diff="attemptLog.diff.correct"
       />
       <KIcon
         v-if="attemptLog.noattempt"
         class="item svg-item"
+        data-test="question-attempt-icons"
         icon="notStarted"
       />
       <KIcon
         v-else-if="attemptLog.correct"
         class="item svg-item"
+        data-test="question-attempt-icons"
         :style="{ fill: $themeTokens.correct }"
         icon="correct"
       />
       <KIcon
         v-else-if="attemptLog.error"
         class="svg-item"
+        data-test="question-attempt-icons"
         :style=" { fill: $themeTokens.annotation }"
         icon="helpNeeded"
       />
       <KIcon
         v-else-if="!attemptLog.correct"
         class="item svg-item"
+        data-test="question-attempt-icons"
         :style="{ fill: $themeTokens.incorrect }"
         icon="incorrect"
       />
       <KIcon
         v-else-if="attemptLog.hinted"
         class="item svg-item"
+        data-test="question-attempt-icons"
         :style=" { fill: $themeTokens.annotation }"
         icon="hint"
       />
-      <CoachContentLabel
-        class="coach-content-label"
-        :value="attemptLog.num_coach_contents || 0"
-        :isTopic="false"
-      />
     </template>
+    <CoachContentLabel
+      class="coach-content-label"
+      :value="attemptLog.num_coach_contents || 0"
+      :isTopic="false"
+    />
   </span>
 
 </template>

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -66,7 +66,10 @@
       />
     </template>
 
-    <template v-if="!windowIsSmall && !loading && currentTry.attemptlogs.length" #aside>
+    <template
+      v-if="!windowIsSmall && !loading && currentTry && currentTry.attemptlogs.length"
+      #aside
+    >
       <AttemptLogList
         :attemptLogs="attemptLogs"
         :selectedQuestionNumber="questionNumber"
@@ -75,7 +78,7 @@
       />
     </template>
 
-    <template v-if="currentTry.attemptlogs.length" #main>
+    <template v-if="currentTry && currentTry.attemptlogs.length" #main>
       <KCircularLoader v-if="loading" class="loader" />
       <template v-else-if="itemId">
         <AttemptLogList


### PR DESCRIPTION
## Summary
* Fixes regression introduced by survey work, where wrapping the icons in a div caused them to break the layout styling
* Fixes errors that happen during rendering when `currentTry` is undefined on the ExamReport

## References
Fixes #9116

## Reviewer guidance
See issue for before image.

After fix:
Big
![Screenshot from 2022-02-16 12-59-55](https://user-images.githubusercontent.com/1680573/154356437-05059275-819d-4131-b8d3-7d018dcd104a.png)

Medium
![Screenshot from 2022-02-16 13-00-08](https://user-images.githubusercontent.com/1680573/154356467-ebb623d0-7fca-4f7a-a665-b4e5a58f2b5a.png)

Mobile
![Screenshot from 2022-02-16 13-00-17](https://user-images.githubusercontent.com/1680573/154356493-1961a42c-f098-4e6b-b7a5-0f59d2eef6c8.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
