### PR TITLE
CSV Endpoint permissions and error handling

### DIFF
--- a/kolibri/core/logger/api_urls.py
+++ b/kolibri/core/logger/api_urls.py
@@ -1,12 +1,9 @@
-from django.conf.urls import url
 from rest_framework import routers
 
 from .api import AttemptLogViewSet
 from .api import MasteryLogViewSet
 from .api import ProgressTrackingViewSet
 from .api import TotalContentProgressViewSet
-from .csv_export import download_csv_file
-from .csv_export import exported_logs_info
 
 router = routers.SimpleRouter()
 
@@ -14,21 +11,5 @@ router.register(r"masterylog", MasteryLogViewSet, base_name="masterylog")
 router.register(r"attemptlog", AttemptLogViewSet, base_name="attemptlog")
 router.register(r"userprogress", TotalContentProgressViewSet, base_name="userprogress")
 router.register(r"trackprogress", ProgressTrackingViewSet, base_name="trackprogress")
-
-router.urls.append(
-    url(
-        r"^downloadcsvfile/(?P<log_type>.*)/(?P<facility_id>.*)/$",
-        download_csv_file,
-        name="download_csv_file",
-    )
-)
-
-router.urls.append(
-    url(
-        r"^exportedlogsinfo/(?P<facility_id>.*)/(?P<facility>.*)/$",
-        exported_logs_info,
-        name="exportedlogsinfo",
-    )
-)
 
 urlpatterns = router.urls

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals
 
 import csv
-import io
-import json
 import logging
 import math
 import os
@@ -10,25 +8,14 @@ from collections import OrderedDict
 from functools import partial
 
 from django.core.cache import cache
-from django.http import Http404
-from django.http import HttpResponse
-from django.http import HttpResponseForbidden
-from django.http.response import FileResponse
-from django.template.defaultfilters import slugify
-from django.utils import translation
-from django.utils.translation import get_language_from_request
-from django.utils.translation import pgettext
 from le_utils.constants import content_kinds
 
 from .models import ContentSessionLog
 from .models import ContentSummaryLog
-from kolibri.core.auth.constants import role_kinds
-from kolibri.core.auth.models import Facility
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.utils.csv import open_csv_for_writing
 from kolibri.core.utils.csv import output_mapper
-from kolibri.utils import conf
 
 
 logger = logging.getLogger(__name__)
@@ -159,97 +146,3 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
         ):
             writer.writerow(map_object(item))
             yield
-
-
-def exported_logs_info(request, facility_id, facility):
-    """
-    Get the last modification timestamp of the summary logs exported
-
-    :returns: An object with the files informatin
-    """
-    logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
-    csv_statuses = {}
-
-    for log_type in CSV_EXPORT_FILENAMES:
-        log_path = os.path.join(
-            logs_dir, CSV_EXPORT_FILENAMES[log_type].format(facility, facility_id[:4])
-        )
-        if os.path.exists(log_path):
-            csv_statuses[log_type] = os.path.getmtime(log_path)
-        else:
-            csv_statuses[log_type] = None
-
-    return HttpResponse(json.dumps(csv_statuses), content_type="application/json")
-
-
-def download_csv_file(request, log_type, facility_id):
-    if request.user.is_anonymous:
-        return HttpResponseForbidden("You must be logged in to download this file")
-
-    if facility_id:
-        facility = Facility.objects.get(pk=facility_id)
-    else:
-        facility = request.user.facility
-        facility_id = request.user.facility.id
-
-    if not request.user.has_role_for_collection(role_kinds.ADMIN, facility):
-        return HttpResponseForbidden(
-            "You must be logged in as an admin for this facility or a superadmin to download this file"
-        )
-
-    facility_name = facility.name
-
-    locale = get_language_from_request(request)
-    translation.activate(locale)
-
-    csv_translated_filenames = {
-        "session": (
-            "{}_{}_"
-            + slugify(
-                pgettext(
-                    "Default name for the exported CSV file with content session logs. Please keep the underscores between words in the translation",
-                    "content_session_logs",
-                )
-            )
-            + ".csv"
-        ).replace("-", "_"),
-        "summary": (
-            "{}_{}_"
-            + slugify(
-                pgettext(
-                    "Default name for the exported CSV file with content summary logs. Please keep the underscores between words in the translation",
-                    "content_summary_logs",
-                )
-            )
-            + ".csv"
-        ).replace("-", "_"),
-    }
-
-    if log_type in CSV_EXPORT_FILENAMES.keys():
-        filepath = os.path.join(
-            conf.KOLIBRI_HOME,
-            "log_export",
-            CSV_EXPORT_FILENAMES[log_type].format(facility_name, facility_id[:4]),
-        )
-    else:
-        filepath = None
-
-    # if the file does not exist on disk, return a 404
-    if filepath is None or not os.path.exists(filepath):
-        raise Http404("There is no csv export file for {} available".format(log_type))
-
-    # generate a file response
-    response = FileResponse(io.open(filepath, "rb"))
-    # set the content-type by guessing from the filename
-    response["Content-Type"] = "text/csv"
-
-    # set the content-disposition as attachment to force download
-    response["Content-Disposition"] = "attachment; filename={}".format(
-        str(csv_translated_filenames[log_type]).format(facility_name, facility_id[:4])
-    )
-    translation.deactivate()
-
-    # set the content-length to the file size
-    response["Content-Length"] = os.path.getsize(filepath)
-
-    return response

--- a/kolibri/core/logger/csv_export.py
+++ b/kolibri/core/logger/csv_export.py
@@ -132,7 +132,7 @@ def csv_file_generator(facility, log_type, filepath, overwrite=False):
     header_labels = tuple(
         label
         for label in labels.values()
-        if log_type == "summary" or label != "completion_timestamp"
+        if log_type == "summary" or label != labels["completion_timestamp"]
     )
 
     csv_file = open_csv_for_writing(filepath)

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -4,11 +4,13 @@ Tests that ensure the correct items are returned from api calls.
 Also tests whether the users with permissions can create logs.
 """
 import csv
+import os
 import sys
 import tempfile
 import uuid
 
 from django.core.management import call_command
+from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from ..models import ContentSessionLog
@@ -16,10 +18,23 @@ from ..models import ContentSummaryLog
 from .factory_logger import ContentSessionLogFactory
 from .factory_logger import ContentSummaryLogFactory
 from .factory_logger import FacilityUserFactory
+from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
+from kolibri.core.logger.csv_export import CSV_EXPORT_FILENAMES
+from kolibri.utils import conf
+
+
+def output_filename(log_type, facility):
+    logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
+    if not os.path.isdir(logs_dir):
+        os.mkdir(logs_dir)
+    return os.path.join(
+        logs_dir,
+        CSV_EXPORT_FILENAMES[log_type].format(facility.name, facility.id[:4]),
+    )
 
 
 class ContentSummaryLogCSVExportTestCase(APITestCase):
@@ -103,6 +118,61 @@ class ContentSummaryLogCSVExportTestCase(APITestCase):
             self.assertEqual(len(results[0]), len(row))
         self.assertEqual(len(results[1:]), expected_count)
 
+    def test_csv_download_anonymous_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_non_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.admin.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
 
 class ContentSessionLogCSVExportTestCase(APITestCase):
 
@@ -114,10 +184,10 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
         # provision device to pass the setup_wizard middleware check
         provision_device()
         cls.admin = FacilityUserFactory.create(facility=cls.facility)
-        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility)
         cls.interaction_logs = [
             ContentSessionLogFactory.create(
-                user=cls.user,
+                user=cls.user1,
                 content_id=uuid.uuid4().hex,
                 channel_id="6199dde695db4ee4ab392222d5af1e5c",
             )
@@ -184,3 +254,58 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
         for row in results[1:]:
             self.assertEqual(len(results[0]), len(row))
         self.assertEqual(len(results[1:]), expected_count)
+
+    def test_csv_download_anonymous_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_non_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="session",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="session",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.admin.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:core:download_csv_file",
+                kwargs={"log_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)

--- a/kolibri/core/logger/test/test_api.py
+++ b/kolibri/core/logger/test/test_api.py
@@ -20,6 +20,7 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
+from kolibri.core.logger.csv_export import labels
 
 
 class ContentSummaryLogCSVExportTestCase(APITestCase):
@@ -184,3 +185,17 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
         for row in results[1:]:
             self.assertEqual(len(results[0]), len(row))
         self.assertEqual(len(results[1:]), expected_count)
+
+    def test_csv_download_no_completion_timestamp(self):
+        _, filepath = tempfile.mkstemp(suffix=".csv")
+        call_command(
+            "exportlogs", log_type="session", output_file=filepath, overwrite=True
+        )
+        if sys.version_info[0] < 3:
+            csv_file = open(filepath, "rb")
+        else:
+            csv_file = open(filepath, "r", newline="")
+        with csv_file as f:
+            results = list(csv.reader(f))
+        for column_label in results[0]:
+            self.assertNotEqual(column_label, labels["completion_timestamp"])

--- a/kolibri/plugins/facility/api_urls.py
+++ b/kolibri/plugins/facility/api_urls.py
@@ -1,11 +1,17 @@
 from django.conf.urls import url
 
 from .views import download_csv_file
+from .views import exported_csv_info
 
 urlpatterns = [
     url(
-        r"^downloadcsvfile/(?P<filename>.*)/(?P<facility_id>.*)$",
+        r"^downloadcsvfile/(?P<csv_type>.*)/(?P<facility_id>.*)/$",
         download_csv_file,
         name="download_csv_file",
-    )
+    ),
+    url(
+        r"^exportedcsvinfo/(?P<facility_id>.*)/$",
+        exported_csv_info,
+        name="exportedcsvinfo",
+    ),
 ]

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -38,23 +38,24 @@ function startSessionCSVExport(store) {
   );
 }
 
-function getExportedLogsInfo(store) {
+function getExportedCSVsInfo(store) {
   return client({
-    url: urls['kolibri:core:exportedlogsinfo'](
-      store.rootGetters.activeFacilityId,
-      store.rootGetters.currentFacilityName
+    url: urls['kolibri:kolibri.plugins.facility:exportedcsvinfo'](
+      store.rootGetters.activeFacilityId
     ),
   }).then(response => {
     const data = response.data;
-    let sessionTimeStamp = null;
     if (data.session != null) {
-      sessionTimeStamp = new Date(data.session * 1000);
+      const sessionTimeStamp = new Date(data.session * 1000);
       store.commit('SET_FINISHED_SESSION_CSV_CREATION', sessionTimeStamp);
     }
-    let summaryTimeStamp = null;
     if (data.summary != null) {
-      summaryTimeStamp = new Date(data.summary * 1000);
+      const summaryTimeStamp = new Date(data.summary * 1000);
       store.commit('SET_FINISHED_SUMMARY_CSV_CREATION', summaryTimeStamp);
+    }
+    if (data.user != null) {
+      const userTimeStamp = new Date(data.user * 1000);
+      store.commit('SET_FINISH_EXPORT_USERS', userTimeStamp);
     }
   });
 }
@@ -140,6 +141,6 @@ export default {
   refreshTaskList,
   startSummaryCSVExport,
   startSessionCSVExport,
-  getExportedLogsInfo,
+  getExportedCSVsInfo,
   startExportUsers,
 };

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/index.js
@@ -13,8 +13,8 @@ function defaultState() {
     facilities: [],
     facilityTaskId: '',
     exportUsersTaskId: '',
-    exportUsersStatus: '',
-    exportUsersFilename: '',
+    exportUsersStatus: CSVGenerationStatuses.NO_LOGS_CREATED,
+    exportUsersDateCreated: null,
   };
 }
 
@@ -47,10 +47,10 @@ export default {
       return state.summaryLogStatus === CSVGenerationStatuses.AVAILABLE;
     },
     exportingUsers(state) {
-      return state.status === UsersExportStatuses.EXPORTING;
+      return state.exportUsersStatus === UsersExportStatuses.EXPORTING;
     },
     exported(state) {
-      return state.exportUsersStatus === UsersExportStatuses.FINISHED;
+      return state.exportUsersStatus !== CSVGenerationStatuses.NO_LOGS_CREATED;
     },
   },
   mutations: {
@@ -92,8 +92,9 @@ export default {
       state.exportUsersTaskId = payload.id;
     },
     SET_FINISH_EXPORT_USERS(state, payload) {
-      state.exportUsersFilename = payload;
+      state.exportUsersDateCreated = payload;
       state.exportUsersStatus = UsersExportStatuses.FINISHED;
+      state.exportUsersTaskId = '';
     },
   },
   actions,

--- a/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/ImportInterface/index.vue
@@ -75,7 +75,7 @@
     },
     computed: {
       ...mapGetters('manageCSV', ['exported']),
-      ...mapState('manageCSV', ['exportUsersStatus', 'exportUsersFilename']),
+      ...mapState('manageCSV', ['exportUsersStatus']),
       isExporting() {
         return this.exportUsersStatus === UsersExportStatuses.EXPORTING;
       },
@@ -88,7 +88,7 @@
       downloadCsv() {
         window.open(
           urls['kolibri:kolibri.plugins.facility:download_csv_file'](
-            this.exportUsersFilename,
+            'user',
             this.$store.getters.activeFacilityId
           ),
           '_blank'

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -160,7 +160,7 @@
         'startSummaryCSVExport',
         'startSessionCSVExport',
         'refreshTaskList',
-        'getExportedLogsInfo',
+        'getExportedCSVsInfo',
       ]),
       generateSessionLog() {
         this.startSessionCSVExport();
@@ -169,7 +169,7 @@
         this.startSummaryCSVExport();
       },
       startTaskPolling() {
-        this.getExportedLogsInfo();
+        this.getExportedCSVsInfo();
         if (!this.intervalId) {
           this.intervalId = setInterval(this.refreshTaskList, 1000);
         }
@@ -181,13 +181,19 @@
       },
       downloadSessionLog() {
         window.open(
-          urls['kolibri:core:download_csv_file']('session', this.activeFacilityId),
+          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
+            'session',
+            this.activeFacilityId
+          ),
           '_blank'
         );
       },
       downloadSummaryLog() {
         window.open(
-          urls['kolibri:core:download_csv_file']('summary', this.activeFacilityId),
+          urls['kolibri:kolibri.plugins.facility:download_csv_file'](
+            'summary',
+            this.activeFacilityId
+          ),
           '_blank'
         );
       },

--- a/kolibri/plugins/facility/test/test_api.py
+++ b/kolibri/plugins/facility/test/test_api.py
@@ -1,0 +1,250 @@
+# -*- coding: utf-8 -*-
+"""
+Tests that ensure the correct items are returned from api calls.
+Also tests whether the users with permissions can create logs.
+"""
+import os
+import uuid
+
+from django.core.management import call_command
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from kolibri.core.auth.test.helpers import DUMMY_PASSWORD
+from kolibri.core.auth.test.helpers import provision_device
+from kolibri.core.auth.test.test_api import FacilityFactory
+from kolibri.core.logger.test.factory_logger import ContentSessionLogFactory
+from kolibri.core.logger.test.factory_logger import ContentSummaryLogFactory
+from kolibri.core.logger.test.factory_logger import FacilityUserFactory
+from kolibri.plugins.facility.views import CSV_EXPORT_FILENAMES
+from kolibri.utils import conf
+
+
+def output_filename(log_type, facility):
+    logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
+    if not os.path.isdir(logs_dir):
+        os.mkdir(logs_dir)
+    return os.path.join(
+        logs_dir,
+        CSV_EXPORT_FILENAMES[log_type].format(facility.name, facility.id[:4]),
+    )
+
+
+class ContentSummaryLogCSVExportTestCase(APITestCase):
+
+    fixtures = ["content_test.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        # provision device to pass the setup_wizard middleware check
+        provision_device()
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility)
+        cls.summary_logs = [
+            ContentSummaryLogFactory.create(
+                user=cls.user1,
+                content_id=uuid.uuid4().hex,
+                channel_id="6199dde695db4ee4ab392222d5af1e5c",
+            )
+            for _ in range(3)
+        ]
+        cls.facility.add_admin(cls.admin)
+
+    def test_csv_download_anonymous_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_non_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="summary",
+            output_file=output_filename("summary", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.admin.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "summary", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+class ContentSessionLogCSVExportTestCase(APITestCase):
+
+    fixtures = ["content_test.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        # provision device to pass the setup_wizard middleware check
+        provision_device()
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility)
+        cls.interaction_logs = [
+            ContentSessionLogFactory.create(
+                user=cls.user1,
+                content_id=uuid.uuid4().hex,
+                channel_id="6199dde695db4ee4ab392222d5af1e5c",
+            )
+            for _ in range(3)
+        ]
+        cls.facility.add_admin(cls.admin)
+
+    def test_csv_download_anonymous_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="session",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_non_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="session",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_admin_permissions(self):
+        call_command(
+            "exportlogs",
+            log_type="session",
+            output_file=output_filename("session", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.admin.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "session", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+class UserCSVExportTestCase(APITestCase):
+
+    fixtures = ["content_test.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = FacilityFactory.create()
+        # provision device to pass the setup_wizard middleware check
+        provision_device()
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
+
+    def test_csv_download_anonymous_permissions(self):
+        call_command(
+            "bulkexportusers",
+            output_file=output_filename("user", self.facility),
+            overwrite=True,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "user", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_non_admin_permissions(self):
+        call_command(
+            "bulkexportusers",
+            output_file=output_filename("user", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "user", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_csv_download_admin_permissions(self):
+        call_command(
+            "bulkexportusers",
+            output_file=output_filename("user", self.facility),
+            overwrite=True,
+        )
+        self.client.login(
+            username=self.admin.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        response = self.client.get(
+            reverse(
+                "kolibri:kolibri.plugins.facility:download_csv_file",
+                kwargs={"csv_type": "user", "facility_id": self.facility.id},
+            )
+        )
+        self.assertEqual(response.status_code, 200)

--- a/kolibri/plugins/facility/views.py
+++ b/kolibri/plugins/facility/views.py
@@ -3,11 +3,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import io
+import json
 import os
-from datetime import datetime
 
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
+from django.http import HttpResponse
 from django.http.response import FileResponse
+from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import slugify
 from django.utils import translation
 from django.utils.decorators import method_decorator
@@ -15,9 +18,21 @@ from django.utils.translation import get_language_from_request
 from django.utils.translation import pgettext
 from django.views.generic.base import TemplateView
 
+from kolibri.core.auth.constants import role_kinds
+from kolibri.core.auth.management.commands.bulkexportusers import (
+    CSV_EXPORT_FILENAMES as USER_CSV_EXPORT_FILENAMES,
+)
 from kolibri.core.auth.models import Facility
 from kolibri.core.decorators import cache_no_user_data
+from kolibri.core.logger.csv_export import (
+    CSV_EXPORT_FILENAMES as LOGGER_CSV_EXPORT_FILENAMES,
+)
 from kolibri.utils import conf
+
+
+CSV_EXPORT_FILENAMES = {}
+CSV_EXPORT_FILENAMES.update(LOGGER_CSV_EXPORT_FILENAMES)
+CSV_EXPORT_FILENAMES.update(USER_CSV_EXPORT_FILENAMES)
 
 
 @method_decorator(cache_no_user_data, name="dispatch")
@@ -25,19 +40,98 @@ class FacilityManagementView(TemplateView):
     template_name = "facility_management.html"
 
 
-def download_csv_file(request, filename, facility_id):
+def _get_facility_check_permissions(request, facility_id):
+    if request.user.is_anonymous:
+        raise PermissionDenied("You must be logged in to download this file")
+
     if facility_id:
-        facility_name = Facility.objects.get(pk=facility_id).name
+        facility = get_object_or_404(Facility, pk=facility_id)
     else:
-        facility_name = request.user.facility.name
+        facility = request.user.facility
+
+    if not request.user.has_role_for_collection(role_kinds.ADMIN, facility):
+        raise PermissionDenied(
+            "You must be logged in as an admin for this facility or a superadmin to download this file"
+        )
+    return facility
+
+
+def exported_csv_info(request, facility_id):
+    """
+    Get the last modification timestamp of the summary logs exported
+
+    :returns: An object with the files informatin
+    """
+    facility = _get_facility_check_permissions(request, facility_id)
+
+    logs_dir = os.path.join(conf.KOLIBRI_HOME, "log_export")
+    csv_statuses = {}
+
+    for log_type in CSV_EXPORT_FILENAMES:
+        log_path = os.path.join(
+            logs_dir,
+            CSV_EXPORT_FILENAMES[log_type].format(facility.name, facility.id[:4]),
+        )
+        if os.path.exists(log_path):
+            csv_statuses[log_type] = os.path.getmtime(log_path)
+        else:
+            csv_statuses[log_type] = None
+
+    return HttpResponse(json.dumps(csv_statuses), content_type="application/json")
+
+
+def download_csv_file(request, csv_type, facility_id):
+
+    facility = _get_facility_check_permissions(request, facility_id)
 
     locale = get_language_from_request(request)
     translation.activate(locale)
-    filepath = os.path.join(conf.KOLIBRI_HOME, "temp", filename)
+
+    csv_translated_filenames = {
+        "session": (
+            "{}_{}_"
+            + slugify(
+                pgettext(
+                    "Default name for the exported CSV file with content session logs. Please keep the underscores between words in the translation",
+                    "content_session_logs",
+                )
+            )
+            + ".csv"
+        ).replace("-", "_"),
+        "summary": (
+            "{}_{}_"
+            + slugify(
+                pgettext(
+                    "Default name for the exported CSV file with content summary logs. Please keep the underscores between words in the translation",
+                    "content_summary_logs",
+                )
+            )
+            + ".csv"
+        ).replace("-", "_"),
+        "user": (
+            "{}_{}_"
+            + slugify(
+                pgettext(
+                    "Default name for the exported CSV file of facility user data. Please keep the underscore between words in the translation",
+                    "users",
+                )
+            )
+            + ".csv"
+        ).replace("-", "_"),
+    }
+
+    if csv_type in CSV_EXPORT_FILENAMES.keys():
+        filepath = os.path.join(
+            conf.KOLIBRI_HOME,
+            "log_export",
+            CSV_EXPORT_FILENAMES[csv_type].format(facility.name, facility.id[:4]),
+        )
+    else:
+        filepath = None
 
     # if the file does not exist on disk, return a 404
     if filepath is None or not os.path.exists(filepath):
-        raise Http404("Creation of users export file has failed")
+        raise Http404("There is no csv export file for {} available".format(csv_type))
 
     # generate a file response
     response = FileResponse(io.open(filepath, "rb"))
@@ -45,24 +139,12 @@ def download_csv_file(request, filename, facility_id):
     response["Content-Type"] = "text/csv"
 
     # set the content-disposition as attachment to force download
-    exported_filename = (
-        slugify(
-            pgettext(
-                "Default name for the exported CSV file of facility user data. Please keep the underscore between words in the translation",
-                "users_{}",
-            ).format(datetime.now().strftime("%Y%m%d_%H%M%S"))
-        ).replace("-", "_")
-        + ".csv"
-    )
-
-    # Append the facility name to the beginning of the filename
-    filename_with_facility = "{}_{}".format(facility_name, str(exported_filename))
     response["Content-Disposition"] = "attachment; filename={}".format(
-        filename_with_facility
+        str(csv_translated_filenames[csv_type]).format(facility.name, facility.id[:4])
     )
+    translation.deactivate()
 
     # set the content-length to the file size
     response["Content-Length"] = os.path.getsize(filepath)
-    translation.deactivate()
 
     return response


### PR DESCRIPTION
## Summary
* Consolidates 'download CSV' endpoints into the Facility plugin where they are used
* Moves exportlogsinfo endpoint into Facility plugin and expands remit to cover all exported CSV files
* Adds permissions checks and facility existence checks to both endpoints
* Adds permissions tests for the download CSV endpoint
* Updates the frontend to reference the single location for these endpoints and makes status checking consistent across session/summary log and user CSV exports

## References
Fixes #8256
Fixes #9656

## Reviewer guidance
Are the updates consistent in the frontend and backend?
Does the code refactoring seem suitable?


Note that this affects the Session/Summary Log and User Export CSV workflows and should be tested accordingly.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
