### PR TITLE
Move get_device_info into the device module.

### DIFF
--- a/kolibri/core/device/test/test_syncqueue.py
+++ b/kolibri/core/device/test/test_syncqueue.py
@@ -86,7 +86,7 @@ class TestRequestSoUDSync(TestCase):
 
     @mock.patch("kolibri.core.public.utils.queue")
     @mock.patch(
-        "kolibri.core.public.utils.get_device_setting",
+        "kolibri.core.device.utils.get_device_setting",
         return_value=True,
     )
     def test_begin_request_soud_sync(self, mock_device_info, queue):

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -6,12 +6,14 @@ circular imports.
 import json
 import logging
 import os
+import platform
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.utils import OperationalError
 from django.db.utils import ProgrammingError
 
+import kolibri
 from kolibri.core.auth.constants.facility_presets import mappings
 
 logger = logging.getLogger(__name__)
@@ -370,3 +372,64 @@ def provision_from_file(file_path):
     )
 
     remove_provisioning_file(file_path)
+
+
+device_info_keys = {
+    "1": [
+        "application",
+        "kolibri_version",
+        "instance_id",
+        "device_name",
+        "operating_system",
+    ],
+    "2": [
+        "application",
+        "kolibri_version",
+        "instance_id",
+        "device_name",
+        "operating_system",
+        "subset_of_users_device",
+    ],
+}
+
+DEVICE_INFO_VERSION = "2"
+
+
+def get_device_info(version=DEVICE_INFO_VERSION):
+    """
+    Returns metadata information about the device
+    The default kwarg version should always be the latest
+    version of device info that this function supports.
+    We maintain historic versions for backwards compatibility
+    """
+
+    if version not in device_info_keys:
+        version = DEVICE_INFO_VERSION
+
+    from morango.models import InstanceIDModel
+
+    instance_model = InstanceIDModel.get_or_create_current_instance()[0]
+    try:
+        device_name = get_device_setting("name")
+        subset_of_users_device = get_device_setting("subset_of_users_device")
+    # When Koliri starts at the first time, and device hasn't been created
+    except DeviceNotProvisioned:
+        device_name = instance_model.hostname
+        subset_of_users_device = False
+
+    all_info = {
+        "application": "kolibri",
+        "kolibri_version": kolibri.__version__,
+        "instance_id": instance_model.id,
+        "device_name": device_name,
+        "operating_system": platform.system(),
+        "subset_of_users_device": subset_of_users_device,
+    }
+
+    info = {}
+
+    # By this point, we have validated that the version is in device_info_keys
+    for key in device_info_keys.get(version, []):
+        info[key] = all_info[key]
+
+    return info

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -15,7 +15,7 @@ from zeroconf import ServiceStateChange
 from zeroconf import USE_IP_OF_OUTGOING_INTERFACE
 from zeroconf import Zeroconf
 
-from kolibri.core.public.utils import get_device_info
+from kolibri.core.device.utils import get_device_info
 
 
 SERVICE_TYPE = "Kolibri._sub._http._tcp.local."

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -37,8 +37,8 @@ class NetworkClient(object):
             )
 
     def _attempt_connections(self, urls):
-        from kolibri.core.public.utils import DEVICE_INFO_VERSION
-        from kolibri.core.public.utils import device_info_keys
+        from kolibri.core.device.utils import DEVICE_INFO_VERSION
+        from kolibri.core.device.utils import device_info_keys
 
         # try each of the URLs in turn, returning the first one that succeeds
         for url in urls:

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -21,8 +21,6 @@ from rest_framework.response import Response
 from .. import error_constants
 from .constants.user_sync_statuses import QUEUED
 from .constants.user_sync_statuses import SYNC
-from .utils import get_device_info
-from .utils import get_device_setting
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
@@ -32,6 +30,8 @@ from kolibri.core.content.utils.file_availability import generate_checksum_integ
 from kolibri.core.device.models import SyncQueue
 from kolibri.core.device.models import UserSyncStatus
 from kolibri.core.device.utils import allow_peer_unlisted_channel_import
+from kolibri.core.device.utils import get_device_info
+from kolibri.core.device.utils import get_device_setting
 from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
 from kolibri.core.public.constants.user_sync_options import HANDSHAKING_TIME
 from kolibri.core.public.constants.user_sync_options import MAX_CONCURRENT_SYNCS


### PR DESCRIPTION
## Summary
[TASK API CLEANUP]
* Moves the get_device_info function and associated constants into the device module, rather than public.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
