### PR TITLE
Set up to track KDS develop

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.38",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#develop",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8083,6 +8083,21 @@ kolibri-constants@0.1.38:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.38.tgz#f6c51c429963210e6e866c72260c9d13d41a1273"
   integrity sha512-IUWZtm+ceA9PF1lCT8+/E6Cjmy+ihiB+xIKfDGI8SrZ6c2VEG7Ku5tyW26Uf0n34olzjeO9zO6nBYjZ+A92Ijw==
 
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#develop":
+  version "1.3.0"
+  resolved "https://github.com/learningequality/kolibri-design-system#37dcf4f8db24d0afc5a72586bb35771dd29c8b1d"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#26c0c302d548afa63aaff32d4539c510c3351f82"


### PR DESCRIPTION
## Summary
Sets up the kds dependency to be `kolibri-design-system#develop` so that KDS and Kolibri frontend work can be done in parallel for 0.16. 

## Reviewer guidance
Have been issues with this in the past, possibly due to yarn caching. We are giving it a try, and can make changes as we work with this! But - anything we should do differently right now?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
