### PR TITLE
Don't run updates when starting from no version

### DIFF
--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -342,7 +342,7 @@ def set_leaf_node_availability_from_local_file_availability(
             )
         )
         # Only look at files that are required (not supplementary)
-        .where(FileTable.c.supplementary == False)
+        .where(FileTable.c.supplementary == False)  # noqa
         # Correlate between the contentnode id and the foreign key
         # to the content node on the file table to complete the
         # many to many lookup

--- a/kolibri/core/test/test_upgrade.py
+++ b/kolibri/core/test/test_upgrade.py
@@ -107,7 +107,7 @@ def test_blank_old_version():
 
     with patch("kolibri.core.upgrade.get_upgrades", return_value=[first]):
         run_upgrades("", "1.1.2")
-        function.assert_called_once()
+        function.assert_not_called()
 
 
 def test_invalid_old_version():

--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -145,7 +145,10 @@ def run_upgrades(old_version, new_version, app_configs=None):
             and matches_version(new_version, upgrade.NEW_VERSION)
         )
 
-    for version_upgrade in sorted(
-        filter(filter_upgrade, get_upgrades(app_configs=app_configs))
-    ):
-        version_upgrade()
+    # Only run upgrades if we had a previous version, otherwise
+    # we're just upgrading from a blank slate, so no need to run anything
+    if old_version:
+        for version_upgrade in sorted(
+            filter(filter_upgrade, get_upgrades(app_configs=app_configs))
+        ):
+            version_upgrade()

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -346,7 +346,7 @@ def initialize(skip_update=False):  # noqa: max-complexity=12
 
     updated = version_updated(kolibri.__version__, version)
 
-    if updated:
+    if version and updated:
         check_plugin_config_file_location(version)
         # Reset the enabled plugins to the defaults
         # This needs to be run before dbbackup because

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,3 +6,4 @@ sphinx-intl==1.0.0
 sphinx-rtd-theme==0.4.3
 sphinx-autobuild==0.7.1
 m2r==0.2.1
+mistune==0.8.4


### PR DESCRIPTION
## Summary
In 0.14.x when installing on a machine that has  not a previous kolibri installation upgrades are run.
This does not make sense when there's nothing to upgrade and can cause big delays if the database is on a Postgresql server that has already data for the same version. This problem is specifically causing cronjobs on KDP server running for too long and timing out.
This is a backport of the fix applied for 0.15.x in #8351 


## References
Refers #8351 , specifically commit https://github.com/learningequality/kolibri/commit/75e1d1d6469

## Reviewer guidance
On an home without a previous installation of kolibri, run `kolibri start `and ensure upgrading messages do not appear and everything works fine

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
