### PR TITLE
Create a state machine and new routes for change facility workflow

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -1,0 +1,272 @@
+import { createMachine, assign } from 'xstate';
+// This machine can be visualized and tested at https://stately.ai/viz/c1316a38-033d-4c57-8d9f-e282310e341d
+/* SETCONTEXT event example:
+{
+	"type": "SETCONTEXT",
+	"value": {
+		"facility": "fac1",
+		"username": "username1",
+		"role": "learner"
+	}
+}
+SELECTFACILITY event example:
+  {
+      "type": "SELECTFACILITY",
+      "value": {
+          "name": "fac2",
+          "url": "http...",
+          "id": "ca88.."
+      }
+  }
+*/
+const setInitialContext = assign((_, event) => {
+  return {
+    sourceFacility: event.value.facility,
+    username: event.value.username,
+    role: event.value.role,
+  };
+});
+
+const connectToTargetKolibri = event => {
+  const facility = event.value;
+  return new Promise(function(resolve) {
+    setTimeout(
+      () => {
+        return resolve({
+          facility: facility,
+          users: [
+            { id: 1, username: 'username1' },
+            { id: 2, username: 'username2' },
+          ],
+        });
+      },
+      1000,
+      facility
+    );
+  });
+};
+
+const checkExists = assign((context, event) => {
+  const filtered = event.data.users.filter(user => user.username === context.username);
+  const exists = filtered.length > 0;
+  return {
+    accountExists: exists,
+    targetFacility: event.data.facility,
+    targetAccount: filtered[0],
+  };
+});
+
+const setNewSuperAdmin = assign({
+  newSuperAdmin: (_, event) => event.value,
+});
+
+const setTargetAccount = assign({
+  targetAccount: (_, event) => event.value,
+});
+
+const setMerging = assign({
+  isMerging: () => true,
+});
+
+const saveAccountDetails = () => {
+  // to be done
+};
+
+export const changeFacilityMachine = createMachine({
+  id: 'machine',
+  initial: 'selectFacility',
+  context: {
+    role: 'learner',
+    username: '',
+    targetAccount: { username: '', id: '' },
+    sourceFacility: '',
+    targetFacility: {}, //should be an object with the facility name, id & url
+    newSuperAdmin: '',
+    taskPolling: false,
+    accountExists: false,
+    isMerging: false,
+  },
+  states: {
+    profile: {
+      meta: { route: 'PROFILE', path: '/' },
+      on: {
+        CONTINUE: {
+          target: 'selectFacility',
+          cond: context => !!context.sourceFacility && !!context.username,
+        },
+        SETCONTEXT: { actions: setInitialContext },
+      },
+    },
+    selectFacility: {
+      meta: { route: 'SELECT_FACILITY', path: '/change_facility' },
+      on: {
+        CONTINUE: {
+          target: 'changeFacility',
+          cond: context => Object.keys(context.targetFacility).length > 0,
+        },
+        BACK: 'profile',
+        SETCONTEXT: { actions: setInitialContext },
+        SELECTFACILITY: {
+          actions: assign({
+            targetFacility: () => {
+              return {};
+            },
+          }),
+          target: 'getFacilityUsernames',
+        },
+      },
+    },
+    getFacilityUsernames: {
+      invoke: {
+        id: 'getUserNames',
+        src: (context, event) => connectToTargetKolibri(event),
+        onDone: {
+          target: 'selectFacility',
+          actions: checkExists,
+        },
+        onError: {
+          target: 'selectFacility',
+        },
+      },
+    },
+    changeFacility: {
+      meta: { route: 'CHANGE_FACILITY', path: '/change_facility' },
+      on: {
+        MERGE: {
+          target: 'mergeAccounts',
+          actions: setMerging,
+        },
+        CONTINUE: 'checkUsernameExists',
+        BACK: 'selectFacility',
+      },
+    },
+    checkUsernameExists: {
+      always: [
+        {
+          cond: context => !!context.accountExists,
+          target: 'usernameExists',
+          actions: setMerging,
+        },
+        {
+          target: 'confirmAccount',
+        },
+      ],
+    },
+    confirmAccount: {
+      meta: { route: 'CONFIRM_ACCOUNT', path: '/change_facility' },
+      on: {
+        NEW: 'createAccount',
+        CONTINUE: 'isAdmin',
+        BACK: 'changeFacility',
+      },
+    },
+    isAdmin: {
+      always: [
+        {
+          cond: context => context.role === 'superadmin',
+          target: 'chooseAdmin',
+        },
+        {
+          target: 'checkIsMerging',
+        },
+      ],
+    },
+    chooseAdmin: {
+      meta: { route: 'CHOOSE_ADMIN', path: '/change_facility' },
+      on: {
+        CONTINUE: {
+          target: 'checkIsMerging',
+          cond: context => !!context.newSuperAdmin,
+        },
+        SELECTNEWSUPERADMIN: { actions: setNewSuperAdmin },
+        BACK: 'confirmAccount',
+      },
+    },
+    checkIsMerging: {
+      always: [
+        {
+          cond: context => context.isMerging,
+          target: 'confirmMerge',
+        },
+        {
+          target: 'syncChangeFacility',
+        },
+      ],
+    },
+    confirmMerge: {
+      meta: { route: 'CONFIRM_MERGE', path: '/change_facility' },
+      on: {
+        CONTINUE: 'syncChangeFacility',
+        BACK: 'changeFacility',
+      },
+    },
+    syncChangeFacility: {
+      meta: { route: 'SYNCING_CHANGE_FACILITY', path: '/change_facility' },
+      type: 'final',
+    },
+    createAccount: {
+      on: {
+        meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
+        CONTINUE: {
+          // event.value must be an object {id:, usename:}
+          target: 'isAdmin',
+          actions: setTargetAccount,
+        },
+        BACK: 'changeFacility',
+        BACKMERGING: 'confirmMerge',
+      },
+    },
+    usernameExists: {
+      meta: { route: 'USERNAME_EXISTS', path: '/change_facility' },
+      on: {
+        MERGE: 'requireAccountCreds',
+        NEW: 'createAccount',
+        BACK: 'selectFacility',
+      },
+    },
+    requireAccountCreds: {
+      meta: { route: 'REQUIRE_ACCOUNT_CREDENTIALS', path: '/change_facility' },
+      on: {
+        CONTINUE: 'showAccounts',
+        USEADMIN: 'useAdminPassword',
+        BACK: 'confirmMerge',
+      },
+    },
+    useAdminPassword: {
+      meta: { route: 'ADMIN_PASSWORD', path: '/change_facility' },
+      on: {
+        CONTINUE: 'showAccounts',
+        BACK: 'requireAccountCreds',
+      },
+    },
+    showAccounts: {
+      meta: { route: 'SHOW_ACCOUNTS', path: '/change_facility' },
+      on: {
+        CONTINUE: 'confirmAccountDetails',
+        BACK: 'requireAccountCreds',
+      },
+    },
+    confirmAccountDetails: {
+      meta: { route: 'CONFIRM_DETAILS', path: '/change_facility' },
+      on: {
+        CONTINUE: 'isAdmin',
+        EDITDETAILS: 'editAccountDetails',
+        BACK: 'showAccounts',
+      },
+    },
+    editAccountDetails: {
+      meta: { route: 'EDIT_DETAILS', path: '/change_facility' },
+      on: {
+        SAVE: { actions: saveAccountDetails },
+        BACK: 'confirmAccountDetails',
+      },
+    },
+    mergeAccounts: {
+      meta: { route: 'MERGE_ACCOUNTS', path: '/change_facility' },
+      on: {
+        CONTINUE: 'requireAccountCreds',
+        BACK: 'selectFacility',
+      },
+    },
+  },
+});

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -2,6 +2,7 @@ import store from 'kolibri.coreVue.vuex.store';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
+import ChangeFacility from './views/ChangeFacility';
 
 function preload(next) {
   store.commit('CORE_SET_PAGE_LOADING', true);
@@ -14,6 +15,7 @@ function preload(next) {
 export default [
   {
     path: '/',
+    name: 'PROFILE',
     component: ProfilePage,
     beforeEnter(to, from, next) {
       if (!store.getters.isUserLoggedIn) {
@@ -25,6 +27,7 @@ export default [
   },
   {
     path: '/edit',
+    name: 'PROFILE_EDIT',
     component: ProfileEditPage,
     beforeEnter(to, from, next) {
       if (!store.getters.isUserLoggedIn) {
@@ -33,6 +36,86 @@ export default [
         preload(next);
       }
     },
+  },
+
+  {
+    path: '/change_facility',
+    name: 'SELECT_FACILITY',
+    component: ChangeFacility,
+    beforeEnter(to, from, next) {
+      if (!store.getters.isUserLoggedIn) {
+        redirectBrowser();
+      } else {
+        preload(next);
+      }
+    },
+    children: [
+      {
+        path: 'change',
+        name: 'CHANGE_FACILITY',
+        component: ChangeFacility,
+      },
+      {
+        path: 'confirm_account',
+        name: 'CONFIRM_ACCOUNT',
+        component: ChangeFacility,
+      },
+      {
+        path: 'choose_admin',
+        name: 'CHOOSE_ADMIN',
+        component: ChangeFacility,
+      },
+      {
+        path: 'confirm_merge',
+        name: 'CONFIRM_MERGE',
+        component: ChangeFacility,
+      },
+      {
+        path: 'syncing_change_facility',
+        name: 'SYNCING_CHANGE_FACILITY',
+        component: ChangeFacility,
+      },
+      {
+        path: 'create_account',
+        name: 'CREATE_ACCOUNT',
+        component: ChangeFacility,
+      },
+      {
+        path: 'username_exists',
+        name: 'USERNAME_EXISTS',
+        component: ChangeFacility,
+      },
+      {
+        path: 'require_account_credentials',
+        name: 'REQUIRE_ACCOUNT_CREDENTIALS',
+        component: ChangeFacility,
+      },
+      {
+        path: 'admin_password',
+        name: 'ADMIN_PASSWORD',
+        component: ChangeFacility,
+      },
+      {
+        path: 'show_accounts',
+        name: 'SHOW_ACCOUNTS',
+        component: ChangeFacility,
+      },
+      {
+        path: 'show_accounts',
+        name: 'CONFIRM_DETAILS',
+        component: ChangeFacility,
+      },
+      {
+        path: 'show_accounts',
+        name: 'EDIT_DETAILS',
+        component: ChangeFacility,
+      },
+      {
+        path: 'merge_accounts',
+        name: 'MERGE_ACCOUNTS',
+        component: ChangeFacility,
+      },
+    ],
   },
   {
     path: '*',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -1,0 +1,161 @@
+<template>
+
+  <CoreBase
+    :immersivePage="false"
+    :appBarTitle="coreString('profileLabel')"
+    :immersivePagePrimary="true"
+  >
+    <KPageContainer>
+
+      <KGrid>
+        <KGridItem sizes="100, 75, 75" percentage>
+          <h1>Change Facility</h1>
+        </KGridItem>
+        <!-- Users cannot edit their profile if on a SoUD -->
+        <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+          Route name: {{ currentRoute }}
+        </KGridItem>
+        <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+          Machine state: {{ state.value }}
+        </KGridItem>
+        <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+          Machine context: {{ state.context }}
+        </KGridItem>
+      </KGrid>
+
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            @click="to_continue"
+          />
+
+          <KButton
+            :primary="true"
+            :text="coreString('goBackAction')"
+            @click="goBack"
+          />
+          <KButton
+            :primary="true"
+            text="select Facility"
+            @click="selectFacility"
+          />
+        </KButtonGroup>
+      </slot>
+
+
+    </KPageContainer>
+  </CoreBase>
+
+</template>
+
+
+<script>
+
+  import CoreBase from 'kolibri.coreVue.components.CoreBase';
+  import { computed } from 'kolibri.lib.vueCompositionApi';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { interpret } from 'xstate';
+  import { mapGetters } from 'vuex';
+  import { changeFacilityMachine } from '../../machines/changeFacilityMachine';
+  import plugin_data from 'plugin_data';
+
+  export default {
+    name: 'ChangeFacility',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: {
+      CoreBase,
+    },
+
+    mixins: [responsiveWindowMixin, commonCoreStrings],
+    setup() {
+      const { isSubsetOfUsersDevice } = plugin_data;
+      return {
+        isSubsetOfUsersDevice,
+      };
+    },
+    data() {
+      return {
+        service: interpret(changeFacilityMachine),
+        state: changeFacilityMachine.initialState,
+        currentRoute: this.$router.currentRoute.name,
+      };
+    },
+    provide() {
+      return {
+        changeFacilityService: this.service,
+        state: computed(() => this.state.context),
+      };
+    },
+    computed: {
+      ...mapGetters(['session', 'getUserKind']),
+    },
+    created() {
+      this.service.start();
+      this.service.onTransition(state => {
+        const stateID = Object.keys(state.meta)[0];
+        if (state.meta[stateID] !== undefined) {
+          let newRoute = state.meta[stateID].route;
+          if (newRoute != this.$router.currentRoute.name) {
+            if ('path' in state.meta[stateID]) {
+              this.backRoute = this.currentRoute;
+              this.$router.push({ name: newRoute, path: state.meta[stateID].path });
+            } else this.$router.push(newRoute);
+          }
+          this.currentRoute = newRoute;
+        }
+        this.state = state;
+      });
+    },
+    destroyed() {
+      this.service.stop();
+    },
+    mounted() {
+      const ctx = this.service.state.context;
+      if (ctx.username === '') {
+        // machine initialized with its default context
+        this.service.send({
+          type: 'SETCONTEXT',
+          value: {
+            facility: this.session.facility_id,
+            username: this.session.username,
+            role: this.getUserKind,
+          },
+        });
+      }
+    },
+    methods: {
+      selectFacility() {
+        this.service.send({
+          type: 'SELECTFACILITY',
+          value: {
+            name: 'fac2',
+            url: 'http...',
+            id: 'ca88..',
+          },
+        });
+      },
+      goBack() {
+        this.service.send({ type: 'BACK' });
+      },
+      to_continue() {
+        this.service.send({
+          type: 'CONTINUE',
+        });
+      },
+    },
+    $trs: {
+      documentTitle: {
+        message: 'Change Facility',
+        context: 'Title of the change facility page.',
+      },
+    },
+  };
+
+</script>


### PR DESCRIPTION
## Summary
Creation of:

- New routes to support the new change facility workflow
- New state machine to control the flow and its information
- Component to show how it works and scaffold future components implementing the flow UI


![Peek 08-05-2022 10-54](https://user-images.githubusercontent.com/1008178/167289017-34dab590-dad2-4516-90cc-3d61ec383dd5.gif)

At https://stately.ai/viz/c1316a38-033d-4c57-8d9f-e282310e341d the flow can be simulated (excepting the router paths information and the `BACK` button behaviour to make it more easy to visualize)

At https://stately.ai/viz/6bbba9ea-4561-4ffd-9dc9-402dd9aa2881 the final and complete machine can be visualized and simulated.

## References
Closes: #9318 , #9319 

## Reviewer guidance
After starting kolibri, the url to test it is http://localhost:8000/en/profile/#/change_facility/
It should not be accesible if the user has not logged in.
 * Does the machine flow follow the design?
 
Note: there is one machine action, `connectToTargetKolibri`, that is not in its final implementation. Now it's an example on how to work with Promises in xstate. Current implementation just returns a fixed list of values after one second. Final implementation must connect to the device where the user is going to merge and retrieve a list of its users.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
