### PR TITLE
Remote URL cleanup

### DIFF
--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -15,7 +15,6 @@ from django.db.models import Max
 from django.db.models import Min
 from django.db.models import Q
 from django.db.models import Sum
-from django.utils.six.moves.urllib.parse import urljoin
 from django.utils.timezone import get_current_timezone
 from django.utils.timezone import localtime
 from le_utils.constants import content_kinds
@@ -42,6 +41,7 @@ from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import MasteryLog
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.utils.lock import db_lock
+from kolibri.core.utils.urls import join_url
 from kolibri.utils import conf
 from kolibri.utils.server import installation_type
 from kolibri.utils.time_utils import local_now
@@ -423,7 +423,7 @@ def create_and_update_notifications(data, source):
 
 def perform_ping(started, server=DEFAULT_SERVER_URL):
 
-    url = urljoin(server, "/api/v1/pingback")
+    url = join_url(server, "/api/v1/pingback")
 
     instance, _ = InstanceIDModel.get_or_create_current_instance()
 
@@ -461,7 +461,7 @@ def perform_ping(started, server=DEFAULT_SERVER_URL):
 
 
 def perform_statistics(server, pingback_id):
-    url = urljoin(server, "/api/v1/statistics")
+    url = join_url(server, "/api/v1/statistics")
     channels = [extract_channel_statistics(c) for c in ChannelMetadata.objects.all()]
     facilities = [extract_facility_statistics(f) for f in Facility.objects.all()]
     data = {"pi": pingback_id, "c": channels, "f": facilities}

--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -17,10 +17,10 @@ from rest_framework.serializers import UUIDField
 from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_201_CREATED
 from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
-from six.moves.urllib.parse import urljoin
 
 from .utils.portal import registerfacility
 from kolibri.core.auth.models import Facility
+from kolibri.core.utils.urls import join_url
 from kolibri.utils import conf
 
 
@@ -40,7 +40,7 @@ class KolibriDataPortalViewSet(viewsets.ViewSet):
         try:
             # token is in query params
             response = requests.get(
-                urljoin(
+                join_url(
                     PORTAL_URL, "portal/api/public/v1/registerfacility/validate_token"
                 ),
                 params=request.query_params,

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -35,7 +35,6 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.api import BaseValuesViewset
 from kolibri.core.api import ListModelMixin
@@ -75,6 +74,7 @@ from kolibri.core.query import SQSum
 from kolibri.core.utils.pagination import ValuesViewsetCursorPagination
 from kolibri.core.utils.pagination import ValuesViewsetLimitOffsetPagination
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
+from kolibri.core.utils.urls import join_url
 from kolibri.utils.conf import OPTIONS
 
 
@@ -148,7 +148,7 @@ class RemoteMixin(object):
         qs = request.GET.copy()
         del qs[self.remote_url_param]
         qs.pop("contentCacheKey", None)
-        remote_url = urljoin(baseurl, remote_path)
+        remote_url = join_url(baseurl, remote_path)
         try:
             response = requests.get(
                 remote_url, params=qs, headers=self._get_request_headers(request)

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1826,7 +1826,7 @@ class ProxyContentMetadataTestCase(ContentNodeAPIBase, LiveServerTestCase):
         return self.client.get(*args, **kwargs)
 
 
-@override_option("Deployment", "URL_PATH_PREFIX", "test")
+@override_option("Deployment", "URL_PATH_PREFIX", "test/")
 class PrefixedProxyContentMetadataTestCase(ProxyContentMetadataTestCase):
     @property
     def baseurl(self):

--- a/kolibri/core/content/utils/paths.py
+++ b/kolibri/core/content/utils/paths.py
@@ -4,9 +4,9 @@ import re
 
 from django.conf import settings
 from django.utils.http import urlencode
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.content.errors import InvalidStorageFilenameError
+from kolibri.core.utils.urls import join_url
 from kolibri.utils import conf
 from kolibri.utils.server import get_zip_port
 
@@ -202,15 +202,15 @@ def get_content_url(baseurl=None):
 
 
 def get_content_database_url(baseurl=None):
-    return urljoin(get_content_url(baseurl), "databases/")
+    return join_url(get_content_url(baseurl), "databases/")
 
 
 def get_content_database_file_url(channel_id, baseurl=None):
-    return urljoin(get_content_database_url(baseurl), "{}.sqlite3".format(channel_id))
+    return join_url(get_content_database_url(baseurl), "{}.sqlite3".format(channel_id))
 
 
 def get_content_storage_url(baseurl=None):
-    return urljoin(get_content_url(baseurl), "storage/")
+    return join_url(get_content_url(baseurl), "storage/")
 
 
 def get_content_storage_remote_url(filename, baseurl=None):
@@ -222,7 +222,7 @@ def get_content_storage_remote_url(filename, baseurl=None):
 def get_content_server_url(path, baseurl=None):
     if not baseurl:
         baseurl = conf.OPTIONS["Urls"]["CENTRAL_CONTENT_BASE_URL"]
-    return urljoin(baseurl, path)
+    return join_url(baseurl, path)
 
 
 def get_info_url(baseurl=None):
@@ -305,7 +305,7 @@ def get_hashi_html_filename():
 
 
 def zip_content_static_root():
-    return urljoin(get_content_url(zip_content_path_prefix()), "static/")
+    return join_url(get_content_url(zip_content_path_prefix()), "static/")
 
 
 def get_hashi_path():

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -10,7 +10,6 @@ from django.db.models.expressions import Subquery
 from django.db.models.query import Q
 from django.http import Http404
 from django.http.response import HttpResponseBadRequest
-from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import get_language
 from django_filters.rest_framework import DjangoFilterBackend
@@ -25,7 +24,6 @@ from rest_framework import views
 from rest_framework import viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-from six.moves.urllib.parse import urljoin
 
 import kolibri
 from .models import DevicePermissions
@@ -53,6 +51,7 @@ from kolibri.core.public.constants.user_sync_statuses import QUEUED
 from kolibri.core.public.constants.user_sync_statuses import RECENTLY_SYNCED
 from kolibri.core.public.constants.user_sync_statuses import SYNCING
 from kolibri.core.public.constants.user_sync_statuses import UNABLE_TO_SYNC
+from kolibri.core.utils.urls import reverse_remote
 from kolibri.plugins.utils import initialize_kolibri_plugin
 from kolibri.plugins.utils import iterate_plugins
 from kolibri.plugins.utils import PluginDoesNotExist
@@ -390,8 +389,7 @@ class RemoteFacilitiesViewset(views.APIView):
 
     def get(self, request):
         baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
-        path = reverse("kolibri:core:publicfacility-list").lstrip("/")
-        url = urljoin(baseurl, path)
+        url = reverse_remote(baseurl, "kolibri:core:publicfacility-list")
         try:
             response = requests.get(url)
             if response.status_code == 200:

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -3,7 +3,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
-from six.moves.urllib.parse import urljoin
 
 from .models import DynamicNetworkLocation
 from .models import NetworkLocation
@@ -11,6 +10,7 @@ from .models import StaticNetworkLocation
 from .permissions import NetworkLocationPermissions
 from .serializers import NetworkLocationSerializer
 from kolibri.core.device.permissions import NotProvisionedHasPermission
+from kolibri.core.utils.urls import join_url
 
 
 class NetworkLocationViewSet(viewsets.ModelViewSet):
@@ -46,7 +46,7 @@ class NetworkLocationFacilitiesView(viewsets.GenericViewSet):
             base_url = peer_device.base_url
 
             # Step 2: Make request to the /facility endpoint
-            response = requests.get(urljoin(base_url, "api/public/v1/facility"))
+            response = requests.get(join_url(base_url, "api/public/v1/facility"))
             response.raise_for_status()
         except (requests.RequestException, NetworkLocation.DoesNotExist):
             raise NotFound()

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -1,11 +1,11 @@
 import logging
 
 import requests
-from six.moves.urllib.parse import urljoin
 from six.moves.urllib.parse import urlparse
 
 from . import errors
 from .urls import get_normalized_url_variations
+from kolibri.core.utils.urls import join_url
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ class NetworkClient(object):
 
     def request(self, method, path, base_url=None, **kwargs):
         base_url = base_url or self.base_url
-        url = urljoin(base_url, path)
+        url = join_url(base_url, path)
         response = getattr(self.session, method)(url, **kwargs)
         response.raise_for_status()
         return response

--- a/kolibri/core/utils/portal.py
+++ b/kolibri/core/utils/portal.py
@@ -4,9 +4,9 @@ import requests
 from morango.api.serializers import CertificateSerializer
 from morango.constants.api_urls import NONCE
 from morango.models import Certificate
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
+from kolibri.core.utils.urls import join_url
 from kolibri.utils import conf
 
 
@@ -14,7 +14,7 @@ def registerfacility(token, facility):
 
     # request the server for a one-time-use nonce
     PORTAL_URL = conf.OPTIONS["Urls"]["DATA_PORTAL_SYNCING_BASE_URL"]
-    response = requests.post(urljoin(PORTAL_URL, NONCE))
+    response = requests.post(join_url(PORTAL_URL, NONCE))
     response.raise_for_status()
     server_nonce = response.json()["id"]
 
@@ -47,7 +47,7 @@ def registerfacility(token, facility):
 
     # attempt to claim the facility
     response = requests.post(
-        urljoin(PORTAL_URL, "portal/api/public/v1/registerfacility/"), data=data
+        join_url(PORTAL_URL, "portal/api/public/v1/registerfacility/"), data=data
     )
     response.raise_for_status()
     return response

--- a/kolibri/core/utils/urls.py
+++ b/kolibri/core/utils/urls.py
@@ -4,6 +4,13 @@ from six.moves.urllib.parse import urljoin
 from kolibri.utils.conf import OPTIONS
 
 
+def join_url(baseurl, url):
+    # Join the URL to baseurl, but remove any leading "/" to ensure that if there is a path prefix on baseurl
+    # it doesn't get ignored by the urljoin (which it would if the reversed_url had a leading '/',
+    # as it would be read as an absolute path)
+    return urljoin(baseurl, url.lstrip("/"))
+
+
 def reverse_remote(
     baseurl, viewname, urlconf=None, args=None, kwargs=None, current_app=None
 ):
@@ -17,4 +24,4 @@ def reverse_remote(
     # Join the URL to baseurl, but remove any leading "/" to ensure that if there is a path prefix on baseurl
     # it doesn't get ignored by the urljoin (which it would if the reversed_url had a leading '/',
     # as it would be read as an absolute path)
-    return urljoin(baseurl, reversed_url.lstrip("/"))
+    return join_url(baseurl, reversed_url)

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -1,8 +1,5 @@
-from urllib.parse import urljoin
-
 import requests
 from django.core.management import call_command
-from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.status import HTTP_201_CREATED
@@ -16,6 +13,7 @@ from kolibri.core.tasks.permissions import IsFacilityAdmin
 from kolibri.core.tasks.permissions import IsSelf
 from kolibri.core.tasks.permissions import IsSuperAdmin
 from kolibri.core.tasks.permissions import PermissionsFromAny
+from kolibri.core.utils.urls import reverse_remote
 
 
 class MergeUserValidator(PeerImportSingleSyncJobValidator):
@@ -41,9 +39,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
             "password": data["password"],
             "facility": facility,
         }
-        public_signup_url = urljoin(
-            baseurl, reverse("kolibri:core:publicsignup-list").lstrip("/")
-        )
+        public_signup_url = reverse_remote(baseurl, "kolibri:core:publicsignup-list")
         response = requests.post(public_signup_url, data=user_data)
         if response.status_code != HTTP_201_CREATED:
             raise serializers.ValidationError(response.json()[0]["id"])

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -1,11 +1,10 @@
 import requests
-from django.urls import reverse
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from six.moves.urllib.parse import urljoin
 
 from kolibri.core.device.utils import get_device_setting
+from kolibri.core.utils.urls import reverse_remote
 
 
 class UserIndividualViewset(APIView):
@@ -32,8 +31,7 @@ class RemoteFacilityUserViewset(APIView):
         facility = request.query_params.get("facility", None)
         if username is None or facility is None:
             raise ValidationError(detail="Both username and facility are required")
-        path = reverse("kolibri:core:publicsearchuser-list").lstrip("/")
-        url = urljoin(baseurl, path)
+        url = reverse_remote(baseurl, "kolibri:core:publicsearchuser-list")
         try:
             response = requests.get(
                 url, params={"facility": facility, "search": username}

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -366,5 +366,7 @@ class DynamicWhiteNoise(WhiteNoise):
             self.add_headers_function(headers, path, url)
         headers["Content-Encoding"] = ""
         return StreamingStaticFile(
-            os.path.join(local_dir, path), headers, urljoin(remote_baseurl, url)
+            os.path.join(local_dir, path),
+            headers,
+            urljoin(remote_baseurl, url.lstrip("/")),
         )


### PR DESCRIPTION
## Summary
* Creates join_url utility function that lstrips the URL.
* Use in all cases where we would otherwise use urljoin, except out of caution to not import Django.
* Uses `reverse_remote` utility function in places not previously fixed in 0.15 as new in develop.

## References
Fixes #9568

## Reviewer guidance
Is there any case where this switch out is breaking existing expectations?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
