### PR TITLE
Import fail on error fixes

### DIFF
--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -32,8 +32,13 @@ COPY_METHOD = "copy"
 
 logger = logging.getLogger(__name__)
 
-FILE_TRANSFERRED = 0
-FILE_SKIPPED = 1
+
+class FileCorrupted(Exception):
+    """
+    Transferred file does not match the expected checksum
+    """
+
+    pass
 
 
 def lookup_channel_listing_status(channel_id, baseurl=None):
@@ -454,12 +459,19 @@ class Command(AsyncCommand):
                     ):
                         f, filetransfer = future_file_transfers[future]
                         try:
-                            status, data_transferred = future.result()
+                            error, data_transferred = future.result()
                             overall_progress_update(data_transferred)
                             if self.is_cancelled():
                                 break
 
-                            if status == FILE_SKIPPED:
+                            if error:
+                                if fail_on_error:
+                                    raise error
+                                logger.error(
+                                    "An error occurred during content import: {}".format(
+                                        error
+                                    )
+                                )
                                 number_of_skipped_files += 1
                             else:
                                 file_checksums_to_annotate.append(f["id"])
@@ -534,9 +546,10 @@ class Command(AsyncCommand):
     def _start_file_transfer(self, f, filetransfer):
         """
         Start to transfer the file from network/disk to the destination.
-        Return value:
-            * FILE_TRANSFERRED - successfully transfer the file.
-            * FILE_SKIPPED - the file does not exist so it is skipped.
+
+        Returns a tuple containing an error that occurred and the amount
+        of data transferred. The error value will be None if no error
+        occurred.
         """
         data_transferred = 0
 
@@ -560,15 +573,14 @@ class Command(AsyncCommand):
             except (IOError, OSError):
                 checksum_correctness = False
             if not checksum_correctness:
-                e = "File {} is corrupted.".format(filetransfer.source)
-                logger.error("An error occurred during content import: {}".format(e))
+                e = FileCorrupted("File {} is corrupted.".format(filetransfer.source))
                 try:
                     os.remove(filetransfer.dest)
                 except OSError:
                     pass
-                return FILE_SKIPPED, data_transferred
+                return e, data_transferred
 
-        return FILE_TRANSFERRED, data_transferred
+        return None, data_transferred
 
     def handle_async(self, *args, **options):
         try:

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -477,11 +477,12 @@ class Command(AsyncCommand):
                                 "An error occurred during content import: {}".format(e)
                             )
 
-                            if (
-                                not fail_on_error
-                                and isinstance(e, requests.exceptions.HTTPError)
+                            is_file_missing_error = (
+                                isinstance(e, requests.exceptions.HTTPError)
                                 and e.response.status_code == 404
-                            ) or (isinstance(e, OSError) and e.errno == 2):
+                            ) or (isinstance(e, OSError) and e.errno == 2)
+
+                            if is_file_missing_error and not fail_on_error:
                                 # Continue file import when the current file is not found from the source and is skipped.
                                 overall_progress_update(f["file_size"])
                                 number_of_skipped_files += 1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Make the `importcontent` `--fail-on-error` option handle more error cases.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Previously this was implemented in #9259 to address #9258. I opened #9590 to track the fixes here.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

There are test cases added and #9590 has a procedure to test with local kolibri instances.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~~If there are any front-end changes, before/after screenshots are included~~
- [ ] ~~Critical user journeys are covered by Gherkin stories~~
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
