### PR TITLE
Check node being available on filtered queryset to prevent index error.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -969,8 +969,12 @@ class TreeQueryMixin(object):
 
     def get_tree_queryset(self, request, pk):
         # Get the model for the parent node here - we do this so that we trigger a 404 immediately if the node
-        # does not exist (or exists but is not available).
-        parent_id = pk if pk and self.get_queryset().filter(id=pk).exists() else None
+        # does not exist (or exists but is not available, or is filtered).
+        parent_id = (
+            pk
+            if pk and self.filter_queryset(self.get_queryset()).filter(id=pk).exists()
+            else None
+        )
 
         if parent_id is None:
             raise Http404

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -422,6 +422,14 @@ class ContentNodeAPITestCase(APITestCase):
         )
         self._recurse_and_assert([response.data], [root])
 
+    def test_contentnode_tree_filtered_queryset_node(self):
+        root = content.ContentNode.objects.get(title="root")
+        response = self.client.get(
+            reverse("kolibri:core:contentnode_tree-detail", kwargs={"pk": root.id})
+            + "?parent={}".format(uuid.uuid4().hex)
+        )
+        self.assertEqual(response.status_code, 404)
+
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]
         == "django.db.backends.postgresql",


### PR DESCRIPTION
## Summary
* Due to a difference in the queryset filtering for existence checking and the queryset returned from the `get_tree_queryset` method, it was possible for entirely filtered nodes to not return a 404 from the content node tree endpoint
* This adds a regression test for this by filtering a specific node and adding a filter parameter that no node can pass (a non-existent but valid parent id)
* This fixes this issue by filtering the queryset used for the existence check in the same way as the returned queryset 

## References
Fixes #9537

## Reviewer guidance
Make a request to `/api/content/contentnode_tree/<existing_id>/?parent=<valid_but_nonexistent_id>` and confirm that it does not produce a 500.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
