### PR TITLE
Update KDS package to the latest version on develop

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#develop",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -52,14 +52,12 @@
             :checked="superuserChecked"
             @change="superuserChecked = $event"
           >
-            <label :style="superuserLabelStyle">
-              <span>{{ $tr('makeSuperAdmin') }}</span>
-              <PermissionsIcon
-                permissionType="SUPERUSER"
-                class="permissions-icon"
-                :lightIcon="superuserDisabled"
-              />
-            </label>
+            <span :style="superuserLabelStyle">{{ $tr('makeSuperAdmin') }}</span>
+            <PermissionsIcon
+              permissionType="SUPERUSER"
+              class="permissions-icon"
+              :lightIcon="superuserDisabled"
+            />
           </KCheckbox>
 
           <ul

--- a/yarn.lock
+++ b/yarn.lock
@@ -8266,9 +8266,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#develop":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#37dcf4f8db24d0afc5a72586bb35771dd29c8b1d"
+  resolved "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary

This prepares Kolibri for this KCheckbox update https://github.com/learningequality/kolibri-design-system/pull/351 by updating checkbox used on user's permission page to not provide its own `<label>` (which wasn't working anyways since it didn't have `for`) since it's now KCheckbox that provides it.

~~It also serves for testing by referencing my fork (commit will be reverted after the corresponding KDS PR gets merged)~~ Reverted. The PR now points to the latest KDS develop commit.

## References

https://github.com/learningequality/kolibri-design-system/pull/351

## Reviewer guidance

- Preview _Make super admin_ checkbox on the user's permissions page in the _Device Permissions_ tab as a super admin (checkbox label should be formatted as disabled) and as a learner (checkbox label should be formatted as enabled)
- Preview a couple of other places in Kolibri where we use checkboxes, for example on the _Facility settings_ page
- Check labels markup
- There should be no visual changes or regressions in checkboxes behavior

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
