### PR TITLE
ref(FSSP): Implements suggestions in #8989

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -77,6 +77,9 @@
         type: String,
         required: true,
         default: 'close',
+        validator: value => {
+          return ['close', 'back'].includes(value);
+        },
       },
       /* Optionally override the default width of the side panel with valid CSS value */
       sidePanelWidth: {
@@ -150,7 +153,7 @@
           'z-index': 12,
         };
       },
-      /* Change of position with change of close button type, default is close, */
+      /* Change of position with change of close button type, default is close */
       closeButtonStyle() {
         if (this.isRtl) {
           if (this.closeButtonIconType === 'close') {

--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -30,9 +30,9 @@
           </div>
 
           <KIconButton
-            v-if="fullScreenSidePanelCloseButton"
-            icon="close"
+            :icon="closeButtonIconType"
             class="close-button"
+            :style="closeButtonStyle"
             :ariaLabel="coreString('closeAction')"
             :tooltip="coreString('closeAction')"
             @click="closePanel"
@@ -72,9 +72,11 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     props: {
-      fullScreenSidePanelCloseButton: {
-        type: Boolean,
-        default: true,
+      /* CloseButtonIconType icon from parent component */
+      closeButtonIconType: {
+        type: String,
+        required: true,
+        default: 'close',
       },
       /* Optionally override the default width of the side panel with valid CSS value */
       sidePanelWidth: {
@@ -148,9 +150,45 @@
           'z-index': 12,
         };
       },
+      /* Change of position with change of close button type, default is close, */
+      closeButtonStyle() {
+        if (this.isRtl) {
+          if (this.closeButtonIconType === 'close') {
+            return {
+              position: 'absolute',
+              top: '16px',
+              left: '16px',
+              'z-index': '24',
+            };
+          } else {
+            return {
+              position: 'absolute',
+              top: '16px',
+              right: '24px',
+              'z-index': '24',
+            };
+          }
+        }
+        if (this.closeButtonIconType === 'back') {
+          return {
+            position: 'absolute',
+            top: '16px',
+            left: '16px',
+            'z-index': '24',
+          };
+        } else {
+          return {
+            position: 'absolute',
+            top: '16px',
+            right: '24px',
+            'z-index': '24',
+          };
+        }
+      },
       contentStyles() {
         return {
-          'margin-top': this.fixedHeaderHeight,
+          /* When the header margin is 0px from top, add 24 to accomodate close button */
+          'margin-top': this.fixedHeaderHeight === '0px' ? '24px' : this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
           height: `calc((100vh - ${this.fixedHeaderHeight}px))`,
@@ -164,8 +202,8 @@
     mounted() {
       const htmlTag = window.document.getElementsByTagName('html')[0];
       htmlTag.style['overflow-y'] = 'hidden';
-      // Gets the height of the fixed header - adds 40 to account for padding
-      this.fixedHeaderHeight = this.$refs.fixedHeader.clientHeight + 'px';
+      // Gets the height of the fixed header - adds 40 to account for padding + 24 for closeButton
+      this.fixedHeaderHeight = `${this.$refs.fixedHeader.clientHeight}px`;
       this.$nextTick(() => {
         this.$emit('shouldFocusFirstEl');
       });
@@ -203,13 +241,6 @@
 
   .header-content {
     width: 100%;
-  }
-
-  .close-button {
-    position: absolute;
-    top: 16px;
-    right: 16px;
-    z-index: 24;
   }
 
   /** Need to be sure a KDropdownMenu shows up on the Side Panel */

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -37,6 +37,7 @@
     <FullScreenSidePanel
       v-if="sidePanelContent"
       alignment="right"
+      closeButtonIconType="close"
       @closePanel="sidePanelContent = null"
       @shouldFocusFirstEl="findFirstEl()"
     >

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -69,6 +69,7 @@
     <FullScreenSidePanel
       v-if="sidePanelContent"
       alignment="right"
+      closeButtonIconType="close"
       @closePanel="sidePanelContent = null"
     >
       <template #header>
@@ -101,6 +102,7 @@
       v-if="showViewResourcesSidePanel"
       class="also-in-this-side-panel"
       alignment="right"
+      closeButtonIconType="close"
       @closePanel="showViewResourcesSidePanel = false"
     >
       <template #header>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -161,14 +161,6 @@
       @closePanel="closeEventHandler()"
       @shouldFocusFirstEl="findFirstEl()"
     >
-      <!-- <KIconButton
-        v-if="(windowIsSmall || windowIsMedium) && currentCategory"
-        icon="close"
-        :ariaLabel="coreString('goBackAction')"
-        :color="$themeTokens.text"
-        :tooltip="coreString('goBackAction')"
-        @click="closeEventHandler()"
-      /> -->
       <EmbeddedSidePanel
         v-if="!currentCategory"
         ref="embeddedPanel"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -156,19 +156,19 @@
       class="full-screen-side-panel"
       data-test="filters-side-panel"
       alignment="left"
-      :fullScreenSidePanelCloseButton="displayCloseButton"
+      :closeButtonIconType="closeButtonIcon"
       :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
-      @closePanel="toggleSidePanelVisibility"
+      @closePanel="closeEventHandler()"
       @shouldFocusFirstEl="findFirstEl()"
     >
-      <KIconButton
+      <!-- <KIconButton
         v-if="(windowIsSmall || windowIsMedium) && currentCategory"
-        icon="back"
+        icon="close"
         :ariaLabel="coreString('goBackAction')"
         :color="$themeTokens.text"
         :tooltip="coreString('goBackAction')"
-        @click="closeCategoryModal"
-      />
+        @click="closeEventHandler()"
+      /> -->
       <EmbeddedSidePanel
         v-if="!currentCategory"
         ref="embeddedPanel"
@@ -214,7 +214,7 @@
       v-if="sidePanelContent"
       data-test="content-side-panel"
       alignment="right"
-      :fullScreenSidePanelCloseButton="true"
+      :closeButtonIconType="closeButtonIcon"
       @closePanel="sidePanelContent = null"
       @shouldFocusFirstEl="findFirstEl()"
     >
@@ -355,11 +355,11 @@
         }
         return null;
       },
-      displayCloseButton() {
-        if (this.currentCategory) {
-          return false;
+      closeButtonIcon() {
+        if ((this.windowIsSmall || this.windowIsMedium) && this.currentCategory) {
+          return 'back';
         } else {
-          return true;
+          return 'close';
         }
       },
       numCols() {
@@ -420,8 +420,11 @@
       toggleInfoPanel(content) {
         this.sidePanelContent = content;
       },
-      closeCategoryModal() {
-        this.currentCategory = null;
+      closeEventHandler() {
+        this.sidePanelIsOpen = !this.sidePanelIsOpen;
+        if ((this.windowIsSmall || this.windowIsMedium) && this.currentCategory) {
+          this.currentCategory = null;
+        }
       },
       handleCategory(category) {
         this.setCategory(category);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -291,19 +291,11 @@
         v-if="!windowIsLarge && sidePanelIsOpen"
         class="full-screen-side-panel"
         alignment="left"
-        :fullScreenSidePanelCloseButton="true"
+        :closeButtonIconType="closeButtonIcon"
         :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
-        @closePanel="toggleFolderSearchSidePanel"
+        @closePanel="closeEventHandler()"
         @shouldFocusFirstEl="findFirstEl()"
       >
-        <KIconButton
-          v-if="windowIsSmall && currentCategory"
-          icon="back"
-          :ariaLabel="coreString('back')"
-          :color="$themeTokens.text"
-          :tooltip="coreString('back')"
-          @click="closeCategoryModal"
-        />
         <EmbeddedSidePanel
           v-if="!currentCategory"
           ref="embeddedPanel"
@@ -348,6 +340,7 @@
     <FullScreenSidePanel
       v-if="sidePanelContent"
       alignment="right"
+      :closeButtonIconType="closeButtonIcon"
       @closePanel="sidePanelContent = null"
       @shouldFocusFirstEl="findFirstEl()"
     >
@@ -541,6 +534,13 @@
       channelTitle() {
         return this.channel.name;
       },
+      closeButtonIcon() {
+        if (this.windowIsSmall && this.currentCategory) {
+          return 'back';
+        } else {
+          return 'close';
+        }
+      },
       resources() {
         const resources = this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
         // If there are no topics, then just display all resources we have loaded.
@@ -708,9 +708,6 @@
         this.showSearchModal = true;
         !this.windowIsSmall ? (this.sidePanelIsOpen = false) : '';
       },
-      closeCategoryModal() {
-        this.currentCategory = null;
-      },
       handleCategory(category) {
         this.setCategory(category);
         this.currentCategory = null;
@@ -721,6 +718,12 @@
       toggleFolderSearchSidePanel(option) {
         option == 'search' ? (this.mobileSearchActive = true) : (this.mobileSearchActive = false);
         this.sidePanelIsOpen = !this.sidePanelIsOpen;
+      },
+      closeEventHandler() {
+        if (this.windowIsSmall && this.currentCategory) {
+          this.currentCategory = null;
+        }
+        this.toggleFolderSearchSidePanel();
       },
       // Stick the side panel to top. That can be on the very top of the viewport
       // or right under the 'Browse channel' toolbar, depending on whether the toolbar


### PR DESCRIPTION
## Summary:
Changed location of closeButton,
Changed handling in Library and Topics,
Added props in all 4 pages that implement,
Added RTL and LTR handling for style of button,
Added icon handler for button.


In the following screenshots you can see the future implementation:
![fssp_LTR](https://user-images.githubusercontent.com/71641765/161194608-efc2e6f6-48aa-471f-8502-d55fdfcfad87.png)
![fssp_LTR_arrow](https://user-images.githubusercontent.com/71641765/161194609-6257ba20-cd25-4a21-b13f-83e4fd3c6a67.png)
![fssp_RTL](https://user-images.githubusercontent.com/71641765/161194610-9d655a67-cfd1-4074-a640-268962a7bd20.png)
![fssp_RTL_arrow](https://user-images.githubusercontent.com/71641765/161194611-915a8bc3-efa4-4754-bd75-f7d00b7ff3ac.png)

Moved the logic of the button to FSSP, 
Added event handlers that mimic the previous ones in Library and Topic, 
Removed the check if the FSSP close button needs to be shown since we always use it now,
Added prop to determine which Icon it is.
Added computed properties that change icon according to FSSP width in Topic and Library.


## References
Resolves #8989


## Reviewer guidance
Open Library Page, Any Folders Info or filter, 
Infor or Bookmark, 
And in Learn > Any Resource > The book icon or Info icon. 
These are all the uses of FSSP

## Tech Debt
There is a props error in console, Width prop on the child  EmbeddedSidePanel is missing when it's used in FSSP, yet it uses a computed property otherwise. 
I need consultation on how to make the Top and Right/left positioning on the sidepanel more scalable and adjustable to different components it appears in.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
