### PR TITLE
Fix tests to not fail when run from non "en" terminals.

### DIFF
--- a/kolibri/core/test/test_setlanguage.py
+++ b/kolibri/core/test/test_setlanguage.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.http import HttpResponseNotAllowed
+from django.test import override_settings
 from django.test import TestCase
 from django.urls import reverse
 from django.urls import translate_url
@@ -7,6 +8,7 @@ from django.utils.translation import get_language
 from django.utils.translation import LANGUAGE_SESSION_KEY
 
 
+@override_settings(LANGUAGE_CODE="en")
 class I18NTests(TestCase):
     """
     Tests set_language view in kolibri/core/views.py


### PR DESCRIPTION
## Summary
* Fixes tests that assume an "en" `LANGUAGE_CODE` to explicitly set that with `override_settings`

## Reviewer guidance
I ran tests with this: `LOCALE=es_ES.UTF-8 LANG=es_ES.UTF-8 pytest` to confirm that tests were working properly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
