### PR TITLE
Compress HTML files for serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ clean: clean-build clean-pyc clean-assets clean-staticdeps
 
 clean-assets:
 	yarn run clean
+	rm -fr kolibri/core/content/static/hashi/
 
 clean-build:
 	rm -f kolibri/VERSION

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
     "hashi-build": "yarn workspace hashi run build",
-    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{js,css,ico,svg,map,eot,woff,ttf,woff2}'"
+    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{html,js,css,ico,svg,map,eot,woff,ttf,woff2}'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Cherry picks the safe parts of #8958
Adds HTML files to the precompressed files.
Cleans up hashi built files when cleaning up assets.


## References
Follow up to #8958

## Reviewer guidance
Do HTML5 and H5P still work?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
