### PR TITLE
Add importcontent --timeout option

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -152,6 +152,14 @@ class Command(AsyncCommand):
             "--peer_id", type=str, default="", dest="peer_id"
         )
 
+        network_subparser.add_argument(
+            "--timeout",
+            type=int,
+            default=transfer.Transfer.DEFAULT_TIMEOUT,
+            dest="timeout",
+            help="Specify network timeout in seconds (default: %(default)d)",
+        )
+
         disk_subparser = subparsers.add_parser(
             name="disk", cmd=self, help="Copy the content from the given folder."
         )
@@ -169,6 +177,7 @@ class Command(AsyncCommand):
         renderable_only=True,
         import_updates=False,
         fail_on_error=False,
+        timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
         self._transfer(
             DOWNLOAD_METHOD,
@@ -180,6 +189,7 @@ class Command(AsyncCommand):
             renderable_only=renderable_only,
             import_updates=import_updates,
             fail_on_error=fail_on_error,
+            timeout=timeout,
         )
 
     def copy_content(
@@ -218,6 +228,7 @@ class Command(AsyncCommand):
         renderable_only=True,
         import_updates=False,
         fail_on_error=False,
+        timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
         try:
             if not import_updates:
@@ -392,6 +403,7 @@ class Command(AsyncCommand):
                                     dest,
                                     session=session,
                                     cancel_check=self.is_cancelled,
+                                    timeout=timeout,
                                 )
                             elif method == COPY_METHOD:
                                 try:
@@ -553,6 +565,7 @@ class Command(AsyncCommand):
                 renderable_only=options["renderable_only"],
                 import_updates=options["import_updates"],
                 fail_on_error=options["fail_on_error"],
+                timeout=options["timeout"],
             )
         elif options["command"] == "disk":
             self.copy_content(

--- a/kolibri/core/content/utils/transfer.py
+++ b/kolibri/core/content/utils/transfer.py
@@ -27,13 +27,15 @@ class TransferNotYetClosed(Exception):
 
 
 class Transfer(object):
+    DEFAULT_TIMEOUT = 60
+
     def __init__(
         self,
         source,
         dest,
         block_size=2097152,
         remove_existing_temp_file=True,
-        timeout=60,
+        timeout=DEFAULT_TIMEOUT,
         cancel_check=None,
     ):
         self.source = source


### PR DESCRIPTION
Allow overriding the network timeout for cases where the default 60
second timeout isn't appropriate.

Fixes: #9269

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Allow changing the `FileDownload` timeout from the `Transfer` default of 60 seconds. Mostly this would be for increasing the timeout in the case when you know that the network or content server has a lot of latency, but you could also decrease it when you know it should work much faster.

I added a unit test, but I also did a manual test using [`delayserver.py`](https://gist.github.com/dbnicholson/c2902cec7bb74d01ccc9327c0d8619f3) similar to #9281. Details below.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#9269

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test, you can run `importcontent network --timeout 1`, but if you're on a fast network you might still get responses from Cloudflare within that window.

I think since the default timeout is maintained (as confirmed in the tests), there's little risk. I don't love that `Transfer.DEFAULT_TIMEOUT` is used in several places. I think it might be nicer to use `None` as the default in the `importcontent` internal interfaces and only add the keyword arg to `FileDownload` when it's not `None`.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

To manually test, you can setup a local server with delays. First, download [delayserver.py](https://gist.github.com/dbnicholson/c2902cec7bb74d01ccc9327c0d8619f3).

Next, seed some content to a temporary directory:

```
$ KOLIBRI_HOME=$PWD/tmp/server python -m kolibri manage importchannel network f393c30f95fb4bec87f873b2013ec9e3
$ KOLIBRI_HOME=$PWD/tmp/server python -m kolibri manage importcontent network f393c30f95fb4bec87f873b2013ec9e3
```

Serve that content with a 5 second delay from another shell using `delayserver.py`:

```
$ ./delayserver.py --delay 5 --root $PWD/tmp/server
```

Import the channel to a 2nd installation and then try to import the contents from the local server with a timeout of 1 second:

```
$ KOLIBRI_HOME=$PWD/tmp/client python -m kolibri manage importchannel network f393c30f95fb4bec87f873b2013ec9e3
$ KOLIBRI_HOME=$PWD/tmp/client python -m kolibri manage importcontent network --timeout 1 --baseurl http://127.0.0.1:8000 f393c30f95fb4bec87f873b2013ec9e3
```

This produced several `Read timed out. (read timeout=1)` errors. Repeating again with a delay of `0` specified to `delayserver.py` resulted in successfully importing all the content.

## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
