### PR TITLE
Fix pagination user tables

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -214,6 +214,9 @@ class FacilityUserFilter(FilterSet):
     exclude_member_of = ModelChoiceFilter(
         method="filter_exclude_member_of", queryset=Collection.objects.all()
     )
+    exclude_coach_for = ModelChoiceFilter(
+        method="filter_exclude_coach_for", queryset=Collection.objects.all()
+    )
     exclude_user_type = ChoiceFilter(
         choices=USER_TYPE_CHOICES,
         method="filter_exclude_user_type",
@@ -231,6 +234,16 @@ class FacilityUserFilter(FilterSet):
 
     def filter_exclude_member_of(self, queryset, name, value):
         return queryset.exclude(Q(memberships__collection=value) | Q(facility=value))
+
+    def filter_exclude_coach_for(self, queryset, name, value):
+        return queryset.exclude(
+            Q(roles__in=Role.objects.filter(kind=role_kinds.COACH, collection=value))
+            | Q(
+                roles__in=Role.objects.filter(
+                    kind=role_kinds.COACH, collection_id=value.parent_id
+                )
+            )
+        )
 
     def filter_exclude_user_type(self, queryset, name, value):
         if value == "learner":

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -2,7 +2,6 @@ import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import pickBy from 'lodash/pickBy';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { ClassroomResource, FacilityUserResource } from 'kolibri.resources';
-import { UserKinds } from 'kolibri.coreVue.vuex.constants';
 import { _userState } from '../mappers';
 
 export function showLearnerClassEnrollmentPage(store, toRoute) {
@@ -15,25 +14,18 @@ export function showLearnerClassEnrollmentPage(store, toRoute) {
       page: toRoute.query.page || 1,
       page_size: toRoute.query.page_size || 30,
       exclude_member_of: id,
+      exclude_coach_for: id,
     }),
     force: true,
   });
   // current class
   const classPromise = ClassroomResource.fetchModel({ id });
-  // users in current class
-  const classUsersPromise = FacilityUserResource.fetchCollection({
-    getParams: {
-      member_of: id,
-    },
-    force: true,
-  });
 
-  return ConditionalPromise.all([userPromise, classPromise, classUsersPromise]).only(
+  return ConditionalPromise.all([userPromise, classPromise]).only(
     samePageCheckGenerator(store),
-    ([facilityUsers, classroom, classUsers]) => {
+    ([facilityUsers, classroom]) => {
       store.commit('classAssignMembers/SET_STATE', {
         facilityUsers: facilityUsers.results.map(_userState),
-        classUsers: classUsers.results,
         totalPageNumber: facilityUsers.total_pages,
         totalLearners: facilityUsers.count,
         class: classroom,
@@ -47,23 +39,20 @@ export function showLearnerClassEnrollmentPage(store, toRoute) {
   );
 }
 
-const eligibleRoles = [
-  UserKinds.ASSIGNABLE_COACH,
-  UserKinds.COACH,
-  UserKinds.ADMIN,
-  UserKinds.SUPERUSER,
-];
-
 export function showCoachClassAssignmentPage(store, toRoute) {
   const { id, facility_id } = toRoute.params;
   store.commit('CORE_SET_PAGE_LOADING', true);
   const facilityId = facility_id || store.getters.activeFacilityId;
-  // all users in facility
-  // NOTE:
-  // don't use backend pagination here, since we are filtering users with multiple eligible roles
-  // just exclude the learners to reduce the queryset size
+  // all users in facility eligible to be a coach that is not already a coach
   const userPromise = FacilityUserResource.fetchCollection({
-    getParams: { member_of: facilityId, exclude_member_of: id, exclude_user_type: 'learner' },
+    getParams: {
+      member_of: facilityId,
+      exclude_member_of: id,
+      exclude_user_type: 'learner',
+      exclude_coach_for: id,
+      page: toRoute.query.page || 1,
+      page_size: toRoute.query.page_size || 30,
+    },
     force: true,
   });
   // current class
@@ -72,17 +61,11 @@ export function showCoachClassAssignmentPage(store, toRoute) {
   return ConditionalPromise.all([userPromise, classPromise]).only(
     samePageCheckGenerator(store),
     ([facilityUsers, classroom]) => {
-      let filteredFacilityUsers = facilityUsers
-        .filter(user => {
-          // filter out users who are not eligible to be coaches
-          return user.roles.some(({ kind }) => eligibleRoles.includes(kind));
-        })
-        .map(_userState);
       store.commit('classAssignMembers/SET_STATE', {
         // facilityUsers now only contains users that are eligible for coachdom
-        // TODO rename
-        facilityUsers: filteredFacilityUsers,
-        classUsers: classroom.coaches.map(_userState),
+        facilityUsers: facilityUsers.results.map(_userState),
+        totalPageNumber: facilityUsers.total_pages,
+        totalLearners: facilityUsers.count,
         class: classroom,
         modalShown: false,
       });

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -1,4 +1,5 @@
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
+import pickBy from 'lodash/pickBy';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { ClassroomResource, FacilityUserResource } from 'kolibri.resources';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
@@ -9,12 +10,12 @@ export function showLearnerClassEnrollmentPage(store, toRoute) {
   store.dispatch('preparePage');
   // facility users that are not enrolled in this class
   const userPromise = FacilityUserResource.fetchCollection({
-    getParams: {
+    getParams: pickBy({
       member_of: facility_id || store.getters.activeFacilityId,
-      page_size: 30,
-      page: 1,
+      page: toRoute.query.page || 1,
+      page_size: toRoute.query.page_size || 30,
       exclude_member_of: id,
-    },
+    }),
     force: true,
   });
   // current class
@@ -23,8 +24,6 @@ export function showLearnerClassEnrollmentPage(store, toRoute) {
   const classUsersPromise = FacilityUserResource.fetchCollection({
     getParams: {
       member_of: id,
-      page_size: 30,
-      page: 1,
     },
     force: true,
   });
@@ -34,7 +33,7 @@ export function showLearnerClassEnrollmentPage(store, toRoute) {
     ([facilityUsers, classroom, classUsers]) => {
       store.commit('classAssignMembers/SET_STATE', {
         facilityUsers: facilityUsers.results.map(_userState),
-        classUsers: classUsers.results.map(_userState),
+        classUsers: classUsers.results,
         totalPageNumber: facilityUsers.total_pages,
         totalLearners: facilityUsers.count,
         class: classroom,

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/index.js
@@ -4,7 +4,6 @@ import { assignCoachesToClass, enrollLearnersInClass } from './actions';
 function defaultState() {
   return {
     class: {},
-    classUsers: [],
     facilityUsers: [],
     modalShown: false,
   };

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -34,7 +34,6 @@
 <script>
 
   import pickBy from 'lodash/pickBy';
-  import differenceWith from 'lodash/differenceWith';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import PaginatedListContainerWithBackend from './PaginatedListContainerWithBackend';
@@ -58,11 +57,6 @@
         type: String,
         required: true,
       },
-      classUsers: {
-        type: Array,
-        required: false,
-        default: () => [],
-      },
       disabled: {
         type: Boolean,
         default: false,
@@ -85,7 +79,7 @@
     },
     computed: {
       usersNotInClass() {
-        return differenceWith(this.facilityUsers, this.classUsers, (a, b) => a.id === b.id);
+        return this.facilityUsers;
       },
       totalPages() {
         return this.totalPageNumber;

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -5,7 +5,8 @@
     <p>{{ $tr('pageSubheader') }}</p>
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
-      :classUsers="classUsers"
+      :totalPageNumber="totalPageNumber"
+      :totalUsers="totalLearners"
       pageType="coaches"
       :disabled="formIsDisabled"
       @submit="assignCoaches"
@@ -38,7 +39,12 @@
       };
     },
     computed: {
-      ...mapState('classAssignMembers', ['class', 'classUsers', 'facilityUsers']),
+      ...mapState('classAssignMembers', [
+        'class',
+        'facilityUsers',
+        'totalLearners',
+        'totalPageNumber',
+      ]),
       className() {
         return this.class.name;
       },

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -5,9 +5,7 @@
     <p>{{ $tr('pageSubheader') }}</p>
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
-      :classUsers="classLearners"
       :disabled="formIsDisabled"
-      :classId="classId"
       :totalPageNumber="totalPageNumber"
       :totalUsers="totalLearners"
       pageType="learners"
@@ -43,16 +41,12 @@
     computed: {
       ...mapState('classAssignMembers', [
         'class',
-        'classLearners',
         'facilityUsers',
         'totalLearners',
         'totalPageNumber',
       ]),
       className() {
         return this.class.name;
-      },
-      classId() {
-        return this.class.id;
       },
     },
     methods: {

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -5,12 +5,11 @@
     <p>{{ $tr('pageSubheader') }}</p>
     <ClassEnrollForm
       :facilityUsers="facilityUsers"
-      :classUsers="classUsers"
+      :classUsers="classLearners"
       :disabled="formIsDisabled"
       :classId="classId"
       :totalPageNumber="totalPageNumber"
       :totalUsers="totalLearners"
-      :isBackendPaginated="true"
       pageType="learners"
       @submit="enrollLearners"
     />
@@ -44,10 +43,10 @@
     computed: {
       ...mapState('classAssignMembers', [
         'class',
+        'classLearners',
         'facilityUsers',
-        'classUsers',
-        'totalPageNumber',
         'totalLearners',
+        'totalPageNumber',
       ]),
       className() {
         return this.class.name;


### PR DESCRIPTION
## Summary
Updates `handler.js` for the class enrollment user management, and simplifies the vue components to better match the updates in the FacilityUsers page. Now learners should be accurately displaying in the user table for enrollment in a class.


## References
Fixes #9448
![learners](https://user-images.githubusercontent.com/17235236/169159219-599b16da-845e-44b1-8016-1163617e7946.gif)


## Reviewer guidance

Is the pagination working as expected with > 30 users? 

Also... am I supposed to be filtering out anyone not exclusively a learner? Truly cannot remember.... I think coaches and admins can still be added to classes

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
