### PR TITLE
Enable "continue" in quiz creation only once exercises selected

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -170,6 +170,7 @@
           <KButton
             :text="coreString('continueAction')"
             primary
+            :disabled="!exercisesHaveBeenSelected"
             @click="continueProcess"
           />
         </KButtonGroup>
@@ -333,6 +334,9 @@
       },
       addableExercises() {
         return this.allExercises.filter(exercise => !this.selectedExercises[exercise.id]);
+      },
+      exercisesHaveBeenSelected() {
+        return Object.keys(this.selectedExercises).length > 0;
       },
       selectAllChecked() {
         return this.addableExercises.length === 0;


### PR DESCRIPTION
## Summary

This adds a conditional check during quiz creation, and only allows a user to continue once one or more exercises have been selected.

## References
Fixes #9472


https://user-images.githubusercontent.com/17235236/173593939-e231db1b-af7e-4b87-acfe-02221ea67969.mp4

## Reviewer guidance

1. Go to create a new quiz
2. Continue button should be disabled at start 
3. Continue button should be enabled after selecting at least one exercise 
4. unselecting all exercises (individually or for example at the folder level) should re-disable the continue button


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
