### PR TITLE
Add SWAGGER_SETTINGS with DEFAULT_INFO

### DIFF
--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -17,13 +17,17 @@ def webpack_redirect_view(request):
     )
 
 
-schema_view = get_schema_view(
+api_info = (
     openapi.Info(
         title="Kolibri API",
         default_version="v0",
         description="Kolibri Swagger API",
         license=openapi.License(name="MIT"),
     ),
+)
+
+schema_view = get_schema_view(
+    api_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -54,3 +54,5 @@ REST_FRAMEWORK = {
     ),
     "EXCEPTION_HANDLER": "kolibri.core.utils.exception_handler.custom_exception_handler",
 }
+
+SWAGGER_SETTINGS = {"DEFAULT_INFO": "kolibri.deployment.default.dev_urls.api_info"}


### PR DESCRIPTION
## Summary

At the moment, generating a swagger schema involves starting Kolibri with the dev settings and browsing to `http://localhost/swagger.json`. With this change, we can use the generate_swagger management command, which is still a bit clunky but spares us from running the server for the one task:

```
env DJANGO_SETTINGS_MODULE=kolibri.deployment.default.settings.dev kolibri manage generate_swagger swagger.json
```
