### PR TITLE
Direct ERROR and CRITICAL messages only to stderr

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -24,14 +24,16 @@ logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
 
 if StreamHandler and getLogger and ColoredFormatter:
-    handler = StreamHandler()
+    handler = StreamHandler(stream=sys.stdout)
     handler.setFormatter(
         ColoredFormatter(
             fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
         )
     )
+    handler.setLevel(logging.INFO)
     logger = getLogger("env")
     logger.addHandler(handler)
+    logger.propagate = False
 else:
     logger = logging.getLogger("env")
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -121,6 +121,16 @@ def get_require_debug_true(debug):
     return RequireDebugTrue
 
 
+class NoExceptionsFilter(logging.Filter):
+    """
+    A filter that ignores errors and critical messages, used to suppress
+    error messages to stdout that are also being piped to stderr.
+    """
+
+    def filter(self, record):
+        return record.levelno < logging.ERROR
+
+
 def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     """
     A minimal logging config for just kolibri without any Django
@@ -131,7 +141,9 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     """
 
     DEFAULT_HANDLERS = (
-        ["console"] if NO_FILE_BASED_LOGGING else ["file", "console", "file_debug"]
+        ["console", "console-error"]
+        if NO_FILE_BASED_LOGGING
+        else ["file", "console", "console-error", "file_debug"]
     )
 
     # This is the general level
@@ -141,7 +153,10 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     return {
         "version": 1,
         "disable_existing_loggers": False,
-        "filters": {"require_debug_true": {"()": FalseFilter}},  # Replaced later
+        "filters": {
+            "require_debug_true": {"()": FalseFilter},  # Replaced later
+            "no_exceptions": {"()": NoExceptionsFilter},
+        },
         "formatters": {
             "verbose": {
                 "format": "%(levelname)s %(asctime)s %(name)s %(process)d %(thread)d %(message)s"
@@ -155,10 +170,18 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
         },
         "handlers": {
-            "console": {
-                "level": DEFAULT_LEVEL,
+            "console-error": {
+                "level": "ERROR",
                 "class": "logging.StreamHandler",
                 "formatter": "color",
+                "stream": "ext://sys.stderr",
+            },
+            "console": {
+                "level": DEFAULT_LEVEL,
+                "filters": ["no_exceptions"],
+                "class": "logging.StreamHandler",
+                "formatter": "color",
+                "stream": "ext://sys.stdout",
             },
             "file": {
                 "level": "INFO",

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -201,6 +201,10 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
         },
         "loggers": {
+            "": {
+                "handlers": DEFAULT_HANDLERS,
+                "level": DEFAULT_LEVEL,
+            },
             "kolibri": {
                 "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,


### PR DESCRIPTION
## Summary
* Sets up separate console handlers for ERROR and CRITICAL messages vs others
* Directs the former to stderr, the latter to stdout

## References
Fixes #9162

## Reviewer guidance
Run kolibri with `1>/dev/null` and `2>/dev/null` after to see the difference.
Add additional error logging messages to ensure that they only get logged once, and are sent to the correct output.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
