### PR TITLE
Ensure we continue routing in ready() in Learn in any case

### DIFF
--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -20,25 +20,27 @@ class LearnModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
-    // If we are not logged in and are forbidden from accessing as guest
-    // redirect to CONTENT_UNAVAILABLE.
     router.beforeEach((to, from, next) => {
-      if (
-        to.name !== PageNames.CONTENT_UNAVAILABLE &&
-        !this.store.state.allowGuestAccess &&
-        !this.store.getters.isUserLoggedIn
-      ) {
-        // Pass the ?next param on to AuthMessage
-        const currentURL = window.encodeURIComponent(window.location.href);
-        router.replace({
-          name: PageNames.CONTENT_UNAVAILABLE,
-          query: {
-            next: currentURL,
-          },
-        });
-      } else {
-        next();
+      if (to.name !== PageNames.CONTENT_UNAVAILABLE && !this.store.getters.isUserLoggedIn) {
+        // if we are not logged in and are forbidden from accessing as guest
+        // redirect to content_unavailable.
+        if (!this.store.state.allowGuestAccess) {
+          // Pass the ?next param on to AuthMessage
+          const currentURL = window.encodeURIComponent(window.location.href);
+          router.replace({
+            name: PageNames.CONTENT_UNAVAILABLE,
+            query: {
+              next: currentURL,
+            },
+          });
+        }
+
+        if (to.name === PageNames.BOOKMARKS) {
+          this.store.commit('CORE_SET_ERROR', { response: { status: 403 } });
+          this.store.commit('CORE_SET_PAGE_LOADING', false);
+        }
       }
+      next();
     });
 
     // after every navigation, block double-clicks


### PR DESCRIPTION
## Summary

I ran into not being able to load anything in Learn as a guest and found the issue.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

I didn't see this reported.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does this introduce any new issues with routing?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
