### PR TITLE
Clean up theme regressions

### DIFF
--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -91,7 +91,20 @@ export default {
       topLogo: {
         type: Object,
         default: null,
-        spec: _imageSpec,
+        spec: {
+          src: {
+            type: String,
+            default: null,
+          },
+          style: {
+            type: String,
+            default: null,
+          },
+          alt: {
+            type: String,
+            default: null,
+          },
+        },
       },
       poweredByStyle: {
         type: String,
@@ -111,7 +124,7 @@ export default {
       },
       showPoweredBy: {
         type: Boolean,
-        default: true,
+        default: false,
       },
     },
   },
@@ -129,10 +142,6 @@ export default {
         spec: _imageSpec,
       },
       showKolibriFooterLogo: {
-        type: Boolean,
-        default: true,
-      },
-      showPoweredBy: {
         type: Boolean,
         default: true,
       },


### PR DESCRIPTION
## Summary
* Make powered by false by default.
* Remove unused poweredby from side nav theme.
* Tweak spec for signin top logo to remove requirement for src.

## References
Fixes minor regressions from https://github.com/learningequality/kolibri/pull/8918
Fixes unreported bug where 'powered by Kolibri' is always shown
Fixes #9531

## Reviewer guidance
Before:
![image](https://user-images.githubusercontent.com/1680573/178369039-56fd8371-bb55-4f97-a949-94d2a92ea6c9.png)

After:
![image](https://user-images.githubusercontent.com/1680573/178369082-dd259571-57cb-40b1-a001-5f4264b6cfc9.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
