### PR TITLE
New content import flow

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -148,8 +148,17 @@
         }
       },
       immersivePagePrimary() {
-        if (this.pageName === PageNames.MANAGE_TASKS) {
+        if (
+          this.pageName === PageNames.MANAGE_TASKS &&
+          this.$route.query &&
+          this.$route.query.last
+        ) {
           return true;
+        } else if (
+          this.pageName === PageNames.MANAGE_TASKS &&
+          (!this.$route.query || !this.$route.query.last)
+        ) {
+          return false;
         }
         return this.inContentManagementPage;
       },

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -100,6 +100,12 @@
         return this.pageName === 'AVAILABLE_CHANNELS' && this.$route.query.multiple;
       },
       immersivePageRoute() {
+        if (this.$route.query && this.pageName === PageNames.MANAGE_TASKS) {
+          const route = this.$router.getRoute(this.$route.query.last, {
+            channel_id: this.$route.query.channel_id,
+          });
+          return route;
+        }
         if (this.$route.query.last) {
           return {
             name: this.$route.query.last,
@@ -108,9 +114,7 @@
             query: omit(this.$route.query, ['last']),
           };
         }
-        if (this.pageName === PageNames.MANAGE_TASKS) {
-          return this.$route.params.lastRoute || { name: PageNames.MANAGE_CONTENT_PAGE };
-        }
+
         if (this.pageName === PageNames.MANAGE_CHANNEL) {
           return { name: PageNames.MANAGE_CONTENT_PAGE };
         }
@@ -145,7 +149,7 @@
       },
       immersivePagePrimary() {
         if (this.pageName === PageNames.MANAGE_TASKS) {
-          return false;
+          return true;
         }
         return this.inContentManagementPage;
       },
@@ -161,10 +165,7 @@
         return 'close';
       },
       currentPageIsImmersive() {
-        if (
-          this.pageName == PageNames.MANAGE_CONTENT_PAGE ||
-          this.pageName === PageNames.MANAGE_TASKS
-        ) {
+        if (this.pageName == PageNames.MANAGE_CONTENT_PAGE) {
           return false;
         }
         return (

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -100,11 +100,15 @@
         return this.pageName === 'AVAILABLE_CHANNELS' && this.$route.query.multiple;
       },
       immersivePageRoute() {
-        if (this.$route.query && this.pageName === PageNames.MANAGE_TASKS) {
-          const route = this.$router.getRoute(this.$route.query.last, {
-            channel_id: this.$route.query.channel_id,
-          });
-          return route;
+        if (this.pageName === PageNames.MANAGE_TASKS) {
+          if (this.$route.query.last) {
+            const route = this.$router.getRoute(this.$route.query.last, {
+              channel_id: this.$route.query.channel_id,
+            });
+            return route;
+          } else {
+            return { name: PageNames.MANAGE_CONTENT_PAGE };
+          }
         }
         if (this.$route.query.last) {
           return {
@@ -114,7 +118,6 @@
             query: omit(this.$route.query, ['last']),
           };
         }
-
         if (this.pageName === PageNames.MANAGE_CHANNEL) {
           return { name: PageNames.MANAGE_CONTENT_PAGE };
         }

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -244,7 +244,13 @@
                 }
               });
             } else {
-              this.$router.push(this.$router.getRoute(PageNames.MANAGE_TASKS));
+              this.$router.push({
+                name: PageNames.MANAGE_TASKS,
+                query: {
+                  last: PageNames.MANAGE_CHANNEL,
+                  channel_id: this.params.channelId,
+                },
+              });
             }
           })
           .catch(error => {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -1,13 +1,6 @@
 <template>
 
   <div>
-
-    <p>
-      <BackLink
-        :to="$router.getRoute(homeRoute)"
-        :text="$tr('backToChannelsAction')"
-      />
-    </p>
     <KGrid>
       <KGridItem :layout8="{ span: 5 }" :layout12="{ span: 8 }">
         <h1>
@@ -20,7 +13,7 @@
       >
         <KButton
           v-if="showClearCompletedButton"
-          :text="$tr('clearCompletedAction')"
+          :text="coreString('continueAction')"
           :class="{ 'button-offset': windowIsLarge }"
           @click="handleClickClearAll"
         />
@@ -57,10 +50,8 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonDeviceStrings from '../commonDeviceStrings';
-  import { PageNames } from '../../constants';
 
   import TaskPanel from './TaskPanel';
-  import BackLink from './BackLink';
 
   // A page to view content import/export/deletion tasks
   export default {
@@ -72,7 +63,6 @@
     },
     components: {
       TaskPanel,
-      BackLink,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings, commonDeviceStrings],
     data() {
@@ -87,9 +77,6 @@
       },
       showClearCompletedButton() {
         return some(this.managedTasks, task => task.clearable);
-      },
-      homeRoute() {
-        return PageNames.MANAGE_CONTENT_PAGE;
       },
     },
     watch: {
@@ -118,14 +105,14 @@
       },
       handleClickClearAll() {
         TaskResource.deleteFinishedTasks();
+        this.$router.push(
+          this.$router.getRoute(this.$route.query.last, {
+            channel_id: this.$route.query.channel_id,
+          })
+        );
       },
     },
     $trs: {
-      backToChannelsAction: {
-        message: 'Back to channels',
-        context:
-          'Link that takes user back to the list of channels in the Device > Channels section.',
-      },
       tasksHeader: {
         message: 'Tasks',
         context: 'Heading in the task manager section.',
@@ -133,11 +120,6 @@
       appBarTitle: {
         message: 'Task manager',
         context: 'Title of the page that displays all the tasks in the task manager. ',
-      },
-      clearCompletedAction: {
-        message: 'Clear completed',
-        context:
-          'Button on the task manager page. When pressed it will clear all the completed tasks from the list.',
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -39,12 +39,11 @@
         />
       </transition-group>
     </div>
-    <BottomAppBar>
+    <BottomAppBar v-if="immersivePage">
       <KButton
         :text="coreString('continueAction')"
         appearance="raised-button"
         :primary="true"
-        :disabled="loadingChannel || loadingTask"
         @click="handleRedirectToImportPage()"
       />
     </BottomAppBar>
@@ -91,6 +90,9 @@
       },
       showClearCompletedButton() {
         return some(this.managedTasks, task => task.clearable);
+      },
+      immersivePage() {
+        return this.$route.query && this.$route.query.last;
       },
     },
     watch: {

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -1,41 +1,53 @@
 <template>
 
   <div>
-    <KGrid>
-      <KGridItem :layout8="{ span: 5 }" :layout12="{ span: 8 }">
-        <h1>
-          {{ $tr('tasksHeader') }}
-        </h1>
-      </KGridItem>
-      <KGridItem
-        :layout8="{ span: 3, alignment: 'right' }"
-        :layout12="{ span: 4, alignment: 'right' }"
-      >
-        <KButton
-          v-if="showClearCompletedButton"
-          :text="coreString('continueAction')"
-          :class="{ 'button-offset': windowIsLarge }"
-          @click="handleClickClearAll"
+
+    <div>
+      <KGrid>
+        <KGridItem :layout8="{ span: 5 }" :layout12="{ span: 8 }">
+          <h1>
+            {{ $tr('tasksHeader') }}
+          </h1>
+        </KGridItem>
+        <KGridItem
+          :layout8="{ span: 3, alignment: 'right' }"
+          :layout12="{ span: 4, alignment: 'right' }"
+        >
+          <KButton
+            v-if="showClearCompletedButton"
+            :text="$tr('clearCompletedAction')"
+            :class="{ 'button-offset': windowIsLarge }"
+            @click="handleClickClearAll"
+          />
+        </KGridItem>
+      </KGrid>
+
+      <KLinearLoader v-if="loading" :delay="false" type="indeterminate" />
+
+      <p v-if="!loading && managedTasks.length === 0" class="empty-tasks-message">
+        {{ deviceString('emptyTasksMessage') }}
+      </p>
+      <transition-group name="fade" class="task-panels">
+        <TaskPanel
+          v-for="task in sortedTaskList"
+          :key="task.id"
+          :task="task"
+          class="task-panel"
+          :style="{ borderBottomColor: $themePalette.grey.v_200 }"
+          @clickclear="handleClickClear(task)"
+          @clickcancel="handleClickCancel(task)"
         />
-      </KGridItem>
-    </KGrid>
-
-    <KLinearLoader v-if="loading" :delay="false" type="indeterminate" />
-
-    <p v-if="!loading && managedTasks.length === 0" class="empty-tasks-message">
-      {{ deviceString('emptyTasksMessage') }}
-    </p>
-    <transition-group name="fade" class="task-panels">
-      <TaskPanel
-        v-for="task in sortedTaskList"
-        :key="task.id"
-        :task="task"
-        class="task-panel"
-        :style="{ borderBottomColor: $themePalette.grey.v_200 }"
-        @clickclear="handleClickClear(task)"
-        @clickcancel="handleClickCancel(task)"
+      </transition-group>
+    </div>
+    <BottomAppBar>
+      <KButton
+        :text="coreString('continueAction')"
+        appearance="raised-button"
+        :primary="true"
+        :disabled="loadingChannel || loadingTask"
+        @click="handleRedirectToImportPage()"
       />
-    </transition-group>
+    </BottomAppBar>
   </div>
 
 </template>
@@ -49,6 +61,7 @@
   import { TaskResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import commonDeviceStrings from '../commonDeviceStrings';
 
   import TaskPanel from './TaskPanel';
@@ -63,6 +76,7 @@
     },
     components: {
       TaskPanel,
+      BottomAppBar,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings, commonDeviceStrings],
     data() {
@@ -105,6 +119,8 @@
       },
       handleClickClearAll() {
         TaskResource.deleteFinishedTasks();
+      },
+      handleRedirectToImportPage() {
         this.$router.push(
           this.$router.getRoute(this.$route.query.last, {
             channel_id: this.$route.query.channel_id,
@@ -116,6 +132,11 @@
       tasksHeader: {
         message: 'Tasks',
         context: 'Heading in the task manager section.',
+      },
+      clearCompletedAction: {
+        message: 'Clear completed',
+        context:
+          'Button on the task manager page. When pressed it will clear all the completed tasks from the list.',
       },
       appBarTitle: {
         message: 'Task manager',


### PR DESCRIPTION
## Summary
Maintains the "Manage Tasks" page, but changes it to be an immersive page in the same style as the content import page for less jarring UI

The workflow (in questionably-accurate gherkin format -- I did my best @radinamatic ) should be something like: 

```
Scenario: Upgrading a channel
   When I am on the 'Manage Channel' Page
   And a new version is available
    Then I see a link that allows me to view changes
    When I click the *View changes* link
    Then I see the version changes
    When I click the *Update Channel* button
    Then I see the *Update Channel* modal
    When I click the *Continue* button
    Then I see the *Tasks* progress page     
    When I click the Task's *Clear* button
    The task is cleared
    When I click the *Continue* button
    Then I am returned to main channel import page of the channel I have just updated
    When I click the *X* button
    Then I am returned to main channel import page of the channel I have just updated
```

## References
Fixes #8826 
Supersedes #9086 

The main change to the Manage Tasks page in the flow is seen here: 
![new-content-flow](https://user-images.githubusercontent.com/17235236/162061150-2174de46-0237-4e04-969d-f05391c66dac.gif)


## Reviewer guidance
1) Update the versions of several channels. Are there any issues with things loading, or is the navigation confusing?


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
