### PR TITLE
Onboarding wrapper component

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -1,13 +1,29 @@
 <template>
 
-  <div class="base-container">
+  <!-- Always base-container class, wrapping screen size class when small -->
+  <div
+    :class="{ 'base-container': true, 'windowIsSmall': windowIsSmall }"
+    :style="{ 'background-color': windowIsSmall ? $themeTokens.surface : '' }"
+  >
 
     <div class="logo-lang-container">
-      <div class="logo-wrapper">
+      <!--
+        Small Screen: Back button (if not hidden by prop)
+        Med-Lg Screen: Logo
+        -->
+      <div v-if="!windowIsSmall" class="logo-wrapper">
         <CoreLogo class="logo-image" />
         <span class="logo-text">{{ coreString('kolibriLabel') }}</span>
       </div>
 
+      <KIconButton
+        v-else-if="!noBackAction"
+        class="back-icon-button"
+        icon="back"
+        @click="$emit('back')"
+      />
+
+      <!-- Language switcher visible regardless of screen size -->
       <KButton
         class="languages-button"
         icon="language"
@@ -18,18 +34,55 @@
       />
     </div>
 
-    <KPageContainer :topMargin="16" :noPadding="true" :style="contentContainerStyles">
+    <!-- topMargin & noPadding props for KPageContainer - harmless when case of div -->
+    <component
+      :is="windowIsSmall ? 'div' : 'KPageContainer'"
+      :topMargin="16"
+      :noPadding="true"
+    >
       <div class="content">
         <slot></slot>
       </div>
-      <div 
-        v-if="$slots.footer" 
-        class="footer" 
-        :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
+
+      <!-- Border hidden on mobile by making it the same as the background -->
+      <div
+        class="footer"
+        :style="{
+          borderTop: `1px solid ${windowIsSmall ? $themeTokens.surface : $themeTokens.fineLine}`
+        }"
       >
-        <slot name="footer"></slot>
+        <!-- No room for slot on small screens -->
+        <div v-if="!windowIsSmall" class="footer-section">
+          <slot name="footer"></slot>
+        </div>
+
+        <!-- Footer for medium+ screens -->
+        <KButtonGroup v-if="!windowIsSmall" class="footer-actions footer-section">
+          <KButton
+            v-if="!noBackAction"
+            :text="coreString('goBackAction')"
+            appearance="flat-button"
+            :primary="false"
+            @click="$emit('back')"
+          />
+          <KButton
+            :text="coreString('continueAction')"
+            :primary="true"
+            @click="$emit('continue')"
+          />
+        </KButtonGroup>
+
+        <!-- Simpler to do a big button for the small screen separately -->
+        <div v-if="windowIsSmall" class="mobile-footer">
+          <KButton
+            class="mobile-continue-button"
+            :text="coreString('continueAction')"
+            :primary="true"
+            @click="$emit('continue')"
+          />
+        </div>
       </div>
-    </KPageContainer>
+    </component>
 
     <LanguageSwitcherModal
       v-if="showLanguageModal"
@@ -47,21 +100,25 @@
   import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
 
   export default {
     name: 'OnboardingStepBase',
     components: { CoreLogo, LanguageSwitcherModal },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, responsiveWindowMixin],
+    props: {
+      noBackAction: {
+        type: Boolean,
+        default: false,
+      },
+    },
     data() {
       return {
         showLanguageModal: false,
       };
     },
     computed: {
-      contentContainerStyles() {
-        return {};
-      },
       selectedLanguage() {
         return availableLanguages[currentLanguage];
       },
@@ -76,12 +133,22 @@
   .base-container {
     max-width: 700px;
     margin: 10% auto 0;
+
+    &.windowIsSmall {
+      width: 100vw;
+      height: 100vh;
+      margin: 0;
+    }
   }
 
   .logo-lang-container {
     position: relative;
     width: 100%;
     height: 32px;
+  }
+
+  .windowIsSmall .logo-lang-container {
+    padding: 16px;
   }
 
   .logo-wrapper {
@@ -115,12 +182,53 @@
     font-weight: bold;
   }
 
+  .windowIsSmall .languages-button {
+    top: 16px;
+    right: 16px;
+  }
+
+  // Padding difference between small vs medium+ screens is to account for
+  // default margins on H tags.
   .content {
+    padding: 16px 32px 32px;
+  }
+
+  .windowIsSmall .content {
     padding: 32px;
   }
 
   .footer {
+    display: flex;
+    justify-content: space-between;
     padding: 16px 32px;
+  }
+
+  .footer-section {
+    max-width: 50%;
+
+    &.footer-actions {
+      // Aligns action buttons with right-most text
+      margin-right: -16px;
+    }
+  }
+
+  .windowIsSmall .footer-section {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .mobile-footer {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 64px;
+    padding: 16px;
+  }
+
+  .mobile-continue-button {
+    width: 100%;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -51,7 +51,8 @@
           borderTop: `1px solid ${windowIsSmall ? $themeTokens.surface : $themeTokens.fineLine}`
         }"
       >
-        <!-- No room for slot on small screens -->
+        <!-- No room for slot on small screens.
+             On med+ screens, to be used to show short strings of text eg, "Step 1 / 4" -->
         <div v-if="!windowIsSmall" class="footer-section">
           <slot name="footer"></slot>
         </div>
@@ -229,6 +230,10 @@
 
   .mobile-continue-button {
     width: 100%;
+  }
+
+  .ta-l {
+    text-align: left;
   }
 
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -1,0 +1,126 @@
+<template>
+
+  <div class="base-container">
+
+    <div class="logo-lang-container">
+      <div class="logo-wrapper">
+        <CoreLogo class="logo-image" />
+        <span class="logo-text">{{ coreString('kolibriLabel') }}</span>
+      </div>
+
+      <KButton
+        class="languages-button"
+        icon="language"
+        :text="selectedLanguage.lang_name"
+        :primary="false"
+        appearance="flat-button"
+        @click="showLanguageModal = true"
+      />
+    </div>
+
+    <KPageContainer :topMargin="16" :noPadding="true" :style="contentContainerStyles">
+      <div class="content">
+        <slot></slot>
+      </div>
+      <div 
+        v-if="$slots.footer" 
+        class="footer" 
+        :style="{ borderTop: `1px solid ${$themeTokens.fineLine}` }"
+      >
+        <slot name="footer"></slot>
+      </div>
+    </KPageContainer>
+
+    <LanguageSwitcherModal
+      v-if="showLanguageModal"
+      class="ta-l"
+      @cancel="showLanguageModal = false"
+    />
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
+  import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
+
+  export default {
+    name: 'OnboardingStepBase',
+    components: { CoreLogo, LanguageSwitcherModal },
+    mixins: [commonCoreStrings],
+    data() {
+      return {
+        showLanguageModal: false,
+      };
+    },
+    computed: {
+      contentContainerStyles() {
+        return {};
+      },
+      selectedLanguage() {
+        return availableLanguages[currentLanguage];
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .base-container {
+    max-width: 700px;
+    margin: 10% auto 0;
+  }
+
+  .logo-lang-container {
+    position: relative;
+    width: 100%;
+    height: 32px;
+  }
+
+  .logo-wrapper {
+    position: absolute;
+    left: 0;
+    // Match height of parent
+    height: 100%;
+
+    .logo-image {
+      width: auto;
+      height: 32px;
+    }
+
+    .logo-text {
+      position: absolute;
+      // Aligns text vertically with logo
+      bottom: 3px;
+      // Spaces the text from the logo
+      left: 48px;
+      font-size: 18px;
+    }
+  }
+
+  .languages-button {
+    position: absolute;
+    // Aligns text with right side of content container
+    right: -16px;
+    // Aligns button vertically with logo
+    bottom: -2px;
+    font-size: 14px;
+    font-weight: bold;
+  }
+
+  .content {
+    padding: 32px;
+  }
+
+  .footer {
+    padding: 16px 32px;
+  }
+
+</style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -133,11 +133,6 @@
 
   // Override KPageContainer styles
   /deep/ .page-container {
-    // A little narrower than the default, but wide enough to fit whole
-    // language-switcher
-    max-width: 700px;
-    padding: 32px;
-    margin: auto;
     overflow: visible;
 
     &.small {


### PR DESCRIPTION
## Summary

Adds a new mobile-responsive component `OnboardingStepBase` to serve as a presentation wrapper component for all steps in the updated onboarding flow.

Due to the consistency in the designs ([Figma](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=0%3A1)) this component is opinionated, providing two slots:

_default_ - which is where a form's content will be put
_footer_ - which is where medium-screen or larger versions can have some metadata available (ie, Step n/m).

Additionally, the component exposes a language switcher displaying the name of the currently selected language and the modal window used to select a different language.

Two actions can come from this component:

'back' - indicating the "back" button was clicked
'continue' - indicating the "continue" button was clicked

Additionally, it has one boolean prop `noBackAction` which hides the "back" button altogether.

---

Because I had to kind of hack some other files that don't need to be committed here to test things out, I've made this video displaying the responsive, RTL-friendly and some i18n for the component in action.

https://user-images.githubusercontent.com/6356129/165999085-79697c5d-d43a-481c-982b-c563673261ba.mp4

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9301 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Devs: Code review - I think that we can get more feedback on the experience of using this as we proceed in building the upcoming steps. The video above was the result of my hacking at the router and an existing component a bit. 

- Is the flow and styling of the component intuitive?
- Do you foresee any issues as we start building the real pages with this?
- How do you feel this might be improved structurally - anything that looks hard to change?
- I didn't see anything that seems to demand tests - let me know if you think anything should be covered.

Design: Is there anything I've missed on the design side? Does everything look spaced well and positioned correctly?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
