### PR TITLE
Fix height calculation of `FullScreenSidePanel`

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -94,7 +94,7 @@
     data() {
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
-        fixedHeaderHeight: 0,
+        fixedHeaderHeight: '0px',
         lastFocus: null,
       };
     },
@@ -153,7 +153,7 @@
           'margin-top': this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
-          height: `calc((100vh - ${this.fixedHeaderHeight}px))`,
+          height: `calc(100vh - ${this.fixedHeaderHeight})`,
         };
       },
     },


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The height of FullScreenSidePanel was being miscalculated since when `fixedHeaderHeight` was set, it already included the "px" units, but when inserting it into the inline styles to calculate the height of FSSP, it was putting the units again. 

This PR fix that removing the repeated units, and setting the initial value of `fixedHeaderHeight` with the units to avoid having inconsistent values like `calc(100vh - 0)`.

### Before:

![HiddenContent](https://user-images.githubusercontent.com/51239030/162635610-ab081c8c-27f8-4f4f-9609-7897dfb5d0f8.gif)

### After:

![HiddenContent_solved](https://user-images.githubusercontent.com/51239030/162638583-6885cb9b-24db-4bce-b849-2130282182a7.gif)


## References

Fixes #9271 

## Reviewer guidance

1. Log in.
2. Go to Learn section.
3. Click on "View information" of any resource whose information on the side panel is higher than the viewport (e.g. Ciensación channel > Física > Respirando Agua).

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
