### PR TITLE
Enable standard Django temporary file upload storage.

### DIFF
--- a/kolibri/deployment/default/settings/base.py
+++ b/kolibri/deployment/default/settings/base.py
@@ -39,6 +39,9 @@ except ImportError:
     pass
 
 
+if not os.path.exists(conf.KOLIBRI_HOME):
+    raise RuntimeError("The KOLIBRI_HOME dir does not exist")
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 # import kolibri, so we can get the path to the module.
 # we load other utilities related to i18n
@@ -331,6 +334,16 @@ STATIC_ROOT = os.path.join(conf.KOLIBRI_HOME, "static")
 MEDIA_URL = urljoin(path_prefix, "media/")
 MEDIA_ROOT = os.path.join(conf.KOLIBRI_HOME, "media")
 
+FILE_UPLOAD_TEMP_DIR = os.path.join(conf.KOLIBRI_HOME, "tmp")
+
+if not os.path.exists(FILE_UPLOAD_TEMP_DIR):
+    os.mkdir(FILE_UPLOAD_TEMP_DIR)
+
+
+FILE_UPLOAD_HANDLERS = [
+    "django.core.files.uploadhandler.TemporaryFileUploadHandler",
+]
+
 # https://docs.djangoproject.com/en/1.11/ref/settings/#csrf-cookie-path
 # Ensure that our CSRF cookie does not collide with other CSRF cookies
 # set by other Django apps served from the same domain.
@@ -396,8 +409,6 @@ SESSION_FILE_PATH = os.path.join(conf.KOLIBRI_HOME, "sessions")
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
 if not os.path.exists(SESSION_FILE_PATH):
-    if not os.path.exists(conf.KOLIBRI_HOME):
-        raise RuntimeError("The KOLIBRI_HOME dir does not exist")
     os.mkdir(SESSION_FILE_PATH)
 
 SESSION_COOKIE_NAME = "kolibri"


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
* Sets a directory for temporary file upload storage (see https://docs.djangoproject.com/en/1.11/ref/settings/#file-upload-temp-dir) 
* Forces all uploads to be put into temporary file storage for easy reference (https://docs.djangoproject.com/en/1.11/ref/settings/#file-upload-handlers)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
