### PR TITLE
Restrict branches that pull request and push checks run on.

### DIFF
--- a/.github/workflows/c_extensions.yml
+++ b/.github/workflows/c_extensions.yml
@@ -1,6 +1,14 @@
 name: Static dependencies with and without C extensions
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -1,6 +1,14 @@
 name: Docs
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -1,6 +1,14 @@
 name: Licenses
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -1,6 +1,14 @@
 name: No zombie threads
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,14 @@
 name: Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/python2lint.yml
+++ b/.github/workflows/python2lint.yml
@@ -1,6 +1,14 @@
 name: Python 2 linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,6 +1,14 @@
 name: Python tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -1,6 +1,14 @@
 name: Javascript Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    - 'release-v**'
+  pull_request:
+    branches:
+    - develop
+    - 'release-v**'
 
 jobs:
   pre_job:


### PR DESCRIPTION
## Summary
* Reduces erroneous checks by filtering check runs to pushes to our develop and release branches, and on pull requests made to those branches

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
