### PR TITLE
Add REST API for enabling and disabling plugins

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -307,7 +307,8 @@ class PluginsViewSet(viewsets.ViewSet):
     def list(self, request):
         plugins = []
         for plugin in iterate_plugins():
-            plugins.append(self._serialize(plugin))
+            if plugin.can_manage_while_running:
+                plugins.append(self._serialize(plugin))
 
         return Response(plugins)
 
@@ -315,7 +316,10 @@ class PluginsViewSet(viewsets.ViewSet):
         if not pk:
             raise Http404
         try:
-            return self._get_plugin(pk.replace("*", "."))
+            plugin = self._get_plugin(pk.replace("*", "."))
+            if not plugin.can_manage_while_running:
+                raise Http404
+            return plugin
         except PluginDoesNotExist:
             raise Http404
 

--- a/kolibri/core/urls.py
+++ b/kolibri/core/urls.py
@@ -36,6 +36,7 @@ from __future__ import unicode_literals
 
 from django.conf.urls import include
 from django.conf.urls import url
+from rest_framework import routers
 
 from .views import GuestRedirectView
 from .views import logout_view
@@ -43,10 +44,15 @@ from .views import RootURLRedirectView
 from .views import set_language
 from .views import StatusCheckView
 from .views import UnsupportedBrowserView
+from kolibri.core.device.api import PluginsViewSet
 from kolibri.core.device.translation import i18n_patterns
 from kolibri.plugins.utils.urls import get_urls as plugin_urls
 
 app_name = "kolibri"
+
+router = routers.SimpleRouter()
+
+router.register(r"plugins", PluginsViewSet, base_name="plugins")
 
 # Patterns that we want to prefix because they need access to the current language
 lang_prefixed_patterns = [
@@ -56,6 +62,7 @@ lang_prefixed_patterns = [
     url(r"^guestaccess/$", GuestRedirectView.as_view(), name="guest"),
     url(r"^unsupported/$", UnsupportedBrowserView.as_view(), name="unsupported"),
     url(r"^$", RootURLRedirectView.as_view(), name="root_redirect"),
+    url(r"^", include(router.urls)),
 ]
 
 core_urlpatterns = [

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -201,6 +201,14 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
     # }
     kolibri_option_defaults = None
 
+    #: Comment
+    # Property that indicates whether it is safe to allow this plugin to be disabled via the GUI
+    # This is used to prevent plugins that are required by the system from being disabled except
+    # through the command line. This property is purely advisory, and does not affect the
+    # functionality of the plugin, or the ability to disable it via the command line or other
+    # configuration mechanisms.
+    can_manage_while_running = False
+
     def __init__(self):
         self.INSTALLED_APPS = []
 

--- a/kolibri/plugins/__init__.py
+++ b/kolibri/plugins/__init__.py
@@ -201,15 +201,6 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
     # }
     kolibri_option_defaults = None
 
-    # : Suggested property, not yet in use
-    migrate_on_enable = False
-
-    # : Suggested property, not yet in use
-    collect_static_on_enable = False
-
-    # : Suggested property, not yet in use
-    collect_static_on_enable = False
-
     def __init__(self):
         self.INSTALLED_APPS = []
 
@@ -220,6 +211,13 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
     @property
     def module_path(self):
         return self.class_module_path()
+
+    def name(self, lang):
+        """
+        A function to return a name for the plugin.
+        Accepts a lang argument to allow for internationalization of the name.
+        """
+        return self.__class__.__name__
 
     def _installed_apps_add(self):
         """Call this from your enable() method to have the plugin automatically
@@ -234,6 +232,10 @@ class KolibriPluginBase(with_metaclass(SingletonMeta)):
     def enable(self):
         """Modify the kolibri config dict to your plugin's needs"""
         self._installed_apps_add()
+
+    @property
+    def enabled(self):
+        return self.module_path in config.ACTIVE_PLUGINS
 
     def disable(self):
         """Modify the kolibri config dict to your plugin's needs"""

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -13,6 +13,7 @@ from kolibri.plugins.hooks import register_hook
 
 class Coach(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
+    can_manage_while_running = True
 
     @property
     def translated_view_urls(self):

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
 from kolibri.core.auth.constants.user_kinds import COACH
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
@@ -22,6 +25,10 @@ class Coach(KolibriPluginBase):
         if not get_device_setting("subset_of_users_device", False):
             return "urls"
         return None
+
+    def name(self, lang):
+        with translation.override(lang):
+            return _("Coach")
 
 
 @register_hook

--- a/kolibri/plugins/device/assets/src/composables/usePlugins.js
+++ b/kolibri/plugins/device/assets/src/composables/usePlugins.js
@@ -1,0 +1,49 @@
+/**
+ * A composable function containing logic related to channels
+ */
+
+import { ref } from 'kolibri.lib.vueCompositionApi';
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
+
+export default function usePlugins() {
+  const plugins = ref(null);
+  function fetchPlugins() {
+    return client({
+      url: urls['kolibri:core:plugins-list'](),
+    }).then(response => {
+      plugins.value = response.data;
+    });
+  }
+  fetchPlugins();
+  function togglePlugin(pluginId, value) {
+    const pluginIndex = plugins.value.findIndex(plugin => plugin.id === pluginId);
+    if (pluginIndex !== -1) {
+      const plugin = plugins.value[pluginIndex];
+      if (plugin.enabled !== value) {
+        return client({
+          method: 'PATCH',
+          url: urls['kolibri:core:plugins-detail'](pluginId),
+          data: {
+            enabled: value,
+          },
+        }).then(response => {
+          plugins.value.splice(pluginIndex, 1, response.data);
+        });
+      }
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error(`Plugin ${pluginId} not found`));
+  }
+  function enablePlugin(pluginId) {
+    return togglePlugin(pluginId, true);
+  }
+  function disablePlugin(pluginId) {
+    return togglePlugin(pluginId, false);
+  }
+  return {
+    plugins,
+    enablePlugin,
+    disablePlugin,
+  };
+}

--- a/kolibri/plugins/facility/kolibri_plugin.py
+++ b/kolibri/plugins/facility/kolibri_plugin.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
 from kolibri.core.auth.constants.user_kinds import ADMIN
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
@@ -22,6 +25,10 @@ class FacilityManagementPlugin(KolibriPluginBase):
         if not get_device_setting("subset_of_users_device", False):
             return "urls"
         return None
+
+    def name(self, lang):
+        with translation.override(lang):
+            return _("Facility")
 
 
 @register_hook

--- a/kolibri/plugins/facility/kolibri_plugin.py
+++ b/kolibri/plugins/facility/kolibri_plugin.py
@@ -13,6 +13,7 @@ from kolibri.plugins.hooks import register_hook
 
 class FacilityManagementPlugin(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
+    can_manage_while_running = True
 
     @property
     def translated_view_urls(self):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -23,6 +23,7 @@ class Learn(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
     translated_view_urls = "urls"
     kolibri_options = "options"
+    can_manage_while_running = True
 
 
 @register_hook

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.urls import reverse
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
 
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.auth.constants.user_kinds import LEARNER
@@ -24,6 +26,10 @@ class Learn(KolibriPluginBase):
     translated_view_urls = "urls"
     kolibri_options = "options"
     can_manage_while_running = True
+
+    def name(self, lang):
+        with translation.override(lang):
+            return _("Learn")
 
 
 @register_hook

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
 from kolibri.core.device.hooks import SetupHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
@@ -16,6 +19,10 @@ class SetupWizardPlugin(KolibriPluginBase):
     @property
     def url_slug(self):
         return "setup"
+
+    def name(self, lang):
+        with translation.override(lang):
+            return _("Setup Wizard")
 
 
 @register_hook

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -11,6 +11,7 @@ from kolibri.plugins.hooks import register_hook
 class SetupWizardPlugin(KolibriPluginBase):
     untranslated_view_urls = "api_urls"
     translated_view_urls = "urls"
+    can_manage_while_running = True
 
     @property
     def url_slug(self):

--- a/kolibri/plugins/user_profile/kolibri_plugin.py
+++ b/kolibri/plugins/user_profile/kolibri_plugin.py
@@ -11,6 +11,7 @@ from kolibri.plugins.hooks import register_hook
 
 class UserProfile(KolibriPluginBase):
     translated_view_urls = "urls"
+    can_manage_while_running = True
 
     @property
     def url_slug(self):

--- a/kolibri/plugins/user_profile/kolibri_plugin.py
+++ b/kolibri/plugins/user_profile/kolibri_plugin.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
@@ -16,6 +19,10 @@ class UserProfile(KolibriPluginBase):
     @property
     def url_slug(self):
         return "profile"
+
+    def name(self, lang):
+        with translation.override(lang):
+            return _("User Profile")
 
 
 @register_hook

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -461,19 +461,15 @@ def check_plugin_config_file_location(version):
                 os.remove(old_conf_file)
 
 
-def _can_import_plugin(plugin):
-    try:
-        initialize_kolibri_plugin(plugin)
-        return True
-    except Exception:
-        pass
-
-
 def iterate_plugins():
     # Use to dedupe plugins
-    plugins = set()
+    plugin_ids = set()
     for entry_point in iter_entry_points("kolibri.plugins"):
         name = entry_point.module_name
-        if _can_import_plugin(name) and name not in plugins:
-            plugins.add(name)
-            yield name
+        if name not in plugin_ids:
+            plugin_ids.add(name)
+            try:
+                plugin = initialize_kolibri_plugin(name)
+                yield plugin
+            except Exception:
+                pass

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -449,17 +449,26 @@ def apply(ctx, plugin_names):
 @plugin.command(help="List all available Kolibri plugins")
 def list():
     plugins = [plugin for plugin in iterate_plugins()]
-    max_len = max((len(plugin) for plugin in plugins))
+    lang = "en"
+    max_name_len = max((len(plugin.name(lang)) for plugin in plugins))
+    max_module_path_len = max((len(plugin.module_path) for plugin in plugins))
     available_plugins = "Available plugins"
+    plugin_id = "Plugin identifier"
     status = "Status"
     click.echo(
-        available_plugins + " " * (max_len - len(available_plugins) + 4) + status
+        available_plugins
+        + " " * (max_name_len - len(available_plugins) + 4)
+        + plugin_id
+        + " " * (max_module_path_len - len(plugin_id) + 4)
+        + status
     )
-    for plugin in sorted(plugins):
+    for plugin in sorted(plugins, key=lambda x: x.module_path):
         click.echo(
-            plugin
-            + " " * (max_len - len(plugin) + 4)
-            + ("ENABLED" if plugin in config.ACTIVE_PLUGINS else "DISABLED")
+            plugin.name(lang)
+            + " " * (max_name_len - len(plugin.name(lang)) + 4)
+            + plugin.module_path
+            + " " * (max_module_path_len - len(plugin.module_path) + 4)
+            + ("ENABLED" if plugin.enabled else "DISABLED")
         )
 
 


### PR DESCRIPTION
## Summary
* Cleans up cruft and adds capability to the plugin object
* Adds name method to allow internationalization of plugin names
* Uses this in the CLI
* Adds language prefixed REST API endpoint for plugins
* Adds composable for managing plugin state

## References
Fixes #9290 

## Reviewer guidance
I tested this by adding this diff to `kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue`:
```
@@ -14,10 +14,19 @@
         />
       </p>
     </section>
 
     <section>
+      <ul v-if="plugins">
+        <li v-for="plugin in plugins" :key="plugin.id">
+          <span>{{ plugin.name }}</span>
+          <KButton
+            :text="plugin.enabled ? 'Disable' : 'Enable'"
+            @click="plugin.enabled ? disablePlugin(plugin.id) : enablePlugin(plugin.id)"
+          />
+        </li>
+      </ul>
       <div class="fieldset">
         <KSelect
           v-model="language"
           :label="$tr('selectedLanguageLabel')"
           :options="languageOptions"
@@ -127,10 +136,11 @@
   import urls from 'kolibri.urls';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import { LandingPageChoices } from '../../constants';
+  import usePlugins from '../../composables/usePlugins';
   import { getDeviceSettings, saveDeviceSettings } from './api';
 
   const SignInPageOptions = Object.freeze({
     LOCKED_CONTENT: 'LOCKED_CONTENT',
     DISALLOW_GUEST_ACCESS: 'DISALLOW_GUEST_ACCESS',
@@ -143,10 +153,18 @@
       return {
         title: this.$tr('pageHeader'),
       };
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { plugins, enablePlugin, disablePlugin } = usePlugins();
+      return {
+        plugins,
+        enablePlugin,
+        disablePlugin,
+      };
+    },
     data() {
       return {
         language: {},
         landingPage: '',
         allowPeerUnlistedChannelImport: null,
```


https://user-images.githubusercontent.com/1680573/164490139-cbaca380-ea2e-401a-8bdb-37e626bc12c1.mp4



----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
