### PR TITLE
Adjust padding for visible focus outline on bottom bar buttons

### DIFF
--- a/kolibri/core/assets/src/views/BottomAppBar.vue
+++ b/kolibri/core/assets/src/views/BottomAppBar.vue
@@ -39,7 +39,7 @@
     z-index: 8; // material - Bottom app bar
     width: 100%;
     height: 72px;
-    padding: 16px 24px 0;
+    padding: 0 8px;
     margin: 0;
     overflow-x: hidden;
     font-size: 14px;
@@ -53,6 +53,8 @@
 
   .inner-bottom {
     height: 100%;
+    padding-top: 16px;
+    padding-right: 16px;
     overflow-x: hidden;
     overflow-y: visible; // Ensures feedback text is visible
   }

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -544,6 +544,7 @@ oriented data synchronization.
 
   .overall-status {
     margin-bottom: 8px;
+    margin-left: 12px;
   }
 
   .overall-status-text {
@@ -557,6 +558,7 @@ oriented data synchronization.
 
   .table {
     display: table;
+    padding-left: 12px;
   }
 
   .row {


### PR DESCRIPTION
## Summary
This PR redistributes some of the the padding from the outer div of the BottomBar to an inner div so the focus ring is not cut off. It does not change the visual appearance of the spacing (it add up to the same amount for the component). 

On the bar on the content renderer, it adds some padding, for the same purpose.

## References
Fixes #9464 
Fixes #9181

Selection of some pages with the changes applied
| **Page**  |  **Screen** |
|---|---|
| Content Renderer (Exercise) | <img width="1126" alt="Screen Shot 2022-06-02 at 9 07 53 AM" src="https://user-images.githubusercontent.com/17235236/171639428-1035a364-e327-47c8-a850-a59a2956d0bf.png"> |
| Manage Channel Content | <img width="1124" alt="Screen Shot 2022-06-02 at 9 08 25 AM" src="https://user-images.githubusercontent.com/17235236/171639534-dc824c53-e1ee-4d4f-9758-5d8c9953d317.png"> |
| Manage Lesson Resources | <img width="1123" alt="Screen Shot 2022-06-02 at 9 12 14 AM" src="https://user-images.githubusercontent.com/17235236/171639667-40c32910-13d8-43ea-b08d-155235389f58.png"> |
| Create Quiz  | <img width="1125" alt="Screen Shot 2022-06-02 at 9 14 05 AM" src="https://user-images.githubusercontent.com/17235236/171639812-5b6330d9-96ef-4e1c-9835-ba9425c2a1bb.png"> |
| Taking a quiz  | <img width="1126" alt="Screen Shot 2022-06-02 at 9 16 21 AM" src="https://user-images.githubusercontent.com/17235236/171639867-e65b89f7-af2d-4782-a42b-d161f7e5f29f.png"> |


## Reviewer guidance
I think since I made the changes to the bottom bar itself, most of the issues should be resolved. I cross referenced on multiple pages where it is implemented (see screenshots). However, it is possible there are cases that follow a similar pattern but do not use the `BottomBar` component (such as in the content page, where I added the changes separately).

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
