### PR TITLE
[KDS update added] App Bar Refresh: browser spacing

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -32,6 +32,10 @@
         >
       </template>
 
+      <template v-if="windowIsLarge" #navigation>
+        <slot name="sub-nav"></slot>
+      </template>
+
       <template #actions>
         <div>
           <slot name="app-bar-actions"></slot>
@@ -55,7 +59,7 @@
         </div>
       </template>
     </UiToolbar>
-    <div class="subpage-nav">
+    <div v-if="!windowIsLarge" class="subpage-nav">
       <slot name="sub-nav"></slot>
     </div>
   </div>
@@ -71,6 +75,7 @@
   import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
   import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
   import themeConfig from 'kolibri.themeConfig';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import navComponentsMixin from '../mixins/nav-components';
   import SkipNavigationLink from './SkipNavigationLink';
   import plugin_data from 'plugin_data';
@@ -84,7 +89,7 @@
       KIconButton,
       SkipNavigationLink,
     },
-    mixins: [commonCoreStrings, navComponentsMixin],
+    mixins: [commonCoreStrings, navComponentsMixin, responsiveWindowMixin],
     setup() {
       return { themeConfig };
     },
@@ -219,12 +224,19 @@
     margin-left: 16px;
   }
 
-  /deep/ .ui-toolbar__brand {
-    min-width: inherit;
+  /deep/ .ui-toolbar__body {
+    display: inline-block;
+    margin-bottom: 12px;
   }
 
   /deep/ .ui-toolbar__title {
-    margin-right: 10px;
+    display: flex;
+    align-items: center;
+  }
+
+  /deep/ .ui-toolbar__nav-icon {
+    display: flex;
+    align-items: center;
   }
 
   .brand-logo {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -42,18 +42,16 @@
           <div class="total-points">
             <slot name="totalPointsMenuItem"></slot>
           </div>
-          <span v-if="isUserLoggedIn" class="username" tabindex="-1">
+          <span v-if="isUserLoggedIn" tabindex="-1">
             <KIcon
               icon="person"
               :style="{
                 fill: $themeTokens.textInverted,
-                height: '24px',
-                width: '24px',
-                margin: '4px',
-                top: '8px',
+                height: '20px',
+                width: '20px',
               }"
             />
-            {{ usernameForDisplay }}
+            <span class="username">{{ usernameForDisplay }}</span>
           </span>
 
         </div>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -108,11 +108,12 @@
   //     https://github.com/vuejs/rfcs/pull/34
   //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
-    padding-bottom: 2px;
+    font-weight: bold;
+    // padding-bottom: 2px;
     color: white;
     border-bottom-color: white;
     border-bottom-style: solid;
-    border-bottom-width: 2px;
+    border-bottom-width: 4px;
 
     .dimmable {
       opacity: 1;
@@ -131,9 +132,7 @@
 
   .tab-title {
     display: inline-block;
-    font-weight: bold;
     text-overflow: ellipsis;
-    text-transform: uppercase;
     vertical-align: middle;
   }
 

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -165,6 +165,16 @@
     .router-link-active {
       border-bottom-width: 2px;
     }
+
+    /deep/ .ui-icon {
+      width: 20px !important;
+      height: 20px !important;
+    }
+
+    /deep/ svg {
+      width: 16px !important;
+      height: 16px !important;
+    }
   }
 
 </style>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -85,8 +85,8 @@
     display: inline-block;
     min-width: 72px;
     max-width: 264px;
-    padding: 0 18px;
-    padding-bottom: 3px;
+    padding: 0 16px;
+    padding-bottom: 4px;
     margin: 0;
     font-size: 14px;
     text-decoration: none;
@@ -121,7 +121,12 @@
   }
 
   .icon {
-    font-size: 24px;
+    top: 0;
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
   }
 
   .tab-icon {
@@ -133,7 +138,33 @@
   .tab-title {
     display: inline-block;
     text-overflow: ellipsis;
-    vertical-align: middle;
+  }
+
+  /deep/ .ui-icon {
+    width: 22px !important;
+    height: 22px !important;
+  }
+
+  /deep/ svg {
+    width: 20px !important;
+    height: 20px !important;
+  }
+
+  @media (max-width: 600px) {
+    .tab {
+      padding: 0 8px;
+      font-size: 12px;
+    }
+
+    .tab-icon {
+      display: inline-block;
+      padding: 10px 0;
+      margin-right: 0;
+    }
+
+    .router-link-active {
+      border-bottom-width: 2px;
+    }
   }
 
 </style>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -7,13 +7,7 @@
       :to="link"
     >
       <div class="dimmable tab-icon">
-        <UiIcon
-          class="icon"
-          tabindex="-1"
-        >
-          <!--The icon svg-->
-          <slot></slot>
-        </UiIcon>
+        <slot></slot>
       </div>
 
       <div class="dimmable tab-title" tabindex="-1">
@@ -28,14 +22,13 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import UiIcon from 'kolibri-design-system/lib/keen/UiIcon';
+  // import UiIcon from 'kolibri-design-system/lib/keen/UiIcon';
 
   /**
    Links for use inside the Navbar
    */
   export default {
     name: 'NavbarLink',
-    components: { UiIcon },
     props: {
       /**
        * The text
@@ -86,7 +79,7 @@
     min-width: 72px;
     max-width: 264px;
     padding: 0 16px;
-    padding-bottom: 4px;
+    padding-bottom: 6px;
     margin: 0;
     font-size: 14px;
     text-decoration: none;
@@ -140,15 +133,7 @@
     text-overflow: ellipsis;
   }
 
-  /deep/ .ui-icon {
-    width: 22px !important;
-    height: 22px !important;
-  }
-
-  /deep/ svg {
-    width: 20px !important;
-    height: 20px !important;
-  }
+  // for small screens
 
   @media (max-width: 600px) {
     .tab {
@@ -156,24 +141,8 @@
       font-size: 12px;
     }
 
-    .tab-icon {
-      display: inline-block;
-      padding: 10px 0;
-      margin-right: 0;
-    }
-
     .router-link-active {
       border-bottom-width: 2px;
-    }
-
-    /deep/ .ui-icon {
-      width: 20px !important;
-      height: 20px !important;
-    }
-
-    /deep/ svg {
-      width: 16px !important;
-      height: 16px !important;
     }
   }
 

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -22,7 +22,6 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
-  // import UiIcon from 'kolibri-design-system/lib/keen/UiIcon';
 
   /**
    Links for use inside the Navbar
@@ -102,7 +101,6 @@
   //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
     font-weight: bold;
-    // padding-bottom: 2px;
     color: white;
     border-bottom-color: white;
     border-bottom-style: solid;

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -1,110 +1,26 @@
 <template>
 
-  <div
-    class="wrapper"
-    :class="wrapperClass"
-    :style="{ backgroundColor: $themeTokens.appBar }"
-  >
-    <nav>
-      <button
-        v-show="!enoughSpace"
-        class="scroll-button"
-        aria-hidden="true"
-        @click="handleClickPrevious"
-      >
-        <KIcon
-          icon="chevronLeft"
-          :style="{ fill: $themeTokens.textInverted, top: 0, width: '24px', height: '24px', }"
-        />
-      </button>
-
-      <ul
-        ref="navbarUl"
-        class="items"
-        tabindex="-1"
-        :style="{ maxWidth: `${ maxWidth }px` }"
-      >
-        <!-- Contains NavbarLink components -->
-        <slot></slot>
-      </ul>
-
-      <button
-        v-show="!enoughSpace"
-        class="scroll-button"
-        aria-hidden="true"
-        @click="handleClickNext"
-      >
-        <KIcon
-          icon="chevronRight"
-          :style="{ fill: $themeTokens.textInverted, top: 0, width: '24px', height: '24px', }"
-        />
-      </button>
-    </nav>
-  </div>
+  <nav>
+    <ul
+      ref="navbarUl"
+      class="items"
+      tabindex="-1"
+    >
+      <!-- Contains NavbarLink components -->
+      <slot></slot>
+    </ul>
+  </nav>
 
 </template>
 
 
 <script>
 
-  import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
-  import throttle from 'lodash/throttle';
-
   /**
    * Used for navigation between sub-pages of a top-level Kolibri section
    */
   export default {
     name: 'Navbar',
-    mixins: [responsiveElementMixin],
-    data() {
-      return {
-        enoughSpace: true,
-      };
-    },
-    computed: {
-      maxWidth() {
-        return this.enoughSpace ? this.elementWidth : this.elementWidth - 38 * 2;
-      },
-      wrapperClass() {
-        if (!this.enoughSpace) {
-          return ['wrapper-narrow'];
-        }
-
-        return [];
-      },
-    },
-    mounted() {
-      this.checkSpace();
-      this.$watch('elementWidth', this.throttleCheckSpace);
-    },
-    methods: {
-      checkSpace() {
-        const availableWidth = this.elementWidth;
-        const items = this.$children;
-        let widthOfItems = 0;
-        items.forEach(item => {
-          const itemWidth = Math.ceil(item.$el.getBoundingClientRect().width);
-          widthOfItems += itemWidth;
-        });
-        // Subtract 16px to account for padding-left
-        this.enoughSpace = widthOfItems <= availableWidth - 16;
-      },
-      throttleCheckSpace: throttle(function() {
-        this.checkSpace();
-      }, 100),
-      handleClickPrevious() {
-        this.isRtl ? this.scrollRight() : this.scrollLeft();
-      },
-      handleClickNext() {
-        this.isRtl ? this.scrollLeft() : this.scrollRight();
-      },
-      scrollLeft() {
-        this.$refs.navbarUl.scrollLeft -= this.maxWidth;
-      },
-      scrollRight() {
-        this.$refs.navbarUl.scrollLeft += this.maxWidth;
-      },
-    },
   };
 
 </script>
@@ -114,33 +30,20 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .wrapper {
-    padding-left: 16px;
-  }
-
-  .wrapper-narrow {
-    @extend %momentum-scroll;
-
-    padding-left: 0;
-  }
-
   .items {
-    display: inline-block;
+    display: flex;
     padding: 0;
-    margin: 0;
+    margin-bottom: 4px;
+    margin-left: 16px;
     overflow-x: auto;
     overflow-y: hidden;
     white-space: nowrap;
-    vertical-align: middle;
   }
 
-  .scroll-button {
-    width: 36px;
-    height: 36px;
-    vertical-align: middle;
-    background-color: inherit;
-    border-style: none;
-    appearance: none;
+  @media (max-width: 840px) {
+    .items {
+      margin-top: 0;
+    }
   }
 
 </style>

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/plugins/coach/assets/src/views/TopNavbar.vue
+++ b/kolibri/plugins/coach/assets/src/views/TopNavbar.vue
@@ -8,7 +8,6 @@
       <KIcon
         icon="dashboard"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -18,7 +17,6 @@
       <KIcon
         icon="reports"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -28,7 +26,6 @@
       <KIcon
         icon="edit"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
   </Navbar>

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -9,7 +9,6 @@
       <KIcon
         icon="channel"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -20,7 +19,6 @@
       <KIcon
         icon="permissions"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -31,7 +29,6 @@
       <KIcon
         icon="facility"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -42,7 +39,6 @@
       <KIcon
         icon="deviceInfo"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -53,7 +49,6 @@
       <KIcon
         icon="settings"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
   </Navbar>

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/__test__/__snapshots__/TaskPanel.spec.js.snap
@@ -23,6 +23,7 @@ exports[`TaskPanel renders correctly when it is a canceled DISKCONTENTEXPORT tas
     </p>
   </div>
   <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_37nh0f">
+      <!---->
       <!----> <span class="link-text">Clear</span>
       <!---->
       <!----></button></div>
@@ -52,6 +53,7 @@ exports[`TaskPanel renders correctly when it is a canceled DISKEXPORT task (bulk
     </p>
   </div>
   <div class="buttons"><button dir="auto" type="button" tabindex="0" class="button KButton-noKey-0_37nh0f">
+      <!---->
       <!----> <span class="link-text">Clear</span>
       <!---->
       <!----></button></div>

--- a/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
@@ -8,7 +8,6 @@
       <KIcon
         icon="classes"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -18,7 +17,6 @@
       <KIcon
         icon="people"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -28,7 +26,6 @@
       <KIcon
         icon="settings"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
     <NavbarLink
@@ -38,7 +35,6 @@
       <KIcon
         icon="save"
         :color="$themeTokens.textInverted"
-        style="top: 0; width: 24px; height: 24px;"
       />
     </NavbarLink>
   </Navbar>

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -8,7 +8,6 @@
     >
       <KIcon
         icon="dashboard"
-        style="top: 0; width: 24px; height: 24px;"
         :color="$themeTokens.textInverted"
       />
     </NavbarLink>
@@ -20,7 +19,6 @@
       <!-- todo update icon -->
       <KIcon
         icon="library"
-        style="top: 0; width: 24px; height: 24px;"
         :color="$themeTokens.textInverted"
       />
     </NavbarLink>
@@ -31,7 +29,6 @@
     >
       <KIcon
         icon="bookmark"
-        style="top: 0; width: 24px; height: 24px;"
         :color="$themeTokens.textInverted"
       />
     </NavbarLink>

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8131,10 +8131,25 @@ kolibri-constants@0.1.41:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
 
-launch-editor-middleware@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.5.0.tgz#49d7fedaa06d939a3a780cdf7af959b789934700"
-  integrity sha512-kv9MMO81pbYjznk9j/DBu0uBGxIpT6uYhGajq6fxdGEPb+DCRBoS96jGkhe3MJumdY3zZFkuS8CFPTZI9DaBNw==
+"kolibri-design-system@https://github.com/marcellamaki/kolibri-design-system#2bc581f3abe8298dc10ce8d24e382385d3b5a8cf":
+  version "1.3.0"
+  resolved "https://github.com/marcellamaki/kolibri-design-system#2bc581f3abe8298dc10ce8d24e382385d3b5a8cf"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
+launch-editor-middleware@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz#e14b07e6c7154b0a4b86a0fd345784e45804c157"
+  integrity sha512-s0UO2/gEGiCgei3/2UN3SMuUj1phjQN8lcpnvgLSz26fAzNWPQ6Nf/kF5IFClnfU2ehp6LrmKdMU/beveO+2jg==
   dependencies:
     launch-editor "^2.5.0"
 
@@ -8521,10 +8536,18 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.2"
-    picomatch "^2.3.1"
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
-mime-db@1.44.0:
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
+mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,7 +4005,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -8131,32 +8131,17 @@ kolibri-constants@0.1.41:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
 
-"kolibri-design-system@https://github.com/marcellamaki/kolibri-design-system#2bc581f3abe8298dc10ce8d24e382385d3b5a8cf":
-  version "1.3.0"
-  resolved "https://github.com/marcellamaki/kolibri-design-system#2bc581f3abe8298dc10ce8d24e382385d3b5a8cf"
+launch-editor-middleware@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.6.0.tgz#2ba4fe4b695d7fe3d44dee86b6d46d57b8332dfd"
+  integrity sha512-K2yxgljj5TdCeRN1lBtO3/J26+AIDDDw+04y6VAiZbWcTdBwsYN6RrZBnW5DN/QiSIdKNjKdATLUUluWWFYTIA==
   dependencies:
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "^3.0.21"
-    css-element-queries "^1.2.0"
-    frame-throttle "^3.0.0"
-    fuzzysearch "^1.0.3"
-    keen-ui "^1.3.0"
-    lodash "^4.17.15"
-    popper.js "^1.14.6"
-    purecss "^0.6.2"
-    tippy.js "^4.2.1"
+    launch-editor "^2.6.0"
 
-launch-editor-middleware@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.2.1.tgz#e14b07e6c7154b0a4b86a0fd345784e45804c157"
-  integrity sha512-s0UO2/gEGiCgei3/2UN3SMuUj1phjQN8lcpnvgLSz26fAzNWPQ6Nf/kF5IFClnfU2ehp6LrmKdMU/beveO+2jg==
-  dependencies:
-    launch-editor "^2.5.0"
-
-launch-editor@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.5.0.tgz#d646fcc15ed8589b998950cad1102827d9dcadce"
-  integrity sha512-coRiIMBJ3JF7yX8nZE4Fr+xxUy+3WTRsDSwIzHghU28gjXwkAWsvac3BpZrL/jHtbiqQ4TiRAyTJmsgErNk1jQ==
+launch-editor@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.6.0.tgz#4c0c1a6ac126c572bd9ff9a30da1d2cae66defd7"
+  integrity sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==
   dependencies:
     picocolors "^1.0.0"
     shell-quote "^1.7.3"
@@ -8531,13 +8516,13 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.1"
-    picomatch "^2.0.5"
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 micromatch@^4.0.4:
   version "4.0.4"
@@ -8547,7 +8532,7 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
+mime-db@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
   integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8102,28 +8102,14 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3"
+  resolved "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
     frame-throttle "^3.0.0"
-    fuzzysearch "^1.0.3"
-    keen-ui "^1.3.0"
-    lodash "^4.17.15"
-    popper.js "^1.14.6"
-    purecss "^0.6.2"
-    tippy.js "^4.2.1"
-
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0":
-  version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#26c0c302d548afa63aaff32d4539c510c3351f82"
-  dependencies:
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "^3.0.21"
-    css-element-queries "^1.2.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"


### PR DESCRIPTION
## Summary
Updates the navigation bar font size, spacing, and layout in the browser

## References
Fixes #9274 
Note that the overflow updates are a separate issue (out of scope for this) 

Depends on a corresponding KDS update. Reference to the commit is included, but the KDS update will need to be released and kolibri updated.

## Reviewer guidance
Is it to spec? Is everything lined up? (I did quite a lot of pixel measuring, but something still seems off about the text alignment... I cannot tell if it's an optical illusion. 

Some of the pixels are not quite to our usual "stick to multiples of 8" guidance to allow things to add up to spec 

Tested on Chrome, Firefox, and Safari on MacOS and with multiple languages

<img width="1431" alt="Screen Shot 2022-06-07 at 4 30 17 PM" src="https://user-images.githubusercontent.com/17235236/172620987-a90e4c70-158f-4179-969b-dcdc96879e77.png">
<img width="748" alt="Screen Shot 2022-06-07 at 4 30 10 PM" src="https://user-images.githubusercontent.com/17235236/172621001-589c3b48-57ba-4253-8f25-5330f613249c.png">
<img width="465" alt="Screen Shot 2022-06-07 at 4 30 00 PM" src="https://user-images.githubusercontent.com/17235236/172621012-d15cb00d-fab5-476d-bba2-a1121d3f88ca.png">


<img width="1440" alt="Screen Shot 2022-06-08 at 9 06 33 AM" src="https://user-images.githubusercontent.com/17235236/172623986-f58895c1-c681-4c74-9ab7-26ceb43ab3b8.png">

<img width="1440" alt="Screen Shot 2022-06-08 at 9 06 28 AM" src="https://user-images.githubusercontent.com/17235236/172623995-3ce35576-c971-4a37-ba4d-b8db4d9d09f8.png">

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
