### PR TITLE
server: Set STATUS_RUNNING just once

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -334,7 +334,6 @@ class PIDPlugin(SimplePlugin):
 
     def ZIP_SERVING(self, zip_port):
         self.bus.zip_port = zip_port or self.bus.zip_port
-        self.set_pid_file(STATUS_RUNNING)
 
     def EXIT(self):
         try:


### PR DESCRIPTION
Do not set the STATUS_RUNNING when the ZIP_SERVER started, that state is
set now only when the real backend server is running.

If the zip server starts before the real server it's possible to have the running state in the pid file
when the real server is not still up. With this change the pid file will show the real backend state.