### PR TITLE
Move deviceadmin tasks into tasks.py

### DIFF
--- a/kolibri/core/deviceadmin/tasks.py
+++ b/kolibri/core/deviceadmin/tasks.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import timedelta
+
+from django import db
+from django.apps import apps
+
+from kolibri.core.tasks.decorators import register_task
+from kolibri.core.utils.lock import db_lock
+from kolibri.utils.time_utils import local_now
+
+
+logger = logging.getLogger(__name__)
+
+# Constant job_id for vacuum task
+SCH_VACUUM_JOB_ID = "1"
+
+
+@register_task(job_id=SCH_VACUUM_JOB_ID)
+def perform_vacuum(database=db.DEFAULT_DB_ALIAS, full=False):
+    connection = db.connections[database]
+    if connection.vendor == "sqlite":
+        try:
+            with db_lock():
+                db.close_old_connections()
+                db.connections.close_all()
+                cursor = connection.cursor()
+                cursor.execute("vacuum;")
+                connection.close()
+        except Exception as e:
+            logger.error(e)
+            new_msg = (
+                "Vacuum of database {db_name} couldn't be executed. Possible reasons:\n"
+                "  * There is an open transaction in the db.\n"
+                "  * There are one or more active SQL statements.\n"
+                "The full error: {error_msg}"
+            ).format(
+                db_name=db.connections[database].settings_dict["NAME"], error_msg=e
+            )
+            logger.error(new_msg)
+        else:
+            logger.info("Sqlite database Vacuum finished.")
+    elif connection.vendor == "postgresql":
+        if full:
+            morango_models = ("morango_recordmaxcounterbuffer", "morango_buffer")
+        else:
+            morango_models = [
+                m
+                for m in apps.get_models(include_auto_created=True)
+                if "morango.models" in str(m)
+            ]
+        cursor = connection.cursor()
+        for m in morango_models:
+            if full:
+                cursor.execute("vacuum full analyze {};".format(m))
+            else:
+                cursor.execute("vacuum analyze {};".format(m._meta.db_table))
+        connection.close()
+
+
+def schedule_vacuum():
+    current_dt = local_now()
+    vacuum_time = current_dt.replace(hour=3, minute=0, second=0, microsecond=0)
+    if vacuum_time < current_dt:
+        # If it is past 3AM, change the day to tomorrow.
+        vacuum_time = vacuum_time + timedelta(days=1)
+    # Repeat indefinitely
+    perform_vacuum.enqueue_at(vacuum_time, repeat=None, interval=24 * 60 * 60)

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -256,7 +256,7 @@ class ServicesPlugin(SimplePlugin):
         from kolibri.core.tasks.main import initialize_workers
         from kolibri.core.tasks.main import job_storage
         from kolibri.core.analytics.utils import DEFAULT_PING_JOB_ID
-        from kolibri.core.deviceadmin.utils import SCH_VACUUM_JOB_ID
+        from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
 
         # schedule the pingback job if not already scheduled
         if DEFAULT_PING_JOB_ID not in job_storage:
@@ -266,7 +266,7 @@ class ServicesPlugin(SimplePlugin):
 
         # schedule the vacuum job if not already scheduled
         if SCH_VACUUM_JOB_ID not in job_storage:
-            from kolibri.core.deviceadmin.utils import schedule_vacuum
+            from kolibri.core.deviceadmin.tasks import schedule_vacuum
 
             schedule_vacuum()
 


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
Moves deviceadmin tasks into tasks.py for consistency and to better manage import side effects

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
