### PR TITLE
Fix Kolibri blocking after starting with port 0

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -131,6 +131,9 @@ class ServerPlugin(BaseServerPlugin):
         httpserver = kwargs.get("httpserver")
         if not isinstance(httpserver, BaseServer):
             raise TypeError("httpserver must be a cheroot.wsgi.BaseServer")
+        # The server is initialized without a bind address before it is passed into the plugin.
+        # Because of the property setter below for `bind_addr` the setting of `self.bind_addr`
+        # in the super invocation here, results in the httpserver's `bind_addr` property being set.
         super(ServerPlugin, self).__init__(*args, **kwargs)
         self._default_bind_addr = self.bind_addr
 


### PR DESCRIPTION
## Summary

After the server starts, `BaseServerPlugin` waits for it to respond on the
expected port number. For this feature to work, we need it to see the
bind address from the associated `httpserver,` which is different from the
original bind address when binding to port 0.

For clarity, we will not initialize the `cheroot.wsgi` Server with a
`bind_addr`. Instead, it will be controlled by `ServerPlugin` itself.

With this change in place, we can remove `PortCache` because we no longer
need to reuse port numbers.

## References

The port cache was originally implemented in #8026.

This is dealing with a peculiarity of magicbus, where it waits for the port number described in `ServerPlugin.bind_addr` to be used (and, later, to be freed): https://github.com/cherrypy/magicbus/blob/main/magicbus/plugins/servers.py#L194-L205.

## Reviewer guidance

We need to check that Kolibri starts and stops as expected with this change, both with `KOLIBRI_HTTP_PORT=0` and with some other valid port number such as `KOLIBRI_HTTP_PORT=8080`.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
