### PR TITLE
Conditionalize database preseeding

### DIFF
--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -213,11 +213,14 @@ def _upgrades_before_django_setup(updated, version):
         # that we bundle in the Kolibri whl file.
         if not version:
             logger.info("Attempting to setup using pre-migrated databases")
+            # Only copy the default database if this is a fresh install
+            _copy_preseeded_db("db", target=OPTIONS["Database"]["DATABASE_NAME"])
 
-        _copy_preseeded_db("db", target=OPTIONS["Database"]["DATABASE_NAME"])
-
-        for db_name in ADDITIONAL_SQLITE_DATABASES:
-            _copy_preseeded_db(db_name)
+        if not version or updated:
+            # If this is an upgrade, it is possible we've added an additional
+            # database, so we can attempt to copy a preseeded database here.
+            for db_name in ADDITIONAL_SQLITE_DATABASES:
+                _copy_preseeded_db(db_name)
 
 
 def _post_django_initialization():


### PR DESCRIPTION
## Summary
* Ensures that attempts to preseed only happen on a fresh install for the default database
* Ensures that attempts to preseed only happen on a fresh install or upgrade for other databases

## Reviewer guidance
Do a fresh setup, ensure that no migrations happen, because pre-seeded databases are used.

Upgrade from 0.14 - ensure that an entire migration run doesn't occur for the added databases in 0.15.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
