### PR TITLE
Increase default transfer timeout to 1 minute

### DIFF
--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -33,7 +33,7 @@ class Transfer(object):
         dest,
         block_size=2097152,
         remove_existing_temp_file=True,
-        timeout=20,
+        timeout=60,
         cancel_check=None,
     ):
         self.source = source


### PR DESCRIPTION
Kolibri is expected to be deployed on devices with slow networks. To
help make downloads more likely to succeed, increase the default
transfer timeout to 60 seconds.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Increase the default `Transfer` timeout since 20 seconds is likely too low for devices with slow networks.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#9269

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

This is difficult to test without being on a slow network. I tried delaying the network on Linux using something like [this](https://www.pico.net/kb/how-can-i-simulate-delayed-and-dropped-packets-in-linux/), but it also delayed the DNS resolution, which meant it failed before getting to the actual request timeout. In theory you could bypass DNS by using an IP address for the base URL, but Cloudflare won't respond correctly without the proper `Host` header. You'd need to monkey with `requests` at a lower level than what's exposed in Kolibri.

I think to really test this you'd either need to mock responses like the tests do or use a custom server that delays just the HTTP traffic. I ended up hacking together an HTTP server that can [add delays](https://gist.github.com/dbnicholson/c2902cec7bb74d01ccc9327c0d8619f3) to `GET`s.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

First, seed some content to a temporary directory:

```
$ KOLIBRI_HOME=$PWD/tmp/server python -m kolibri manage importchannel network f393c30f95fb4bec87f873b2013ec9e3
$ KOLIBRI_HOME=$PWD/tmp/server python -m kolibri manage importcontent network f393c30f95fb4bec87f873b2013ec9e3
```

Serve that content with a 70 second delay from another shell using [`delayserver.py`](https://gist.github.com/dbnicholson/c2902cec7bb74d01ccc9327c0d8619f3):

```
$ ./delayserver.py --delay 70 --root $PWD/tmp/server
```

Import the channel to a 2nd installation and then try to import the contents from the local server:

```
$ KOLIBRI_HOME=$PWD/tmp/client python -m kolibri manage importchannel network f393c30f95fb4bec87f873b2013ec9e3
$ KOLIBRI_HOME=$PWD/tmp/client python -m kolibri manage importcontent network --baseurl http://127.0.0.1:8000 f393c30f95fb4bec87f873b2013ec9e3
```

This produced several `Read timed out. (read timeout=60)` errors. Repeating again with a delay of `10` specified to `delayserver.py` resulted in successfully importing all the content.

## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
