### PR TITLE
Change Facility - Create Account

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -60,6 +60,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       "Indicates going back to a previous step.\n\nFor example, when a user creates a quiz in Kolibri using the quiz builder they can either 'CONTINUE' to the next phase of the builder or 'GO BACK'.\n\nIf you go back you exit the quiz builder and loose the resource selection.",
   },
+  backAction: {
+    message: 'Back',
+    context:
+      'Indicates going back to a previous step in multi-step workflows. It can be used as a label of the back button that is displayed next to the continue button.',
+  },
   importAction: {
     message: 'Import',
     context:

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -445,6 +445,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Refers to the option to present the captions (subtitles) of the video in the form of the interactive transcript.',
   },
+  rememberThisAccountInformation: {
+    message: 'Important: please remember this account information. Write it down if needed.',
+    context: 'Helper/information text to remind user to take note of their account information.',
+  },
 
   // Learning Activities
   all: {

--- a/kolibri/core/assets/src/styles/definitions.scss
+++ b/kolibri/core/assets/src/styles/definitions.scss
@@ -1,0 +1,1 @@
+$page-container-max-width: 700px;

--- a/kolibri/core/assets/src/views/userAccounts/FullNameTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/FullNameTextbox.vue
@@ -41,8 +41,11 @@
       };
     },
     computed: {
+      isFullNameValid() {
+        return this.value && this.value.trim() !== '';
+      },
       invalidText() {
-        if (this.value === '') {
+        if (!this.isFullNameValid) {
           return this.coreString('requiredFieldError');
         }
         return '';
@@ -53,12 +56,9 @@
         }
         return '';
       },
-      valid() {
-        return this.invalidText === '';
-      },
     },
     watch: {
-      valid: {
+      isFullNameValid: {
         handler(value) {
           this.$emit('update:isValid', value);
         },

--- a/kolibri/core/assets/src/views/userAccounts/FullNameTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/FullNameTextbox.vue
@@ -25,6 +25,7 @@
     name: 'FullNameTextbox',
     mixins: [commonCoreStrings],
     // NOTE: 'value' and 'isValid' must be .sync'd with parent
+    // You can also pass 'disabled', 'autofocus', and 'autocomplete'
     props: {
       value: {
         type: String,

--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -41,6 +41,7 @@
     mixins: [commonCoreStrings],
     props: {
       // NOTE: 'value', and 'isValid' must be .sync'd with parent
+      // Fallthrough attributes are passed down to the first textbox
       value: {
         type: String,
         default: '',

--- a/kolibri/core/assets/src/views/userAccounts/UsernameTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/UsernameTextbox.vue
@@ -27,6 +27,7 @@
     mixins: [commonCoreStrings],
     props: {
       // NOTE: 'value', 'errors', and 'isValid' must be .sync'ed with parent
+      // You can also pass 'disabled' and 'autofocus'
       value: {
         type: String,
         default: '',

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -146,8 +146,10 @@
 
 <style lang="scss" scoped>
 
+  @import '../../../../../core/assets/src/styles/definitions';
+
   .base-container {
-    max-width: 700px;
+    max-width: $page-container-max-width;
     padding-bottom: 5em;
     margin: 5em auto 0;
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -50,7 +50,7 @@
           <KIcon icon="warning" />
         </div>
         <p class="text">
-          {{ $tr('rememberThisAccountInformation') }}
+          {{ coreString('rememberThisAccountInformation') }}
         </p>
       </div>
     </slot>
@@ -62,6 +62,7 @@
 <script>
 
   import every from 'lodash/every';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
@@ -78,6 +79,7 @@
       PasswordTextbox,
       PrivacyLinkAndModal,
     },
+    mixins: [commonCoreStrings],
     inject: ['wizardService'],
     props: {
       uniqueUsernameValidator: {
@@ -176,11 +178,6 @@
         message:
           'This account allows you to manage the facility, resources, and user accounts on this device',
         context: "Description of the 'Create super admin account' page.",
-      },
-      rememberThisAccountInformation: {
-        message: 'Important: please remember this account information. Write it down if needed',
-        context:
-          'Helper/information text to remind admin to take note of their account information.',
       },
     },
   };

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -224,7 +224,15 @@ export const changeFacilityMachine = createMachine({
           target: 'isAdmin',
           actions: setTargetAccount,
         },
-        BACK: 'confirmAccount',
+        BACK: [
+          {
+            cond: context => context.accountExists,
+            target: 'changeFacility',
+          },
+          {
+            target: 'confirmAccount',
+          },
+        ],
       },
     },
     usernameExists: {

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -83,7 +83,10 @@ export const changeFacilityMachine = createMachine({
     username: '',
     targetAccount: { username: '', id: '' },
     sourceFacility: '',
-    targetFacility: {}, //should be an object with the facility name, id & url
+    // should be an object with the target facility
+    // `name`, `id`, `url`, `learner_can_sign_up` &
+    // `learner_can_login_with_no_password` fields
+    targetFacility: {},
     newSuperAdmin: '',
     taskPolling: false,
     accountExists: false,

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -221,8 +221,7 @@ export const changeFacilityMachine = createMachine({
           target: 'isAdmin',
           actions: setTargetAccount,
         },
-        BACK: 'changeFacility',
-        BACKMERGING: 'confirmMerge',
+        BACK: 'confirmAccount',
       },
     },
     usernameExists: {

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -165,7 +165,10 @@ export const changeFacilityMachine = createMachine({
     confirmAccount: {
       meta: { route: 'CONFIRM_ACCOUNT', path: '/change_facility' },
       on: {
-        NEW: 'createAccount',
+        NEW: {
+          cond: context => context.targetFacility && context.targetFacility.learner_can_sign_up,
+          target: 'createAccount',
+        },
         CONTINUE: 'isAdmin',
         BACK: 'changeFacility',
       },

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -208,8 +208,8 @@ export const changeFacilityMachine = createMachine({
       type: 'final',
     },
     createAccount: {
+      meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
       on: {
-        meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
         CONTINUE: {
           // event.value must be an object {id:, usename:}
           target: 'isAdmin',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -81,7 +81,11 @@ export const changeFacilityMachine = createMachine({
   context: {
     role: 'learner',
     username: '',
-    targetAccount: { username: '', id: '' },
+    targetAccount: {
+      fullName: '',
+      username: '',
+      password: '',
+    },
     sourceFacility: '',
     // should be an object with the target facility
     // `name`, `id`, `url`, `learner_can_sign_up` &
@@ -214,7 +218,6 @@ export const changeFacilityMachine = createMachine({
       meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
       on: {
         CONTINUE: {
-          // event.value must be an object {id:, usename:}
           target: 'isAdmin',
           actions: setTargetAccount,
         },

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -6,6 +6,7 @@ import ChangeFacility from './views/ChangeFacility';
 import SelectFacility from './views/ChangeFacility/SelectFacility';
 import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
 import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
+import CreateAccount from './views/ChangeFacility/CreateAccount';
 import ToBeDone from './views/ChangeFacility/ToBeDone';
 
 function preload(next) {
@@ -88,7 +89,7 @@ export default [
       {
         path: 'create_account',
         name: 'CREATE_ACCOUNT',
-        component: ToBeDone,
+        component: CreateAccount,
       },
       {
         path: 'username_exists',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount.vue
@@ -10,6 +10,7 @@
           <KButton
             :primary="false"
             :text="$tr('createAccount')"
+            appearance="flat-button"
             @click="to_create"
           />
           <KButton

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/__tests__/index.spec.js
@@ -1,9 +1,63 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import ConfirmAccount from '../index.vue';
 
+const sendMachineEvent = jest.fn();
+function makeWrapper({ targetFacility } = {}) {
+  return mount(ConfirmAccount, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+      state: {
+        value: {
+          targetFacility,
+        },
+      },
+    },
+  });
+}
+
+const getCreateNewAccountButton = wrapper => wrapper.find('[data-test="createNewAccountButton"]');
+const clickCreateNewAccountButton = wrapper => getCreateNewAccountButton(wrapper).trigger('click');
+
 describe(`ChangeFacility/ConfirmAccount`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it(`smoke test`, () => {
     const wrapper = shallowMount(ConfirmAccount);
     expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it(`shows the 'Create new account' button`, () => {
+    const wrapper = makeWrapper();
+    expect(getCreateNewAccountButton(wrapper).exists()).toBeTruthy();
+  });
+
+  describe(`when learners are not allowed to sign up in the target facility`, () => {
+    it(`'Create new account' button is disabled`, () => {
+      const wrapper = makeWrapper({ targetFacility: { learner_can_sign_up: false } });
+      expect(getCreateNewAccountButton(wrapper).attributes().disabled).toBeTruthy();
+    });
+  });
+
+  describe(`when learners are allowed to sign up in the target facility`, () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = makeWrapper({ targetFacility: { learner_can_sign_up: true } });
+    });
+
+    it(`'Create new account' button is enabled`, () => {
+      expect(getCreateNewAccountButton(wrapper).attributes().disabled).toBeFalsy();
+    });
+
+    it(`Clicking the 'Create new account' button sends the 'NEW' event to the state machine`, () => {
+      clickCreateNewAccountButton(wrapper);
+      expect(sendMachineEvent).toHaveBeenCalledWith({
+        type: 'NEW',
+      });
+    });
   });
 });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/__tests__/index.spec.js
@@ -1,0 +1,9 @@
+import { shallowMount } from '@vue/test-utils';
+import ConfirmAccount from '../index.vue';
+
+describe(`ChangeFacility/ConfirmAccount`, () => {
+  it(`smoke test`, () => {
+    const wrapper = shallowMount(ConfirmAccount);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+});

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/index.vue
@@ -10,6 +10,8 @@
           <KButton
             :primary="false"
             :text="$tr('createAccount')"
+            :disabled="isCreateAccountButtonDisabled"
+            data-test="createNewAccountButton"
             appearance="flat-button"
             @click="to_create"
           />
@@ -55,6 +57,9 @@
       },
       usernameExists() {
         return get(this.state, 'value.accountExists');
+      },
+      isCreateAccountButtonDisabled() {
+        return !get(this.targetFacility, 'learner_can_sign_up');
       },
       firstLine() {
         return this.$tr('confirmAccountLine1', {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccount/index.vue
@@ -30,6 +30,7 @@
 
 <script>
 
+  import get from 'lodash/get';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
 
@@ -47,23 +48,23 @@
     inject: ['changeFacilityService', 'state'],
     computed: {
       targetFacility() {
-        return this.state.value.targetFacility;
+        return get(this.state, 'value.targetFacility');
       },
       username() {
-        return this.state.value.username;
+        return get(this.state, 'value.username');
       },
       usernameExists() {
-        return this.state.value.accountExists;
+        return get(this.state, 'value.accountExists');
       },
       firstLine() {
         return this.$tr('confirmAccountLine1', {
-          target_facility: this.targetFacility.name,
+          target_facility: get(this.targetFacility, 'name', ''),
           username: this.username,
         });
       },
       secondLine() {
         return this.$tr('confirmAccountLine2', {
-          target_facility: this.targetFacility.name,
+          target_facility: get(this.targetFacility, 'name', ''),
         });
       },
     },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -11,6 +11,7 @@
           <KButton
             :primary="false"
             :text="$tr('mergeAccounts')"
+            appearance="flat-button"
             @click="to_merge"
           />
           <KButton

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -1,0 +1,65 @@
+import { shallowMount, mount } from '@vue/test-utils';
+import CreateAccount from '../index.vue';
+
+const sendMachineEvent = jest.fn();
+function makeWrapper() {
+  return mount(CreateAccount, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+      state: {
+        value: {
+          targetFacility: {
+            name: 'Test Facility',
+          },
+        },
+      },
+    },
+  });
+}
+
+const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
+const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+
+describe(`ChangeFacility/CreateAccount`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = shallowMount(CreateAccount);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it(`shows the message about creating a new account in the target facility`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.text()).toContain('New account for ‘Test Facility’ learning facility');
+  });
+
+  it(`shows the back button`, () => {
+    const wrapper = makeWrapper();
+    expect(getBackButton(wrapper).exists()).toBeTruthy();
+  });
+
+  it(`shows the continue button`, () => {
+    const wrapper = makeWrapper();
+    expect(getContinueButton(wrapper).exists()).toBeTruthy();
+  });
+
+  it(`clicking the back button sends the back event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    expect(getBackButton(wrapper).trigger('click'));
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'BACK',
+    });
+  });
+
+  it(`clicking the continue button sends the continue event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    expect(getContinueButton(wrapper).trigger('click'));
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'CONTINUE',
+    });
+  });
+});

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -80,6 +80,11 @@ describe(`ChangeFacility/CreateAccount`, () => {
     expect(getUsernameTextbox(wrapper).exists()).toBeTruthy();
   });
 
+  it(`shows the privacy modal link`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.findAll('a').filter(link => link.text() === 'Usage and privacy').length).toBe(1);
+  });
+
   describe(`when the target facility doesn't require password on learner accounts`, () => {
     it(`doesn't show the password textbox`, () => {
       const wrapper = makeWrapper({ targetFacility: { learner_can_login_with_no_password: true } });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -21,6 +21,20 @@ function makeWrapper() {
 
 const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
 const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+const clickBackButton = wrapper => getBackButton(wrapper).trigger('click');
+const clickContinueButton = wrapper => getContinueButton(wrapper).trigger('click');
+const getFullNameTextbox = wrapper => wrapper.find('[data-test="fullNameTextbox"]');
+const getUsernameTextbox = wrapper => wrapper.find('[data-test="usernameTextbox"]');
+const setFullNameTextboxValue = (wrapper, value) => {
+  getFullNameTextbox(wrapper)
+    .find('input')
+    .setValue(value);
+};
+const setUsernameTextboxValue = (wrapper, value) => {
+  getUsernameTextbox(wrapper)
+    .find('input')
+    .setValue(value);
+};
 
 describe(`ChangeFacility/CreateAccount`, () => {
   beforeEach(() => {
@@ -47,19 +61,44 @@ describe(`ChangeFacility/CreateAccount`, () => {
     expect(getContinueButton(wrapper).exists()).toBeTruthy();
   });
 
+  it(`shows the full name textbox`, () => {
+    const wrapper = makeWrapper();
+    expect(getFullNameTextbox(wrapper).exists()).toBeTruthy();
+  });
+
+  it(`shows the username textbox`, () => {
+    const wrapper = makeWrapper();
+    expect(getUsernameTextbox(wrapper).exists()).toBeTruthy();
+  });
+
   it(`clicking the back button sends the back event to the state machine`, () => {
     const wrapper = makeWrapper();
-    expect(getBackButton(wrapper).trigger('click'));
+    clickBackButton(wrapper);
     expect(sendMachineEvent).toHaveBeenCalledWith({
       type: 'BACK',
     });
   });
 
-  it(`clicking the continue button sends the continue event to the state machine`, () => {
-    const wrapper = makeWrapper();
-    expect(getContinueButton(wrapper).trigger('click'));
-    expect(sendMachineEvent).toHaveBeenCalledWith({
-      type: 'CONTINUE',
+  describe(`when the new user account form is valid`, () => {
+    it(`clicking the continue button sends the continue event to the state machine`, async () => {
+      const wrapper = makeWrapper();
+      setFullNameTextboxValue(wrapper, 'Test Fullname');
+      setUsernameTextboxValue(wrapper, 'testusername');
+      // wait for validation
+      await wrapper.vm.$nextTick();
+      clickContinueButton(wrapper);
+      expect(sendMachineEvent).toHaveBeenCalledWith({
+        type: 'CONTINUE',
+      });
+    });
+  });
+
+  describe(`when the new user account form is invalid`, () => {
+    it(`clicking the continue button doesn't send the continue event to the state machine`, () => {
+      const wrapper = makeWrapper();
+      // the form is empty and therefore invalid
+      clickContinueButton(wrapper);
+      expect(sendMachineEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -101,6 +101,13 @@ describe(`ChangeFacility/CreateAccount`, () => {
     });
   });
 
+  it(`shows the message for users to remember their account information`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.text()).toContain(
+      'Important: please remember this account information. Write it down if needed.'
+    );
+  });
+
   it(`clicking the back button sends the back event to the state machine`, () => {
     const wrapper = makeWrapper();
     clickBackButton(wrapper);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -105,7 +105,7 @@ describe(`ChangeFacility/CreateAccount`, () => {
   });
 
   describe(`when the new user account form is valid`, () => {
-    it(`clicking the continue button sends the continue event to the state machine`, async () => {
+    it(`clicking the continue button sends the continue event with the form data as its value to the state machine`, async () => {
       const wrapper = makeWrapper();
       setFullNameTextboxValue(wrapper, 'Test Fullname');
       setUsernameTextboxValue(wrapper, 'testusername');
@@ -115,6 +115,11 @@ describe(`ChangeFacility/CreateAccount`, () => {
       clickContinueButton(wrapper);
       expect(sendMachineEvent).toHaveBeenCalledWith({
         type: 'CONTINUE',
+        value: {
+          fullName: 'Test Fullname',
+          username: 'testusername',
+          password: 'testpassword',
+        },
       });
     });
   });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -29,6 +29,8 @@
       :shouldValidate="isFormSubmitted"
     />
 
+    <PrivacyLinkAndModal />
+
     <BottomAppBar>
       <slot name="buttons">
         <KButtonGroup>
@@ -60,6 +62,7 @@
   import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
+  import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
 
   export default {
     name: 'CreateAccount',
@@ -73,6 +76,7 @@
       FullNameTextbox,
       UsernameTextbox,
       PasswordTextbox,
+      PrivacyLinkAndModal,
     },
     mixins: [commonCoreStrings],
     inject: ['changeFacilityService', 'state'],

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -1,0 +1,79 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p>{{ description }}</p>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('goBackAction')"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="sendContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+  </div>
+
+</template>
+
+
+<script>
+
+  import get from 'lodash/get';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+
+  export default {
+    name: 'CreateAccount',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+    mixins: [commonCoreStrings],
+    inject: ['changeFacilityService', 'state'],
+    computed: {
+      description() {
+        return this.$tr('description', {
+          targetFacility: get(this.state, 'value.targetFacility.name', ''),
+        });
+      },
+    },
+    methods: {
+      sendContinue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      },
+      sendBack() {
+        this.changeFacilityService.send({
+          type: 'BACK',
+        });
+      },
+    },
+    $trs: {
+      documentTitle: {
+        message: 'Create new account',
+        context:
+          'Title of the step for creating a new account in a target facility when changing facility.',
+      },
+      description: {
+        message: 'New account for ‘{targetFacility}’ learning facility',
+        context:
+          'Shows above a new user form where a user can create a new account in a target facility when changing facility.',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -4,6 +4,23 @@
     <h1>{{ $tr('documentTitle') }}</h1>
     <p>{{ description }}</p>
 
+    <FullNameTextbox
+      ref="fullNameTextbox"
+      data-test="fullNameTextbox"
+      :value.sync="formData.fullName"
+      :isValid.sync="isFullNameValid"
+      :shouldValidate="isFormSubmitted"
+      :autofocus="true"
+      autocomplete="name"
+    />
+    <UsernameTextbox
+      ref="usernameTextbox"
+      data-test="usernameTextbox"
+      :value.sync="formData.username"
+      :isValid.sync="isUsernameValid"
+      :shouldValidate="isFormSubmitted"
+    />
+
     <BottomAppBar>
       <slot name="buttons">
         <KButtonGroup>
@@ -17,7 +34,7 @@
             :primary="true"
             :text="coreString('continueAction')"
             data-test="continueButton"
-            @click="sendContinue"
+            @click="handleContinue"
           />
         </KButtonGroup>
       </slot>
@@ -32,6 +49,8 @@
   import get from 'lodash/get';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
+  import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
 
   export default {
     name: 'CreateAccount',
@@ -40,17 +59,50 @@
         title: this.$tr('documentTitle'),
       };
     },
-    components: { BottomAppBar },
+    components: {
+      BottomAppBar,
+      FullNameTextbox,
+      UsernameTextbox,
+    },
     mixins: [commonCoreStrings],
     inject: ['changeFacilityService', 'state'],
+    data() {
+      return {
+        formData: {
+          fullName: '',
+          username: '',
+        },
+        isFullNameValid: false,
+        isUsernameValid: false,
+        isFormSubmitted: false,
+      };
+    },
     computed: {
       description() {
         return this.$tr('description', {
           targetFacility: get(this.state, 'value.targetFacility.name', ''),
         });
       },
+      isFormValid() {
+        return [this.isFullNameValid, this.isUsernameValid].every(Boolean);
+      },
     },
     methods: {
+      handleContinue() {
+        this.isFormSubmitted = true;
+        if (this.isFormValid) {
+          this.sendContinue();
+        } else {
+          this.focusOnInvalidField();
+        }
+      },
+      focusOnInvalidField() {
+        if (!this.isFullNameValid) {
+          this.$refs.fullNameTextbox.focus();
+        } else if (!this.isUsernameValid) {
+          this.$refs.usernameTextbox.focus();
+        }
+      },
       sendContinue() {
         this.changeFacilityService.send({
           type: 'CONTINUE',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -41,6 +41,7 @@
           <KButton
             :primary="false"
             :text="coreString('backAction')"
+            appearance="flat-button"
             data-test="backButton"
             @click="sendBack"
           />

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -127,6 +127,7 @@
       sendContinue() {
         this.changeFacilityService.send({
           type: 'CONTINUE',
+          value: this.formData,
         });
       },
       sendBack() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -31,6 +31,10 @@
 
     <PrivacyLinkAndModal />
 
+    <p :style=" { color: $themeTokens.annotation }">
+      {{ coreString('rememberThisAccountInformation') }}
+    </p>
+
     <BottomAppBar>
       <slot name="buttons">
         <KButtonGroup>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -20,6 +20,14 @@
       :isValid.sync="isUsernameValid"
       :shouldValidate="isFormSubmitted"
     />
+    <PasswordTextbox
+      v-if="showPasswordTextbox"
+      ref="passwordTextbox"
+      data-test="passwordTextbox"
+      :value.sync="formData.password"
+      :isValid.sync="isPasswordValid"
+      :shouldValidate="isFormSubmitted"
+    />
 
     <BottomAppBar>
       <slot name="buttons">
@@ -51,6 +59,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
+  import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
 
   export default {
     name: 'CreateAccount',
@@ -63,6 +72,7 @@
       BottomAppBar,
       FullNameTextbox,
       UsernameTextbox,
+      PasswordTextbox,
     },
     mixins: [commonCoreStrings],
     inject: ['changeFacilityService', 'state'],
@@ -71,9 +81,11 @@
         formData: {
           fullName: '',
           username: '',
+          password: '',
         },
         isFullNameValid: false,
         isUsernameValid: false,
+        isPasswordValid: false,
         isFormSubmitted: false,
       };
     },
@@ -83,8 +95,15 @@
           targetFacility: get(this.state, 'value.targetFacility.name', ''),
         });
       },
+      showPasswordTextbox() {
+        return !get(this.state, 'value.targetFacility.learner_can_login_with_no_password', false);
+      },
       isFormValid() {
-        return [this.isFullNameValid, this.isUsernameValid].every(Boolean);
+        return (
+          this.isFullNameValid &&
+          this.isUsernameValid &&
+          (!this.showPasswordTextbox || this.isPasswordValid)
+        );
       },
     },
     methods: {
@@ -101,6 +120,8 @@
           this.$refs.fullNameTextbox.focus();
         } else if (!this.isUsernameValid) {
           this.$refs.usernameTextbox.focus();
+        } else if (this.showPasswordTextbox && !this.isPasswordValid) {
+          this.$refs.passwordTextbox.focus();
         }
       },
       sendContinue() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -40,7 +40,7 @@
         <KButtonGroup>
           <KButton
             :primary="false"
-            :text="coreString('goBackAction')"
+            :text="coreString('backAction')"
             data-test="backButton"
             @click="sendBack"
           />

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -189,7 +189,7 @@
                 name: facility.name,
                 base_url: address.base_url,
                 address_id: address.id,
-                learner_can_sign_up: facility.learner_can_sign_up || true,
+                learner_can_sign_up: facility.learner_can_sign_up,
                 learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
               };
               if (!this.availableFacilities.find(f => f.id === facility.id))

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -224,8 +224,9 @@
                 learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
                 kolibri_version: address.kolibri_version,
               };
-              if (!this.availableFacilities.find(f => f.id === facility.id))
+              if (!this.availableFacilities.find(f => f.id === facility.id)) {
                 this.availableFacilities.push(newFacility);
+              }
             });
           });
           this.availableAddressIds = availableDevices.map(address => address.id);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -224,9 +224,8 @@
                 learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
                 kolibri_version: address.kolibri_version,
               };
-              if (!this.availableFacilities.find(f => f.id === facility.id)) {
+              if (!this.availableFacilities.find(f => f.id === facility.id))
                 this.availableFacilities.push(newFacility);
-              }
             });
           });
           this.availableAddressIds = availableDevices.map(address => address.id);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -164,6 +164,7 @@
             url: facility.base_url,
             id: facility.id,
             learner_can_sign_up: facility.learner_can_sign_up,
+            learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
           },
         });
       },
@@ -189,6 +190,7 @@
                 base_url: address.base_url,
                 address_id: address.id,
                 learner_can_sign_up: facility.learner_can_sign_up || true,
+                learner_can_login_with_no_password: facility.learner_can_login_with_no_password,
               };
               if (!this.availableFacilities.find(f => f.id === facility.id))
                 this.availableFacilities.push(newFacility);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -7,7 +7,7 @@
         :appBarTitle="coreString('changeLearningFacility')"
         :route="$router.getRoute('PROFILE')"
       />
-      <KPageContainer>
+      <KPageContainer class="container">
 
         <router-view />
 
@@ -132,3 +132,16 @@
   };
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  @import '../../../../../../core/assets/src/styles/definitions';
+
+  .container {
+    max-width: $page-container-max-width;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+</style>


### PR DESCRIPTION
## Summary

- Adds _Create Account_ page
- Updates _Create new account_ button to be disabled on _Confirm account username_ page when learners are not allowed to sign up on the target facility
- `FullNameTextbox` now trims the full name before validating it so that names made of empty characters won't be accepted (impacts all forms where we use the component - setup wizard, sign up, user profile settings, and creating/editing users of a facility)
- Sets `max-width` to `700px` on page containers for all change facility steps that have been implemented (the same value that was used in the onboarding setup wizard and is pretty close to `656px` width used on designs) 
- Updates secondary buttons for all change facility steps that have been implemented to have flat appearance

### Screenshots

| | _Confirm account username_ page | _Create account_ page |
| --- | --- | --- |
| The target facility doesn't allow learners to create accounts | ![cant-sign-up](https://user-images.githubusercontent.com/13509191/179225692-c1113af1-6f1a-4532-b93c-58ac286c2eaf.png) | --- |
| The target facility allows learners to create accounts and it doesn't require a password | ![can-sign-up](https://user-images.githubusercontent.com/13509191/179228663-43afff6f-cbc9-4884-b5c7-06f5467f2375.png) | ![no-pw](https://user-images.githubusercontent.com/13509191/179228542-4fd2a2e9-04fb-4015-84c7-3cde5668dc05.png) |
| The target facility allows learners to create accounts and it requires a password | ![can-sign-up](https://user-images.githubusercontent.com/13509191/179228663-43afff6f-cbc9-4884-b5c7-06f5467f2375.png) | ![wants-pw](https://user-images.githubusercontent.com/13509191/179229721-93f39197-f305-4066-9349-83a6c6fb1922.png) |

#### Max container width and secondary buttons appearance (applies to all change facility steps):

| Before | After |
| ---------| ------- |
| ![Screenshot from 2022-07-15 15-13-57](https://user-images.githubusercontent.com/13509191/179230325-817d4596-2827-40f5-9e37-16848fb38171.png) | ![Screenshot from 2022-07-15 15-12-25](https://user-images.githubusercontent.com/13509191/179230054-1d0ef170-38b7-4b10-84d7-ad4cf7cb7091.png) |

## References

- Solves the first part of #9329
- [Figma designs](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=596%3A10379)

## Notes

- With @jredrejo, @marcellamaki, and @rtibbles we agreed that the API call for creating a new account will happen later during the _Changing learning facility_ step => in this PR, clicking the _Continue_ button on _Create new account_ page only saves the target account data to the state machine's context from where it can be sent to backend later
- It's possible that later I will consider extracting form to its own component since _Edit existing account_ form (second part of #9329) is the same but I decided to open PRs separately
- _Back_ navigation on _Create account_ page will need some more work as soon as we start using this state in other branches of the flow as the button will lead somewhere else. But for that, we will need to implement more states at first.

## Reviewer guidance

### Setup

You need to have two facilities to be able to test the change facility workflow:

**Source facility**
1. You can run the development server as usual
2. Your Kolibri instance shouldn't be the learner only device and also you need to make sure there's only one user account, otherwise you won't be able to access the _Change learner facility_ feature in _Profile_

**Target facility**

If you already have a target facility with some user accounts, make sure that in the source facility, you log in as a user with a username that doesn't match any username on the target facility (otherwise you'll be taken to a different part of the flow). Also, it needs to be v0.16.

If you don't have a target facility, you can follow these steps:
1. `cd` to your `kolibri` development directory and make sure to activate your virtual environment like when developing
2. Run ` pip install -e .` to ensure that the target facility has `develop` (`0.16.x`) updates that are required (`kolibri --version` should show something like `0.16.0.dev0+git.20220715072421`)
3. Run Kolibri with the `kolibri` command with `KOLIBRI_HOME` environment variable different from your usual setup so that you don't override your development Kolibri  `KOLIBRI_HOME=~/.tmp kolibri start --foreground`
4. You need to go through the onboarding setup, otherwise the target facility may not be discovered. It seems that we have some onboarding work in progress so it's possible that you won't be able to go through the onboarding forms and complete the setup. I solved this by switching to `0.15.x` version where I did the onboarding and then switched to this branch using the same `KOLIBRI_HOME` and then went through steps 1-3.

### Test scenarios

#### (1)
In the facility settings of the target facility
- do not _Allow users to create accounts_

On the source facility
1. Navigate to _Profile -> Change facility -> Change_
2. Select the target facility and click _Continue_
3. On _Change Facility_ page click _Continue_
4. On _Confirm account username_ page, check that _Create new account_ button is disabled

#### (2)
In the facility settings of the target facility
- do _Allow users to create accounts_
- do not _Require password for learners_

On the source facility
1. Navigate to _Profile -> Change facility -> Change_
2. Select the target facility and click _Continue_
3. On _Change Facility_ page click _Continue_
4. On _Confirm account username_ page, click _Create new account_ button
6. Check that you can see _Create new account_ page
7. Test _Create new account_ page:
    - full name and username textboxes are visible
    - password textbox is not visible
    - test _Back_ navigation
    - check form validation - you should be able to _Continue_ only when the form is valid
    - test keyboard navigation

#### (3)
In the facility settings of the target facility
- do _Allow users to create accounts_
- do _Require password for learners_

On the source facility
- same as (2) but two password textboxes should show up

Note that there's a focus ring missing around password textboxes when testing keyboard navigation (https://github.com/learningequality/kolibri/issues/9563)

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md