### PR TITLE
Fix bug for content deletion reported resources and files

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -33,7 +33,7 @@ def delete_metadata(channel, node_ids, exclude_node_ids, force_delete):
     # If we have been passed node ids do not do a full deletion pass
     set_content_invisible(channel.id, node_ids, exclude_node_ids)
     # If everything has been made invisible, delete all the metadata
-    delete_all_metadata = not channel.root.available
+    delete_all_metadata = delete_all_metadata or not channel.root.available
 
     total_resource_number = (
         resources_before

--- a/kolibri/core/content/test/test_deletechannel.py
+++ b/kolibri/core/content/test/test_deletechannel.py
@@ -1,12 +1,18 @@
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TransactionTestCase
 from mock import call
 from mock import patch
 
+from .sqlalchemytesting import django_connection_engine
 from kolibri.core.content import models as content
 
 
-class DeleteChannelTestCase(TestCase):
+def get_engine(connection_string):
+    return django_connection_engine()
+
+
+@patch("kolibri.core.content.utils.sqlalchemybridge.get_engine", new=get_engine)
+class DeleteChannelTestCase(TransactionTestCase):
     """
     Testcase for delete channel management command
     """
@@ -51,3 +57,7 @@ class DeleteChannelTestCase(TestCase):
         num_files = content.LocalFile.objects.filter(available=True).count()
         self.delete_channel()
         os_remove_mock.assert_has_calls([call(path)] * num_files)
+
+    def tearDown(self):
+        call_command("flush", interactive=False)
+        super(DeleteChannelTestCase, self).tearDown()


### PR DESCRIPTION
## Summary
* Fixes regression introduced by https://github.com/learningequality/kolibri/pull/8506 due to the collapsing of resource counting for full and partial channel deletion
* Simplifies how the resources and files being deleted are counted

## Reviewer guidance
Partially import content for a channel
Delete all content from the channel
Confirm that the reported deletion matches the number of imported resources and files, and not the whole channel.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
