### PR TITLE
Remove width property on learning activity label on lesson card so lo…

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -145,7 +145,6 @@
     position: absolute;
     top: $margin;
     right: $margin;
-    width: 100px;
   }
 
   .mobile-card.card {


### PR DESCRIPTION
## Summary

Removes width property on Lesson Activity Label (not needed, and causing problems) 


## References
Fixes #9124
|   |   |
|---|---|
| Mobile  | <img width="492" alt="Screen Shot 2022-02-17 at 11 27 19 AM" src="https://user-images.githubusercontent.com/17235236/154526219-13e22139-a2ac-468d-b218-ce1d2c11caf2.png">  |
|  Desktop | <img width="1001" alt="Screen Shot 2022-02-17 at 11 27 26 AM" src="https://user-images.githubusercontent.com/17235236/154526220-b13e6508-8e8d-4297-ad4b-2404d55b247f.png">  |


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
