### PR TITLE
Link users to Vue docs, make note of "legacy"

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -283,7 +283,7 @@ We have a project-level *.editorconfig* file to help you configure your text edi
 Vue development tools
 ---------------------
 
-`Vue.js devtools <https://github.com/vuejs/vue-devtools>`__ is a browser plugin that is very helpful when working with Vue.js components and Vuex.
+`Vue.js devtools (Legacy) <https://devtools.vuejs.org/guide/installation.html>`__ is a browser plugin that is very helpful when working with Vue.js components and Vuex. Kolibri is using Vue 2, so be sure to find the "Legacy" plugin as the latest version of the extension is for Vue 3.
 
 To ensure a more efficient workflow, install appropriate editor plugins for Vue.js, ESLint, and stylelint.
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Vue Devtools' latest release works primarily with Vue 3 and our documentation points to Github

This points now to the official Vue doc that mentions and links to the "Legacy" version - the docs now point that out. Might save new folks some trouble in avoiding the wrong extension.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Should the docs just link to the respective Firefox and Chrome Legacy plugins instead?

