### PR TITLE
Fix show more of top level resources

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -530,11 +530,11 @@
       },
       resourcesDisplayed() {
         // if no folders are shown at this level, show more resources to fill the space
-        if (!this.topics) {
-          return this.resources.slice(0, 8);
+        if (this.topics.length == 0 && !this.showMoreResources) {
+          return this.resources.slice(0, this.childrenToDisplay * 2);
           // if there are topics, and the user has not clicked show more
           // default to just the preview number
-        } else if (this.topics && !this.showMoreResources) {
+        } else if (this.topics.length > 0 && !this.showMoreResources) {
           return this.resources.slice(0, this.childrenToDisplay);
           // otherwise display all resources
         } else {
@@ -542,10 +542,7 @@
         }
       },
       moreResources() {
-        return (
-          this.resources.length > this.childrenToDisplay &&
-          this.resourcesDisplayed.length < this.resources.length
-        );
+        return this.resourcesDisplayed.length < this.resources.length;
       },
       topics() {
         return this.contents.filter(content => content.kind === ContentNodeKinds.TOPIC);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -202,6 +202,16 @@
             >
               {{ $tr('showMore') }}
             </KButton>
+            <div v-else-if="topicMore" class="end-button-block">
+              <KButton
+                v-if="!topicMoreLoading"
+                :text="coreString('viewMoreAction')"
+                appearance="raised-button"
+                :disabled="topicMoreLoading"
+                @click="handleLoadMoreInTopic"
+              />
+              <KCircularLoader v-else />
+            </div>
           </div>
           <div v-else-if="!searchLoading">
             <h2 class="results-title">
@@ -529,17 +539,15 @@
         return this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
       },
       resourcesDisplayed() {
+        let displayed;
         // if no folders are shown at this level, show more resources to fill the space
-        if (this.topics.length == 0 && !this.showMoreResources) {
-          return this.resources.slice(0, this.childrenToDisplay * 2);
-          // if there are topics, and the user has not clicked show more
-          // default to just the preview number
-        } else if (this.topics.length > 0 && !this.showMoreResources) {
-          return this.resources.slice(0, this.childrenToDisplay);
+        if (!this.showMoreResources) {
+          displayed = this.resources.slice(0, this.childrenToDisplay);
           // otherwise display all resources
         } else {
-          return this.resources;
+          displayed = this.resources;
         }
+        return displayed;
       },
       moreResources() {
         return this.resourcesDisplayed.length < this.resources.length;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage.vue
@@ -539,15 +539,12 @@
         return this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
       },
       resourcesDisplayed() {
-        let displayed;
         // if no folders are shown at this level, show more resources to fill the space
-        if (!this.showMoreResources) {
-          displayed = this.resources.slice(0, this.childrenToDisplay);
-          // otherwise display all resources
-        } else {
-          displayed = this.resources;
+        // or if the user has explicitly requested to show more resources
+        if (!this.topics.length || this.showMoreResources) {
+          return this.resources;
         }
-        return displayed;
+        return this.resources.slice(0, this.childrenToDisplay);
       },
       moreResources() {
         return this.resourcesDisplayed.length < this.resources.length;


### PR DESCRIPTION
## Summary

Updates the "resource" display logic to be more distinct from topics and search results logic and to have separate management of display.

## References
Fixes #9553 

## Reviewer guidance

Not-logged in and logged-in views: 

![not-logged-in](https://user-images.githubusercontent.com/17235236/177994570-abcdd04e-843a-4b51-9014-a4bd25b0805d.gif)


https://user-images.githubusercontent.com/17235236/177994588-f7633e8d-7444-460b-84b9-8329a63d7ebb.mp4


**QUESTIONS**

1. Is this too "simple" of a fix, i.e. should it be more complex to potentially allow for more incremented "view more" display? (such as appending 10 more at a time, rather than just all?) 

2. Is this too different from some of the composable setup?

3. Have I accidentally broken anything else?

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
