### PR TITLE
Catch errors from overly aggressive upgrades.

### DIFF
--- a/kolibri/core/tasks/upgrade.py
+++ b/kolibri/core/tasks/upgrade.py
@@ -3,6 +3,8 @@ A file to contain specific logic to handle version upgrades in Kolibri.
 """
 import logging
 
+from sqlalchemy.exc import OperationalError
+
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.upgrade import version_upgrade
 
@@ -21,4 +23,9 @@ def drop_old_iceqube_tables():
     Rather than write a migration for the iceqube database, it is simpler to just drop the tables
     and let iceqube reinitialize the tables from scratch.
     """
-    job_storage.recreate_tables()
+    try:
+        job_storage.recreate_tables()
+    except OperationalError:
+        logger.warning(
+            "Could not recreate job storage table. This is probably because the database already exists and did not need to be recreated."
+        )


### PR DESCRIPTION
## Summary
* Catches upgrade errors when the index already exists


## References
Fixes #9353 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
