### PR TITLE
Update webpack hooks to listen for proper stats status

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -101,7 +101,7 @@ class WebpackBundleHook(hooks.KolibriHook):
         if getattr(settings, "DEVELOPER_MODE", False):
             timeout = 0
 
-            while stats["status"] == "compiling":
+            while stats["status"] == "compile":
                 time.sleep(0.1)
                 timeout += 0.1
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The stats lib we use was recently updated and it apparently outputs a slightly different status than it used to - thanks to @rtibbles for helping hone in on this issue.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9440 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

On `develop` - start up the devserver and if you don't get the error noted in the issue above, then try stopping the devserver and switching branches then restarting. Or try switching branches while the devserver is running?

Then checkout this branch and try starting up again (maybe throw a `yarn clean` in there for good measure). It should not run into any problems.

----

