### PR TITLE
Move perseus specific logic into perseus renderer.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -301,11 +301,7 @@
     },
     watch: {
       attemptLogItemValue(newVal, oldVal) {
-        // HACK: manually dismiss the perseus renderer message when moving
-        // to a different item (fixes #3853)
         if (newVal !== oldVal) {
-          this.$refs.contentRenderer.$refs.contentView.dismissMessage &&
-            this.$refs.contentRenderer.$refs.contentView.dismissMessage();
           this.startTime = Date.now();
         }
       },

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -275,6 +275,9 @@
         // Don't store blank state for another item.
         this.blankState = null;
 
+        // Clear any currently displayed messages when we render an item.
+        this.dismissMessage();
+
         // Create react component with current item data.
         // If the component already existed, this will perform an update.
         this.$set(


### PR DESCRIPTION
## Summary
* Moves message dismissal in Perseus renderer inside the `renderItem` method

## References
Fixes #9402

## Reviewer guidance
See the original reports referenced in the issue above. The fix should persist.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
