### PR TITLE
Force translations in bulk export/import of user data

### DIFF
--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -108,13 +108,14 @@ output_mappings = {
 }
 
 
-map_output = None  # to be assigned after labels are translated
+def map_output(item):
+    return partial(
+        output_mapper, labels=translate_labels(), output_mappings=output_mappings
+    )(item)
 
 
 def translate_labels():
-    global labels
-    global map_output
-    labels = OrderedDict(
+    return OrderedDict(
         (
             ("id", _("Database ID ({})").format("UUID")),
             ("username", _("Username ({})").format("USERNAME")),
@@ -146,7 +147,6 @@ def translate_labels():
             ),
         )
     )
-    map_output = partial(output_mapper, labels=labels, output_mappings=output_mappings)
 
 
 def csv_file_generator(facility, filepath, overwrite=True):
@@ -154,7 +154,7 @@ def csv_file_generator(facility, filepath, overwrite=True):
         raise ValueError("{} already exists".format(filepath))
     queryset = FacilityUser.objects.filter(facility=facility)
 
-    header_labels = labels.values()
+    header_labels = translate_labels().values()
 
     csv_file = open_csv_for_writing(filepath)
 
@@ -259,7 +259,6 @@ class Command(AsyncCommand):
         # set language for the translation of the messages
         locale = settings.LANGUAGE_CODE if not options["locale"] else options["locale"]
         translation.activate(locale)
-        translate_labels()
 
         self.overall_error = []
         filepath = self.get_filepath(options)

--- a/kolibri/core/auth/management/commands/bulkexportusers.py
+++ b/kolibri/core/auth/management/commands/bulkexportusers.py
@@ -108,11 +108,12 @@ output_mappings = {
 }
 
 
-map_output = partial(output_mapper, labels=labels, output_mappings=output_mappings)
+map_output = None  # to be assigned after labels are translated
 
 
 def translate_labels():
     global labels
+    global map_output
     labels = OrderedDict(
         (
             ("id", _("Database ID ({})").format("UUID")),
@@ -145,6 +146,7 @@ def translate_labels():
             ),
         )
     )
+    map_output = partial(output_mapper, labels=labels, output_mappings=output_mappings)
 
 
 def csv_file_generator(facility, filepath, overwrite=True):


### PR DESCRIPTION
## Summary
After some refactoring in the csv functions, the strings that were translated in the backend were not being translated or serialized in json format when they were still a lazy proxy

This PR:
a) forces all the translation scafolding to be active before calling labeling functions
b) ensures the errors are fully converted to string and not lazy functions before being serialized

## References
Closes: #9554

## Reviewer guidance
When the server is set to other language different than English check that:
a) Bulk export in the Facility-Data tab works fine, check the exported csv file has its headers translated (if using a language Kolibri supports)
b) Modify the exported csv to introduce error, and import it: It should show the error messages correctly translated in the web UI (while triggering an exception in the server console)
c) tests pass

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
