### PR TITLE
Change facility first screens

### DIFF
--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -133,13 +133,23 @@ class FacilitySerializer(serializers.ModelSerializer):
 
 class PublicFacilitySerializer(serializers.ModelSerializer):
     learner_can_login_with_no_password = serializers.SerializerMethodField()
+    learner_can_sign_up = serializers.SerializerMethodField()
 
     def get_learner_can_login_with_no_password(self, instance):
         return instance.dataset.learner_can_login_with_no_password
 
+    def get_learner_can_sign_up(self, instance):
+        return instance.dataset.learner_can_sign_up
+
     class Meta:
         model = Facility
-        fields = ("id", "dataset", "name", "learner_can_login_with_no_password")
+        fields = (
+            "id",
+            "dataset",
+            "name",
+            "learner_can_login_with_no_password",
+            "learner_can_sign_up",
+        )
 
 
 class ClassroomSerializer(serializers.ModelSerializer):

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -386,10 +386,8 @@ class RemoteFacilitiesViewset(views.APIView):
     permission_classes = (IsNotAnonymous,)
 
     def get(self, request):
-        baseurl = request.query_params.get(
-            "baseurl", request.build_absolute_uri("/")[:-1]
-        )
-        path = reverse("kolibri:core:publicfacility-list")
+        baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
+        path = reverse("kolibri:core:publicfacility-list").lstrip("/")
         url = urljoin(baseurl, path)
         try:
             response = requests.get(url)

--- a/kolibri/core/device/api_urls.py
+++ b/kolibri/core/device/api_urls.py
@@ -10,6 +10,7 @@ from .api import DeviceRestartView
 from .api import DeviceSettingsView
 from .api import DriveInfoViewSet
 from .api import FreeSpaceView
+from .api import RemoteFacilitiesViewset
 from .api import UserSyncStatusViewSet
 
 router = routers.SimpleRouter()
@@ -32,4 +33,7 @@ urlpatterns = [
     url(r"^devicesettings/", DeviceSettingsView.as_view(), name="devicesettings"),
     url(r"^devicename/", DeviceNameView.as_view(), name="devicename"),
     url(r"^devicerestart/", DeviceRestartView.as_view(), name="devicerestart"),
+    url(
+        r"^remotefacilities", RemoteFacilitiesViewset.as_view(), name="remotefacilities"
+    ),
 ]

--- a/kolibri/core/device/permissions.py
+++ b/kolibri/core/device/permissions.py
@@ -33,3 +33,8 @@ class UserHasAnyDevicePermissions(DenyAll):
 class IsSuperuser(DenyAll):
     def has_permission(self, request, view):
         return request.user.is_superuser
+
+
+class IsNotAnonymous(DenyAll):
+    def has_permission(self, request, view):
+        return request.user.is_authenticated

--- a/kolibri/core/discovery/permissions.py
+++ b/kolibri/core/discovery/permissions.py
@@ -1,6 +1,7 @@
 from rest_framework.permissions import BasePermission
 
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
+from kolibri.core.device.utils import get_device_setting
 
 
 class NetworkLocationPermissions(BasePermission):
@@ -8,15 +9,28 @@ class NetworkLocationPermissions(BasePermission):
     A user can access NetworkLocation objects if:
     1. User can manage content (to get import/export peers)
     2. User is a facility admin (to be able to sync facility with peer)
+    In not Learner Only Devices, for users to be able to change to another facility,
+    any facility user must be able to discover other facilities
     """
 
     def has_permission(self, request, view):
-        return request.user.can_manage_content or _user_is_admin_for_own_facility(
-            request.user
+        subset_of_users_device = get_device_setting(
+            "subset_of_users_device", default=False
         )
+        if subset_of_users_device:
+            return request.user.can_manage_content or _user_is_admin_for_own_facility(
+                request.user
+            )
+        else:
+            return request.user.is_facility_user
 
     def has_object_permission(self, request, view, obj):
-        # Don't pass `obj` because locations don't have facilities attached to them
-        return request.user.can_manage_content or _user_is_admin_for_own_facility(
-            request.user
+        subset_of_users_device = get_device_setting(
+            "subset_of_users_device", default=False
         )
+        if subset_of_users_device:
+            return request.user.can_manage_content or _user_is_admin_for_own_facility(
+                request.user
+            )
+        else:
+            return request.user.is_facility_user

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -84,21 +84,7 @@ class NetworkLocationAPITestCase(APITestCase):
         response = self.client.get(reverse("kolibri:core:staticnetworklocation-list"))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_cannot_read_network_location_list_as_learner(self):
-        self.login(self.learner)
-        response = self.client.get(reverse("kolibri:core:staticnetworklocation-list"))
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     def test_cannot_create_location_as_anon_user(self):
-        response = self.client.post(
-            reverse("kolibri:core:staticnetworklocation-list"),
-            data={"base_url": "kolibrihappyurl.qqq"},
-            format="json",
-        )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_cannot_create_location_as_learner(self):
-        self.login(self.learner)
         response = self.client.post(
             reverse("kolibri:core:staticnetworklocation-list"),
             data={"base_url": "kolibrihappyurl.qqq"},

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -12,8 +12,10 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.gzip import gzip_page
+from django_filters.rest_framework import DjangoFilterBackend
 from morango.constants import transfer_statuses
 from morango.models.core import TransferSession
+from rest_framework import filters
 from rest_framework import status
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
@@ -324,3 +326,16 @@ class SyncQueueViewSet(viewsets.ViewSet):
 
     def update(self, request, pk=None):
         return self.check_queue(request, pk=pk)
+
+
+class FacilitySearchUsernameViewSet(ReadOnlyValuesViewset):
+    filter_backends = (DjangoFilterBackend, filters.SearchFilter)
+    filter_fields = ("facility",)
+    search_fields = ("^username",)
+
+    values = ("id", "username")
+
+    def get_queryset(self):
+        return FacilityUser.objects.filter(roles=None).filter(
+            Q(devicepermissions__is_superuser=False) | Q(devicepermissions__isnull=True)
+        )

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -340,7 +340,7 @@ class FacilitySearchUsernameViewSet(ReadOnlyValuesViewset):
         facility_id = request.query_params.get("facility", None)
         try:
             facility = Facility.objects.get(id=facility_id)
-        except AttributeError:
+        except (AttributeError, Facility.DoesNotExist):
             # non existing facility
             return Response({})
 

--- a/kolibri/core/public/api_urls.py
+++ b/kolibri/core/public/api_urls.py
@@ -22,6 +22,7 @@ from rest_framework import routers
 from ..auth.api import PublicFacilityUserViewSet
 from ..auth.api import PublicFacilityViewSet
 from ..auth.api import PublicSignUpViewSet
+from .api import FacilitySearchUsernameViewSet
 from .api import get_public_channel_list
 from .api import get_public_channel_lookup
 from .api import get_public_file_checksums
@@ -36,6 +37,9 @@ router = routers.SimpleRouter()
 
 router.register(r"v1/facility", PublicFacilityViewSet, basename="publicfacility")
 router.register(r"facilityuser", PublicFacilityUserViewSet, basename="publicuser")
+router.register(
+    r"facilitysearchuser", FacilitySearchUsernameViewSet, basename="publicsearchuser"
+)
 router.register(r"signup", PublicSignUpViewSet, basename="publicsignup")
 router.register(r"info", InfoViewSet, basename="info")
 router.register(r"syncqueue", SyncQueueViewSet, basename="syncqueue")

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -1,14 +1,10 @@
 from django.conf.urls import url
 
-from .viewsets import RemoteFacilitiesViewset
 from .viewsets import RemoteFacilityUserViewset
 from .viewsets import UserIndividualViewset
 
 urlpatterns = [
     url(r"userindividual", UserIndividualViewset.as_view(), name="userindividual"),
-    url(
-        r"remotefacilities", RemoteFacilitiesViewset.as_view(), name="remotefacilities"
-    ),
     url(
         r"remotefacilityuser",
         RemoteFacilityUserViewset.as_view(),

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -1,7 +1,18 @@
 from django.conf.urls import url
 
+from .viewsets import RemoteFacilitiesViewset
+from .viewsets import RemoteFacilityUserViewset
 from .viewsets import UserIndividualViewset
 
 urlpatterns = [
     url(r"userindividual", UserIndividualViewset.as_view(), name="userindividual"),
+    # url(r"remotefacilities/(?P<baseurl>[^/]+)", RemoteFacilitiesViewset.as_view(), name="remotefacilities"),
+    url(
+        r"remotefacilities", RemoteFacilitiesViewset.as_view(), name="remotefacilities"
+    ),
+    url(
+        r"remotefacilityuser",
+        RemoteFacilityUserViewset.as_view(),
+        name="remotefacilityuser",
+    ),
 ]

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -6,7 +6,6 @@ from .viewsets import UserIndividualViewset
 
 urlpatterns = [
     url(r"userindividual", UserIndividualViewset.as_view(), name="userindividual"),
-    # url(r"remotefacilities/(?P<baseurl>[^/]+)", RemoteFacilitiesViewset.as_view(), name="remotefacilities"),
     url(
         r"remotefacilities", RemoteFacilitiesViewset.as_view(), name="remotefacilities"
     ),

--- a/kolibri/plugins/user_profile/assets/src/composables/useIndividualDevice.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useIndividualDevice.js
@@ -9,6 +9,7 @@ export default function useIndividualDevice() {
     client({ url: urls['kolibri:kolibri.plugins.user_profile:userindividual']() }).then(
       response => {
         isIndividual.value = response.data.individual && !response.data.lod;
+        // isIndividual.value = true;
       }
     );
   });

--- a/kolibri/plugins/user_profile/assets/src/composables/useIndividualDevice.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useIndividualDevice.js
@@ -9,7 +9,6 @@ export default function useIndividualDevice() {
     client({ url: urls['kolibri:kolibri.plugins.user_profile:userindividual']() }).then(
       response => {
         isIndividual.value = response.data.individual && !response.data.lod;
-        // isIndividual.value = true;
       }
     );
   });

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -1,3 +1,5 @@
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
 import { createMachine, assign } from 'xstate';
 // This machine can be visualized and tested at https://stately.ai/viz/c1316a38-033d-4c57-8d9f-e282310e341d
 /* SETCONTEXT event example:
@@ -27,30 +29,31 @@ const setInitialContext = assign((_, event) => {
   };
 });
 
-const connectToTargetKolibri = event => {
+const connectToTargetKolibri = (context, event) => {
   const facility = event.value;
-  return new Promise(function(resolve) {
-    setTimeout(
-      () => {
-        return resolve({
-          facility: facility,
-          users: [
-            { id: 1, username: 'username1' },
-            { id: 2, username: 'username2' },
-          ],
-        });
-      },
-      1000,
-      facility
-    );
+  const params = {
+    baseurl: facility.url,
+    facility: facility.id,
+    username: context.username,
+  };
+  return client({
+    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityuser'](),
+    params: params,
+  }).then(response => {
+    let users = response.data;
+    if (Object.keys(response.data).length === 0) users = [];
+    return { facility: facility, users: users };
   });
 };
 
 const checkExists = assign((context, event) => {
   const filtered = event.data.users.filter(user => user.username === context.username);
   const exists = filtered.length > 0;
+  if (!exists) {
+    return { accountExists: false };
+  }
   return {
-    accountExists: exists,
+    accountExists: true,
     targetFacility: event.data.facility,
     targetAccount: filtered[0],
   };
@@ -108,8 +111,8 @@ export const changeFacilityMachine = createMachine({
         SETCONTEXT: { actions: setInitialContext },
         SELECTFACILITY: {
           actions: assign({
-            targetFacility: () => {
-              return {};
+            targetFacility: (_, event) => {
+              return event.value;
             },
           }),
           target: 'getFacilityUsernames',
@@ -119,7 +122,7 @@ export const changeFacilityMachine = createMachine({
     getFacilityUsernames: {
       invoke: {
         id: 'getUserNames',
-        src: (context, event) => connectToTargetKolibri(event),
+        src: (context, event) => connectToTargetKolibri(context, event),
         onDone: {
           target: 'selectFacility',
           actions: checkExists,
@@ -130,7 +133,7 @@ export const changeFacilityMachine = createMachine({
       },
     },
     changeFacility: {
-      meta: { route: 'CHANGE_FACILITY', path: '/change_facility' },
+      meta: { route: 'CONFIRM_CHANGE_FACILITY', path: '/change_facility' },
       on: {
         MERGE: {
           target: 'mergeAccounts',
@@ -157,13 +160,12 @@ export const changeFacilityMachine = createMachine({
       on: {
         NEW: 'createAccount',
         CONTINUE: 'isAdmin',
-        BACK: 'changeFacility',
       },
     },
     isAdmin: {
       always: [
         {
-          cond: context => context.role === 'superadmin',
+          cond: context => context.role === 'superuser',
           target: 'chooseAdmin',
         },
         {

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -160,6 +160,7 @@ export const changeFacilityMachine = createMachine({
       on: {
         NEW: 'createAccount',
         CONTINUE: 'isAdmin',
+        BACK: 'changeFacility',
       },
     },
     isAdmin: {

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -60,7 +60,7 @@ export default [
         component: SelectFacility,
       },
       {
-        path: 'change',
+        path: 'confirm_change',
         name: 'CONFIRM_CHANGE_FACILITY',
         component: ConfirmChangeFacility,
       },

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -3,6 +3,10 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';
+import SelectFacility from './views/ChangeFacility/SelectFacility';
+import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
+import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
+import ToBeDone from './views/ChangeFacility/ToBeDone';
 
 function preload(next) {
   store.commit('CORE_SET_PAGE_LOADING', true);
@@ -40,7 +44,7 @@ export default [
 
   {
     path: '/change_facility',
-    name: 'SELECT_FACILITY',
+    name: 'CHANGE_FACILITY',
     component: ChangeFacility,
     beforeEnter(to, from, next) {
       if (!store.getters.isUserLoggedIn) {
@@ -52,68 +56,74 @@ export default [
     children: [
       {
         path: 'change',
-        name: 'CHANGE_FACILITY',
-        component: ChangeFacility,
+        name: 'SELECT_FACILITY',
+        component: SelectFacility,
       },
+      {
+        path: 'change',
+        name: 'CONFIRM_CHANGE_FACILITY',
+        component: ConfirmChangeFacility,
+      },
+
       {
         path: 'confirm_account',
         name: 'CONFIRM_ACCOUNT',
-        component: ChangeFacility,
+        component: ConfirmAccount,
       },
       {
         path: 'choose_admin',
         name: 'CHOOSE_ADMIN',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'confirm_merge',
         name: 'CONFIRM_MERGE',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'syncing_change_facility',
         name: 'SYNCING_CHANGE_FACILITY',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'create_account',
         name: 'CREATE_ACCOUNT',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'username_exists',
         name: 'USERNAME_EXISTS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'require_account_credentials',
         name: 'REQUIRE_ACCOUNT_CREDENTIALS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'admin_password',
         name: 'ADMIN_PASSWORD',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'show_accounts',
         name: 'SHOW_ACCOUNTS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'show_accounts',
         name: 'CONFIRM_DETAILS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'show_accounts',
         name: 'EDIT_DETAILS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
       {
         path: 'merge_accounts',
         name: 'MERGE_ACCOUNTS',
-        component: ChangeFacility,
+        component: ToBeDone,
       },
     ],
   },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount.vue
@@ -1,0 +1,106 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p>{{ firstLine }}</p>
+    <p>{{ secondLine }}</p>
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="$tr('createAccount')"
+            @click="to_create"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            :disabled="usernameExists"
+            @click="to_continue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+
+  export default {
+    name: 'ConfirmAccount',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+
+    inject: ['changeFacilityService', 'state'],
+    computed: {
+      targetFacility() {
+        return this.state.value.targetFacility;
+      },
+      username() {
+        return this.state.value.username;
+      },
+      usernameExists() {
+        return this.state.value.accountExists;
+      },
+      firstLine() {
+        return this.$tr('confirmAccountLine1', {
+          target_facility: this.targetFacility.name,
+          username: this.username,
+        });
+      },
+      secondLine() {
+        return this.$tr('confirmAccountLine2', {
+          target_facility: this.targetFacility.name,
+        });
+      },
+    },
+
+    methods: {
+      to_continue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      },
+      to_create() {
+        this.changeFacilityService.send({
+          type: 'NEW',
+        });
+      },
+    },
+
+    $trs: {
+      documentTitle: {
+        message: 'Confirm account username',
+        context: 'Title of this step for the change facility page.',
+      },
+      createAccount: {
+        message: 'Create new account',
+        context: 'Button for the create new account in the new facility.',
+      },
+      confirmAccountLine1: {
+        message: 'You are about to join ‘{target_facility}’ learning facility as ‘{username}’.',
+        context:
+          'First line of text confirming the username and facility where the user is changing.',
+      },
+      confirmAccountLine2: {
+        message:
+          "You can continue using this username or create a new account username for '{target_facility}'.",
+        context:
+          'Second line of text confirming the username and facility where the user is changing',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -89,7 +89,7 @@
       },
       mergeAccounts: {
         message: 'Merge Accounts',
-        context: 'Button for the merge accounts between facilities button.',
+        context: 'Button for the merge accounts between facilities.',
       },
       changeFacilityInfoLine1: {
         message:

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -1,0 +1,113 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p>{{ firstLine }}</p>
+    <p>{{ secondLine }}</p>
+    <p>{{ thirdLine }}</p>
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="$tr('mergeAccounts')"
+            @click="to_merge"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            @click="to_continue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+
+  export default {
+    name: 'ConfirmChangeFacility',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+
+    inject: ['changeFacilityService', 'state'],
+    computed: {
+      targetFacility() {
+        return this.state.value.targetFacility;
+      },
+      role() {
+        return this.state.value.role;
+      },
+      firstLine() {
+        return this.$tr('changeFacilityInfoLine1', {
+          target_facility: this.targetFacility.name,
+        });
+      },
+      secondLine() {
+        if (this.role === 'learner') return '';
+        return this.$tr('changeFacilityInfoLine2', {
+          role: this.role,
+        });
+      },
+      thirdLine() {
+        return this.$tr('changeFacilityInfoLine3', {
+          target_facility: this.targetFacility.name,
+        });
+      },
+    },
+
+    methods: {
+      to_continue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      },
+      to_merge() {
+        this.changeFacilityService.send({
+          type: 'MERGE',
+        });
+      },
+    },
+
+    $trs: {
+      documentTitle: {
+        message: 'Change Facility',
+        context: 'Title of this step for the change facility page.',
+      },
+      mergeAccounts: {
+        message: 'Merge Accounts',
+        context: 'Button for the merge accounts between facilities button.',
+      },
+      changeFacilityInfoLine1: {
+        message:
+          'You are about to move your account and progress data to ‘{target_facility}’ learning facility. Your data will still be available to you and will also be accessible to any administrators of this learning facility.',
+        context: 'First line of text explaining what changing to another learning facility means.',
+      },
+      changeFacilityInfoLine2: {
+        message:
+          'Your user account type will change from ‘{role} to ‘learner’. You will need another admin to change your account type to ‘{role}’ again.',
+        context:
+          'Second line of text explaining that changing to another learning facility will downgrade the user role to learner',
+      },
+      changeFacilityInfoLine3: {
+        message:
+          'You can also search for an account to merge with in ‘{target_facility}’ learning facility. Progress data from both accounts will be combined into one account.',
+        context: 'Last line of text explaining what changing to another learning facility means.',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -1,0 +1,279 @@
+<template>
+
+  <div>
+    <span class="headercontainer">
+      <h1>{{ $tr('documentTitle') }}</h1>
+
+      <transition name="spinner-fade">
+
+        <div v-if="discoveringPeers">
+          <KLabeledIcon>
+            <template #icon>
+              <KCircularLoader :size="16" :stroke="6" class="loader" />
+            </template>
+          </KLabeledIcon>
+        </div>
+      </transition>
+
+    </span>
+    <p v-if="initialFetchingComplete && !availableFacilities.length">
+      {{ $tr('noFacilitiesText') }}
+    </p>
+    <template v-for="f in availableFacilities">
+      <div :key="`div-${f.id}`">
+        <KRadioButton
+          :key="f.id"
+          v-model="selectedFacilityId"
+          class="radio-button"
+          :value="f.id"
+          :label="formatNameAndId(f.name, f.id)"
+          :disabled="discoveryFailed || !isAddressAvailable(f.address_id)"
+        />
+      </div>
+
+    </template>
+
+    <KGrid
+      :style="{
+        marginTop: '34px',
+        paddingTop: '10px',
+        borderTop: `1px solid ${$themePalette.grey.v_300}`
+      }"
+    >
+
+      <KGridItem>{{ $tr('doNotSeeYourFacility') }}</KGridItem>
+      <KGridItem>
+        <KButton
+          class="new-address-button"
+          :text="$tr('newAddressButtonLabel')"
+          appearance="basic-link"
+          @click="showAddAddressModal = true"
+        />
+      </KGridItem>
+    </KGrid>
+
+    <AddAddressForm
+      v-if="showAddAddressModal"
+      @cancel="showAddAddressModal = false"
+      @added_address="handleAddedAddress"
+    />
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            :disabled="selectedFacilityId === ''"
+            @click="to_continue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import { useLocalStorage } from '@vueuse/core';
+  import { computed } from 'kolibri.lib.vueCompositionApi';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import client from 'kolibri.client';
+  import urls from 'kolibri.urls';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import useSavedAddresses from '../../../../../../core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js';
+  import useDynamicAddresses from '../../../../../../core/assets/src/views/sync/SelectAddressModalGroup/useDynamicAddresses.js';
+  import AddAddressForm from '../../../../../../core/assets/src/views/sync/SelectAddressModalGroup/AddAddressForm';
+
+  export default {
+    name: 'SelectFacility',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { AddAddressForm, BottomAppBar },
+
+    mixins: [responsiveWindowMixin, commonCoreStrings, commonSyncElements],
+    setup(props, context) {
+      const {
+        addresses: discoveredAddresses,
+        discoveringPeers,
+        discoveryFailed,
+        discoveredAddressesInitiallyFetched,
+      } = useDynamicAddresses(props);
+      const {
+        addresses: savedAddresses,
+        removeSavedAddress,
+        refreshSavedAddressList,
+        savedAddressesInitiallyFetched,
+        requestsFailed,
+        deletingAddress,
+        fetchingAddresses,
+      } = useSavedAddresses(props, context);
+      const combinedAddresses = computed(() => {
+        return [...savedAddresses.value, ...discoveredAddresses.value];
+      });
+      const initialFetchingComplete = computed(() => {
+        return savedAddressesInitiallyFetched.value && discoveredAddressesInitiallyFetched.value;
+      });
+      const storageFacilityId = useLocalStorage('kolibri-lastSelectedFacilityId', '');
+      return {
+        combinedAddresses,
+        initialFetchingComplete,
+        discoveredAddresses,
+        discoveryFailed,
+        discoveringPeers,
+        discoveredAddressesInitiallyFetched,
+        savedAddresses,
+        savedAddressesInitiallyFetched,
+        removeSavedAddress,
+        refreshSavedAddressList,
+        requestsFailed,
+        deletingAddress,
+        fetchingAddresses,
+        storageFacilityId,
+      };
+    },
+    data() {
+      return {
+        availableAddressIds: [],
+        availableFacilities: [],
+        selectedFacilityId: '',
+        showAddAddressModal: false,
+      };
+    },
+    inject: ['changeFacilityService'],
+    computed: {
+      isAddressAvailable() {
+        return function(addressId) {
+          return Boolean(this.availableAddressIds.find(id => id === addressId));
+        };
+      },
+    },
+    watch: {
+      selectedFacilityId(newVal) {
+        this.storageFacilityId = newVal;
+        const facility = this.availableFacilities.find(f => f.id === newVal);
+        this.changeFacilityService.send({
+          type: 'SELECTFACILITY',
+          value: {
+            name: facility.name,
+            url: facility.base_url,
+            id: facility.id,
+            learner_can_sign_up: facility.learner_can_sign_up,
+          },
+        });
+      },
+      combinedAddresses(addrs) {
+        const availableDevices = addrs.filter(
+          address =>
+            address.available &&
+            address.application === 'kolibri' &&
+            !address.subset_of_users_device
+        );
+        const newDevices = availableDevices.filter(
+          address => !this.availableAddressIds.includes(address.id)
+        );
+        newDevices.forEach(address => {
+          client({
+            url: urls['kolibri:kolibri.plugins.user_profile:remotefacilities'](),
+            params: { baseurl: address.base_url },
+          }).then(response => {
+            response.data.forEach(facility => {
+              const newFacility = {
+                id: facility.id,
+                name: facility.name,
+                base_url: address.base_url,
+                address_id: address.id,
+                learner_can_sign_up: facility.learner_can_sign_up || true,
+              };
+              if (!this.availableFacilities.find(f => f.id === facility.id))
+                this.availableFacilities.push(newFacility);
+            });
+          });
+          this.availableAddressIds = availableDevices.map(address => address.id);
+
+          if (address.facility_name) {
+            this.availableFacilities.push({
+              id: address.id,
+              name: address.facility_name,
+            });
+          }
+        });
+
+        if (!this.availableFacilities.map(f => f.id).includes(this.selectedFacilityId)) {
+          this.selectedFacilityId = '';
+        }
+        if (!this.selectedFacilityId) {
+          this.resetSelectedAddress();
+        }
+      },
+    },
+    methods: {
+      createSnackbar(args) {
+        this.$store.dispatch('createSnackbar', args);
+      },
+      handleAddedAddress() {
+        this.refreshSavedAddressList();
+        this.createSnackbar(this.$tr('addAddressSnackbarText'));
+      },
+      resetSelectedAddress() {
+        if (this.availableFacilities.length !== 0) {
+          const selectedId = this.selectedId || this.storageFacilityId || this.selectedFacilityId;
+          this.selectedFacilityId =
+            this.availableFacilities.map(f => f.id).find(f => f.id === selectedId) ||
+            this.availableFacilities[0].id;
+        } else {
+          this.selectedFacilityId = '';
+        }
+      },
+      to_continue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      },
+    },
+    $trs: {
+      addAddressSnackbarText: {
+        message: 'Successfully added address',
+        context: 'This message appears if a network address has been added correctly.',
+      },
+      documentTitle: {
+        message: 'Select learning facility',
+        context: 'Title of this step for the change facility page.',
+      },
+      doNotSeeYourFacility: {
+        message: 'Don’t see your learning facility?',
+        context:
+          'This text appears next to the "Add new address" link. This option allows you to add a new network address from which to sync data.',
+      },
+      newAddressButtonLabel: {
+        message: 'Add new address',
+        context:
+          'The "Add new address" link appears in the \'Select network address\' screen. This option allows you to add a new network address from which to sync data.',
+      },
+      noFacilitiesText: {
+        message: 'No learning facilities found',
+        context:
+          'This message displays when there are no accesible facilities found in the network. It can appear after the user selects to change to another existing facility.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .headercontainer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+</style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -9,7 +9,7 @@
         <div v-if="discoveringPeers">
           <KLabeledIcon>
             <template #icon>
-              <KCircularLoader :size="16" :stroke="6" class="loader" />
+              <KCircularLoader :size="16" :stroke="6" />
             </template>
           </KLabeledIcon>
         </div>
@@ -24,7 +24,6 @@
         <KRadioButton
           :key="f.id"
           v-model="selectedFacilityId"
-          class="radio-button"
           :value="f.id"
           :label="formatNameAndId(f.name, f.id)"
           :disabled="discoveryFailed || !isAddressAvailable(f.address_id)"
@@ -44,7 +43,6 @@
       <KGridItem>{{ $tr('doNotSeeYourFacility') }}</KGridItem>
       <KGridItem>
         <KButton
-          class="new-address-button"
           :text="$tr('newAddressButtonLabel')"
           appearance="basic-link"
           @click="showAddAddressModal = true"

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -179,7 +179,7 @@
         );
         newDevices.forEach(address => {
           client({
-            url: urls['kolibri:kolibri.plugins.user_profile:remotefacilities'](),
+            url: urls['kolibri:core:remotefacilities'](),
             params: { baseurl: address.base_url },
           }).then(response => {
             response.data.forEach(facility => {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ToBeDone.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ToBeDone.vue
@@ -1,0 +1,71 @@
+<template>
+
+  <div>
+    <KGrid>
+      <KGridItem sizes="100, 75, 75" percentage>
+        <h1>Scalfolding page</h1>
+      </KGridItem>
+      <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+        Route name: {{ currentRoute }}
+      </KGridItem>
+      <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+        Machine state: {{ changeFacilityService.state.value }}
+      </KGridItem>
+      <KGridItem v-if="!isSubsetOfUsersDevice" sizes="100, 25, 25" percentage alignment="right">
+        Machine context: {{ state.value }}
+      </KGridItem>
+    </KGrid>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            @click="to_continue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import plugin_data from 'plugin_data';
+
+  export default {
+    name: 'ToBeDone',
+
+    components: { BottomAppBar },
+    inject: ['changeFacilityService', 'state'],
+    mixins: [responsiveWindowMixin, commonCoreStrings],
+    setup() {
+      const { isSubsetOfUsersDevice } = plugin_data;
+      return {
+        isSubsetOfUsersDevice,
+      };
+    },
+    data() {
+      return {
+        currentRoute: this.$router.currentRoute.name,
+      };
+    },
+
+    methods: {
+      to_continue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <NotificationsRoot>
-    <div class="main-wrapper" :style="wrapperStyles">
+    <div :style="wrapperStyles">
       <ImmersiveToolbar
         ref="appBar"
         :appBarTitle="coreString('changeLearningFacility')"
@@ -81,7 +81,6 @@
       this.service.start();
       this.service.onTransition(state => {
         const stateID = Object.keys(state.meta)[0];
-        console.log(state);
         if (state.meta[stateID] !== undefined) {
           let newRoute = state.meta[stateID].route;
           if (newRoute != this.$router.currentRoute.name) {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -53,6 +53,7 @@
         state: changeFacilityMachine.initialState,
         currentRoute: this.$router.currentRoute.name,
         appBarHeight: 0,
+        internalNavigation: false,
       };
     },
     provide() {
@@ -77,6 +78,10 @@
       },
     },
 
+    beforeRouteUpdate(to, from, next) {
+      if (!this.internalNavigation) this.service.send('BACK');
+      next();
+    },
     created() {
       this.service.start();
       this.service.onTransition(state => {
@@ -85,8 +90,13 @@
           let newRoute = state.meta[stateID].route;
           if (newRoute != this.$router.currentRoute.name) {
             if ('path' in state.meta[stateID]) {
-              this.backRoute = this.currentRoute;
-              this.$router.push({ name: newRoute, path: state.meta[stateID].path });
+              this.internalNavigation = true;
+              this.$router.push(
+                { name: newRoute, path: state.meta[stateID].path },
+                function() {
+                  this.internalNavigation = false;
+                }.bind(this)
+              );
             } else this.$router.push(newRoute);
           }
           this.currentRoute = newRoute;

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -141,7 +141,7 @@
                 :text="$tr('changeAction')"
                 appearance="raised-button"
                 :primary="false"
-                :to="$router.getRoute('SELECT_FACILITY')"
+                :to="$router.getRoute('CHANGE_FACILITY')"
               />
             </h2>
           </KGridItem>

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -41,7 +41,9 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
             "password": data["password"],
             "facility": facility,
         }
-        public_signup_url = urljoin(baseurl, reverse("kolibri:core:publicsignup-list"))
+        public_signup_url = urljoin(
+            baseurl, reverse("kolibri:core:publicsignup-list").lstrip("/")
+        )
         response = requests.post(public_signup_url, data=user_data)
         if response.status_code != HTTP_201_CREATED:
             raise serializers.ValidationError(response.json()[0]["id"])

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -30,14 +30,12 @@ class UserIndividualViewset(APIView):
 
 class RemoteFacilityUserViewset(APIView):
     def get(self, request):
-        baseurl = request.query_params.get(
-            "baseurl", request.build_absolute_uri("/")[:-1]
-        )
+        baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
         username = request.query_params.get("username", None)
         facility = request.query_params.get("facility", None)
         if username is None or facility is None:
             raise ValidationError(detail="Both username and facility are required")
-        path = reverse("kolibri:core:publicsearchuser-list")
+        path = reverse("kolibri:core:publicsearchuser-list").lstrip("/")
         url = urljoin(baseurl, path)
         try:
             response = requests.get(

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -28,23 +28,6 @@ class UserIndividualViewset(APIView):
         )
 
 
-class RemoteFacilitiesViewset(APIView):
-    def get(self, request):
-        baseurl = request.query_params.get(
-            "baseurl", request.build_absolute_uri("/")[:-1]
-        )
-        path = reverse("kolibri:core:publicfacility-list")
-        url = urljoin(baseurl, path)
-        try:
-            response = requests.get(url)
-            if response.status_code == 200:
-                return Response(response.json())
-            else:
-                return Response({})
-        except Exception as e:
-            raise ValidationError(detail=str(e))
-
-
 class RemoteFacilityUserViewset(APIView):
     def get(self, request):
         baseurl = request.query_params.get(


### PR DESCRIPTION
## Summary
Creation of the first screens for the Change facility flow.

In order to do it, some backend additions have been needed:
* `learner_can_sign_up` is added now to the returned fields by ` /api/public/v1/facility/`
* In not _Learner only devices,_ permission to detect other facilities has to be done to any facility user. Currently only superusers and users having access to manage content could discover other devices.
* Created a new public api,` /api/public/facilitysearchuser/` that allows searching for existing (non-superuser) users in another facility, retrieving both the id and usernames for the found users.
* In the `user_profile` plugin, a couple of apis, `remotefacilities` and `remotefacilityuser` are added to proxy the search of information in a different device in the network

In the frontend side:
- Created a main component for the `ChangeFacility/index.vue` , using the new design without `CoreBase` containing the component of the different states, depending on the state machine and the assigned routes
- Some small changes in the `changeMachineFacility.js` to use the new apis
- Changes in the routes to use the new components
 - a provisional component, `ToBeDone.vue` has been created to show information of the machine states that don't have a screen implemented yet.
 - New components `SelectFacility`, `ConfirmAccount` and `ConfirmChangeFacility` to implement some of the first screens in the change facility flow
![changefacility1](https://user-images.githubusercontent.com/1008178/173111163-0f99ce1d-93ba-4830-9b25-9c46542a4f85.png)
![selectfacility1](https://user-images.githubusercontent.com/1008178/173111202-0c4950dc-f525-4e00-9831-495ddf86f071.png)
![selectfacility2](https://user-images.githubusercontent.com/1008178/173111224-d4d17180-e305-4bcf-9e8d-0d41c3989fa2.png)
![superuser](https://user-images.githubusercontent.com/1008178/173110948-7c3f10ae-e0d7-48cb-b390-f6c128295034.gif)






## References
Closes: #9324 , #9325, #9469 

## Reviewer guidance
- Are the design and behaviour following the guideliines in the proposed design https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=596%3A10350 ?
- Are all the backend api changes safe?

In order to test it, it would be good to test:
- a normal user, with and without its username existing in the new facility
- a super user, , with and without its username existing in the new facility
Also, for the frontend to work correctly, both the current facility and the new device where the user is moving need to have these api changes. This is not compatible with previous versions of kolibri

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
