### PR TITLE
Allow internationalization of text before Django initialization.

### DIFF
--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
-
 from kolibri.core.auth.constants.user_kinds import COACH
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
@@ -12,6 +9,8 @@ from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 
 class Coach(KolibriPluginBase):

--- a/kolibri/plugins/facility/kolibri_plugin.py
+++ b/kolibri/plugins/facility/kolibri_plugin.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
-
 from kolibri.core.auth.constants.user_kinds import ADMIN
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
@@ -12,6 +9,8 @@ from kolibri.core.hooks import RoleBasedRedirectHook
 from kolibri.core.webpack.hooks import WebpackBundleHook
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 
 class FacilityManagementPlugin(KolibriPluginBase):

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.urls import reverse
-from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
 
 from kolibri.core.auth.constants.user_kinds import ANONYMOUS
 from kolibri.core.auth.constants.user_kinds import LEARNER
@@ -19,6 +17,8 @@ from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
 from kolibri.utils import conf
+from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 
 class Learn(KolibriPluginBase):

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -2,13 +2,12 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
-
 from kolibri.core.device.hooks import SetupHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 
 class SetupWizardPlugin(KolibriPluginBase):

--- a/kolibri/plugins/user_profile/kolibri_plugin.py
+++ b/kolibri/plugins/user_profile/kolibri_plugin.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from django.utils import translation
-from django.utils.translation import ugettext_lazy as _
-
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
 from kolibri.plugins.hooks import register_hook
+from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 
 class UserProfile(KolibriPluginBase):

--- a/kolibri/utils/translation.py
+++ b/kolibri/utils/translation.py
@@ -1,0 +1,173 @@
+"""
+This module is used to provide translation support for Kolibri,
+prior to the loading of the Django stack.
+Most of these functions are vendored from Django:
+https://github.com/django/django/blob/stable/1.11.x/django/utils/translation/trans_real.py
+
+In order to give a completely transparent interface.
+"""
+import gettext as gettext_module
+import os
+from threading import local
+
+from django.core.exceptions import AppRegistryNotReady
+from django.core.exceptions import ImproperlyConfigured
+from django.utils import six
+from django.utils import translation as django_translation_module
+from django.utils.decorators import ContextDecorator
+from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeData
+from django.utils.translation.trans_real import DjangoTranslation
+
+import kolibri
+
+
+# Translations are cached in a dictionary for every language.
+# The active translations are stored by threadid to make them thread local.
+_translations = {}
+_active = local()
+_default = "en"
+
+
+class KolibriTranslation(DjangoTranslation):
+    domain = "kolibri"
+
+
+def translation(language):
+    """
+    Returns a translation object in the default 'kolibri' domain.
+    """
+    global _translations
+    if language not in _translations:
+        _translations[language] = KolibriTranslation(
+            language,
+            localedirs=[os.path.join(os.path.dirname(kolibri.__file__), "locale")],
+        )
+    return _translations[language]
+
+
+def prefer_django(fn):
+    """
+    Decorator that will call the Django translation function first
+    but catch any exceptions related to Django not being initialized
+    and call the kolibri translation function if needed.
+    """
+
+    def wrapped(*args, **kwargs):
+        try:
+            return getattr(django_translation_module, fn.__name__)(*args, **kwargs)
+        except (AppRegistryNotReady, ImproperlyConfigured):
+            return fn(*args, **kwargs)
+
+    return wrapped
+
+
+@prefer_django
+def activate(language):
+    """
+    Fetches the translation object for a given language and installs it as the
+    current translation object for the current thread.
+    """
+    if not language:
+        return
+    _active.value = translation(language)
+
+
+@prefer_django
+def deactivate():
+    """
+    Deinstalls the currently active translation object so that further _ calls
+    will resolve against the default translation object, again.
+    """
+    if hasattr(_active, "value"):
+        del _active.value
+
+
+@prefer_django
+def deactivate_all():
+    """
+    Makes the active translation object a NullTranslations() instance. This is
+    useful when we want delayed translations to appear as the original string
+    for some reason.
+    """
+    _active.value = gettext_module.NullTranslations()
+    _active.value.to_language = lambda *args: None
+
+
+@prefer_django
+def get_language():
+    """Returns the currently selected language."""
+    t = getattr(_active, "value", None)
+    if t is not None:
+        try:
+            return t.to_language()
+        except AttributeError:
+            pass
+    # If we don't have a real translation object, just return None.
+    return None
+
+
+class override(ContextDecorator):
+    def __init__(self, language, deactivate=False):
+        self.language = language
+        self.deactivate = deactivate
+
+    def __enter__(self):
+        self.old_language = get_language()
+        if self.language is not None:
+            activate(self.language)
+        else:
+            deactivate_all()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.old_language is None:
+            deactivate_all()
+        elif self.deactivate:
+            deactivate()
+        else:
+            activate(self.old_language)
+
+
+def do_translate(message, translation_function):
+    """
+    Translates 'message' using the given 'translation_function' name -- which
+    will be either gettext or ugettext. It uses the current thread to find the
+    translation object to use. If no current translation is activated, the
+    message will be run through the default translation object.
+    """
+    global _default
+
+    # str() is allowing a bytestring message to remain bytestring on Python 2
+    eol_message = message.replace(str("\r\n"), str("\n")).replace(str("\r"), str("\n"))
+
+    if len(eol_message) == 0:
+        # Returns an empty value of the corresponding type if an empty message
+        # is given, instead of metadata, which is the default gettext behavior.
+        result = type(message)("")
+    else:
+        translation_object = getattr(_active, "value", _default)
+
+        result = getattr(translation_object, translation_function)(eol_message)
+
+    if isinstance(message, SafeData):
+        return mark_safe(result)
+
+    return result
+
+
+@prefer_django
+def gettext(message):
+    """
+    Returns a string of the translation of the message.
+    Returns a string on Python 3 and an UTF-8-encoded bytestring on Python 2.
+    """
+    return do_translate(message, "gettext")
+
+
+if six.PY3:
+    ugettext = gettext
+else:
+
+    @prefer_django
+    def ugettext(message):
+        return do_translate(message, "ugettext")


### PR DESCRIPTION
## Summary
* #9343 broke `kolibri plugins list` by relying on Django machinery for translating plugin names
* This fixes that by adding a pre-Django initialization proxy for accessing core Kolibri translations

## Reviewer guidance
Run `kolibri plugins list`

Before:
```
Traceback (most recent call last):
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/trans_real.py", line 168, in _add_installed_apps_translations
    app_configs = reversed(list(apps.get_app_configs()))
  File "/home/richard/github/kolibri/kolibri/dist/django/apps/registry.py", line 138, in get_app_configs
    self.check_apps_ready()
  File "/home/richard/github/kolibri/kolibri/dist/django/apps/registry.py", line 125, in check_apps_ready
    raise AppRegistryNotReady("Apps aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/richard/.virtualenvs/kolibripy3/bin/kolibri", line 33, in <module>
    sys.exit(load_entry_point('kolibri', 'console_scripts', 'kolibri')())
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/richard/github/kolibri/kolibri/utils/cli.py", line 172, in invoke
    return super(KolibriGroupCommand, self).invoke(ctx)
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/richard/github/kolibri/kolibri/dist/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/richard/github/kolibri/kolibri/utils/cli.py", line 453, in list
    max_name_len = max((len(plugin.name(lang)) for plugin in plugins))
  File "/home/richard/github/kolibri/kolibri/utils/cli.py", line 453, in <genexpr>
    max_name_len = max((len(plugin.name(lang)) for plugin in plugins))
  File "/home/richard/github/kolibri/kolibri/plugins/coach/kolibri_plugin.py", line 30, in name
    with translation.override(lang):
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/__init__.py", line 181, in __enter__
    activate(self.language)
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/__init__.py", line 166, in activate
    return _trans.activate(language)
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/trans_real.py", line 239, in activate
    _active.value = translation(language)
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/trans_real.py", line 228, in translation
    _translations[language] = DjangoTranslation(language)
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/trans_real.py", line 129, in __init__
    self._add_installed_apps_translations()
  File "/home/richard/github/kolibri/kolibri/dist/django/utils/translation/trans_real.py", line 171, in _add_installed_apps_translations
    "The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure cannot be initialized before the apps registry is ready. Check that you don't make non-lazy gettext calls at import time.
```

After:
```
Available plugins           Plugin identifier                   Status
App                         kolibri.plugins.app                 DISABLED
Coach                       kolibri.plugins.coach               DISABLED
DefaultThemePlugin          kolibri.plugins.default_theme       ENABLED
DemoServer                  kolibri.plugins.demo_server         DISABLED
DeviceManagementPlugin      kolibri.plugins.device              ENABLED
DocumentEPUBRenderPlugin    kolibri.plugins.epub_viewer         ENABLED
Facility                    kolibri.plugins.facility            ENABLED
HTML5AppPlugin              kolibri.plugins.html5_viewer        ENABLED
Learn                       kolibri.plugins.learn               ENABLED
MediaPlayerPlugin           kolibri.plugins.media_player        ENABLED
DocumentPDFRenderPlugin     kolibri.plugins.pdf_viewer          ENABLED
Setup Wizard                kolibri.plugins.setup_wizard        ENABLED
SlideshowRenderPlugin       kolibri.plugins.slideshow_viewer    ENABLED
UserAuth                    kolibri.plugins.user_auth           ENABLED
User Profile                kolibri.plugins.user_profile        ENABLED
```


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
