### PR TITLE
Read options from a manifest file in importcontent

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -294,7 +294,7 @@ class Command(AsyncCommand):
         if manifest_file:
             content_manifest.read_file(manifest_file)
             use_content_manifest = True
-        elif path and detect_manifest and not (node_ids or exclude_node_ids):
+        elif path and detect_manifest and node_ids is None and exclude_node_ids is None:
             manifest_path = os.path.join(path, "content", "manifest.json")
             if content_manifest.read(manifest_path):
                 use_content_manifest = True
@@ -627,7 +627,9 @@ class Command(AsyncCommand):
         return FILE_TRANSFERRED, data_transferred
 
     def handle_async(self, *args, **options):
-        if options["manifest"] and (options["node_ids"] or options["exclude_node_ids"]):
+        if options["manifest"] and (
+            options["node_ids"] is not None or options["exclude_node_ids"] is not None
+        ):
             raise CommandError(
                 "The --manifest option must not be combined with --node_ids or --exclude_node_ids."
             )

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -92,7 +92,7 @@ class Command(AsyncCommand):
             "--node_ids",
             "-n",
             # Split the comma separated string we get, into a list of strings
-            type=lambda x: x.split(","),
+            type=lambda x: x.split(",") if x else [],
             default=None,
             required=False,
             dest="node_ids",
@@ -109,7 +109,7 @@ class Command(AsyncCommand):
         parser.add_argument(
             "--exclude_node_ids",
             # Split the comma separated string we get, into a list of string
-            type=lambda x: x.split(","),
+            type=lambda x: x.split(",") if x else [],
             default=None,
             required=False,
             dest="exclude_node_ids",

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -73,7 +73,6 @@ class Command(AsyncCommand):
         """
         parser.add_argument(
             "--manifest",
-            # Split the comma separated string we get, into a list of strings
             type=argparse.FileType("r"),
             default=None,
             required=False,
@@ -108,7 +107,7 @@ class Command(AsyncCommand):
         """
         parser.add_argument(
             "--exclude_node_ids",
-            # Split the comma separated string we get, into a list of string
+            # Split the comma separated string we get, into a list of strings
             type=lambda x: x.split(",") if x else [],
             default=None,
             required=False,
@@ -285,7 +284,8 @@ class Command(AsyncCommand):
             # If manifest_file is stdin, its name will be "<stdin>" and path
             # will become "". This feels clumsy, but the resulting behaviour
             # is reasonable.
-            manifest_dir = os.path.dirname(manifest_file.name)
+            manifest_file_name = getattr(manifest_file, "name", "")
+            manifest_dir = os.path.dirname(manifest_file_name)
             path = os.path.dirname(manifest_dir)
 
         content_manifest = ContentManifest()

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -280,6 +280,12 @@ class Command(AsyncCommand):
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
         content_dir=None,
     ):
+        if node_ids is not None:
+            node_ids = set(node_ids)
+
+        if exclude_node_ids is not None:
+            exclude_node_ids = set(exclude_node_ids)
+
         if manifest_file and not path:
             # If manifest_file is stdin, its name will be "<stdin>" and path
             # will become "". This feels clumsy, but the resulting behaviour
@@ -688,7 +694,7 @@ class Command(AsyncCommand):
 
 
 def _node_ids_from_content_manifest(content_manifest, channel_id):
-    node_ids = []
+    node_ids = set()
 
     channel_metadata = ChannelMetadata.objects.get(id=channel_id)
 
@@ -701,7 +707,7 @@ def _node_ids_from_content_manifest(content_manifest, channel_id):
                     local_version=channel_metadata.version,
                 )
             )
-        node_ids.extend(
+        node_ids.update(
             content_manifest.get_include_node_ids(channel_id, channel_version)
         )
 

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1,4 +1,3 @@
-import io
 import itertools
 import json
 import os
@@ -10,6 +9,7 @@ from django.core.management import call_command
 from django.core.management import CommandError
 from django.db.models import Q
 from django.test import TestCase
+from django.utils import six
 from le_utils.constants import content_kinds
 from mock import call
 from mock import MagicMock
@@ -1438,7 +1438,7 @@ class ImportContentTestCase(TestCase):
 
         get_import_export_mock.return_value = (0, [], 0)
 
-        manifest_file = io.StringIO(
+        manifest_file = six.StringIO(
             json.dumps(
                 {
                     "channels": [
@@ -1499,7 +1499,7 @@ class ImportContentTestCase(TestCase):
             "disk",
             self.the_channel_id,
             import_source_dir,
-            manifest=io.StringIO(
+            manifest=six.StringIO(
                 json.dumps(
                     {
                         "channels": [
@@ -1635,7 +1635,7 @@ class ImportContentTestCase(TestCase):
             "disk",
             self.the_channel_id,
             import_source_dir,
-            manifest=io.StringIO(
+            manifest=six.StringIO(
                 json.dumps(
                     {
                         "channels": [
@@ -1735,7 +1735,7 @@ class ImportContentTestCase(TestCase):
             "importcontent",
             "network",
             self.the_channel_id,
-            manifest=io.StringIO(
+            manifest=six.StringIO(
                 json.dumps(
                     {
                         "channels": [

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -529,6 +529,9 @@ class ImportContentTestCase(TestCase):
     fixtures = ["content_test.json"]
     the_channel_id = "6199dde695db4ee4ab392222d5af1e5c"
 
+    c2c1_node_id = "2b6926ed22025518a8b9da91745b51d3"
+    c2c2_node_id = "4d0c890de9b65d6880ccfa527800e0f4"
+
     def setUp(self):
         LocalFile.objects.update(available=False)
 
@@ -811,23 +814,21 @@ class ImportContentTestCase(TestCase):
             local_dest_path_2,
             local_dest_path_3,
         ]
-        ContentNode.objects.filter(pk="2b6926ed22025518a8b9da91745b51d3").update(
-            available=False
+        ContentNode.objects.filter(pk=self.c2c1_node_id).update(available=False)
+        LocalFile.objects.filter(files__contentnode__pk=self.c2c1_node_id).update(
+            file_size=1, available=False
         )
-        LocalFile.objects.filter(
-            files__contentnode__pk="2b6926ed22025518a8b9da91745b51d3"
-        ).update(file_size=1, available=False)
         get_import_export_mock.return_value = (
             1,
             list(
                 LocalFile.objects.filter(
-                    files__contentnode__pk="2b6926ed22025518a8b9da91745b51d3"
+                    files__contentnode__pk=self.c2c1_node_id
                 ).values("id", "file_size", "extension")
             ),
             10,
         )
 
-        node_id = ["2b6926ed22025518a8b9da91745b51d3"]
+        node_id = [self.c2c1_node_id]
         call_command(
             "importcontent",
             "network",
@@ -1422,23 +1423,21 @@ class ImportContentTestCase(TestCase):
             local_dest_path_2,
             local_dest_path_3,
         ]
-        ContentNode.objects.filter(pk="2b6926ed22025518a8b9da91745b51d3").update(
-            available=False
+        ContentNode.objects.filter(pk=self.c2c1_node_id).update(available=False)
+        LocalFile.objects.filter(files__contentnode__pk=self.c2c1_node_id).update(
+            file_size=1, available=False
         )
-        LocalFile.objects.filter(
-            files__contentnode__pk="2b6926ed22025518a8b9da91745b51d3"
-        ).update(file_size=1, available=False)
         get_import_export_mock.return_value = (
             1,
             list(
                 LocalFile.objects.filter(
-                    files__contentnode__pk="2b6926ed22025518a8b9da91745b51d3"
+                    files__contentnode__pk=self.c2c1_node_id
                 ).values("id", "file_size", "extension")
             ),
             10,
         )
 
-        node_id = ["2b6926ed22025518a8b9da91745b51d3"]
+        node_id = [self.c2c1_node_id]
         with self.assertRaises(HTTPError):
             call_command(
                 "importcontent",

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1355,8 +1355,6 @@ class ImportContentTestCase(TestCase):
         import_source_dir = tempfile.mkdtemp()
         os.mkdir(os.path.join(import_source_dir, "content"))
 
-        manifest_node_ids = [self.c2c1_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         with open(
@@ -1368,7 +1366,7 @@ class ImportContentTestCase(TestCase):
                         {
                             "id": self.the_channel_id,
                             "version": self.the_channel_version,
-                            "include_node_ids": manifest_node_ids,
+                            "include_node_ids": [self.c2c1_node_id],
                         }
                     ]
                 },
@@ -1384,7 +1382,7 @@ class ImportContentTestCase(TestCase):
 
         get_import_export_mock.assert_called_with(
             self.the_channel_id,
-            manifest_node_ids,
+            [six.text_type(self.c2c1_node_id)],
             None,
             False,
             renderable_only=True,
@@ -1433,9 +1431,6 @@ class ImportContentTestCase(TestCase):
     ):
         import_source_dir = tempfile.mkdtemp()
 
-        manifest_node_ids = [self.c2c1_node_id]
-        extra_node_ids = [self.c2c2_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         manifest_file = six.StringIO(
@@ -1445,7 +1440,7 @@ class ImportContentTestCase(TestCase):
                         {
                             "id": self.the_channel_id,
                             "version": self.the_channel_version,
-                            "include_node_ids": manifest_node_ids,
+                            "include_node_ids": [self.c2c1_node_id, self.c2c2_node_id],
                         }
                     ]
                 }
@@ -1458,7 +1453,17 @@ class ImportContentTestCase(TestCase):
                 "disk",
                 self.the_channel_id,
                 import_source_dir,
-                node_ids=extra_node_ids,
+                node_ids=[self.c2c2_node_id],
+                manifest=manifest_file,
+            )
+
+        with self.assertRaises(CommandError):
+            call_command(
+                "importcontent",
+                "disk",
+                self.the_channel_id,
+                import_source_dir,
+                exclude_node_ids=[self.c2c2_node_id],
                 manifest=manifest_file,
             )
 
@@ -1469,16 +1474,6 @@ class ImportContentTestCase(TestCase):
                 self.the_channel_id,
                 import_source_dir,
                 node_ids=[],
-                manifest=manifest_file,
-            )
-
-        with self.assertRaises(CommandError):
-            call_command(
-                "importcontent",
-                "disk",
-                self.the_channel_id,
-                import_source_dir,
-                exclude_node_ids=extra_node_ids,
                 manifest=manifest_file,
             )
 
@@ -1530,7 +1525,7 @@ class ImportContentTestCase(TestCase):
 
         get_import_export_mock.assert_called_with(
             self.the_channel_id,
-            [self.c2c1_node_id, self.c2c2_node_id],
+            [six.text_type(self.c2c1_node_id), six.text_type(self.c2c2_node_id)],
             None,
             False,
             renderable_only=True,
@@ -1547,9 +1542,6 @@ class ImportContentTestCase(TestCase):
         import_source_dir = tempfile.mkdtemp()
         os.mkdir(os.path.join(import_source_dir, "content"))
 
-        manifest_node_ids = [self.c2c1_node_id]
-        input_node_ids = [self.c2c2_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         with open(
@@ -1561,7 +1553,7 @@ class ImportContentTestCase(TestCase):
                         {
                             "id": self.the_channel_id,
                             "version": self.the_channel_version,
-                            "include_node_ids": manifest_node_ids,
+                            "include_node_ids": [self.c2c1_node_id],
                         }
                     ]
                 },
@@ -1573,12 +1565,12 @@ class ImportContentTestCase(TestCase):
             "disk",
             self.the_channel_id,
             import_source_dir,
-            node_ids=input_node_ids,
+            node_ids=[self.c2c2_node_id],
         )
 
         get_import_export_mock.assert_called_with(
             self.the_channel_id,
-            input_node_ids,
+            [six.text_type(self.c2c2_node_id)],
             None,
             False,
             renderable_only=True,
@@ -1609,9 +1601,6 @@ class ImportContentTestCase(TestCase):
         import_source_dir = tempfile.mkdtemp()
         os.mkdir(os.path.join(import_source_dir, "content"))
 
-        manifest_node_ids = [self.c2c1_node_id]
-        input_node_ids = [self.c2c2_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         with open(
@@ -1623,7 +1612,7 @@ class ImportContentTestCase(TestCase):
                         {
                             "id": self.the_channel_id,
                             "version": self.the_channel_version,
-                            "include_node_ids": manifest_node_ids,
+                            "include_node_ids": [self.c2c1_node_id],
                         }
                     ]
                 },
@@ -1642,7 +1631,7 @@ class ImportContentTestCase(TestCase):
                             {
                                 "id": self.the_channel_id,
                                 "version": self.the_channel_version,
-                                "include_node_ids": input_node_ids,
+                                "include_node_ids": [self.c2c2_node_id],
                             }
                         ]
                     }
@@ -1652,7 +1641,7 @@ class ImportContentTestCase(TestCase):
 
         get_import_export_mock.assert_called_with(
             self.the_channel_id,
-            input_node_ids,
+            [six.text_type(self.c2c2_node_id)],
             None,
             False,
             renderable_only=True,
@@ -1669,8 +1658,6 @@ class ImportContentTestCase(TestCase):
         import_source_dir = tempfile.mkdtemp()
         os.mkdir(os.path.join(import_source_dir, "content"))
 
-        manifest_node_ids = [self.c2c1_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         with open(
@@ -1682,7 +1669,7 @@ class ImportContentTestCase(TestCase):
                         {
                             "id": self.the_channel_id,
                             "version": self.the_channel_version,
-                            "include_node_ids": manifest_node_ids,
+                            "include_node_ids": [self.c2c1_node_id],
                         }
                     ]
                 },
@@ -1727,8 +1714,6 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        manifest_node_ids = [self.c2c1_node_id]
-
         get_import_export_mock.return_value = (0, [], 0)
 
         call_command(
@@ -1742,7 +1727,7 @@ class ImportContentTestCase(TestCase):
                             {
                                 "id": self.the_channel_id,
                                 "version": self.the_channel_version,
-                                "include_node_ids": manifest_node_ids,
+                                "include_node_ids": [self.c2c1_node_id],
                             }
                         ]
                     }
@@ -1752,7 +1737,7 @@ class ImportContentTestCase(TestCase):
 
         get_import_export_mock.assert_called_with(
             self.the_channel_id,
-            manifest_node_ids,
+            [six.text_type(self.c2c1_node_id)],
             None,
             False,
             renderable_only=True,


### PR DESCRIPTION
## Summary

This adds a `--manifest` option to the `importcontent` management command.

With this change, one can export content from one Kolibri instance…

```
kolibri manage exportcontent c9d7f950ab6b5a1199e3d6c10d7f0103 my_export_dir
```

And then import it in another Kolibri instance…

```
kolbri manage importchannel network c9d7f950ab6b5a1199e3d6c10d7f0103
kolibri manage importcontent --manifest=my_export_dir/content/manifest.json disk c9d7f950ab6b5a1199e3d6c10d7f0103
```

Or…

```
kolbri manage importchannel network c9d7f950ab6b5a1199e3d6c10d7f0103
kolibri manage importcontent disk c9d7f950ab6b5a1199e3d6c10d7f0103 my_export_dir
```

That second option changes some existing behaviour: it automatically detects if there is a file named `manifest.json` in the path we are importing from, and uses _that_ for the default `node_ids` and `exclude_node_ids` (instead of the previous behaviour where it would attempt to import everything). This should be the same in practice, as `manifest.json` should select all of the content which has been exported. I add a `--no_detect_manifest` option to preserve the previous behaviour.

## References

This is a counterpart to my changes in #9460, adding support for _exporting_ a manifest file.

## Reviewer guidance

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
