### PR TITLE
Update side panel focus trapping

### DIFF
--- a/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
+++ b/kolibri/core/assets/src/views/FullScreenSidePanel/index.vue
@@ -184,6 +184,13 @@
       focusLastEl() {
         this.$el.querySelector('.close-button').focus();
       },
+      /**
+       * @public
+       * Reset the next focus to the first focus element
+       */
+      focusFirstEl() {
+        this.$el.querySelector('.close-button').focus();
+      },
     },
     $trs: {
       /* eslint-disable kolibri/vue-no-unused-translations */

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -61,8 +61,10 @@
     <!-- Side Panel for content metadata -->
     <FullScreenSidePanel
       v-if="sidePanelContent"
+      ref="resourcePanel"
       alignment="right"
       @closePanel="sidePanelContent = null"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <template #header>
         <!-- Flex styles tested in ie11 and look good. Ensures good spacing between
@@ -92,9 +94,11 @@
     <!-- Side Panel for "view resources" or "lesson resources" -->
     <FullScreenSidePanel
       v-if="showViewResourcesSidePanel"
+      ref="resourcePanel"
       class="also-in-this-side-panel"
       alignment="right"
       @closePanel="showViewResourcesSidePanel = false"
+      @shouldFocusFirstEl="findFirstEl()"
     >
       <template #header>
         <h2 style="margin: 0;">
@@ -407,6 +411,13 @@
       },
       toggleResourceList() {
         this.showViewResourcesSidePanel = true;
+      },
+      findFirstEl() {
+        if (this.$refs.embeddedPanel) {
+          this.$refs.embeddedPanel.focusFirstEl();
+        } else {
+          this.$refs.resourcePanel.focusFirstEl();
+        }
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
This PR uses a slightly modified version of the existing FocusTrap pattern's functions to ensure the focus shifts to the side panel correctly within the Content display and that a user can tab through each element of the side panel. 

## References
Fixes learningequality/kolibri#9178 
Fixes learningequality/kolibri#9096 
Fixes learningequality/kolibri#9175 
Possibly fixes learningequality/kolibri#9193 ? (A few extra tabs are required vs. in Chrome and Safari, but all elements are accessible via tab key when correct settings are enabled... I will see if I can continue to improve this in follow up, but I think the initial improvements are at least a step in the right direction since the content is now _available_ even if it is not the best experience) 

…

## Reviewer guidance
Use the tab key to navigate within various pieces of content (videos, exercises, etc.)
Opening the side panel to view information or to view additional resources should: 
- shift the focus to the side panel 
- cycle through the focusable elements - including links or buttons as well as the main close button 
- should work in Safari and Chrome. Improvements tbd in Firefox...

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
