### PR TITLE
Restrict exclude coach for to assigned coaches only.

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -238,11 +238,6 @@ class FacilityUserFilter(FilterSet):
     def filter_exclude_coach_for(self, queryset, name, value):
         return queryset.exclude(
             Q(roles__in=Role.objects.filter(kind=role_kinds.COACH, collection=value))
-            | Q(
-                roles__in=Role.objects.filter(
-                    kind=role_kinds.COACH, collection_id=value.parent_id
-                )
-            )
         )
 
     def filter_exclude_user_type(self, queryset, name, value):


### PR DESCRIPTION
## Summary
Fixes regression that excluded Facility coaches from the assigned coaches list

## Reviewer guidance
Ensure that a facility coach shows up in the list of coaches assignable to a class when they are not already assigned as a coach to that class.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
