### PR TITLE
Move drive info endpoint into device app.

### DIFF
--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -156,10 +156,6 @@ export default new Resource({
     );
   },
 
-  localDrives() {
-    return this.getListEndpoint('localdrive');
-  },
-
   // TODO: switch to Model.delete()
   cancelTask(taskId) {
     return this.postListEndpoint('canceltask', {

--- a/kolibri/core/content/utils/channels.py
+++ b/kolibri/core/content/utils/channels.py
@@ -142,7 +142,7 @@ def get_channels_for_data_folder(datafolder):
 MOUNTED_DRIVES_CACHE_KEY = "mounted_drives_cache_key"
 
 
-def get_mounted_drives_with_channel_info():
+def _read_mounted_drives_with_channel_info():
     drives = enumerate_mounted_disk_partitions()
     for drive in drives.values():
         drive.metadata["channels"] = (
@@ -152,8 +152,12 @@ def get_mounted_drives_with_channel_info():
     return drives
 
 
+def get_mounted_drives_with_channel_info():
+    return _read_mounted_drives_with_channel_info().values()
+
+
 def get_mounted_drive_by_id(drive_id):
     drives = cache.get(MOUNTED_DRIVES_CACHE_KEY)
     if drives is None or drives.get(drive_id, None) is None:
-        drives = get_mounted_drives_with_channel_info()
+        drives = _read_mounted_drives_with_channel_info()
     return drives[drive_id]

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -36,6 +36,8 @@ from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.models import Collection
 from kolibri.core.content.permissions import CanManageContent
+from kolibri.core.content.utils.channels import get_mounted_drive_by_id
+from kolibri.core.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.models import DynamicNetworkLocation
@@ -356,3 +358,14 @@ class DeviceRestartView(views.APIView):
         if restarted:
             return Response(status)
         return HttpResponseBadRequest(status)
+
+
+class DriveInfoViewSet(viewsets.ViewSet):
+    permission_classes = (CanManageContent,)
+
+    def list(self, request):
+        drives = get_mounted_drives_with_channel_info()
+        return Response([mountdata._asdict() for mountdata in drives])
+
+    def retrieve(self, request, pk):
+        return Response(get_mounted_drive_by_id(pk)._asdict())

--- a/kolibri/core/device/api_urls.py
+++ b/kolibri/core/device/api_urls.py
@@ -8,6 +8,7 @@ from .api import DevicePermissionsViewSet
 from .api import DeviceProvisionView
 from .api import DeviceRestartView
 from .api import DeviceSettingsView
+from .api import DriveInfoViewSet
 from .api import FreeSpaceView
 from .api import UserSyncStatusViewSet
 
@@ -16,6 +17,7 @@ router.register(
     r"devicepermissions", DevicePermissionsViewSet, base_name="devicepermissions"
 )
 router.register(r"usersyncstatus", UserSyncStatusViewSet, base_name="usersyncstatus")
+router.register(r"driveinfo", DriveInfoViewSet, base_name="driveinfo")
 
 
 urlpatterns = [

--- a/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
@@ -1,6 +1,8 @@
 import logger from 'kolibri.lib.logging';
 import coreStore from 'kolibri.coreVue.vuex.store';
 import { TaskResource } from 'kolibri.resources';
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/fp/pick';
 import { TaskStatuses, TaskTypes } from '../../../constants';
@@ -48,7 +50,7 @@ export function refreshTaskList(store) {
 }
 
 export function refreshDriveList(store) {
-  return TaskResource.localDrives().then(({ data }) => {
+  return client({ url: urls['kolibri:core:driveinfo-list']() }).then(({ data }) => {
     store.commit('wizard/SET_DRIVE_LIST', data);
     return data;
   });

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/api.js
@@ -1,25 +1,25 @@
 import find from 'lodash/find';
 import { TaskResource, ChannelResource, RemoteChannelResource } from 'kolibri.resources';
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
 import { TaskTypes } from '../../constants';
 import { NetworkLocationResource } from '../../apiResources';
 
 function getChannelOnDrive(driveId, channelId) {
-  const reject = () => Promise.reject('CHANNEL_NOT_ON_DRIVE');
-  return TaskResource.localDrives().then(response => {
-    const drives = response.data;
-    const driveMatch = find(drives, { id: driveId });
-    if (!driveMatch) {
-      return reject();
-    }
-    const channelMatch = find(driveMatch.metadata.channels, { id: channelId });
-    if (!channelMatch) {
-      return reject();
-    }
-    return {
-      ...channelMatch,
-      driveId,
-    };
-  });
+  return client({ url: urls['kolibri:core:driveinfo-detail'](driveId) })
+    .then(({ data }) => {
+      const channelMatch = find(data.metadata.channels, { id: channelId });
+      if (!channelMatch) {
+        throw ReferenceError('CHANNEL_NOT_ON_DRIVE');
+      }
+      return {
+        ...channelMatch,
+        driveId,
+      };
+    })
+    .catch(() => {
+      return Promise.reject('CHANNEL_NOT_ON_DRIVE');
+    });
 }
 
 function getChannelOnPeer(addressId, channelId) {


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
* Moves the drive info endpoint out of the tasks/api.py
* Updates all frontend references to this

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
