### PR TITLE
Update bottom bar text in lesson resources to say save on changes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -183,8 +183,8 @@
       bottomBarButtonText() {
         if (this.inSearchMode) {
           return this.$tr('exitSearchButtonLabel');
-        } else if (this.resourcesChanged) {
-          return this.coreString('saveAction');
+        } else if (this.resourcesChanged && this.workingResources.length > 0) {
+          return this.coreString('saveChangesAction');
         } else {
           return this.coreString('closeAction');
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -98,7 +98,7 @@
 
     <BottomAppBar>
       <KRouterLink
-        :text="inSearchMode ? $tr('exitSearchButtonLabel') : coreString('closeAction')"
+        :text="bottomBarButtonText"
         :primary="true"
         appearance="raised-button"
         :to="exitButtonRoute"
@@ -179,6 +179,15 @@
           return this.$router.getRoute(this.$route.query.last);
         }
         return this.$store.state.toolbarRoute;
+      },
+      bottomBarButtonText() {
+        if (this.inSearchMode) {
+          return this.$tr('exitSearchButtonLabel');
+        } else if (this.resourcesChanged) {
+          return this.coreString('saveAction');
+        } else {
+          return this.coreString('closeAction');
+        }
       },
       pageTitle() {
         return this.$tr('documentTitle', { lessonName: this.currentLesson.title });


### PR DESCRIPTION
## Summary
When `resourcesChanged` is true on the Mange Lesson Resources page, the button changes to say "save" instead of "close". It stays "close" when navigating through the folder structure, or when there are no changes.


## References
Fixes #9473

## Reviewer guidance
1. Navigate through the "manage lesson resources" flow
2. "Close" should appear by default 
3. Selecting and/or deselecting resources should change the button to save

https://user-images.githubusercontent.com/17235236/173601638-f668a93e-bda3-4eea-9755-bde462807551.mp4


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
