### PR TITLE
Add API endpoint for UI initiated device restart

### DIFF
--- a/kolibri/core/assets/src/core-app/baseClient.js
+++ b/kolibri/core/assets/src/core-app/baseClient.js
@@ -19,6 +19,9 @@ export default function clientFactory(options) {
   client.interceptors.response.use(
     response => response,
     function(error) {
+      if (!error) {
+        error = {};
+      }
       if (!error.response) {
         error.response = {
           status: 0,

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -1,7 +1,5 @@
-import time
 from datetime import timedelta
 from sys import version_info
-from threading import Thread
 
 from django.conf import settings
 from django.db.models import Max
@@ -343,15 +341,6 @@ class PluginsViewSet(viewsets.ViewSet):
         return Response(self._serialize(plugin))
 
 
-def delayed_restart(delay):
-    """
-    Restart the server after a delay.
-    Do this to allow the request to complete before restarting.
-    """
-    time.sleep(delay)
-    restart()
-
-
 class DeviceRestartView(views.APIView):
 
     permission_classes = (IsSuperuser,)
@@ -363,6 +352,7 @@ class DeviceRestartView(views.APIView):
     def post(self, request):
         status = get_status_from_pid_file()
         if status == STATUS_RUNNING:
-            thread = Thread(target=delayed_restart, args=(0.5,))
-            thread.start()
-        return Response(status)
+            restarted = restart()
+        if restarted:
+            return Response(status)
+        return HttpResponseBadRequest(status)

--- a/kolibri/core/device/api_urls.py
+++ b/kolibri/core/device/api_urls.py
@@ -6,6 +6,7 @@ from .api import DeviceInfoView
 from .api import DeviceNameView
 from .api import DevicePermissionsViewSet
 from .api import DeviceProvisionView
+from .api import DeviceRestartView
 from .api import DeviceSettingsView
 from .api import FreeSpaceView
 from .api import UserSyncStatusViewSet
@@ -28,4 +29,5 @@ urlpatterns = [
     url(r"^deviceinfo/", DeviceInfoView.as_view(), name="deviceinfo"),
     url(r"^devicesettings/", DeviceSettingsView.as_view(), name="devicesettings"),
     url(r"^devicename/", DeviceNameView.as_view(), name="devicename"),
+    url(r"^devicerestart/", DeviceRestartView.as_view(), name="devicerestart"),
 ]

--- a/kolibri/plugins/device/assets/src/composables/useDeviceRestart.js
+++ b/kolibri/plugins/device/assets/src/composables/useDeviceRestart.js
@@ -1,0 +1,57 @@
+/**
+ * A composable function containing logic related to restarting the device
+ */
+
+import { ref } from 'kolibri.lib.vueCompositionApi';
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
+
+// The refs are defined in the outer scope so they can be used as a shared store
+const restarting = ref(false);
+
+// POST to /api/device/devicerestart
+export function restartDevice() {
+  return client({
+    url: urls['kolibri:core:devicerestart'](),
+    method: 'POST',
+  }).then(resp => Boolean(resp.data));
+}
+
+export function isDeviceRestarting() {
+  return client({
+    url: urls['kolibri:core:devicerestart'](),
+  })
+    .then(resp => Boolean(resp.data))
+    .catch(() => true);
+}
+
+function restart() {
+  restarting.value = true;
+  let statusPromise = restartDevice();
+  const checkStatus = expectedStatus => {
+    return statusPromise.then(status => {
+      if (status !== expectedStatus) {
+        statusPromise = new Promise(resolve => {
+          setTimeout(() => {
+            isDeviceRestarting().then(resolve);
+          }, 500);
+        });
+        return checkStatus(expectedStatus);
+      }
+    });
+  };
+  // First wait for the device to be restarting
+  checkStatus(true).then(() => {
+    // Then wait for it to have finished restarting
+    checkStatus(false).then(() => {
+      restarting.value = false;
+    });
+  });
+}
+
+export default function useDeviceRestart() {
+  return {
+    restarting,
+    restart,
+  };
+}

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -28,6 +28,7 @@ class DeviceManagementAsset(WebpackBundleHook):
                 "subset_of_users_device", False
             ),
             "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"],
+            "canRestart": bool(OPTIONS["Deployment"]["RESTART_HOOKS"]),
         }
 
 

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -354,7 +354,7 @@ def restart():
     """
     Restarts the server if it is running
     """
-    if server.restart():
+    if server.restart_and_wait():
         logger.info("Kolibri has successfully restarted")
         sys.exit(0)
     logger.info("Kolibri has failed to restart - confirm that the server is running")

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -694,7 +694,7 @@ def _set_from_envvars(conf):
     for section, opts in option_spec.items():
         for optname, attrs in opts.items():
             for envvar in attrs.get("envvars", []):
-                if os.environ.get(envvar):
+                if envvar in os.environ:
                     deprecated_envvars = attrs.get("deprecated_envvars", ())
                     if envvar in deprecated_envvars:
                         logger.warn(

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -112,6 +112,27 @@ def _process_language_string(value):
     raise ValueError
 
 
+def _process_list(value, separator=","):
+    """
+    Used to validate list values.
+    The only valid argument in this case is that it is a list
+    so we first try to coerce it to a list, then do some checks
+    to see if it is any of our special values. Then if it is an
+    appropriate list value.
+    If no value is appropriate, raise a ValueError.
+    """
+
+    # Check the supplied value is a list
+    if not isinstance(value, list):
+        if not value:
+            value = []
+        elif isinstance(value, string_types):
+            value = value.split(separator)
+        else:
+            value = [value]
+    return value
+
+
 def language_list(value):
     """
     Check that the supplied value is a list of languages,
@@ -127,9 +148,7 @@ def language_list(value):
     or one of the special strings represented by ALL_LANGUAGES or SUPPORTED_LANGUAGES
     A list must be a list of these strings.
     """
-    # Check the supplied value is a list
-    if not isinstance(value, list):
-        value = [value]
+    value = _process_list(value)
 
     out = set()
     errors = []

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -792,6 +792,14 @@ def _read_pid_file(filename):
     return None, None, None, STATUS_PID_FILE_INVALID
 
 
+def get_status_from_pid_file():
+    """
+    Returns the status of the server process from the PID file.
+    """
+    _, _, _, status = _read_pid_file(PID_FILE)
+    return status
+
+
 def get_zip_port():
     _, _, zip_port, _ = _read_pid_file(PID_FILE)
     return zip_port

--- a/kolibri/utils/tests/do_not_import.py
+++ b/kolibri/utils/tests/do_not_import.py
@@ -1,0 +1,2 @@
+def dummy_function():
+    raise RuntimeError

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -71,8 +71,7 @@ def test_option_reading_and_precedence_rules():
 
     # when env vars are empty, values are drawn from ini file
     with mock.patch.dict(
-        os.environ,
-        {"KOLIBRI_CONTENT_DIR": "", "KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": ""},
+        os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
     ):
         OPTIONS = options.read_options_file(ini_filename=tmp_ini_path)
         assert OPTIONS["Paths"]["CONTENT_DIR"] == _CONTENT_DIR
@@ -81,7 +80,11 @@ def test_option_reading_and_precedence_rules():
     # when an env var is set, use those instead of ini file values
     with mock.patch.dict(
         os.environ,
-        {"KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": str(_HTTP_PORT_ENV)},
+        {
+            "KOLIBRI_LISTEN_PORT": str(_HTTP_PORT_ENV),
+            "KOLIBRI_HOME": os.environ["KOLIBRI_HOME"],
+        },
+        clear=True,
     ):
         OPTIONS = options.read_options_file(ini_filename=tmp_ini_path)
         assert OPTIONS["Deployment"]["HTTP_PORT"] == _HTTP_PORT_ENV
@@ -128,7 +131,7 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Deployment]", "HTTP_PORT = abba"]))
         with mock.patch.dict(
-            os.environ, {"KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": ""}
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
         ):
             with pytest.raises(SystemExit):
                 options.read_options_file(ini_filename=tmp_ini_path)
@@ -138,7 +141,9 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Deployment]", "HTTP_PORT = 1278"]))
         with mock.patch.dict(
-            os.environ, {"KOLIBRI_HTTP_PORT": "baba", "KOLIBRI_LISTEN_PORT": ""}
+            os.environ,
+            {"KOLIBRI_HTTP_PORT": "baba", "KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]},
+            clear=True,
         ):
             with pytest.raises(SystemExit):
                 options.read_options_file(ini_filename=tmp_ini_path)
@@ -147,7 +152,9 @@ def test_improper_settings_display_errors_and_exit(monkeypatch):
         # invalid choice for "option" type causes it to bail
         with open(tmp_ini_path, "w") as f:
             f.write("\n".join(["[Database]", "DATABASE_ENGINE = penguin"]))
-        with mock.patch.dict(os.environ, {"KOLIBRI_DATABASE_ENGINE": ""}):
+        with mock.patch.dict(
+            os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
+        ):
             with pytest.raises(SystemExit):
                 options.read_options_file(ini_filename=tmp_ini_path)
             assert 'value "penguin" is unacceptable' in LOG_LOGGER[-2][1]
@@ -180,7 +187,14 @@ def test_deprecated_values_envvars(monkeypatch):
         # deprecated options in the envvars log warnings
         with open(tmp_ini_path, "w") as f:
             f.write("\n")
-        with mock.patch.dict(os.environ, {"KOLIBRI_CHERRYPY_START": "false"}):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "KOLIBRI_CHERRYPY_START": "false",
+                "KOLIBRI_HOME": os.environ["KOLIBRI_HOME"],
+            },
+            clear=True,
+        ):
             options.read_options_file(ini_filename=tmp_ini_path)
             assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
 
@@ -197,7 +211,9 @@ def test_deprecated_envvars(monkeypatch):
         with open(tmp_ini_path, "w") as f:
             f.write("\n")
         with mock.patch.dict(
-            os.environ, {"KOLIBRI_LISTEN_PORT": "1234", "KOLIBRI_HTTP_PORT": ""}
+            os.environ,
+            {"KOLIBRI_LISTEN_PORT": "1234", "KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]},
+            clear=True,
         ):
             options.read_options_file(ini_filename=tmp_ini_path)
             assert any("deprecated" in msg[1] for msg in LOG_LOGGER)
@@ -261,7 +277,7 @@ def test_option_writing():
         )
 
     with mock.patch.dict(
-        os.environ, {"KOLIBRI_HTTP_PORT": "", "KOLIBRI_LISTEN_PORT": ""}
+        os.environ, {"KOLIBRI_HOME": os.environ["KOLIBRI_HOME"]}, clear=True
     ):
 
         # check that values are set correctly to begin with

--- a/kolibri/utils/tests/test_options.py
+++ b/kolibri/utils/tests/test_options.py
@@ -338,3 +338,23 @@ def test_path_expansion():
         with mock.patch.dict(os.environ, {"KOLIBRI_CONTENT_DIR": user_path}):
             OPTIONS = options.read_options_file(ini_filename=tmp_ini_path)
             assert OPTIONS["Paths"]["CONTENT_DIR"] == os.path.expanduser(user_path)
+
+
+def test_lazy_function_import():
+    """
+    Checks that a lazily loaded function is not imported until called
+    """
+
+    dummy_function = options.LazyImportFunction(
+        "kolibri.utils.tests.do_not_import.dummy_function"
+    )
+
+    assert "kolibri.utils.tests.do_not_import" not in sys.modules
+
+    try:
+        dummy_function()
+        assert False, "Correct function was not imported"
+    except RuntimeError:
+        pass
+
+    assert "kolibri.utils.tests.do_not_import" in sys.modules


### PR DESCRIPTION
## Summary
* Adds an API endpoint to call the 'restart' function from `server.py`
* Modifies the `restart` function to only emit the signal, and adds a `restart_and_wait` function that is used by the CLI command
* Adds a frontend composable to handle the restart process, exposing a `restart` method and a `restarting` Boolean state
* Caveat: This will not work for kolibri-server or BCK. We need to define some way of disabling this behaviour or making it work for uwsgi (there is a uwsgi.restart() method that we could use).
* Adds a `RESTART_HOOKS` option to allow completely disabling restart behaviour, or adding additional restart behaviour for, say, uwsgi deployment scenarios.

## References
Fixes #9293

## Reviewer guidance
To test this I added this diff to `kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue`
```
@@ -3,10 +3,13 @@
   <div>
     <section>
       <h1>
         {{ $tr('pageHeader') }}
       </h1>
+      <KButton :disabled="restarting" @click="restart">
+        RESTART
+      </KButton>
       <p>
         {{ $tr('pageDescription') }}
         <KExternalLink
           v-if="!isMultiFacilitySuperuser && getFacilitySettingsPath()"
           :text="$tr('facilitySettings')"
@@ -127,10 +130,11 @@
   import urls from 'kolibri.urls';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import { LandingPageChoices } from '../../constants';
+  import useDeviceRestart from '../../composables/useDeviceRestart';
   import { getDeviceSettings, saveDeviceSettings } from './api';
 
   const SignInPageOptions = Object.freeze({
     LOCKED_CONTENT: 'LOCKED_CONTENT',
     DISALLOW_GUEST_ACCESS: 'DISALLOW_GUEST_ACCESS',
@@ -143,10 +147,17 @@
       return {
         title: this.$tr('pageHeader'),
       };
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { restarting, restart } = useDeviceRestart();
+      return {
+        restarting,
+        restart,
+      };
+    },
     data() {
       return {
         language: {},
         landingPage: '',
         allowPeerUnlistedChannelImport: null,
```

This produced this result:

https://user-images.githubusercontent.com/1680573/164297491-e36801df-f435-4bb3-8d18-bfdeb8d25582.mp4

----


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
