### PR TITLE
Use system default language when possible.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -293,9 +293,11 @@ EXTRA_LANG_INFO = {
 }
 locale.LANG_INFO.update(EXTRA_LANG_INFO)
 
+default_language = i18n.get_system_default_language()
+
 LANGUAGE_CODE = (
-    "en"
-    if "en" in conf.OPTIONS["Deployment"]["LANGUAGES"]
+    default_language
+    if default_language in conf.OPTIONS["Deployment"]["LANGUAGES"]
     else conf.OPTIONS["Deployment"]["LANGUAGES"][0]
 )
 

--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -2,7 +2,10 @@
 import importlib
 import io
 import json
+import locale
 import os
+
+from django.utils.translation.trans_real import to_language
 
 import kolibri
 
@@ -41,7 +44,7 @@ def _get_language_info():
 KOLIBRI_LANGUAGE_INFO = _get_language_info()
 
 # List of intl codes that Kolibri officially supports
-KOLIBRI_SUPPORTED_LANGUAGES = [
+KOLIBRI_SUPPORTED_LANGUAGES = {
     "ar",
     "bg-bg",
     "bn-bd",
@@ -73,4 +76,16 @@ KOLIBRI_SUPPORTED_LANGUAGES = [
     "vi",
     "yo",
     "zh-hans",
-]
+}
+
+
+def get_system_default_language():
+    for loc in (locale.getlocale()[0], locale.getdefaultlocale()[0]):
+        if loc:
+            lang = to_language(loc)
+            for lang_code in (lang, lang.split("-")[0]):
+                if lang_code in KOLIBRI_SUPPORTED_LANGUAGES:
+                    return lang_code
+
+    # If all else fails we fall back to "en"
+    return "en"


### PR DESCRIPTION
## Summary
* Sets the default Django language to the system default language when available

## References
Fixes #2528

## Reviewer guidance
Does Kolibri start?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
