### PR TITLE
Add Debian and Windows installers to Github Action for PR Builds

### DIFF
--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -19,6 +19,9 @@ jobs:
       tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        lfs: true
     - name: Install Ubuntu dependencies
       run: |
         sudo apt-get -y -qq update

--- a/.github/workflows/pr_build_comment.yml
+++ b/.github/workflows/pr_build_comment.yml
@@ -35,22 +35,9 @@ jobs:
               fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
 
               let text = `### [**Build Artifacts**](${context.payload.workflow_run.html_url})`
-              artifacts.sort((a, b) => {
-                if (a.name < b.name) {
-                  return -1
-                }
-                if (b.name < a.name) {
-                  return 1
-                }
-                return 0
-              })
 
               const checkSuiteNumber = context.payload.workflow_run.check_suite_id
               const repoHtmlUrl = context.payload.repository.html_url
-
-              const artifactsToDisplay = artifacts.filter((artifact) => {
-                return !artifact.expired && artifact.name != "pr_number"
-              })
 
               const file_manifest = {
                 "deb": "Debian Package",
@@ -61,6 +48,32 @@ jobs:
                 "gz": "Source Tarball",
                 "zip": "Raspberry Pi Image",
               }
+
+              const artifactsToDisplay = artifacts.filter((artifact) => {
+                return !artifact.expired && file_manifest[artifact.name.split('.').pop()]
+              })
+
+              const file_order = [
+                "whl",
+                "pex",
+                "exe",
+                "deb",
+                "dmg",
+                "zip",
+                "gz",
+              ]
+
+              artifactsToDisplay.sort((a, b) => {
+                const a_order = file_order.findIndex(a.name.split('.').pop()) || 100
+                const b_order = file_order.findIndex(b.name.split('.').pop()) || 100
+                if (a_order < b_order) {
+                  return -1
+                }
+                if (b_order < a_order) {
+                  return 1
+                }
+                return 0
+              })
 
               if (artifactsToDisplay.length) {
                 text += '\n| Asset type | Download link |\n|-|-|'

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -38,3 +38,17 @@ jobs:
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       ref: main
+  deb:
+    name: Build DEB file
+    needs: whl
+    uses: learningequality/kolibri-installer-debian/.github/workflows/build_deb.yml@master
+    with:
+      tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
+      ref: master
+  exe:
+    name: Build EXE file
+    needs: whl
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@develop
+    with:
+      whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
+      ref: develop

--- a/Makefile
+++ b/Makefile
@@ -180,8 +180,11 @@ dist: setrequirements writeversion staticdeps staticdeps-cext buildconfig i18n-e
 	python setup.py bdist_wheel
 	ls -l dist
 
-pex: writeversion
-	ls dist/*.whl | while read whlfile; do pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python; done
+read-whl-file-version:
+	python ./build_tools/read_whl_version.py ${whlfile} > kolibri/VERSION
+
+pex:
+	ls dist/*.whl | while read whlfile; do $(MAKE) read-whl-file-version whlfile=$$whlfile; pex $$whlfile --disable-cache -o dist/kolibri-`cat kolibri/VERSION | sed 's/+/_/g'`.pex -m kolibri --python-shebang=/usr/bin/python; done
 
 i18n-extract-backend:
 	cd kolibri && python -m kolibri manage makemessages -- -l en --ignore 'node_modules/*' --ignore 'kolibri/dist/*'

--- a/build_tools/read_whl_version.py
+++ b/build_tools/read_whl_version.py
@@ -1,0 +1,14 @@
+import sys
+
+from pkginfo import Wheel
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: read_whl_version.py <whl_file>")
+        sys.exit(1)
+
+    whl_file = sys.argv[1]
+    whl = Wheel(whl_file)
+    print(whl.version)
+    sys.exit(0)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,3 +6,4 @@ pex<1.6
 setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.8.2
 requests==2.21.0
+pkginfo==1.8.2


### PR DESCRIPTION
## Summary
Integrates the Windows and Debian build actions into the PR Builds

Adds explicit ordering to the PR comments (may not show in this PR, because that gets triggered from develop).

Does a full checkout of all tags and branches + LFS files in the WHL action to ensure proper versioning and files.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
