### PR TITLE
Copy preseeded database using shutil.copyfile()

### DIFF
--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -176,7 +176,7 @@ def _copy_preseeded_db(db_name, target=None):
                     "home/{}.sqlite3".format(db_name),
                 )
             )
-            shutil.copy(db_path, target)
+            shutil.copyfile(db_path, target)
             logger.info(
                 "Copied preseeded database from {} to {}".format(db_path, target)
             )


### PR DESCRIPTION
## Summary
Using `shutil.copyfile` works on Androd for external storage devices and is harmless.

## References
https://github.com/learningequality/kolibri-installer-android/issues/111

## Reviewer guidance
See https://github.com/learningequality/kolibri-installer-android/issues/111 for the steps to reproduce this.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
