### PR TITLE
add .trim to v-model for username

### DIFF
--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -58,7 +58,7 @@
             <KTextbox
               id="username"
               ref="username"
-              v-model="username"
+              v-model.trim="username"
               autocomplete="username"
               :autofocus="true"
               :label="coreString('usernameLabel')"


### PR DESCRIPTION
## Summary

Adds `.trim` to the v-model for username on login, so that adding a space before or after the username does not cause a validation failure.

## References
Fixes #9471

![whitespace-login](https://user-images.githubusercontent.com/17235236/173582625-d310340c-c8e5-45ed-9b22-0035eec8d31d.gif)

<img width="633" alt="Screen Shot 2022-06-14 at 8 53 41 AM" src="https://user-images.githubusercontent.com/17235236/173582038-ccc8ec1a-2699-4e92-90ac-ceaed7d0ba3c.png">



## Reviewer guidance
1. Log in with an existing account, adding a space both before and after the username. The log in should work
2. After entering a username with whitespace and advancing to enter the password, click "change user". This should work and return to a blank form 
3. Add a space or a special character in the middle of the username. This should fail validation


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
