### PR TITLE
Update firefox bookmarks cards focus outline

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningCardGrid.vue
@@ -183,7 +183,7 @@
 
 <style lang="scss" scoped>
 
-  $gutters: 16px;
+  $gutters: 32px;
 
   .card-grid-item {
     margin-bottom: $gutters;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -171,6 +171,10 @@
   $h-padding: 24px;
   $v-padding: 16px;
 
+  a {
+    display: block;
+  }
+
   .card {
     @extend %dropshadow-1dp;
 
@@ -179,7 +183,6 @@
     width: 100%;
     min-height: 246px;
     padding: $v-padding $h-padding;
-    margin-bottom: 24px;
     text-decoration: none;
     vertical-align: top;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
Updates focus outline styles on Bookmarks cards to ensure proper styling on firefox

## References
Fixes #9192 
<img width="1433" alt="Screen Shot 2022-05-05 at 2 23 28 PM" src="https://user-images.githubusercontent.com/17235236/166990099-d13dbfbf-31ac-4d42-adce-90563c2ab8f2.png">

Before: 
![bookmarks-navigation-firefox](https://user-images.githubusercontent.com/17235236/166990930-cc345902-3274-4f83-97db-81f554647628.gif)



## Reviewer guidance
Use tab navigation on to test focus outline on bookmarks page in Firefox. Outline should properly surround the card.
Should _not_ cause regressions on Chrome or Safari (or IE)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
