### PR TITLE
Ensure deprovisioning management command deletes DMC

### DIFF
--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -1,10 +1,11 @@
 import logging
 import sys
 
-from morango.models import Buffer
 from morango.models import Certificate
 from morango.models import DatabaseIDModel
+from morango.models import DatabaseMaxCounter
 from morango.models import DeletedModels
+from morango.models import HardDeletedModels
 from morango.models import Store
 
 from kolibri.core.auth.management.utils import confirm_or_exit
@@ -27,13 +28,14 @@ MODELS_TO_DELETE = [
     ContentSummaryLog,
     FacilityUser,
     FacilityDataset,
+    HardDeletedModels,
     Certificate,
     DatabaseIDModel,
     Store,
-    Buffer,
     DevicePermissions,
     DeletedModels,
     DeviceSettings,
+    DatabaseMaxCounter,
 ]
 
 


### PR DESCRIPTION
## Summary

We weren't clearing the DatabaseMaxCounter table when deprovisioning, which could impede the same data from being synced in again following a deprovisioning run.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
