### PR TITLE
Move CACHES import into function scope to prevent side effects.

### DIFF
--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -25,7 +25,6 @@ from kolibri.core.tasks.main import import_tasks_module_from_django_apps
 from kolibri.core.upgrade import matches_version
 from kolibri.core.upgrade import run_upgrades
 from kolibri.core.utils.cache import process_cache
-from kolibri.deployment.default.cache import CACHES
 from kolibri.deployment.default.sqlite_db_names import ADDITIONAL_SQLITE_DATABASES
 from kolibri.plugins.utils import autoremove_unavailable_plugins
 from kolibri.plugins.utils import check_plugin_config_file_location
@@ -225,6 +224,10 @@ def _upgrades_before_django_setup(updated, version):
 
 
 def _post_django_initialization():
+    # Import here to prevent the module level access to Kolibri options
+    # which causes premature registration of Kolibri plugins.
+    from kolibri.deployment.default.cache import CACHES
+
     if "process_cache" in CACHES:  # usually it means not using redis
         if "DatabaseCache" not in CACHES["process_cache"]["BACKEND"]:
             try:


### PR DESCRIPTION
## Summary
* The default cache module involves module level access to the Kolibri OPTIONS object
* This results in evaluation and initialization of the plugin registry
* This causes an issue for anything importing from `main` expecting to be able to enable plugins, as the enabled plugins will not be properly registered

## References
Fixes a reported issue for the Mac app.
I am hopeful that this behaviour would raise a runtime error in develop due to some stricter checking, but it might still need some follow up to prevent this happening in future.

## Reviewer guidance
Test the [mac app](https://github.com/learningequality/kolibri-app/actions/runs/2673793226) that is built from the WHL file from this PR and ensure it starts.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
