### PR TITLE
Public signup viewset

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -60,7 +60,6 @@ from .serializers import FacilityUserSerializer
 from .serializers import LearnerGroupSerializer
 from .serializers import MembershipSerializer
 from .serializers import PublicFacilitySerializer
-from .serializers import PublicFacilityUserSerializer
 from .serializers import RoleSerializer
 from kolibri.core import error_constants
 from kolibri.core.api import ReadOnlyValuesViewset
@@ -247,7 +246,6 @@ class FacilityUserFilter(FilterSet):
 
 class PublicFacilityUserViewSet(ReadOnlyValuesViewset):
     queryset = FacilityUser.objects.all()
-    serializer_class = PublicFacilityUserSerializer
     authentication_classes = [BasicMultiArgumentAuthentication]
     permission_classes = [IsAuthenticated]
     values = (

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -26,6 +26,12 @@ class RoleSerializer(serializers.ModelSerializer):
 
 class FacilityUserSerializer(serializers.ModelSerializer):
     roles = RoleSerializer(many=True, read_only=True)
+    facility = serializers.PrimaryKeyRelatedField(
+        queryset=Facility.objects.all(),
+        default=Facility.get_default_facility,
+        required=False,
+        error_messages={"does_not_exist": "Facility does not exist."},
+    )
 
     class Meta:
         model = FacilityUser
@@ -44,10 +50,28 @@ class FacilityUserSerializer(serializers.ModelSerializer):
         )
         read_only_fields = ("is_superuser",)
 
+    def save(self, **kwargs):
+        instance = super(FacilityUserSerializer, self).save(**kwargs)
+        validated_data = dict(list(self.validated_data.items()) + list(kwargs.items()))
+        password = validated_data.get("password")
+        if password and password != "NOT_SPECIFIED":
+            instance.set_password(password)
+            instance.save()
+        return instance
+
     def validate(self, attrs):
         username = attrs.get("username")
         # first condition is for creating object, second is for updating
         facility = attrs.get("facility") or getattr(self.instance, "facility")
+        if (
+            "password" in attrs
+            and attrs["password"] == "NOT_SPECIFIED"
+            and not facility.dataset.learner_can_login_with_no_password
+        ):
+            raise serializers.ValidationError(
+                "No password specified and it is required",
+                code=error_constants.PASSWORD_NOT_SPECIFIED,
+            )
         # if obj doesn't exist, return data
         try:
             obj = FacilityUser.objects.get(username__iexact=username, facility=facility)

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -142,19 +142,6 @@ class PublicFacilitySerializer(serializers.ModelSerializer):
         fields = ("id", "dataset", "name", "learner_can_login_with_no_password")
 
 
-class PublicFacilityUserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = FacilityUser
-        fields = (
-            "id",
-            "username",
-            "full_name",
-            "facility",
-            "roles",
-            "is_superuser",
-        )
-
-
 class ClassroomSerializer(serializers.ModelSerializer):
     class Meta:
         model = Classroom

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import base64
 import collections
 import sys
+import uuid
 from importlib import import_module
 
 import factory
@@ -963,6 +964,17 @@ class AnonSignUpTestCase(APITestCase):
             models.FacilityUser.objects.get(id=user_id).facility.id, other_facility.id
         )
         self.assertTrue(other_facility.get_members().filter(id=user_id).exists())
+
+    def test_create_user_for_nonexistent_facility(self):
+        response = self.post_to_sign_up(
+            {
+                "username": "bob",
+                "password": DUMMY_PASSWORD,
+                "facility": uuid.uuid4().hex,
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(models.FacilityUser.objects.all())
 
     def test_create_bad_username_fails(self):
         response = self.post_to_sign_up(

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -21,6 +21,7 @@ from rest_framework import routers
 
 from ..auth.api import PublicFacilityUserViewSet
 from ..auth.api import PublicFacilityViewSet
+from ..auth.api import PublicSignUpViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
@@ -31,6 +32,7 @@ router = routers.SimpleRouter()
 
 router.register(r"v1/facility", PublicFacilityViewSet, base_name="publicfacility")
 router.register(r"facilityuser", PublicFacilityUserViewSet, base_name="publicuser")
+router.register(r"signup", PublicSignUpViewSet, base_name="publicsignup")
 router.register(r"info", InfoViewSet, base_name="info")
 router.register(r"syncqueue", SyncQueueViewSet, base_name="syncqueue")
 


### PR DESCRIPTION
## Summary
* Cleans up existing facility user serializer to consolidate logic
* Removes unused public facility user serializer on read only viewset
* Adds public sign up viewset
* Exposes on the public APIs
* Adds capability for keeping old serializers around to handle historic data formats for future back compatibility

## References
Fixes #9356

## Reviewer guidance
Anything I missed? Does it make sense to even bother with the legacy serializers at this stage?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
