### PR TITLE
Side panel uses full width

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -166,7 +166,6 @@
         v-if="!currentCategory"
         ref="embeddedPanel"
         v-model="searchTerms"
-        :width="`${sidePanelOverlayWidth - 64}px`"
         :availableLabels="labels"
         position="overlay"
         :activeActivityButtons="activeActivityButtons"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -300,7 +300,6 @@
           :topicsLoading="topicMoreLoading"
           :more="topicMore"
           :genContentLink="genContentLink"
-          :width="`${sidePanelOverlayWidth - 64}px`"
           :availableLabels="labels"
           :activeActivityButtons="activeActivityButtons"
           :activeCategories="activeCategories"


### PR DESCRIPTION
## Summary

The TopicsPage and LibraryPage side panel was cut off due to hard-coded px width. With that removed, it fills out the space as expected.

![image](https://user-images.githubusercontent.com/6356129/156083099-39bc5e95-6a7e-4d05-9094-00c14ff73015.png)
 


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #8993 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Is there anywhere this might be a problem?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
