### PR TITLE
Check for developer mode env var for telemetry.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -1030,12 +1030,12 @@ def installation_type(cmd_line=None):  # noqa:C901
     if install_type == "Unknown":
         if on_android():
             install_type = installation_types.APK
+        elif os.environ.get("KOLIBRI_DEVELOPER_MODE", False):
+            install_type = "devserver"
         elif len(cmd_line) > 1 or "uwsgi" in cmd_line:
             launcher = cmd_line[0]
             if launcher.endswith(".pex"):
                 install_type = installation_types.PEX
-            elif "runserver" in cmd_line:
-                install_type = "devserver"
             elif launcher == "/usr/bin/kolibri":
                 install_type = is_debian_package()
             elif launcher == "uwsgi":

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -25,15 +25,7 @@ class TestServerInstallation(object):
         assert install_type == installation_types.PEX
 
     def test_dev(self):
-        sys_args = [
-            "kolibri",
-            "--debug",
-            "manage",
-            "runserver",
-            "--settings=kolibri.deployment.default.settings.dev",
-            '"0.0.0.0:8000"',
-        ]
-        with mock.patch("sys.argv", sys_args):
+        with mock.patch("os.environ", {"KOLIBRI_DEVELOPER_MODE": "True"}):
             install_type = server.installation_type()
             assert install_type == "devserver"
 


### PR DESCRIPTION
## Summary
* Updates installation type inference now that Django runserver is no longer used

## References
Fixes #7680

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
