### PR TITLE
Use scroll position

### DIFF
--- a/kolibri/core/assets/src/composables/__tests__/useScrollPosition.spec.js
+++ b/kolibri/core/assets/src/composables/__tests__/useScrollPosition.spec.js
@@ -1,0 +1,29 @@
+import { get, set } from '@vueuse/core';
+import useScrollPosition from '../useScrollPosition';
+
+const { scrollPosition, scrollToSavedPosition, doNotSaveScrollPosition } = useScrollPosition();
+
+describe(`useScrollPosition`, () => {
+  describe(`scrollPosition computed ref getter/setter`, () => {
+    it(`can set the coordinates and then return a cached position when there is a cached position`, () => {
+      global.window.history.pushState({ key: 1 }, '');
+      set(scrollPosition, { x: 150, y: 200 });
+      expect(get(scrollPosition)).toEqual({ x: 150, y: 200 });
+    });
+  });
+  describe('scrollToSavedPosition method', () => {
+    it('calls window.scrollTo with the saved ScrollPosition', () => {
+      expect(get(scrollPosition)).toEqual({ x: 150, y: 200 });
+      jest.spyOn(window, 'scrollTo');
+      scrollToSavedPosition();
+      expect(window.scrollTo).toHaveBeenCalledWith(150, 200);
+    });
+  });
+  describe('doNotSaveScrollPosition method', () => {
+    it('when there is an existing state, it removes the cached state key', () => {
+      expect(global.window.history.state.key).toEqual(1);
+      doNotSaveScrollPosition();
+      expect(global.window.history.state.key).toBeNull;
+    });
+  });
+});

--- a/kolibri/core/assets/src/composables/useScrollPosition.js
+++ b/kolibri/core/assets/src/composables/useScrollPosition.js
@@ -1,0 +1,72 @@
+/* eslint-disable */
+
+export default function useScrollPosition() {
+  let _scrollPositions = {};
+
+  const scrollPosition = computed({
+    get() {
+      // Use key set by Vue Router on the history state.
+      const key = (window.history.state || {}).key;
+      const defaultPos = { x: 0, y: 0 };
+      if (key && this._scrollPositions[key]) {
+        return this._scrollPositions[key];
+      }
+      return defaultPos;
+    },
+    set(oldLocation, newLocation) {
+      if (newLocation !== oldLocation) {
+        // reference location can be { x: 0, y: 0 } coordinates using a Object,
+        // or a string i.e. a css selector
+        // for any instance
+        let x, y;
+        if (newLocation instanceof String) {
+          if (document.querySelector(newLocation)) {
+            const position = document.querySelector(newLocation).getBoundingClientRect();
+            x = position.left;
+            y = position.top;
+          } else {
+            x = 0;
+            y = 0;
+          }
+        } else if (newLocation instanceof Object) {
+          if (newLocation.x instanceof Number && newLocation.x >= 0) {
+            x = newLocation.x;
+          } else {
+            x = 0;
+          }
+          if (newLocation.y instanceof Number && newLocation.y >= 0) {
+            y = newLocation.y;
+          } else {
+            y = 0;
+          }
+        } else {
+          x = 0;
+          y = 0;
+        }
+        const key = (window.history.state || {}).key;
+        // Only set if we have a vue router key on the state,
+        // otherwise we don't do anything.
+        if (key) {
+          this._scrollPositions[window.history.state.key] = { x: x, y: y };
+        }
+      }
+    },
+  });
+
+  function scrollToSavedPosition() {
+    // set the scrollPosition of the window to the saved position state
+    // for the current history state OR to the default scrollPosition { x: 0, y: 0}
+    const position = this.scrollPosition;
+    window.scrollTo(position.x, position.y);
+  }
+
+  function doNotSaveScrollPosition() {
+    // called when the page's scroll position should NOT be saved in the current history state
+    const key = (window.history.state || {}).key;
+    // If we have a vue router key on the state, unset it.
+    if (key) {
+      delete this._scrollPositions[window.history.state.key];
+    }
+    // Otherwise we don't do anything.
+  }
+}

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -145,6 +145,9 @@
   import CoreBanner from '../CoreBanner';
   import ScrollingHeader from './ScrollingHeader';
 
+  // NOTE: there is a new useScrollPosition composable in kolibri.core
+  // that can be used when CoreBase is refactored
+  // This version should be depricated
   const scrollPositions = {
     _scrollPositions: {},
     getScrollPosition() {


### PR DESCRIPTION
## Summary

Moves the existing features of scrollPosition in CoreBase into a composable in `kolibri.core`

Does _not_ remove the function from CoreBase, but adds a note to remove it when the file is refactored, and use the composable instead. 

Adds basic tests.

## References

Fixes #9099

## Reviewer guidance

I have not added a test for the 'css selector' condition, because I couldn't figure out how to test it, but if anyone has a suggestion, I would be happy to add it.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
