### PR TITLE
Avoid repeated and unnecessary foreignkey lookups during validation

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -238,7 +238,8 @@ class AbstractFacilityDataModel(FacilityDataSyncableModel):
 
     def clean_fields(self, *args, **kwargs):
         # ensure that we have, or can infer, a dataset for the model instance
-        self.ensure_dataset(validating=True)
+        if not self.dataset_id:
+            self.ensure_dataset(validating=True)
         super(AbstractFacilityDataModel, self).clean_fields(*args, **kwargs)
 
     def full_clean(self, *args, **kwargs):

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -7,7 +7,7 @@ from .base import *  # noqa isort:skip @UnusedWildImport
 DEBUG = True
 
 # Settings might be tuples, so switch to lists
-INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg"]  # noqa F405
+INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg", "django_extensions"]  # noqa F405
 webpack_middleware = "kolibri.core.webpack.middleware.WebpackErrorHandler"
 no_login_popup_middleware = (
     "kolibri.core.auth.middleware.XhrPreventLoginPromptMiddleware"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,3 +12,4 @@ fonttools==3.29.0
 nodeenv==1.3.3
 click==7.0
 sqlacodegen==2.1.0
+django-extensions==3.1.5


### PR DESCRIPTION
Supersedes https://github.com/learningequality/kolibri/pull/9365 by @jamalex 

## Summary

We were seeing very inefficient deserialization during syncing, as a result of repeated database queries to the referents of foreignkeys for each of the models being deserialized, as described [here](https://github.com/learningequality/morango/issues/111). @bjester made [fixes in Morango](https://github.com/learningequality/morango/pull/159) to address this, but there still seemed to be repeated queries being made when performing deserialization in Kolibri. This turned out to be due to calls to `ensure_dataset`, which in turn involved lookups to related models in order to infer the dataset for the record being validated. However, the only reason we were calling `ensure_dataset` was to make sure there _was_ a dataset_id on the record, before saving. If there already is (which there always will be, for incoming synced records), we can just skip that expensive call and carry on merrily.

## References

Helps to fix https://github.com/learningequality/morango/issues/111

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
