### PR TITLE
Creation of remote users if needed

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -58,6 +58,23 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
     ],
 )
 def mergeuser(command, **kwargs):
+    """
+    This is an example of the POST payload to create this task:
+    {
+        "type": "kolibri.plugins.user_profile.tasks.mergeuser",
+        "baseurl": "http://192.168.0.201:80/",
+        "facility": "41d0e8bb1600347f17ab3d9172fff87a",
+        "username": "uno",
+        "local_user_id": "05685392311d1d259fe01c65c7a6c28e"
+    }
+    being baseurl, facility and username all parameters of the remote server.
+    If the remote server requires password to authenticate user,
+    a "password" parameter must be added, otherwise it's not needed.
+
+    If the username/password does not exist in the remote server,
+    this task will try to create the user.
+    """
+
     local_user_id = kwargs.pop("local_user_id")
     local_user = FacilityUser.objects.get(id=local_user_id)
     call_command(command, **kwargs)

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -1,10 +1,15 @@
+from urllib.parse import urljoin
+
+import requests
 from django.core.management import call_command
+from django.core.urlresolvers import reverse
 from rest_framework import serializers
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.status import HTTP_201_CREATED
 
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.tasks import PeerImportSingleSyncJobValidator
 from kolibri.core.auth.utils.migrate import merge_users
-from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.permissions import IsFacilityAdmin
@@ -14,17 +19,32 @@ from kolibri.core.tasks.permissions import PermissionsFromAny
 
 
 class MergeUserValidator(PeerImportSingleSyncJobValidator):
-    local_user_id = HexOnlyUUIDField()
+    local_user_id = serializers.PrimaryKeyRelatedField(
+        queryset=FacilityUser.objects.all()
+    )
 
     def validate(self, data):
-        job_data = super(MergeUserValidator, self).validate(data)
-        local_user_id = data["local_user_id"]
-        if not FacilityUser.objects.filter(id=local_user_id).exists():
-            raise serializers.ValidationError(
-                "An user with the given id does not exist in this facility"
-            )
-        job_data["kwargs"]["local_user_id"] = local_user_id
+        try:
+            job_data = super(MergeUserValidator, self).validate(data)
+        except AuthenticationFailed:
+            self.create_remote_user(data)
+            job_data = super(MergeUserValidator, self).validate(data)
+
+        job_data["kwargs"]["local_user_id"] = data["local_user_id"].id
         return job_data
+
+    def create_remote_user(self, data):
+        baseurl = data["baseurl"]
+        facility = data["facility"]
+        user_data = {
+            "username": data["username"],
+            "password": data["password"],
+            "facility": facility,
+        }
+        public_signup_url = urljoin(baseurl, reverse("kolibri:core:publicsignup-list"))
+        response = requests.post(public_signup_url, data=user_data)
+        if response.status_code != HTTP_201_CREATED:
+            raise serializers.ValidationError(response.json()[0]["id"])
 
 
 @register_task(


### PR DESCRIPTION
## Summary
Creation of asyncronous task to merge current user into an existing facility user on a remote server. 
If remote server credentials are provided, the user will be created in the remote server.

The steps this task do are:

1. When accesing to the remote server to fetch the user data, if the user does not exist there, it creates it.
2. Do a single user sync from the server to the local device (initiated by the local device)
3. Merge the existing user from the local device into the single user synced user
4. Resync with the server to update the merged records
5. Delete the existing user from the local device

## References
Closes: #9355 

## Reviewer guidance
In developer mode, using http://localhost:8000/api_explorer/# a `POST` to the `/api/tasks/tasks` endpoint can be done
This is an example of payload to use it:
```
{
    "type": "kolibri.plugins.user_profile.tasks.mergeuser",
    "baseurl": "http://192.168.0.201:80/",
    "facility": "41d0e8bb1600347f17ab3d9172fff87a",
    "username": "unonuevo",
    "local_user_id": "05685392311d1d259fe01c65c7a6c28e"
}
```
being `facility` and `username` data of the remote server. If the remote server requires password to authenticate user, a "password" parameter must be added, otherwise it's not needed

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
