### PR TITLE
Remove corebase from learn index

### DIFF
--- a/kolibri/core/assets/src/views/AppBarCorePage.vue
+++ b/kolibri/core/assets/src/views/AppBarCorePage.vue
@@ -59,9 +59,10 @@
         type: String,
         default: null,
       },
-      applyStandardLayout: {
-        type: Boolean,
-        default: true,
+      appearanceOverrides: {
+        type: Object,
+        required: false,
+        default: null,
       },
     },
     data() {
@@ -76,8 +77,9 @@
         loading: state => state.core.loading,
       }),
       wrapperStyles() {
-        return this.applyStandardLayout
-          ? {
+        return this.appearanceOverrides
+          ? this.appearanceOverrides
+          : {
               width: '100%',
               display: 'inline-block',
               backgroundColor: this.$themePalette.grey.v_100,
@@ -86,8 +88,7 @@
               paddingTop: this.appBarHeight + 32 + 'px',
               paddingBottom: '72px',
               marginTop: 0,
-            }
-          : '';
+            };
       },
     },
     mounted() {

--- a/kolibri/core/assets/src/views/AppBarCorePage.vue
+++ b/kolibri/core/assets/src/views/AppBarCorePage.vue
@@ -49,7 +49,6 @@
   import AppBar from 'kolibri.coreVue.components.AppBar';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import SideNav from 'kolibri.coreVue.components.SideNav';
-  import { mapState } from 'vuex';
 
   export default {
     name: 'AppBarCorePage',
@@ -64,6 +63,10 @@
         required: false,
         default: null,
       },
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
     data() {
       return {
@@ -73,9 +76,6 @@
       };
     },
     computed: {
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
       wrapperStyles() {
         return this.appearanceOverrides
           ? this.appearanceOverrides

--- a/kolibri/core/assets/src/views/AppBarCorePage.vue
+++ b/kolibri/core/assets/src/views/AppBarCorePage.vue
@@ -6,6 +6,7 @@
     <ScrollingHeader :scrollPosition="0">
       <AppBar
         ref="appBar"
+        class="app-bar"
         :title="title"
         @toggleSideNav="navShown = !navShown"
         @showLanguageModal="languageModalShown = true"
@@ -14,6 +15,11 @@
           <slot name="subNav"></slot>
         </template>
       </AppBar>
+      <KLinearLoader
+        v-if="loading"
+        type="indeterminate"
+        :delay="false"
+      />
     </ScrollingHeader>
 
     <div class="main-wrapper" :style="wrapperStyles">
@@ -43,6 +49,7 @@
   import AppBar from 'kolibri.coreVue.components.AppBar';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import SideNav from 'kolibri.coreVue.components.SideNav';
+  import { mapState } from 'vuex';
 
   export default {
     name: 'AppBarCorePage',
@@ -51,6 +58,10 @@
       title: {
         type: String,
         default: null,
+      },
+      applyStandardLayout: {
+        type: Boolean,
+        default: true,
       },
     },
     data() {
@@ -61,17 +72,22 @@
       };
     },
     computed: {
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       wrapperStyles() {
-        return {
-          width: '100%',
-          display: 'inline-block',
-          backgroundColor: this.$themePalette.grey.v_100,
-          paddingLeft: '32px',
-          paddingRight: '32px',
-          paddingTop: this.appBarHeight + 32 + 'px',
-          paddingBottom: '72px',
-          marginTop: 0,
-        };
+        return this.applyStandardLayout
+          ? {
+              width: '100%',
+              display: 'inline-block',
+              backgroundColor: this.$themePalette.grey.v_100,
+              paddingLeft: '32px',
+              paddingRight: '32px',
+              paddingTop: this.appBarHeight + 32 + 'px',
+              paddingBottom: '72px',
+              marginTop: 0,
+            }
+          : '';
       },
     },
     mounted() {
@@ -82,3 +98,16 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .app-bar {
+    @extend %dropshadow-4dp;
+
+    width: 100%;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/AppBarCorePage.vue
+++ b/kolibri/core/assets/src/views/AppBarCorePage.vue
@@ -2,7 +2,7 @@
 
   <!-- TODO useScrollPosition to set scrollPosition...
     here or in router, but somewhere -->
-  <div>
+  <div class="main">
     <ScrollingHeader :scrollPosition="0">
       <AppBar
         ref="appBar"
@@ -81,7 +81,8 @@
           ? this.appearanceOverrides
           : {
               width: '100%',
-              display: 'inline-block',
+              maxWidth: '1064px',
+              margin: 'auto',
               backgroundColor: this.$themePalette.grey.v_100,
               paddingLeft: '32px',
               paddingRight: '32px',

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -8,6 +8,7 @@
     :style="{
       height: topBarHeight + 'px',
       position: 'fixed',
+      zIndex: 4,
       top: 0,
       right: 0,
       left: 0,

--- a/kolibri/core/assets/src/views/NotificationsRoot.vue
+++ b/kolibri/core/assets/src/views/NotificationsRoot.vue
@@ -18,7 +18,7 @@
     </AppBarCorePage>
 
     <div v-else role="main" tabindex="-1" data-test="main">
-      <slot></slot>
+      <slot :loading="loading"></slot>
     </div>
 
     <GlobalSnackbar />
@@ -75,6 +75,10 @@
         type: String,
         default: null,
       },
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
     data() {
       return {
@@ -85,7 +89,6 @@
       ...mapGetters(['isAdmin', 'isSuperuser']),
       ...mapState({
         error: state => state.core.error,
-        loading: state => state.core.loading,
         notifications: state => state.core.notifications,
       }),
       notAuthorized() {

--- a/kolibri/core/assets/test/views/app-bar-core-page.spec.js
+++ b/kolibri/core/assets/test/views/app-bar-core-page.spec.js
@@ -10,6 +10,10 @@ const store = new Vuex.Store({
   },
 });
 
+store.state.core = {
+  loading: false,
+};
+
 function createWrapper({ propsData = {}, slots = {} } = {}) {
   return mount(AppBarCorePage, {
     propsData,

--- a/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-app-bar-page.spec.js
@@ -8,6 +8,10 @@ function makeWrapper({ propsData = {}, vuexData = {} }) {
     facilityPageLinks: () => {},
     ...store.getters,
   };
+  store.state.core = {
+    loading: false,
+    ...store.state.core,
+  };
   return mount(FacilityAppBarPage, {
     propsData,
     store,

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -1,3 +1,4 @@
+// import { LastPages } from './../constants/lastPagesConstants';
 import { PageNames, ClassesPageNames } from './../constants';
 import mutations from './coreLearn/mutations';
 import * as getters from './coreLearn/getters';
@@ -24,53 +25,42 @@ export default {
   getters: {
     ...getters,
     learnPageLinks() {
-      const params = {};
       return {
         HomePage: {
           name: PageNames.HOME,
-          params,
         },
         LibraryPage: {
           name: PageNames.LIBRARY,
-          params,
         },
         TopicsPage: {
           name: PageNames.TOPICS_TOPIC,
-          params,
         },
         TopicsSearchPage: {
           name: PageNames.TOPICS_TOPIC_SEARCH,
-          params,
         },
         ContentUnavailablePage: {
           name: PageNames.CONTENT_UNAVAILABLE,
-          params,
         },
         BookmarksPage: {
           name: PageNames.BOOKMARKS,
-          params,
         },
         ExamPage: id => {
           return {
             name: ClassesPageNames.EXAM_VIWER,
-            params: { params, quizId: id },
+            params: { quizId: id },
           };
         },
         ExamReportViewer: {
           name: ClassesPageNames.EXAM_REPORT_VIEWER,
-          params,
         },
         AllClassesPage: {
           name: ClassesPageNames.ALL_CLASSES,
-          params,
         },
         ClassAssignmentsPage: {
           name: ClassesPageNames.CLASS_ASSIGNMENTS,
-          params,
         },
         LessonPlaylistPage: {
           name: ClassesPageNames.LESSON_PLAYLIST,
-          params,
         },
       };
     },

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -1,3 +1,4 @@
+import { PageNames, ClassesPageNames } from './../constants';
 import mutations from './coreLearn/mutations';
 import * as getters from './coreLearn/getters';
 import * as actions from './coreLearn/actions';
@@ -20,7 +21,60 @@ export default {
     };
   },
   actions,
-  getters,
+  getters: {
+    ...getters,
+    learnPageLinks() {
+      const params = {};
+      return {
+        HomePage: {
+          name: PageNames.HOME,
+          params,
+        },
+        LibraryPage: {
+          name: PageNames.LIBRARY,
+          params,
+        },
+        TopicsPage: {
+          name: PageNames.TOPICS_TOPIC,
+          params,
+        },
+        TopicsSearchPage: {
+          name: PageNames.TOPICS_TOPIC_SEARCH,
+          params,
+        },
+        ContentUnavailablePage: {
+          name: PageNames.CONTENT_UNAVAILABLE,
+          params,
+        },
+        BookmarksPage: {
+          name: PageNames.BOOKMARKS,
+          params,
+        },
+        ExamPage: id => {
+          return {
+            name: ClassesPageNames.EXAM_VIWER,
+            params: { params, quizId: id },
+          };
+        },
+        ExamReportViewer: {
+          name: ClassesPageNames.EXAM_REPORT_VIEWER,
+          params,
+        },
+        AllClassesPage: {
+          name: ClassesPageNames.ALL_CLASSES,
+          params,
+        },
+        ClassAssignmentsPage: {
+          name: ClassesPageNames.CLASS_ASSIGNMENTS,
+          params,
+        },
+        LessonPlaylistPage: {
+          name: ClassesPageNames.LESSON_PLAYLIST,
+          params,
+        },
+      };
+    },
+  },
   mutations,
   modules: {
     classAssignments,

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -1,5 +1,4 @@
 // import { LastPages } from './../constants/lastPagesConstants';
-import { PageNames, ClassesPageNames } from './../constants';
 import mutations from './coreLearn/mutations';
 import * as getters from './coreLearn/getters';
 import * as actions from './coreLearn/actions';
@@ -22,49 +21,7 @@ export default {
     };
   },
   actions,
-  getters: {
-    ...getters,
-    learnPageLinks() {
-      return {
-        HomePage: {
-          name: PageNames.HOME,
-        },
-        LibraryPage: {
-          name: PageNames.LIBRARY,
-        },
-        TopicsPage: {
-          name: PageNames.TOPICS_TOPIC,
-        },
-        TopicsSearchPage: {
-          name: PageNames.TOPICS_TOPIC_SEARCH,
-        },
-        ContentUnavailablePage: {
-          name: PageNames.CONTENT_UNAVAILABLE,
-        },
-        BookmarksPage: {
-          name: PageNames.BOOKMARKS,
-        },
-        ExamPage: id => {
-          return {
-            name: ClassesPageNames.EXAM_VIWER,
-            params: { quizId: id },
-          };
-        },
-        ExamReportViewer: {
-          name: ClassesPageNames.EXAM_REPORT_VIEWER,
-        },
-        AllClassesPage: {
-          name: ClassesPageNames.ALL_CLASSES,
-        },
-        ClassAssignmentsPage: {
-          name: ClassesPageNames.CLASS_ASSIGNMENTS,
-        },
-        LessonPlaylistPage: {
-          name: ClassesPageNames.LESSON_PLAYLIST,
-        },
-      };
-    },
-  },
+  getters,
   mutations,
   modules: {
     classAssignments,

--- a/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
+++ b/kolibri/plugins/learn/assets/src/routes/classesRoutes.js
@@ -8,6 +8,11 @@ import { showAllClassesPage } from '../modules/classes/handlers';
 import { showExam } from '../modules/examViewer/handlers';
 import { showExamReport } from '../modules/examReportViewer/handlers';
 import { inClasses } from '../composables/useCoreLearn';
+import ExamPage from '../views/ExamPage';
+import ExamReportViewer from '../views/LearnExamReportViewer';
+import AllClassesPage from '../views/classes/AllClassesPage';
+import ClassAssignmentsPage from '../views/classes/ClassAssignmentsPage';
+import LessonPlaylistPage from '../views/classes/LessonPlaylistPage';
 
 function noClassesGuard() {
   const { canAccessUnassignedContent } = store.getters;
@@ -26,6 +31,7 @@ export default [
     handler: () => {
       return noClassesGuard() || showAllClassesPage(store);
     },
+    component: AllClassesPage,
   },
   {
     name: ClassesPageNames.CLASS_ASSIGNMENTS,
@@ -34,6 +40,7 @@ export default [
       const { classId } = toRoute.params;
       return noClassesGuard() || showClassAssignmentsPage(store, classId);
     },
+    component: ClassAssignmentsPage,
   },
   {
     name: ClassesPageNames.LESSON_PLAYLIST,
@@ -42,6 +49,7 @@ export default [
       const { classId, lessonId } = toRoute.params;
       return noClassesGuard() || showLessonPlaylist(store, { classId, lessonId });
     },
+    component: LessonPlaylistPage,
   },
   {
     name: ClassesPageNames.EXAM_VIEWER,
@@ -56,6 +64,7 @@ export default [
         toRoute.params.classId === fromRoute.params.classId;
       showExam(store, toRoute.params, alreadyOnQuiz);
     },
+    component: ExamPage,
   },
   {
     name: ClassesPageNames.EXAM_REPORT_VIEWER,
@@ -66,5 +75,6 @@ export default [
       }
       showExamReport(store, toRoute.params);
     },
+    component: ExamReportViewer,
   },
 ];

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -12,6 +12,9 @@ import { showLibrary } from '../modules/recommended/handlers';
 import { PageNames, ClassesPageNames } from '../constants';
 import LibraryPage from '../views/LibraryPage';
 import HomePage from '../views/HomePage';
+import TopicsPage from '../views/TopicsPage';
+import ContentUnavailablePage from '../views/ContentUnavailablePage';
+import BookmarkPage from '../views/BookmarkPage.vue';
 import classesRoutes from './classesRoutes';
 
 const { channels, channelsMap } = useChannels();
@@ -106,6 +109,7 @@ export default [
       store.commit('CORE_SET_PAGE_LOADING', false);
       store.commit('CORE_SET_ERROR', null);
     },
+    component: ContentUnavailablePage,
   },
   {
     // Handle historic channel page with redirect
@@ -120,6 +124,7 @@ export default [
         },
       };
     },
+    component: TopicsPage,
   },
   {
     // Handle redirect for links without the /folder appended
@@ -136,6 +141,7 @@ export default [
       }
       showTopicsTopic(store, { id: toRoute.params.id, pageName: toRoute.name });
     },
+    component: TopicsPage,
   },
   // Have to put TOPICS_TOPIC_SEARCH before TOPICS_TOPIC to ensure
   // search gets picked up before being interpreted as a subtopic id.
@@ -153,6 +159,7 @@ export default [
       }
       showTopicsTopic(store, { id: toRoute.params.id, pageName: toRoute.name });
     },
+    component: TopicsPage,
   },
   {
     name: PageNames.TOPICS_TOPIC,
@@ -168,13 +175,18 @@ export default [
       }
       showTopicsTopic(store, { id: toRoute.params.id, pageName: toRoute.name });
     },
+    component: TopicsPage,
   },
   {
     name: PageNames.TOPICS_CONTENT,
     path: '/topics/c/:id',
     handler: toRoute => {
+      store.commit('CORE_SET_PAGE_LOADING', true);
       showTopicsContent(store, toRoute.params.id);
+      store.commit('SET_PAGE_NAME', PageNames.BOOKMARKS);
+      store.commit('CORE_SET_PAGE_LOADING', false);
     },
+    component: TopicsPage,
   },
   {
     name: PageNames.BOOKMARKS,
@@ -186,6 +198,7 @@ export default [
       store.commit('SET_PAGE_NAME', PageNames.BOOKMARKS);
       store.commit('CORE_SET_PAGE_LOADING', false);
     },
+    component: BookmarkPage,
   },
   {
     path: '*',

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -13,7 +13,7 @@ import { PageNames, ClassesPageNames } from '../constants';
 import LibraryPage from '../views/LibraryPage';
 import HomePage from '../views/HomePage';
 import TopicsPage from '../views/TopicsPage';
-import LearnImmersiveLayout from '../views/LearnImmersiveLayout';
+import TopicsContentPage from '../views/TopicsContentPage';
 import ContentUnavailablePage from '../views/ContentUnavailablePage';
 import BookmarkPage from '../views/BookmarkPage.vue';
 import classesRoutes from './classesRoutes';
@@ -184,7 +184,7 @@ export default [
     handler: toRoute => {
       showTopicsContent(store, toRoute.params.id);
     },
-    component: LearnImmersiveLayout,
+    component: TopicsContentPage,
   },
   {
     name: PageNames.BOOKMARKS,

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -13,6 +13,7 @@ import { PageNames, ClassesPageNames } from '../constants';
 import LibraryPage from '../views/LibraryPage';
 import HomePage from '../views/HomePage';
 import TopicsPage from '../views/TopicsPage';
+import LearnImmersiveLayout from '../views/LearnImmersiveLayout';
 import ContentUnavailablePage from '../views/ContentUnavailablePage';
 import BookmarkPage from '../views/BookmarkPage.vue';
 import classesRoutes from './classesRoutes';
@@ -181,12 +182,9 @@ export default [
     name: PageNames.TOPICS_CONTENT,
     path: '/topics/c/:id',
     handler: toRoute => {
-      store.commit('CORE_SET_PAGE_LOADING', true);
       showTopicsContent(store, toRoute.params.id);
-      store.commit('SET_PAGE_NAME', PageNames.BOOKMARKS);
-      store.commit('CORE_SET_PAGE_LOADING', false);
     },
-    component: TopicsPage,
+    component: LearnImmersiveLayout,
   },
   {
     name: PageNames.BOOKMARKS,

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
     <h1>
       {{ $tr('bookmarksHeader') }}
     </h1>
@@ -67,7 +67,7 @@
         :showLocationsInChannel="true"
       />
     </SidePanelModal>
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -84,6 +84,8 @@
   import genContentLink from '../utils/genContentLink';
   import { normalizeContentNode } from '../modules/coreLearn/utils.js';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
+  import commonLearnStrings from './commonLearnStrings';
+  import LearnAppBarPage from './LearnAppBarPage';
   import LearningActivityChip from './LearningActivityChip';
   import CardList from './CardList';
 
@@ -101,8 +103,9 @@
       SidePanelModal,
       LearningActivityChip,
       CardList,
+      LearnAppBarPage,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     setup() {
       const { fetchContentNodeProgress } = useContentNodeProgress();
       return { fetchContentNodeProgress };

--- a/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentUnavailablePage.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+  >
     <h1>{{ $tr('header') }}</h1>
     <p>
       <KExternalLink v-if="deviceContentUrl" :text="$tr('adminLink')" :href="deviceContentUrl" />
@@ -8,7 +10,7 @@
     <p v-if="showLearnerText">
       {{ $tr('learnerText') }}
     </p>
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -17,6 +19,8 @@
 
   import { mapGetters } from 'vuex';
   import urls from 'kolibri.urls';
+  import LearnAppBarPage from './LearnAppBarPage';
+  import commonLearnStrings from './commonLearnStrings';
 
   export default {
     name: 'ContentUnavailablePage',
@@ -25,6 +29,10 @@
         title: this.$tr('documentTitle'),
       };
     },
+    components: {
+      LearnAppBarPage,
+    },
+    mixins: [commonLearnStrings],
 
     computed: {
       ...mapGetters(['canManageContent', 'isLearner']),

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -229,9 +229,6 @@
     },
     computed: {
       ...mapState('examViewer', ['exam', 'contentNodeMap', 'questions', 'questionNumber']),
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
       gridStyle() {
         if (!this.windowIsSmall) {
           return {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <ImmersivePageRoot
-    :route="$store.getters.learnPageLinks.HomePage"
+    :route="homePageLink"
     :appBarTitle="exam.title || ''"
   >
     <KGrid :gridStyle="gridStyle">
@@ -178,7 +178,7 @@
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useProgressTracking from '../../composables/useProgressTracking';
-  import { ClassesPageNames } from '../../constants';
+  import { PageNames, ClassesPageNames } from '../../constants';
   import { LearnerClassroomResource } from '../../apiResources';
   import ImmersivePageRoot from './../ImmersivePageRoot';
 
@@ -253,6 +253,11 @@
       backPageLink() {
         return {
           name: ClassesPageNames.CLASS_ASSIGNMENTS,
+        };
+      },
+      homePageLink() {
+        return {
+          name: PageNames.HOME,
         };
       },
       content() {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -3,7 +3,6 @@
   <ImmersivePageRoot
     :route="$store.getters.learnPageLinks.HomePage"
     :appBarTitle="exam.title || ''"
-    :applyStandardLayout="false"
   >
     <KGrid :gridStyle="gridStyle">
       <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
@@ -187,11 +186,11 @@
 
   export default {
     name: 'ExamPage',
-    // metaInfo() {
-    //   return {
-    //     title: this.exam.title,
-    //   };
-    // },
+    metaInfo() {
+      return {
+        title: this.exam.title,
+      };
+    },
     components: {
       AnswerHistory,
       UiAlert,

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -46,7 +46,7 @@
       </KGridItem>
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
         <div :class="{ 'column-contents-wrapper': !windowIsSmall }">
-          <KPageContainer>
+          <KPageContainer v-if="!loading">
             <h1>
               {{ $tr('question', { num: questionNumber + 1, total: exam.question_count }) }}
             </h1>
@@ -230,6 +230,9 @@
     },
     computed: {
       ...mapState('examViewer', ['exam', 'contentNodeMap', 'questions', 'questionNumber']),
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       gridStyle() {
         if (!this.windowIsSmall) {
           return {
@@ -333,7 +336,11 @@
     },
     watch: {
       attemptLogItemValue(newVal, oldVal) {
-        if (newVal !== oldVal) {
+        // HACK: manually dismiss the perseus renderer message when moving
+        // to a different item (fixes #3853)
+        if (newVal !== oldVal && this.$refs.contentRenderer) {
+          this.$refs.contentRenderer.$refs.contentView.dismissMessage &&
+            this.$refs.contentRenderer.$refs.contentView.dismissMessage();
           this.startTime = Date.now();
         }
       },

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <div>
+  <ImmersivePageRoot
+    :route="$store.getters.learnPageLinks.HomePage"
+    :appBarTitle="exam.title || ''"
+    :applyStandardLayout="false"
+  >
     <KGrid :gridStyle="gridStyle">
       <!-- this.$refs.questionListWrapper is referenced inside AnswerHistory for scrolling -->
       <KGridItem
@@ -16,10 +20,14 @@
               <div :style="{ paddingBottom: '8px' }">
                 <TimeDuration class="timer" :seconds="time_spent" />
               </div>
-              <p v-if="duration">
+              <p v-if="content && content.duration">
                 {{ learnString('suggestedTime') }}
               </p>
-              <SuggestedTime v-if="content.duration" class="timer" :seconds="content.duration" />
+              <SuggestedTime
+                v-if="content && content.duration"
+                class="timer"
+                :seconds="content.duration"
+              />
             </div>
             <span
               class="divider"
@@ -153,7 +161,7 @@
         {{ $tr('unanswered', { numLeft: questionsUnanswered } ) }}
       </p>
     </KModal>
-  </div>
+  </ImmersivePageRoot>
 
 </template>
 
@@ -173,15 +181,17 @@
   import useProgressTracking from '../../composables/useProgressTracking';
   import { ClassesPageNames } from '../../constants';
   import { LearnerClassroomResource } from '../../apiResources';
+  import ImmersivePageRoot from './../ImmersivePageRoot';
+
   import AnswerHistory from './AnswerHistory';
 
   export default {
     name: 'ExamPage',
-    metaInfo() {
-      return {
-        title: this.exam.title,
-      };
-    },
+    // metaInfo() {
+    //   return {
+    //     title: this.exam.title,
+    //   };
+    // },
     components: {
       AnswerHistory,
       UiAlert,
@@ -189,6 +199,7 @@
       BottomAppBar,
       TimeDuration,
       SuggestedTime,
+      ImmersivePageRoot,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     setup() {
@@ -262,10 +273,10 @@
         return this.questions[this.questionNumber];
       },
       nodeId() {
-        return this.currentQuestion.exercise_id;
+        return this.currentQuestion ? this.currentQuestion.exercise_id : null;
       },
       itemId() {
-        return this.currentQuestion.question_id;
+        return this.currentQuestion ? this.currentQuestion.question_id : null;
       },
       // We generate a special item value to save to the backend that encodes
       // both the itemId and the nodeId
@@ -328,7 +339,7 @@
       },
     },
     created() {
-      this.initContentSession({ quizId: this.exam.id })
+      this.initContentSession({ quizId: this.$route.params.examId })
         .then(this.startTrackingProgress)
         .catch(err => {
           if (err.response && err.response.status === 403) {

--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount, mount, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
+import Vuex from 'vuex';
 
 import { ClassesPageNames } from '../../../constants';
 import HomePage from '../index';
@@ -29,7 +30,11 @@ jest.mock('kolibri.utils.coreStrings', () => {
 });
 
 const localVue = createLocalVue();
+localVue.use(Vuex);
 localVue.use(VueRouter);
+const mockStore = new Vuex.Store({
+  state: { core: { loading: false } },
+});
 
 function makeWrapper() {
   const router = new VueRouter({
@@ -49,6 +54,8 @@ function makeWrapper() {
   return mount(HomePage, {
     localVue,
     router,
+    stubs: ['SideNav'],
+    store: mockStore,
   });
 }
 
@@ -86,7 +93,9 @@ describe(`HomePage`, () => {
   });
 
   it(`smoke test`, () => {
-    const wrapper = shallowMount(HomePage);
+    const wrapper = shallowMount(HomePage, {
+      store: mockStore,
+    });
     expect(wrapper.exists()).toBe(true);
   });
 

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -3,48 +3,51 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <YourClasses
-      v-if="displayClasses"
-      class="section"
-      :classes="classes"
-      data-test="classes"
-      short
-    />
-    <ContinueLearning
-      v-if="continueLearning"
-      class="section"
-      :fromClasses="continueLearningFromClasses"
-      :data-test="continueLearningFromClasses ?
-        'continueLearningFromClasses' :
-        'continueLearningOnYourOwn'"
-    />
-    <AssignedLessonsCards
-      v-if="hasActiveClassesLessons"
-      class="section"
-      :lessons="activeClassesLessons"
-      displayClassName
-      recent
-      data-test="recentLessons"
-    />
-    <AssignedQuizzesCards
-      v-if="hasActiveClassesQuizzes"
-      class="section"
-      :quizzes="activeClassesQuizzes"
-      displayClassName
-      recent
-      data-test="recentQuizzes"
-    />
-    <ExploreChannels
-      v-if="displayExploreChannels"
-      :channels="channels"
-      class="section"
-      data-test="exploreChannels"
-      :short="displayClasses ||
-        continueLearning ||
-        hasActiveClassesLessons ||
-        hasActiveClassesQuizzes
-      "
-    />
+    <div v-if="!loading">
+      <YourClasses
+        v-if="displayClasses"
+        class="section"
+        :classes="classes"
+        data-test="classes"
+        short
+      />
+      <ContinueLearning
+        v-if="continueLearning"
+        class="section"
+        :fromClasses="continueLearningFromClasses"
+        :data-test="continueLearningFromClasses ?
+          'continueLearningFromClasses' :
+          'continueLearningOnYourOwn'"
+      />
+      <AssignedLessonsCards
+        v-if="hasActiveClassesLessons"
+        class="section"
+        :lessons="activeClassesLessons"
+        displayClassName
+        recent
+        data-test="recentLessons"
+      />
+      <AssignedQuizzesCards
+        v-if="hasActiveClassesQuizzes"
+        class="section"
+        :quizzes="activeClassesQuizzes"
+        displayClassName
+        recent
+        data-test="recentQuizzes"
+      />
+      <ExploreChannels
+        v-if="displayExploreChannels"
+        :channels="channels"
+        class="section"
+        data-test="exploreChannels"
+        :short="displayClasses ||
+          continueLearning ||
+          hasActiveClassesLessons ||
+          hasActiveClassesQuizzes
+        "
+      />
+
+    </div>
   </LearnAppBarPage>
 
 </template>
@@ -53,6 +56,7 @@
 <script>
 
   import { computed } from 'kolibri.lib.vueCompositionApi';
+  import { mapState } from 'vuex';
   import { get } from '@vueuse/core';
   import useChannels from '../../composables/useChannels';
   import useDeviceSettings from '../../composables/useDeviceSettings';
@@ -150,6 +154,11 @@
         displayExploreChannels,
         displayClasses,
       };
+    },
+    computed: {
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -2,6 +2,7 @@
 
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
+    :loading="loading"
   >
     <div v-if="!loading">
       <YourClasses
@@ -56,7 +57,6 @@
 <script>
 
   import { computed } from 'kolibri.lib.vueCompositionApi';
-  import { mapState } from 'vuex';
   import { get } from '@vueuse/core';
   import useChannels from '../../composables/useChannels';
   import useDeviceSettings from '../../composables/useDeviceSettings';
@@ -155,10 +155,11 @@
         displayClasses,
       };
     },
-    computed: {
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
+    props: {
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+  >
     <YourClasses
       v-if="displayClasses"
       class="section"
@@ -43,7 +45,7 @@
         hasActiveClassesQuizzes
       "
     />
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -59,6 +61,8 @@
   import AssignedLessonsCards from '../classes/AssignedLessonsCards';
   import AssignedQuizzesCards from '../classes/AssignedQuizzesCards';
   import YourClasses from '../YourClasses';
+  import LearnAppBarPage from '../LearnAppBarPage';
+  import commonLearnStrings from './../commonLearnStrings';
   import ContinueLearning from './ContinueLearning';
   import ExploreChannels from './ExploreChannels';
 
@@ -76,7 +80,9 @@
       YourClasses,
       ContinueLearning,
       ExploreChannels,
+      LearnAppBarPage,
     },
+    mixins: [commonLearnStrings],
     setup() {
       const { isUserLoggedIn } = useUser();
       const { canAccessUnassignedContent } = useDeviceSettings();

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/index.vue
@@ -182,7 +182,6 @@
   .card {
     position: relative;
     display: inline-block;
-    width: 100%;
     vertical-align: top;
     border-radius: 8px;
     transition: box-shadow $core-time ease;
@@ -194,6 +193,7 @@
   }
 
   .card-link {
+    width: 100%;
     text-decoration: none;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -2,12 +2,17 @@
 
   <div class="main-wrapper" :style="wrapperStyles">
     <ImmersiveToolbar
-      v-if="!loading"
       ref="appBar"
       :appBarTitle="appBarTitle"
       :route="route"
     />
-    <slot></slot>
+    <slot v-if="!loading"></slot>
+    <KLinearLoader
+      v-else
+      class="loader"
+      type="indeterminate"
+      :delay="false"
+    />
   </div>
 
 </template>
@@ -66,3 +71,15 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .loader {
+    position: fixed;
+    top: 64px;
+    right: 0;
+    left: 0;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -6,9 +6,9 @@
       :appBarTitle="appBarTitle"
       :route="route"
     />
-    <slot v-if="!loading"></slot>
+    <slot></slot>
     <KLinearLoader
-      v-else
+      v-if="loading"
       class="loader"
       type="indeterminate"
       :delay="false"

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -1,0 +1,66 @@
+<template>
+
+  <div class="main-wrapper" :style="wrapperStyles">
+    <ImmersiveToolbar
+      v-if="!loading"
+      ref="appBar"
+      :appBarTitle="appBarTitle"
+      :route="route"
+    />
+    <slot></slot>
+  </div>
+
+</template>
+
+
+<script>
+
+  import ImmersiveToolbar from 'kolibri.coreVue.components.ImmersiveToolbar';
+  import { mapState } from 'vuex';
+
+  export default {
+    name: 'ImmersivePageRoot',
+    components: { ImmersiveToolbar },
+    props: {
+      appBarTitle: {
+        type: String,
+        default: '',
+      },
+      route: {
+        type: Object,
+        default: null,
+      },
+      applyStandardLayout: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    data() {
+      return {
+        appBarHeight: 0,
+      };
+    },
+    computed: {
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
+      wrapperStyles() {
+        return this.applyStandardLayout
+          ? {
+              width: '100%',
+              display: 'inline-block',
+              backgroundColor: this.$themePalette.grey.v_100,
+              paddingLeft: '32px',
+              paddingRight: '32px',
+              paddingBottom: '72px',
+              paddingTop: this.appBarHeight + 16 + 'px',
+            }
+          : '';
+      },
+    },
+    mounted() {
+      this.appBarHeight = this.$refs.appBar.$el.clientHeight;
+    },
+  };
+
+</script>

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -3,7 +3,7 @@
   <div :style="wrapperStyles">
     <ImmersiveToolbar
       ref="appBar"
-      :appBarTitle="appBarTitle"
+      :appBarTitle="(!loading ? appBarTitle : '')"
       :route="route"
     />
     <slot></slot>
@@ -21,7 +21,6 @@
 <script>
 
   import ImmersiveToolbar from 'kolibri.coreVue.components.ImmersiveToolbar';
-  import { mapState } from 'vuex';
 
   export default {
     name: 'ImmersivePageRoot',
@@ -40,6 +39,10 @@
         required: false,
         default: null,
       },
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
     data() {
       return {
@@ -47,9 +50,6 @@
       };
     },
     computed: {
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
       wrapperStyles() {
         return this.appearanceOverrides
           ? this.appearanceOverrides

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -59,7 +59,9 @@
       },
     },
     mounted() {
-      this.appBarHeight = this.$refs.appBar.$el.clientHeight;
+      if (this.$refs.appBar) {
+        this.appBarHeight = this.$refs.appBar.$el.clientHeight;
+      }
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
+++ b/kolibri/plugins/learn/assets/src/views/ImmersivePageRoot.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="main-wrapper" :style="wrapperStyles">
+  <div :style="wrapperStyles">
     <ImmersiveToolbar
       ref="appBar"
       :appBarTitle="appBarTitle"
@@ -35,9 +35,10 @@
         type: Object,
         default: null,
       },
-      applyStandardLayout: {
-        type: Boolean,
-        default: true,
+      appearanceOverrides: {
+        type: Object,
+        required: false,
+        default: null,
       },
     },
     data() {
@@ -50,8 +51,9 @@
         loading: state => state.core.loading,
       }),
       wrapperStyles() {
-        return this.applyStandardLayout
-          ? {
+        return this.appearanceOverrides
+          ? this.appearanceOverrides
+          : {
               width: '100%',
               display: 'inline-block',
               backgroundColor: this.$themePalette.grey.v_100,
@@ -59,8 +61,7 @@
               paddingRight: '32px',
               paddingBottom: '72px',
               paddingTop: this.appBarHeight + 16 + 'px',
-            }
-          : '';
+            };
       },
     },
     mounted() {

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -6,9 +6,15 @@
       <LearnTopNav ref="topNav" />
     </template>
 
-    <div :style="styles">
+    <div v-if="!loading" :style="styles">
       <slot></slot>
     </div>
+    <KLinearLoader
+      v-if="loading"
+      class="loader"
+      type="indeterminate"
+      :delay="false"
+    />
 
   </AppBarCorePage>
 
@@ -17,6 +23,7 @@
 
 <script>
 
+  import { mapState } from 'vuex';
   import AppBarCorePage from 'kolibri.coreVue.components.AppBarCorePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import LearnTopNav from './LearnTopNav';
@@ -36,6 +43,9 @@
       },
     },
     computed: {
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       styles() {
         return this.applyStandardLayout ? 'max-width: 1000px; margin: 0 auto;' : '';
       },
@@ -43,3 +53,15 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .loader {
+    position: fixed;
+    top: 64px;
+    right: 0;
+    left: 0;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -1,6 +1,10 @@
 <template>
 
-  <AppBarCorePage :title="appBarTitle" :appearanceOverrides="appearanceOverrides">
+  <AppBarCorePage
+    :title="appBarTitle"
+    :appearanceOverrides="appearanceOverrides"
+    :loading="loading"
+  >
 
     <template #subNav>
       <LearnTopNav ref="topNav" />
@@ -31,6 +35,10 @@
       appearanceOverrides: {
         type: Object,
         required: false,
+        default: null,
+      },
+      loading: {
+        type: Boolean,
         default: null,
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -1,0 +1,45 @@
+<template>
+
+  <AppBarCorePage :title="appBarTitle" :applyStandardLayout="applyStandardLayout">
+
+    <template #subNav>
+      <LearnTopNav ref="topNav" />
+    </template>
+
+    <div :style="styles">
+      <slot></slot>
+    </div>
+
+  </AppBarCorePage>
+
+</template>
+
+
+<script>
+
+  import AppBarCorePage from 'kolibri.coreVue.components.AppBarCorePage';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import LearnTopNav from './LearnTopNav';
+
+  export default {
+    name: 'LearnAppBarPage',
+    components: { AppBarCorePage, LearnTopNav },
+    mixins: [commonCoreStrings],
+    props: {
+      appBarTitle: {
+        type: String,
+        default: null,
+      },
+      applyStandardLayout: {
+        type: Boolean,
+        default: true,
+      },
+    },
+    computed: {
+      styles() {
+        return this.applyStandardLayout ? 'max-width: 1000px; margin: 0 auto;' : '';
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -1,20 +1,12 @@
 <template>
 
-  <AppBarCorePage :title="appBarTitle" :applyStandardLayout="applyStandardLayout">
+  <AppBarCorePage :title="appBarTitle" :appearanceOverrides="appearanceOverrides">
 
     <template #subNav>
       <LearnTopNav ref="topNav" />
     </template>
 
-    <div v-if="!loading" :style="styles">
-      <slot></slot>
-    </div>
-    <KLinearLoader
-      v-if="loading"
-      class="loader"
-      type="indeterminate"
-      :delay="false"
-    />
+    <slot></slot>
 
   </AppBarCorePage>
 
@@ -23,7 +15,6 @@
 
 <script>
 
-  import { mapState } from 'vuex';
   import AppBarCorePage from 'kolibri.coreVue.components.AppBarCorePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import LearnTopNav from './LearnTopNav';
@@ -37,17 +28,10 @@
         type: String,
         default: null,
       },
-      applyStandardLayout: {
-        type: Boolean,
-        default: true,
-      },
-    },
-    computed: {
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
-      styles() {
-        return this.applyStandardLayout ? 'max-width: 1000px; margin: 0 auto;' : '';
+      appearanceOverrides: {
+        type: Object,
+        required: false,
+        default: null,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -1,7 +1,7 @@
 <template>
 
   <ImmersivePageRoot
-    :route="this.$store.getters.learnPageLinks.HomePage"
+    :route="homePageLink"
     :appBarTitle="exam.title || ''"
   >
     <KPageContainer :topMargin="50" class="container">
@@ -37,7 +37,7 @@
 
   import { mapState } from 'vuex';
   import ExamReport from 'kolibri.coreVue.components.ExamReport';
-  import { ClassesPageNames } from '../constants';
+  import { PageNames, ClassesPageNames } from '../constants';
   import ImmersivePageRoot from './ImmersivePageRoot';
 
   export default {
@@ -68,6 +68,11 @@
         userName: state => state.core.session.full_name,
         userId: state => state.core.session.user_id,
       }),
+      homePageLink() {
+        return {
+          name: PageNames.HOME,
+        };
+      },
     },
     methods: {
       navigateTo(tryIndex, questionNumber, interaction) {

--- a/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnExamReportViewer.vue
@@ -1,28 +1,34 @@
 <template>
 
-  <KPageContainer :topMargin="0">
-    <div v-if="exerciseContentNodes && exerciseContentNodes.length">
-      <ExamReport
-        :contentId="exam.id"
-        :title="exam.title"
-        :userName="userName"
-        :userId="userId"
-        :selectedInteractionIndex="selectedInteractionIndex"
-        :questionNumber="questionNumber"
-        :tryIndex="tryIndex"
-        :exercise="exercise"
-        :exerciseContentNodes="exerciseContentNodes"
-        :navigateTo="navigateTo"
-        :questions="questions"
-        @noCompleteTries="noCompleteTries"
-      />
-    </div>
-    <div v-else>
-      <p class="no-exercise">
-        {{ $tr('missingContent') }}
-      </p>
-    </div>
-  </KPageContainer>
+  <ImmersivePageRoot
+    :route="this.$store.getters.learnPageLinks.HomePage"
+    :appBarTitle="exam.title || ''"
+  >
+    <KPageContainer :topMargin="50" class="container">
+      <div v-if="exerciseContentNodes && exerciseContentNodes.length">
+        <ExamReport
+          :contentId="exam.id"
+          :title="exam.title"
+          :userName="userName"
+          :userId="userId"
+          :selectedInteractionIndex="selectedInteractionIndex"
+          :questionNumber="questionNumber"
+          :tryIndex="tryIndex"
+          :exercise="exercise"
+          :exerciseContentNodes="exerciseContentNodes"
+          :navigateTo="navigateTo"
+          :questions="questions"
+          @noCompleteTries="noCompleteTries"
+        />
+      </div>
+      <div v-else>
+        <p class="no-exercise">
+          {{ $tr('missingContent') }}
+        </p>
+      </div>
+    </KPageContainer>
+
+  </ImmersivePageRoot>
 
 </template>
 
@@ -32,6 +38,7 @@
   import { mapState } from 'vuex';
   import ExamReport from 'kolibri.coreVue.components.ExamReport';
   import { ClassesPageNames } from '../constants';
+  import ImmersivePageRoot from './ImmersivePageRoot';
 
   export default {
     name: 'LearnExamReportViewer',
@@ -42,6 +49,7 @@
     },
     components: {
       ExamReport,
+      ImmersivePageRoot,
     },
     computed: {
       ...mapState('examReportViewer', [
@@ -102,6 +110,11 @@
 
   .no-exercise {
     text-align: center;
+  }
+
+  .container {
+    max-width: 1000px;
+    margin: auto;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -282,20 +282,16 @@
         return this.contentPageMounted ? this.$refs.contentPage.time_spent : 0;
       },
       back() {
-        // extract the key pieces of routing from immersive page props, but since we don't need
-        // them all, just create two alternative route paths for return/'back' navigation
         let route = {};
         const query = { ...this.$route.query };
+        const lastPage = (this.$route.query || {}).last;
         delete query.last;
         delete query.topicId;
-        if (
-          this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH ||
-          this.$route.query.last === PageNames.TOPICS_TOPIC
-        ) {
+        // returning to a topic page requires an id
+        if (lastPage === PageNames.TOPICS_TOPIC_SEARCH || lastPage === PageNames.TOPICS_TOPIC) {
           const lastId = this.$route.query.topicId
             ? this.$route.query.topicId
             : this.content.parent;
-          const lastPage = this.$route.query.last;
           // Need to guard for parent being non-empty to avoid console errors
           route = this.$router.getRoute(
             lastPage,
@@ -304,12 +300,10 @@
             },
             query
           );
-        } else if (this.$route.query && this.$route.query.last === PageNames.LIBRARY) {
-          const lastPage = this.$route.query.last;
+        } else if (lastPage === PageNames.LIBRARY) {
           route = this.$router.getRoute(lastPage, {}, query);
-        } else if (this.$route.query && this.$route.query.last) {
-          const last = this.$route.query.last;
-          route = this.$router.getRoute(last, query);
+        } else if (lastPage) {
+          route = this.$router.getRoute(lastPage, query);
         } else {
           route = this.$router.getRoute(PageNames.HOME);
         }

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -4,9 +4,7 @@
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
   >
-    <div>
-      <router-view />
-    </div>
+    <router-view />
 
   </NotificationsRoot>
 
@@ -43,10 +41,5 @@
 <style lang="scss" scoped>
 
   @import './learn';
-
-  .content {
-    height: 100%;
-    margin: auto;
-  }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -1,11 +1,10 @@
-<template>
+<template slot-scope="{ loading }">
 
   <NotificationsRoot
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
   >
-    <router-view />
-
+    <router-view :loading="loading" />
   </NotificationsRoot>
 
 </template>
@@ -13,7 +12,7 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import { PageNames } from '../constants';
   import plugin_data from 'plugin_data';
@@ -25,6 +24,9 @@
     },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
           return this.isUserLoggedIn;

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -1,15 +1,6 @@
 <template>
 
-  <LearnImmersiveLayout
-    v-if="currentPageIsContent"
-    :authorized="userIsAuthorized"
-    authorizedRole="registeredUser"
-    :back="learnBackPageRoute"
-    :content="content"
-  />
-
   <NotificationsRoot
-    v-else
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
   >
@@ -24,25 +15,17 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import { mapGetters } from 'vuex';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
-  import { PageNames } from '../constants';
-  import commonLearnStrings from './commonLearnStrings';
-  import LearnImmersiveLayout from './LearnImmersiveLayout';
   import plugin_data from 'plugin_data';
 
   export default {
     name: 'LearnIndex',
     components: {
       NotificationsRoot,
-      LearnImmersiveLayout,
     },
-    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     computed: {
       ...mapGetters(['isUserLoggedIn']),
-      ...mapState('topicsTree', ['content']),
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
           return this.isUserLoggedIn;
@@ -50,48 +33,6 @@
         return (
           (plugin_data.allowGuestAccess && this.$store.getters.allowAccess) || this.isUserLoggedIn
         );
-      },
-      currentPageIsContent() {
-        return this.$route.name === PageNames.TOPICS_CONTENT;
-      },
-      // currentTopicIsCustom() {
-      //   return (
-      //     this.topic && this.topic.options && this.topic.options.modality === 'CUSTOM_NAVIGATION'
-      //   );
-      // },
-      learnBackPageRoute() {
-        // extract the key pieces of routing from immersive page props, but since we don't need
-        // them all, just create two alternative route paths for return/'back' navigation
-        let route = {};
-        const query = { ...this.$route.query };
-        delete query.last;
-        delete query.topicId;
-        if (
-          this.$route.query.last === PageNames.TOPICS_TOPIC_SEARCH ||
-          this.$route.query.last === PageNames.TOPICS_TOPIC
-        ) {
-          const lastId = this.$route.query.topicId
-            ? this.$route.query.topicId
-            : this.content.parent;
-          const lastPage = this.$route.query.last;
-          // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(
-            lastPage,
-            {
-              id: lastId,
-            },
-            query
-          );
-        } else if (this.$route.query && this.$route.query.last === PageNames.LIBRARY) {
-          const lastPage = this.$route.query.last;
-          route = this.$router.getRoute(lastPage, {}, query);
-        } else if (this.$route.query && this.$route.query.last) {
-          const last = this.$route.query.last;
-          route = this.$router.getRoute(last, query);
-        } else {
-          route = this.$router.getRoute(PageNames.HOME);
-        }
-        return route;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -8,29 +8,16 @@
     :content="content"
   />
 
-  <CoreBase
+  <NotificationsRoot
     v-else
-    :marginBottom="bottomSpaceReserved"
-    :showSubNav="topNavIsVisible"
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
-    v-bind="immersivePageProps"
   >
-
-    <template #sub-nav>
-      <LearnTopNav />
-    </template>
-
-    <template #totalPointsMenuItem>
-      <TotalPoints />
-    </template>
-
     <div>
-      <component :is="currentPage" v-if="currentPage" />
       <router-view />
     </div>
 
-  </CoreBase>
+  </NotificationsRoot>
 
 </template>
 
@@ -38,62 +25,24 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
-  import lastItem from 'lodash/last';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import CoreBase from 'kolibri.coreVue.components.CoreBase';
-  import { PageNames, ClassesPageNames } from '../constants';
-  import useChannels from '../composables/useChannels';
+  import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
+  import { PageNames } from '../constants';
   import commonLearnStrings from './commonLearnStrings';
-  import TopicsPage from './TopicsPage';
-  import ContentUnavailablePage from './ContentUnavailablePage';
   import LearnImmersiveLayout from './LearnImmersiveLayout';
-  import ExamPage from './ExamPage';
-  import ExamReportViewer from './LearnExamReportViewer';
-  import TotalPoints from './TotalPoints';
-  import AllClassesPage from './classes/AllClassesPage';
-  import ClassAssignmentsPage from './classes/ClassAssignmentsPage';
-  import LessonPlaylistPage from './classes/LessonPlaylistPage';
-  import LearnTopNav from './LearnTopNav';
-  import { ASSESSMENT_FOOTER, QUIZ_FOOTER } from './footers.js';
-  import BookmarkPage from './BookmarkPage.vue';
   import plugin_data from 'plugin_data';
-
-  const pageNameToComponentMap = {
-    [PageNames.TOPICS_TOPIC]: TopicsPage,
-    [PageNames.TOPICS_TOPIC_SEARCH]: TopicsPage,
-    [PageNames.CONTENT_UNAVAILABLE]: ContentUnavailablePage,
-    [PageNames.BOOKMARKS]: BookmarkPage,
-    [ClassesPageNames.EXAM_VIEWER]: ExamPage,
-    [ClassesPageNames.EXAM_REPORT_VIEWER]: ExamReportViewer,
-    [ClassesPageNames.ALL_CLASSES]: AllClassesPage,
-    [ClassesPageNames.CLASS_ASSIGNMENTS]: ClassAssignmentsPage,
-    [ClassesPageNames.LESSON_PLAYLIST]: LessonPlaylistPage,
-  };
 
   export default {
     name: 'LearnIndex',
     components: {
-      CoreBase,
-      LearnTopNav,
-      TotalPoints,
+      NotificationsRoot,
       LearnImmersiveLayout,
     },
     mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
-    setup() {
-      const { channelsMap } = useChannels();
-      return {
-        channelsMap,
-      };
-    },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
-      ...mapState('classAssignments', {
-        classroomName: state => state.currentClassroom.name,
-      }),
-      ...mapState('topicsTree', ['content', 'topic']),
-      ...mapState('examReportViewer', ['exam']),
-      ...mapState(['pageName']),
+      ...mapState('topicsTree', ['content']),
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
           return this.isUserLoggedIn;
@@ -102,131 +51,14 @@
           (plugin_data.allowGuestAccess && this.$store.getters.allowAccess) || this.isUserLoggedIn
         );
       },
-      currentPage() {
-        return pageNameToComponentMap[this.pageName] || null;
-      },
       currentPageIsContent() {
-        return this.pageName === PageNames.TOPICS_CONTENT;
+        return this.$route.name === PageNames.TOPICS_CONTENT;
       },
-      currentTopicIsCustom() {
-        return (
-          this.topic && this.topic.options && this.topic.options.modality === 'CUSTOM_NAVIGATION'
-        );
-      },
-      immersivePageProps() {
-        if (this.pageName === ClassesPageNames.EXAM_VIEWER) {
-          return {
-            appBarTitle: this.classroomName || '',
-            immersivePage: true,
-            immersivePageRoute: this.$router.getRoute(ClassesPageNames.CLASS_ASSIGNMENTS),
-            immersivePagePrimary: true,
-            immersivePageIcon: 'close',
-          };
-        }
-        if (this.pageName === ClassesPageNames.EXAM_REPORT_VIEWER) {
-          if (this.exam) {
-            return {
-              appBarTitle: this.$tr('examReportTitle', {
-                examTitle: this.exam.title,
-              }),
-              immersivePage: true,
-              immersivePageRoute: this.$router.getRoute(ClassesPageNames.CLASS_ASSIGNMENTS),
-              immersivePagePrimary: false,
-              immersivePageIcon: 'close',
-            };
-          }
-        }
-        if (this.pageName === PageNames.TOPICS_TOPIC && this.currentTopicIsCustom) {
-          return {
-            appBarTitle: this.channelsMap[this.topic.channel_id].title || '',
-            immersivePage: true,
-            immersivePageRoute: this.$router.getRoute(PageNames.LIBRARY),
-            immersivePagePrimary: false,
-            immersivePageIcon: 'back',
-          };
-        }
-        if (this.pageName === PageNames.TOPICS_CONTENT) {
-          let immersivePageRoute = {};
-          let appBarTitle;
-          const { last } = this.$route.query;
-          if (last) {
-            // 'last' should only be route names for Recommended Page and its subpages
-            immersivePageRoute = this.$router.getRoute(last);
-            appBarTitle = {
-              [PageNames.RECOMMENDED_POPULAR]: this.learnString('popularLabel'),
-              [PageNames.RECOMMENDED_RESUME]: this.learnString('resumeLabel'),
-              [PageNames.RECOMMENDED_NEXT_STEPS]: this.learnString('nextStepsLabel'),
-              [PageNames.LIBRARY]: this.learnString('libraryLabel'),
-            }[last];
-          } else if (this.content.parent) {
-            // Need to guard for parent being non-empty to avoid console errors
-            immersivePageRoute = this.$router.getRoute(PageNames.TOPICS_TOPIC, {
-              id: this.content.parent,
-            });
-
-            if (this.content.ancestors.length > 1) {
-              appBarTitle = lastItem(this.content.ancestors).title;
-            } else {
-              // `ancestors` only has one entry if the direct parent is the channel
-              appBarTitle = this.channelsMap[this.content.channel_id].title;
-            }
-          }
-          return {
-            appBarTitle,
-            immersivePage: true,
-            immersivePageRoute,
-            immersivePagePrimary: false,
-            immersivePageIcon: 'close',
-          };
-        }
-        if (this.pageName === PageNames.LIBRARY) {
-          return {
-            appBarTitle: this.learnString('learnLabel'),
-            immersivePage: false,
-            hasSidebar: true,
-          };
-        }
-        if (
-          this.pageName === PageNames.TOPICS_TOPIC ||
-          this.pageName === PageNames.TOPICS_TOPIC_SEARCH
-        ) {
-          let immersivePageRoute;
-          if (this.$route.query.last == PageNames.HOME) {
-            immersivePageRoute = this.$router.getRoute(PageNames.HOME);
-          } else {
-            immersivePageRoute = this.$router.getRoute(PageNames.LIBRARY);
-          }
-          return {
-            appBarTitle: this.coreString('browseChannel'),
-            immersivePage: true,
-            immersivePageRoute,
-            immersivePagePrimary: true,
-            immersivePageIcon: 'close',
-            hasSidebar: true,
-          };
-        }
-        return {
-          appBarTitle: this.learnString('learnLabel'),
-          immersivePage: false,
-        };
-      },
-      topNavIsVisible() {
-        return (
-          this.pageName !== PageNames.CONTENT_UNAVAILABLE && !this.immersivePageProps.immersivePage
-        );
-      },
-      bottomSpaceReserved() {
-        if (this.pageName === ClassesPageNames.EXAM_VIEWER) {
-          return QUIZ_FOOTER;
-        }
-        let content;
-        if (this.pageName === PageNames.RECOMMENDED_CONTENT) {
-          content = this.content;
-        }
-        const isAssessment = content && content.assessment;
-        // height of .attempts-container in AssessmentWrapper
-        return isAssessment ? ASSESSMENT_FOOTER : 0;
-      },
+      // currentTopicIsCustom() {
+      //   return (
+      //     this.topic && this.topic.options && this.topic.options.modality === 'CUSTOM_NAVIGATION'
+      //   );
+      // },
       learnBackPageRoute() {
         // extract the key pieces of routing from immersive page props, but since we don't need
         // them all, just create two alternative route paths for return/'back' navigation
@@ -262,12 +94,6 @@
         return route;
       },
     },
-    $trs: {
-      examReportTitle: {
-        message: 'Report for { examTitle }',
-        context: 'Indicates the title of the quiz that the report corresponds to.',
-      },
-    },
   };
 
 </script>
@@ -278,6 +104,7 @@
   @import './learn';
 
   .content {
+    height: 100%;
     margin: auto;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -15,6 +15,7 @@
 
   import { mapGetters } from 'vuex';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
+  import { PageNames } from '../constants';
   import plugin_data from 'plugin_data';
 
   export default {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -129,9 +129,9 @@
   import ChannelCardGroupGrid from '../ChannelCardGroupGrid';
   import LearningActivityChip from '../LearningActivityChip';
   import SearchResultsGrid from '../SearchResultsGrid';
+  import LearnAppBarPage from '../LearnAppBarPage';
   import ResumableContentGrid from './ResumableContentGrid';
   import SidePanel from './SidePanel';
-  import LearnAppBarPage from './LearnAppBarPage';
 
   export default {
     name: 'LibraryPage',
@@ -278,7 +278,7 @@
 <style lang="scss" scoped>
 
   .main-grid {
-    margin-top: 40px;
+    margin-top: 140px;
     margin-right: 24px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -1,6 +1,9 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+    :applyStandardLayout="false"
+  >
     <main
       class="main-grid"
       :style="gridOffset"
@@ -104,7 +107,7 @@
         :showLocationsInChannel="true"
       />
     </SidePanelModal>
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -128,6 +131,7 @@
   import SearchResultsGrid from '../SearchResultsGrid';
   import ResumableContentGrid from './ResumableContentGrid';
   import SidePanel from './SidePanel';
+  import LearnAppBarPage from './LearnAppBarPage';
 
   export default {
     name: 'LibraryPage',
@@ -144,6 +148,7 @@
       ResumableContentGrid,
       SearchResultsGrid,
       SidePanel,
+      LearnAppBarPage,
     },
     mixins: [commonLearnStrings, commonCoreStrings, responsiveWindowMixin],
     setup() {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -2,7 +2,7 @@
 
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
-    :applyStandardLayout="false"
+    :appearanceOverrides="{}"
   >
     <main
       class="main-grid"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -3,6 +3,7 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
     :appearanceOverrides="{}"
+    :loading="loading"
   >
     <main
       class="main-grid"
@@ -197,6 +198,12 @@
         moreResumableContentNodes,
         fetchMoreResumableContentNodes,
       };
+    },
+    props: {
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
     data: function() {
       return {

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -394,7 +394,6 @@
     left: 0;
     height: 100%;
     padding: 24px;
-    padding-top: 140px;
     overflow-y: scroll;
     font-size: 14px;
     box-shadow: 0 3px 3px 0 #00000040;

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -282,34 +282,33 @@
         return this.contentPageMounted ? this.$refs.contentPage.time_spent : 0;
       },
       back() {
-        let route = {};
-        if (this.$route) {
-          const query = { ...this.$route.query };
-          const lastPage = (this.$route.query || {}).last;
-          delete query.last;
-          delete query.topicId;
-          // returning to a topic page requires an id
-          if (lastPage === PageNames.TOPICS_TOPIC_SEARCH || lastPage === PageNames.TOPICS_TOPIC) {
-            const lastId = this.$route.query.topicId
-              ? this.$route.query.topicId
-              : this.content.parent;
-            // Need to guard for parent being non-empty to avoid console errors
-            route = this.$router.getRoute(
-              lastPage,
-              {
-                id: lastId,
-              },
-              query
-            );
-          } else if (lastPage === PageNames.LIBRARY) {
-            route = this.$router.getRoute(lastPage, {}, query);
-          } else if (lastPage) {
-            route = this.$router.getRoute(lastPage, query);
-          } else {
-            route = this.$router.getRoute(PageNames.HOME);
-          }
+        if (!this.$route) {
+          return null;
         }
-        return route;
+        const query = { ...this.$route.query };
+        const lastPage = (this.$route.query || {}).last;
+        delete query.last;
+        delete query.topicId;
+        // returning to a topic page requires an id
+        if (lastPage === PageNames.TOPICS_TOPIC_SEARCH || lastPage === PageNames.TOPICS_TOPIC) {
+          const lastId = this.$route.query.topicId
+            ? this.$route.query.topicId
+            : this.content.parent;
+          // Need to guard for parent being non-empty to avoid console errors
+          return this.$router.getRoute(
+            lastPage,
+            {
+              id: lastId,
+            },
+            query
+          );
+        } else if (lastPage === PageNames.LIBRARY) {
+          return this.$router.getRoute(lastPage, {}, query);
+        } else if (lastPage) {
+          return this.$router.getRoute(lastPage, query);
+        } else {
+          return this.$router.getRoute(PageNames.HOME);
+        }
       },
     },
     watch: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -207,6 +207,11 @@
       };
     },
     props: {
+      loading: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
       // AUTHORIZATION SPECIFIC
       authorized: {
         type: Boolean,
@@ -234,7 +239,6 @@
       ...mapGetters(['currentUserId', 'isUserLoggedIn']),
       ...mapState({
         error: state => state.core.error,
-        loading: state => state.core.loading,
         blockDoubleClicks: state => state.core.blockDoubleClicks,
       }),
       ...mapState('topicsTree', ['content']),

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -159,7 +159,7 @@
   const lessonStrings = crossComponentTranslator(LessonResourceViewer);
 
   export default {
-    name: 'LearnImmersiveLayout',
+    name: 'TopicsContentPage',
     metaInfo() {
       return {
         // Use arrow function to bind $tr to this component

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -283,29 +283,31 @@
       },
       back() {
         let route = {};
-        const query = { ...this.$route.query };
-        const lastPage = (this.$route.query || {}).last;
-        delete query.last;
-        delete query.topicId;
-        // returning to a topic page requires an id
-        if (lastPage === PageNames.TOPICS_TOPIC_SEARCH || lastPage === PageNames.TOPICS_TOPIC) {
-          const lastId = this.$route.query.topicId
-            ? this.$route.query.topicId
-            : this.content.parent;
-          // Need to guard for parent being non-empty to avoid console errors
-          route = this.$router.getRoute(
-            lastPage,
-            {
-              id: lastId,
-            },
-            query
-          );
-        } else if (lastPage === PageNames.LIBRARY) {
-          route = this.$router.getRoute(lastPage, {}, query);
-        } else if (lastPage) {
-          route = this.$router.getRoute(lastPage, query);
-        } else {
-          route = this.$router.getRoute(PageNames.HOME);
+        if (this.$route) {
+          const query = { ...this.$route.query };
+          const lastPage = (this.$route.query || {}).last;
+          delete query.last;
+          delete query.topicId;
+          // returning to a topic page requires an id
+          if (lastPage === PageNames.TOPICS_TOPIC_SEARCH || lastPage === PageNames.TOPICS_TOPIC) {
+            const lastId = this.$route.query.topicId
+              ? this.$route.query.topicId
+              : this.content.parent;
+            // Need to guard for parent being non-empty to avoid console errors
+            route = this.$router.getRoute(
+              lastPage,
+              {
+                id: lastId,
+              },
+              query
+            );
+          } else if (lastPage === PageNames.LIBRARY) {
+            route = this.$router.getRoute(lastPage, {}, query);
+          } else if (lastPage) {
+            route = this.$router.getRoute(lastPage, query);
+          } else {
+            route = this.$router.getRoute(PageNames.HOME);
+          }
         }
         return route;
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -23,7 +23,7 @@
       data-test="children-cards-grid"
       :contents="topic.children"
       currentCardViewStyle="card"
-      :gridType="1"
+      :gridType="2"
       @toggleInfoPanel="$emit('toggleInfoPanel', $event)"
     />
     <KButton

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -8,7 +8,7 @@
       borderBottom: `1px solid ${$themeTokens.fineLine}`
     }"
   >
-    <KGrid>
+    <KGrid gutter="0">
       <KGridItem
         class="breadcrumbs"
         data-test="header-breadcrumbs"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -71,7 +71,7 @@
       :style="{ borderBottomColor: !$isPrint ? $themeTokens.fineLine : 'transparent' }"
     >
       <router-link
-        v-if="topics.length"
+        v-if="topics.length && windowIsLarge"
         :to="foldersLink"
         class="header-tab"
         :activeClass="activeTabClasses"
@@ -85,6 +85,7 @@
       </router-link>
 
       <router-link
+        v-if="windowIsLarge"
         :to="topics.length ? searchTabLink : {}"
         class="header-tab"
         :activeClass="activeTabClasses"
@@ -180,9 +181,11 @@
   @import '~kolibri-design-system/lib/styles/definitions';
 
   $header-height: 324px;
+  $toolbar-height: 70px;
 
   .header {
     position: relative;
+    top: $toolbar-height;
     width: 100%;
     height: $header-height;
     padding-top: 16px;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -8,7 +8,7 @@
     <!-- by replacing it with an empty object -->
     <ImmersivePageRoot
       v-else-if="!loading"
-      :route="$store.getters.learnPageLinks.LibraryPage"
+      :route="libraryPageLink"
       :appBarTitle="topic.title || ''"
       :appearanceOverrides="{}"
       class="page"
@@ -392,6 +392,11 @@
           };
         }
         return {};
+      },
+      libraryPageLink() {
+        return {
+          name: PageNames.LIBRARY,
+        };
       },
       desktopSearchActive() {
         return this.$route.name === PageNames.TOPICS_TOPIC_SEARCH;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -8,6 +8,7 @@
     <!-- by replacing it with an empty object -->
     <ImmersivePageRoot
       v-else-if="!loading"
+      :loading="loading"
       :route="libraryPageLink"
       :appBarTitle="topic.title || ''"
       :appearanceOverrides="{}"
@@ -342,6 +343,12 @@
         setSearchWithinDescendant,
       };
     },
+    props: {
+      loading: {
+        type: Boolean,
+        default: null,
+      },
+    },
     data: function() {
       return {
         sidePanelStyleOverrides: {},
@@ -358,9 +365,6 @@
     },
     computed: {
       ...mapState('topicsTree', ['channel', 'contents', 'isRoot', 'topic']),
-      ...mapState({
-        loading: state => state.core.loading,
-      }),
       childrenToDisplay() {
         return Math.max(this.numCols, 3);
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -7,7 +7,7 @@
     <!-- appearanceOverrides overrides the default page styling -->
     <!-- by replacing it with an empty object -->
     <ImmersivePageRoot
-      v-else
+      v-else-if="!loading"
       :route="$store.getters.learnPageLinks.LibraryPage"
       :appBarTitle="topic.title || ''"
       :appearanceOverrides="{}"
@@ -358,6 +358,9 @@
     },
     computed: {
       ...mapState('topicsTree', ['channel', 'contents', 'isRoot', 'topic']),
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       childrenToDisplay() {
         return Math.max(this.numCols, 3);
       },
@@ -672,6 +675,7 @@
   .side-panel {
     position: absolute;
     top: $header-height;
+    height: calc(100% - #{$header-height});
     padding-top: 16px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -187,7 +187,6 @@
           :activeCategories="activeCategories"
           :showChannels="false"
           position="overlay"
-          :style="sidePanelStyleOverrides"
           @currentCategory="handleShowSearchModal"
           @loadMoreTopics="handleLoadMoreInTopic"
         />
@@ -220,7 +219,7 @@
           <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
             multiple chips - not a common thing but just in case -->
           <div
-            v-for="activity in sidePanelContent.learning_activities"
+            v-for="activity in metadataSidePanelContent.learning_activities"
             :key="activity"
             class="side-panel-chips"
             :class="$computedClass({ '::after': {
@@ -238,14 +237,13 @@
 
         <BrowseResourceMetadata
           ref="resourcePanel"
-          :content="sidePanelContent"
+          :content="metadataSidePanelContent"
           :showLocationsInChannel="true"
         />
       </SidePanelModal>
+
     </ImmersivePageRoot>
   </div>
-
-  <!-- Side panel for showing the information of selected content with a link to view it -->
 
 </template>
 
@@ -266,6 +264,7 @@
   import { normalizeContentNode } from '../../modules/coreLearn/utils.js';
   import useSearch from '../../composables/useSearch';
   import genContentLink from '../../utils/genContentLink';
+  import LibraryAndChannelBrowserMainContent from '../LibraryAndChannelBrowserMainContent';
   import SearchFiltersPanel from '../SearchFiltersPanel';
   import BrowseResourceMetadata from '../BrowseResourceMetadata';
   import LearningActivityChip from '../LearningActivityChip';
@@ -299,6 +298,7 @@
     components: {
       KBreadcrumbs,
       TopicsHeader,
+      LibraryAndChannelBrowserMainContent,
       CustomContentRenderer,
       CategorySearchModal,
       SearchFiltersPanel,
@@ -614,17 +614,20 @@
       // down and appears again when scrolling up).
       // Takes effect only when the side panel is not displayed full-screen.
       stickyCalculation() {
-        const header = this.$refs.header.$el;
-        console.log(header);
-        const topbar = document.querySelector('.ui-toolbar');
+        const header = this.$refs.header;
+        const topbar = document.querySelector('.scrolling-header');
         const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
         const topbarBottom = topbar ? topbar.getBoundingClientRect().bottom : 0;
 
-        this.sidePanelStyleOverrides = {
-          position: 'fixed',
-          top: `${Math.max(0, headerBottom, topbarBottom)}px`,
-          height: '100%',
-        };
+        if (headerBottom < Math.max(topbarBottom, 0)) {
+          this.sidePanelStyleOverrides = {
+            position: 'fixed',
+            top: `${Math.max(0, headerBottom, topbarBottom)}px`,
+            height: '100%',
+          };
+        } else {
+          this.sidePanelStyleOverrides = {};
+        }
       },
       handleShowMore(topicId) {
         this.expandedTopics = {
@@ -672,6 +675,7 @@
 
   $header-height: 324px;
   $toolbar-height: 70px;
+  $total-height: 394px;
 
   .page {
     position: relative;
@@ -679,8 +683,15 @@
     min-height: calc(100vh - #{$toolbar-height});
   }
 
+  .side-panel {
+    position: absolute;
+    top: $total-height;
+    padding-top: 16px;
+  }
+
   .main-content-grid {
     position: relative;
+    top: $toolbar-height;
     margin: 24px;
   }
 
@@ -724,10 +735,6 @@
     width: 100%;
     margin-top: 16px;
     text-align: center;
-  }
-
-  .side-panel {
-    top: $header-height;
   }
 
   .side-panel-chips {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -4,11 +4,13 @@
     <div v-if="currentChannelIsCustom">
       <CustomContentRenderer :topic="topic" />
     </div>
+    <!-- appearanceOverrides overrides the default page styling -->
+    <!-- by replacing it with an empty object -->
     <ImmersivePageRoot
       v-else
       :route="$store.getters.learnPageLinks.LibraryPage"
       :appBarTitle="topic.title || ''"
-      :applyStandardLayout="false"
+      :appearanceOverrides="{}"
       class="page"
     >
       <!-- Header with thumbail and tagline -->

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -605,7 +605,7 @@
       // Takes effect only when the side panel is not displayed full-screen.
       stickyCalculation() {
         const header = this.$refs.header;
-        const topbar = document.querySelector('.scrolling-header');
+        const topbar = document.querySelector('.ui-toolbar');
         const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
         const topbarBottom = topbar ? topbar.getBoundingClientRect().bottom : 0;
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -238,7 +238,7 @@
           :content="sidePanelContent"
           :showLocationsInChannel="true"
         />
-      </FullScreenSidePanel>
+      </SidePanelModal>
     </ImmersivePageRoot>
   </div>
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -74,13 +74,14 @@
             <!----
               TODO - is this necessary at all? how is this different than the search results below?
             -->
-            <HybridLearningCardGrid
+            <LibraryAndChannelBrowserMainContent
               v-if="resources.length"
+              :gridType="2"
               data-test="search-results"
               :contents="resources"
               :numCols="numCols"
               :genContentLink="genContentLink"
-              cardViewStyle="card"
+              currentCardViewStyle="card"
               @toggleInfoPanel="toggleInfoPanel"
             />
             <div v-if="topicMore" class="end-button-block">

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -4,8 +4,13 @@
     <div v-if="currentChannelIsCustom">
       <CustomContentRenderer :topic="topic" />
     </div>
-
-    <div v-else class="page">
+    <ImmersivePageRoot
+      v-else
+      :route="$store.getters.learnPageLinks.LibraryPage"
+      :appBarTitle="topic.title || ''"
+      :applyStandardLayout="false"
+      class="page"
+    >
       <!-- Header with thumbail and tagline -->
       <TopicsHeader
         v-if="!windowIsSmall"
@@ -196,7 +201,6 @@
         @input="handleCategory"
       />
 
-    </div>
 
     <!-- Side panel for showing the information of selected content with a link to view it -->
     <SidePanelModal
@@ -209,31 +213,33 @@
       <template #header>
         <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
             multiple chips - not a common thing but just in case -->
-        <div
-          v-for="activity in metadataSidePanelContent.learning_activities"
-          :key="activity"
-          class="side-panel-chips"
-          :class="$computedClass({ '::after': {
-            content: '',
-            flex: 'auto'
-          } })"
-        >
-          <LearningActivityChip
-            class="chip"
-            style="margin-left: 8px; margin-bottom: 8px;"
-            :kind="activity"
-          />
-        </div>
-      </template>
+          <div
+            v-for="activity in sidePanelContent.learning_activities"
+            :key="activity"
+            class="side-panel-chips"
+            :class="$computedClass({ '::after': {
+              content: '',
+              flex: 'auto'
+            } })"
+          >
+            <LearningActivityChip
+              class="chip"
+              style="margin-left: 8px; margin-bottom: 8px;"
+              :kind="activity"
+            />
+          </div>
+        </template>
 
-      <BrowseResourceMetadata
-        ref="resourcePanel"
-        :content="metadataSidePanelContent"
-        :showLocationsInChannel="true"
-      />
-    </SidePanelModal>
-
+        <BrowseResourceMetadata
+          ref="resourcePanel"
+          :content="sidePanelContent"
+          :showLocationsInChannel="true"
+        />
+      </FullScreenSidePanel>
+    </ImmersivePageRoot>
   </div>
+
+  <!-- Side panel for showing the information of selected content with a link to view it -->
 
 </template>
 
@@ -298,6 +304,7 @@
       TopicsMobileHeader,
       TopicSubsection,
       SearchPanelModal,
+      ImmersivePageRoot,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     setup() {
@@ -662,7 +669,6 @@
   .side-panel {
     position: absolute;
     top: $header-height;
-    height: calc(100% - #{$header-height});
     padding-top: 16px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -17,6 +17,7 @@
       <!-- Header with thumbail and tagline -->
       <TopicsHeader
         v-if="!windowIsSmall"
+        ref="header"
         data-test="header-breadcrumbs"
         :topics="topics"
         :topic="topic"
@@ -186,6 +187,7 @@
           :activeCategories="activeCategories"
           :showChannels="false"
           position="overlay"
+          :style="sidePanelStyleOverrides"
           @currentCategory="handleShowSearchModal"
           @loadMoreTopics="handleLoadMoreInTopic"
         />
@@ -206,16 +208,16 @@
       />
 
 
-    <!-- Side panel for showing the information of selected content with a link to view it -->
-    <SidePanelModal
-      v-if="metadataSidePanelContent"
-      alignment="right"
-      :closeButtonIconType="closeButtonIcon"
-      @closePanel="metadataSidePanelContent = null"
-      @shouldFocusFirstEl="findFirstEl()"
-    >
-      <template #header>
-        <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
+      <!-- Side panel for showing the information of selected content with a link to view it -->
+      <SidePanelModal
+        v-if="metadataSidePanelContent"
+        alignment="right"
+        :closeButtonIconType="closeButtonIcon"
+        @closePanel="metadataSidePanelContent = null"
+        @shouldFocusFirstEl="findFirstEl()"
+      >
+        <template #header>
+          <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
             multiple chips - not a common thing but just in case -->
           <div
             v-for="activity in sidePanelContent.learning_activities"
@@ -264,7 +266,6 @@
   import { normalizeContentNode } from '../../modules/coreLearn/utils.js';
   import useSearch from '../../composables/useSearch';
   import genContentLink from '../../utils/genContentLink';
-  import HybridLearningCardGrid from '../HybridLearningCardGrid';
   import SearchFiltersPanel from '../SearchFiltersPanel';
   import BrowseResourceMetadata from '../BrowseResourceMetadata';
   import LearningActivityChip from '../LearningActivityChip';
@@ -272,6 +273,7 @@
   import CategorySearchModal from '../CategorySearchModal';
   import SearchResultsGrid from '../SearchResultsGrid';
   import LibraryPage from '../LibraryPage';
+  import ImmersivePageRoot from '../ImmersivePageRoot';
   import TopicsHeader from './TopicsHeader';
   import TopicsMobileHeader from './TopicsMobileHeader';
   import TopicSubsection from './TopicSubsection';
@@ -297,7 +299,6 @@
     components: {
       KBreadcrumbs,
       TopicsHeader,
-      HybridLearningCardGrid,
       CustomContentRenderer,
       CategorySearchModal,
       SearchFiltersPanel,
@@ -613,20 +614,17 @@
       // down and appears again when scrolling up).
       // Takes effect only when the side panel is not displayed full-screen.
       stickyCalculation() {
-        const header = this.$refs.header;
+        const header = this.$refs.header.$el;
+        console.log(header);
         const topbar = document.querySelector('.ui-toolbar');
         const headerBottom = header ? header.getBoundingClientRect().bottom : 0;
         const topbarBottom = topbar ? topbar.getBoundingClientRect().bottom : 0;
 
-        if (headerBottom < Math.max(topbarBottom, 0)) {
-          this.sidePanelStyleOverrides = {
-            position: 'fixed',
-            top: `${Math.max(0, headerBottom, topbarBottom)}px`,
-            height: '100%',
-          };
-        } else {
-          this.sidePanelStyleOverrides = {};
-        }
+        this.sidePanelStyleOverrides = {
+          position: 'fixed',
+          top: `${Math.max(0, headerBottom, topbarBottom)}px`,
+          height: '100%',
+        };
       },
       handleShowMore(topicId) {
         this.expandedTopics = {
@@ -681,13 +679,6 @@
     min-height: calc(100vh - #{$toolbar-height});
   }
 
-  .side-panel {
-    position: absolute;
-    top: $header-height;
-    height: calc(100% - #{$header-height});
-    padding-top: 16px;
-  }
-
   .main-content-grid {
     position: relative;
     margin: 24px;
@@ -733,6 +724,10 @@
     width: 100%;
     margin-top: 16px;
     text-align: center;
+  }
+
+  .side-panel {
+    top: $header-height;
   }
 
   .side-panel-chips {

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -1,13 +1,15 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+  >
     <KBreadcrumbs :items="breadcrumbs" />
     <YourClasses
       v-if="isUserLoggedIn"
       :classes="classrooms"
     />
     <AuthMessage v-else authorizedRole="learner" />
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -20,6 +22,8 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import YourClasses from '../YourClasses';
   import { PageNames } from '../../constants';
+  import commonLearnStrings from './../commonLearnStrings';
+  import LearnAppBarPage from './../LearnAppBarPage';
 
   export default {
     name: 'AllClassesPage',
@@ -32,8 +36,9 @@
       KBreadcrumbs,
       AuthMessage,
       YourClasses,
+      LearnAppBarPage,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       ...mapState('classes', ['classrooms']),

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+  >
     <KBreadcrumbs :items="breadcrumbs" />
     <h1 class="classroom-name">
       <KLabeledIcon icon="classes" :label="className" />
@@ -9,7 +11,7 @@
     <AssignedLessonsCards :lessons="activeLessons" />
     <AssignedQuizzesCards :quizzes="activeQuizzes" :style="{ marginTop: '44px' }" />
 
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -24,6 +26,8 @@
   import { PageNames, ClassesPageNames } from '../../constants';
 
   import useLearnerResources from '../../composables/useLearnerResources';
+  import commonLearnStrings from './../commonLearnStrings';
+  import LearnAppBarPage from './../LearnAppBarPage';
   import AssignedQuizzesCards from './AssignedQuizzesCards';
   import AssignedLessonsCards from './AssignedLessonsCards';
 
@@ -38,8 +42,9 @@
       AssignedQuizzesCards,
       AssignedLessonsCards,
       KBreadcrumbs,
+      LearnAppBarPage,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup(_, { root }) {
       const {
         fetchClass,

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <div>
+  <LearnAppBarPage
+    :appBarTitle="learnString('learnLabel')"
+  >
     <KBreadcrumbs :items="breadcrumbs" />
     <section class="lesson-details">
       <div>
@@ -38,7 +40,7 @@
         {{ $tr('noResourcesInLesson') }}
       </p>
     </section>
-  </div>
+  </LearnAppBarPage>
 
 </template>
 
@@ -54,6 +56,8 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import genContentLink from '../../utils/genContentLink';
   import { PageNames, ClassesPageNames } from '../../constants';
+  import commonLearnStrings from './../commonLearnStrings';
+  import LearnAppBarPage from './../LearnAppBarPage';
   import HybridLearningLessonCard from './../HybridLearningLessonCard';
 
   export default {
@@ -68,8 +72,9 @@
       HybridLearningLessonCard,
       ContentIcon,
       ProgressIcon,
+      LearnAppBarPage,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     computed: {
       ...mapState('lessonPlaylist', ['contentNodes', 'currentLesson']),
       lessonHasResources() {
@@ -89,26 +94,29 @@
         return undefined;
       },
       breadcrumbs() {
-        return [
-          {
-            text: this.coreString('homeLabel'),
-            link: { name: PageNames.HOME },
-          },
-          {
-            text: this.coreString('classesLabel'),
-            link: { name: ClassesPageNames.ALL_CLASSES },
-          },
-          {
-            text: this.currentLesson.classroom.name,
-            link: {
-              name: ClassesPageNames.CLASS_ASSIGNMENTS,
-              params: { classId: this.currentLesson.classroom.id },
-            },
-          },
-          {
-            text: this.currentLesson.title,
-          },
-        ];
+        console.log(this.currentLesson);
+        return this.currentLesson && this.currentLesson.classroom
+          ? [
+              {
+                text: this.coreString('homeLabel'),
+                link: { name: PageNames.HOME },
+              },
+              {
+                text: this.coreString('classesLabel'),
+                link: { name: ClassesPageNames.ALL_CLASSES },
+              },
+              {
+                text: this.currentLesson.classroom.name,
+                link: {
+                  name: ClassesPageNames.CLASS_ASSIGNMENTS,
+                  params: { classId: this.currentLesson.classroom.id },
+                },
+              },
+              {
+                text: this.currentLesson.title,
+              },
+            ]
+          : [];
       },
       backRoute() {
         return this.$route.name;

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -94,7 +94,6 @@
         return undefined;
       },
       breadcrumbs() {
-        console.log(this.currentLesson);
         return this.currentLesson && this.currentLesson.classroom
           ? [
               {

--- a/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/breadcrumbs.spec.js
@@ -59,6 +59,7 @@ describe('learn page breadcrumbs', () => {
   describe('when in Topic Browsing mode', () => {
     it('shows no breadcrumbs on topics root (i.e. Channels)', () => {
       const store = makeStore({ pageName: PageNames.LIBRARY });
+      store.state.core.loading = false;
       const wrapper = makeWrapper({ store });
       const { breadcrumbs } = getElements(wrapper);
       expect(breadcrumbs().exists()).toEqual(false);
@@ -66,6 +67,7 @@ describe('learn page breadcrumbs', () => {
 
     it('shows correct breadcrumbs at a Channel', () => {
       const store = makeStore({ pageName: PageNames.TOPICS_TOPIC });
+      store.state.core.loading = false;
       store.state.topicsTree.channel = {
         id: 'channel-1',
         root: 'root-1',
@@ -87,6 +89,7 @@ describe('learn page breadcrumbs', () => {
 
     it('shows correct breadcrumbs at a non-Channel Topic', () => {
       const store = makeStore({ pageName: PageNames.TOPICS_TOPIC });
+      store.state.core.loading = false;
       store.state.topicsTree.channel = {
         id: 'channel-1',
         root: 'root-1',

--- a/kolibri/plugins/learn/assets/test/views/learn-top-nav.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learn-top-nav.spec.js
@@ -1,6 +1,6 @@
 import VueRouter from 'vue-router';
 import { mount, createLocalVue } from '@vue/test-utils';
-import LearnIndex from '../../src/views/LearnIndex';
+import LearnTopNav from '../../src/views/LearnTopNav';
 import makeStore from '../makeStore';
 // eslint-disable-next-line import/named
 import useCoreLearn, { useCoreLearnMock } from '../../src/composables/useCoreLearn';
@@ -33,21 +33,11 @@ const router = new VueRouter({
 });
 
 function makeWrapper(options) {
-  return mount(LearnIndex, {
+  return mount(LearnTopNav, {
     ...options,
     stubs: {
       breadcrumbs: true,
       contentUnavailablePage: true,
-      CoreBase: {
-        name: 'CoreBase',
-        props: ['showSubNav'],
-        template: `
-          <div>
-            <slot></slot>
-            <slot name="sub-nav"></slot>
-          </div>
-        `,
-      },
       topicsPage: true,
       TotalPoints: true,
     },
@@ -63,7 +53,6 @@ function getElements(wrapper) {
     bookmarksLink: () => wrapper.find('[href="#/bookmarks"]'),
     libraryLink: () => wrapper.find('[href="#/library"]'),
     tabLinks: () => wrapper.findAllComponents({ name: 'NavbarLink' }),
-    CoreBase: () => wrapper.findComponent({ name: 'CoreBase' }),
   };
 }
 
@@ -93,10 +82,9 @@ describe('learn plugin index page', () => {
   it('there are no tabs if showing content unavailable page', () => {
     setPageName('CONTENT_UNAVAILABLE');
     const wrapper = makeWrapper({ store });
-    const { CoreBase } = getElements(wrapper);
-    expect(CoreBase().props().showSubNav).toEqual(false);
+    const { tabLinks } = getElements(wrapper);
+    expect(tabLinks().length).toEqual(0);
   });
-
   describe('when allowed to access unassigned content', () => {
     beforeEach(() => {
       setCanAccessUnassignedContent(true);
@@ -106,7 +94,8 @@ describe('learn plugin index page', () => {
       setSessionUserKind('anonymous');
       setMemberships([]);
       const wrapper = makeWrapper({ store });
-      const { tabLinks, libraryLink } = getElements(wrapper);
+      const { tabLinks } = getElements(wrapper);
+      const { libraryLink } = getElements(wrapper);
       expect(tabLinks().length).toEqual(1);
       expect(libraryLink().element.tagName).toBe('A');
     });

--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -22,7 +22,7 @@ const router = new VueRouter({
 
 // rootNodes used when showing default view, should always have length
 const mockStore = new Vuex.Store({
-  state: { rootNodes: ['length'] },
+  state: { rootNodes: ['length'], core: { loading: false } },
   getters: { isUserLoggedIn: jest.fn() },
 });
 

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -18,6 +18,7 @@ const localVue = createLocalVue();
 const store = makeStore();
 store.state.core = {
   blockDoubleClicks: true,
+  loading: false,
   logging: {
     summary: {
       progress: 0,

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -1,6 +1,6 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import makeStore from '../makeStore';
-import LearnImmersiveLayout from '../../src/views/LearnImmersiveLayout';
+import TopicsContentPage from '../../src/views/TopicsContentPage';
 
 jest.mock('kolibri.urls');
 
@@ -37,7 +37,7 @@ store.getters = {
 };
 
 function makeWrapper({ propsData } = {}) {
-  return shallowMount(LearnImmersiveLayout, {
+  return shallowMount(TopicsContentPage, {
     propsData,
     store,
     localVue,
@@ -57,7 +57,7 @@ function makeWrapper({ propsData } = {}) {
   });
 }
 
-describe('LearnImmersiveLayout', () => {
+describe('TopicsContentPage', () => {
   const wrapper = makeWrapper({
     propsData: {
       content: { id: 'test' },

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -18,7 +18,6 @@ const localVue = createLocalVue();
 const store = makeStore();
 store.state.core = {
   blockDoubleClicks: true,
-  loading: false,
   logging: {
     summary: {
       progress: 0,
@@ -47,6 +46,7 @@ function makeWrapper({ propsData } = {}) {
         name: 'LearningActivityBar',
         propsData: {
           resourceTitle: 'Test Title',
+          loading: false,
         },
         template: '<div></div>',
       },
@@ -62,6 +62,7 @@ describe('TopicsContentPage', () => {
   const wrapper = makeWrapper({
     propsData: {
       content: { id: 'test' },
+      loading: false,
     },
   });
   it('smoke test', () => {

--- a/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
@@ -1,4 +1,5 @@
 import VueRouter from 'vue-router';
+
 import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import makeStore from '../makeStore';
@@ -52,10 +53,16 @@ describe('TopicsPage', () => {
   let store;
 
   beforeEach(() => {
-    store = makeStore();
+    store = makeStore({
+      getters: { isUserLoggedIn: jest.fn() },
+    });
     store.state.topicsTree.topic = {
       ...store.state.topicsTree.topic,
       options: { modality: null },
+    };
+    store.state.core = {
+      ...store.state.core,
+      loading: false,
     };
   });
 
@@ -75,7 +82,7 @@ describe('TopicsPage', () => {
       };
 
       const wrapper = shallowMount(TopicsPage, {
-        store: makeStore(),
+        store: store,
         localVue,
         router,
       });
@@ -86,7 +93,7 @@ describe('TopicsPage', () => {
   describe('Displaying the header', () => {
     it('displays breadcrumbs when not on a small screen', () => {
       const wrapper = shallowMount(TopicsPage, {
-        store,
+        store: store,
         localVue,
         router,
         computed: { windowIsSmall: () => false },
@@ -98,7 +105,7 @@ describe('TopicsPage', () => {
 
   it('displays the header with tabs when on a large screen', () => {
     const wrapper = shallowMount(TopicsPage, {
-      store,
+      store: store,
       localVue,
       router,
       computed: { windowIsLarge: () => true },
@@ -110,8 +117,9 @@ describe('TopicsPage', () => {
   it('displays the topic title when page is medium - large', () => {
     store.state.topicsTree.topic.title = 'Test Title';
     const wrapper = mount(TopicsPage, {
-      store,
+      store: store,
       localVue,
+
       router,
     });
     expect(wrapper.find("[data-test='header-title']").element).toHaveTextContent('Test Title');
@@ -120,7 +128,7 @@ describe('TopicsPage', () => {
   it('displays the topic title when page is small', () => {
     store.state.topicsTree.topic.title = 'Test Title';
     const smallScreenWrapper = mount(TopicsPage, {
-      store,
+      store: store,
       localVue,
       router,
       computed: { windowIsSmall: () => true },
@@ -136,7 +144,7 @@ describe('TopicsPage', () => {
     beforeEach(() => {
       store.state.topicsTree.contents = [{ kind: ContentNodeKinds.TOPIC }];
       wrapper = shallowMount(TopicsPage, {
-        store,
+        store: store,
         localVue,
         router,
         computed: {
@@ -197,9 +205,10 @@ describe('TopicsPage', () => {
         }));
 
         wrapper = mount(TopicsPage, {
-          store,
+          store: store,
           localVue,
           router,
+
           computed: {
             windowIsLarge: () => false,
             windowIsSmall: () => true,
@@ -227,7 +236,7 @@ describe('TopicsPage', () => {
           setSearchWithinDescendant: jest.fn(),
         }));
         wrapper = mount(TopicsPage, {
-          store,
+          store: store,
           localVue,
           router,
           computed: {


### PR DESCRIPTION
### Overview 

Fixes #9137

This PR removes CoreBase from `LearnIndex.vue` and adopts the `<router-view/>` pattern created by @nucleogenesis in his `FacilityIndex` refactor. (For more background on the logic of the architecture, see #9196)

There are two wrapper pages, `LearnAppBarPage` and `ImmersivePageRoot` that manage the style of the page. 

In the Learn plugin versions, I've added a new prop `applyStandardLayout` which defaults to true and applies the default  styles of each type of page, but can also be overridden, such as in the Library and Topics pages, where the use the full screen, rather than a centered block of main content.

This PR also removes `LearnImmersiveLayout` from `LearnIndex` and puts it in a router-view (although this is probably out of scope) for the sake of consistency. I have not addressed the rather chaotic `backRoute` situation in `LearnImmersiveLayout`, but the existing logic has been moved out of `LearnIndex` and is working.

#### Places of consideration 

Basically all of Learn has been refactored, so this will require a thorough going-over with manual QA. I have tried to be very thorough with my testing on multiple browsers and screen sizes in advance of this PR, but... definitely probably that I have missed something. On the flip side, very few of the code changes are different from the pattern @nucleogenesis set up, and they actually are mostly straightforward (I hope). 

Tricky spots were mostly around `content` since it is no longer passed from LearnIndex. So, things to think about here: 
1. Is actually working everywhere? 
2. Are there any places where I dropped the loading state handling and things look janky while content is being fetched? 

CSS changes to note: 
1. (especially @MisRob) I want to be sure the improvements made for 0.15.1 fixes, especially around the scrolling header jumpiness and the height of various elements of the page layout has not been lost. It looks okay to me, and I have done QA on multiple browsers, but your attention and review there would be helpful in case I accidentally removed something that was needed. (cc @pcenov and @radinamatic for testing on IE)
2. I have had to add a z-index to the `ImmersiveToolbar` that is in `LearnIndex` due to the cards (without it, they scroll over it). Is this okay? Is there something I should do instead that would make adding an explicit z-index unnecessary?
3. I updated the `card` width property which resolved the problems with the grid. I do not know why this is necessary in this version 🙃 but it seems to be working now. Are there any places on Library or Topics page where the grid layout is wrong? 