### PR TITLE
Disable mac app pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,18 +6,6 @@ steps:
 
   - wait
 
-  - trigger: "kolibri-macos"
-    label: ":mac:"
-    build:
-      message: "${BUILDKITE_MESSAGE}"
-      branch: "v0.2.1"
-      env:
-        LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
-        LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"
-        # Determines whether build will be autoblocked or not.
-        # Autoblock unless there's a tag associated with the commit. Usually a release.
-        LE_KOLIBRI_RELEASE: "${BUILDKITE_TAG:-false}"
-
   - label: ":android:"
     trigger: "kolibri-android-installer"
     build:


### PR DESCRIPTION
## Summary
Disables the mac app buildkite pipeline trigger. All mac app assets must now be manually built using the Github Action workflow on the repository.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202178874447018