### PR TITLE
Fix task permission tests for regressions

### DIFF
--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -211,7 +211,7 @@ class BaseViewSet(viewsets.ViewSet):
         """
         job_facility_id = None
         if job:
-            job_facility_id = getattr(job, "facility_id", None)
+            job_facility_id = getattr(job, "job_facility_id", None)
 
         try:
             if not request.user.is_superuser and request.user.is_facility_user:


### PR DESCRIPTION
## Summary
Pull request https://github.com/learningequality/kolibri/pull/8303 introduced a regression. This PR fixes that regression and tests have been updated to catch such future regressions.

## Reviewer guidance
Do tests pass?

## Testing checklist
- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process
- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist
- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md