### PR TITLE
Ensure all file handlers use utf-8 encoding.

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -11,13 +11,12 @@ try:
     # TODO: Move version tools to build tools, so we don't have to do this
     from colorlog import ColoredFormatter
     from colorlog import getLogger
-    from colorlog import StreamHandler
 except ImportError:
-    StreamHandler = None
     getLogger = None
     ColoredFormatter = None
 
 from .logger import LOG_COLORS
+from .logger import EncodingStreamHandler as StreamHandler
 from kolibri.utils.compat import monkey_patch_collections
 
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -191,6 +191,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "formatter": "simple_date",
                 "when": "midnight",
                 "backupCount": 30,
+                "encoding": "utf-8",
             },
             "file_debug": {
                 "level": "DEBUG",
@@ -198,6 +199,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "class": "logging.FileHandler",
                 "filename": os.path.join(LOG_ROOT, "debug.txt"),
                 "formatter": "simple_date",
+                "encoding": "utf-8",
             },
         },
         "loggers": {


### PR DESCRIPTION
## Summary
* Sets explicit utf-8 encoding on logging file handlers
* Encodes messages to utf-8 before writing them as bytes to the stream for logging to terminal

## References
Attempts to fix #6298

## Reviewer guidance
Try running `kolibri manage listchannels` on a Windows machine with a non-Latin alphabet entitled channel.
Check the logs from Kolibri running and see if it is full of lots of errors from logging.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
