### PR TITLE
Fix missing search results in coach quiz creation

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -16,7 +16,11 @@
 
       <h1>{{ $tr('createNewExamLabel') }}</h1>
 
-      <UiAlert v-if="showError && !inSearchMode" type="error" :dismissible="false">
+      <UiAlert
+        v-if="showError && !inSearchMode"
+        type="error"
+        :dismissible="false"
+      >
         {{ selectionIsInvalidText }}
       </UiAlert>
 
@@ -34,7 +38,11 @@
         </KGridItem>
         <KGridItem :layout12="{ span: 6 }">
           <KGrid>
-            <KGridItem :layout4="{ span: 2 }" :layout8="{ span: 5 }" :layout12="{ span: 8 }">
+            <KGridItem
+              :layout4="{ span: 2 }"
+              :layout8="{ span: 5 }"
+              :layout12="{ span: 8 }"
+            >
               <KTextbox
                 ref="questionsInput"
                 v-model.trim.number="numQuestions"
@@ -75,7 +83,10 @@
       <h2>{{ $tr('chooseExercises') }}</h2>
       <div v-if="bookmarksRoute">
         <strong>
-          <KRouterLink :text="coreString('channelsLabel')" :to="channelsLink" />
+          <KRouterLink
+            :text="coreString('channelsLabel')"
+            :to="channelsLink"
+          />
         </strong>
         <ContentCardList
           :contentList="bookmarks"
@@ -97,7 +108,11 @@
         <p v-if="bookmarksCount">
           {{ coreString('selectFromBookmarks') }}
         </p>
-        <KRouterLink v-if="bookmarksCount" :style="{ width: '100%' }" :to="getBookmarksLink()">
+        <KRouterLink
+          v-if="bookmarksCount"
+          :style="{ width: '100%' }"
+          :to="getBookmarksLink()"
+        >
           <div class="bookmark-container">
             <BookmarkIcon />
             <div class="text">
@@ -109,7 +124,10 @@
       </div>
 
       <div v-if="examCreationRoute || examTopicRoute || inSearchMode">
-        <LessonsSearchBox class="search-box" @searchterm="handleSearchTerm" />
+        <LessonsSearchBox
+          class="search-box"
+          @searchterm="handleSearchTerm"
+        />
 
         <LessonsSearchFilters
           v-if="inSearchMode"
@@ -585,7 +603,6 @@
         }
       },
       handleSearchTerm(searchTerm) {
-        console.log('handle search');
         const lastId = this.$route.query.last_id || this.$route.params.topicId;
         this.$router.push({
           name: PageNames.EXAM_CREATION_SEARCH,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -16,11 +16,7 @@
 
       <h1>{{ $tr('createNewExamLabel') }}</h1>
 
-      <UiAlert
-        v-if="showError && !inSearchMode"
-        type="error"
-        :dismissible="false"
-      >
+      <UiAlert v-if="showError && !inSearchMode" type="error" :dismissible="false">
         {{ selectionIsInvalidText }}
       </UiAlert>
 
@@ -38,11 +34,7 @@
         </KGridItem>
         <KGridItem :layout12="{ span: 6 }">
           <KGrid>
-            <KGridItem
-              :layout4="{ span: 2 }"
-              :layout8="{ span: 5 }"
-              :layout12="{ span: 8 }"
-            >
+            <KGridItem :layout4="{ span: 2 }" :layout8="{ span: 5 }" :layout12="{ span: 8 }">
               <KTextbox
                 ref="questionsInput"
                 v-model.trim.number="numQuestions"
@@ -83,10 +75,7 @@
       <h2>{{ $tr('chooseExercises') }}</h2>
       <div v-if="bookmarksRoute">
         <strong>
-          <KRouterLink
-            :text="coreString('channelsLabel')"
-            :to="channelsLink"
-          />
+          <KRouterLink :text="coreString('channelsLabel')" :to="channelsLink" />
         </strong>
         <ContentCardList
           :contentList="bookmarks"
@@ -105,12 +94,10 @@
         />
       </div>
       <div v-if="examCreationRoute">
-        <p>{{ coreString('selectFromBookmarks') }}</p>
-        <KRouterLink
-          v-if="bookmarksCount"
-          :style="{ width: '100%' }"
-          :to="getBookmarksLink()"
-        >
+        <p v-if="bookmarksCount">
+          {{ coreString('selectFromBookmarks') }}
+        </p>
+        <KRouterLink v-if="bookmarksCount" :style="{ width: '100%' }" :to="getBookmarksLink()">
           <div class="bookmark-container">
             <BookmarkIcon />
             <div class="text">
@@ -121,11 +108,8 @@
         </KRouterLink>
       </div>
 
-      <div v-if="examCreationRoute || examTopicRoute">
-        <LessonsSearchBox
-          class="search-box"
-          @searchterm="handleSearchTerm"
-        />
+      <div v-if="examCreationRoute || examTopicRoute || inSearchMode">
+        <LessonsSearchBox class="search-box" @searchterm="handleSearchTerm" />
 
         <LessonsSearchFilters
           v-if="inSearchMode"
@@ -601,6 +585,7 @@
         }
       },
       handleSearchTerm(searchTerm) {
+        console.log('handle search');
         const lastId = this.$route.query.last_id || this.$route.params.topicId;
         this.$router.push({
           name: PageNames.EXAM_CREATION_SEARCH,


### PR DESCRIPTION


## Summary
Ensures cards display "`inSearchMode`" 

Also adds a condition to the display of the "select from bookmarks" so it only shows up when there are bookmarks (otherwise, quite confusing)

## References
Fixes #9520 
![quiz-search](https://user-images.githubusercontent.com/17235236/174674632-936e50d6-62cd-4110-9758-7f8db17df0de.gif)



## Reviewer guidance
Does searching within "create quiz" yield results of available exercises?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
