### PR TITLE
Simplify task execution

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -84,15 +84,15 @@ class Priority(object):
     Priorities = {HIGH, REGULAR}
 
 
-def execute_job(job_id, db_type, db_url):
+def execute_job(job_id):
     """
     Call the function stored in the job.func.
     :return: Any
     """
-    from kolibri.core.tasks.main import make_connection
     from kolibri.core.tasks.storage import Storage
+    from kolibri.core.tasks.utils import db_connection
 
-    connection = make_connection(db_type, db_url)
+    connection = db_connection()
 
     storage = Storage(connection)
 

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -1,15 +1,9 @@
 import logging
-import os
-import sqlite3
 
 from django.utils.functional import SimpleLazyObject
-from sqlalchemy import create_engine
-from sqlalchemy import event
-from sqlalchemy import exc
 
-from kolibri.core.sqlite.utils import check_sqlite_integrity
-from kolibri.core.sqlite.utils import repair_sqlite_db
 from kolibri.core.tasks.storage import Storage
+from kolibri.core.tasks.utils import db_connection
 from kolibri.core.tasks.worker import Worker
 from kolibri.utils import conf
 
@@ -17,84 +11,7 @@ from kolibri.utils import conf
 logger = logging.getLogger(__name__)
 
 
-def create_db_url(
-    db_type, path=None, name=None, password=None, user=None, host=None, port=None
-):
-    if db_type == "sqlite":
-        return "sqlite:///{path}".format(path=path)
-    elif db_type == "postgres":
-        return "postgresql://{user}:{password}@{host}{port}/{name}".format(
-            name=name,
-            password=password,
-            user=user,
-            host=host,
-            port=":" + port if port else "",
-        )
-
-
-def make_connection(db_type, url):
-    if db_type == "sqlite":
-        kwargs = dict(
-            connect_args={"check_same_thread": False},
-        )
-
-    elif db_type == "postgres":
-        kwargs = dict(
-            pool_pre_ping=True,
-            client_encoding="utf8",
-        )
-    else:
-        raise Exception("Unknown database engine option: {}".format(db_type))
-
-    connection = create_engine(url, **kwargs)
-
-    # Add multiprocessing safeguards as recommended by:
-    # https://docs.sqlalchemy.org/en/13/core/pooling.html#pooling-multiprocessing
-    # Don't make a connection before we've added the multiprocessing guards
-    # as otherwise we will have a connection that doesn't have the 'pid' attribute set.
-    @event.listens_for(connection, "connect")
-    def connect(dbapi_connection, connection_record):
-        connection_record.info["pid"] = os.getpid()
-
-    @event.listens_for(connection, "checkout")
-    def checkout(dbapi_connection, connection_record, connection_proxy):
-        pid = os.getpid()
-        if connection_record.info["pid"] != pid:
-            connection_record.connection = connection_proxy.connection = None
-            raise exc.DisconnectionError(
-                "Connection record belongs to pid %s, attempting to check out in pid %s"
-                % (connection_record.info["pid"], pid)
-            )
-
-    return connection
-
-
-def __initialize_connection():
-    db_url = create_db_url(
-        conf.OPTIONS["Database"]["DATABASE_ENGINE"],
-        path=os.path.join(conf.KOLIBRI_HOME, "job_storage.sqlite3"),
-        name=conf.OPTIONS["Database"]["DATABASE_NAME"],
-        password=conf.OPTIONS["Database"]["DATABASE_PASSWORD"],
-        user=conf.OPTIONS["Database"]["DATABASE_USER"],
-        host=conf.OPTIONS["Database"]["DATABASE_HOST"],
-        port=conf.OPTIONS["Database"]["DATABASE_PORT"],
-    )
-    connection = make_connection(
-        conf.OPTIONS["Database"]["DATABASE_ENGINE"],
-        db_url,
-    )
-
-    # Check if the database is corrupted
-    try:
-        check_sqlite_integrity(connection)
-    except (exc.DatabaseError, sqlite3.DatabaseError):
-        logger.warn("Job storage database has been corrupted, regenerating")
-        repair_sqlite_db(connection)
-
-    return connection
-
-
-connection = SimpleLazyObject(__initialize_connection)
+connection = SimpleLazyObject(db_connection)
 
 
 def __job_storage():

--- a/kolibri/core/tasks/test/base.py
+++ b/kolibri/core/tasks/test/base.py
@@ -2,22 +2,15 @@ import os
 import tempfile
 from contextlib import contextmanager
 
-from kolibri.core.tasks.main import create_db_url
-from kolibri.core.tasks.main import make_connection
-from kolibri.utils import conf
+from kolibri.core.tasks.utils import db_connection
+from kolibri.utils.tests.helpers import override_option
 
 
 @contextmanager
 def connection():
-    database_engine_option = conf.OPTIONS["Database"]["DATABASE_ENGINE"]
-
-    if database_engine_option == "sqlite":
-        fd, filepath = tempfile.mkstemp()
-        db_url = create_db_url(
-            conf.OPTIONS["Database"]["DATABASE_ENGINE"],
-            path=filepath,
-        )
-        engine = make_connection(database_engine_option, db_url)
+    fd, filepath = tempfile.mkstemp()
+    with override_option("Tasks", "JOB_STORAGE_FILEPATH", filepath):
+        engine = db_connection()
         yield engine
         engine.dispose()
         os.close(fd)
@@ -26,22 +19,3 @@ def connection():
         except OSError:
             # Don't fail test because of difficulty cleaning up.
             pass
-    elif database_engine_option == "postgres":
-        db_url = create_db_url(
-            conf.OPTIONS["Database"]["DATABASE_ENGINE"],
-            name=conf.OPTIONS["Database"]["DATABASE_NAME"],
-            password=conf.OPTIONS["Database"]["DATABASE_PASSWORD"],
-            user=conf.OPTIONS["Database"]["DATABASE_USER"],
-            host=conf.OPTIONS["Database"]["DATABASE_HOST"],
-            port=conf.OPTIONS["Database"]["DATABASE_PORT"],
-        )
-        engine = make_connection(
-            database_engine_option,
-            db_url,
-        )
-        yield engine
-        engine.dispose()
-    else:
-        raise Exception(
-            "Unknown database engine option: {}".format(database_engine_option)
-        )

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import sqlite3
 import time
 import uuid
 from threading import Thread
@@ -6,9 +8,17 @@ from threading import Thread
 from django.utils.functional import SimpleLazyObject
 from django.utils.module_loading import import_string
 from six import string_types
+from sqlalchemy import create_engine
+from sqlalchemy import event
+from sqlalchemy import exc
 
+from kolibri.core.sqlite.utils import check_sqlite_integrity
+from kolibri.core.sqlite.utils import repair_sqlite_db
 from kolibri.core.tasks import compat
+from kolibri.utils import conf
 
+
+logger = logging.getLogger(__name__)
 
 # An object on which to store data about the current job
 # So far the only use is to track the job, but other metadata
@@ -119,3 +129,80 @@ class InfiniteLoopThread(Thread):
 
     def shutdown(self):
         self.stop()
+
+
+def create_db_url(
+    db_type, path=None, name=None, password=None, user=None, host=None, port=None
+):
+    if db_type == "sqlite":
+        return "sqlite:///{path}".format(path=path)
+    elif db_type == "postgres":
+        return "postgresql://{user}:{password}@{host}{port}/{name}".format(
+            name=name,
+            password=password,
+            user=user,
+            host=host,
+            port=":" + port if port else "",
+        )
+
+
+def make_connection(db_type, url):
+    if db_type == "sqlite":
+        kwargs = dict(
+            connect_args={"check_same_thread": False},
+        )
+
+    elif db_type == "postgres":
+        kwargs = dict(
+            pool_pre_ping=True,
+            client_encoding="utf8",
+        )
+    else:
+        raise Exception("Unknown database engine option: {}".format(db_type))
+
+    connection = create_engine(url, **kwargs)
+
+    # Add multiprocessing safeguards as recommended by:
+    # https://docs.sqlalchemy.org/en/13/core/pooling.html#pooling-multiprocessing
+    # Don't make a connection before we've added the multiprocessing guards
+    # as otherwise we will have a connection that doesn't have the 'pid' attribute set.
+    @event.listens_for(connection, "connect")
+    def connect(dbapi_connection, connection_record):
+        connection_record.info["pid"] = os.getpid()
+
+    @event.listens_for(connection, "checkout")
+    def checkout(dbapi_connection, connection_record, connection_proxy):
+        pid = os.getpid()
+        if connection_record.info["pid"] != pid:
+            connection_record.connection = connection_proxy.connection = None
+            raise exc.DisconnectionError(
+                "Connection record belongs to pid %s, attempting to check out in pid %s"
+                % (connection_record.info["pid"], pid)
+            )
+
+    return connection
+
+
+def db_connection():
+    db_url = create_db_url(
+        conf.OPTIONS["Database"]["DATABASE_ENGINE"],
+        path=conf.OPTIONS["Tasks"]["JOB_STORAGE_FILEPATH"],
+        name=conf.OPTIONS["Database"]["DATABASE_NAME"],
+        password=conf.OPTIONS["Database"]["DATABASE_PASSWORD"],
+        user=conf.OPTIONS["Database"]["DATABASE_USER"],
+        host=conf.OPTIONS["Database"]["DATABASE_HOST"],
+        port=conf.OPTIONS["Database"]["DATABASE_PORT"],
+    )
+    connection = make_connection(
+        conf.OPTIONS["Database"]["DATABASE_ENGINE"],
+        db_url,
+    )
+
+    # Check if the database is corrupted
+    try:
+        check_sqlite_integrity(connection)
+    except (exc.DatabaseError, sqlite3.DatabaseError):
+        logger.warn("Job storage database has been corrupted, regenerating")
+        repair_sqlite_db(connection)
+
+    return connection

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -142,18 +142,9 @@ class Worker(object):
         """
         self.storage.mark_job_as_running(job.job_id)
 
-        db_type_lookup = {
-            "sqlite": "sqlite",
-            "postgresql": "postgres",
-        }
-
-        db_type = db_type_lookup[self.storage.engine.dialect.name]
-
         future = self.workers.submit(
             execute_job,
             job_id=job.job_id,
-            db_type=db_type,
-            db_url=self.storage.engine.url,
         )
 
         # assign the futures to a dict, mapping them to a job

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -677,6 +677,13 @@ base_option_spec = {
                 The number of workers to spin up for high priority asynchronous tasks.
             """,
         },
+        "JOB_STORAGE_FILEPATH": {
+            "type": "path",
+            "default": "job_storage.sqlite3",
+            "description": """
+                The file to use for the job storage database. This is only used in the case that the database backend being used is SQLite.
+            """,
+        },
     },
 }
 

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -28,7 +28,7 @@ class override_option(TestContextDecorator):
         self.old_envvars = {}
         for envvar in envvars:
             self.old_envvars[envvar] = os.environ.get(envvar, None)
-            os.environ[envvar] = self.temp_value
+            os.environ[envvar] = str(self.temp_value)
         conf.OPTIONS[self.section][self.key] = self.temp_value
 
     def disable(self):

--- a/kolibri/utils/tests/helpers.py
+++ b/kolibri/utils/tests/helpers.py
@@ -1,6 +1,9 @@
+import os
+
 from django.test.utils import TestContextDecorator
 
 from kolibri.utils import conf
+from kolibri.utils.options import option_spec
 
 
 class override_option(TestContextDecorator):
@@ -21,7 +24,17 @@ class override_option(TestContextDecorator):
 
     def enable(self):
         self.old_value = conf.OPTIONS[self.section][self.key]
+        envvars = option_spec[self.section][self.key]["envvars"]
+        self.old_envvars = {}
+        for envvar in envvars:
+            self.old_envvars[envvar] = os.environ.get(envvar, None)
+            os.environ[envvar] = self.temp_value
         conf.OPTIONS[self.section][self.key] = self.temp_value
 
     def disable(self):
         conf.OPTIONS[self.section][self.key] = self.old_value
+        for envvar, value in self.old_envvars.items():
+            if value is None:
+                del os.environ[envvar]
+            else:
+                os.environ[envvar] = value


### PR DESCRIPTION
## Summary
* Minor tweaks to job execution connection management to simplify reuse of the `execute_job` function for https://github.com/learningequality/kolibri-installer-android/issues/104
* Makes the job storage path into an option so it can be configured via env vars, which lets the tests set the environment variable value for it to allow the multiprocessing environment to be properly configured without manually passing in the values through the worker execution
* Moves utility functions from main to utils as cleanup

## Reviewer guidance
Do all the tests still pass?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
