### PR TITLE
Rendering PDF text layer

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -1,0 +1,199 @@
+/* Copyright 2012 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderTextLayer } from 'pdfjs-dist/legacy/build/pdf';
+
+const EXPAND_DIVS_TIMEOUT = 300; // ms
+
+/**
+ * @typedef {Object} TextLayerBuilderOptions
+ * @property {HTMLDivElement} textLayerDiv - The text layer container.
+ * @property {number} pageIndex - The page index.
+ * @property {PageViewport} viewport - The viewport of the text layer.
+ * @property {TextHighlighter} highlighter - Optional object that will handle
+ *   highlighting text from the find controller.
+ * @property {boolean} enhanceTextSelection - Option to turn on improved
+ *   text selection.
+ */
+
+/**
+ * The text layer builder provides text selection functionality for the PDF.
+ * It does this by creating overlay divs over the PDF's text. These divs
+ * contain text that matches the PDF text they are overlaying.
+ */
+class TextLayerBuilder {
+  constructor({
+    textLayerDiv,
+    pageIndex,
+    viewport,
+    highlighter = null,
+    enhanceTextSelection = false,
+  }) {
+    this.textLayerDiv = textLayerDiv;
+    this.textContent = null;
+    this.textContentItemsStr = [];
+    this.textContentStream = null;
+    this.renderingDone = false;
+    this.pageNumber = pageIndex + 1;
+    this.viewport = viewport;
+    this.textDivs = [];
+    this.textLayerRenderTask = null;
+    this.highlighter = highlighter;
+    this.enhanceTextSelection = enhanceTextSelection;
+
+    this._bindMouse();
+  }
+
+  /**
+   * @private
+   */
+  _finishRendering() {
+    this.renderingDone = true;
+
+    if (!this.enhanceTextSelection) {
+      const endOfContent = document.createElement('div');
+      endOfContent.className = 'endOfContent';
+      this.textLayerDiv.append(endOfContent);
+    }
+  }
+
+  /**
+   * Renders the text layer.
+   *
+   * @param {number} [timeout] - Wait for a specified amount of milliseconds
+   *                             before rendering.
+   */
+  render(timeout = 0) {
+    if (!(this.textContent || this.textContentStream) || this.renderingDone) {
+      return;
+    }
+    this.cancel();
+
+    this.textDivs.length = 0;
+    if (this.highlighter) {
+      this.highlighter.setTextMapping(this.textDivs, this.textContentItemsStr);
+    }
+
+    const textLayerFrag = document.createDocumentFragment();
+    this.textLayerRenderTask = renderTextLayer({
+      textContent: this.textContent,
+      textContentStream: this.textContentStream,
+      container: textLayerFrag,
+      viewport: this.viewport,
+      textDivs: this.textDivs,
+      textContentItemsStr: this.textContentItemsStr,
+      timeout,
+      enhanceTextSelection: this.enhanceTextSelection,
+    });
+    this.textLayerRenderTask.promise.then(
+      () => {
+        this.textLayerDiv.append(textLayerFrag);
+        this._finishRendering();
+        if (this.highlighter) {
+          this.highlighter.enable();
+        }
+      },
+      err => {
+        console.error('Error rendering text layer: ', err);
+      }
+    );
+  }
+
+  /**
+   * Cancel rendering of the text layer.
+   */
+  cancel() {
+    if (this.textLayerRenderTask) {
+      this.textLayerRenderTask.cancel();
+      this.textLayerRenderTask = null;
+      this.textLayerDiv.textContent = '';
+    }
+    if (this.highlighter) {
+      this.highlighter.disable();
+    }
+  }
+
+  setTextContentStream(readableStream) {
+    this.cancel();
+    this.textContentStream = readableStream;
+  }
+
+  setTextContent(textContent) {
+    this.cancel();
+    this.textContent = textContent;
+  }
+
+  /**
+   * Improves text selection by adding an additional div where the mouse was
+   * clicked. This reduces flickering of the content if the mouse is slowly
+   * dragged up or down.
+   *
+   * @private
+   */
+  _bindMouse() {
+    const div = this.textLayerDiv;
+    let expandDivsTimer = null;
+
+    div.addEventListener('mousedown', evt => {
+      if (this.enhanceTextSelection && this.textLayerRenderTask) {
+        this.textLayerRenderTask.expandTextDivs(true);
+        if (expandDivsTimer) {
+          clearTimeout(expandDivsTimer);
+          expandDivsTimer = null;
+        }
+        return;
+      }
+
+      const end = div.querySelector('.endOfContent');
+      if (!end) {
+        return;
+      }
+      // On non-Firefox browsers, the selection will feel better if the height
+      // of the `endOfContent` div is adjusted to start at mouse click
+      // location. This avoids flickering when the selection moves up.
+      // However it does not work when selection is started on empty space.
+      let adjustTop =
+        evt.target !== div &&
+        window.getComputedStyle(end).getPropertyValue('-moz-user-select') !== 'none';
+      if (adjustTop) {
+        const divBounds = div.getBoundingClientRect();
+        const r = Math.max(0, (evt.pageY - divBounds.top) / divBounds.height);
+        end.style.top = (r * 100).toFixed(2) + '%';
+      }
+      end.classList.add('active');
+    });
+
+    div.addEventListener('mouseup', () => {
+      if (this.enhanceTextSelection && this.textLayerRenderTask) {
+        expandDivsTimer = setTimeout(() => {
+          if (this.textLayerRenderTask) {
+            this.textLayerRenderTask.expandTextDivs(false);
+          }
+          expandDivsTimer = null;
+        }, EXPAND_DIVS_TIMEOUT);
+        return;
+      }
+
+      const end = div.querySelector('.endOfContent');
+      if (!end) {
+        return;
+      }
+      end.style.top = '';
+      end.classList.remove('active');
+    });
+  }
+}
+
+export default TextLayerBuilder;

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -15,7 +15,12 @@
 
 /*
  * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/text_layer_builder.js
  */
+
+// Modified: typedef imports deleted
+// Original line: 17
 
 import { renderTextLayer } from 'pdfjs-dist/legacy/build/pdf';
 
@@ -40,12 +45,14 @@ const EXPAND_DIVS_TIMEOUT = 300; // ms
 class TextLayerBuilder {
   constructor({
     textLayerDiv,
+    eventBus,
     pageIndex,
     viewport,
     highlighter = null,
     enhanceTextSelection = false,
   }) {
     this.textLayerDiv = textLayerDiv;
+    this.eventBus = eventBus;
     this.textContent = null;
     this.textContentItemsStr = [];
     this.textContentStream = null;
@@ -71,6 +78,16 @@ class TextLayerBuilder {
       endOfContent.className = 'endOfContent';
       this.textLayerDiv.append(endOfContent);
     }
+
+    // Modified: Validate eventBus is defined
+    // Original line: 79
+    if (this.eventBus) {
+      this.eventBus.dispatch('textlayerrendered', {
+        source: this,
+        pageNumber: this.pageNumber,
+        numTextDivs: this.textDivs.length,
+      });
+    }
   }
 
   /**
@@ -86,6 +103,9 @@ class TextLayerBuilder {
     this.cancel();
 
     this.textDivs.length = 0;
+
+    // Modified: Validate highlighter is defined instead of using optional chain operator
+    // Original line: 99
     if (this.highlighter) {
       this.highlighter.setTextMapping(this.textDivs, this.textContentItemsStr);
     }
@@ -105,10 +125,14 @@ class TextLayerBuilder {
       () => {
         this.textLayerDiv.append(textLayerFrag);
         this._finishRendering();
+        // Modified: Validate highlighter is defined instead of using optional chain operator
+        // Original line: 116
         if (this.highlighter) {
           this.highlighter.enable();
         }
       },
+      // Modified: Logging errors
+      // Original line: 118
       err => {
         console.error('Error rendering text layer: ', err);
       }
@@ -122,8 +146,12 @@ class TextLayerBuilder {
     if (this.textLayerRenderTask) {
       this.textLayerRenderTask.cancel();
       this.textLayerRenderTask = null;
+      // Modified: Removing content from text layer to avoid multiple layers rendering on zoom
+      // Original line: 131
       this.textLayerDiv.textContent = '';
     }
+    // Modified: Validate highlighter is defined instead of using optional chain operator
+    // Original line: 132
     if (this.highlighter) {
       this.highlighter.disable();
     }
@@ -153,6 +181,8 @@ class TextLayerBuilder {
     div.addEventListener('mousedown', evt => {
       if (this.enhanceTextSelection && this.textLayerRenderTask) {
         this.textLayerRenderTask.expandTextDivs(true);
+        // Modified: Delete PDFJS Dev global variables references
+        // Original line: 159
         if (expandDivsTimer) {
           clearTimeout(expandDivsTimer);
           expandDivsTimer = null;
@@ -164,10 +194,16 @@ class TextLayerBuilder {
       if (!end) {
         return;
       }
+      // Modified: Delete PDFJS Dev global variables references
+      // Original line: 173
+
       // On non-Firefox browsers, the selection will feel better if the height
       // of the `endOfContent` div is adjusted to start at mouse click
       // location. This avoids flickering when the selection moves up.
       // However it does not work when selection is started on empty space.
+
+      // Modified: Refactor simplified code for deleting PDFJS Dev global variables references
+      // Original line: 178
       let adjustTop =
         evt.target !== div &&
         window.getComputedStyle(end).getPropertyValue('-moz-user-select') !== 'none';
@@ -181,6 +217,8 @@ class TextLayerBuilder {
 
     div.addEventListener('mouseup', () => {
       if (this.enhanceTextSelection && this.textLayerRenderTask) {
+        // Modified: Delete PDFJS Dev global variables references
+        // Original line: 197
         expandDivsTimer = setTimeout(() => {
           if (this.textLayerRenderTask) {
             this.textLayerRenderTask.expandTextDivs(false);
@@ -194,10 +232,14 @@ class TextLayerBuilder {
       if (!end) {
         return;
       }
+      // Modified: Delete PDFJS Dev global variables references
+      // Original line: 214
       end.style.top = '';
       end.classList.remove('active');
     });
   }
 }
 
+// Modified: Exporting TextLayerBuilder as a default export
+// Original line: 222
 export default TextLayerBuilder;

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -13,6 +13,10 @@
  * limitations under the License.
  */
 
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ */
+
 import { renderTextLayer } from 'pdfjs-dist/legacy/build/pdf';
 
 const EXPAND_DIVS_TIMEOUT = 300; // ms

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
@@ -13,6 +13,12 @@
  * limitations under the License.
  */
 
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/text_layer_builder.css
+ */
+
 .text-layer {
   position: absolute;
   top: 0;
@@ -22,6 +28,10 @@
   overflow: hidden;
   line-height: 1;
   text-align: initial;
+
+  /* Modified: specifiying letter-spacing as normal to avoid kolibri's default letter-spacing
+   * misaligning text-layer with the canvas.
+   * Original line: 28 */
   letter-spacing: normal;
   opacity: 0.2;
   text-size-adjust: none;
@@ -49,7 +59,7 @@
   padding: 1px;
   margin: -1px;
 
-  /* TODO Manage with colibri standards */
+  /* TODO Manage with Kolibri standards */
   background-color: rgba(180, 0, 170, 1);
   border-radius: 4px;
 }
@@ -71,12 +81,15 @@
 }
 
 .text-layer .highlight.selected {
-  /* TODO Manage with colibri standards */
+  /* TODO Manage with Kolibri standards */
   background-color: rgba(0, 100, 0, 1);
 }
 
 .text-layer ::selection {
-  /* TODO Manage with colibri standards */
+  /* Modified: selection color.
+   * Original line: 74 */
+
+  /* TODO Manage with Kolibri standards */
   background: rgb(0, 168, 255);
 }
 

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
@@ -1,0 +1,101 @@
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.text-layer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  line-height: 1;
+  text-align: initial;
+  letter-spacing: normal;
+  opacity: 0.2;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+}
+
+.text-layer span,
+.text-layer br {
+  position: absolute;
+  color: transparent;
+  white-space: pre;
+  cursor: text;
+  user-select: text;
+  transform-origin: 0% 0%;
+}
+
+/* Only necessary in Google Chrome, see issue 14205, and most unfortunately
+ * the problem doesn't show up in "text" reference tests. */
+.text-layer span.markedContent {
+  top: 0;
+  height: 0;
+}
+
+.text-layer .highlight {
+  padding: 1px;
+  margin: -1px;
+
+  /* TODO Change with colibri standards */
+  background-color: rgba(180, 0, 170, 1);
+  border-radius: 4px;
+}
+
+.text-layer .highlight.appended {
+  position: initial;
+}
+
+.text-layer .highlight.begin {
+  border-radius: 4px 0 0 4px;
+}
+
+.text-layer .highlight.end {
+  border-radius: 0 4px 4px 0;
+}
+
+.text-layer .highlight.middle {
+  border-radius: 0;
+}
+
+.text-layer .highlight.selected {
+  /* TODO Change with colibri standards */
+  background-color: rgba(0, 100, 0, 1);
+}
+
+.text-layer ::selection {
+  background: rgb(2, 128, 95);
+}
+
+/* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */
+.text-layer br::selection {
+  background: transparent;
+}
+
+.text-layer .endOfContent {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+  display: block;
+  cursor: default;
+  user-select: none;
+}
+
+.text-layer .endOfContent.active {
+  top: 0;
+}

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
@@ -49,7 +49,7 @@
   padding: 1px;
   margin: -1px;
 
-  /* TODO Change with colibri standards */
+  /* TODO Manage with colibri standards */
   background-color: rgba(180, 0, 170, 1);
   border-radius: 4px;
 }
@@ -71,12 +71,13 @@
 }
 
 .text-layer .highlight.selected {
-  /* TODO Change with colibri standards */
+  /* TODO Manage with colibri standards */
   background-color: rgba(0, 100, 0, 1);
 }
 
 .text-layer ::selection {
-  background: rgb(2, 128, 95);
+  /* TODO Manage with colibri standards */
+  background: rgb(0, 168, 255);
 }
 
 /* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */


### PR DESCRIPTION
## Summary
Adding a new layer on top of the canvas pdf rendering for supporting selectable text.

After:
![Grabación de pantalla 2022-06-27 a la(s) 15 48 24 (1)](https://user-images.githubusercontent.com/51239030/176033679-e4015877-00ae-4541-a446-750b1f664be6.gif)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to learn tab, pick any reading-type resource, and check whether the text on the PDF resource is selectable.

Fixes #7547

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
