### PR TITLE
Align common string modules

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -84,6 +84,21 @@ Then messages are available from the ``$tr`` method on the translator object:
 
   console.log(translator.$tr('helloWorld'));
 
+
+common*String modules
+~~~~~~~~~~~~~~~~~~~~~
+
+A pattern we use in order to avoid having to define the same string across multiple Vue or JS files is to define "common" strings translator. These common translators are typically used within plugins for strings common to that plugin alone. However, there is also a "core" set of common strings available to be used throughout the application.
+
+In order to avoid bloating the common modules, we typically will not add a string we are duplicating to a common module unless it is being used across three or more files.
+
+Common strings modules should typically have the following components:
+
+- A translator created using the ``createTranslator`` function in which strings are defined.
+- An exported function that accepts a ``string`` and an ``object`` - which it then passes to the ``$tr()`` function to get a string from the translator in the module.
+- An exported Vue mixin that exposes the exported function as a ``method``. This allows Vue components to use the mixin and have the exported function to get a translated string readily at hand easily.
+
+
 ICU message syntax
 ~~~~~~~~~~~~~~~~~~
 

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1128,41 +1128,42 @@ const MetadataLookup = invert(
     METADATA.ResourcesNeededTypes
   )
 );
+/**
+ * Return translated string for key defined in the coreStrings translator. Will map
+ * ID keys generated in the kolibri-constants library to their appropriate translations
+ * if available.
+ *
+ * @param {string} key - A key as defined in the coreStrings translator; also accepts keys
+ * for the object MetadataLookup.
+ * @param {object} args - An object with keys matching ICU syntax arguments for the translation
+ * string mapping to the values to be passed for those arguments.
+ */
+export function coreString(key, args) {
+  if (key === 'None of the above' || key === METADATA.NoCategories) {
+    return noneOfTheAboveTranslator.$tr('None of the above', args);
+  }
+
+  if (key === 'overCertainNumberOfSearchResults') {
+    return overResultsTranslator.$tr(key, args);
+  }
+
+  const metadataKey = get(MetadataLookup, key, null);
+  key = metadataKey ? camelCase(metadataKey) : key;
+
+  if (nonconformingKeys[key]) {
+    return coreStrings.$tr(nonconformingKeys[key], args);
+  }
+
+  if (nonconformingKeys[metadataKey]) {
+    return coreStrings.$tr(nonconformingKeys[metadataKey], args);
+  }
+
+  return coreStrings.$tr(key, args);
+}
 
 export default {
   methods: {
-    /**
-     * Return translated string for key defined in the coreStrings translator. Will map
-     * ID keys generated in the kolibri-constants library to their appropriate translations
-     * if available.
-     *
-     * @param {string} key - A key as defined in the coreStrings translator; also accepts keys
-     * for the object MetadataLookup.
-     * @param {object} args - An object with keys matching ICU syntax arguments for the translation
-     * string mapping to the values to be passed for those arguments.
-     */
-    coreString(key, args) {
-      if (key === 'None of the above' || key === METADATA.NoCategories) {
-        return noneOfTheAboveTranslator.$tr('None of the above', args);
-      }
-
-      if (key === 'overCertainNumberOfSearchResults') {
-        return overResultsTranslator.$tr(key, args);
-      }
-
-      const metadataKey = get(MetadataLookup, key, null);
-      key = metadataKey ? camelCase(metadataKey) : key;
-
-      if (nonconformingKeys[key]) {
-        return coreStrings.$tr(nonconformingKeys[key], args);
-      }
-
-      if (nonconformingKeys[metadataKey]) {
-        return coreStrings.$tr(nonconformingKeys[metadataKey], args);
-      }
-
-      return coreStrings.$tr(key, args);
-    },
+    coreString,
     /**
      * Shows a specific snackbar notification from our notificationStrings translator.
      *

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -536,15 +536,17 @@ const MissingContentStrings = createTranslator('MissingContentStrings', {
   },
 });
 
+function coachString(key, args) {
+  return coachStrings.$tr(key, args);
+}
+
 const coachStringsMixin = {
   methods: {
-    coachString(key, args) {
-      return coachStrings.$tr(key, args);
-    },
+    coachString,
     getMissingContentString(key, args) {
       return MissingContentStrings.$tr(key, args);
     },
   },
 };
 
-export { coachStrings, coachStringsMixin };
+export { coachString, coachStrings, coachStringsMixin };

--- a/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
+++ b/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
@@ -20,10 +20,10 @@ const deviceStrings = createTranslator('CommonDeviceStrings', {
   },
 });
 
+export function deviceString(key, args) {
+  return deviceStrings.$tr(key, args);
+}
+
 export default {
-  methods: {
-    deviceString(key, args) {
-      return deviceStrings.$tr(key, args);
-    },
-  },
+  methods: { deviceString },
 };

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -82,10 +82,10 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
   },
 });
 
+export function learnString(key, args) {
+  return learnStrings.$tr(key, args);
+}
+
 export default {
-  methods: {
-    learnString(key, args) {
-      return learnStrings.$tr(key, args);
-    },
-  },
+  methods: { learnString },
 };

--- a/kolibri/plugins/user_auth/assets/src/views/commonUserStrings.js
+++ b/kolibri/plugins/user_auth/assets/src/views/commonUserStrings.js
@@ -28,10 +28,10 @@ const commonUserStrings = createTranslator('CommonUserPageStrings', {
   },
 });
 
+export function userString(key, args) {
+  return commonUserStrings.$tr(key, args);
+}
+
 export default {
-  methods: {
-    userString(key, args) {
-      return commonUserStrings.$tr(key, args);
-    },
-  },
+  methods: { userString },
 };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Applies to the common strings modules the pattern @rtibbles [noted here](https://github.com/learningequality/kolibri/pull/9534#discussion_r908960312) where they will export a getter function as well as the mixin for the case in which one wants to just get a string not in the context of a Vue component.

Some i18n follow-up is needed in general. This pattern could be extended to some of our other string definitions files - but this will make a bit of that easier to do. 

Follow-up issue: TBD

I also added documentation re: our common modules - not sure if this is any good or helpful, very much open to feedback on this.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Is there room for regression I'm not seeing?
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
