### PR TITLE
Remove shrink ray from TopicsPage content side panel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -666,6 +666,7 @@
       },
       sidePanelContent() {
         if (this.sidePanelContent) {
+          // Ensure the content underneath isn't scrolled - unset this when destroyed
           document.documentElement.style.position = 'fixed';
           return;
         }
@@ -674,6 +675,8 @@
     },
     beforeDestroy() {
       window.removeEventListener('scroll', this.throttledHandleScroll);
+      // Unsetting possible change in sidePanelContent watcher to avoid leaving `fixed` position
+      document.documentElement.style.position = '';
     },
     created() {
       this.translator = crossComponentTranslator(LibraryPage);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes #9347 wherein the View Resource link from the metadata side panel on the Topics page would cause the content you navigate to being shrunken and squeezed.

The issue was that in order to avoid the content underneath the side panel scrolling when scrolling within the modal side panel, we watch the value that triggers the opening of the modal. In that watcher, it sets the html.style.position to 'fixed', which remains through router navigation and caused the entire <html> tag to be smushed.

The fix was to unset it in the `beforeDestroy` hook in TopicsPage - I added some comments to explain the behavior.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9434 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to a Topics page, open a content item's side panel, click "View Resource" and see the content in the expected form.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
