### PR TITLE
Update Node version reference in getting_started.rst

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -45,13 +45,13 @@ Next, initialize Git LFS:
 
 .. code-block:: bash
 
+  cd kolibri  # Enter the Kolibri directory
   git lfs install
 
 Finally, add the Learning Equality repo as a remote. That way you can keep your local checkout updated with the most recent changes:
 
 .. code-block:: bash
 
-  cd kolibri  # Enter the Kolibri directory
   git remote add upstream git@github.com:learningequality/kolibri.git
   git fetch --all  # Check if there are changes upstream
   git checkout develop # Checkout the development branch
@@ -154,7 +154,7 @@ Note that the ``--upgrade`` flags above can usually be omitted to speed up the p
 Install Node.js, Yarn and other dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Install Node.js (version 10 is required)
+#. Install Node.js (version 16.x is required)
 #. Install `Yarn <https://yarnpkg.com/>`__
 #. Install non-python project-specific dependencies
 


### PR DESCRIPTION

## Summary
Node version was out of date in the getting started doc for new developers on the project. Also moved the "cd" command to a more appropriate place (it needs to be run before the Git LFS install command). As noted in the references, this was something someone had to explain in an issue. It should just be in the getting started doc in the first place.

## References
https://github.com/learningequality/kolibri/issues/9097

## Reviewer guidance
Check the doc, follow setup instructions in a new directory or on a new linux distro

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [X] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
