### PR TITLE
No longer attempt to inline assets.

### DIFF
--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -26,9 +26,7 @@ from kolibri.plugins.utils import plugin_url
 
 @define_hook
 class NavigationHook(WebpackBundleHook):
-
-    # Set this to True so that the resulting frontend code will be rendered inline.
-    inline = True
+    pass
 
 
 @define_hook

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -164,7 +164,6 @@ class FrontendHeadAssetsHook(WebpackBundleHook):
     """
 
     bundle_id = "frontend_head_assets"
-    inline = True
 
     def render_to_page_load_sync_html(self):
         """

--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -69,10 +69,6 @@ class WebpackBundleHook(hooks.KolibriHook):
     def bundle_id(self):
         pass
 
-    # : When being included for synchronous loading, should the source files
-    # : for this be inlined?
-    inline = False
-
     # : A mapping of key to JSON serializable value.
     # : This plugin_data will be bootstrapped into a global object on window
     # : with a key of the unique_id as a Javascript object
@@ -205,37 +201,12 @@ class WebpackBundleHook(hooks.KolibriHook):
     def js_and_css_tags(self):
         js_tag = '<script type="text/javascript" src="{url}"></script>'
         css_tag = '<link type="text/css" href="{url}" rel="stylesheet"/>'
-        inline_js_tag = '<script type="text/javascript">{src}</script>'
-        inline_css_tag = "<style>{src}</style>"
         # Sorted to load css before js
         for chunk in self.sorted_chunks():
-            src = None
             if chunk["name"].endswith(".js"):
-                if self.inline:
-                    # During development, we do not write built files to disk
-                    # Because of this, this call might return None
-                    src = self.get_filecontent(chunk["url"])
-                if src is not None:
-                    # If it is not None, then we can inline it
-                    yield inline_js_tag.format(src=src)
-                else:
-                    # If src is None, either this is not something we should be inlining
-                    # or we are in development mode and need to fetch the file from the
-                    # development server, not the disk
-                    yield js_tag.format(url=chunk["url"])
+                yield js_tag.format(url=chunk["url"])
             elif chunk["name"].endswith(".css"):
-                if self.inline:
-                    # During development, we do not write built files to disk
-                    # Because of this, this call might return None
-                    src = self.get_filecontent(chunk["url"])
-                if src is not None:
-                    # If it is not None, then we can inline it
-                    yield inline_css_tag.format(src=src)
-                else:
-                    # If src is None, either this is not something we should be inlining
-                    # or we are in development mode and need to fetch the file from the
-                    # development server, not the disk
-                    yield css_tag.format(url=chunk["url"])
+                yield css_tag.format(url=chunk["url"])
 
     def frontend_message_tag(self):
         if self.frontend_messages():

--- a/kolibri/plugins/hooks.py
+++ b/kolibri/plugins/hooks.py
@@ -110,9 +110,7 @@ Here is the definition of the abstract NavigatonHook in kolibri.core.hooks:
 
     @define_hook
     class NavigationHook(WebpackBundleHook):
-
-        # Set this to True so that the resulting frontend code will be rendered inline.
-        inline = True
+        pass
 
 As can be seen from above, to define an abstract hook, instead of using the ``@register_hook``
 decorator, the ``@define_hook`` decorator is used instead, to signal that this instance of


### PR DESCRIPTION
## Summary
* Removes asset inlining to allow better caching of assets between pages
* Should reduce the size of our Kolibri HTML and allow for cached fetching of navigation items

## References
Brings in a good idea from the ill fated #8958

## Reviewer guidance
Everything should run just as before, but with a few more asset fetches.
Note that this brings dev and production closer to parity, as the devserver could never use inlined assets.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
