### PR TITLE
Force unicode literals for Python 2 compatibility of string handling.

### DIFF
--- a/kolibri/core/auth/csv_utils.py
+++ b/kolibri/core/auth/csv_utils.py
@@ -97,9 +97,6 @@ labels = OrderedDict(
 )
 
 
-map_output = partial(output_mapper, labels=labels, output_mappings=output_mappings)
-
-
 input_fields = (
     "full_name",
     "username",
@@ -180,6 +177,14 @@ def csv_file_generator(facility, filepath, overwrite=True, demographic=False):
     )
 
     csv_file = open_csv_for_writing(filepath)
+
+    mappings = {}
+
+    for key in output_mappings:
+        if demographic or key not in DEMO_FIELDS:
+            mappings[key] = output_mappings[key]
+
+    map_output = partial(output_mapper, labels=labels, output_mappings=mappings)
 
     with csv_file as f:
         writer = csv.DictWriter(f, header_labels)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import base64
 import collections
 import sys
+import time
 import uuid
 from datetime import datetime
 from importlib import import_module
@@ -1104,6 +1105,7 @@ class LoginLogoutTestCase(APITestCase):
             format="json",
         )
         expire_date = self.client.session.get_expiry_date()
+        time.sleep(0.01)
         self.client.get(
             reverse("kolibri:core:session-detail", kwargs={"pk": "current"})
         )

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -771,6 +771,7 @@ class SyncQueueViewSetTestCase(APITestCase):
             user_id=self.learner.id, instance_id=self.instance_id, keep_alive=10
         )
         old_updated = queue.updated
+        time.sleep(0.01)
         response = self.client.put(
             reverse("kolibri:core:syncqueue-detail", kwargs={"pk": queue.id}),
             data={"user": self.learner.id, "instance": self.instance_id},

--- a/kolibri/core/utils/csv.py
+++ b/kolibri/core/utils/csv.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import io
 import re
 import sys

--- a/kolibri/core/utils/csv.py
+++ b/kolibri/core/utils/csv.py
@@ -37,7 +37,9 @@ def sanitize(value):
     return value
 
 
-def output_mapper(obj, labels=None, output_mappings=None):
+def output_mapper(obj, labels=None, output_mappings=None, exclude_fields=None):
+    if exclude_fields is None:
+        exclude_fields = set()
     mapped_obj = {}
     labels = labels or {}
     output_mappings = output_mappings or {}

--- a/kolibri/core/utils/csv.py
+++ b/kolibri/core/utils/csv.py
@@ -42,7 +42,7 @@ def output_mapper(obj, labels=None, output_mappings=None):
     labels = labels or {}
     output_mappings = output_mappings or {}
     for header, label in labels.items():
-        if header in output_mappings and header in obj:
+        if header in output_mappings:
             mapped_obj[label] = sanitize(output_mappings[header](obj))
         elif header in obj:
             mapped_obj[label] = sanitize(obj[header])


### PR DESCRIPTION
## Summary
* In https://github.com/learningequality/kolibri/commit/95609c11f4497a64f24a3949779969e0badcd55c we started doing string handling in the core CSV utils module
* We had not imported unicode literals into that module
* This seems to have caused issues with string handling in Python 2.7 where this is necessary
* This rectifies that
* This was not the issue ^
* Rather the unification of `output_mapper` functions between the three places it was used meant that there was a conditional in the combined output mapper that was not in the original log export one.
* This removes that conditional, and updates the demographic exclusion code for user exports to compensate.

## References
Fixes #9601

## Reviewer guidance
Run Kolibri in Python 2.7
Export session or summary logs
Check if resource and channel titles are present

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
