### PR TITLE
Fix quiz display for non-admins

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -1,9 +1,10 @@
-import { ContentNodeResource, ClassroomResource, ExamResource } from 'kolibri.resources';
+import { ContentNodeResource, ExamResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { convertExamQuestionSources } from 'kolibri.utils.exams';
 import ConditionalPromise from 'kolibri.lib.conditionalPromise';
 import shuffled from 'kolibri.utils.shuffled';
 import { ClassesPageNames } from '../../constants';
+import { LearnerClassroomResource } from '../../apiResources';
 import { contentState } from '../coreLearn/utils';
 
 export function showExam(store, params, alreadyOnQuiz) {
@@ -21,7 +22,7 @@ export function showExam(store, params, alreadyOnQuiz) {
     store.commit('CORE_SET_PAGE_LOADING', false);
   } else {
     const promises = [
-      ClassroomResource.fetchModel({ id: classId }),
+      LearnerClassroomResource.fetchModel({ id: classId }),
       ExamResource.fetchModel({ id: examId }),
       store.dispatch('setAndCheckChannels'),
     ];


### PR DESCRIPTION
## Summary
* Displaying exams in learn was using the ClassroomResource which with the security fixes in #9523 is no longer accessible to non-admins
* Updates the code to use the LearnerClassroomResource that is used in the rest of learn

## References
Fixes #9544

## Reviewer guidance
Can you view a quiz as a learner? (must not be an admin or superadmin)

https://user-images.githubusercontent.com/1680573/176763856-6a44e471-0045-4aab-8efb-200fb04a6d05.mp4


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
