### PR TITLE
Adds new public content metadata endpoints, allows for remote browsing of metadata

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -115,11 +115,23 @@ export default new Resource({
     });
     return promise;
   },
-  fetchPopular(getParams) {
-    return this.fetchListCollection('popular', getParams);
+  fetchPopular(params = { popular: true }) {
+    const promise = new ConditionalPromise();
+    const url = urls['kolibri:core:usercontentnode_list']();
+    promise._promise = this.client({ url, params }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+    return promise;
   },
-  fetchNextSteps(getParams) {
-    return this.fetchListCollection('next_steps', getParams);
+  fetchNextSteps(params = { next_steps: true }) {
+    const promise = new ConditionalPromise();
+    const url = urls['kolibri:core:usercontentnode_list']();
+    promise._promise = this.client({ url, params }).then(response => {
+      this.cacheData(response.data);
+      return response.data;
+    });
+    return promise;
   },
   cache: {},
   fetchModel({ id }) {

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -140,7 +140,9 @@ class RemoteMixin(object):
     def _hande_proxied_request(self, request):
         full_path = request.get_full_path().split("?")[0]
         remote_path = full_path.replace(
-            "{}api/content/".format(OPTIONS["Deployment"]["URL_PATH_PREFIX"]),
+            "/{}api/content/".format(
+                OPTIONS["Deployment"]["URL_PATH_PREFIX"].lstrip("/")
+            ),
             "/api/public/v2/",
         )
         baseurl = request.GET[self.remote_url_param]

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -654,7 +654,10 @@ class BaseContentNodeMixin(object):
             if "more" in response_data and "results" in response_data:
                 # This is a paginated object
                 if response_data["more"] is not None:
-                    response_data["more"][self.remote_url_param] = baseurl
+                    if type(response_data["more"].get("params", None)) is dict:
+                        response_data["more"]["params"][self.remote_url_param] = baseurl
+                    else:
+                        response_data["more"][self.remote_url_param] = baseurl
                 response_data["results"] = self.update_data(
                     response_data["results"], baseurl
                 )
@@ -676,7 +679,8 @@ class BaseContentNodeMixin(object):
         if node["thumbnail"]:
             node["thumbnail"] += baseurl_querystring
         for file in node["files"]:
-            file["storage_url"] += baseurl_querystring
+            if file["storage_url"]:
+                file["storage_url"] += baseurl_querystring
         return node
 
 

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1361,7 +1361,9 @@ class ContentNodeAPITestCase(APITestCase):
 
     def test_popular(self):
         expected_content_ids = self._create_session_logs()
-        response = self.client.get(reverse("kolibri:core:contentnode-popular"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"popular": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1372,8 +1374,8 @@ class ContentNodeAPITestCase(APITestCase):
         node.save()
         expected_content_ids = expected_content_ids[1:]
         response = self.client.get(
-            reverse("kolibri:core:contentnode-popular"),
-            data={"include_coach_content": False},
+            reverse("kolibri:core:usercontentnode-list"),
+            data={"popular": True, "include_coach_content": False},
         )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
@@ -1389,16 +1391,11 @@ class ContentNodeAPITestCase(APITestCase):
         node.save()
         self.client.login(username="coach", password=DUMMY_PASSWORD)
         response = self.client.get(
-            reverse("kolibri:core:contentnode-popular"),
-            data={"include_coach_content": True},
+            reverse("kolibri:core:usercontentnode-list"),
+            data={"popular": True, "include_coach_content": True},
         )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
-
-    def test_popular_ten_minute_cache(self):
-        self._create_session_logs()
-        response = self.client.get(reverse("kolibri:core:contentnode-popular"))
-        self.assertEqual(response["Cache-Control"], "max-age=600")
 
     def _create_summary_logs(self):
         facility = Facility.objects.create(name="MyFac")
@@ -1441,14 +1438,18 @@ class ContentNodeAPITestCase(APITestCase):
     def test_resume(self):
         user, expected_content_ids = self._create_summary_logs()
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:core:contentnode-resume"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"resume": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
     def test_resume_zero_cache(self):
         user, expected_content_ids = self._create_summary_logs()
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:core:contentnode-resume"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"resume": True}
+        )
         self.assertEqual(response["Cache-Control"], "max-age=0")
 
     def test_next_steps_prereq(self):
@@ -1468,7 +1469,9 @@ class ContentNodeAPITestCase(APITestCase):
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
         post_req = root.prerequisite_for.first()
         expected_content_ids = (post_req.content_id,)
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1487,7 +1490,9 @@ class ContentNodeAPITestCase(APITestCase):
         user.set_password(DUMMY_PASSWORD)
         user.save()
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         self.assertEqual(response["Cache-Control"], "max-age=0")
 
     def test_next_steps_prereq_in_progress(self):
@@ -1515,7 +1520,9 @@ class ContentNodeAPITestCase(APITestCase):
             kind="audio",
         )
         expected_content_ids = []
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1537,7 +1544,9 @@ class ContentNodeAPITestCase(APITestCase):
         post_req = root.prerequisite_for.first()
         post_req.coach_content = True
         post_req.save()
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(), response_content_ids)
 
@@ -1561,7 +1570,9 @@ class ContentNodeAPITestCase(APITestCase):
         post_req.coach_content = True
         post_req.save()
         expected_content_ids = (post_req.content_id,)
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1584,7 +1595,9 @@ class ContentNodeAPITestCase(APITestCase):
         self.client.login(username=user.username, password=DUMMY_PASSWORD)
         sibling = node.get_next_sibling()
         expected_content_ids = (sibling.content_id,)
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1615,7 +1628,9 @@ class ContentNodeAPITestCase(APITestCase):
             kind="audio",
         )
         expected_content_ids = []
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 
@@ -1639,7 +1654,9 @@ class ContentNodeAPITestCase(APITestCase):
         sibling = node.get_next_sibling()
         sibling.coach_content = True
         sibling.save()
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(), response_content_ids)
 
@@ -1665,7 +1682,9 @@ class ContentNodeAPITestCase(APITestCase):
         sibling.coach_content = True
         sibling.save()
         expected_content_ids = (sibling.content_id,)
-        response = self.client.get(reverse("kolibri:core:contentnode-next-steps"))
+        response = self.client.get(
+            reverse("kolibri:core:usercontentnode-list"), data={"next_steps": True}
+        )
         response_content_ids = {node["content_id"] for node in response.json()}
         self.assertSetEqual(set(expected_content_ids), response_content_ids)
 

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -22,6 +22,7 @@ from .. import error_constants
 from .constants.user_sync_statuses import QUEUED
 from .constants.user_sync_statuses import SYNC
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.content.api import ChannelMetadataViewSet
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
@@ -95,6 +96,15 @@ def _get_channel_list_v1(params, identifier=None):
         channels = channels.exclude(public=False)
 
     return channels.filter(root__available=True).distinct()
+
+
+class PublicChannelMetadataViewSet(ChannelMetadataViewSet):
+    def get_queryset(self):
+        return (
+            ChannelMetadata.objects.all()
+            if allow_peer_unlisted_channel_import()
+            else ChannelMetadata.objects.filter(public=True)
+        )
 
 
 @api_view(["GET"])

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseNotFound
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.gzip import gzip_page
 from morango.constants import transfer_statuses
@@ -21,8 +22,13 @@ from rest_framework.response import Response
 from .. import error_constants
 from .constants.user_sync_statuses import QUEUED
 from .constants.user_sync_statuses import SYNC
+from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.content.api import ChannelMetadataViewSet
+from kolibri.core.content.api import BaseChannelMetadataMixin
+from kolibri.core.content.api import BaseContentNodeMixin
+from kolibri.core.content.api import BaseContentNodeTreeViewset
+from kolibri.core.content.api import metadata_cache
+from kolibri.core.content.api import OptionalContentNodePagination
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
@@ -98,13 +104,24 @@ def _get_channel_list_v1(params, identifier=None):
     return channels.filter(root__available=True).distinct()
 
 
-class PublicChannelMetadataViewSet(ChannelMetadataViewSet):
+@method_decorator(metadata_cache, name="dispatch")
+class PublicChannelMetadataViewSet(BaseChannelMetadataMixin, ReadOnlyValuesViewset):
     def get_queryset(self):
         return (
             ChannelMetadata.objects.all()
             if allow_peer_unlisted_channel_import()
             else ChannelMetadata.objects.filter(public=True)
         )
+
+
+@method_decorator(metadata_cache, name="dispatch")
+class PublicContentNodeViewSet(BaseContentNodeMixin, ReadOnlyValuesViewset):
+    pagination_class = OptionalContentNodePagination
+
+
+@method_decorator(metadata_cache, name="dispatch")
+class PublicContentNodeTreeViewSet(BaseContentNodeTreeViewset):
+    pass
 
 
 @api_view(["GET"])

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -27,9 +27,10 @@ from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
 from .api import InfoViewSet
 from .api import PublicChannelMetadataViewSet
+from .api import PublicContentNodeTreeViewSet
+from .api import PublicContentNodeViewSet
 from .api import SyncQueueViewSet
-from kolibri.core.content.api import ContentNodeTreeViewset
-from kolibri.core.content.api import ContentNodeViewset
+
 
 router = routers.SimpleRouter()
 
@@ -44,10 +45,12 @@ public_content_v2_router.register(
     r"channel", PublicChannelMetadataViewSet, base_name="publicchannel"
 )
 public_content_v2_router.register(
-    r"contentnode", ContentNodeViewset, base_name="publiccontentnode"
+    r"contentnode", PublicContentNodeViewSet, base_name="publiccontentnode"
 )
 public_content_v2_router.register(
-    r"contentnode_tree", ContentNodeTreeViewset, base_name="publiccontentnode_tree"
+    r"contentnode_tree",
+    PublicContentNodeTreeViewSet,
+    base_name="publiccontentnode_tree",
 )
 
 # Add public api endpoints

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -26,8 +26,8 @@ from .api import get_public_channel_list
 from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
 from .api import InfoViewSet
+from .api import PublicChannelMetadataViewSet
 from .api import SyncQueueViewSet
-from kolibri.core.content.api import ChannelMetadataViewSet
 from kolibri.core.content.api import ContentNodeTreeViewset
 from kolibri.core.content.api import ContentNodeViewset
 
@@ -41,7 +41,7 @@ router.register(r"syncqueue", SyncQueueViewSet, base_name="syncqueue")
 
 public_content_v2_router = routers.SimpleRouter()
 public_content_v2_router.register(
-    r"channel", ChannelMetadataViewSet, base_name="publicchannel"
+    r"channel", PublicChannelMetadataViewSet, base_name="publicchannel"
 )
 public_content_v2_router.register(
     r"contentnode", ContentNodeViewset, base_name="publiccontentnode"

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -27,6 +27,9 @@ from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
 from .api import InfoViewSet
 from .api import SyncQueueViewSet
+from kolibri.core.content.api import ChannelMetadataViewSet
+from kolibri.core.content.api import ContentNodeTreeViewset
+from kolibri.core.content.api import ContentNodeViewset
 
 router = routers.SimpleRouter()
 
@@ -36,9 +39,21 @@ router.register(r"signup", PublicSignUpViewSet, base_name="publicsignup")
 router.register(r"info", InfoViewSet, base_name="info")
 router.register(r"syncqueue", SyncQueueViewSet, base_name="syncqueue")
 
+public_content_v2_router = routers.SimpleRouter()
+public_content_v2_router.register(
+    r"channel", ChannelMetadataViewSet, base_name="publicchannel"
+)
+public_content_v2_router.register(
+    r"contentnode", ContentNodeViewset, base_name="publiccontentnode"
+)
+public_content_v2_router.register(
+    r"contentnode_tree", ContentNodeTreeViewset, base_name="publiccontentnode_tree"
+)
+
 # Add public api endpoints
 urlpatterns = [
     url(r"^", include(router.urls)),
+    url(r"v2/", include(public_content_v2_router.urls)),
     url(
         r"(?P<version>[^/]+)/channels/lookup/(?P<identifier>[^/]+)",
         get_public_channel_lookup,


### PR DESCRIPTION
## Summary
* Cleans up all previously existing 'user data' specific endpoints for content node
* Simplifies and adds etags to all content metadata endpoints
* Adds a new v2 namespace for public content metadata endpoints
* Expands the existing internal ChannelMetadataViewset to include all public data and uses it for the v2 endpoint
* Adds public ContentNodeViewset and ContentNodeTreeViewset to allow remote browsing of public metadata
* Adds `baseurl` query parameter handling to these three internal endpoints
* This means that the internal endpoints can now proxy fetches to other Kolibri's public endpoints

## References
Fixes #9381
Fixes #9380
Fixes #9390
Fixes #9385
Fixes #9382
Fixes #9391

## Reviewer guidance
Test the three endpoints with another instance of Kolibri running (preferably from a different Kolibri home dir, so that different metadata will be returned).

Example URLs:

Channel:
`http://127.0.0.1:8000/api/content/channel/?format=json&baseurl=http://127.0.0.1:8080/`
Public:
`http://127.0.0.1:8000/api/public/v2/channel/?format=json`

ContentNode:
`http://127.0.0.1:8000/api/content/contentnode/?format=json&max_results=25&baseurl=http://127.0.0.1:8080/`
Public:
`http://127.0.0.1:8000/api/public/v2/contentnode/?format=json&max_results=25`

Tree:
`http://127.0.0.1:8000/api/content/contentnode_tree/<topic_id>/?format=json&max_results=2&baseurl=http://127.0.0.1:8080/`
Public:
`http://127.0.0.1:8000/api/public/v2/contentnode_tree/<topic_id>/?format=json&max_results=2`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
