### PR TITLE
height = width in import cards on thumbnail, fix misaligned text

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -118,6 +118,7 @@
   .col-1 {
     display: flex;
     flex-grow: 0;
+    width: $thumbside;
     height: $thumbside;
     margin-right: 16px;
 


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixed issue with text not being aligned on cards during content import with @AllanOXDi 

There was not a width set, and our images are not forced to any particular aspect ratio by Studio (yet?) -- so we set a width there so the images all have an equal space to sit into.

![image](https://user-images.githubusercontent.com/6356129/186451427-2a385019-f249-45c7-957c-f1a70c0cf35f.png)

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #7751 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try to import from Studio on 0.15.x and see the misaligned images as noted in the linked issue.
- Checkout the release-v0.15.x branch locally and run the server
- Log in as your Super User account
- Go to the Device section (you should go there on login)
- Go to Import content, select Studio as the source
- See the cards listed out there, are they aligned as noted in the linked issue?

Then, checkout this branch/asset and see that the text and images are aligned.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided
