### PR TITLE
When changing facility , ensure version is at least 0.16.0

### DIFF
--- a/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
+++ b/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
@@ -23,5 +23,16 @@ describe(`useMinimumKolibriVersion`, () => {
     it(`higher version is detected, without default`, () => {
       expect(isMinimumKolibriVersion.value('0.16.1', 0, 16, 0)).toBe(true);
     });
+
+    it(`check beta versions work fine with equal values`, () => {
+      expect(isMinimumKolibriVersion.value('0.16.1-b4', 0, 16, 1)).toBe(false);
+    });
+    it(`check beta versions work when betas are included`, () => {
+      expect(isMinimumKolibriVersion.value('0.16.1-b4', 0, 16)).toBe(true);
+    });
+
+    it(`check beta versions work fine with upper values`, () => {
+      expect(isMinimumKolibriVersion.value('0.16.1-b4', 0, 16, 0)).toBe(true);
+    });
   });
 });

--- a/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
+++ b/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
@@ -28,7 +28,7 @@ describe(`useMinimumKolibriVersion`, () => {
       expect(isMinimumKolibriVersion.value('0.16.1-b4', 0, 16, 1)).toBe(false);
     });
     it(`check beta versions work when betas are included`, () => {
-      expect(isMinimumKolibriVersion.value('0.16.1-b4', 0, 16)).toBe(true);
+      expect(isMinimumKolibriVersion.value('0.16.0-b4', 0, 16)).toBe(true);
     });
 
     it(`check beta versions work fine with upper values`, () => {

--- a/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
+++ b/kolibri/core/assets/src/composables/__tests__/useMinimumKolibriVersion.spec.js
@@ -1,0 +1,27 @@
+import useMinimumKolibriVersion from '../useMinimumKolibriVersion';
+
+const { isMinimumKolibriVersion } = useMinimumKolibriVersion();
+
+describe(`useMinimumKolibriVersion`, () => {
+  describe(`isMinimumKolibriVersion computed function`, () => {
+    it(`lower version is detected, with 0.15.0 as default`, () => {
+      expect(isMinimumKolibriVersion.value('0.14.99')).toBe(false);
+    });
+
+    it(`same version is detected, with 0.15.0 as default`, () => {
+      expect(isMinimumKolibriVersion.value('0.15.0')).toBe(true);
+    });
+
+    it(`lower version is detected, without default`, () => {
+      expect(isMinimumKolibriVersion.value('0.15.4', 0, 16, 0)).toBe(false);
+    });
+
+    it(`same version is detected, without default`, () => {
+      expect(isMinimumKolibriVersion.value('0.16.0', 0, 16, 0)).toBe(true);
+    });
+
+    it(`higher version is detected, without default`, () => {
+      expect(isMinimumKolibriVersion.value('0.16.1', 0, 16, 0)).toBe(true);
+    });
+  });
+});

--- a/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
+++ b/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
@@ -1,0 +1,27 @@
+import { computed } from 'kolibri.lib.vueCompositionApi';
+
+export default function useMinimumKolibriVersion() {
+  const isMinimumKolibriVersion = computed(() => {
+    return function(version, majorVersion = 0, minorVersion = 15, revisionVersion = 0) {
+      // defaults to kolibri 0.15.0
+      const v = version.split('.');
+      if (v.length < 2) return false;
+      const mayor = parseInt(v[0]);
+      const minor = parseInt(v[1]);
+      const revision = parseInt(v[2]);
+      if (!(!isNaN(mayor) && !isNaN(minor) && !isNaN(revision))) return false;
+      if (mayor > majorVersion) return true;
+      if (mayor === majorVersion) {
+        if (minor > minorVersion) return true;
+        if (minor === minorVersion) {
+          if (revision >= revisionVersion) return true;
+        }
+      }
+      return false;
+    };
+  });
+
+  return {
+    isMinimumKolibriVersion,
+  };
+}

--- a/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
+++ b/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
@@ -2,19 +2,27 @@ import { computed } from 'kolibri.lib.vueCompositionApi';
 
 export default function useMinimumKolibriVersion() {
   const isMinimumKolibriVersion = computed(() => {
-    return function(version, majorVersion = 0, minorVersion = 15, revisionVersion = 0) {
-      // defaults to kolibri 0.15.0
+    return function(version, majorVersion = 0, minorVersion = 15, revisionVersion = null) {
+      /*
+      defaults to kolibri 0.15.x
+      If values are not provided for revisionVersion, then any values are allowed.
+      This means that if no value is provided for revisionVersion then
+      alpha and beta versions will be permitted.
+      Just providing 0 as majorVersion and 15 as minorVersion would allow any version
+      greater than or equal to 0.15 (including any alphas or betas)
+      */
       const v = version.split('.');
       if (v.length < 2) return false;
-      const mayor = parseInt(v[0]);
+      const major = parseInt(v[0]);
       const minor = parseInt(v[1]);
-      const revision = parseInt(v[2]);
-      if (!(!isNaN(mayor) && !isNaN(minor) && !isNaN(revision))) return false;
-      if (mayor > majorVersion) return true;
-      if (mayor === majorVersion) {
+      let revision = parseInt(v[2]);
+      if (version.includes('-')) revision--;
+      if (!(!isNaN(major) && !isNaN(minor) && !isNaN(revision))) return false;
+      if (major > majorVersion) return true;
+      if (major === majorVersion) {
         if (minor > minorVersion) return true;
         if (minor === minorVersion) {
-          if (revision >= revisionVersion) return true;
+          if (revisionVersion === null || revision >= revisionVersion) return true;
         }
       }
       return false;

--- a/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
+++ b/kolibri/core/assets/src/composables/useMinimumKolibriVersion.js
@@ -12,7 +12,9 @@ export default function useMinimumKolibriVersion() {
       greater than or equal to 0.15 (including any alphas or betas)
       */
       const v = version.split('.');
-      if (v.length < 2) return false;
+      if (v.length < 3) {
+        throw new Error('The full version format (e.g. 0.15.0) is required');
+      }
       const major = parseInt(v[0]);
       const minor = parseInt(v[1]);
       let revision = parseInt(v[2]);

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -124,33 +124,6 @@
       const selectedFacilityId = ref('');
       const showAddAddressModal = ref(false);
 
-      // methods:
-      function createSnackbar(args) {
-        this.$store.dispatch('createSnackbar', args);
-      }
-
-      function handleAddedAddress() {
-        refreshSavedAddressList();
-        createSnackbar(this.$tr('addAddressSnackbarText'));
-      }
-
-      function resetSelectedAddress() {
-        if (availableFacilities.value.length !== 0) {
-          const selectedId = this.selectedId || this.storageFacilityId || this.selectedFacilityId;
-          selectedFacilityId.value =
-            availableFacilities.value.map(f => f.id).find(f => f.id === selectedId) ||
-            availableFacilities.value[0].id;
-        } else {
-          selectedFacilityId.value = '';
-        }
-      }
-
-      function to_continue() {
-        this.changeFacilityService.send({
-          type: 'CONTINUE',
-        });
-      }
-
       // computed properties (functions):
       const { isMinimumKolibriVersion } = useMinimumKolibriVersion();
       const facilityDisabled = computed(() => {
@@ -163,6 +136,36 @@
         };
       });
 
+      // methods:
+      function createSnackbar(args) {
+        this.$store.dispatch('createSnackbar', args);
+      }
+
+      function handleAddedAddress() {
+        refreshSavedAddressList();
+        createSnackbar(this.$tr('addAddressSnackbarText'));
+      }
+
+      function resetSelectedAddress() {
+        const enabledFacilities = availableFacilities.value
+          .map(f => f.id)
+          .find(f => isMinimumKolibriVersion.value(f.kolibri_version, 0, 16, 0));
+        if (enabledFacilities.length !== 0) {
+          const selectedId = storageFacilityId.value || selectedFacilityId.value;
+          selectedFacilityId.value =
+            enabledFacilities.map(f => f.id).find(f => f.id === selectedId) ||
+            enabledFacilities[0].id;
+        } else {
+          selectedFacilityId.value = '';
+        }
+      }
+
+      function to_continue() {
+        this.changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      }
+
       return {
         combinedAddresses,
         initialFetchingComplete,
@@ -174,10 +177,10 @@
         availableFacilities,
         selectedFacilityId,
         showAddAddressModal,
+        facilityDisabled,
         handleAddedAddress,
         resetSelectedAddress,
         to_continue,
-        facilityDisabled,
       };
     },
     inject: ['changeFacilityService'],

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -149,7 +149,7 @@
       function resetSelectedAddress() {
         const enabledFacilities = availableFacilities.value
           .map(f => f.id)
-          .find(f => isMinimumKolibriVersion.value(f.kolibri_version, 0, 16, 0));
+          .find(f => isMinimumKolibriVersion.value(f.kolibri_version, 0, 16));
         if (enabledFacilities.length !== 0) {
           const selectedId = storageFacilityId.value || selectedFacilityId.value;
           selectedFacilityId.value =

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -147,14 +147,13 @@
       }
 
       function resetSelectedAddress() {
-        const enabledFacilities = availableFacilities.value
-          .map(f => f.id)
-          .find(f => isMinimumKolibriVersion.value(f.kolibri_version, 0, 16));
+        const enabledFacilities = availableFacilities.value.filter(f =>
+          isMinimumKolibriVersion.value(f.kolibri_version, 0, 16)
+        );
         if (enabledFacilities.length !== 0) {
           const selectedId = storageFacilityId.value || selectedFacilityId.value;
           selectedFacilityId.value =
-            enabledFacilities.map(f => f.id).find(f => f.id === selectedId) ||
-            enabledFacilities[0].id;
+            enabledFacilities.map(f => f.id).find(f => f === selectedId) || enabledFacilities[0].id;
         } else {
           selectedFacilityId.value = '';
         }


### PR DESCRIPTION
## Summary

- Created a composable to check kolibri versions in JavaScript
- After some comments from @MisRob in a previous PR, passed most of the vue component to use the composition api instead of the options api.


## References
Relates to #9324

## Reviewer guidance
Do changes make sense?
Do tests pass?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
