### PR TITLE
Clean up state management for user management page

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -3,8 +3,10 @@ import { FacilityUserResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { _userState } from '../mappers';
 // An action for setting up the initial state of the app by fetching data from the server
-export function showUserPage(store, toRoute) {
-  store.dispatch('preparePage');
+export function showUserPage(store, toRoute, fromRoute) {
+  if (toRoute.name !== fromRoute.name) {
+    store.dispatch('preparePage');
+  }
   const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
   return FacilityUserResource.fetchCollection({
     getParams: pickBy({

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/index.js
@@ -3,6 +3,8 @@ import * as userManagementActions from './actions';
 function defaultState() {
   return {
     facilityUsers: [],
+    totalPages: 0,
+    usersCount: 0,
   };
 }
 

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -69,8 +69,8 @@ export default [
     name: PageNames.USER_MGMT_PAGE,
     component: UserPage,
     path: '/:facility_id?/users',
-    handler: toRoute => {
-      showUserPage(store, toRoute);
+    handler: (toRoute, fromRoute) => {
+      showUserPage(store, toRoute, fromRoute);
     },
   },
   {


### PR DESCRIPTION
## Summary
* Removes loading state when moving between pages of the user management page
* Set default state to ensure reactivity from `Object.assign`.

## References
Fixes #9528 

## Reviewer guidance
Does the user management page in Facility still function as expected - for filtering, pagination? Does it show the correct number of users once filtering has happened or been removed?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
