### PR TITLE
Webpack build caching updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "makemessages": "kolibri-tools i18n-extract-messages --pluginFile ./build_tools/build_plugins.txt",
     "createprofiles": "kolibri-tools i18n-profile --pluginFile ./build_tools/build_plugins.txt --output-file ./kolibri/locale/en/LC_MESSAGES/profiles/strings.csv",
     "transfercontext": "kolibri-tools i18n-transfer-context --pluginFile ./build_tools/build_plugins.txt",
-    "watch": "kolibri-tools build dev --file ./build_tools/build_plugins.txt",
+    "watch": "kolibri-tools build dev --file ./build_tools/build_plugins.txt --cache",
     "watch-hot": "yarn run watch --hot",
     "python-devserver": "kolibri start --debug --foreground --port=8000 --settings=kolibri.deployment.default.settings.dev",
     "python-devserver-no-update": "kolibri start --debug --skip-update --foreground --port=8000 --settings=kolibri.deployment.default.settings.dev",

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -57,6 +57,7 @@ program
   .option('-p, --port <port>', 'Set a port number to start devserver on', Number, 3000)
   .option('--host <host>', 'Set a host to serve devserver', String, '0.0.0.0')
   .option('--json', 'Output webpack stats in JSON format - only works in prod mode', false)
+  .option('--cache', 'Use cache in webpack', false)
   .action(function(mode, options) {
     const buildLogging = logger.getLogger('Kolibri Build');
     const modes = {
@@ -116,7 +117,12 @@ program
       [modes.STATS]: 'production',
     }[mode];
 
-    const buildOptions = { hot: options.hot, port: options.port, mode: webpackMode };
+    const buildOptions = {
+      hot: options.hot,
+      port: options.port,
+      mode: webpackMode,
+      cache: options.cache,
+    };
 
     const webpackConfig = require('./webpack.config.plugin');
 

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -5,7 +5,7 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
 
-module.exports = ({ mode = 'development', hot = false } = {}) => {
+module.exports = ({ mode = 'development', hot = false, cache = false } = {}) => {
   const production = mode === 'production';
 
   // Have to pass this option to prevent complaints about empty exports:
@@ -37,9 +37,12 @@ module.exports = ({ mode = 'development', hot = false } = {}) => {
   return {
     target: 'browserslist',
     mode,
-    cache: !production && {
+    cache: cache && {
       type: 'filesystem',
       version: '1.0.0',
+      buildDependencies: {
+        config: [__filename],
+      },
     },
     module: {
       rules: [
@@ -58,7 +61,8 @@ module.exports = ({ mode = 'development', hot = false } = {}) => {
           loader: 'babel-loader',
           exclude: { and: [/(node_modules\/vue|dist|core-js)/, { not: [/\.(esm\.js|mjs)$/] }] },
           options: {
-            cacheDirectory: !production,
+            cacheDirectory: cache,
+            cacheCompression: false,
           },
         },
         {

--- a/packages/kolibri-tools/lib/webpack.config.plugin.js
+++ b/packages/kolibri-tools/lib/webpack.config.plugin.js
@@ -36,7 +36,7 @@ const WebpackMessages = require('./webpackMessages');
  */
 module.exports = (
   data,
-  { mode = 'development', hot = false, port = 3000, address = 'localhost' } = {}
+  { mode = 'development', hot = false, port = 3000, address = 'localhost', cache = false } = {}
 ) => {
   if (
     typeof data.name === 'undefined' ||
@@ -164,7 +164,7 @@ module.exports = (
     );
   }
 
-  bundle = merge(bundle, baseConfig({ mode, hot }), webpackConfig);
+  bundle = merge(bundle, baseConfig({ mode, hot, cache }), webpackConfig);
 
   if (mode === 'development') {
     const publicPath = `http://${address}:${port}/${data.name}/`;
@@ -174,6 +174,10 @@ module.exports = (
       aggregateTimeout: 300,
       poll: 1000,
     };
+  }
+
+  if (cache) {
+    bundle.cache.buildDependencies.config.push(__filename, data.config_path);
   }
 
   return bundle;


### PR DESCRIPTION
## Summary
* Make build caching sensitive to config file changes.
* Toggle build caching via CLI flag.

## Reviewer guidance
Following the guidance here: https://webpack.js.org/configuration/cache/#cachebuilddependencies to ensure that individual plugin configuration is included for cache invalidation purposes.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
