### PR TITLE
Delete any annotated channelmetadata many to many fields to avoid integrity errors

### DIFF
--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -29,6 +29,7 @@ from kolibri.core.content.models import AssessmentMetaData
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
+from kolibri.core.content.models import Language
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import recurse_annotation_up_tree
 from kolibri.core.content.utils.annotation import (
@@ -475,6 +476,17 @@ class NaiveImportTestCase(ContentNodeTestBase, ContentImportTestBase):
         self.set_content_fixture()
         with self.assertRaises(ContentNode.DoesNotExist):
             assert ContentNode.objects.get(pk=obj_id)
+
+    def test_residual_included_languages_deleted_after_reimport(self):
+        lang = Language.objects.create(id="en")
+        channel = ChannelMetadata.objects.first()
+        # Decrement current channel version to ensure reimport
+        channel.version -= 1
+        channel.included_languages.add(lang)
+        channel.save()
+        self.set_content_fixture()
+        channel = ChannelMetadata.objects.first()
+        self.assertEqual(channel.included_languages.count(), 0)
 
     def test_prerequisites_not_duplicated(self):
         prereqs = ContentNode.has_prerequisite.through.objects.all().count()

--- a/kolibri/core/content/utils/sqlalchemybridge.py
+++ b/kolibri/core/content/utils/sqlalchemybridge.py
@@ -337,6 +337,12 @@ class Bridge(object):
         """
         return self.get_class(DjangoModel).__table__
 
+    def get_current_table(self, DjangoModel):
+        """
+        Convenience method to get a table for the Django database schema
+        """
+        return get_class(DjangoModel, BASES[CURRENT_SCHEMA_VERSION]).__table__
+
     def get_raw_connection(self):
         conn = self.get_connection()
         return conn.connection


### PR DESCRIPTION
## Summary
* Currently `included_languages` is a many to many field from ChannelMetadata to Languages
* Django implements this via a through table
* When we delete the ChannelMetadata object via SQLAlchemy, this does not get properly deleted, because the schema we are using does not know about the included languages table
* This is because using a schema that did know about it would cause other errors, so we let sleeping dogs lie
* To workaround this, we explicitly delete any many to many through tables that are pointing at ChannelMetadata in order to prevent Integrity errors caused by trying to delete a channel metadata row when a many to many through row still points at it
* Adds a regression test that does not replicate the integrity errors, but does at least assert that the deletion of the included languages has occurred.

## Reviewer guidance
Does the test make sense?
Can you think of another way to try to actually get the reported integrity error to trigger in the test?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
