### PR TITLE
Improve facility sync status reporting to users

### DIFF
--- a/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/__tests__/index.spec.js
+++ b/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/__tests__/index.spec.js
@@ -1,0 +1,9 @@
+import { shallowMount } from '@vue/test-utils';
+import FacilityNameAndSyncStatus from '../index';
+
+describe('FacilityNameAndSyncStatus', () => {
+  it('smoke test', () => {
+    const wrapper = shallowMount(FacilityNameAndSyncStatus);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+});

--- a/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/__tests__/index.spec.js
+++ b/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/__tests__/index.spec.js
@@ -1,9 +1,135 @@
 import { shallowMount } from '@vue/test-utils';
 import FacilityNameAndSyncStatus from '../index';
 
-describe('FacilityNameAndSyncStatus', () => {
-  it('smoke test', () => {
+describe(`FacilityNameAndSyncStatus`, () => {
+  it(`smoke test`, () => {
     const wrapper = shallowMount(FacilityNameAndSyncStatus);
     expect(wrapper.exists()).toBeTruthy();
+  });
+
+  describe(`sync status`, () => {
+    describe(`when a facility has never been synced`, () => {
+      it(`shows the "Never synced" message`, () => {
+        const wrapper = shallowMount(FacilityNameAndSyncStatus, {
+          propsData: {
+            facility: {
+              name: 'Test facility',
+              last_successful_sync: null,
+              last_failed_sync: null,
+            },
+          },
+        });
+        expect(wrapper.html()).toContain('Never synced');
+      });
+
+      describe(`when the sync task has failed`, () => {
+        let wrapper;
+        beforeEach(() => {
+          wrapper = shallowMount(FacilityNameAndSyncStatus, {
+            propsData: {
+              facility: {
+                name: 'Test facility',
+                last_successful_sync: null,
+                last_failed_sync: null,
+              },
+              syncTaskHasFailed: true,
+            },
+          });
+        });
+
+        it(`doesn't show the "Never synced" message`, () => {
+          expect(wrapper.html()).not.toContain('Never synced');
+        });
+
+        it(`shows the "Most recent sync failed" message`, () => {
+          expect(wrapper.html()).toContain('Most recent sync failed');
+        });
+      });
+    });
+
+    describe(`when a facility has been synced at least once in the past`, () => {
+      describe(`when the last failed sync is more recent than the last successful sync`, () => {
+        let wrapper;
+        beforeEach(() => {
+          wrapper = shallowMount(FacilityNameAndSyncStatus, {
+            propsData: {
+              facility: {
+                name: 'Test facility',
+                last_successful_sync: '2022-04-21T16:00:00Z',
+                last_failed_sync: '2022-06-25T13:00:00Z',
+              },
+            },
+          });
+        });
+
+        it(`shows relative time of the last successful sync`, () => {
+          expect(wrapper.html()).toContain(
+            `Last successful sync: ${wrapper.vm.$formatRelative('2022-04-21T16:00:00Z', {
+              now: wrapper.vm.now,
+            })}`
+          );
+        });
+
+        it(`shows the "Most recent sync failed" message`, () => {
+          expect(wrapper.html()).toContain('Most recent sync failed');
+        });
+      });
+
+      describe(`when the last failed sync is older than the last successful sync`, () => {
+        let wrapper;
+        beforeEach(() => {
+          wrapper = shallowMount(FacilityNameAndSyncStatus, {
+            propsData: {
+              facility: {
+                name: 'Test facility',
+                last_successful_sync: '2022-06-25T13:00:00Z',
+                last_failed_sync: '2022-04-21T16:00:00Z',
+              },
+            },
+          });
+        });
+
+        it(`shows relative time of the last successful sync`, () => {
+          expect(wrapper.html()).toContain(
+            `Last successful sync: ${wrapper.vm.$formatRelative('2022-06-25T13:00:00Z', {
+              now: wrapper.vm.now,
+            })}`
+          );
+        });
+
+        it(`doesn't show the "Most recent sync failed" message`, () => {
+          expect(wrapper.html()).not.toContain('Most recent sync failed');
+        });
+      });
+
+      describe(`when the sync task has failed`, () => {
+        let wrapper;
+        beforeEach(() => {
+          wrapper = shallowMount(FacilityNameAndSyncStatus, {
+            propsData: {
+              facility: {
+                name: 'Test facility',
+                last_successful_sync: '2022-06-25T13:00:00Z',
+                last_failed_sync: '2022-04-21T16:00:00Z',
+              },
+              syncTaskHasFailed: true,
+            },
+          });
+        });
+
+        it(`shows relative time of the last successful sync`, () => {
+          expect(wrapper.html()).toContain(
+            `Last successful sync: ${wrapper.vm.$formatRelative('2022-06-25T13:00:00Z', {
+              now: wrapper.vm.now,
+            })}`
+          );
+        });
+
+        // failed sync task information takes precendence over information on the facility object
+        it(`shows the "Most recent sync failed" message`, () => {
+          expect(wrapper.html()).toContain('Most recent sync failed');
+        });
+      });
+    });
   });
 });

--- a/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
@@ -33,14 +33,15 @@
           {{ getTaskString('removingFacilityStatus') }}
         </template>
         <template v-else>
-          <span v-if="syncHasFailed" class="sync-message">
+          <span v-if="syncFailed" class="sync-message">
             {{ $tr('syncFailed') }}
           </span>
-          <span v-if="facility.last_synced === null" class="sync-message">
+          <span v-else-if="neverSynced" class="sync-message">
             {{ $tr('neverSynced') }}
           </span>
-          <span v-else class="sync-message">
-            {{ $tr('lastSync', { relativeTime: formattedTime(facility.last_synced) }) }}
+          <!-- Always show the last successful sync time when available -->
+          <span v-if="facility.last_successful_sync" class="sync-message">
+            {{ $tr('lastSync', { relativeTime: formattedTime(facility.last_successful_sync) }) }}
           </span>
         </template>
       </span>
@@ -67,7 +68,7 @@
         type: Boolean,
         default: false,
       },
-      syncHasFailed: {
+      syncTaskHasFailed: {
         type: Boolean,
         default: false,
       },
@@ -80,6 +81,22 @@
       return {
         now: now(),
       };
+    },
+    computed: {
+      syncFailed() {
+        const lastSyncFailed =
+          this.facility &&
+          this.facility.last_successful_sync &&
+          this.facility.last_failed_sync &&
+          new Date(this.facility.last_successful_sync).getTime() <
+            new Date(this.facility.last_failed_sync).getTime();
+        return this.syncTaskHasFailed || lastSyncFailed;
+      },
+      neverSynced() {
+        return (
+          this.facility && !this.facility.last_successful_sync && !this.facility.last_failed_sync
+        );
+      },
     },
     methods: {
       formattedTime(datetime) {

--- a/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div v-if="facility">
     <div>
       <h2 class="name">
         <KLabeledIcon icon="facility">

--- a/kolibri/core/assets/src/views/sync/syncComponentSet.js
+++ b/kolibri/core/assets/src/views/sync/syncComponentSet.js
@@ -2,7 +2,7 @@ export { default as SelectAddressForm } from './SelectAddressModalGroup/SelectAd
 export { default as SelectAddressModalGroup } from './SelectAddressModalGroup';
 export { default as ConfirmationRegisterModal } from './ConfirmationRegisterModal';
 export { default as FacilityAdminCredentialsForm } from './FacilityAdminCredentialsForm';
-export { default as FacilityNameAndSyncStatus } from './FacilityNameAndSyncStatus';
+export { default as FacilityNameAndSyncStatus } from './FacilityNameAndSyncStatus/index';
 export { default as RadioButtonGroup } from './RadioButtonGroup';
 export { default as RegisterFacilityModal } from './RegisterFacilityModal';
 export { default as SelectSourceModal } from './SelectSourceModal';

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -62,12 +62,12 @@
       };
     },
     computed: {
-      // Assume that if first facility has non-null 'last_synced'
+      // Assume that if first facility has non-null 'last_successful_sync'
       // field, then it was imported in Setup Wizard.
       // This used to determine Select Source workflow to enter into
       importedFacility() {
         const [facility] = this.$store.state.core.facilities;
-        if (facility && facility.last_synced !== null) {
+        if (facility && facility.last_successful_sync !== null) {
           return facility;
         }
         return null;

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
@@ -80,21 +80,6 @@ export default {
       state.sessionDateCreated = payload;
     },
     /*State for sync tasks*/
-    START_FACILITY_SYNC(state, payload) {
-      const match = state.facilities.find(f => f.id === payload.facility);
-      if (match) {
-        Vue.set(match, 'syncing', true);
-      }
-      state.facilityTaskId = payload.id;
-    },
-    SET_FINISH_FACILITY_SYNC(state, payload) {
-      state.facilityTaskId = '';
-      const match = state.facilities.find(f => f.syncing === true);
-      if (match) {
-        Vue.set(match, 'last_synced', payload);
-        Vue.set(match, 'syncing', false);
-      }
-    },
     SET_REGISTERED(state, facility) {
       const match = state.facilities.find(f => f.id === facility.id);
       if (match) {


### PR DESCRIPTION
## Summary

Previously, it wasn't possible to find out whether the last sync was successful or if it failed from the facility object itself. We were only able to derive information about failure from task objects while a task was running and that information wasn't persisted on the page reload, resulting in confusing UX.

This PR improves facility sync status reporting to users by persisting information about the success or failure of a facility sync task on the facility object by replacing the `last_synced` field by `last_successful_sync` and `last_failed_sync` fields (that said, we still continue using the failed task information from the task object to display fast update on the sync process to users without the need to re-fetch a facility when the task fails)

### Preview of possible states

|  Never synced  | There was no successful sync in the past and the most recent sync failed | There was a successful sync in the past and the most recent sync failed | The most recent sync was successful | 
| --- | --- | --- | --- |
| ![never-synced](https://user-images.githubusercontent.com/13509191/176894192-d6d0eef3-e0ba-4a03-9be4-c79859e3c029.png) | ![sync-failed](https://user-images.githubusercontent.com/13509191/176894359-37488670-a7b3-4c33-9ade-30b27e1b26d5.png) | ![success-fail](https://user-images.githubusercontent.com/13509191/176894776-efa54a69-dae4-41a2-825f-49ec7a09b3f0.png) | ![success](https://user-images.githubusercontent.com/13509191/176894559-db87c8c6-bb73-4ef6-bdfe-769511cfe731.png) |

## References

Resolves https://github.com/learningequality/kolibri/issues/9091

## Reviewer guidance

- From _"Device -> Facilities"_ or from _"Facility -> Data"_, sync a facility to another facility or to KDP to test successful sync information
- We currently have no simple mechanism for end-to-end testing of a sync failure - we're planning to do it at least once together with @bjester though

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
