### PR TITLE
Change facility - full name updates on the Create Account page

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -25,6 +25,7 @@ const setInitialContext = assign((_, event) => {
   return {
     sourceFacility: event.value.facility,
     username: event.value.username,
+    fullName: event.value.fullName,
     role: event.value.role,
   };
 });
@@ -81,6 +82,7 @@ export const changeFacilityMachine = createMachine({
   context: {
     role: 'learner',
     username: '',
+    fullName: '',
     targetAccount: {
       username: '',
       password: '',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -25,7 +25,6 @@ const setInitialContext = assign((_, event) => {
   return {
     sourceFacility: event.value.facility,
     username: event.value.username,
-    fullName: event.value.fullName,
     role: event.value.role,
   };
 });
@@ -82,7 +81,6 @@ export const changeFacilityMachine = createMachine({
   context: {
     role: 'learner',
     username: '',
-    fullName: '',
     targetAccount: {
       username: '',
       password: '',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -82,7 +82,6 @@ export const changeFacilityMachine = createMachine({
     role: 'learner',
     username: '',
     targetAccount: {
-      fullName: '',
       username: '',
       password: '',
     },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -1,8 +1,19 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
 import CreateAccount from '../index.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
 const sendMachineEvent = jest.fn();
 function makeWrapper({ targetFacility, fullName } = {}) {
+  const store = new Vuex.Store({
+    getters: {
+      session: () => {
+        return { full_name: fullName };
+      },
+    },
+  });
   return mount(CreateAccount, {
     provide: {
       changeFacilityService: {
@@ -11,10 +22,11 @@ function makeWrapper({ targetFacility, fullName } = {}) {
       state: {
         value: {
           targetFacility,
-          fullName,
         },
       },
     },
+    localVue,
+    store,
   });
 }
 
@@ -46,7 +58,7 @@ describe(`ChangeFacility/CreateAccount`, () => {
   });
 
   it(`smoke test`, () => {
-    const wrapper = shallowMount(CreateAccount);
+    const wrapper = makeWrapper();
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -2,7 +2,7 @@ import { shallowMount, mount } from '@vue/test-utils';
 import CreateAccount from '../index.vue';
 
 const sendMachineEvent = jest.fn();
-function makeWrapper({ targetFacility } = {}) {
+function makeWrapper({ targetFacility, fullName } = {}) {
   return mount(CreateAccount, {
     provide: {
       changeFacilityService: {
@@ -11,6 +11,7 @@ function makeWrapper({ targetFacility } = {}) {
       state: {
         value: {
           targetFacility,
+          fullName,
         },
       },
     },
@@ -49,9 +50,15 @@ describe(`ChangeFacility/CreateAccount`, () => {
     expect(wrapper.exists()).toBeTruthy();
   });
 
-  it(`shows the message about creating a new account in the target facility`, () => {
-    const wrapper = makeWrapper({ targetFacility: { name: 'Test Facility' } });
-    expect(wrapper.text()).toContain('New account for ‘Test Facility’ learning facility');
+  it(`shows the message about creating a new account in the target facility
+    that contains user's full name and the target facility name`, () => {
+    const wrapper = makeWrapper({
+      targetFacility: { name: 'Test Facility' },
+      fullName: 'Test User',
+    });
+    expect(wrapper.text()).toContain(
+      'New account for ‘Test User’ in ‘Test Facility’ learning facility'
+    );
   });
 
   it(`shows the back button`, () => {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/__tests__/index.spec.js
@@ -19,16 +19,10 @@ function makeWrapper({ targetFacility } = {}) {
 
 const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
 const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
-const getFullNameTextbox = wrapper => wrapper.find('[data-test="fullNameTextbox"]');
 const getUsernameTextbox = wrapper => wrapper.find('[data-test="usernameTextbox"]');
 const getPasswordTextbox = wrapper => wrapper.find('[data-test="passwordTextbox"]');
 const clickBackButton = wrapper => getBackButton(wrapper).trigger('click');
 const clickContinueButton = wrapper => getContinueButton(wrapper).trigger('click');
-const setFullNameTextboxValue = (wrapper, value) => {
-  getFullNameTextbox(wrapper)
-    .find('input')
-    .setValue(value);
-};
 const setUsernameTextboxValue = (wrapper, value) => {
   getUsernameTextbox(wrapper)
     .find('input')
@@ -68,11 +62,6 @@ describe(`ChangeFacility/CreateAccount`, () => {
   it(`shows the continue button`, () => {
     const wrapper = makeWrapper();
     expect(getContinueButton(wrapper).exists()).toBeTruthy();
-  });
-
-  it(`shows the full name textbox`, () => {
-    const wrapper = makeWrapper();
-    expect(getFullNameTextbox(wrapper).exists()).toBeTruthy();
   });
 
   it(`shows the username textbox`, () => {
@@ -119,7 +108,6 @@ describe(`ChangeFacility/CreateAccount`, () => {
   describe(`when the new user account form is valid`, () => {
     it(`clicking the continue button sends the continue event with the form data as its value to the state machine`, async () => {
       const wrapper = makeWrapper();
-      setFullNameTextboxValue(wrapper, 'Test Fullname');
       setUsernameTextboxValue(wrapper, 'testusername');
       setPasswordTextboxValue(wrapper, 'testpassword');
       // wait for validation
@@ -128,7 +116,6 @@ describe(`ChangeFacility/CreateAccount`, () => {
       expect(sendMachineEvent).toHaveBeenCalledWith({
         type: 'CONTINUE',
         value: {
-          fullName: 'Test Fullname',
           username: 'testusername',
           password: 'testpassword',
         },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -88,6 +88,7 @@
     computed: {
       description() {
         return this.$tr('description', {
+          fullName: get(this.state, 'value.fullName'),
           targetFacility: get(this.state, 'value.targetFacility.name', ''),
         });
       },
@@ -133,7 +134,7 @@
           'Title of the step for creating a new account in a target facility when changing facility.',
       },
       description: {
-        message: 'New account for ‘{targetFacility}’ learning facility',
+        message: 'New account for ‘{fullName}’ in ‘{targetFacility}’ learning facility',
         context:
           'Shows above a new user form where a user can create a new account in a target facility when changing facility.',
       },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -4,15 +4,6 @@
     <h1>{{ $tr('documentTitle') }}</h1>
     <p>{{ description }}</p>
 
-    <FullNameTextbox
-      ref="fullNameTextbox"
-      data-test="fullNameTextbox"
-      :value.sync="formData.fullName"
-      :isValid.sync="isFullNameValid"
-      :shouldValidate="isFormSubmitted"
-      :autofocus="true"
-      autocomplete="name"
-    />
     <UsernameTextbox
       ref="usernameTextbox"
       data-test="usernameTextbox"
@@ -64,7 +55,6 @@
   import get from 'lodash/get';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
-  import FullNameTextbox from 'kolibri.coreVue.components.FullNameTextbox';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
@@ -78,7 +68,6 @@
     },
     components: {
       BottomAppBar,
-      FullNameTextbox,
       UsernameTextbox,
       PasswordTextbox,
       PrivacyLinkAndModal,
@@ -88,11 +77,9 @@
     data() {
       return {
         formData: {
-          fullName: '',
           username: '',
           password: '',
         },
-        isFullNameValid: false,
         isUsernameValid: false,
         isPasswordValid: false,
         isFormSubmitted: false,
@@ -108,11 +95,7 @@
         return !get(this.state, 'value.targetFacility.learner_can_login_with_no_password', false);
       },
       isFormValid() {
-        return (
-          this.isFullNameValid &&
-          this.isUsernameValid &&
-          (!this.showPasswordTextbox || this.isPasswordValid)
-        );
+        return this.isUsernameValid && (!this.showPasswordTextbox || this.isPasswordValid);
       },
     },
     methods: {
@@ -125,9 +108,7 @@
         }
       },
       focusOnInvalidField() {
-        if (!this.isFullNameValid) {
-          this.$refs.fullNameTextbox.focus();
-        } else if (!this.isUsernameValid) {
+        if (!this.isUsernameValid) {
           this.$refs.usernameTextbox.focus();
         } else if (this.showPasswordTextbox && !this.isPasswordValid) {
           this.$refs.passwordTextbox.focus();

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -7,6 +7,7 @@
     <UsernameTextbox
       ref="usernameTextbox"
       data-test="usernameTextbox"
+      :autofocus="true"
       :value.sync="formData.username"
       :isValid.sync="isUsernameValid"
       :shouldValidate="isFormSubmitted"

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/CreateAccount/index.vue
@@ -54,6 +54,7 @@
 <script>
 
   import get from 'lodash/get';
+  import { mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
@@ -87,9 +88,10 @@
       };
     },
     computed: {
+      ...mapGetters(['session']),
       description() {
         return this.$tr('description', {
-          fullName: get(this.state, 'value.fullName'),
+          fullName: get(this.session, 'full_name', ''),
           targetFacility: get(this.state, 'value.targetFacility.name', ''),
         });
       },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -118,7 +118,6 @@
           value: {
             facility: this.session.facility_id,
             username: this.session.username,
-            fullName: this.session.full_name,
             role: this.getUserKind,
           },
         });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -118,6 +118,7 @@
           value: {
             facility: this.session.facility_id,
             username: this.session.username,
+            fullName: this.session.full_name,
             role: this.getUserKind,
           },
         });


### PR DESCRIPTION
## Summary

Updates the Create Account page to the latest design updates regarding full name
- the full name textbox has been removed
- the current user's full name is displayed in the message below the title to provide context

| Before | After |
| --------- | ------ |
| ![before](https://user-images.githubusercontent.com/13509191/180438521-82678c4f-b8b5-4c9c-a57c-965042a97c9e.png) | ![after](https://user-images.githubusercontent.com/13509191/180438548-901ce101-2b4b-49c7-8221-b43e01de1475.png) |

## References

- Related to #9329
- [Figma designs](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=596%3A10379)

## Reviewer guidance

### Setup

You need to have two facilities to be able to test the change facility workflow:

**Source facility**
- You can run the development server as usual
- Your Kolibri instance shouldn't be the learner only device and also you need to make sure there's only one user account, otherwise you won't be able to access the _Change learner facility_ feature in _Profile_
- If you already have a target facility with some user accounts, make sure that in the source facility, you log in as a user with a username that doesn't match any username on the target facility (otherwise you'll be taken to a different part of the flow)

**Target facility**
- It needs to be v0.16
- In the facility settings, do _Allow users to create accounts_
- Not required to test this PR's changes but note that if you don't _Require password for learners_ in the facility settings, you won't see password textboxes like on the screenshots above

If you don't have a target facility, you can follow these steps:
1. `cd` to your `kolibri` development directory and make sure to activate your virtual environment like when developing
2. Run ` pip install -e .` to ensure that the target facility has `develop` (`0.16.x`) updates that are required (`kolibri --version` should show something like `0.16.0.dev0+git.20220715072421`)
3. Run Kolibri with the `kolibri` command with `KOLIBRI_HOME` environment variable different from your usual setup so that you don't override your development Kolibri  `KOLIBRI_HOME=~/.tmp kolibri start --foreground`
4. You need to go through the onboarding setup, otherwise the target facility may not be discovered. It seems that we have some onboarding work in progress so it's possible that you won't be able to go through the onboarding forms and complete the setup. I solved this by switching to `0.15.x` version where I did the onboarding and then switched to this branch using the same `KOLIBRI_HOME` and then went through steps 1-3.

### Test scenario

On the source facility
1. Navigate to _Profile -> Change facility -> Change_
2. Select the target facility and click _Continue_
3. On _Change Facility_ page click _Continue_
4. On _Confirm account username_ page, click _Create new account_ button
6. Preview _Create new account_ page

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
