### PR TITLE
Remove additional reference to django_extensions

### DIFF
--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -9,7 +9,7 @@ from .base import *  # noqa isort:skip @UnusedWildImport
 DEBUG = True
 
 # Settings might be tuples, so switch to lists
-INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg", "django_extensions"]  # noqa F405
+INSTALLED_APPS = list(INSTALLED_APPS) + ["drf_yasg"]  # noqa F405
 webpack_middleware = "kolibri.core.webpack.middleware.WebpackErrorHandler"
 no_login_popup_middleware = (
     "kolibri.core.auth.middleware.XhrPreventLoginPromptMiddleware"


### PR DESCRIPTION
There is an additional reference to `django_extensions` that was not removed with the rollback last week. 

After testing locally, removing this seems to allow the `devserver` to run as expected

Fixes #9396

Reviewer questions:
Is there anything else that needs to be changed?