### PR TITLE
Fixes incorrect run method for full Kolibri Process Bus.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -720,6 +720,10 @@ class KolibriProcessBus(KolibriServicesProcessBus):
         kolibri_server.subscribe()
         alt_port_server.subscribe()
 
+    def run(self):
+        self.graceful()
+        self.block()
+
 
 def start(port=0, zip_port=0, serve_http=True, background=False):
     """


### PR DESCRIPTION
## Summary
Fixes regression from #9291
Accidentally inherited the run method from the services bus, which includes an additional publish of the SERVING event - which will instead happen from the Server plugin.

## Reviewer guidance
When the main port was set to 0, this might have caused issues.
Compare with previous code: https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/utils/server.py#L701 where the publish was only done when HTTP is not being served.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
