### PR TITLE
Push PDF pages rendering below full screen bar

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -429,6 +429,11 @@
     height: calc(100vh - #{$top-bar-height} - #{$controls-height} + 16px);
     overflow-y: hidden;
   }
+
+  .pdf-container {
+    position: relative;
+    top: $controls-height;
+  }
   .controls {
     position: relative;
     z-index: 0; // Hide icons with transition


### PR DESCRIPTION
## Summary
Updates the PDF renderer index so that the full screen bar does not cover the top of the first page of the PDF.

## References
Fixes #8745

<img width="1437" alt="Screen Shot 2022-05-16 at 9 41 01 AM" src="https://user-images.githubusercontent.com/17235236/168606927-87232467-00dd-454c-a85d-8c09100aa317.png">

## Reviewer guidance
Open a PDF in the content renderer. 

Is this spacing okay, or should there be an additional scrolling/height calculation so the page moves up when the bar disappears?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
