### PR TITLE
Unwrap API info from tuple.

### DIFF
--- a/kolibri/deployment/default/dev_urls.py
+++ b/kolibri/deployment/default/dev_urls.py
@@ -17,13 +17,11 @@ def webpack_redirect_view(request):
     )
 
 
-api_info = (
-    openapi.Info(
-        title="Kolibri API",
-        default_version="v0",
-        description="Kolibri Swagger API",
-        license=openapi.License(name="MIT"),
-    ),
+api_info = openapi.Info(
+    title="Kolibri API",
+    default_version="v0",
+    description="Kolibri Swagger API",
+    license=openapi.License(name="MIT"),
 )
 
 schema_view = get_schema_view(


### PR DESCRIPTION
## Summary
* Fixes regression from #9314 that broke the API explorer

## Reviewer guidance
Can you access the API explorer?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
