### PR TITLE
Setup wizard with new tasks permissions

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
@@ -153,7 +153,6 @@
                 });
             }
           }
-          if (tasks.length == 0) this.isPolling = false;
         });
         if (this.isPolling) {
           setTimeout(() => {


### PR DESCRIPTION
## Summary
After the latest tasks api changes, the permissions restrictions made the setup wizard failed due to several race conditions that only happen in this special plugin.
The main problems came by a two factors combination:

- When provisioning a device, the setup wizard only can do anonymous requests as no users exists, but permissions can depend on being a not provisioned device.
- When the syncing task finishes, the device is marked as provisioned, but the requests are still anonymous so the frontend does not receive the COMPLETE job message.

This PR adds a new permission that allows listing the syncing requests for any user. Creating a new job is still restricted but being able to see the list of syncing jobs in execution is considered a harmless situation.
It also removes an unneeded frontend condition that now was interrupting the task polling due to the new way the viewset works.

## References
Closes: #9298 

## Reviewer guidance
- Does code looks good
- Can you think of any possible security issue with the new permission?
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
