### PR TITLE
Fix bug that causes all topic thumbnails to be imported for a channel.

### DIFF
--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -2,6 +2,7 @@ import hashlib
 from math import ceil
 
 from django.db.models import Max
+from django.db.models import Min
 from django.db.models import Q
 from le_utils.constants import content_kinds
 from requests.exceptions import ChunkedEncodingError
@@ -184,11 +185,20 @@ def get_import_export_data(  # noqa: C901
 
             if topic_thumbnails:
                 # Do a query to get all the descendant and ancestor topics for this segment
+                segment_boundaries = nodes_segment.aggregate(
+                    min_boundary=Min("lft"), max_boundary=Max("rght")
+                )
                 segment_topics = ContentNode.objects.filter(
                     channel_id=channel_id, kind=content_kinds.TOPIC
                 ).filter(
-                    Q(rght__gte=min_boundary, rght__lte=max_boundary)
-                    | Q(lft__lte=max_boundary, rght__gte=min_boundary)
+                    Q(
+                        lft__lte=segment_boundaries["min_boundary"],
+                        rght__gte=segment_boundaries["max_boundary"],
+                    )
+                    | Q(
+                        lft__lte=segment_boundaries["max_boundary"],
+                        rght__gte=segment_boundaries["min_boundary"],
+                    )
                 )
 
                 file_objects = LocalFile.objects.filter(


### PR DESCRIPTION
## Summary
* Fixes a previously unreported bug whereby all thumbnails for a channel would be imported regardless of how many resources were imported for the channel
* Adds a regression test to prevent 'uncle' nodes having their thumbnails imported

## Reviewer guidance
* Run kolibri in debug mode `KOLIBRI_DEBUG=True kolibri start --foreground`
* Import a single node in a fairly large channel - confirm that the import is relatively fast and that only a few png files are imported as thumbnails (this will be logged in the terminal)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
