### PR TITLE
Fix builds for IE11

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.38",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.3.0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.3.0",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/packages/hashi/webpack.config.js
+++ b/packages/hashi/webpack.config.js
@@ -40,7 +40,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        exclude: [/(uuid|core-js)/, { not: [/\.(esm\.js|mjs)$/] }],
+        exclude: { and: [/(uuid|core-js)/, { not: [/\.(esm\.js|mjs)$/] }] },
       },
     ],
   },

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.38",
-    "kolibri-design-system": "git://github.com/learningequality/kolibri-design-system#v1.3.0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.3.0",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -56,7 +56,7 @@ module.exports = ({ mode = 'development', hot = false } = {}) => {
         {
           test: /\.js$/,
           loader: 'babel-loader',
-          exclude: [/(node_modules\/vue|dist|core-js)/, { not: [/\.(esm\.js|mjs)$/] }],
+          exclude: { and: [/(node_modules\/vue|dist|core-js)/, { not: [/\.(esm\.js|mjs)$/] }] },
         },
         {
           test: /\.css$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8099,9 +8099,9 @@ kolibri-constants@0.1.38:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.38.tgz#f6c51c429963210e6e866c72260c9d13d41a1273"
   integrity sha512-IUWZtm+ceA9PF1lCT8+/E6Cjmy+ihiB+xIKfDGI8SrZ6c2VEG7Ku5tyW26Uf0n34olzjeO9zO6nBYjZ+A92Ijw==
 
-"kolibri-design-system@git://github.com/learningequality/kolibri-design-system#v1.3.0":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.0":
   version "1.3.0"
-  resolved "git://github.com/learningequality/kolibri-design-system#c2acc3fd19cee52ccd2a17fa8d2b10cddb2b3d63"
+  resolved "https://github.com/learningequality/kolibri-design-system#c2acc3fd19cee52ccd2a17fa8d2b10cddb2b3d63"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary
* The migration to Webpack 5 meant we had to update our exclude rules.
* The exclude rules for the babel-loader were accidentally updated to an array, which is an implicit OR
* What we actually needed was an AND for the two tests that we had previously
* This PR updates to an explicit AND in both our main webpack config and the hashi webpack config.

## References
Fixes #9132

## Reviewer guidance
Use browserstack or VM with IE11.
Access Kolibri with IE11, confirm that it loads.
Access an HTML5 app with Kolibri and confirm that it loads.

Screenshots from IE11 in Browserstack:

App
![Screenshot from 2022-03-18 14-53-24](https://user-images.githubusercontent.com/1680573/159090695-2c274494-f670-4a9f-9b60-a822939186f8.png)

HTML5
![Screenshot from 2022-03-18 15-00-00](https://user-images.githubusercontent.com/1680573/159090730-28c24bda-9de8-4b9f-ab58-562b6e535e25.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
