### PR TITLE
Redirect for Bookmarks when user is not logged in

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -95,6 +95,9 @@
       ...mapState('examReportViewer', ['exam']),
       ...mapState(['pageName']),
       userIsAuthorized() {
+        if (this.pageName === PageNames.BOOKMARKS) {
+          return this.isUserLoggedIn;
+        }
         return (
           (plugin_data.allowGuestAccess && this.$store.getters.allowAccess) || this.isUserLoggedIn
         );


### PR DESCRIPTION
## Summary
Added a check to see whether or not a user is logged in. If a user is not logged in, they are redirected to the "content unavailable" view.

## References
Fixes #9057

## Reviewer guidance
Follow the guidance from the original issue:
1. Select "Allow users to explore resources without signing in" in device settings as an admin
2. Sign out
3. Type /en/learn/#/bookmarks URL to the browser address bar
4. Make sure that you see the image below

![message](https://user-images.githubusercontent.com/13509191/151524825-27382ff8-b7b3-4f41-8a52-aeb3d4ef507b.png)

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
