### PR TITLE
Ensure peer import and sync tasks for data and content work with servers using a prefix path

### DIFF
--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.core.validators import URLValidator
-from django.urls import reverse
 from django.utils.six.moves import input
 from morango.models import Certificate
 from morango.models import Filter
@@ -13,7 +12,6 @@ from morango.models import InstanceIDModel
 from morango.models import ScopeDefinition
 from morango.sync.controller import MorangoProfileController
 from requests.exceptions import ConnectionError
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
@@ -22,6 +20,7 @@ from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_device
 from kolibri.core.tasks.management.commands.base import AsyncCommand
+from kolibri.core.utils.urls import reverse_remote
 
 
 class Command(AsyncCommand):
@@ -36,7 +35,7 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        facility_url = urljoin(base_url, reverse("kolibri:core:publicfacility-list"))
+        facility_url = reverse_remote(base_url, "kolibri:core:publicfacility-list")
         facility_resp = requests.get(facility_url)
         facility_resp.raise_for_status()
         facilities = facility_resp.json()

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -125,7 +125,9 @@ def get_facility(facility_id=None, noninteractive=False):
 
 def get_facility_dataset_id(baseurl, identifier=None, noninteractive=False):
     # get list of facilities and if more than 1, display all choices to user
-    facility_url = urljoin(baseurl, reverse("kolibri:core:publicfacility-list"))
+    facility_url = urljoin(
+        baseurl, reverse("kolibri:core:publicfacility-list").lstrip("/")
+    )
     response = requests.get(facility_url)
     response.raise_for_status()
     facilities = response.json()

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -11,13 +11,11 @@ from functools import wraps
 
 import requests
 from django.core.management.base import CommandError
-from django.urls import reverse
 from django.utils.six.moves import input
 from morango.models import Certificate
 from morango.models import InstanceIDModel
 from morango.models import ScopeDefinition
 from morango.sync.controller import MorangoProfileController
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants.morango_sync import DATA_PORTAL_SYNCING_BASE_URL
@@ -38,6 +36,7 @@ from kolibri.core.discovery.utils.network.errors import URLParseError
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.utils.lock import db_lock
+from kolibri.core.utils.urls import reverse_remote
 from kolibri.utils.data import bytes_for_humans
 
 
@@ -125,9 +124,7 @@ def get_facility(facility_id=None, noninteractive=False):
 
 def get_facility_dataset_id(baseurl, identifier=None, noninteractive=False):
     # get list of facilities and if more than 1, display all choices to user
-    facility_url = urljoin(
-        baseurl, reverse("kolibri:core:publicfacility-list").lstrip("/")
-    )
+    facility_url = reverse_remote(baseurl, "kolibri:core:publicfacility-list")
     response = requests.get(facility_url)
     response.raise_for_status()
     facilities = response.json()

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -226,13 +226,13 @@ def get_content_server_url(path, baseurl=None):
 
 
 def get_info_url(baseurl=None):
-    return get_content_server_url("/api/public/info", baseurl=baseurl)
+    return get_content_server_url("api/public/info", baseurl=baseurl)
 
 
 def get_channel_lookup_url(
     version="1", identifier=None, baseurl=None, keyword=None, language=None
 ):
-    content_server_path = "/api/public/v{}/channels".format(version)
+    content_server_path = "api/public/v{}/channels".format(version)
     if identifier:
         content_server_path += "/lookup/{}".format(identifier)
     content_server_path += "?"
@@ -249,7 +249,7 @@ def get_channel_lookup_url(
 def get_file_checksums_url(channel_id, baseurl, version="1"):
     # This endpoint does not exist on Studio, so a baseurl is required.
     return get_content_server_url(
-        "/api/public/v{version}/file_checksums/{channel_id}".format(
+        "api/public/v{version}/file_checksums/{channel_id}".format(
             version=version, channel_id=channel_id
         ),
         baseurl=baseurl,

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -52,7 +52,7 @@ class NetworkLocationAPITestCase(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data["base_url"], "https://kolibrihappyurl.qqq")
+        self.assertEqual(response.data["base_url"], "https://kolibrihappyurl.qqq/")
 
     def test_creating_good_address_with_one_url_timing_out(self):
         self.login(self.superuser)
@@ -63,7 +63,7 @@ class NetworkLocationAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(
-            response.data["base_url"], "http://timeoutonport80url.qqq:8080"
+            response.data["base_url"], "http://timeoutonport80url.qqq:8080/"
         )
 
     def test_creating_bad_address(self):

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -144,7 +144,7 @@ class TestURLParsing(TestCase):
 class TestNetworkClientConnections(TestCase):
     def test_successful_connection_to_kolibri_address(self):
         nc = NetworkClient(address="kolibrihappyurl.qqq")
-        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq")
+        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq/")
 
     def test_unsuccessful_connection_to_unavailable_address(self):
         with self.assertRaises(errors.NetworkLocationNotFound):
@@ -156,11 +156,11 @@ class TestNetworkClientConnections(TestCase):
 
     def test_successful_connection_to_address_with_port80_timeout(self):
         nc = NetworkClient(address="timeoutonport80url.qqq")
-        self.assertEqual(nc.base_url, "http://timeoutonport80url.qqq:8080")
+        self.assertEqual(nc.base_url, "http://timeoutonport80url.qqq:8080/")
 
     def test_successful_connection_to_kolibri_base_url(self):
         nc = NetworkClient(base_url="https://kolibrihappyurl.qqq/")
-        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq")
+        self.assertEqual(nc.base_url, "https://kolibrihappyurl.qqq/")
 
     def test_unsuccessful_connection_to_unavailable_base_url(self):
         with self.assertRaises(errors.NetworkLocationNotFound):

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -16,6 +16,7 @@ from zeroconf import USE_IP_OF_OUTGOING_INTERFACE
 from zeroconf import Zeroconf
 
 from kolibri.core.public.utils import get_device_info
+from kolibri.utils.conf import OPTIONS
 
 
 SERVICE_TYPE = "Kolibri._sub._http._tcp.local."
@@ -77,9 +78,12 @@ class KolibriInstance(object):
         "is_self",
         "device_info",
         "service_info",
+        "prefix",
     )
 
-    def __init__(self, instance_id, ip=None, port=None, host=None, device_info=None):
+    def __init__(
+        self, instance_id, ip=None, port=None, host=None, device_info=None, prefix="/"
+    ):
         self.id = instance_id
         self.zeroconf_id = instance_id
         self.ip = ip
@@ -88,6 +92,7 @@ class KolibriInstance(object):
         self.device_info = device_info or {}
         self.is_self = False
         self.service_info = None
+        self.prefix = prefix
 
     @property
     def name(self):
@@ -103,7 +108,9 @@ class KolibriInstance(object):
 
     @property
     def base_url(self):
-        return "http://{ip}:{port}/".format(ip=self.ip, port=self.port)
+        return "http://{ip}:{port}/{prefix}".format(
+            ip=self.ip, port=self.port, prefix=self.prefix.lstrip("/")
+        )
 
     @property
     def is_broadcasting(self):
@@ -146,6 +153,7 @@ class KolibriInstance(object):
                 # info backwards incompatible with older versions of Kolibri
                 val = TRUE if val else FALSE
             properties[key] = json.dumps(val)
+        properties["prefix"] = json.dumps(self.prefix)
 
         return ServiceInfo(
             SERVICE_TYPE,
@@ -171,20 +179,27 @@ class KolibriInstance(object):
 
         # parse out device info
         device_info = {}
+        prefix = "/"
         for key, val in service_info.properties.items():
             if isinstance(val, bytes):
                 val = val.decode("utf-8")
-            device_info[bytes.decode(key)] = json.loads(val)
-            if device_info[bytes.decode(key)] == TRUE:
-                device_info[bytes.decode(key)] = True
-            if device_info[bytes.decode(key)] == FALSE:
-                device_info[bytes.decode(key)] = False
+            key = bytes.decode(key)
+            val = json.loads(val)
+            if key == "prefix":
+                prefix = val
+                continue
+            device_info[key] = val
+            if device_info[key] == TRUE:
+                device_info[key] = True
+            if device_info[key] == FALSE:
+                device_info[key] = False
 
         kwargs.update(
             ip=socket.inet_ntoa(service_info.address),
             port=service_info.port,
             host=service_info.server.strip("."),
             device_info=device_info,
+            prefix=prefix,
         )
 
         instance_id = device_info.get("instance_id")
@@ -203,6 +218,7 @@ def build_broadcast_instance(port):
         port=port,
         device_info=device_info,
         ip=USE_IP_OF_OUTGOING_INTERFACE,
+        prefix=OPTIONS["Deployment"]["URL_PATH_PREFIX"],
     )
 
 

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -209,6 +209,10 @@ def build_broadcast_instance(port):
 class KolibriBroadcastEvents(Bus):
     """Event bus for handling events from Zeroconf"""
 
+    # The base magicbus Bus requires this to exist in error handling
+    # but does not set a default value.
+    throws = tuple()
+
     event_map = {
         ServiceStateChange.Added: EVENT_ADD_SERVICE,
         ServiceStateChange.Removed: EVENT_REMOVE_SERVICE,

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -45,7 +45,7 @@ class NetworkClient(object):
             try:
                 logger.info("Attempting connection to: {}".format(url))
                 response = self.get(
-                    "/api/public/info/",
+                    "api/public/info/",
                     base_url=url,
                     timeout=self.timeout,
                     allow_redirects=True,
@@ -67,7 +67,11 @@ class NetworkClient(object):
                         )
                     logger.info("Success! We connected to: {}".format(response.url))
 
-                    return "{}://{}".format(parsed_url.scheme, parsed_url.netloc)
+                    return "{}://{}{}".format(
+                        parsed_url.scheme,
+                        parsed_url.netloc,
+                        parsed_url.path.rstrip("/").replace("api/public/info", ""),
+                    )
             except (requests.RequestException) as e:
                 logger.info("Unable to connect: {}".format(e))
             except ValueError:

--- a/kolibri/core/public/utils.py
+++ b/kolibri/core/public/utils.py
@@ -7,14 +7,12 @@ import random
 
 import requests
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
 from django.utils import timezone
 from morango.errors import MorangoResumeSyncError
 from morango.models import InstanceIDModel
 from morango.models import SyncSession
 from requests.exceptions import ConnectionError
 from rest_framework import status
-from six.moves.urllib.parse import urljoin
 
 import kolibri
 from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
@@ -33,6 +31,7 @@ from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.main import queue
 from kolibri.core.tasks.main import scheduler
+from kolibri.core.utils.urls import reverse_remote
 from kolibri.utils.conf import OPTIONS
 
 
@@ -323,11 +322,11 @@ def request_soud_sync(server, user, queue_id=None, ttl=4):
     """
 
     if queue_id is None:
-        endpoint = reverse("kolibri:core:syncqueue-list")
+        server_url = reverse_remote(server, "kolibri:core:syncqueue-list")
     else:
-        endpoint = reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue_id})
-
-    server_url = urljoin(server, endpoint)
+        server_url = reverse_remote(
+            server, "kolibri:core:syncqueue-detail", kwargs={"pk": queue_id}
+        )
 
     instance_model = InstanceIDModel.get_or_create_current_instance()[0]
 

--- a/kolibri/core/utils/urls.py
+++ b/kolibri/core/utils/urls.py
@@ -12,7 +12,8 @@ def reverse_remote(
         viewname, urlconf=urlconf, args=args, kwargs=kwargs, current_app=current_app
     )
     # Remove any configured URL prefix from the URL that is specific to this deployment
-    reversed_url = reversed_url.replace(OPTIONS["Deployment"]["URL_PATH_PREFIX"], "")
+    prefix_length = len(OPTIONS["Deployment"]["URL_PATH_PREFIX"])
+    reversed_url = reversed_url[prefix_length:]
     # Join the URL to baseurl, but remove any leading "/" to ensure that if there is a path prefix on baseurl
     # it doesn't get ignored by the urljoin (which it would if the reversed_url had a leading '/',
     # as it would be read as an absolute path)

--- a/kolibri/core/utils/urls.py
+++ b/kolibri/core/utils/urls.py
@@ -1,0 +1,19 @@
+from django.urls import reverse
+from six.moves.urllib.parse import urljoin
+
+from kolibri.utils.conf import OPTIONS
+
+
+def reverse_remote(
+    baseurl, viewname, urlconf=None, args=None, kwargs=None, current_app=None
+):
+    # Get the reversed URL
+    reversed_url = reverse(
+        viewname, urlconf=urlconf, args=args, kwargs=kwargs, current_app=current_app
+    )
+    # Remove any configured URL prefix from the URL that is specific to this deployment
+    reversed_url = reversed_url.replace(OPTIONS["Deployment"]["URL_PATH_PREFIX"], "")
+    # Join the URL to baseurl, but remove any leading "/" to ensure that if there is a path prefix on baseurl
+    # it doesn't get ignored by the urljoin (which it would if the reversed_url had a leading '/',
+    # as it would be read as an absolute path)
+    return urljoin(baseurl, reversed_url.lstrip("/"))

--- a/kolibri/plugins/setup_wizard/tasks.py
+++ b/kolibri/plugins/setup_wizard/tasks.py
@@ -1,14 +1,12 @@
 import requests
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.urls import reverse
 from morango.models import InstanceIDModel
 from requests.exceptions import ConnectionError
 from requests.exceptions import HTTPError
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants.user_kinds import ADMIN
@@ -23,6 +21,7 @@ from kolibri.core.tasks.api import prepare_soud_sync_job
 from kolibri.core.tasks.api import prepare_sync_task
 from kolibri.core.tasks.api import validate_and_create_sync_credentials
 from kolibri.core.tasks.decorators import register_task
+from kolibri.core.utils.urls import reverse_remote
 
 
 def getusersinfo(request):
@@ -44,7 +43,7 @@ def getusersinfo(request):
     username = request.data.get("username", None)
     password = request.data.get("password", None)
 
-    user_info_url = urljoin(baseurl, reverse("kolibri:core:publicuser-list"))
+    user_info_url = reverse_remote(baseurl, "kolibri:core:publicuser-list")
     params = {
         "facility_id": facility_id,
     }


### PR DESCRIPTION
## Summary
* Includes the server prefix in zeroconf broadcast information
* Adds a prefix to the KolibriInstance baseurl
* Fixes url concatenation to ensure that prefixes persist
* Prevents magicbus from throwing an uncaught exception when an exception is caught
* Maintain prefix on NetworkClient when it has successfully detected the actual URL for a server

## References
Fixes #9455

## Reviewer guidance
* Run one server with either the `Deployment` `URL_PATH_PREFIX` option set in options.ini or with the env var `KOLIBRI_PATH_URL_PREFIX` to so something other than `/`.
* Run another server unprefixed.
* Import a facility to the unprefixed server from the prefixed server.
* Import resources to the unprefixed server from the prefixed server.
* Sync a facility on the unprefixed server with the prefixed server.

For regression testing, worth testing these scenarios without any prefixing to ensure everything is working.

I have done manual testing of the three scenarios above, and ensured that resource import still functions for unprefixed servers.

One caveat is that our zeroconf info does not update well when a server changes its baseurl - not sure if there's something that can be done about that?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
