### PR TITLE
Fix alignment and improve visibility of navigation buttons in a practice quiz 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -61,63 +61,35 @@
           </KPageContainer>
 
           <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
-            <KButtonGroup>
-              <UiIconButton
-                v-if="windowBreakpoint === 0"
-                :aria-label="$tr('nextQuestion')"
-                size="large"
-                type="secondary"
-                class="footer-button"
-                :disabled="questionNumber === questionsTotal - 1"
-                @click="goToQuestion(questionNumber + 1)"
-              >
-                <KIcon
-                  icon="forward"
-                  :style="{ fill: $themeTokens.primary }"
-                />
-              </UiIconButton>
+            <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
               <KButton
-                v-else
                 :disabled="questionNumber === questionsTotal - 1"
                 :primary="true"
-                class="footer-button"
                 :dir="layoutDirReset"
+                :aria-label="$tr('nextQuestion')"
+                :appearanceOverrides="navigationButtonStyle"
                 @click="goToQuestion(questionNumber + 1)"
               >
-                {{ $tr('nextQuestion') }}
+                <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
                 <template #iconAfter>
-                  <KIcon icon="forward" color="white" class="forward-icon" />
+                  <KIcon icon="forward" color="white" :style="navigationIconStyleNext" />
                 </template>
               </KButton>
-              <UiIconButton
-                v-if="windowBreakpoint === 0"
-                :aria-label="$tr('previousQuestion')"
-                size="large"
-                type="secondary"
-                class="footer-button left-align"
-                :disabled="questionNumber === 0"
-                @click="goToQuestion(questionNumber - 1)"
-              >
-                <KIcon
-                  icon="back"
-                  :style="{ fill: $themeTokens.primary }"
-                />
-              </UiIconButton>
               <KButton
-                v-else
                 :disabled="questionNumber === 0"
                 :primary="true"
-                class="footer-button"
                 :dir="layoutDirReset"
+                :appearanceOverrides="navigationButtonStyle"
+                :aria-label="$tr('previousQuestion')"
                 :class="{ 'left-align': windowIsSmall }"
                 @click="goToQuestion(questionNumber - 1)"
               >
                 <template #icon>
-                  <KIcon icon="back" color="white" class="back-icon" />
+                  <KIcon icon="back" color="white" :style="navigationIconStylePrevious" />
                 </template>
-                {{ $tr('previousQuestion') }}
+                <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
               </KButton>
-            </KButtonGroup>
+            </component>
 
             <!-- below prev/next buttons in tab and DOM order, in footer -->
             <div
@@ -337,6 +309,24 @@
         // Overrides bottomBarLayoutDirection reversal
         return this.isRtl ? 'rtl' : 'ltr';
       },
+      displayNavigationButtonLabel() {
+        return this.windowBreakpoint > 0;
+      },
+      navigationButtonStyle() {
+        return this.displayNavigationButtonLabel
+          ? {}
+          : { minWidth: '36px', width: '36px', padding: 0 };
+      },
+      navigationIconStyleNext() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '4px' }
+          : {};
+      },
+      navigationIconStylePrevious() {
+        return this.displayNavigationButtonLabel
+          ? { position: 'relative', top: '3px', left: '-4px' }
+          : {};
+      },
     },
     watch: {
       itemId(newVal, oldVal) {
@@ -540,25 +530,9 @@
     text-align: center;
   }
 
-  .back-icon {
-    position: relative;
-    top: 3px;
-    left: -4px;
-  }
-
-  .forward-icon {
-    position: relative;
-    top: 3px;
-    left: 4px;
-  }
-
   .left-align {
     position: absolute;
     left: 16px;
-    display: inline-block;
-  }
-
-  .footer-button {
     display: inline-block;
   }
 


### PR DESCRIPTION
## Summary
Uses the fix in @MisRob's PR #9085 to fix button alignment in the bottom bar for practice quizzes.

<img width="597" alt="Screen Shot 2022-02-17 at 11 32 08 AM" src="https://user-images.githubusercontent.com/13563002/154556850-caefd791-b384-4fe0-a9e8-35d710f57f69.png">

## References
Fixes #9123

## Reviewer guidance

Follow the issue's guidance:
1. Install the following [0.16 build](https://buildkite.com/learningequality/kolibri-debian/builds/3799)
2. Import the QA Channel and as a Coach assign a Survey and a Practice quiz to a Learner
3. Sign in as a Learner using a mobile device and attempt to complete the Survey and/or Practice quiz

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
