### PR TITLE
Adds aria-live=polite to the global snackbar component

### DIFF
--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -103,7 +103,10 @@
       </div>
     </div>
 
-    <GlobalSnackbar />
+
+    <div aria-live="polite">
+      <GlobalSnackbar />
+    </div>
     <UpdateNotification
       v-if="!loading && showNotification && mostRecentNotification"
       :id="mostRecentNotification.id"

--- a/kolibri/core/assets/src/views/GlobalSnackbar.vue
+++ b/kolibri/core/assets/src/views/GlobalSnackbar.vue
@@ -3,7 +3,6 @@
   <CoreSnackbar
     v-if="snackbarIsVisible"
     :key="key"
-    aria-live="polite"
     :text="snackbarOptions.text"
     :actionText="snackbarOptions.actionText"
     :backdrop="snackbarOptions.backdrop"

--- a/kolibri/core/assets/src/views/GlobalSnackbar.vue
+++ b/kolibri/core/assets/src/views/GlobalSnackbar.vue
@@ -3,6 +3,7 @@
   <CoreSnackbar
     v-if="snackbarIsVisible"
     :key="key"
+    aria-live="polite"
     :text="snackbarOptions.text"
     :actionText="snackbarOptions.actionText"
     :backdrop="snackbarOptions.backdrop"


### PR DESCRIPTION
## Summary
This adds `aria-live=polite` to the global snackbar component. This setting does not "overly interrupt" on screen readers, but provides update notifications when changes happen.

## References
Fixes #9406 

## Reviewer guidance
The reviewer should test on a screen reader device or on a device with voiceover or similar settings enabled, anywhere where there are snackbar notifications.

I found testing on the "users" table to be easiest -- by creating and deleting a user, I was able to test easily several times.

I have _only_ tested this on MacOS with voiceover... It does seem to be working as expected in this setting, and the reading I have done would indicate that this is fairly universal, but I'm not sure about other devices.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
