### PR TITLE
Backport "Fix height calculation of FullScreenSidePanel" contribution PR to the release branch 

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -94,7 +94,7 @@
     data() {
       return {
         /* Will be calculated in mounted() as it will get the height of the fixedHeader then */
-        fixedHeaderHeight: 0,
+        fixedHeaderHeight: '0px',
         lastFocus: null,
       };
     },
@@ -153,7 +153,7 @@
           'margin-top': this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
-          height: `calc((100vh - ${this.fixedHeaderHeight}px))`,
+          height: `calc(100vh - ${this.fixedHeaderHeight})`,
         };
       },
     },


### PR DESCRIPTION
## Summary

Backports @AlexVelezLl 's [fix for the side panel height](https://github.com/learningequality/kolibri/pull/9272) to the release branch.


## Reviewer guidance

Follow test instructions in https://github.com/learningequality/kolibri/pull/9272

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
