### PR TITLE
Refactor TaskRegistry and Job object signature

### DIFF
--- a/kolibri/core/tasks/decorators.py
+++ b/kolibri/core/tasks/decorators.py
@@ -1,13 +1,8 @@
-import logging
 from functools import partial
 
-from kolibri.core.tasks.job import JobRegistry
+from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.job import Priority
-from kolibri.core.tasks.job import RegisteredJob
-from kolibri.core.tasks.queue import DEFAULT_QUEUE
-from kolibri.core.tasks.utils import stringify_func
-
-logger = logging.getLogger(__name__)
+from kolibri.core.tasks.registry import RegisteredTask
 
 
 def register_task(
@@ -38,7 +33,7 @@ def register_task(
             permission_classes=permission_classes,
         )
 
-    registered_job = RegisteredJob(
+    return RegisteredTask(
         func,
         job_id=job_id,
         queue=queue,
@@ -48,14 +43,3 @@ def register_task(
         track_progress=track_progress,
         permission_classes=permission_classes,
     )
-
-    func.enqueue = registered_job.enqueue
-    func.enqueue_in = registered_job.enqueue_in
-    func.enqueue_at = registered_job.enqueue_at
-
-    funcstring = stringify_func(func)
-    JobRegistry.REGISTERED_JOBS[funcstring] = registered_job
-
-    logger.debug("Successfully registered '%s' as job.", funcstring)
-
-    return func

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import sqlite3
-from importlib import import_module
 
-from django.apps import apps as django_apps
 from django.utils.functional import SimpleLazyObject
 from sqlalchemy import create_engine
 from sqlalchemy import event
@@ -141,16 +139,3 @@ def initialize_workers():
         regular_workers=conf.OPTIONS["Tasks"]["REGULAR_PRIORITY_WORKERS"],
         high_workers=conf.OPTIONS["Tasks"]["HIGH_PRIORITY_WORKERS"],
     )
-
-
-def import_tasks_module_from_django_apps(app_configs=None):
-    if app_configs is None:
-        app_configs = django_apps.get_app_configs()
-
-    logger.info("Importing 'tasks' module from django apps")
-
-    for app_config in app_configs:
-        try:
-            import_module(".tasks", app_config.module.__name__)
-        except ImportError:
-            pass

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -1,0 +1,205 @@
+import logging
+from functools import update_wrapper
+from importlib import import_module
+
+from django.apps import apps
+from django.utils.functional import SimpleLazyObject
+from rest_framework import serializers
+from six import string_types
+
+from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.job import Job
+from kolibri.core.tasks.job import Priority
+from kolibri.core.tasks.main import job_storage
+from kolibri.core.tasks.utils import stringify_func
+
+logger = logging.getLogger(__name__)
+
+
+class _registry(dict):
+    """
+    All jobs that get registered via `register_task` decorator are placed
+    in this registry.
+
+    It gets populated lazily, with jobs being imported as they are looked up.
+
+    This registry's key is the stringified form of decorated function and value
+    is an instance of `RegisteredJob`. For example,
+
+        {
+            ...
+            "kolibri.core.content.tasks.importchannel": <RegisteredJob>,
+            "kolibri.core.content.tasks.exportchannel": <RegisteredJob>,
+            ...
+        }
+    """
+
+    def __init__(self):
+        logger.debug("Importing 'tasks' module from django apps")
+
+        for app_config in apps.get_app_configs():
+            try:
+                module = import_module(".tasks", app_config.module.__name__)
+                for cls in module.__dict__.values():
+                    if isinstance(cls, RegisteredTask):
+                        self._register_task(cls)
+            except ImportError:
+                pass
+
+    def _register_task(self, registered_task):
+        funcstring = stringify_func(registered_task)
+        self[funcstring] = registered_task
+        logger.debug("Successfully registered '%s' as task.", funcstring)
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, RegisteredTask):
+            raise TypeError("Value must be an instance of RegisteredJob")
+        return super(_registry, self).__setitem__(key, value)
+
+    def update(self, other):
+        # Coerce args to a dict and then set each key in that dict
+        other = {}.update(other)
+        for key, value in other.items():
+            self[key] = value
+
+    def validate_task(self, task):
+        if not isinstance(task, string_types):
+            raise serializers.ValidationError("The 'task' value must be a string.")
+        if task not in self:
+            raise serializers.ValidationError(
+                "{} is not a registered task - is it in a tasks module of an installed app?".format(
+                    task
+                )
+            )
+        return self[task]
+
+
+TaskRegistry = SimpleLazyObject(_registry)
+
+
+class RegisteredTask(object):
+    """
+    This class acts as a transparent wrapper around the `func` argument.
+
+    For example, if `add` is registered as:
+
+        @register_task(priority=Priority.HIGH, cancellable=True)
+        def add(x, y):
+            return x + y
+
+        Then, we can enqueue `add` by calling `add.enqueue(args=(4, 2))`.
+
+        Also, we can schedule `add` by calling `add.enqueue_in(timedelta(1), args=(4, 2))`
+        or `add.enqueue_at(datetime.now(), args=(4, 2))`.
+
+        Look at each method's docstring for more info.
+    """
+
+    def __init__(
+        self,
+        func,
+        job_id=None,
+        queue=DEFAULT_QUEUE,
+        validator=None,
+        priority=Priority.REGULAR,
+        cancellable=False,
+        track_progress=False,
+        permission_classes=None,
+    ):
+        if permission_classes is None:
+            permission_classes = []
+        if validator is not None and not callable(validator):
+            raise TypeError("Can't assign validator of type {}".format(type(validator)))
+        if priority not in Priority.Priorities:
+            raise ValueError("priority must be one of '5' or '10' (integer).")
+        if not isinstance(permission_classes, list):
+            raise TypeError("permission_classes must be of list type.")
+        if not isinstance(queue, string_types):
+            raise TypeError("queue must be of string type.")
+        if not isinstance(cancellable, bool):
+            raise TypeError("cancellable must be of bool type.")
+        if not isinstance(track_progress, bool):
+            raise TypeError("track_progress must be of bool type.")
+
+        self.func = func
+        self.validator = validator
+        self.priority = priority
+        self.queue = queue
+
+        self.permissions = [perm() for perm in permission_classes]
+
+        self.job_id = job_id
+        self.cancellable = cancellable
+        self.track_progress = track_progress
+
+        # Make this wrapper object look seamlessly like the wrapped function
+        update_wrapper(self, func)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    def __repr__(self):
+        return "<RegisteredJob: {func}>".format(func=self.func)
+
+    def enqueue(self, job=None, **job_kwargs):
+        """
+        Enqueue the function with arguments passed to this method.
+
+        :return: enqueued job's id.
+        """
+        return job_storage.enqueue_job(
+            job or self._ready_job(**job_kwargs),
+            queue=self.queue,
+            priority=self.priority,
+        )
+
+    def enqueue_in(self, delta_time, interval=0, repeat=0, job=None, **job_kwargs):
+        """
+        Schedule the function to get enqueued in `delta_time` with args and
+        kwargs as its positional and keyword arguments.
+
+        Repeat of None with a specified interval means the job will repeat
+        forever at that interval.
+
+        :return: scheduled job's id.
+        """
+        return job_storage.enqueue_in(
+            delta_time,
+            job or self._ready_job(**job_kwargs),
+            queue=self.queue,
+            priority=self.priority,
+            interval=interval,
+            repeat=repeat,
+        )
+
+    def enqueue_at(self, datetime, interval=0, repeat=0, job=None, **job_kwargs):
+        """
+        Schedule the function to get enqueued at a specific `datetime` with
+        args and kwargs as its positional and keyword arguments.
+
+        Repeat of None with a specified interval means the job will repeat
+        forever at that interval.
+
+        :return: scheduled job's id.
+        """
+        return job_storage.enqueue_at(
+            datetime,
+            job or self._ready_job(**job_kwargs),
+            queue=self.queue,
+            priority=self.priority,
+            interval=interval,
+            repeat=repeat,
+        )
+
+    def _ready_job(self, **job_kwargs):
+        """
+        Returns a job object with args and kwargs as its positional and keyword arguments.
+        """
+        job_obj = Job(
+            self,
+            job_id=job_kwargs.pop("job_id", self.job_id),
+            cancellable=job_kwargs.pop("cancellable", self.cancellable),
+            track_progress=job_kwargs.pop("track_progress", self.track_progress),
+            **job_kwargs
+        )
+        return job_obj

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -18,7 +18,6 @@ from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import JobRegistry
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
 from kolibri.utils.time_utils import local_now
@@ -138,9 +137,7 @@ class Storage(object):
         job.storage = self
         return job
 
-    def enqueue_job(
-        self, func, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, args=(), kwargs=None
-    ):
+    def enqueue_job(self, job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR):
         """
         Add the job given by j to the job queue.
 
@@ -149,13 +146,11 @@ class Storage(object):
         dt = self._now()
         return self.schedule(
             dt,
-            func,
+            job,
             queue,
             priority=priority,
             interval=0,
             repeat=0,
-            args=args,
-            kwargs=kwargs,
         )
 
     def mark_job_as_canceled(self, job_id):
@@ -245,16 +240,18 @@ class Storage(object):
         Raises `JobNotRestartable` exception if the job with id = job_id state is
         not in CANCELED or FAILED.
         """
-        job_to_restart = self.get_job(job_id=job_id)
-        registered_job = JobRegistry.REGISTERED_JOBS[job_to_restart.func]
+        with self.session_scope() as session:
+            job_to_restart, orm_job = self._get_job_and_orm_job(job_id, session)
+            queue = orm_job.queue
+            priority = orm_job.priority
 
         if job_to_restart.state in [State.CANCELED, State.FAILED]:
             self.clear(job_id=job_to_restart.job_id, force=False)
-            return registered_job.enqueue(
-                *job_to_restart.args,
+            job = Job.from_job(
+                job_to_restart,
                 job_id=job_to_restart.job_id,
-                **job_to_restart.kwargs
             )
+            return self.enqueue_job(job, queue=queue, priority=priority)
         else:
             raise JobNotRestartable(
                 "Cannot restart job with state={}".format(job_to_restart.state)
@@ -409,38 +406,32 @@ class Storage(object):
     def enqueue_at(
         self,
         dt,
-        func,
+        job,
         queue=DEFAULT_QUEUE,
         priority=Priority.REGULAR,
         interval=0,
         repeat=0,
-        args=(),
-        kwargs=None,
     ):
         """
         Add the job for the specified time
         """
         return self.schedule(
             dt,
-            func,
+            job,
             queue,
             priority=priority,
             interval=interval,
             repeat=repeat,
-            args=args,
-            kwargs=kwargs,
         )
 
     def enqueue_in(
         self,
         delta_t,
-        func,
+        job,
         queue=DEFAULT_QUEUE,
         priority=Priority.REGULAR,
         interval=0,
         repeat=0,
-        args=(),
-        kwargs=None,
     ):
         """
         Add the job in the specified time delta
@@ -450,25 +441,21 @@ class Storage(object):
         dt = self._now() + delta_t
         return self.schedule(
             dt,
-            func,
+            job,
             queue=queue,
             priority=priority,
             interval=interval,
             repeat=repeat,
-            args=args,
-            kwargs=kwargs,
         )
 
     def schedule(
         self,
         dt,
-        func,
+        job,
         queue=DEFAULT_QUEUE,
         priority=Priority.REGULAR,
         interval=0,
         repeat=0,
-        args=(),
-        kwargs=None,
     ):
         """
         Add the job for the specified time, interval, and number of repeats.
@@ -483,13 +470,8 @@ class Storage(object):
             raise ValueError(
                 "Must use a timezone aware datetime object for scheduling tasks"
             )
-        if kwargs is None:
-            kwargs = {}
-        if isinstance(func, Job):
-            job = func
-        # else, turn it into a job first.
-        else:
-            job = Job(func, *args, **kwargs)
+        if not isinstance(job, Job):
+            raise ValueError("Job argument must be a Job object.")
 
         with self.session_scope() as session:
             orm_job = session.query(ORMJob).get(job.job_id)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -7,9 +7,9 @@ from mock import patch
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import JobRegistry
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
+from kolibri.core.tasks.registry import TaskRegistry
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.test.base import connection
 from kolibri.core.tasks.utils import stringify_func
@@ -33,8 +33,10 @@ def func():
     def add(x, y):
         return x + y
 
+    TaskRegistry["kolibri.core.tasks.test.taskrunner.test_storage.add"] = add
+
     yield add
-    JobRegistry.REGISTERED_JOBS.clear()
+    TaskRegistry.clear()
 
 
 @pytest.fixture

--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -36,7 +36,7 @@ def worker():
 @pytest.mark.django_db
 class TestWorker:
     def test_enqueue_job_runs_job(self, worker):
-        job = Job(id, 9)
+        job = Job(id, args=(9,))
         worker.storage.enqueue_job(job, QUEUE)
 
         while job.state != State.COMPLETED:
@@ -72,7 +72,7 @@ class TestWorker:
 
     def test_enqueue_job_writes_to_storage_on_success(self, worker):
         # this job should never fail.
-        job = Job(id, 9)
+        job = Job(id, args=(9,))
         worker.storage.enqueue_job(job, QUEUE)
 
         while job.state == State.QUEUED:
@@ -95,7 +95,7 @@ class TestWorker:
         # We have one task running right now.
         worker.future_job_mapping = {"job_id": "future"}
 
-        job = Job(id, 10)
+        job = Job(id, args=(10,))
         worker.storage.enqueue_job(job, QUEUE, Priority.REGULAR)
 
         job = worker.get_next_job()
@@ -108,7 +108,7 @@ class TestWorker:
         # We have one task running right now.
         worker.future_job_mapping = {"job_id": "future"}
 
-        job = Job(id, 10)
+        job = Job(id, args=(10,))
         worker.storage.enqueue_job(job, QUEUE, Priority.HIGH)
 
         job = worker.get_next_job()

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+from datetime import timedelta
+
 import mock
 from django.test.testcases import TestCase
 
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import Priority
-from kolibri.core.tasks.job import RegisteredJob
+from kolibri.core.tasks.registry import RegisteredTask
 
 
 class JobTest(TestCase):
@@ -48,9 +51,9 @@ class JobTest(TestCase):
             self.job.save_as_cancellable(cancellable=cancellable)
 
 
-class TestRegisteredJob(TestCase):
+class TestRegisteredTask(TestCase):
     def setUp(self):
-        self.registered_job = RegisteredJob(
+        self.registered_task = RegisteredTask(
             int,
             validator=int,
             priority=Priority.HIGH,
@@ -71,77 +74,81 @@ class TestRegisteredJob(TestCase):
         self.assertEqual(self.registered_job.cancellable, True)
         self.assertEqual(self.registered_job.track_progress, True)
 
-    @mock.patch("kolibri.core.tasks.job.Job", spec=True)
+    @mock.patch("kolibri.core.tasks.registry.Job", spec=True)
     def test__ready_job(self, MockJob):
-        result = self.registered_job._ready_job("10", base=10)
+        result = self.registered_task._ready_job(args=("10",), kwargs=dict(base=10))
 
         MockJob.assert_called_once_with(
-            int,
-            "10",  # arg that was passed to _ready_job()
+            self.registered_task,
+            args=("10",),  # arg that was passed to _ready_job()
             job_id="test",
             cancellable=True,
             track_progress=True,
-            base=10,  # kwarg that was passed to _ready_job()
+            kwargs=dict(base=10),  # kwarg that was passed to _ready_job()
         )
 
         # Do we return the job object?
         self.assertIsInstance(result, Job)
 
-    @mock.patch("kolibri.core.tasks.job.RegisteredJob._ready_job")
-    @mock.patch("kolibri.core.tasks.main.job_storage")
+    @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
+    @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue_in(self, mock_job_storage, _ready_job_mock):
         args = ("10",)
         kwargs = dict(base=10)
 
         _ready_job_mock.return_value = "job"
 
-        self.registered_job.enqueue_in(
-            delta_time="delta_time",
+        delta = timedelta(seconds=5)
+
+        self.registered_task.enqueue_in(
+            delta_time=delta,
             interval=10,
             repeat=10,
             args=args,
             kwargs=kwargs,
         )
 
-        _ready_job_mock.assert_called_once_with(*args, **kwargs)
+        _ready_job_mock.assert_called_once_with(args=args, kwargs=kwargs)
         mock_job_storage.enqueue_in.assert_called_once_with(
-            "delta_time", "job", queue="test", interval=10, priority=5, repeat=10
+            delta, "job", queue="test", interval=10, priority=5, repeat=10
         )
 
-    @mock.patch("kolibri.core.tasks.job.RegisteredJob._ready_job")
-    @mock.patch("kolibri.core.tasks.main.job_storage")
+    @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
+    @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue_at(self, mock_job_storage, _ready_job_mock):
         args = ("10",)
         kwargs = dict(base=10)
 
         _ready_job_mock.return_value = "job"
 
-        self.registered_job.enqueue_at(
-            datetime="datetime",
+        now = datetime.now()
+
+        self.registered_task.enqueue_at(
+            datetime=now,
             interval=10,
             repeat=10,
             args=args,
             kwargs=kwargs,
         )
 
-        _ready_job_mock.assert_called_once_with(*args, **kwargs)
+        _ready_job_mock.assert_called_once_with(args=args, kwargs=kwargs)
         mock_job_storage.enqueue_at.assert_called_once_with(
-            "datetime", "job", queue="test", interval=10, priority=5, repeat=10
+            now, "job", queue="test", interval=10, priority=5, repeat=10
         )
 
-    @mock.patch("kolibri.core.tasks.job.RegisteredJob._ready_job")
-    @mock.patch("kolibri.core.tasks.main.job_storage")
+    @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
+    @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue(self, job_storage_mock, _ready_job_mock):
         args = ("10",)
         kwargs = dict(base=10)
 
         _ready_job_mock.return_value = "job"
 
-        self.registered_job.enqueue(*args, **kwargs)
+        self.registered_task.enqueue(args=args, kwargs=kwargs)
 
-        _ready_job_mock.assert_called_once_with(*args, **kwargs)
+        _ready_job_mock.assert_called_once_with(args=args, kwargs=kwargs)
         job_storage_mock.enqueue_job.assert_called_once_with(
             "job",
-            queue=self.registered_job.queue,
-            priority=self.registered_job.priority,
+            queue=self.registered_task.queue,
+            priority=self.registered_task.priority,
         )

--- a/kolibri/core/tasks/test/test_no_connection.py
+++ b/kolibri/core/tasks/test/test_no_connection.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.django_db
-def test_importing_queue_no_open_connection():
-    from kolibri.core.tasks.main import queue
+def test_importing_job_storage_no_open_connection():
+    from kolibri.core.tasks.main import job_storage
 
-    queue.empty()
+    job_storage.clear(force=True)

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -21,7 +21,6 @@ from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_from_file
 from kolibri.core.deviceadmin.exceptions import IncompatibleDatabase
 from kolibri.core.deviceadmin.utils import get_backup_files
-from kolibri.core.tasks.main import import_tasks_module_from_django_apps
 from kolibri.core.upgrade import matches_version
 from kolibri.core.upgrade import run_upgrades
 from kolibri.core.utils.cache import process_cache
@@ -322,8 +321,6 @@ def initialize(
             raise
 
         _upgrades_after_django_setup(updated, version)
-
-    import_tasks_module_from_django_apps()
 
 
 def update(old_version, new_version):


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
* Turns JobRegistry and RegisteredJob into TaskRegistry and RegisteredTask to maintain the distinction between a Task and a Job
* Changes the job object signature to take explicit args and kwargs to be forwarded to the function executed
* Changes `job_facility_id` back to `facility_id` which is now distinct from any kwargs
* Updates the storage class to only accept instantiated jobs for enqueueing.
* Does a bodge update of the `Queue` class to handle these changes - this will be deleted in a follow up PR

Fixes #9313

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
