### PR TITLE
Generate a content manifest file with exportcontent

### DIFF
--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -5,7 +5,10 @@ from django.core.management.base import CommandError
 
 from ...utils import paths
 from kolibri.core.content.errors import InvalidStorageFilenameError
-from kolibri.core.content.utils.import_export_content import get_import_export_data
+from kolibri.core.content.utils.import_export_content import get_content_nodes_data
+from kolibri.core.content.utils.import_export_content import get_content_nodes_selectors
+from kolibri.core.content.utils.import_export_content import get_import_export_nodes
+from kolibri.core.content.utils.import_export_content import update_content_manifest
 from kolibri.core.content.utils.paths import get_content_file_name
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
@@ -76,11 +79,13 @@ class Command(AsyncCommand):
             "Exporting content for channel id {} to {}".format(channel_id, data_dir)
         )
 
-        (
-            total_resource_count,
-            files,
-            total_bytes_to_transfer,
-        ) = get_import_export_data(channel_id, node_ids, exclude_node_ids, True)
+        nodes_queries_list = get_import_export_nodes(
+            channel_id, node_ids, exclude_node_ids, available=True
+        )
+
+        (total_resource_count, files, total_bytes_to_transfer) = get_content_nodes_data(
+            channel_id, nodes_queries_list, available=True
+        )
 
         self.update_job_metadata(total_bytes_to_transfer, total_resource_count)
 
@@ -100,6 +105,14 @@ class Command(AsyncCommand):
 
             if self.is_cancelled():
                 self.cancel()
+
+        logger.info(
+            "Exporting manifest for channel id {} to {}".format(channel_id, data_dir)
+        )
+
+        nodes_selectors = get_content_nodes_selectors(channel_id, nodes_queries_list)
+        manifest_file = os.path.join(data_dir, "content", "manifest.json")
+        update_content_manifest(manifest_file, nodes_selectors)
 
     def export_file(self, f, data_dir, overall_progress_update):
         filename = get_content_file_name(f)

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -34,8 +34,8 @@ class Command(AsyncCommand):
             "--node_ids",
             "-n",
             # Split the comma separated string we get, into a list of strings
-            type=lambda x: x.split(","),
-            default=[],
+            type=lambda x: x.split(",") if x else [],
+            default=None,
             required=False,
             dest="node_ids",
             help=node_ids_help_text,
@@ -51,8 +51,8 @@ class Command(AsyncCommand):
         """
         parser.add_argument(
             "--exclude_node_ids",
-            type=lambda x: x.split(","),
-            default=[],
+            type=lambda x: x.split(",") if x else [],
+            default=None,
             required=False,
             dest="exclude_node_ids",
             help=exclude_node_ids_help_text,

--- a/kolibri/core/content/test/test_content_manifest.py
+++ b/kolibri/core/content/test/test_content_manifest.py
@@ -1,0 +1,241 @@
+import tempfile
+
+from django.test import TestCase
+from le_utils.constants import content_kinds
+from mock import patch
+
+from kolibri.core.content.models import ContentNode
+from kolibri.core.content.utils.content_manifest import ContentManifest
+from kolibri.core.content.utils.content_manifest import get_content_nodes_selectors
+from kolibri.utils.tests.helpers import override_option
+
+
+@override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
+class ContentManifestTestCase(TestCase):
+    """
+    Test case for utils.content_manifest.ContentManifest
+    """
+
+    fixtures = ["content_test.json"]
+    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+    the_channel_version = 0
+
+    c1_node_id = "32a941fb77c2576e8f6b294cde4c3b0c"
+    c2_node_id = "2e8bac07947855369fe2d77642dfc870"
+
+    def setUp(self):
+        self.content_manifest = ContentManifest()
+
+    def test_empty(self):
+        self.assertCountEqual(self.content_manifest.get_channel_ids(), [])
+
+        self.assertCountEqual(
+            self.content_manifest.get_channel_versions(self.the_channel_id), []
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_include_node_ids(
+                self.the_channel_id, self.the_channel_version
+            ),
+            [],
+        )
+
+    @patch("kolibri.core.content.utils.content_manifest.get_content_nodes_selectors")
+    def test_add_content_nodes_1(self, get_content_nodes_selectors_mock):
+        get_content_nodes_selectors_mock.return_value = [self.c1_node_id]
+        self.content_manifest.add_content_nodes(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_channel_ids(), [self.the_channel_id]
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_channel_versions(self.the_channel_id),
+            [self.the_channel_version],
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_include_node_ids(
+                self.the_channel_id, self.the_channel_version
+            ),
+            [self.c1_node_id],
+        )
+
+    @patch("kolibri.core.content.utils.content_manifest.get_content_nodes_selectors")
+    def test_add_content_nodes_with_duplicates(self, get_content_nodes_selectors_mock):
+        get_content_nodes_selectors_mock.return_value = [self.c1_node_id]
+        self.content_manifest.add_content_nodes(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        get_content_nodes_selectors_mock.return_value = [self.c1_node_id]
+        self.content_manifest.add_content_nodes(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_include_node_ids(
+                self.the_channel_id, self.the_channel_version
+            ),
+            [self.c1_node_id],
+        )
+
+    def test_read_dict(self):
+        self.content_manifest.read_dict(
+            {
+                "channels": [
+                    {
+                        "id": self.the_channel_id,
+                        "version": self.the_channel_version,
+                        "include_node_ids": [self.c1_node_id],
+                    }
+                ],
+                "channel_list_hash": "dcba190e9d79f20e4fbcc3890fe9b4fd",
+            }
+        )
+
+        self.assertCountEqual(
+            self.content_manifest.get_include_node_ids(
+                self.the_channel_id, self.the_channel_version
+            ),
+            [self.c1_node_id],
+        )
+
+    def test_to_dict_with_no_content_nodes(self):
+        self.assertEqual(
+            self.content_manifest.to_dict(),
+            {"channels": [], "channel_list_hash": "d751713988987e9331980363e24189ce"},
+        )
+
+    @patch("kolibri.core.content.utils.content_manifest.get_content_nodes_selectors")
+    def test_to_dict_with_one_content_node(self, get_content_nodes_selectors_mock):
+        get_content_nodes_selectors_mock.return_value = [self.c1_node_id]
+        self.content_manifest.add_content_nodes(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        self.assertEqual(
+            self.content_manifest.to_dict(),
+            {
+                "channels": [
+                    {
+                        "id": self.the_channel_id,
+                        "version": self.the_channel_version,
+                        "include_node_ids": [self.c1_node_id],
+                    }
+                ],
+                "channel_list_hash": "dcba190e9d79f20e4fbcc3890fe9b4fd",
+            },
+        )
+
+    @patch("kolibri.core.content.utils.content_manifest.get_content_nodes_selectors")
+    def test_update_existing_manifest(self, get_content_nodes_selectors_mock):
+        self.content_manifest.read_dict(
+            {
+                "channels": [
+                    {
+                        "id": self.the_channel_id,
+                        "version": self.the_channel_version,
+                        "include_node_ids": [self.c1_node_id],
+                    }
+                ],
+                "channel_list_hash": "dcba190e9d79f20e4fbcc3890fe9b4fd",
+            }
+        )
+
+        get_content_nodes_selectors_mock.return_value = [self.c2_node_id]
+        self.content_manifest.add_content_nodes(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        self.assertEqual(
+            self.content_manifest.to_dict(),
+            {
+                "channels": [
+                    {
+                        "id": self.the_channel_id,
+                        "version": self.the_channel_version,
+                        "include_node_ids": [self.c2_node_id, self.c1_node_id],
+                    }
+                ],
+                "channel_list_hash": "8adc9c51281efc80cfa02cc65a5d5417",
+            },
+        )
+
+
+@override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
+class GetContentNodesSelectorsTestCase(TestCase):
+    """
+    Test case for utils.content_manifest.get_content_nodes_selectors
+    """
+
+    fixtures = ["content_test.json"]
+    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+    the_channel_version = 0
+
+    root_node_id = "da7ecc42e62553eebc8121242746e88a"
+    c2_node_id = "2e8bac07947855369fe2d77642dfc870"
+    c2c1_node_id = "2b6926ed22025518a8b9da91745b51d3"
+    c2c2_node_id = "4d0c890de9b65d6880ccfa527800e0f4"
+    c2c3_node_id = "b391bfeec8a458f89f013cf1ca9cf33a"
+    c3_node_id = "c391bfeec8a458f89f013cf1ca9cf33b"
+    c3copy_node_id = "c391bfeec8a458f89f013cf1ca9cf33b"
+
+    def test_with_empty_selection(self):
+        selectors = get_content_nodes_selectors(
+            self.the_channel_id, self.the_channel_version, []
+        )
+
+        self.assertCountEqual(
+            selectors,
+            set(),
+        )
+
+    def test_with_complete_selection(self):
+        selected_content_nodes = ContentNode.objects.filter(
+            channel_id=self.the_channel_id
+        ).exclude(kind=content_kinds.TOPIC)
+
+        selectors = get_content_nodes_selectors(
+            self.the_channel_id, self.the_channel_version, [selected_content_nodes]
+        )
+
+        self.assertCountEqual(
+            selectors,
+            {self.root_node_id},
+        )
+
+    def test_with_specific_leaf_nodes(self):
+        selected_pks_list = [self.c2c1_node_id, self.c2c2_node_id]
+
+        selected_content_nodes = ContentNode.objects.filter(
+            channel_id=self.the_channel_id, pk__in=selected_pks_list
+        ).exclude(kind=content_kinds.TOPIC)
+
+        selectors = get_content_nodes_selectors(
+            self.the_channel_id, self.the_channel_version, [selected_content_nodes]
+        )
+
+        self.assertCountEqual(
+            selectors,
+            {self.c2c1_node_id, self.c2c2_node_id},
+        )
+
+    def test_with_entire_topic_1(self):
+        # Select all non-topic nodes that are descendents of "c2"
+        selected_pks_list = [self.c2c1_node_id, self.c2c2_node_id, self.c2c3_node_id]
+
+        selected_content_nodes = ContentNode.objects.filter(
+            channel_id=self.the_channel_id, pk__in=selected_pks_list
+        ).exclude(kind=content_kinds.TOPIC)
+
+        selectors = get_content_nodes_selectors(
+            self.the_channel_id, self.the_channel_version, [selected_content_nodes]
+        )
+
+        self.assertCountEqual(
+            selectors,
+            {self.c2_node_id},
+        )

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1275,7 +1275,9 @@ class ExportChannelTestCase(TestCase):
 
 
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
-@patch("kolibri.core.content.management.commands.exportcontent.get_import_export_data")
+@patch("kolibri.core.content.management.commands.exportcontent.get_import_export_nodes")
+@patch("kolibri.core.content.management.commands.exportcontent.get_content_nodes_data")
+@patch("kolibri.core.content.management.commands.exportcontent.update_content_manifest")
 class ExportContentTestCase(TestCase):
     """
     Test case for the exportcontent management command.
@@ -1295,11 +1297,13 @@ class ExportContentTestCase(TestCase):
         is_cancelled_mock,
         cancel_mock,
         FileCopyMock,
-        get_import_export_mock,
+        update_content_manifest_mock,
+        get_content_nodes_data_mock,
+        get_import_export_nodes_mock,
     ):
         # If cancel comes in before we do anything, make sure nothing happens!
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (
+        get_content_nodes_data_mock.return_value = (
             1,
             [LocalFile.objects.values("id", "file_size", "extension").first()],
             10,
@@ -1328,7 +1332,9 @@ class ExportContentTestCase(TestCase):
         FileCopyMock,
         local_path_mock,
         start_progress_mock,
-        get_import_export_mock,
+        update_content_manifest_mock,
+        get_content_nodes_data_mock,
+        get_import_export_nodes_mock,
     ):
         # Make sure we cancel during transfer
         fd1, local_dest_path = tempfile.mkstemp()
@@ -1337,7 +1343,7 @@ class ExportContentTestCase(TestCase):
         os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
         FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
-        get_import_export_mock.return_value = (
+        get_content_nodes_data_mock.return_value = (
             1,
             [LocalFile.objects.values("id", "file_size", "extension").first()],
             10,

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -28,7 +28,6 @@ from kolibri.core.content.utils.content_types_tools import (
     renderable_contentnodes_q_filter,
 )
 from kolibri.core.content.utils.import_export_content import get_content_nodes_data
-from kolibri.core.content.utils.import_export_content import get_content_nodes_selectors
 from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.import_export_content import get_import_export_nodes
 from kolibri.utils.file_transfer import Transfer
@@ -178,7 +177,7 @@ class GetImportExportNodesTestCase(TestCase):
         )
 
     def test_with_node_ids_equals_exclude_node_ids(self):
-        expected_content_nodes = list()
+        expected_content_nodes = []
 
         matched_nodes_queries_list = get_import_export_nodes(
             self.the_channel_id,
@@ -213,7 +212,7 @@ class GetImportExportNodesTestCase(TestCase):
         )
 
     def test_with_node_ids_empty(self):
-        expected_content_nodes = list()
+        expected_content_nodes = []
 
         matched_nodes_queries_list = get_import_export_nodes(
             self.the_channel_id,
@@ -324,99 +323,6 @@ class GetContentNodesDataTestCase(TestCase):
         self.assertEqual(total_resource_count, 2)
         self.assertCountEqual(files, expected_files_list)
         self.assertEqual(total_bytes_to_transfer, 0)
-
-
-@override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
-class GetContentNodesSelectorsTestCase(TestCase):
-    """
-    Test case for utils.import_export_content.get_content_nodes_selectors
-    """
-
-    fixtures = ["content_test.json"]
-    the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
-
-    root_node_id = "da7ecc42e62553eebc8121242746e88a"
-    c2_node_id = "2e8bac07947855369fe2d77642dfc870"
-    c2c1_node_id = "2b6926ed22025518a8b9da91745b51d3"
-    c2c2_node_id = "4d0c890de9b65d6880ccfa527800e0f4"
-    c2c3_node_id = "b391bfeec8a458f89f013cf1ca9cf33a"
-    c3_node_id = "c391bfeec8a458f89f013cf1ca9cf33b"
-    c3copy_node_id = "c391bfeec8a458f89f013cf1ca9cf33b"
-
-    def test_with_empty_selection(self):
-        selectors = get_content_nodes_selectors(self.the_channel_id, [])
-
-        self.assertEqual(
-            selectors,
-            {
-                "id": self.the_channel_id,
-                "version": 0,
-                "include_node_ids": [],
-                "exclude_node_ids": [],
-            },
-        )
-
-    def test_with_complete_selection(self):
-        selected_content_nodes = ContentNode.objects.filter(
-            channel_id=self.the_channel_id
-        ).exclude(kind=content_kinds.TOPIC)
-
-        selectors = get_content_nodes_selectors(
-            self.the_channel_id, [selected_content_nodes]
-        )
-
-        self.assertEqual(
-            selectors,
-            {
-                "id": self.the_channel_id,
-                "version": 0,
-                "include_node_ids": [self.root_node_id],
-                "exclude_node_ids": [],
-            },
-        )
-
-    def test_with_specific_leaf_nodes(self):
-        selected_pks_list = [self.c2c1_node_id, self.c2c2_node_id]
-
-        selected_content_nodes = ContentNode.objects.filter(
-            channel_id=self.the_channel_id, pk__in=selected_pks_list
-        ).exclude(kind=content_kinds.TOPIC)
-
-        selectors = get_content_nodes_selectors(
-            self.the_channel_id, [selected_content_nodes]
-        )
-
-        self.assertEqual(
-            selectors,
-            {
-                "id": self.the_channel_id,
-                "version": 0,
-                "include_node_ids": [self.c2c1_node_id, self.c2c2_node_id],
-                "exclude_node_ids": [],
-            },
-        )
-
-    def test_with_entire_topic_1(self):
-        # Select all non-topic nodes that are descendents of "c2"
-        selected_pks_list = [self.c2c1_node_id, self.c2c2_node_id, self.c2c3_node_id]
-
-        selected_content_nodes = ContentNode.objects.filter(
-            channel_id=self.the_channel_id, pk__in=selected_pks_list
-        ).exclude(kind=content_kinds.TOPIC)
-
-        selectors = get_content_nodes_selectors(
-            self.the_channel_id, [selected_content_nodes]
-        )
-
-        self.assertEqual(
-            selectors,
-            {
-                "id": self.the_channel_id,
-                "version": 0,
-                "include_node_ids": [self.c2_node_id],
-                "exclude_node_ids": [],
-            },
-        )
 
 
 @patch(
@@ -1643,7 +1549,7 @@ class ExportChannelTestCase(TestCase):
 @override_option("Paths", "CONTENT_DIR", tempfile.mkdtemp())
 @patch("kolibri.core.content.management.commands.exportcontent.get_import_export_nodes")
 @patch("kolibri.core.content.management.commands.exportcontent.get_content_nodes_data")
-@patch("kolibri.core.content.management.commands.exportcontent.update_content_manifest")
+@patch("kolibri.core.content.management.commands.exportcontent.ContentManifest")
 class ExportContentTestCase(TestCase):
     """
     Test case for the exportcontent management command.
@@ -1663,7 +1569,7 @@ class ExportContentTestCase(TestCase):
         is_cancelled_mock,
         cancel_mock,
         FileCopyMock,
-        update_content_manifest_mock,
+        ContentManifestMock,
         get_content_nodes_data_mock,
         get_import_export_nodes_mock,
     ):
@@ -1698,7 +1604,7 @@ class ExportContentTestCase(TestCase):
         FileCopyMock,
         local_path_mock,
         start_progress_mock,
-        update_content_manifest_mock,
+        ContentManifestMock,
         get_content_nodes_data_mock,
         get_import_export_nodes_mock,
     ):

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -1,0 +1,195 @@
+import hashlib
+import itertools
+import json
+import os
+from collections import namedtuple
+
+from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentNode
+
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+
+ContentManifestChannelData = namedtuple(
+    "ContentManifestChannelData", ["channel_id", "channel_version", "include_node_ids"]
+)
+
+
+class ContentManifestParseError(ValueError):
+    pass
+
+
+class ContentManifest(object):
+    """
+    A content manifest describes a selection of Kolibri content across
+    multiple channels. It is usually stored as a JSON file along with exported
+    content. It contains a list of channels, with their versions, and a list
+    of node IDs associated with each channel ID + version.
+
+    When adding content to the manifest, this implementation optimizes the list
+    of node IDs to contain the smallest possible number of topic nodes, instead
+    of every included node. When nodes are added to a channel ID and version
+    that is already in the content manifest, those nodes will be added to the
+    existing list.
+    """
+
+    def __init__(self):
+        self._channels_dict = {}
+
+    def read(self, filenames):
+        if not isinstance(filenames, list):
+            filenames = [filenames]
+
+        files_read = []
+
+        for filename in filenames:
+            try:
+                with open(filename, "r") as fp:
+                    self.read_file(fp)
+            except FileNotFoundError:
+                pass
+            else:
+                files_read.append(filename)
+
+        return files_read
+
+    def read_file(self, fp):
+        json_str = fp.read()
+        if not json_str:
+            return
+        # Raises JSONDecodeError if the file is invalid
+        manifest_data = json.loads(json_str)
+        self.read_dict(manifest_data)
+
+    def read_dict(self, manifest_data):
+        for channel_data in manifest_data.get("channels", []):
+            channel_id = channel_data.get("id", None)
+            channel_version = channel_data.get("version", None)
+            include_node_ids = channel_data.get("include_node_ids", [])
+            if channel_id is None or channel_version is None:
+                raise ContentManifestParseError("id and version are required fields")
+            self._update_channel_data(channel_id, channel_version, include_node_ids)
+
+    def write(self, path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as fp:
+            self.write_file(fp)
+
+    def write_file(self, fp):
+        json.dump(self.to_dict(), fp, indent=4)
+
+    def to_dict(self):
+        channels_list = list(self._iter_channel_dicts())
+        return {
+            "channels": channels_list,
+            "channel_list_hash": hashlib.md5(
+                json.dumps(channels_list, sort_keys=True).encode()
+            ).hexdigest(),
+        }
+
+    def _iter_channel_dicts(self):
+        for channel_data in self._iter_channel_data():
+            yield {
+                "id": channel_data.channel_id,
+                "version": channel_data.channel_version,
+                "include_node_ids": sorted(channel_data.include_node_ids),
+            }
+
+    def _iter_channel_data(self):
+        for channel_id in self.get_channel_ids():
+            for channel_version in self.get_channel_versions(channel_id):
+                yield self.get_channel_data(channel_id, channel_version)
+
+    def get_channel_ids(self):
+        return self._channels_dict.keys()
+
+    def get_channel_versions(self, channel_id):
+        return self._channels_dict.get(channel_id, {}).keys()
+
+    def get_channel_data(self, channel_id, channel_version):
+        channel_data = self._channels_dict.get(channel_id, {}).get(
+            channel_version, None
+        )
+        if channel_data is None:
+            channel_data = ContentManifestChannelData(None, None, set())
+        return channel_data
+
+    def get_include_node_ids(self, channel_id, channel_version):
+        channel_data = self.get_channel_data(channel_id, channel_version)
+        return channel_data.include_node_ids
+
+    def add_content_nodes(self, channel_id, channel_version, nodes_queries_list):
+        include_node_ids = get_content_nodes_selectors(
+            channel_id, channel_version, nodes_queries_list
+        )
+        self._update_channel_data(channel_id, channel_version, include_node_ids)
+
+    def _update_channel_data(self, channel_id, channel_version, include_node_ids):
+        old_include_node_ids = self.get_include_node_ids(channel_id, channel_version)
+        channel_data = ContentManifestChannelData(
+            channel_id,
+            channel_version,
+            set(old_include_node_ids) | set(include_node_ids),
+        )
+        self._set_channel_data(channel_data)
+
+    def _set_channel_data(self, channel_data):
+        assert isinstance(channel_data, ContentManifestChannelData)
+        self._channels_dict.setdefault(channel_data.channel_id, {})[
+            channel_data.channel_version
+        ] = channel_data
+
+
+def get_content_nodes_selectors(channel_id, channel_version, nodes_queries_list):
+    """
+    Returns a set of include_node_ids that can be used with the given
+    channel_id to import only the nodes contained in nodes_queries_list.
+    """
+
+    include_node_ids = set()
+
+    channel_metadata = ChannelMetadata.objects.get(
+        id=channel_id, version=channel_version
+    )
+
+    available_node_ids = set(
+        itertools.chain.from_iterable(
+            nodes_query.values_list("id", flat=True)
+            for nodes_query in nodes_queries_list
+        )
+    )
+
+    available_nodes_queue = [channel_metadata.root]
+
+    while len(available_nodes_queue) > 0:
+        node = available_nodes_queue.pop(0)
+
+        # We could add nodes to exclude_node_ids when less than half of the
+        # sibling nodes are missing. However, it is unclear if this would
+        # be useful.
+
+        if node.kind == "topic":
+            leaf_node_ids = _get_leaf_node_ids(node)
+            matching_leaf_nodes = leaf_node_ids.intersection(available_node_ids)
+            missing_leaf_nodes = leaf_node_ids.difference(available_node_ids)
+            if len(missing_leaf_nodes) == 0:
+                include_node_ids.add(node.id)
+            elif len(matching_leaf_nodes) > 0:
+                available_nodes_queue.extend(node.children.all())
+        elif node.id in available_node_ids:
+            include_node_ids.add(node.id)
+
+    return include_node_ids
+
+
+def _get_leaf_node_ids(node):
+    return set(
+        ContentNode.objects.filter(
+            lft__gte=node.lft, lft__lte=node.rght, channel_id=node.channel_id
+        )
+        .exclude(kind="topic")
+        .values_list("id", flat=True)
+    )

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -235,7 +235,7 @@ def get_content_nodes_selectors(channel_id, channel_version, nodes_queries_list)
             if len(missing_leaf_nodes) == 0:
                 include_node_ids.add(node.id)
             elif len(matching_leaf_nodes) > 0:
-                available_nodes_queue.extend(node.children.all())
+                available_nodes_queue.extend(node.children.filter(available=True))
         elif node.id in available_node_ids:
             include_node_ids.add(node.id)
 

--- a/kolibri/core/content/utils/content_manifest.py
+++ b/kolibri/core/content/utils/content_manifest.py
@@ -12,6 +12,11 @@ try:
 except NameError:
     FileNotFoundError = IOError
 
+try:
+    from json import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError
+
 
 ContentManifestChannelData = namedtuple(
     "ContentManifestChannelData", ["channel_id", "channel_version", "include_node_ids"]
@@ -57,11 +62,11 @@ class ContentManifest(object):
         return files_read
 
     def read_file(self, fp):
-        json_str = fp.read()
-        if not json_str:
-            return
-        # Raises JSONDecodeError if the file is invalid
-        manifest_data = json.loads(json_str)
+        try:
+            manifest_data = json.load(fp)
+        except JSONDecodeError as error:
+            raise ContentManifestParseError("Error decoding JSON: {}".format(error))
+
         self.read_dict(manifest_data)
 
     def read_dict(self, manifest_data):

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -1,4 +1,7 @@
 import hashlib
+import itertools
+import json
+import os
 from math import ceil
 
 from django.db.models import Max
@@ -6,6 +9,7 @@ from django.db.models import Min
 from django.db.models import Q
 from le_utils.constants import content_kinds
 
+from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.content_types_tools import (
@@ -18,6 +22,11 @@ from kolibri.core.content.utils.importability_annotation import (
     get_channel_stats_from_peer,
 )
 
+
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
 
 CHUNKSIZE = 10000
 
@@ -97,15 +106,52 @@ def filter_by_file_availability(nodes_to_include, channel_id, drive_id, peer_id)
 
 def get_import_export_data(  # noqa: C901
     channel_id,
-    node_ids,
-    exclude_node_ids,
-    available,
+    node_ids=None,
+    exclude_node_ids=None,
+    available=None,
     drive_id=None,
     peer_id=None,
     renderable_only=True,
     topic_thumbnails=True,
 ):
+    """
+    Helper function that calls get_import_export_nodes followed by
+    get_content_nodes_data.
+    """
 
+    nodes_queries_list = get_import_export_nodes(
+        channel_id,
+        node_ids,
+        exclude_node_ids,
+        available=available,
+        drive_id=drive_id,
+        peer_id=peer_id,
+        renderable_only=renderable_only,
+    )
+    return get_content_nodes_data(
+        channel_id,
+        nodes_queries_list,
+        available=available,
+        topic_thumbnails=topic_thumbnails,
+    )
+
+
+def get_import_export_nodes(  # noqa: C901
+    channel_id,
+    node_ids=None,
+    exclude_node_ids=None,
+    available=None,
+    drive_id=None,
+    peer_id=None,
+    renderable_only=True,
+):
+    """
+    Returns a list of queries for ContentNode objects matching the given
+    constraints. This can be used with get_content_nodes_data and with
+    get_content_nodes_selectors.
+    """
+
+    nodes_queries_list = []
     min_boundary = 1
 
     max_rght, dynamic_chunksize = _calculate_batch_params(
@@ -123,18 +169,13 @@ def get_import_export_data(  # noqa: C901
         nodes_to_include, channel_id, drive_id, peer_id
     )
 
-    queried_file_objects = {}
-    number_of_resources = 0
-
     while min_boundary < max_rght:
-
         max_boundary = min_boundary + dynamic_chunksize
-
-        nodes_segment = nodes_to_include
+        nodes_query = nodes_to_include
 
         # if requested, filter down to only include particular topics/nodes
         if node_ids:
-            nodes_segment = nodes_segment.filter_by_uuids(
+            nodes_query = nodes_query.filter_by_uuids(
                 _mptt_descendant_ids(
                     channel_id, node_ids, min_boundary, min_boundary + dynamic_chunksize
                 )
@@ -142,11 +183,11 @@ def get_import_export_data(  # noqa: C901
 
         # if requested, filter out nodes we're not able to render
         if renderable_only:
-            nodes_segment = nodes_segment.filter(renderable_contentnodes_q_filter)
+            nodes_query = nodes_query.filter(renderable_contentnodes_q_filter)
 
         # filter down the query to remove files associated with nodes we've specifically been asked to exclude
         if exclude_node_ids:
-            nodes_segment = nodes_segment.order_by().exclude_by_uuids(
+            nodes_query = nodes_query.order_by().exclude_by_uuids(
                 _mptt_descendant_ids(
                     channel_id,
                     exclude_node_ids,
@@ -155,50 +196,158 @@ def get_import_export_data(  # noqa: C901
                 )
             )
 
-        count_content_ids = nodes_segment.count()
+        min_boundary += dynamic_chunksize
+
         # Only bother with this query if there were any resources returned above.
-        if count_content_ids:
-            number_of_resources = number_of_resources + count_content_ids
+
+        if nodes_query.count() > 0:
+            nodes_queries_list.append(nodes_query)
+
+    return nodes_queries_list
+
+
+def get_content_nodes_data(
+    channel_id, nodes_queries_list, available=None, topic_thumbnails=True
+):
+    """
+    Returns a set of resources, file names, and a total size in bytes for all
+    data files associated with the content nodes in nodes_queries_list.
+    """
+
+    queried_file_objects = {}
+    number_of_resources = 0
+
+    for nodes_query in nodes_queries_list:
+        number_of_resources = number_of_resources + nodes_query.count()
+
+        file_objects = LocalFile.objects.filter(
+            files__contentnode__in=nodes_query
+        ).values("id", "file_size", "extension")
+        if available is not None:
+            file_objects = file_objects.filter(available=available)
+        for f in file_objects:
+            queried_file_objects[f["id"]] = f
+
+        if topic_thumbnails:
+            # Do a query to get all the descendant and ancestor topics for this segment
+            segment_boundaries = nodes_query.aggregate(
+                min_boundary=Min("lft"), max_boundary=Max("rght")
+            )
+            segment_topics = ContentNode.objects.filter(
+                channel_id=channel_id, kind=content_kinds.TOPIC
+            ).filter(
+                Q(
+                    lft__lte=segment_boundaries["min_boundary"],
+                    rght__gte=segment_boundaries["max_boundary"],
+                )
+                | Q(
+                    lft__lte=segment_boundaries["max_boundary"],
+                    rght__gte=segment_boundaries["min_boundary"],
+                )
+            )
+
             file_objects = LocalFile.objects.filter(
-                files__contentnode__in=nodes_segment
+                files__contentnode__in=segment_topics,
             ).values("id", "file_size", "extension")
             if available is not None:
                 file_objects = file_objects.filter(available=available)
             for f in file_objects:
                 queried_file_objects[f["id"]] = f
 
-            if topic_thumbnails:
-                # Do a query to get all the descendant and ancestor topics for this segment
-                segment_boundaries = nodes_segment.aggregate(
-                    min_boundary=Min("lft"), max_boundary=Max("rght")
-                )
-                segment_topics = ContentNode.objects.filter(
-                    channel_id=channel_id, kind=content_kinds.TOPIC
-                ).filter(
-                    Q(
-                        lft__lte=segment_boundaries["min_boundary"],
-                        rght__gte=segment_boundaries["max_boundary"],
-                    )
-                    | Q(
-                        lft__lte=segment_boundaries["max_boundary"],
-                        rght__gte=segment_boundaries["min_boundary"],
-                    )
-                )
-
-                file_objects = LocalFile.objects.filter(
-                    files__contentnode__in=segment_topics,
-                ).values("id", "file_size", "extension")
-                if available is not None:
-                    file_objects = file_objects.filter(available=available)
-                for f in file_objects:
-                    queried_file_objects[f["id"]] = f
-
-        min_boundary += dynamic_chunksize
-
     files_to_download = list(queried_file_objects.values())
 
     total_bytes_to_transfer = sum(map(lambda x: x["file_size"] or 0, files_to_download))
     return number_of_resources, files_to_download, total_bytes_to_transfer
+
+
+def get_content_nodes_selectors(channel_id, nodes_queries_list):
+    """
+    Returns a dictionary with a set of include_node_ids and exclude_node_ids
+    that can be used with the given channel_id to import the nodes contained
+    in nodes_queries_list.
+    """
+
+    include_node_ids = list()
+    exclude_node_ids = list()
+
+    channel_metadata = ChannelMetadata.objects.get(id=channel_id)
+
+    available_node_ids = set(
+        itertools.chain.from_iterable(
+            nodes_query.values_list("id", flat=True)
+            for nodes_query in nodes_queries_list
+        )
+    )
+
+    available_nodes_queue = [channel_metadata.root]
+
+    while len(available_nodes_queue) > 0:
+        node = available_nodes_queue.pop(0)
+
+        # We could add nodes to exclude_node_ids when less than half of the
+        # sibling nodes are missing. However, it is unclear if this would
+        # be useful.
+
+        if node.kind == "topic":
+            leaf_node_ids = _get_leaf_node_ids(node)
+            matching_leaf_nodes = leaf_node_ids.intersection(available_node_ids)
+            missing_leaf_nodes = leaf_node_ids.difference(available_node_ids)
+            if len(missing_leaf_nodes) == 0:
+                assert node.id not in include_node_ids
+                include_node_ids.append(node.id)
+            elif len(matching_leaf_nodes) > 0:
+                available_nodes_queue.extend(node.children.all())
+        elif node.id in available_node_ids:
+            assert node.id not in include_node_ids
+            include_node_ids.append(node.id)
+
+    if len(exclude_node_ids) == 0 and include_node_ids == [channel_id]:
+        include_node_ids = []
+
+    return {
+        "id": channel_id,
+        "version": channel_metadata.version,
+        "include_node_ids": include_node_ids,
+        "exclude_node_ids": exclude_node_ids,
+    }
+
+
+def update_content_manifest(manifest_file, nodes_selectors):
+    try:
+        with open(manifest_file, "r") as fp:
+            manifest_data = json.load(fp)
+    except (FileNotFoundError, ValueError):
+        # Use ValueError rather than JSONDecodeError for Py2 compatibility
+        manifest_data = None
+
+    if not isinstance(manifest_data, dict):
+        manifest_data = {}
+
+    channels = manifest_data.setdefault("channels", [])
+
+    # TODO: If the channel is already listed, it would be nice to merge the
+    #       new selectors instead of adding another entry for the same channel.
+
+    if nodes_selectors not in channels:
+        channels.append(nodes_selectors)
+
+    manifest_data["channel_list_hash"] = hashlib.md5(
+        json.dumps(channels).encode()
+    ).hexdigest()
+
+    os.makedirs(os.path.dirname(manifest_file), exist_ok=True)
+    with open(manifest_file, "w") as fp:
+        manifest_data = json.dump(manifest_data, fp, indent=4)
+
+
+def _get_leaf_node_ids(node):
+    return set(
+        ContentNode.objects.filter(
+            lft__gte=node.lft, lft__lte=node.rght, channel_id=node.channel_id
+        )
+        .exclude(kind="topic")
+        .values_list("id", flat=True)
+    )
 
 
 def compare_checksums(file_name, file_id):

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -95,7 +95,7 @@ def filter_by_file_availability(nodes_to_include, channel_id, drive_id, peer_id)
     return nodes_to_include
 
 
-def get_import_export_data(  # noqa: C901
+def get_import_export_data(
     channel_id,
     node_ids=None,
     exclude_node_ids=None,

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -149,6 +149,10 @@ def get_import_export_nodes(  # noqa: C901
     Returns a list of queries for ContentNode objects matching the given
     constraints. This can be used with get_content_nodes_data and with
     get_content_nodes_selectors.
+
+    There is a distinction between calling this function with node_ids=[] and
+    with node_ids=None. With an empty list, no nodes will be selected. With a
+    value of None, all nodes will be selected.
     """
 
     nodes_queries_list = []
@@ -174,7 +178,7 @@ def get_import_export_nodes(  # noqa: C901
         nodes_query = nodes_to_include
 
         # if requested, filter down to only include particular topics/nodes
-        if node_ids:
+        if node_ids is not None:
             nodes_query = nodes_query.filter_by_uuids(
                 _mptt_descendant_ids(
                     channel_id, node_ids, min_boundary, min_boundary + dynamic_chunksize
@@ -186,7 +190,7 @@ def get_import_export_nodes(  # noqa: C901
             nodes_query = nodes_query.filter(renderable_contentnodes_q_filter)
 
         # filter down the query to remove files associated with nodes we've specifically been asked to exclude
-        if exclude_node_ids:
+        if exclude_node_ids is not None:
             nodes_query = nodes_query.order_by().exclude_by_uuids(
                 _mptt_descendant_ids(
                     channel_id,

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -301,9 +301,6 @@ def get_content_nodes_selectors(channel_id, nodes_queries_list):
             assert node.id not in include_node_ids
             include_node_ids.append(node.id)
 
-    if len(exclude_node_ids) == 0 and include_node_ids == [channel_id]:
-        include_node_ids = []
-
     return {
         "id": channel_id,
         "version": channel_metadata.version,

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -139,7 +139,7 @@ def get_import_export_nodes(  # noqa: C901
     """
     Returns a list of queries for ContentNode objects matching the given
     constraints. This can be used with get_content_nodes_data and with
-    get_content_nodes_selectors.
+    ContentManifest.add_content_nodes.
 
     There is a distinction between calling this function with node_ids=[] and
     with node_ids=None. With an empty list, no nodes will be selected. With a


### PR DESCRIPTION
## Summary

This change will update Kolibri's `exportcontent` command to generate a manifest file, describing an _intentional_ content selection associated with the exported data files. This is distinct from the user's provided `node_ids` and `exclude_node_ids`, because it needs to be reproducible on another Kolibri instance with a different set of available content. To achieve this, I split `get_import_export_data` into a few different functions, and added another function (`get_content_nodes_selectors`) which finds the optimal list of include nodes to describe the list of content being exported.

_That_ list of nodes is what is written to a `manifest.json` file alongside the exported content. For simplicity, it is possible for the same channel ID to be repeated multiple times, with different sets of include nodes and export nodes, in the same `manifest.json` file. This will only happen if the user runs `exportcontent` multiple times for the same channel.

This pull request does not include the `importcontent` counterpart to this work, which is in #9467.

## References

## Reviewer guidance

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
