### PR TITLE
Remote_Content frontend implementation

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -126,6 +126,7 @@
   import ChannelTokenModal from './ChannelTokenModal';
   import ChannelUpdateModal from './ChannelUpdateModal';
   import { getFreeSpaceOnServer } from './api';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'AvailableChannelsPage',
@@ -154,6 +155,7 @@
         freeSpace: null,
         disableBottomBar: false,
         disableModal: false,
+        remoteContentEnabled: plugin_data.isRemoteContent,
       };
     },
     computed: {
@@ -235,6 +237,10 @@
         return this.channelsAreAvailable && (this.inRemoteImportMode || this.isStudioApplication);
       },
       notEnoughFreeSpace() {
+        // if the REMOTE_CONTENT option is true, we should not be submitting disk space issues
+        if (this.remoteContentEnabled) {
+          return false;
+        }
         if (this.freeSpace === null) {
           return false;
         }

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -68,7 +68,7 @@
         <td>{{ $tr('resourceCount', { count: channel.new_resource_count || 0 }) }}</td>
         <td>{{ bytesForHumans(channel.new_resource_total_size || 0) }}</td>
       </tr>
-      <tr>
+      <tr v-if="!remoteContentEnabled">
         <th>{{ deviceInfo.$tr('freeDisk') }}</th>
         <td></td>
         <td>{{ bytesForHumans(freeSpace || 0) }}</td>
@@ -108,6 +108,11 @@
       freeSpace: {
         type: Number,
         required: true,
+      },
+      remoteContentEnabled: {
+        type: Boolean,
+        required: true,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -30,6 +30,7 @@
           :channel="transferredChannel"
           :channelOnDevice="channelOnDevice"
           :freeSpace="availableSpace"
+          :remoteContentEnabled="remoteContentEnabled"
         />
 
         <UiAlert
@@ -48,7 +49,7 @@
           {{ $tr('problemTransferringContents') }}
         </UiAlert>
         <UiAlert
-          v-show="transferFileSize > availableSpace"
+          v-show="isFileSpaceEnough"
           :dismissible="false"
           type="error"
         >
@@ -67,7 +68,7 @@
       objectType="resource"
       actionType="import"
       :resourceCounts="{ count: transferResourceCount, fileSize: transferFileSize }"
-      :disabled="disableBottomBar || newVersionAvailable || transferFileSize > availableSpace"
+      :disabled="disableBottomBar || newVersionAvailable || isFileSpaceEnough"
       @clickconfirm="handleClickConfirm"
     />
   </div>
@@ -96,6 +97,7 @@
   import ContentTreeViewer from './ContentTreeViewer';
   import ContentWizardUiAlert from './ContentWizardUiAlert';
   import { startImportTask } from './api';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'SelectContentPage',
@@ -121,6 +123,7 @@
         // in beforeRouteLeave
         metadataDownloadTaskId: '',
         disableBottomBar: false,
+        remoteContentEnabled: plugin_data.isRemoteContent,
       };
     },
     computed: {
@@ -175,6 +178,11 @@
       },
       newVersionAvailable() {
         return this.availableVersions.source > this.availableVersions.installed;
+      },
+      isFileSpaceEnough() {
+        if (this.remoteContentEnabled) {
+          return false;
+        } else return this.transferFileSize > this.availableSpace;
       },
     },
     watch: {

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -9,6 +9,7 @@ from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils.conf import OPTIONS
 
 
 class DeviceManagementPlugin(KolibriPluginBase):
@@ -26,6 +27,7 @@ class DeviceManagementAsset(WebpackBundleHook):
             "isSubsetOfUsersDevice": get_device_setting(
                 "subset_of_users_device", False
             ),
+            "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"]
         }
 
 

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -27,7 +27,7 @@ class DeviceManagementAsset(WebpackBundleHook):
             "isSubsetOfUsersDevice": get_device_setting(
                 "subset_of_users_device", False
             ),
-            "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"]
+            "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"],
         }
 
 


### PR DESCRIPTION

## Summary

added a path to check if remote content is enabled, Thanks @rtibbles 
added checks for it to stop the disable of import buttons,
added check to hide free space available

## Screenshots
When Remote_Content is off, And file storage space is enough and not enough:
![remote_off](https://user-images.githubusercontent.com/71641765/161315922-2fe4325e-5f2d-48b6-b860-06f538c120c1.png)
![remote_off_file_low](https://user-images.githubusercontent.com/71641765/161315926-6a494e77-5348-4f31-aeb3-3cbb681d4c59.png)

When Remote_Content is on, and file storage space is enough and not enough:
![remote_on](https://user-images.githubusercontent.com/71641765/161316115-085b8e80-e4cb-4f25-9ebf-ec84977a55f1.png)
![remote_on_file_low](https://user-images.githubusercontent.com/71641765/161316121-88839e2f-4c77-47f4-8549-b1a86ac3bb8b.png)

## References
@rtibbles Helped me with the python part, and linking it to the JS data ingestion point.
Resolves #8994

## Reviewer guidance
by using the Options.ini file to change REMOTE_CONTENT=TRUE or optimally by loading in remote content

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
