### PR TITLE
Adds aria labels to immersive toolbar buttons for back and close

### DIFF
--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -21,6 +21,7 @@
         <!-- TODO add aria label? -->
         <KIconButton
           v-if="icon === 'close'"
+          :ariaLabel="coreString('closeAction')"
           icon="close"
           :color="$themeTokens.textInverted"
           tabindex="-1"
@@ -28,6 +29,7 @@
         <KIconButton
           v-else
           icon="back"
+          :ariaLabel="coreString('goBackAction')"
           :color="$themeTokens.textInverted"
         />
       </router-link>
@@ -35,6 +37,7 @@
       <span v-else>
         <KIconButton
           v-if="icon === 'close'"
+          :ariaLabel="coreString('closeAction')"
           icon="close"
           :color="$themeTokens.textInverted"
           tabindex="-1"
@@ -43,6 +46,7 @@
         <KIconButton
           v-else
           icon="back"
+          :ariaLabel="coreString('goBackAction')"
           :color="$themeTokens.textInverted"
           @click="$emit('navIconClick')"
         />
@@ -57,12 +61,14 @@
 
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import { validateLinkObject } from 'kolibri.utils.validators';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'ImmersiveToolbar',
     components: {
       UiToolbar,
     },
+    mixins: [commonCoreStrings],
     props: {
       appBarTitle: {
         type: String,


### PR DESCRIPTION
## Summary
This uses the existing `ariaLabel` prop on `KIconButton` and coreStrings to add labels to the "Back" and "Close" buttons on the immersive toolbar.

## References
Fixes #9407 

## Reviewer guidance
The reviewer should test on a screen reader device or on a device with voiceover or similar settings enabled, anywhere where there is an immersive toolbar (Topics Page, many places is facility settings with users)

I have only tested this on MacOS with voiceover... It does seem to be working as expected in this setting, and the reading I have done would indicate that this is fairly universal, but I'm not sure about other devices.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
