### PR TITLE
Fix whole channel getting imported instead of selected resources

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -168,7 +168,7 @@ def remotechannelimport(channel_id, baseurl=None, peer_id=None):
 
 
 class RemoteChannelResourcesImportValidator(
-    RemoteImportMixin, ChannelResourcesValidator
+    RemoteImportMixin, ChannelResourcesImportValidator
 ):
     pass
 
@@ -269,12 +269,8 @@ def deletechannel(
     )
 
 
-class RemoteUpdatedChannelValidator(RemoteImportMixin, ChannelResourcesImportValidator):
-    pass
-
-
 @register_task(
-    validator=RemoteUpdatedChannelValidator,
+    validator=RemoteChannelResourcesImportValidator,
     cancellable=True,
     track_progress=True,
     permission_classes=[CanManageContent],


### PR DESCRIPTION
## Summary

This PR fixes the remote channel import issue wherein the whole channel was getting imported instead of a selection of resources.

## References
Refers https://github.com/learningequality/kolibri/issues/9479. Fixes the first problem. Second problem is under investigation. 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Does this PR solved the mentioned issue properly?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
