### PR TITLE
Remote content endpoint streaming

### DIFF
--- a/kolibri/core/content/management/commands/exportchannel.py
+++ b/kolibri/core/content/management/commands/exportchannel.py
@@ -2,8 +2,8 @@ import logging
 import os
 
 from ...utils import paths
-from ...utils import transfer
 from kolibri.core.tasks.management.commands.base import AsyncCommand
+from kolibri.utils import file_transfer as transfer
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -4,12 +4,12 @@ import os
 from django.core.management.base import CommandError
 
 from ...utils import paths
-from ...utils import transfer
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.paths import get_content_file_name
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
+from kolibri.utils import file_transfer as transfer
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -6,13 +6,13 @@ from le_utils.constants import content_kinds
 
 from ...utils import channel_import
 from ...utils import paths
-from ...utils import transfer
 from ...utils.annotation import update_content_metadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.errors import KolibriUpgradeError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.utils import conf
+from kolibri.utils import file_transfer as transfer
 
 logger = logging.getLogger(__name__)
 

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -8,7 +8,6 @@ from le_utils.constants import content_kinds
 
 from ...utils import annotation
 from ...utils import paths
-from ...utils import transfer
 from kolibri.core.content.errors import InsufficientStorageSpaceError
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.models import ChannelMetadata
@@ -22,6 +21,7 @@ from kolibri.core.content.utils.upgrade import get_import_data_for_update
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.utils import conf
+from kolibri.utils import file_transfer as transfer
 from kolibri.utils.options import FD_PER_THREAD
 from kolibri.utils.system import get_fd_limit
 from kolibri.utils.system import get_free_space

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -25,8 +25,8 @@ from kolibri.core.content.utils.content_types_tools import (
     renderable_contentnodes_q_filter,
 )
 from kolibri.core.content.utils.import_export_content import get_import_export_data
-from kolibri.core.content.utils.transfer import Transfer
-from kolibri.core.content.utils.transfer import TransferCanceled
+from kolibri.utils.file_transfer import Transfer
+from kolibri.utils.file_transfer import TransferCanceled
 from kolibri.utils.tests.helpers import override_option
 
 # helper class for mocking that is equal to anything
@@ -171,15 +171,13 @@ class ImportChannelTestCase(TestCase):
                     "decryption failed or bad record mac",
                 ]
             )
-        with patch(
-            "kolibri.core.content.utils.transfer.Transfer.next", side_effect=SSLERROR
-        ):
+        with patch("kolibri.utils.file_transfer.Transfer.next", side_effect=SSLERROR):
             call_command("importchannel", "network", "197934f144305350b5820c7c4dd8e194")
             cancel_mock.assert_called_with()
             import_channel_mock.assert_not_called()
 
     @patch(
-        "kolibri.core.content.utils.transfer.Transfer.next",
+        "kolibri.utils.file_transfer.Transfer.next",
         side_effect=ReadTimeout("Read timed out."),
     )
     @patch("kolibri.core.content.management.commands.importchannel.AsyncCommand.cancel")
@@ -471,7 +469,7 @@ class ImportContentTestCase(TestCase):
         annotation_mock.set_content_visibility.assert_called()
 
     @patch(
-        "kolibri.core.content.utils.transfer.Transfer.next",
+        "kolibri.utils.file_transfer.Transfer.next",
         side_effect=ConnectionError("connection error"),
     )
     @patch("kolibri.core.content.management.commands.importcontent.AsyncCommand.cancel")
@@ -610,7 +608,7 @@ class ImportContentTestCase(TestCase):
         sleep_mock.assert_called()
         annotation_mock.set_content_visibility.assert_called()
 
-    @patch("kolibri.core.content.utils.transfer.requests.Session.get")
+    @patch("kolibri.utils.file_transfer.requests.Session.get")
     @patch(
         "kolibri.core.content.management.commands.importcontent.paths.get_content_storage_file_path",
         return_value="test/test",
@@ -740,9 +738,9 @@ class ImportContentTestCase(TestCase):
             self.the_channel_id, [], exclude_node_ids=None, node_ids=None, public=False
         )
 
-    @patch("kolibri.core.content.utils.transfer.sleep")
+    @patch("kolibri.utils.file_transfer.sleep")
     @patch(
-        "kolibri.core.content.utils.transfer.Transfer.next",
+        "kolibri.utils.file_transfer.Transfer.next",
         side_effect=ChunkedEncodingError("Chunked Encoding Error"),
     )
     @patch("kolibri.core.content.management.commands.importcontent.AsyncCommand.cancel")
@@ -822,7 +820,7 @@ class ImportContentTestCase(TestCase):
         annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.core.content.management.commands.importcontent.logger.error")
-    @patch("kolibri.core.content.utils.transfer.os.path.getsize")
+    @patch("kolibri.utils.file_transfer.os.path.getsize")
     @patch(
         "kolibri.core.content.management.commands.importcontent.paths.get_content_storage_file_path"
     )
@@ -1109,7 +1107,7 @@ class ImportContentTestCase(TestCase):
         )
 
         m = mock_open()
-        with patch("kolibri.core.content.utils.transfer.open", m) as open_mock:
+        with patch("kolibri.utils.file_transfer.open", m) as open_mock:
             try:
                 call_command("importcontent", "network", self.the_channel_id)
             except Exception:

--- a/kolibri/utils/tests/test_kolibri_whitenoise.py
+++ b/kolibri/utils/tests/test_kolibri_whitenoise.py
@@ -53,29 +53,29 @@ def test_dynamic_whitenoise():
     )
     assert (
         dynamic_whitenoise.find_and_cache_dynamic_file(
-            prefix1 + "/" + tempdir11tempfilename
+            prefix1 + "/" + tempdir11tempfilename, None
         )
         is not None
     )
     assert (
         dynamic_whitenoise.find_and_cache_dynamic_file(
-            prefix1 + "/" + tempdir12tempfilename
+            prefix1 + "/" + tempdir12tempfilename, None
         )
         is not None
     )
     assert (
         dynamic_whitenoise.find_and_cache_dynamic_file(
-            prefix2 + "/" + tempdir21tempfilename
+            prefix2 + "/" + tempdir21tempfilename, None
         )
         is not None
     )
     assert (
         dynamic_whitenoise.find_and_cache_dynamic_file(
-            prefix2 + "/" + tempdir22tempfilename
+            prefix2 + "/" + tempdir22tempfilename, None
         )
         is not None
     )
-    assert dynamic_whitenoise.find_and_cache_dynamic_file("notafile") is None
+    assert dynamic_whitenoise.find_and_cache_dynamic_file("notafile", None) is None
     os.close(tempdir11tempfile)
     os.remove(tempdir11tempfilepath)
     os.close(tempdir12tempfile)


### PR DESCRIPTION
## Summary
* Moves the file transfer utilities into the `kolibri.utils` namespace so that they can be imported without importing the Django stack
* Makes some updates to the file transfer utilities to allow them to be used solely via `next` and not just via explicit iteration in a loop.
* Catches errors that are thrown when a file transfer attempts to move to its destination, but the source transfer file has disappeared, if the destination file already exists, it silently swallows the error - this allows for multiple simultaneous transfers of the same file to co-exist and not stomp each other.
* Adds additional functionality to the DynamicWhitenoise class, whereby it will accept a `baseurl` GET parameter, which, if the file does not exist on disk, will attempt to fetch the file using the `FileDownload` file transfer class.
* As the file is downloading, the file download is wrapped in a special filelike wrapper object that streams the download into the response.
* This wrapper object supports `seek` in order to support range requests, but still downloads the entire file, as it seems complex to construct the full file out of multiple potentially non-sequential range requests.

Note: Cleaning up the downloaded files is deferred to a follow up issue!

## References
Fixes #9386
Fixes #9388

## Reviewer guidance
Test this out by streaming some files directly from Studio, e.g.:
http://127.0.0.1:8000/content/storage/1/1/11e1c2c83b9dd46e584d75f484386021.mp4?baseurl=https://studio.learningequality.org
http://127.0.0.1:8000/content/storage/9/d/9d523f8a736e372fbe10ac895085fce9.png?baseurl=https://studio.learningequality.org
http://127.0.0.1:8000/content/storage/8/a/8a9c9011e527c0ebf9b09d642eba5f78.pdf?baseurl=https://studio.learningequality.org

Confirm that reloading the file also works.
Delete the file from storage and try the request again, confirm that it works.

Question: Is the range request implementation good enough?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
