### PR TITLE
Screens for create merge accounts

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -262,6 +262,9 @@ class PublicFacilityUserViewSet(ReadOnlyValuesViewset):
         "facility",
         "roles__kind",
         "devicepermissions__is_superuser",
+        "id_number",
+        "gender",
+        "birth_year",
     )
     field_map = {
         "is_superuser": lambda x: bool(x.pop("devicepermissions__is_superuser")),

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from .viewsets import OnMyOwnSetupViewset
+from .viewsets import RemoteFacilityUserLoginViewset
 from .viewsets import RemoteFacilityUserViewset
 
 urlpatterns = [
@@ -9,5 +10,10 @@ urlpatterns = [
         r"remotefacilityuser",
         RemoteFacilityUserViewset.as_view(),
         name="remotefacilityuser",
+    ),
+    url(
+        r"remotefacilityloginuser",
+        RemoteFacilityUserLoginViewset.as_view(),
+        name="remotefacilityloginuser",
     ),
 ]

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from .viewsets import OnMyOwnSetupViewset
-from .viewsets import RemoteFacilityUserLoginViewset
+from .viewsets import RemoteFacilityUserAuthenticatedViewset
 from .viewsets import RemoteFacilityUserViewset
 
 urlpatterns = [
@@ -12,8 +12,8 @@ urlpatterns = [
         name="remotefacilityuser",
     ),
     url(
-        r"remotefacilityloginuser",
-        RemoteFacilityUserLoginViewset.as_view(),
-        name="remotefacilityloginuser",
+        r"remotefacilityauthenticateduserinfo",
+        RemoteFacilityUserAuthenticatedViewset.as_view(),
+        name="remotefacilityauthenticateduserinfo",
     ),
 ]

--- a/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
@@ -1,0 +1,41 @@
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
+
+function remoteFacilityLoginUser(baseurl, facility_id, username, password) {
+  const params = {
+    baseurl: baseurl,
+    facility: facility_id,
+    username: username,
+    password: password,
+  };
+
+  return client({
+    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityloginuser'](),
+    params: params,
+  }).then(response => {
+    if (response.data.error) {
+      return 'error';
+    } else {
+      const user_info = response.data.find(element => element.username === username);
+      return user_info;
+    }
+  });
+}
+
+const remoteFacilityUsers = function(baseurl, facility_id, username) {
+  const params = {
+    baseurl: baseurl,
+    facility: facility_id,
+    username: username,
+  };
+  return client({
+    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityuser'](),
+    params: params,
+  }).then(response => {
+    let users = response.data;
+    if (Object.keys(response.data).length === 0) users = [];
+    return { users: users };
+  });
+};
+export default remoteFacilityLoginUser;
+export { remoteFacilityUsers };

--- a/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
@@ -1,17 +1,17 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 
-function remoteFacilityLoginUser(baseurl, facility_id, username, password, userAdmin = null) {
+function remoteFacilityUserData(baseurl, facility_id, username, password, userAdmin = null) {
   const params = {
     baseurl: baseurl,
     facility: facility_id,
     username: userAdmin === null ? username : userAdmin,
     password: password,
   };
-
   return client({
-    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityloginuser'](),
-    params: params,
+    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityauthenticateduserinfo'](),
+    method: 'POST',
+    data: params,
   }).then(response => {
     if (response.data.error) {
       return 'error';
@@ -37,5 +37,5 @@ const remoteFacilityUsers = function(baseurl, facility_id, username) {
     return { users: users };
   });
 };
-export default remoteFacilityLoginUser;
+export default remoteFacilityUserData;
 export { remoteFacilityUsers };

--- a/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
@@ -1,11 +1,11 @@
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 
-function remoteFacilityLoginUser(baseurl, facility_id, username, password) {
+function remoteFacilityLoginUser(baseurl, facility_id, username, password, userAdmin = null) {
   const params = {
     baseurl: baseurl,
     facility: facility_id,
-    username: username,
+    username: userAdmin === null ? username : userAdmin,
     password: password,
   };
 

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -245,7 +245,7 @@ export const changeFacilityMachine = createMachine({
     requireAccountCreds: {
       meta: { route: 'REQUIRE_ACCOUNT_CREDENTIALS', path: '/change_facility' },
       on: {
-        CONTINUE: 'showAccounts',
+        CONTINUE: { actions: setTargetAccount, target: 'showAccounts' },
         USEADMIN: 'useAdminPassword',
         BACK: 'confirmMerge',
       },
@@ -253,7 +253,7 @@ export const changeFacilityMachine = createMachine({
     useAdminPassword: {
       meta: { route: 'ADMIN_PASSWORD', path: '/change_facility' },
       on: {
-        CONTINUE: 'showAccounts',
+        CONTINUE: { actions: setTargetAccount, target: 'showAccounts' },
         BACK: 'requireAccountCreds',
       },
     },

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -253,13 +253,6 @@ export const changeFacilityMachine = createMachine({
         BACK: 'requireAccountCreds',
       },
     },
-    // showAccounts: {
-    //   meta: { route: 'SHOW_ACCOUNTS', path: '/change_facility' },
-    //   on: {
-    //     CONTINUE: 'confirmAccountDetails',
-    //     BACK: 'requireAccountCreds',
-    //   },
-    // },
     confirmAccountDetails: {
       meta: { route: 'CONFIRM_DETAILS', path: '/change_facility' },
       on: {
@@ -267,13 +260,6 @@ export const changeFacilityMachine = createMachine({
         BACK: 'mergeAccounts',
       },
     },
-    // editAccountDetails: {
-    //   meta: { route: 'EDIT_DETAILS', path: '/change_facility' },
-    //   on: {
-    //     SAVE: { actions: saveAccountDetails },
-    //     BACK: 'confirmAccountDetails',
-    //   },
-    // },
     mergeAccounts: {
       meta: { route: 'MERGE_ACCOUNTS', path: '/change_facility' },
       on: {

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -1,6 +1,6 @@
 import { createMachine, assign } from 'xstate';
 import {
-  default as remoteFacilityLoginUser,
+  default as remoteFacilityUserData,
   remoteFacilityUsers,
 } from '../composables/useRemoteFacility';
 
@@ -41,7 +41,7 @@ const connectToTargetKolibri = (context, event) => {
 
 const getUserWPasswordInfo = context => {
   const facility = context.targetFacility;
-  return remoteFacilityLoginUser(facility.url, facility.id, context.username, null).then(
+  return remoteFacilityUserData(facility.url, facility.id, context.username, null).then(
     user => user
   );
 };

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -74,6 +74,7 @@ const setMerging = assign({
 export const changeFacilityMachine = createMachine({
   id: 'machine',
   initial: 'selectFacility',
+  predictableActionArguments: true,
   context: {
     role: 'learner',
     username: '',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -1,6 +1,9 @@
-import client from 'kolibri.client';
-import urls from 'kolibri.urls';
 import { createMachine, assign } from 'xstate';
+import {
+  default as remoteFacilityLoginUser,
+  remoteFacilityUsers,
+} from '../composables/useRemoteFacility';
+
 // This machine can be visualized and tested at https://stately.ai/viz/c1316a38-033d-4c57-8d9f-e282310e341d
 /* SETCONTEXT event example:
 {
@@ -31,19 +34,16 @@ const setInitialContext = assign((_, event) => {
 
 const connectToTargetKolibri = (context, event) => {
   const facility = event.value;
-  const params = {
-    baseurl: facility.url,
-    facility: facility.id,
-    username: context.username,
-  };
-  return client({
-    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityuser'](),
-    params: params,
-  }).then(response => {
-    let users = response.data;
-    if (Object.keys(response.data).length === 0) users = [];
-    return { facility: facility, users: users };
+  return remoteFacilityUsers(facility.url, facility.id, context.username).then(users => {
+    return { facility: facility, ...users };
   });
+};
+
+const getUserWPasswordInfo = context => {
+  const facility = context.targetFacility;
+  return remoteFacilityLoginUser(facility.url, facility.id, context.username, null).then(
+    user => user
+  );
 };
 
 const checkExists = assign((context, event) => {
@@ -70,10 +70,6 @@ const setTargetAccount = assign({
 const setMerging = assign({
   isMerging: () => true,
 });
-
-const saveAccountDetails = () => {
-  // to be done
-};
 
 export const changeFacilityMachine = createMachine({
   id: 'machine',
@@ -245,7 +241,7 @@ export const changeFacilityMachine = createMachine({
     requireAccountCreds: {
       meta: { route: 'REQUIRE_ACCOUNT_CREDENTIALS', path: '/change_facility' },
       on: {
-        CONTINUE: { actions: setTargetAccount, target: 'showAccounts' },
+        CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
         USEADMIN: 'useAdminPassword',
         BACK: 'confirmMerge',
       },
@@ -253,37 +249,64 @@ export const changeFacilityMachine = createMachine({
     useAdminPassword: {
       meta: { route: 'ADMIN_PASSWORD', path: '/change_facility' },
       on: {
-        CONTINUE: { actions: setTargetAccount, target: 'showAccounts' },
+        CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
         BACK: 'requireAccountCreds',
       },
     },
-    showAccounts: {
-      meta: { route: 'SHOW_ACCOUNTS', path: '/change_facility' },
-      on: {
-        CONTINUE: 'confirmAccountDetails',
-        BACK: 'requireAccountCreds',
-      },
-    },
+    // showAccounts: {
+    //   meta: { route: 'SHOW_ACCOUNTS', path: '/change_facility' },
+    //   on: {
+    //     CONTINUE: 'confirmAccountDetails',
+    //     BACK: 'requireAccountCreds',
+    //   },
+    // },
     confirmAccountDetails: {
       meta: { route: 'CONFIRM_DETAILS', path: '/change_facility' },
       on: {
         CONTINUE: 'isAdmin',
-        EDITDETAILS: 'editAccountDetails',
-        BACK: 'showAccounts',
+        BACK: 'mergeAccounts',
       },
     },
-    editAccountDetails: {
-      meta: { route: 'EDIT_DETAILS', path: '/change_facility' },
-      on: {
-        SAVE: { actions: saveAccountDetails },
-        BACK: 'confirmAccountDetails',
-      },
-    },
+    // editAccountDetails: {
+    //   meta: { route: 'EDIT_DETAILS', path: '/change_facility' },
+    //   on: {
+    //     SAVE: { actions: saveAccountDetails },
+    //     BACK: 'confirmAccountDetails',
+    //   },
+    // },
     mergeAccounts: {
       meta: { route: 'MERGE_ACCOUNTS', path: '/change_facility' },
       on: {
-        CONTINUE: 'requireAccountCreds',
+        CONTINUE: [
+          {
+            cond: context =>
+              context.accountExists && !context.targetFacility.learner_can_login_with_no_password,
+            target: 'requireAccountCreds',
+          },
+          {
+            cond: context =>
+              context.accountExists && context.targetFacility.learner_can_login_with_no_password,
+            target: 'getUserWithoutPasswordInfo',
+          },
+        ],
         BACK: 'selectFacility',
+      },
+    },
+    getUserWithoutPasswordInfo: {
+      invoke: {
+        id: 'getPasswordlessUserInfo',
+        src: (context, event) => getUserWPasswordInfo(context, event),
+        onDone: {
+          target: 'confirmAccountDetails',
+          actions: assign({
+            targetAccount: (_, event) => {
+              return event.data;
+            },
+          }),
+        },
+        onError: {
+          target: 'mergeAccounts',
+        },
       },
     },
   },

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -110,21 +110,11 @@ export default [
         name: 'ADMIN_PASSWORD',
         component: MergeAccountDialog,
       },
-      // {
-      //   path: 'show_accounts',
-      //   name: 'SHOW_ACCOUNTS',
-      //   component: ConfirmAccountDetails,
-      // },
       {
         path: 'show_accounts',
         name: 'CONFIRM_DETAILS',
         component: ConfirmAccountDetails,
       },
-      // {
-      //   path: 'show_accounts',
-      //   name: 'EDIT_DETAILS',
-      //   component: ToBeDone,
-      // },
       {
         path: 'merge_accounts',
         name: 'MERGE_ACCOUNTS',

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -7,6 +7,7 @@ import SelectFacility from './views/ChangeFacility/SelectFacility';
 import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
 import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
 import MergeAccountDialog from './views/ChangeFacility/MergeAccountDialog';
+import ConfirmAccountDetails from './views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails';
 import CreateAccount from './views/ChangeFacility/CreateAccount';
 
 import ToBeDone from './views/ChangeFacility/ToBeDone';
@@ -109,21 +110,21 @@ export default [
         name: 'ADMIN_PASSWORD',
         component: MergeAccountDialog,
       },
-      {
-        path: 'show_accounts',
-        name: 'SHOW_ACCOUNTS',
-        component: ToBeDone,
-      },
+      // {
+      //   path: 'show_accounts',
+      //   name: 'SHOW_ACCOUNTS',
+      //   component: ConfirmAccountDetails,
+      // },
       {
         path: 'show_accounts',
         name: 'CONFIRM_DETAILS',
-        component: ToBeDone,
+        component: ConfirmAccountDetails,
       },
-      {
-        path: 'show_accounts',
-        name: 'EDIT_DETAILS',
-        component: ToBeDone,
-      },
+      // {
+      //   path: 'show_accounts',
+      //   name: 'EDIT_DETAILS',
+      //   component: ToBeDone,
+      // },
       {
         path: 'merge_accounts',
         name: 'MERGE_ACCOUNTS',

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -6,7 +6,9 @@ import ChangeFacility from './views/ChangeFacility';
 import SelectFacility from './views/ChangeFacility/SelectFacility';
 import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
 import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
+import MergeAccountDialog from './views/ChangeFacility/MergeAccountDialog';
 import CreateAccount from './views/ChangeFacility/CreateAccount';
+
 import ToBeDone from './views/ChangeFacility/ToBeDone';
 import UsernameExists from './views/ChangeFacility/UsernameExists';
 
@@ -100,12 +102,12 @@ export default [
       {
         path: 'require_account_credentials',
         name: 'REQUIRE_ACCOUNT_CREDENTIALS',
-        component: ToBeDone,
+        component: MergeAccountDialog,
       },
       {
         path: 'admin_password',
         name: 'ADMIN_PASSWORD',
-        component: ToBeDone,
+        component: MergeAccountDialog,
       },
       {
         path: 'show_accounts',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
@@ -9,14 +9,16 @@
         <th>
           {{ coreString('fullNameLabel') }}
         </th>
-        <td>{{ targetAccount.full_name }}</td>
+        <td data-test="fullname">
+          {{ targetAccount.full_name }}
+        </td>
       </tr>
 
       <tr>
         <th>
           {{ coreString('usernameLabel') }}
         </th>
-        <td>
+        <td data-test="username">
           {{ targetAccount.username }}
         </td>
       </tr>
@@ -25,7 +27,7 @@
         <th>
           {{ coreString('identifierLabel') }}
         </th>
-        <td dir="auto">
+        <td dir="auto" data-test="idnumber">
           {{ cleanValue(targetAccount.id_number) }}
         </td>
       </tr>
@@ -33,7 +35,7 @@
         <th>
           {{ coreString('genderLabel') }}
         </th>
-        <td dir="auto">
+        <td dir="auto" data-test="gender">
           {{ cleanValue(targetAccount.gender) }}
         </td>
       </tr>
@@ -41,7 +43,7 @@
         <th>
           {{ coreString('birthYearLabel') }}
         </th>
-        <td dir="auto">
+        <td dir="auto" data-test="birthyear">
           {{ cleanValue(targetAccount.birth_year) }}
         </td>
       </tr>
@@ -93,7 +95,7 @@
     setup() {
       const changeFacilityService = inject('changeFacilityService');
       const state = inject('state');
-      const targetAccount = computed(() => state.value.targetAccount);
+      const targetAccount = computed(() => get(state, 'value.targetAccount', {}));
 
       const confirmAccountUserInfo = computed({
         get() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
@@ -1,0 +1,169 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+
+    {{ confirmAccountUserInfo }}
+    <table>
+      <tr>
+        <th>
+          {{ coreString('fullNameLabel') }}
+        </th>
+        <td>{{ targetAccount.full_name }}</td>
+      </tr>
+
+      <tr>
+        <th>
+          {{ coreString('usernameLabel') }}
+        </th>
+        <td>
+          {{ targetAccount.username }}
+        </td>
+      </tr>
+
+      <tr>
+        <th>
+          {{ coreString('identifierLabel') }}
+        </th>
+        <td dir="auto">
+          {{ cleanValue(targetAccount.id_number) }}
+        </td>
+      </tr>
+      <tr>
+        <th>
+          {{ coreString('genderLabel') }}
+        </th>
+        <td dir="auto">
+          {{ cleanValue(targetAccount.gender) }}
+        </td>
+      </tr>
+      <tr>
+        <th>
+          {{ coreString('birthYearLabel') }}
+        </th>
+        <td dir="auto">
+          {{ cleanValue(targetAccount.birth_year) }}
+        </td>
+      </tr>
+    </table>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('backAction')"
+            appearance="flat-button"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="handleContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { computed, inject } from 'kolibri.lib.vueCompositionApi';
+  import get from 'lodash/get';
+
+  export default {
+    name: 'ConfirmAccountDetails',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+    setup() {
+      const changeFacilityService = inject('changeFacilityService');
+      const state = inject('state');
+      const targetAccount = computed(() => state.value.targetAccount);
+
+      const confirmAccountUserInfo = computed({
+        get() {
+          return this.$tr('confirmAccountUserInfo', {
+            target_facility: get(state, 'value.targetFacility.name', ''),
+          });
+        },
+      });
+      function cleanValue(value) {
+        return value === DemographicConstants.NOT_SPECIFIED ? '' : value;
+      }
+      function handleContinue() {
+        changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      }
+
+      function sendBack() {
+        changeFacilityService.send({
+          type: 'BACK',
+        });
+      }
+
+      return {
+        confirmAccountUserInfo,
+        cleanValue,
+        sendBack,
+        handleContinue,
+        targetAccount,
+      };
+    },
+    $trs: {
+      documentTitle: {
+        message: 'Confirm account details',
+        context: 'Title of this step for the change facility page.',
+      },
+      confirmAccountUserInfo: {
+        message:
+          'Your account will be merged into this account in ‘{target_facility}’. You will need to use the username and password for this account from now on.',
+        context:
+          'Line of text asking for the password of the user to be merged in the target facility.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  h1 {
+    margin-bottom: 40px;
+  }
+
+  table {
+    margin-top: 40px;
+    line-height: 1.5em;
+    text-align: left;
+    table-layout: fixed;
+  }
+
+  th {
+    min-width: 112px;
+    padding-right: 4px;
+    padding-bottom: 10px;
+  }
+
+  td {
+    padding-bottom: 10px;
+    padding-left: 40px;
+  }
+
+</style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
@@ -67,7 +67,7 @@ describe(`ChangeFacility/MergeAccountDialog/ConfirmAccountDetails`, () => {
     });
   });
 
-  it(`clicking the back button sends the continue event to the state machine`, () => {
+  it(`clicking the back button sends the back event to the state machine`, () => {
     const wrapper = makeWrapper();
     clickBackButton(wrapper);
     expect(sendMachineEvent).toHaveBeenCalledWith({

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
@@ -1,0 +1,77 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import ConfirmAccountDetails from '../ConfirmAccountDetails';
+
+const localVue = createLocalVue();
+const sendMachineEvent = jest.fn();
+
+function makeWrapper({ targetFacility, targetAccount, username } = {}) {
+  return mount(ConfirmAccountDetails, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+      state: {
+        value: {
+          targetFacility,
+          targetAccount,
+          username,
+        },
+      },
+    },
+    localVue,
+  });
+}
+
+const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+const clickContinueButton = wrapper => getContinueButton(wrapper).trigger('click');
+const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
+const clickBackButton = wrapper => getBackButton(wrapper).trigger('click');
+
+describe(`ChangeFacility/MergeAccountDialog/ConfirmAccountDetails`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it(`Show correct info`, () => {
+    const wrapper = makeWrapper({
+      targetFacility: { name: 'Test Facility' },
+      targetAccount: {
+        full_name: 'Test Full Name',
+        username: 'remote_username',
+        gender: 'test gender',
+        id_number: 'test id',
+        birth_year: 'test birth year',
+      },
+      username: 'TestLocalUser',
+    });
+    expect(wrapper.text()).toContain(
+      'Your account will be merged into this account in ‘Test Facility’'
+    );
+    expect(wrapper.find('[data-test="fullname"]').text()).toEqual('Test Full Name');
+    expect(wrapper.find('[data-test="username"]').text()).toEqual('remote_username');
+    expect(wrapper.find('[data-test="gender"]').text()).toEqual('test gender');
+    expect(wrapper.find('[data-test="idnumber"]').text()).toEqual('test id');
+    expect(wrapper.find('[data-test="birthyear"]').text()).toEqual('test birth year');
+  });
+
+  it(`clicking the continue button sends the continue event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    clickContinueButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'CONTINUE',
+    });
+  });
+
+  it(`clicking the back button sends the continue event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    clickBackButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'BACK',
+    });
+  });
+});

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
@@ -1,0 +1,147 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import MergeAccountDialog from '../index.vue';
+
+import * as useRemoteFacility from '../../../../composables/useRemoteFacility';
+import remoteFacilityLoginUser from '../../../../composables/useRemoteFacility';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+const sendMachineEvent = jest.fn();
+
+function makeWrapper({ targetFacility, targetAccount, fullName, username } = {}) {
+  const store = new Vuex.Store({
+    getters: {
+      session: () => {
+        return { full_name: fullName };
+      },
+    },
+  });
+  return mount(MergeAccountDialog, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+        state: { value: 'requireAccountCreds' },
+      },
+      state: {
+        value: {
+          targetFacility,
+          targetAccount,
+        },
+      },
+    },
+    mocks: {
+      $store: {
+        getters: {
+          session: { full_name: fullName, username: username },
+        },
+      },
+    },
+    localVue,
+    store,
+  });
+}
+
+const getUsernameTextbox = wrapper => wrapper.find('[data-test="usernameTextbox"]');
+const setUsernameTextboxValue = (wrapper, value) => {
+  getUsernameTextbox(wrapper)
+    .find('input')
+    .setValue(value);
+};
+const getPasswordTextbox = wrapper => wrapper.find('[data-test="passwordTextbox"]');
+const setPasswordTextboxValue = (wrapper, value) => {
+  getPasswordTextbox(wrapper)
+    .find('input')
+    .setValue(value);
+};
+
+describe(`ChangeFacility/MergeAccountDialog`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it(`Show correct info`, () => {
+    const wrapper = makeWrapper({
+      targetFacility: { name: 'Test Facility' },
+      fullName: 'Test User 1',
+      username: 'test1',
+    });
+    const h2_fullname = wrapper.find('[data-test="fullName"]');
+    expect(h2_fullname.text()).toEqual('Test User 1');
+    const h3_username = wrapper.find('[data-test="username"]');
+    expect(h3_username.text()).toEqual('test1');
+    expect(wrapper.find('[data-test="usernameTextbox"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="passwordTextbox"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain(
+      'Enter the password of the account in ‘Test Facility’ learning facility that you want to merge your account with'
+    );
+  });
+
+  it('Change to useAdminPassword state when clicking link', () => {
+    const wrapper = makeWrapper();
+    const useAdminButton = wrapper.find('[data-test="useAdminAccount"]');
+    useAdminButton.trigger('click');
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'USEADMIN',
+    });
+  });
+
+  it('Check useAdminPassword makes username textbox appear', async () => {
+    const wrapper = makeWrapper();
+    wrapper.setData({ usingAdminPasswordState: true });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="usernameTextbox"]').exists()).toBe(true);
+  });
+
+  it('Check remoteFacilityLoginUser is called with the user credentials', async () => {
+    const wrapper = makeWrapper({
+      targetFacility: { id: 'id_facility', url: 'http://localhost/test' },
+      fullName: 'Test User 1',
+      username: 'test1',
+    });
+    jest.spyOn(useRemoteFacility, 'default').mockReturnValue(Promise.resolve({}));
+    setPasswordTextboxValue(wrapper, 'my password');
+
+    const continueButton = wrapper.find('[data-test="continueButton"]');
+    continueButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(remoteFacilityLoginUser).toHaveBeenCalledWith(
+      'http://localhost/test',
+      'id_facility',
+      'test1',
+      'my password',
+      null
+    );
+  });
+
+  it('Check remoteFacilityLoginUser is called with the admin credentials', async () => {
+    const wrapper = makeWrapper({
+      targetFacility: { id: 'id_facility', url: 'http://localhost/test' },
+      fullName: 'Test User 1',
+      username: 'test1',
+    });
+    jest.spyOn(useRemoteFacility, 'default').mockReturnValue(Promise.resolve({}));
+    wrapper.setData({ usingAdminPasswordState: true });
+    await wrapper.vm.$nextTick();
+
+    setUsernameTextboxValue(wrapper, 'testadmin');
+    setPasswordTextboxValue(wrapper, 'admin password');
+
+    const continueButton = wrapper.find('[data-test="continueButton"]');
+    continueButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(remoteFacilityLoginUser).toHaveBeenCalledWith(
+      'http://localhost/test',
+      'id_facility',
+      'test1',
+      'admin password',
+      'testadmin'
+    );
+  });
+});

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
@@ -3,7 +3,7 @@ import Vuex from 'vuex';
 import MergeAccountDialog from '../index.vue';
 
 import * as useRemoteFacility from '../../../../composables/useRemoteFacility';
-import remoteFacilityLoginUser from '../../../../composables/useRemoteFacility';
+import remoteFacilityUserData from '../../../../composables/useRemoteFacility';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
@@ -98,7 +98,7 @@ describe(`ChangeFacility/MergeAccountDialog`, () => {
     expect(wrapper.find('[data-test="usernameTextbox"]').exists()).toBe(true);
   });
 
-  it('Check remoteFacilityLoginUser is called with the user credentials', async () => {
+  it('Check remoteFacilityUserData is called with the user credentials', async () => {
     const wrapper = makeWrapper({
       targetFacility: { id: 'id_facility', url: 'http://localhost/test' },
       fullName: 'Test User 1',
@@ -111,7 +111,7 @@ describe(`ChangeFacility/MergeAccountDialog`, () => {
     continueButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect(remoteFacilityLoginUser).toHaveBeenCalledWith(
+    expect(remoteFacilityUserData).toHaveBeenCalledWith(
       'http://localhost/test',
       'id_facility',
       'test1',
@@ -120,7 +120,7 @@ describe(`ChangeFacility/MergeAccountDialog`, () => {
     );
   });
 
-  it('Check remoteFacilityLoginUser is called with the admin credentials', async () => {
+  it('Check remoteFacilityUserData is called with the admin credentials', async () => {
     const wrapper = makeWrapper({
       targetFacility: { id: 'id_facility', url: 'http://localhost/test' },
       fullName: 'Test User 1',
@@ -136,7 +136,7 @@ describe(`ChangeFacility/MergeAccountDialog`, () => {
     const continueButton = wrapper.find('[data-test="continueButton"]');
     continueButton.trigger('click');
     await wrapper.vm.$nextTick();
-    expect(remoteFacilityLoginUser).toHaveBeenCalledWith(
+    expect(remoteFacilityUserData).toHaveBeenCalledWith(
       'http://localhost/test',
       'id_facility',
       'test1',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/index.spec.js
@@ -1,22 +1,13 @@
 import { mount, createLocalVue } from '@vue/test-utils';
-import Vuex from 'vuex';
 import MergeAccountDialog from '../index.vue';
 
 import * as useRemoteFacility from '../../../../composables/useRemoteFacility';
 import remoteFacilityUserData from '../../../../composables/useRemoteFacility';
 
 const localVue = createLocalVue();
-localVue.use(Vuex);
 const sendMachineEvent = jest.fn();
 
 function makeWrapper({ targetFacility, targetAccount, fullName, username } = {}) {
-  const store = new Vuex.Store({
-    getters: {
-      session: () => {
-        return { full_name: fullName };
-      },
-    },
-  });
   return mount(MergeAccountDialog, {
     provide: {
       changeFacilityService: {
@@ -38,7 +29,6 @@ function makeWrapper({ targetFacility, targetAccount, fullName, username } = {})
       },
     },
     localVue,
-    store,
   });
 }
 
@@ -71,10 +61,10 @@ describe(`ChangeFacility/MergeAccountDialog`, () => {
       fullName: 'Test User 1',
       username: 'test1',
     });
-    const h2_fullname = wrapper.find('[data-test="fullName"]');
-    expect(h2_fullname.text()).toEqual('Test User 1');
-    const h3_username = wrapper.find('[data-test="username"]');
-    expect(h3_username.text()).toEqual('test1');
+    const fullname_paragraph = wrapper.find('[data-test="fullName"]');
+    expect(fullname_paragraph.text()).toEqual('Test User 1');
+    const username_paragraph = wrapper.find('[data-test="username"]');
+    expect(username_paragraph.text()).toEqual('test1');
     expect(wrapper.find('[data-test="usernameTextbox"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="passwordTextbox"]').exists()).toBe(true);
     expect(wrapper.text()).toContain(

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -132,6 +132,8 @@
 
       function sendContinue(data) {
         if (usingAdminPasswordState.value) {
+          data['username'] = username.value;
+          data['password'] = null;
           data['AdminUsername'] = formData.value.username;
           data['AdminPassword'] = formData.value.password;
         } else data['password'] = formData.value.password;
@@ -147,8 +149,9 @@
         remoteFacilityLoginUser(
           facility.url,
           facility.id,
-          formData.value.username,
-          formData.value.password
+          usingAdminPasswordState.value ? username.value : formData.value.username,
+          formData.value.password,
+          usingAdminPasswordState.value ? formData.value.username : null
         ).then(user_info => {
           if (user_info === 'error') {
             isPasswordInvalid.value = true;

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -5,7 +5,7 @@
     <p class="fullname" data-test="fullName">
       {{ fullName }}
     </p>
-    <p class="username" data-test="username">
+    <p class="username" data-test="username" :style="{ color: $themeTokens.annotation }">
       {{ username }}
     </p>
     <span v-if="usingAdminPasswordState">
@@ -237,14 +237,14 @@
 <style lang="scss" scoped>
 
   .fullname {
-    font-size: 1.17em;
-    font-weight: bold;
+    margin-bottom: 0;
+    font-size: 1em;
   }
 
   .username {
+    margin-top: 0;
     margin-bottom: 40px;
-    font-size: 1em;
-    font-weight: bold;
+    font-size: 0.95em;
   }
 
 </style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -2,13 +2,16 @@
 
   <div>
     <h1>{{ $tr('documentTitle') }}</h1>
-    <h2>{{ fullName }}</h2>
-    <h3>{{ username }}</h3>
+    <h2 data-test="fullName">
+      {{ fullName }}
+    </h2>
+    <h3 data-test="username">
+      {{ username }}
+    </h3>
     <span v-if="usingAdminPasswordState">
       <p>{{ mergeAccountUsingAdminAccount }}</p>
 
       <KTextbox
-        ref="usernameTextbox"
         v-model="formData.username"
         data-test="usernameTextbox"
         :autofocus="true"
@@ -36,6 +39,7 @@
     <div v-if="!usingAdminPasswordState">
       {{ $tr('doNotKnowPassword') }}
       <KButton
+        data-test="useAdminAccount"
         :text="$tr('useAdminAccount')"
         appearance="basic-link"
         @click="useAdminAccount"
@@ -91,7 +95,9 @@
       const isFormSubmitted = ref(false);
       const isPasswordInvalid = ref(false);
       const usingAdminPasswordState = ref(false);
-      const store = context.root.$store;
+      // hack to get the $store in vue tests with composition api:
+      const store =
+        context.root.$store !== undefined ? context.root.$store : context.root.$children[0].$store;
       const session = store.getters['session'];
       const fullName = computed(() => session.full_name);
       const username = computed(() => session.username);
@@ -149,7 +155,7 @@
         remoteFacilityLoginUser(
           facility.url,
           facility.id,
-          usingAdminPasswordState.value ? username.value : formData.value.username,
+          username.value,
           formData.value.password,
           usingAdminPasswordState.value ? formData.value.username : null
         ).then(user_info => {
@@ -162,34 +168,6 @@
             sendContinue(user_info);
           }
         });
-
-        /*
-        const params = {
-          baseurl: facility.url,
-          facility: facility.id,
-          username: formData.value.username,
-          password: formData.value.password,
-        };
-        const component = this;
-
-        return client({
-          url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityloginuser'](),
-          params: params,
-        }).then(response => {
-          if (response.data.error) {
-            isPasswordInvalid.value = true;
-            focusOnInvalidField(component);
-          } else {
-            isPasswordInvalid.value = false;
-            isFormSubmitted.value = true;
-            const user_info = response.data.find(
-              element => element.username === formData.value.username
-            );
-            sendContinue(user_info);
-          }
-        });
-
-        */
       }
 
       function useAdminAccount() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -76,7 +76,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { computed, inject, ref, watch } from 'kolibri.lib.vueCompositionApi';
   import get from 'lodash/get';
-  import remoteFacilityLoginUser from '../../../composables/useRemoteFacility';
+  import remoteFacilityUserData from '../../../composables/useRemoteFacility';
 
   export default {
     name: 'MergeAccountDialog',
@@ -152,7 +152,7 @@
       function handleContinue() {
         const facility = get(state, 'value.targetFacility', {});
         const component = this;
-        remoteFacilityLoginUser(
+        remoteFacilityUserData(
           facility.url,
           facility.id,
           username.value,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -31,6 +31,7 @@
       :invalid="isPasswordInvalid"
       :invalidText="$tr('incorrectPasswordError')"
       :floatingLabel="false"
+      @keydown.enter="handleContinue"
     />
     <div v-if="!usingAdminPasswordState">
       {{ $tr('doNotKnowPassword') }}
@@ -71,8 +72,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { computed, inject, ref, watch } from 'kolibri.lib.vueCompositionApi';
   import get from 'lodash/get';
-  import client from 'kolibri.client';
-  import urls from 'kolibri.urls';
+  import remoteFacilityLoginUser from '../../../composables/useRemoteFacility';
 
   export default {
     name: 'MergeAccountDialog',
@@ -143,6 +143,24 @@
 
       function handleContinue() {
         const facility = get(state, 'value.targetFacility', {});
+        const component = this;
+        remoteFacilityLoginUser(
+          facility.url,
+          facility.id,
+          formData.value.username,
+          formData.value.password
+        ).then(user_info => {
+          if (user_info === 'error') {
+            isPasswordInvalid.value = true;
+            focusOnInvalidField(component);
+          } else {
+            isPasswordInvalid.value = false;
+            isFormSubmitted.value = true;
+            sendContinue(user_info);
+          }
+        });
+
+        /*
         const params = {
           baseurl: facility.url,
           facility: facility.id,
@@ -167,6 +185,8 @@
             sendContinue(user_info);
           }
         });
+
+        */
       }
 
       function useAdminAccount() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -2,12 +2,12 @@
 
   <div>
     <h1>{{ $tr('documentTitle') }}</h1>
-    <h2 data-test="fullName">
+    <p class="fullname" data-test="fullName">
       {{ fullName }}
-    </h2>
-    <h3 data-test="username">
+    </p>
+    <p class="username" data-test="username">
       {{ username }}
-    </h3>
+    </p>
     <span v-if="usingAdminPasswordState">
       <p>{{ mergeAccountUsingAdminAccount }}</p>
 
@@ -236,8 +236,15 @@
 
 <style lang="scss" scoped>
 
-  h3 {
+  .fullname {
+    font-size: 1.17em;
+    font-weight: bold;
+  }
+
+  .username {
     margin-bottom: 40px;
+    font-size: 1em;
+    font-weight: bold;
   }
 
 </style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -1,0 +1,242 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <h2>{{ fullName }}</h2>
+    <h3>{{ username }}</h3>
+    <span v-if="usingAdminPasswordState">
+      <p>{{ mergeAccountUsingAdminAccount }}</p>
+
+      <KTextbox
+        ref="usernameTextbox"
+        v-model="formData.username"
+        data-test="usernameTextbox"
+        :autofocus="true"
+        :label="coreString('usernameLabel')"
+      />
+
+
+    </span>
+    <p v-else>
+      {{ mergeAccountUserInfo }}
+    </p>
+    <KTextbox
+      v-if="showPasswordTextbox"
+      ref="passwordTextbox"
+      v-model="formData.password"
+      data-test="passwordTextbox"
+      type="password"
+      :label="coreString('passwordLabel')"
+      :autofocus="true"
+      :invalid="isPasswordInvalid"
+      :invalidText="$tr('incorrectPasswordError')"
+      :floatingLabel="false"
+    />
+    <div v-if="!usingAdminPasswordState">
+      {{ $tr('doNotKnowPassword') }}
+      <KButton
+        :text="$tr('useAdminAccount')"
+        appearance="basic-link"
+        @click="useAdminAccount"
+      />
+    </div>
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('backAction')"
+            appearance="flat-button"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="handleContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { computed, inject, ref, watch } from 'kolibri.lib.vueCompositionApi';
+  import get from 'lodash/get';
+  import client from 'kolibri.client';
+  import urls from 'kolibri.urls';
+
+  export default {
+    name: 'MergeAccountDialog',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+    setup(_, context) {
+      const changeFacilityService = inject('changeFacilityService');
+      const state = inject('state');
+
+      const isFormSubmitted = ref(false);
+      const isPasswordInvalid = ref(false);
+      const usingAdminPasswordState = ref(false);
+      const store = context.root.$store;
+      const session = store.getters['session'];
+      const fullName = computed(() => session.full_name);
+      const username = computed(() => session.username);
+      const stateName = computed(() => changeFacilityService.state.value);
+      const formData = ref({
+        username: session.username,
+        password: '',
+      });
+
+      watch(changeFacilityService, currentValue => {
+        usingAdminPasswordState.value = currentValue.state.value === 'useAdminPassword';
+      });
+
+      const mergeAccountUserInfo = computed({
+        get() {
+          return this.$tr('mergeAccountUserInfo', {
+            target_facility: get(state, 'value.targetFacility.name', ''),
+          });
+        },
+      });
+      const mergeAccountUsingAdminAccount = computed({
+        get() {
+          return this.$tr('mergeAccountUsingAdminAccount', {
+            target_facility: get(state, 'value.targetFacility.name', ''),
+          });
+        },
+      });
+
+      function showPasswordTextbox() {
+        return !get(state, 'value.targetFacility.learner_can_login_with_no_password', false);
+      }
+
+      function focusOnInvalidField(component) {
+        if (showPasswordTextbox && isPasswordInvalid.value) {
+          component.$refs.passwordTextbox.focus();
+        }
+      }
+
+      function sendContinue(data) {
+        if (usingAdminPasswordState.value) {
+          data['AdminUsername'] = formData.value.username;
+          data['AdminPassword'] = formData.value.password;
+        } else data['password'] = formData.value.password;
+        changeFacilityService.send({
+          type: 'CONTINUE',
+          value: data,
+        });
+      }
+
+      function handleContinue() {
+        const facility = get(state, 'value.targetFacility', {});
+        const params = {
+          baseurl: facility.url,
+          facility: facility.id,
+          username: formData.value.username,
+          password: formData.value.password,
+        };
+        const component = this;
+
+        return client({
+          url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityloginuser'](),
+          params: params,
+        }).then(response => {
+          if (response.data.error) {
+            isPasswordInvalid.value = true;
+            focusOnInvalidField(component);
+          } else {
+            isPasswordInvalid.value = false;
+            isFormSubmitted.value = true;
+            const user_info = response.data.find(
+              element => element.username === formData.value.username
+            );
+            sendContinue(user_info);
+          }
+        });
+      }
+
+      function useAdminAccount() {
+        changeFacilityService.send({
+          type: 'USEADMIN',
+        });
+      }
+
+      function sendBack() {
+        changeFacilityService.send({
+          type: 'BACK',
+        });
+      }
+
+      return {
+        formData,
+        isFormSubmitted,
+        isPasswordInvalid,
+        usingAdminPasswordState,
+        username,
+        fullName,
+        mergeAccountUserInfo,
+        mergeAccountUsingAdminAccount,
+        showPasswordTextbox,
+        useAdminAccount,
+        sendBack,
+        handleContinue,
+        stateName,
+      };
+    },
+    $trs: {
+      documentTitle: {
+        message: 'Merge Accounts',
+        context: 'Title of this step for the change facility page.',
+      },
+      mergeAccountUserInfo: {
+        message:
+          'Enter the password of the account in ‘{target_facility}’ learning facility that you want to merge your account with.',
+        context:
+          'Line of text asking for the password of the user to be merged in the target facility.',
+      },
+      mergeAccountUsingAdminAccount: {
+        message:
+          'Enter the username and password of a facility admin or a super admin for ‘{target_facility}’ learning facility.',
+        context:
+          'Line of text asking for the credentials of an admin account in the target facility.',
+      },
+      doNotKnowPassword: {
+        message: 'Don’t know the password?',
+        context:
+          'Giving an option if the user does not know the password for this user in the target facility',
+      },
+      useAdminAccount: {
+        message: 'Use an admin account',
+        context: 'Link to use an admin account for the target facility to do the merge',
+      },
+      incorrectPasswordError: {
+        message: 'Incorrect password',
+        context: 'Error that is shown if the user provides the wrong password.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  h3 {
+    margin-bottom: 40px;
+  }
+
+</style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -19,18 +19,15 @@
     <p v-if="initialFetchingComplete && !availableFacilities.length">
       {{ $tr('noFacilitiesText') }}
     </p>
-    <template v-for="f in availableFacilities">
-      <div :key="`div-${f.id}`">
-        <KRadioButton
-          :key="f.id"
-          v-model="selectedFacilityId"
-          :value="f.id"
-          :label="formatNameAndId(f.name, f.id)"
-          :disabled="facilityDisabled(f)"
-        />
-      </div>
-
-    </template>
+    <div v-for="f in availableFacilities" :key="`div-${f.id}`">
+      <KRadioButton
+        :key="f.id"
+        v-model="selectedFacilityId"
+        :value="f.id"
+        :label="formatNameAndId(f.name, f.id)"
+        :disabled="facilityDisabled(f)"
+      />
+    </div>
 
     <KGrid
       :style="{

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -128,7 +128,7 @@
           return (
             discoveryFailed.value ||
             availableAddressIds.value.find(id => id == facility.address_id) === undefined ||
-            !isMinimumKolibriVersion.value(facility.kolibri_version, 0, 15, 0)
+            !isMinimumKolibriVersion.value(facility.kolibri_version, 0, 16, 0)
           );
         };
       });
@@ -145,7 +145,7 @@
 
       function resetSelectedAddress() {
         const enabledFacilities = availableFacilities.value.filter(f =>
-          isMinimumKolibriVersion.value(f.kolibri_version, 0, 15)
+          isMinimumKolibriVersion.value(f.kolibri_version, 0, 16)
         );
         if (enabledFacilities.length !== 0) {
           const selectedId = storageFacilityId.value || selectedFacilityId.value;

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -128,7 +128,7 @@
           return (
             discoveryFailed.value ||
             availableAddressIds.value.find(id => id == facility.address_id) === undefined ||
-            !isMinimumKolibriVersion.value(facility.kolibri_version, 0, 16, 0)
+            !isMinimumKolibriVersion.value(facility.kolibri_version, 0, 15, 0)
           );
         };
       });
@@ -145,7 +145,7 @@
 
       function resetSelectedAddress() {
         const enabledFacilities = availableFacilities.value.filter(f =>
-          isMinimumKolibriVersion.value(f.kolibri_version, 0, 16)
+          isMinimumKolibriVersion.value(f.kolibri_version, 0, 15)
         );
         if (enabledFacilities.length !== 0) {
           const selectedId = storageFacilityId.value || selectedFacilityId.value;

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -92,9 +92,12 @@
       this.service.stop();
     },
     mounted() {
-      if (this.$refs.appBar) {
-        this.appBarHeight = this.$refs.appBar.$el.clientHeight;
-      }
+      this.$nextTick(() => {
+        if (this.$refs.appBar) {
+          this.appBarHeight = this.$refs.appBar.$el.clientHeight;
+        }
+      });
+
       const ctx = this.service.state.context;
       if (ctx.username === '') {
         // machine initialized with its default context

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -69,7 +69,6 @@
     created() {
       this.service.start();
       this.service.onTransition(state => {
-        console.log(state.value);
         const stateID = Object.keys(state.meta)[0];
         if (state.meta[stateID] !== undefined) {
           let newRoute = state.meta[stateID].route;

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -69,6 +69,7 @@
     created() {
       this.service.start();
       this.service.onTransition(state => {
+        console.log(state.value);
         const stateID = Object.keys(state.meta)[0];
         if (state.meta[stateID] !== undefined) {
           let newRoute = state.meta[stateID].route;

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -92,8 +92,9 @@
       this.service.stop();
     },
     mounted() {
-      this.appBarHeight = this.$refs.appBar.$el.clientHeight;
-
+      if (this.$refs.appBar) {
+        this.appBarHeight = this.$refs.appBar.$el.clientHeight;
+      }
       const ctx = this.service.state.context;
       if (ctx.username === '') {
         // machine initialized with its default context

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -58,6 +58,9 @@ class RemoteFacilityUserLoginViewset(APIView):
         url = reverse_remote(baseurl, "kolibri:core:publicuser-list")
         params = {"facility": facility, "search": username}
 
+        # adding facility so auth works when learners can login without password:
+        username = "username={}&facility={}".format(username, facility)
+
         auth = requests.auth.HTTPBasicAuth(username, password)
         try:
             response = requests.get(url, params=params, verify=False, auth=auth)

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -47,12 +47,12 @@ class RemoteFacilityUserViewset(APIView):
             raise ValidationError(detail=str(e))
 
 
-class RemoteFacilityUserLoginViewset(APIView):
-    def get(self, request):
-        baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
-        username = request.query_params.get("username", None)
-        facility = request.query_params.get("facility", None)
-        password = request.query_params.get("password", None)
+class RemoteFacilityUserAuthenticatedViewset(APIView):
+    def post(self, request, *args, **kwargs):
+        baseurl = request.data.get("baseurl", request.build_absolute_uri("/"))
+        username = request.data.get("username", None)
+        facility = request.data.get("facility", None)
+        password = request.data.get("password", None)
         if username is None or facility is None:
             raise ValidationError(detail="Both username and facility are required")
         url = reverse_remote(baseurl, "kolibri:core:publicuser-list")

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -45,3 +45,25 @@ class RemoteFacilityUserViewset(APIView):
                 return Response({})
         except Exception as e:
             raise ValidationError(detail=str(e))
+
+
+class RemoteFacilityUserLoginViewset(APIView):
+    def get(self, request):
+        baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
+        username = request.query_params.get("username", None)
+        facility = request.query_params.get("facility", None)
+        password = request.query_params.get("password", None)
+        if username is None or facility is None:
+            raise ValidationError(detail="Both username and facility are required")
+        url = reverse_remote(baseurl, "kolibri:core:publicuser-list")
+        params = {"facility": facility, "search": username}
+
+        auth = requests.auth.HTTPBasicAuth(username, password)
+        try:
+            response = requests.get(url, params=params, verify=False, auth=auth)
+            if response.status_code == 200:
+                return Response(response.json())
+            else:
+                return Response({"error": response.json()["detail"]})
+        except Exception as e:
+            raise ValidationError(detail=str(e))


### PR DESCRIPTION
## Summary
Screen for the user to confirm its credentials, use admin credentials if  they are available and skip it if the target facility allow users without password to login.

While doing this work, some design discussion have taken to changes in the figma design, that have required changes in the xstate machine, the states `showAccounts` and `editAccountDetails` have been removed. Also, a new state `getUserWithoutPasswordInfo` has been added to retrieve the user information if login without  password is allowed in the target facility.

Screencast when the target facility require password for the users, using the user credentials or admin credentials:
![normal](https://user-images.githubusercontent.com/1008178/186945909-093e07c1-42e2-4974-97b1-1c1919b2f7e2.gif)

Screencast when the target facility does not require password for the users to login:
![passwordless](https://user-images.githubusercontent.com/1008178/186945840-b4ab53d4-f8a7-495b-8238-d484eaea1054.gif)


## References
Closes: #9328 

## Reviewer guidance


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
