### PR TITLE
Update windows installer version to fix build error due to python versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
     label: ":windows:"
     build:
       message: "${BUILDKITE_MESSAGE}"
-      branch: "v1.5.0"
+      branch: "v1.5.1"
       env:
         LE_TRIGGERED_FROM_BUILD_ID: "${BUILDKITE_BUILD_ID}"
         LE_TRIGGERED_FROM_JOB_ID: "${BUILDKITE_JOB_ID}"


### PR DESCRIPTION
## Summary
* Properly noting that Kolibri cannot run on Python 3.10 caused our windows installer pipeline to break
* This fixes that by pointing to a version of the installer pipeline that ensures that Python 3.9 is used

## References
Fixes breakage observed here: https://buildkite.com/learningequality/kolibri-windows/builds/3491#db044c1c-ec13-4b55-b298-8176ae54ea18/1464-1466

## Reviewer guidance
Does the windows installer build properly if you unblock the build step?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
