### PR TITLE
Implement TODO to error when registry is edited after initialization.

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -395,8 +395,7 @@ def autoremove_unavailable_plugins():
     from kolibri.plugins.registry import is_initialized
 
     if is_initialized():
-        # TODO: Turn this into a Runtime error
-        logger.warning("Attempted to updated plugins when registry is initialized")
+        raise RuntimeError("Attempted to update plugins when registry is initialized")
     changed = False
     # Iterate over a copy of the set so that it is not modified during the loop
     for module_path in config["INSTALLED_PLUGINS"].copy():
@@ -423,8 +422,7 @@ def enable_new_default_plugins():
     from kolibri.plugins.registry import is_initialized
 
     if is_initialized():
-        # TODO: Turn this into a Runtime error
-        logger.warning("Attempted to updated plugins when registry is initialized")
+        raise RuntimeError("Attempted to update plugins when registry is initialized")
     changed = False
     for module_path in DEFAULT_PLUGINS:
         if module_path not in config["INSTALLED_PLUGINS"]:

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -52,6 +52,7 @@ def plugins():
     plugins.conf_file = old_config_file
 
 
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 def test_bogus_plugin_autoremove(plugins):
     """
     Checks that a plugin is auto-removed when it cannot be imported
@@ -63,6 +64,7 @@ def test_bogus_plugin_autoremove(plugins):
     assert plugin_name not in plugins.config["INSTALLED_PLUGINS"]
 
 
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 def test_bogus_plugin_autoremove_no_path(plugins):
     """
     Checks that a plugin without a dotted path is also auto-removed

--- a/kolibri/utils/tests/test_main.py
+++ b/kolibri/utils/tests/test_main.py
@@ -17,11 +17,14 @@ from kolibri.utils import main
 
 
 @pytest.mark.django_db
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 @patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value="")
 @patch("kolibri.utils.main.update")
 @patch("kolibri.core.deviceadmin.utils.dbbackup")
-def test_first_run(dbbackup, update, get_version, upgrades_after_django_setup):
+def test_first_run(
+    dbbackup, update, get_version, upgrades_after_django_setup, is_initialized
+):
     """
     Tests that the first_run() function performs as expected
     """
@@ -37,10 +40,11 @@ def test_first_run(dbbackup, update, get_version, upgrades_after_django_setup):
 
 
 @pytest.mark.django_db
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 @patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value="0.0.1")
 @patch("kolibri.utils.main.update")
-def test_update(update, get_version, upgrades_after_django_setup):
+def test_update(update, get_version, upgrades_after_django_setup, is_initialized):
     """
     Tests that update() function performs as expected
     """
@@ -49,8 +53,9 @@ def test_update(update, get_version, upgrades_after_django_setup):
 
 
 @pytest.mark.django_db
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 @patch("kolibri.utils.main.get_version", return_value="0.0.1")
-def test_update_exits_if_running(get_version):
+def test_update_exits_if_running(get_version, is_initialized):
     """
     Tests that update() function performs as expected
     """
@@ -121,12 +126,13 @@ def test_conditional_backup():
 
 
 @pytest.mark.django_db
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 @patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main.get_version", return_value=kolibri.__version__)
 @patch("kolibri.utils.main.update")
 @patch("kolibri.core.deviceadmin.utils.dbbackup")
 def test_update_no_version_change(
-    dbbackup, update, get_version, upgrades_after_django_setup
+    dbbackup, update, get_version, upgrades_after_django_setup, is_initialized
 ):
     """
     Tests that when the version doesn't change, we are not doing things we
@@ -137,11 +143,12 @@ def test_update_no_version_change(
     dbbackup.assert_not_called()
 
 
+@patch("kolibri.plugins.registry.is_initialized", return_value=False)
 @patch("kolibri.utils.main._upgrades_after_django_setup")
 @patch("kolibri.utils.main._migrate_databases")
 @patch("kolibri.utils.main.version_updated")
 def test_migrate_if_unmigrated(
-    version_updated, _migrate_databases, _upgrades_after_django_setup
+    version_updated, _migrate_databases, _upgrades_after_django_setup, is_initialized
 ):
     # No matter what, ensure that version_updated returns False
     version_updated.return_value = False


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
Cleans up an extant TODO in the codebase to properly error when the plugin registry is improperly edited during runtime

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
