### PR TITLE
Stop file system polling to reduce CPU load.

### DIFF
--- a/packages/kolibri-tools/lib/webpack.config.plugin.js
+++ b/packages/kolibri-tools/lib/webpack.config.plugin.js
@@ -172,7 +172,6 @@ module.exports = (
     bundle.watch = true;
     bundle.watchOptions = {
       aggregateTimeout: 300,
-      poll: 1000,
     };
   }
 


### PR DESCRIPTION
## Summary
* For some reason we've had polling configured in webpack devserver - although it's not meant to be required unless using virtualized file systems
* This disables this which seems to remove idle CPU load from the devserver

## References
Fixes https://github.com/learningequality/kolibri/issues/9287 (or at least the part I can reproduce)

## Reviewer guidance
Does CPU drop to basically none when the build is complete?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
