### PR TITLE
WebpackBundleHook fixes to allow live reloading of external plugins

### DIFF
--- a/kolibri/core/webpack/hooks.py
+++ b/kolibri/core/webpack/hooks.py
@@ -150,16 +150,16 @@ class WebpackBundleHook(hooks.KolibriHook):
         """
         for f in self._stats_file_content["files"]:
             filename = f["name"]
-            if not getattr(settings, "DEVELOPER_MODE", False):
+
+            if getattr(settings, "DEVELOPER_MODE", True):
+                # Skip IGNORE_PATTERNS matches in DEVELOPER_MODE
                 if any(list(regex.match(filename) for regex in IGNORE_PATTERNS)):
+                    print("Skipping bundle for {}".format(filename))
                     continue
-            relpath = "{0}/{1}".format(self.unique_id, filename)
-            if getattr(settings, "DEVELOPER_MODE", False):
-                try:
-                    f["url"] = f["publicPath"]
-                except KeyError:
-                    f["url"] = staticfiles_storage.url(relpath)
-            else:
+            try:
+                f["url"] = f["publicPath"]
+            except KeyError:
+                relpath = "{0}/{1}".format(self.unique_id, filename)
                 f["url"] = staticfiles_storage.url(relpath)
             yield f
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Front-end development of the Instant Schools plugin and KDP is a nightmare because there is no live reload - so it is several minutes between changes to see the result.

I've recently become familiar enough with the WebpackBundleHook code and the whole live reload workflow and was inspired during the 10th+ time of manually rebuilding the whole IS plugin frontend I thought I might be able to figure out what the problem was.

The bundle method was overwriting its own changes every time and applying the staticfiles path to the URL even if it was getting the proper stats file content.

It set the correct stats file derived path at first, but then in Dev mode, it would get into the `else` statement and overwrite whatever it set into `f["url"]`. This fixed my problem in Instant Schools on 0.15. _This change will need to be merged forward_ 

In KDP, however, the issue I ran into was that the `_stats_file_content` method/property was cached. This was fixed later on in 0.15 so I took the new method from there and put it here. With this change, if KDP is going to remain on 0.14 for a while, the development process can at least be much nicer. Otherwise, we can just forward merge the single commit fixing `bundle` and KDP should be just fine when it goes onto 0.15.

OR - possibly - and I haven't tested this but can - KDP the way I run it might work just fine with 0.15? I just run Kolibri with it installed as a plugin (alongside a bunch of other things that are noted below).


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I run KDP from Kolibri... which doesn't seem to be how it is suggested to be done in the KDP readme. So - there is a solid chance I have missed something important about how KDP is typically setup for development.

All I know is:
- This lets me run KDP in development
- This lets me run KDP in development with live reload (I didn't test hot... but live is such an improvement I wouldn't be mad if hot didn't work) 
- The live reload occurs on changing things both in Python and the front-end.

I hope I'm not missing something there - but in any case, this might be worth having setup and ready to go just for front-end dev.

**KDP Development Workflow:**

- Setup Kolibri (the version you need for your plugin --- RECOMMENDED that you use a new cloned repo or [git worktree](https://git-scm.com/docs/git-worktree))
- Export a new KOLIBRI_HOME value for the plugin  (ie, `KOLIBRI_HOME=~/.kdp`)
- `pip install -e ../path/to/plugin`
- edit `KOLIBRI_REPO/build_tools/build_plugins.txt` to include `kolibri_data_portal`
- Copy all dependencies from the KDP package.json into `kolibri/core/package.json` (maybe this isn't necessary but it worked and I didn't want to fuss with yarn)
- Setup postgress and set the database vars in options.ini to your database, user, password, etc values to be sure it doesn't try to use sqlite3
- Edit `KOLIBRI_REPO/package.json` and change all entries with `--settings=` to point to `kolibri_data_portal.settings.dev`
- `pip install` all of the requirements for Kolibri and KDP while in the Kolibri repo (ie, `pip install -r ../path/to/kdp/requirements.txt`)

I also then run all the commands listed in KDP's readme:

```
yarn install
make plugin-setup
kolibri manage createcachetable --skip-update
kolibri manage migrate
make generatekey
make copy-vega-lite
kolibri manage collectstatic --noinput
kolibri manage generateportaldata
```

If you're going to keep this clone repo around for this kind of dev - then you shouldn't be committing anything from the Kolibri repo itself, so it'll just remain in this uncommitable state and be ready to spin up KDP when you need it.

Then... `yarn devserver` and see your changes reloaded live like this:

https://user-images.githubusercontent.com/6356129/176777889-03e11af9-7c0e-4e6f-98b2-5c587650c966.mp4

