### PR TITLE
Ensure states without route do not break the wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -100,12 +100,13 @@
 
       this.service.onTransition(state => {
         const stateID = Object.keys(state.meta)[0];
-        let newRoute = state.meta[stateID].route;
-
-        if (newRoute != this.$router.currentRoute.name) {
-          if ('path' in state.meta[stateID])
-            this.$router.push({ name: newRoute, path: state.meta[stateID].path });
-          else this.$router.push(newRoute);
+        if (state.meta[stateID] !== undefined) {
+          let newRoute = state.meta[stateID].route;
+          if (newRoute != this.$router.currentRoute.name) {
+            if ('path' in state.meta[stateID])
+              this.$router.push({ name: newRoute, path: state.meta[stateID].path });
+            else this.$router.push(newRoute);
+          }
         }
 
         Lockr.set('savedState', this.service._state);


### PR DESCRIPTION
## Summary
Latest chantes in the setup wizard have introduced states without an associate route.
This was breaking the vue component that pushes the routes.
This PR solves this specific issue (not entering to check the problems with the current routes/machine)


## Reviewer guidance
Does it  make sense?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
