### PR TITLE
Bundle Python 39 C extensions instead of 36 for Windows

### DIFF
--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -185,7 +185,7 @@ def parse_package_page(files, pk_version, index_url, cache_path):
             continue
         if "macosx" in platform:
             continue
-        if "win_amd64" in platform and python_version != "36":
+        if "win_amd64" in platform and python_version != "39":
             continue
 
         # Cryptography builds for Linux target Python 3.4+ but the only existing


### PR DESCRIPTION
## Summary
* We updated the Python version for the windows installer
* This updates the Python version that we bundle c extensions for in Windows

## Reviewer guidance
Does Windows installer still work? Does initial setup feel a bit faster than on previous develop builds?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
