### PR TITLE
Update library and subpages landmarks

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -33,33 +33,33 @@
           >
         </template>
 
-      <template v-if="windowIsLarge" #navigation>
-        <slot name="sub-nav"></slot>
-      </template>
+        <template v-if="windowIsLarge" #navigation>
+          <slot name="sub-nav"></slot>
+        </template>
 
-      <template #actions>
-        <div>
-          <slot name="app-bar-actions"></slot>
-          <div class="total-points">
-            <slot name="totalPointsMenuItem"></slot>
-          </div>
-          <span v-if="isUserLoggedIn" tabindex="-1">
-            <KIcon
-              icon="person"
-              :style="{
-                fill: $themeTokens.textInverted,
-                height: '20px',
-                width: '20px',
-              }"
-            />
-            <span class="username">{{ usernameForDisplay }}</span>
-          </span>
+        <template #actions>
+          <div>
+            <slot name="app-bar-actions"></slot>
+            <div class="total-points">
+              <slot name="totalPointsMenuItem"></slot>
+            </div>
+            <span v-if="isUserLoggedIn" tabindex="-1">
+              <KIcon
+                icon="person"
+                :style="{
+                  fill: $themeTokens.textInverted,
+                  height: '20px',
+                  width: '20px',
+                }"
+              />
+              <span class="username">{{ usernameForDisplay }}</span>
+            </span>
 
           </div>
         </template>
       </UiToolbar>
     </header>
-    <div class="subpage-nav">
+    <div v-if="!windowIsLarge" class="subpage-nav">
       <slot name="sub-nav"></slot>
     </div>
   </div>

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -2,35 +2,36 @@
 
   <div v-show="!$isPrint" :style="{ backgroundColor: $themeTokens.appBar }">
 
-    <SkipNavigationLink />
+    <header>
+      <SkipNavigationLink />
 
-    <UiToolbar
-      :title="title"
-      type="clear"
-      textColor="white"
-      class="app-bar"
-      :style="{ height: topBarHeight + 'px' }"
-      :raised="false"
-      :removeBrandDivider="true"
-    >
-      <template #icon>
-        <KIconButton
-          icon="menu"
-          :color="$themeTokens.textInverted"
-          :ariaLabel="$tr('openNav')"
-          @click="$emit('toggleSideNav')"
-        />
-      </template>
+      <UiToolbar
+        :title="title"
+        type="clear"
+        textColor="white"
+        class="app-bar"
+        :style="{ height: topBarHeight + 'px' }"
+        :raised="false"
+        :removeBrandDivider="true"
+      >
+        <template #icon>
+          <KIconButton
+            icon="menu"
+            :color="$themeTokens.textInverted"
+            :ariaLabel="$tr('openNav')"
+            @click="$emit('toggleSideNav')"
+          />
+        </template>
 
-      <template #brand>
-        <img
-          v-if="themeConfig.appBar.topLogo"
-          :src="themeConfig.appBar.topLogo.src"
-          :alt="themeConfig.appBar.topLogo.alt"
-          :style="themeConfig.appBar.topLogo.style"
-          class="brand-logo"
-        >
-      </template>
+        <template #brand>
+          <img
+            v-if="themeConfig.appBar.topLogo"
+            :src="themeConfig.appBar.topLogo.src"
+            :alt="themeConfig.appBar.topLogo.alt"
+            :style="themeConfig.appBar.topLogo.style"
+            class="brand-logo"
+          >
+        </template>
 
       <template v-if="windowIsLarge" #navigation>
         <slot name="sub-nav"></slot>
@@ -54,10 +55,11 @@
             <span class="username">{{ usernameForDisplay }}</span>
           </span>
 
-        </div>
-      </template>
-    </UiToolbar>
-    <div v-if="!windowIsLarge" class="subpage-nav">
+          </div>
+        </template>
+      </UiToolbar>
+    </header>
+    <div class="subpage-nav">
       <slot name="sub-nav"></slot>
     </div>
   </div>

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -1,63 +1,65 @@
 <template>
 
-  <UiToolbar
-    :title="appBarTitle"
-    textColor="white"
-    type="clear"
-    :showIcon="showIcon"
-    :style="{
-      height: topBarHeight + 'px',
-      position: 'fixed',
-      zIndex: 4,
-      top: 0,
-      right: 0,
-      left: 0,
-      backgroundColor: isFullscreen ? $themeTokens.appBar : $themeTokens.appBarFullscreen,
-    }"
-    @nav-icon-click="$emit('navIconClick')"
-  >
-    <template #icon>
-      <router-link
-        v-if="hasRoute"
-        :to="route"
-        class="link"
-        :class="$computedClass(linkStyle)"
-      >
-        <!-- TODO add aria label? -->
-        <KIconButton
-          v-if="icon === 'close'"
-          :ariaLabel="coreString('closeAction')"
-          icon="close"
-          :color="$themeTokens.textInverted"
-          tabindex="-1"
-        />
-        <KIconButton
-          v-else
-          icon="back"
-          :ariaLabel="coreString('goBackAction')"
-          :color="$themeTokens.textInverted"
-        />
-      </router-link>
+  <header>
+    <UiToolbar
+      :title="appBarTitle"
+      textColor="white"
+      type="clear"
+      :showIcon="showIcon"
+      :style="{
+        height: topBarHeight + 'px',
+        position: 'fixed',
+        zIndex: 4,
+        top: 0,
+        right: 0,
+        left: 0,
+        backgroundColor: isFullscreen ? $themeTokens.appBar : $themeTokens.appBarFullscreen,
+      }"
+      @nav-icon-click="$emit('navIconClick')"
+    >
+      <template #icon>
+        <router-link
+          v-if="hasRoute"
+          :to="route"
+          class="link"
+          :class="$computedClass(linkStyle)"
+        >
+          <!-- TODO add aria label? -->
+          <KIconButton
+            v-if="icon === 'close'"
+            :ariaLabel="coreString('closeAction')"
+            icon="close"
+            :color="$themeTokens.textInverted"
+            tabindex="-1"
+          />
+          <KIconButton
+            v-else
+            icon="back"
+            :ariaLabel="coreString('goBackAction')"
+            :color="$themeTokens.textInverted"
+          />
+        </router-link>
 
-      <span v-else>
-        <KIconButton
-          v-if="icon === 'close'"
-          :ariaLabel="coreString('closeAction')"
-          icon="close"
-          :color="$themeTokens.textInverted"
-          tabindex="-1"
-          @click="$emit('navIconClick')"
-        />
-        <KIconButton
-          v-else
-          icon="back"
-          :ariaLabel="coreString('goBackAction')"
-          :color="$themeTokens.textInverted"
-          @click="$emit('navIconClick')"
-        />
-      </span>
-    </template>
-  </UiToolbar>
+        <span v-else>
+          <KIconButton
+            v-if="icon === 'close'"
+            :ariaLabel="coreString('closeAction')"
+            icon="close"
+            :color="$themeTokens.textInverted"
+            tabindex="-1"
+            @click="$emit('navIconClick')"
+          />
+          <KIconButton
+            v-else
+            icon="back"
+            :ariaLabel="coreString('goBackAction')"
+            :color="$themeTokens.textInverted"
+            @click="$emit('navIconClick')"
+          />
+        </span>
+      </template>
+    </UiToolbar>
+  </header>
 
 </template>
 

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <nav>
+  <nav :aria-label="ariaLabel">
     <ul
       ref="navbarUl"
       class="items"

--- a/kolibri/core/assets/src/views/NotificationsRoot.vue
+++ b/kolibri/core/assets/src/views/NotificationsRoot.vue
@@ -17,7 +17,7 @@
       </KPageContainer>
     </AppBarPage>
 
-    <div v-else role="main" tabindex="-1" data-test="main">
+    <div v-else tabindex="-1" data-test="base-page">
       <slot :loading="loading"></slot>
     </div>
 

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -397,7 +397,7 @@
     },
     $trs: {
       navigationLabel: {
-        message: 'Main user navigation',
+        message: 'Main user menu',
         context:
           'Refers to the main side navigation bar. The message is providing additional context to the screen-reader users, but is not visible in the Kolibri UI.',
       },

--- a/kolibri/core/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/core/assets/src/views/SidePanelModal/index.vue
@@ -11,7 +11,7 @@
         @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
         @shouldFocusLastEl="focusLastEl"
       >
-        <div
+        <aside
           class="side-panel"
           :style="sidePanelStyles"
         >
@@ -43,7 +43,7 @@
             <slot></slot>
           </div>
 
-        </div>
+        </aside>
       </FocusTrap>
     </transition>
 

--- a/kolibri/core/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/core/assets/src/views/SidePanelModal/index.vue
@@ -11,9 +11,10 @@
         @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
         @shouldFocusLastEl="focusLastEl"
       >
-        <aside
+        <section
           class="side-panel"
           :style="sidePanelStyles"
+          :ariaLabel="learnString('filterAndSearchLabel')"
         >
 
           <!-- Fixed header -->
@@ -43,7 +44,7 @@
             <slot></slot>
           </div>
 
-        </aside>
+        </section>
       </FocusTrap>
     </transition>
 
@@ -63,6 +64,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import FocusTrap from 'kolibri.coreVue.components.FocusTrap';
+  import commonLearnStrings from '../../../../../plugins/learn/assets/src/views/commonLearnStrings.js';
 
   export default {
     name: 'SidePanelModal',
@@ -70,7 +72,7 @@
       Backdrop,
       FocusTrap,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
     props: {
       /* CloseButtonIconType icon from parent component */
       closeButtonIconType: {

--- a/kolibri/core/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/core/assets/src/views/SidePanelModal/index.vue
@@ -13,8 +13,9 @@
       >
         <section
           class="side-panel"
+          role="region"
           :style="sidePanelStyles"
-          :ariaLabel="learnString('filterAndSearchLabel')"
+          :aria-label="learnString('filterAndSearchLabel')"
         >
 
           <!-- Fixed header -->

--- a/kolibri/core/assets/test/views/NotificationsRoot.spec.js
+++ b/kolibri/core/assets/test/views/NotificationsRoot.spec.js
@@ -31,17 +31,17 @@ describe('NotificationsRoot', function() {
   });
 
   describe('when loaded', function() {
-    it('if user is authorized and there is no error, main div for displaying <slot> should be displayed', async () => {
+    it('if user is authorized and there is no error, base div for displaying <slot> should be displayed', async () => {
       const { wrapper, store } = makeWrapper();
       store.state.core.loading = false;
       await wrapper.vm.$nextTick();
 
-      expect(wrapper.find('[data-test="main"]').exists()).toBeTruthy();
+      expect(wrapper.find('[data-test="base-page"]').exists()).toBeTruthy();
       expect(wrapper.findComponent({ name: 'AuthMessage' }).exists()).toBeFalsy();
       expect(wrapper.findComponent({ name: 'AppError' }).exists()).toBeFalsy();
     });
 
-    it('if user is not authorized, authorization component in the main page should be rendered', async () => {
+    it('if user is not authorized, authorization component in the base page page should be rendered', async () => {
       const { wrapper, store } = makeWrapper();
       store.state.core.loading = false;
       store.state.core.error = { response: { status: 403 } };
@@ -52,7 +52,7 @@ describe('NotificationsRoot', function() {
       expect(wrapper.find('[data-test="main"]').exists()).toBeFalsy();
     });
 
-    it('if there is an error, the error component in the main page should be rendered', async () => {
+    it('if there is an error, the error component in the base page should be rendered', async () => {
       const { wrapper, store } = makeWrapper();
       store.state.core.loading = false;
       store.state.core.error = 'some error here';
@@ -60,7 +60,7 @@ describe('NotificationsRoot', function() {
 
       expect(wrapper.findComponent({ name: 'AppError' }).exists()).toBeTruthy();
       expect(wrapper.findComponent({ name: 'AuthMessage' }).exists()).toBeFalsy();
-      expect(wrapper.find('[data-test="main"]').exists()).toBeFalsy();
+      expect(wrapper.find('[data-test="base-page"]').exists()).toBeFalsy();
     });
 
     it('notification modal should be rendered if the user is an admin/superuser, a notification exists, and there is a recent notification', async () => {

--- a/kolibri/locale/en/LC_MESSAGES/default_frontend-messages.json
+++ b/kolibri/locale/en/LC_MESSAGES/default_frontend-messages.json
@@ -123,7 +123,7 @@
   "ReportErrorModal.reportErrorHeader": "Report Error",
   "SideNav.closeNav": "Close navigation",
   "SideNav.kolibri": "Kolibri",
-  "SideNav.navigationLabel": "Main user navigation",
+  "SideNav.navigationLabel": "Main user menu",
   "SideNav.poweredBy": "Kolibri {version}",
   "SideNav.privacyLink": "Usage and privacy",
   "TechnicalTextBlock.copiedToClipboardConfirmation": "Copied to clipboard",

--- a/kolibri/locale/en/LC_MESSAGES/kolibri.core.default_frontend-messages.json
+++ b/kolibri/locale/en/LC_MESSAGES/kolibri.core.default_frontend-messages.json
@@ -471,7 +471,7 @@
   "ShortLicenseNames.Public Domain": "Public domain",
   "ShortLicenseNames.Special Permissions": "Special permissions",
   "SideNav.closeNav": "Close navigation",
-  "SideNav.navigationLabel": "Main user navigation",
+  "SideNav.navigationLabel": "Main user menu",
   "SideNav.poweredBy": "Kolibri {version}",
   "SkipNavigationLink.skipToMainContentAction": "Skip to main content",
   "SuggestedTime.suggestedTimeLabel": "Suggested time to complete",

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -1,37 +1,40 @@
 <template>
 
   <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
-    <h1>
-      {{ $tr('bookmarksHeader') }}
-    </h1>
-    <p v-if="!bookmarks.length && !loading">
-      {{ $tr('noBookmarks') }}
-    </p>
+    <div id="main" role="main">
 
-    <CardList
-      v-for="content in bookmarks"
-      v-else
-      :key="content.id"
-      :content="content"
-      class="card-grid-item"
-      :isMobile="windowIsSmall"
-      :link="genContentLink(content)"
-      :footerIcons="footerIcons"
-      :createdDate="content.bookmark ? content.bookmark.created : null"
-      @viewInformation="toggleInfoPanel(content)"
-      @removeFromBookmarks="removeFromBookmarks(content.bookmark)"
-    />
+      <h1>
+        {{ $tr('bookmarksHeader') }}
+      </h1>
+      <p v-if="!bookmarks.length && !loading">
+        {{ $tr('noBookmarks') }}
+      </p>
 
-    <KButton
-      v-if="more && !loading"
-      data-test="load-more-button"
-      :text="coreString('viewMoreAction')"
-      @click="loadMore"
-    />
-    <KCircularLoader
-      v-else-if="loading"
-      :delay="false"
-    />
+      <CardList
+        v-for="content in bookmarks"
+        v-else
+        :key="content.id"
+        :content="content"
+        class="card-grid-item"
+        :isMobile="windowIsSmall"
+        :link="genContentLink(content)"
+        :footerIcons="footerIcons"
+        :createdDate="content.bookmark ? content.bookmark.created : null"
+        @viewInformation="toggleInfoPanel(content)"
+        @removeFromBookmarks="removeFromBookmarks(content.bookmark)"
+      />
+
+      <KButton
+        v-if="more && !loading"
+        data-test="load-more-button"
+        :text="coreString('viewMoreAction')"
+        @click="loadMore"
+      />
+      <KCircularLoader
+        v-else-if="loading"
+        :delay="false"
+      />
+    </div>
 
     <!-- Side panel for showing the information of selected content with a link to view it -->
     <SidePanelModal

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -1,29 +1,31 @@
 <template>
 
-  <ul class="history-list">
-    <li
-      v-for="(question, index) in questions"
-      :key="index"
-      :ref="`item-${index}`"
-      class="list-item"
-    >
-      <button
-        :class="buttonClass(index)"
-        :disabled="questionNumber === index"
-        class="clickable"
-        @click="$emit('goToQuestion', index)"
+  <div :aria-label="$tr('jumpToQuestion')" role="navigation">
+    <ul class="history-list">
+      <li
+        v-for="(question, index) in questions"
+        :key="index"
+        :ref="`item-${index}`"
+        class="list-item"
       >
-        <KIcon
-          class="dot"
-          icon="notStarted"
-          :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
-        />
-        <div class="text">
-          {{ questionText(index + 1) }}
-        </div>
-      </button>
-    </li>
-  </ul>
+        <button
+          :class="buttonClass(index)"
+          :disabled="questionNumber === index"
+          class="clickable"
+          @click="$emit('goToQuestion', index)"
+        >
+          <KIcon
+            class="dot"
+            icon="notStarted"
+            :color="isAnswered(question) ? $themeTokens.progress : $themeTokens.textDisabled"
+          />
+          <div class="text">
+            {{ questionText(index + 1) }}
+          </div>
+        </button>
+      </li>
+    </ul>
+  </div>
 
 </template>
 
@@ -98,6 +100,11 @@
         message: 'Question { num, number, integer}',
         context:
           "In the report section, the 'Answer history' shows the learner if they have answered questions correctly or incorrectly.\n\nOnly translate 'Question'.",
+      },
+      jumpToQuestion: {
+        message: 'Jump to question',
+        context:
+          'A label for the section of the page that contains all questions as clickable links',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -12,7 +12,7 @@
         :layout12="{ span: 4 }"
         class="column-pane"
       >
-        <section class="column-contents-wrapper" :ariaLabel="$tr('information')">
+        <div class="column-contents-wrapper">
           <KPageContainer>
             <div>
               <p>{{ coreString('timeSpentLabel') }}</p>
@@ -34,7 +34,6 @@
             >
             </span>
             <AnswerHistory
-              :ariaLabel="$tr('jumpToQuestion')"
               :pastattempts="pastattempts"
               :questions="questions"
               :questionNumber="questionNumber"
@@ -42,11 +41,11 @@
               @goToQuestion="goToQuestion"
             />
           </KPageContainer>
-        </section>
+        </div>
       </KGridItem>
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
         <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
-          <KPageContainer v-if="!loading">
+          <KPageContainer>
             <h1>
               {{ $tr('question', { num: questionNumber + 1, total: exam.question_count }) }}
             </h1>
@@ -456,16 +455,6 @@
         message: 'Submit quiz',
         context:
           'Action that learner takes to submit their quiz answers so that the coach can review them.',
-      },
-      jumpToQuestion: {
-        message: 'Jump to question',
-        context:
-          'A label for the section of the page that contains all questions as clickable links',
-      },
-      information: {
-        message: 'Information',
-        context:
-          'A label for the section of the page that contains details about the currently in progress quiz',
       },
       questionsAnswered: {
         message:

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -12,7 +12,7 @@
         :layout12="{ span: 4 }"
         class="column-pane"
       >
-        <div class="column-contents-wrapper">
+        <aside class="column-contents-wrapper" :ariaLabel="$tr('information')">
           <KPageContainer>
             <div>
               <p>{{ coreString('timeSpentLabel') }}</p>
@@ -34,6 +34,7 @@
             >
             </span>
             <AnswerHistory
+              :ariaLabel="$tr('jumpToQuestion')"
               :pastattempts="pastattempts"
               :questions="questions"
               :questionNumber="questionNumber"
@@ -41,10 +42,10 @@
               @goToQuestion="goToQuestion"
             />
           </KPageContainer>
-        </div>
+        </aside>
       </KGridItem>
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
-        <div :class="{ 'column-contents-wrapper': !windowIsSmall }">
+        <main :class="{ 'column-contents-wrapper': !windowIsSmall }">
           <KPageContainer v-if="!loading">
             <h1>
               {{ $tr('question', { num: questionNumber + 1, total: exam.question_count }) }}
@@ -142,7 +143,7 @@
               />
             </div>
           </KPageContainer>
-        </div>
+        </main>
       </KGridItem>
     </KGrid>
 
@@ -455,6 +456,16 @@
         message: 'Submit quiz',
         context:
           'Action that learner takes to submit their quiz answers so that the coach can review them.',
+      },
+      jumpToQuestion: {
+        message: 'Jump to question',
+        context:
+          'A label for the section of the page that contains all questions as clickable links',
+      },
+      information: {
+        message: 'Information',
+        context:
+          'A label for the section of the page that contains details about the currently in progress quiz',
       },
       questionsAnswered: {
         message:

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -12,7 +12,7 @@
         :layout12="{ span: 4 }"
         class="column-pane"
       >
-        <aside class="column-contents-wrapper" :ariaLabel="$tr('information')">
+        <section class="column-contents-wrapper" :ariaLabel="$tr('information')">
           <KPageContainer>
             <div>
               <p>{{ coreString('timeSpentLabel') }}</p>
@@ -42,7 +42,7 @@
               @goToQuestion="goToQuestion"
             />
           </KPageContainer>
-        </aside>
+        </section>
       </KGridItem>
       <KGridItem :layout12="{ span: 8 }" class="column-pane">
         <main :class="{ 'column-contents-wrapper': !windowIsSmall }">

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -4,7 +4,7 @@
     :appBarTitle="learnString('learnLabel')"
     :loading="loading"
   >
-    <div v-if="!loading">
+    <main v-if="!loading">
       <YourClasses
         v-if="displayClasses"
         class="section"
@@ -48,7 +48,7 @@
         "
       />
 
-    </div>
+    </main>
   </LearnAppBarPage>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -4,7 +4,7 @@
     :appBarTitle="learnString('learnLabel')"
     :loading="loading"
   >
-    <main v-if="!loading">
+    <div v-if="!loading" id="main" role="main">
       <YourClasses
         v-if="displayClasses"
         class="section"
@@ -48,7 +48,7 @@
         "
       />
 
-    </main>
+    </div>
   </LearnAppBarPage>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -7,7 +7,7 @@
   >
 
     <template #subNav>
-      <LearnTopNav ref="topNav" />
+      <LearnTopNav ref="topNav" :ariaLabel="$tr('learnPageMenuLabel')" />
     </template>
 
     <slot></slot>
@@ -40,6 +40,12 @@
       loading: {
         type: Boolean,
         default: null,
+      },
+    },
+    $trs: {
+      learnPageMenuLabel: {
+        message: 'Learn page menu',
+        context: 'Indicates the purpose of a navigation bar at the top of the page',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -7,7 +7,7 @@
   >
 
     <template #subNav>
-      <LearnTopNav ref="topNav" :ariaLabel="$tr('learnPageMenuLabel')" />
+      <LearnTopNav ref="topNav" />
     </template>
 
     <slot></slot>
@@ -40,12 +40,6 @@
       loading: {
         type: Boolean,
         default: null,
-      },
-    },
-    $trs: {
-      learnPageMenuLabel: {
-        message: 'Learn page menu',
-        context: 'Indicates the purpose of a navigation bar at the top of the page',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <Navbar>
+  <Navbar :ariaLabel="$tr('learnPageMenuLabel')">
     <NavbarLink
       v-if="isUserLoggedIn"
       :title="coreString('homeLabel')"
@@ -75,6 +75,12 @@
     },
     computed: {
       ...mapGetters(['isUserLoggedIn', 'canAccessUnassignedContent']),
+    },
+    $trs: {
+      learnPageMenuLabel: {
+        message: 'Learn page menu',
+        context: 'Indicates the purpose of a navigation bar at the top of the page',
+      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <nav :ariaLabel="$tr('contentMenuLabel')">
+  <nav :aria-label="$tr('optionsLabel')">
     <UiToolbar style="z-index: 8;" :style="contentSpecificStyles" class="toolbar">
       <CoachContentLabel
         :value="isCoachContent"
@@ -455,9 +455,9 @@
         message: 'View folder resources',
         context: 'Tooltip text.',
       },
-      contentMenuLabel: {
-        message: 'Content page menu label',
-        context: 'A label for the section of the page containing menu links',
+      optionsLabel: {
+        message: 'Options',
+        context: 'A label for the section of the page containing toolbar buttons',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -1,131 +1,133 @@
 <template>
 
-  <UiToolbar style="z-index: 8;" :style="contentSpecificStyles" class="toolbar">
-    <CoachContentLabel
-      :value="isCoachContent"
-      style="margin-top: 8px; width: auto;"
-    />
-    <KLabeledIcon :style="{ 'margin-top': '8px' }">
+  <nav :ariaLabel="$tr('contentMenuLabel')">
+    <UiToolbar style="z-index: 8;" :style="contentSpecificStyles" class="toolbar">
+      <CoachContentLabel
+        :value="isCoachContent"
+        style="margin-top: 8px; width: auto;"
+      />
+      <KLabeledIcon :style="{ 'margin-top': '8px' }">
+        <template #icon>
+          <LearningActivityIcon
+            data-test="learningActivityIcon"
+            :kind="learningActivities"
+            :shaded="true"
+          />
+        </template>
+        <TextTruncatorCss
+          :text="resourceTitle"
+          :maxLines="1"
+        />
+      </KLabeledIcon>
+      <ProgressIcon :progress="contentProgress" class="progress-icon" />
+
       <template #icon>
-        <LearningActivityIcon
-          data-test="learningActivityIcon"
-          :kind="learningActivities"
-          :shaded="true"
+        <KIconButton
+          icon="back"
+          data-test="backButton"
+          :tooltip="$tr('goBack')"
+          :ariaLabel="$tr('goBack')"
+          @click="onBackButtonClick"
         />
       </template>
-      <TextTruncatorCss
-        :text="resourceTitle"
-        :maxLines="1"
-      />
-    </KLabeledIcon>
-    <ProgressIcon :progress="contentProgress" class="progress-icon" />
 
-    <template #icon>
-      <KIconButton
-        icon="back"
-        data-test="backButton"
-        :tooltip="$tr('goBack')"
-        :ariaLabel="$tr('goBack')"
-        @click="onBackButtonClick"
-      />
-    </template>
-
-    <template #actions>
-      <KIconButton
-        v-if="isQuiz && !showingReportState"
-        ref="timerButton"
-        data-test="timerButton"
-        icon="timer"
-        :tooltip="coreString('timeSpentLabel')"
-        :ariaLabel="coreString('timeSpentLabel')"
-        @click="toggleTimer"
-      />
-      <CoreMenu
-        v-show="isTimerOpen"
-        ref="timer"
-        class="menu"
-        :style="{ left: isRtl ? '16px' : 'auto', right: isRtl ? 'auto' : '16px' }"
-        :raised="true"
-        :isOpen="isTimerOpen"
-        :containFocus="true"
-        @close="closeTimer"
-      >
-        <template #options>
-          <div class="timer-display">
-            <div>
-              <strong>{{ coreString('timeSpentLabel') }}</strong>
-            </div>
-            <div :style="{ paddingBottom: '8px' }">
-              <TimeDuration :seconds="timeSpent" />
-            </div>
-            <div v-if="duration">
-              <strong>{{ learnString('suggestedTime') }}</strong>
-            </div>
-            <SuggestedTime v-if="duration" :seconds="duration" />
-          </div>
-        </template>
-      </CoreMenu>
-      <KIconButton
-        v-for="action in barActions"
-        :key="action.id"
-        :data-test="`bar_${action.dataTest}`"
-        :icon="action.icon"
-        :color="action.iconColor"
-        :tooltip="action.label"
-        :ariaLabel="action.label"
-        :disabled="action.disabled"
-        @click="onActionClick(action.event)"
-      />
-
-      <span class="menu-wrapper">
+      <template #actions>
         <KIconButton
-          v-if="menuActions.length"
-          ref="moreOptionsButton"
-          data-test="moreOptionsButton"
-          icon="optionsHorizontal"
-          :tooltip="$tr('moreOptions')"
-          :ariaLabel="$tr('moreOptions')"
-          @click="toggleMenu"
+          v-if="isQuiz && !showingReportState"
+          ref="timerButton"
+          data-test="timerButton"
+          icon="timer"
+          :tooltip="coreString('timeSpentLabel')"
+          :ariaLabel="coreString('timeSpentLabel')"
+          @click="toggleTimer"
         />
         <CoreMenu
-          v-show="isMenuOpen"
-          ref="menu"
+          v-show="isTimerOpen"
+          ref="timer"
           class="menu"
           :style="{ left: isRtl ? '16px' : 'auto', right: isRtl ? 'auto' : '16px' }"
           :raised="true"
-          :isOpen="isMenuOpen"
+          :isOpen="isTimerOpen"
           :containFocus="true"
-          @close="closeMenu"
-          @shouldFocusFirstEl="findFirstEl()"
+          @close="closeTimer"
         >
           <template #options>
-            <CoreMenuOption
-              v-for="action in menuActions"
-              :key="action.id"
-              :data-test="`menu_${action.dataTest}`"
-              :style="{ 'cursor': 'pointer' }"
-              @select="onActionClick(action.event)"
-            >
-              <KLabeledIcon>
-                <template #icon>
-                  <KIcon
-                    :icon="action.icon"
-                    :color="action.iconColor"
-                  />
-                </template>
-                <div>{{ action.label }}</div>
-              </KLabeledIcon>
-            </CoreMenuOption>
+            <div class="timer-display">
+              <div>
+                <strong>{{ coreString('timeSpentLabel') }}</strong>
+              </div>
+              <div :style="{ paddingBottom: '8px' }">
+                <TimeDuration :seconds="timeSpent" />
+              </div>
+              <div v-if="duration">
+                <strong>{{ learnString('suggestedTime') }}</strong>
+              </div>
+              <SuggestedTime v-if="duration" :seconds="duration" />
+            </div>
           </template>
         </CoreMenu>
-      </span>
-    </template>
-    <MarkAsCompleteModal
-      v-if="showMarkAsCompleteModal && allowMarkComplete"
-      @complete="showMarkAsCompleteModal = false"
-      @cancel="showMarkAsCompleteModal = false"
-    />
-  </UiToolbar>
+        <KIconButton
+          v-for="action in barActions"
+          :key="action.id"
+          :data-test="`bar_${action.dataTest}`"
+          :icon="action.icon"
+          :color="action.iconColor"
+          :tooltip="action.label"
+          :ariaLabel="action.label"
+          :disabled="action.disabled"
+          @click="onActionClick(action.event)"
+        />
+
+        <span class="menu-wrapper">
+          <KIconButton
+            v-if="menuActions.length"
+            ref="moreOptionsButton"
+            data-test="moreOptionsButton"
+            icon="optionsHorizontal"
+            :tooltip="$tr('moreOptions')"
+            :ariaLabel="$tr('moreOptions')"
+            @click="toggleMenu"
+          />
+          <CoreMenu
+            v-show="isMenuOpen"
+            ref="menu"
+            class="menu"
+            :style="{ left: isRtl ? '16px' : 'auto', right: isRtl ? 'auto' : '16px' }"
+            :raised="true"
+            :isOpen="isMenuOpen"
+            :containFocus="true"
+            @close="closeMenu"
+            @shouldFocusFirstEl="findFirstEl()"
+          >
+            <template #options>
+              <CoreMenuOption
+                v-for="action in menuActions"
+                :key="action.id"
+                :data-test="`menu_${action.dataTest}`"
+                :style="{ 'cursor': 'pointer' }"
+                @select="onActionClick(action.event)"
+              >
+                <KLabeledIcon>
+                  <template #icon>
+                    <KIcon
+                      :icon="action.icon"
+                      :color="action.iconColor"
+                    />
+                  </template>
+                  <div>{{ action.label }}</div>
+                </KLabeledIcon>
+              </CoreMenuOption>
+            </template>
+          </CoreMenu>
+        </span>
+      </template>
+      <MarkAsCompleteModal
+        v-if="showMarkAsCompleteModal && allowMarkComplete"
+        @complete="showMarkAsCompleteModal = false"
+        @cancel="showMarkAsCompleteModal = false"
+      />
+    </UiToolbar>
+  </nav>
 
 </template>
 
@@ -452,6 +454,10 @@
       viewTopicResources: {
         message: 'View folder resources',
         context: 'Tooltip text.',
+      },
+      contentMenuLabel: {
+        message: 'Content page menu label',
+        context: 'A label for the section of the page containing menu links',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
@@ -3,7 +3,7 @@
   <!-- This v-if ensures we don't render an unnecessary empty div
     something will always be showing if one of these is true
   -->
-  <div v-if="windowIsLarge || mobileSidePanelIsOpen">
+  <aside v-if="windowIsLarge || mobileSidePanelIsOpen">
     <!-- Embedded Side panel is on larger views, and exists next to content -->
     <SearchFiltersPanel
       v-if="windowIsLarge"
@@ -73,7 +73,7 @@
       @cancel="currentCategory = null"
       @input="handleCategory"
     />
-  </div>
+  </aside>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
@@ -3,7 +3,10 @@
   <!-- This v-if ensures we don't render an unnecessary empty div
     something will always be showing if one of these is true
   -->
-  <aside v-if="windowIsLarge || mobileSidePanelIsOpen">
+  <section
+    v-if="windowIsLarge || mobileSidePanelIsOpen"
+    :ariaLabel="learnString('filterAndSearchLabel')"
+  >
     <!-- Embedded Side panel is on larger views, and exists next to content -->
     <SearchFiltersPanel
       v-if="windowIsLarge"
@@ -73,7 +76,7 @@
       @cancel="currentCategory = null"
       @input="handleCategory"
     />
-  </aside>
+  </section>
 
 </template>
 
@@ -86,6 +89,7 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CategorySearchModal from '../CategorySearchModal';
   import SearchFiltersPanel from '../SearchFiltersPanel';
+  import commonLearnStrings from './../commonLearnStrings';
 
   export default {
     name: 'SidePanel',
@@ -94,7 +98,7 @@
       SearchFiltersPanel,
       SidePanelModal,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     /* eslint-disable-next-line no-unused-vars */
     setup(props, context) {
       var currentCategory = ref(null);

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
@@ -3,9 +3,8 @@
   <!-- This v-if ensures we don't render an unnecessary empty div
     something will always be showing if one of these is true
   -->
-  <section
+  <div
     v-if="windowIsLarge || mobileSidePanelIsOpen"
-    :ariaLabel="learnString('filterAndSearchLabel')"
   >
     <!-- Embedded Side panel is on larger views, and exists next to content -->
     <SearchFiltersPanel
@@ -76,7 +75,7 @@
       @cancel="currentCategory = null"
       @input="handleCategory"
     />
-  </section>
+  </div>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div
+  <aside
     :style="{
       color: $themeTokens.text,
       backgroundColor: $themeTokens.surface,
@@ -126,7 +126,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </aside>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <aside
+  <div
     :style="{
       color: $themeTokens.text,
       backgroundColor: $themeTokens.surface,
@@ -126,7 +126,7 @@
         </div>
       </div>
     </div>
-  </aside>
+  </div>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <div
+  <section
+    role="region"
+    :aria-label="learnString('filterAndSearchLabel')"
     :style="{
       color: $themeTokens.text,
       backgroundColor: $themeTokens.surface,
@@ -126,7 +128,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </section>
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
@@ -1,0 +1,176 @@
+<template>
+
+  <div
+    v-show="!$isPrint"
+    class="tab-block"
+    :style="{
+      borderBottomColor: !$isPrint ? $themeTokens.fineLine : 'transparent',
+    }"
+  >
+    <router-link
+      v-if="topics.length && windowIsLarge"
+      :to="foldersLink"
+      class="header-tab"
+      :activeClass="activeTabClasses"
+      :style="{ color: $themeTokens.annotation }"
+      :replace="true"
+      :class="defaultTabStyles"
+    >
+      <div class="inner" :style="{ borderColor: this.$themeTokens.primary }">
+        {{ coreString('folders') }}
+      </div>
+    </router-link>
+
+    <router-link
+      v-if="windowIsLarge"
+      :to="topics.length ? searchTabLink : {}"
+      class="header-tab"
+      :activeClass="activeTabClasses"
+      :style="{ color: $themeTokens.annotation }"
+      :replace="true"
+      :class="defaultTabStyles"
+    >
+      <div class="inner" :style="{ borderColor: this.$themeTokens.primary }">
+        {{ coreString('searchLabel') }}
+      </div>
+    </router-link>
+  </div>
+
+</template>
+
+
+<script>
+
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { PageNames } from '../../constants';
+
+  export default {
+    name: 'ToggleHeaderTabs',
+    mixins: [responsiveWindowMixin, commonCoreStrings],
+    props: {
+      topic: {
+        type: Object,
+        required: true,
+      },
+      topics: {
+        type: Array,
+        default() {
+          return [];
+        },
+      },
+    },
+    computed: {
+      // for folder and search tabs
+      activeTabClasses() {
+        // return both fixed and dynamic classes
+        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
+      },
+      defaultTabStyles() {
+        return this.$computedClass({
+          ':focus': this.$coreOutline,
+          ':hover': {
+            backgroundColor: this.$themePalette.grey.v_300,
+          },
+        });
+      },
+      foldersLink() {
+        if (this.topic) {
+          return {
+            name: PageNames.TOPICS_TOPIC,
+            id: this.topic.id,
+          };
+        }
+        return {};
+      },
+      searchTabLink() {
+        // navigates the main page to the search view
+        if (this.topic) {
+          const query = { ...this.$route.query };
+          delete query.dropdown;
+          return {
+            name: PageNames.TOPICS_TOPIC_SEARCH,
+            id: this.topic.id,
+            query: query,
+          };
+        }
+        return {};
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  // Stolen from Coach HeaderTab(s) components
+  .tab-block {
+    position: fixed;
+    top: 324px;
+  }
+
+  .header-tab {
+    display: inline-table; // helps with vertical layout
+    min-width: 64px;
+    max-width: 100%;
+    min-height: 36px;
+    margin-left: 24px;
+    overflow: hidden;
+    font-size: 14px;
+    font-weight: bold;
+    line-height: 36px;
+    text-align: center;
+    text-decoration: none;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+    border: 0;
+    border-style: solid;
+    border-width: 0;
+    border-top-left-radius: $radius;
+    border-top-right-radius: $radius;
+    outline: none;
+    transition: background-color $core-time ease;
+
+    @media print {
+      min-width: 0;
+      min-height: 0;
+      margin: 0;
+      font-size: inherit;
+      line-height: inherit;
+      text-align: left;
+      text-transform: none;
+
+      &:not(.router-link-active) {
+        display: none;
+      }
+    }
+  }
+
+  .search-panel {
+    margin: 24px;
+  }
+
+  .inner {
+    padding: 16px;
+    margin-bottom: 2px;
+    border-style: solid;
+    border-width: 0;
+  }
+
+  .router-link-active .inner {
+    margin-bottom: 0;
+    border-bottom-width: 2px;
+
+    @media print {
+      padding: 0;
+      border-bottom-width: 0;
+    }
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -16,7 +16,11 @@
         :layout8="{ span: 8 }"
         :layout12="{ span: 12 }"
       >
-        <KBreadcrumbs v-if="breadcrumbs.length" :items="breadcrumbs" />
+        <KBreadcrumbs
+          v-if="breadcrumbs.length"
+          :items="breadcrumbs"
+          :ariaLabel="learnString('channelAndFoldersLabel')"
+        />
       </KGridItem>
       <KGridItem
         :layout4="{ span: 4, alignment: 'auto' }"
@@ -63,41 +67,6 @@
       </KGridItem>
     </KGrid>
 
-    <!-- Nested tabs within the header, for toggling sidebar options -->
-    <!-- large screens -->
-    <div
-      v-show="!$isPrint"
-      class="tab-block"
-      :style="{ borderBottomColor: !$isPrint ? $themeTokens.fineLine : 'transparent' }"
-    >
-      <router-link
-        v-if="topics.length && windowIsLarge"
-        :to="foldersLink"
-        class="header-tab"
-        :activeClass="activeTabClasses"
-        :style="{ color: $themeTokens.annotation }"
-        :replace="true"
-        :class="defaultTabStyles"
-      >
-        <div class="inner" :style="{ borderColor: this.$themeTokens.primary }">
-          {{ coreString('folders') }}
-        </div>
-      </router-link>
-
-      <router-link
-        v-if="windowIsLarge"
-        :to="topics.length ? searchTabLink : {}"
-        class="header-tab"
-        :activeClass="activeTabClasses"
-        :style="{ color: $themeTokens.annotation }"
-        :replace="true"
-        :class="defaultTabStyles"
-      >
-        <div class="inner" :style="{ borderColor: this.$themeTokens.primary }">
-          {{ coreString('searchLabel') }}
-        </div>
-      </router-link>
-    </div>
 
   </div>
 
@@ -106,12 +75,12 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
   import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
-  import { PageNames } from '../../constants';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CardThumbnail from '../ContentCard/CardThumbnail';
+  import commonLearnStrings from './../commonLearnStrings';
 
   export default {
     name: 'TopicsHeader',
@@ -120,55 +89,15 @@
       KBreadcrumbs,
       TextTruncator,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
     props: {
       topic: {
         type: Object,
         required: true,
       },
-      topics: {
-        type: Array,
-        required: true,
-      },
       breadcrumbs: {
         type: Array,
         required: true,
-      },
-    },
-    computed: {
-      activeTabClasses() {
-        // return both fixed and dynamic classes
-        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
-      },
-      defaultTabStyles() {
-        return this.$computedClass({
-          ':focus': this.$coreOutline,
-          ':hover': {
-            backgroundColor: this.$themePalette.grey.v_300,
-          },
-        });
-      },
-      foldersLink() {
-        if (this.topic) {
-          return {
-            name: PageNames.TOPICS_TOPIC,
-            id: this.topic.id,
-          };
-        }
-        return {};
-      },
-      searchTabLink() {
-        // navigates the main page to the search view
-        if (this.topic) {
-          const query = { ...this.$route.query };
-          delete query.dropdown;
-          return {
-            name: PageNames.TOPICS_TOPIC_SEARCH,
-            id: this.topic.id,
-            query: query,
-          };
-        }
-        return {};
       },
     },
   };
@@ -195,72 +124,6 @@
 
   .title {
     margin: 8px 0 16px;
-  }
-
-  // Stolen from Coach HeaderTab(s) components
-  .tab-block {
-    position: absolute;
-    bottom: 0;
-    margin-bottom: 0;
-  }
-
-  .header-tab {
-    position: relative;
-    top: 9px;
-    display: inline-table; // helps with vertical layout
-    min-width: 64px;
-    max-width: 100%;
-    min-height: 36px;
-    margin: 8px;
-    overflow: hidden;
-    font-size: 14px;
-    font-weight: bold;
-    line-height: 36px;
-    text-align: center;
-    text-decoration: none;
-    text-overflow: ellipsis;
-    text-transform: uppercase;
-    white-space: nowrap;
-    cursor: pointer;
-    user-select: none;
-    border: 0;
-    border-style: solid;
-    border-width: 0;
-    border-top-left-radius: $radius;
-    border-top-right-radius: $radius;
-    outline: none;
-    transition: background-color $core-time ease;
-
-    @media print {
-      min-width: 0;
-      min-height: 0;
-      margin: 0;
-      font-size: inherit;
-      line-height: inherit;
-      text-align: left;
-      text-transform: none;
-
-      &:not(.router-link-active) {
-        display: none;
-      }
-    }
-  }
-
-  .inner {
-    padding: 16px;
-    margin-bottom: 2px;
-    border-style: solid;
-    border-width: 0;
-  }
-
-  .router-link-active .inner {
-    margin-bottom: 0;
-    border-bottom-width: 2px;
-
-    @media print {
-      padding: 0;
-      border-bottom-width: 0;
-    }
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -36,6 +36,7 @@
           v-if="breadcrumbs.length && windowIsSmall"
           data-test="mobile-breadcrumbs"
           :items="breadcrumbs"
+          :ariaLabel="learnString('channelAndFoldersLabel')"
         />
 
         <div class="card-grid">
@@ -150,26 +151,37 @@
       />
 
       <!-- Embedded Side panel is on larger views, and exists next to content -->
-      <SearchFiltersPanel
-        v-if="!!windowIsLarge"
-        v-model="searchTerms"
-        :topicsListDisplayed="!desktopSearchActive"
-        class="side-panel"
-        topicPage="True"
-        :topics="topics"
-        :activeActivityButtons="activeActivityButtons"
-        :activeCategories="activeCategories"
-        :topicsLoading="topicMoreLoading"
-        :more="topicMore"
-        :genContentLink="genContentLink"
-        :width="`${sidePanelWidth}px`"
-        :availableLabels="labels"
-        :showChannels="false"
-        position="embedded"
-        :style="sidePanelStyleOverrides"
-        @currentCategory="handleShowSearchModal"
-        @loadMoreTopics="handleLoadMoreInTopic"
-      />
+      <section
+        :ariaLabel="learnString('filterAndSearchLabel')"
+      >
+        <ToggleHeaderTabs
+          v-if="!!windowIsLarge"
+          :topic="topic"
+          :topics="topics"
+          :style="tabPosition"
+        />
+        <SearchFiltersPanel
+          v-if="!!windowIsLarge"
+          ref="sidePanel"
+          v-model="searchTerms"
+          :topicsListDisplayed="!desktopSearchActive"
+          class="side-panel"
+          topicPage="True"
+          :topics="topics"
+          :activeActivityButtons="activeActivityButtons"
+          :activeCategories="activeCategories"
+          :topicsLoading="topicMoreLoading"
+          :more="topicMore"
+          :genContentLink="genContentLink"
+          :width="`${sidePanelWidth}px`"
+          :availableLabels="labels"
+          :showChannels="false"
+          position="embedded"
+          :style="sidePanelStyleOverrides"
+          @currentCategory="handleShowSearchModal"
+          @loadMoreTopics="handleLoadMoreInTopic"
+        />
+      </section>
       <!-- The full screen side panel is used on smaller screens, and toggles as an overlay -->
       <!-- FullScreen is a container component, and then the SearchFiltersPanel sits within -->
       <SidePanelModal
@@ -283,9 +295,11 @@
   import SearchResultsGrid from '../SearchResultsGrid';
   import LibraryPage from '../LibraryPage';
   import TopicsHeader from './TopicsHeader';
+  import ToggleHeaderTabs from './ToggleHeaderTabs';
   import TopicsMobileHeader from './TopicsMobileHeader';
   import TopicSubsection from './TopicSubsection';
   import SearchPanelModal from './SearchPanelModal';
+  import commonLearnStrings from './../commonLearnStrings';
   import plugin_data from 'plugin_data';
 
   export default {
@@ -307,6 +321,7 @@
     components: {
       KBreadcrumbs,
       TopicsHeader,
+      ToggleHeaderTabs,
       LibraryAndChannelBrowserMainContent,
       CustomContentRenderer,
       CategorySearchModal,
@@ -320,7 +335,7 @@
       SearchPanelModal,
       ImmersivePage,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
     setup() {
       const {
         searchTerms,
@@ -362,6 +377,7 @@
     data: function() {
       return {
         sidePanelStyleOverrides: {},
+        tabPosition: {},
         currentCategory: null,
         showSearchModal: false,
         showMoreResources: false,
@@ -532,7 +548,8 @@
       },
       // calls handleScroll no more than every 17ms
       throttledHandleScroll() {
-        return throttle(this.stickyCalculation);
+        throttle(this.stickyCalculation);
+        return throttle(this.tabPositionCalculation);
       },
       activeActivityButtons() {
         if (this.searchTerms) {
@@ -623,6 +640,19 @@
           this.currentCategory = null;
         }
         this.toggleFolderSearchSidePanel();
+      },
+      tabPositionCalculation() {
+        const tabBottom = this.$refs.sidePanel
+          ? this.$refs.sidePanel.$el.getBoundingClientRect().top
+          : 0;
+        if (tabBottom > 0) {
+          this.tabPosition = {
+            position: 'fixed',
+            top: `${tabBottom - 70}px`,
+          };
+        } else {
+          this.tabPosition = {};
+        }
       },
       // Stick the side panel to top. That can be on the very top of the viewport
       // or right under the 'Browse channel' toolbar, depending on whether the toolbar

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -18,6 +18,7 @@
       <TopicsHeader
         v-if="!windowIsSmall"
         ref="header"
+        role="complementary"
         data-test="header-breadcrumbs"
         :topics="topics"
         :topic="topic"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -151,37 +151,33 @@
       />
 
       <!-- Embedded Side panel is on larger views, and exists next to content -->
-      <section
-        :ariaLabel="learnString('filterAndSearchLabel')"
-      >
-        <ToggleHeaderTabs
-          v-if="!!windowIsLarge"
-          :topic="topic"
-          :topics="topics"
-          :style="tabPosition"
-        />
-        <SearchFiltersPanel
-          v-if="!!windowIsLarge"
-          ref="sidePanel"
-          v-model="searchTerms"
-          :topicsListDisplayed="!desktopSearchActive"
-          class="side-panel"
-          topicPage="True"
-          :topics="topics"
-          :activeActivityButtons="activeActivityButtons"
-          :activeCategories="activeCategories"
-          :topicsLoading="topicMoreLoading"
-          :more="topicMore"
-          :genContentLink="genContentLink"
-          :width="`${sidePanelWidth}px`"
-          :availableLabels="labels"
-          :showChannels="false"
-          position="embedded"
-          :style="sidePanelStyleOverrides"
-          @currentCategory="handleShowSearchModal"
-          @loadMoreTopics="handleLoadMoreInTopic"
-        />
-      </section>
+      <ToggleHeaderTabs
+        v-if="!!windowIsLarge"
+        :topic="topic"
+        :topics="topics"
+        :style="tabPosition"
+      />
+      <SearchFiltersPanel
+        v-if="!!windowIsLarge"
+        ref="sidePanel"
+        v-model="searchTerms"
+        :topicsListDisplayed="!desktopSearchActive"
+        class="side-panel"
+        topicPage="True"
+        :topics="topics"
+        :activeActivityButtons="activeActivityButtons"
+        :activeCategories="activeCategories"
+        :topicsLoading="topicMoreLoading"
+        :more="topicMore"
+        :genContentLink="genContentLink"
+        :width="`${sidePanelWidth}px`"
+        :availableLabels="labels"
+        :showChannels="false"
+        position="embedded"
+        :style="sidePanelStyleOverrides"
+        @currentCategory="handleShowSearchModal"
+        @loadMoreTopics="handleLoadMoreInTopic"
+      />
       <!-- The full screen side panel is used on smaller screens, and toggles as an overlay -->
       <!-- FullScreen is a container component, and then the SearchFiltersPanel sits within -->
       <SidePanelModal

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -3,7 +3,7 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <KBreadcrumbs :items="breadcrumbs" />
+    <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
     <YourClasses
       v-if="isUserLoggedIn"
       :classes="classrooms"

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -3,14 +3,15 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
-    <h1 class="classroom-name">
-      <KLabeledIcon icon="classes" :label="className" />
-    </h1>
+    <div id="main" role="main">
+      <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
+      <h1 class="classroom-name">
+        <KLabeledIcon icon="classes" :label="className" />
+      </h1>
 
-    <AssignedLessonsCards :lessons="activeLessons" />
-    <AssignedQuizzesCards :quizzes="activeQuizzes" :style="{ marginTop: '44px' }" />
-
+      <AssignedLessonsCards :lessons="activeLessons" />
+      <AssignedQuizzesCards :quizzes="activeQuizzes" :style="{ marginTop: '44px' }" />
+    </div>
   </LearnAppBarPage>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -3,7 +3,7 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <KBreadcrumbs :items="breadcrumbs" />
+    <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
     <h1 class="classroom-name">
       <KLabeledIcon icon="classes" :label="className" />
     </h1>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -3,43 +3,45 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
-    <section class="lesson-details">
-      <div>
-        <ContentIcon
-          kind="lesson"
-          class="lesson-icon"
-        />
-        <h1 dir="auto" class="title">
-          {{ currentLesson.title }}
-          <ProgressIcon
-            v-if="lessonHasResources"
-            class="progress-icon"
-            :progress="lessonProgress"
+    <div id="main" role="main">
+      <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
+      <section class="lesson-details">
+        <div>
+          <ContentIcon
+            kind="lesson"
+            class="lesson-icon"
           />
-        </h1>
-      </div>
-      <div v-if="currentLesson.description !== ''">
-        <h3>{{ $tr('teacherNote') }}</h3>
-        <p dir="auto">
-          {{ currentLesson.description }}
-        </p>
-      </div>
-    </section>
+          <h1 dir="auto" class="title">
+            {{ currentLesson.title }}
+            <ProgressIcon
+              v-if="lessonHasResources"
+              class="progress-icon"
+              :progress="lessonProgress"
+            />
+          </h1>
+        </div>
+        <div v-if="currentLesson.description !== ''">
+          <h3>{{ $tr('teacherNote') }}</h3>
+          <p dir="auto">
+            {{ currentLesson.description }}
+          </p>
+        </div>
+      </section>
 
-    <section v-if="contentNodes && contentNodes.length" class="content-cards">
-      <HybridLearningLessonCard
-        v-for="content in contentNodes"
-        :key="content.id"
-        :content="content"
-        class="content-card"
-        :isMobile="windowIsSmall"
-        :link="genContentLink(content)"
-      />
-      <p v-if="!lessonHasResources" class="no-resources-message">
-        {{ $tr('noResourcesInLesson') }}
-      </p>
-    </section>
+      <section v-if="contentNodes && contentNodes.length" class="content-cards">
+        <HybridLearningLessonCard
+          v-for="content in contentNodes"
+          :key="content.id"
+          :content="content"
+          class="content-card"
+          :isMobile="windowIsSmall"
+          :link="genContentLink(content)"
+        />
+        <p v-if="!lessonHasResources" class="no-resources-message">
+          {{ $tr('noResourcesInLesson') }}
+        </p>
+      </section>
+    </div>
   </LearnAppBarPage>
 
 </template>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -3,7 +3,7 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <KBreadcrumbs :items="breadcrumbs" />
+    <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
     <section class="lesson-details">
       <div>
         <ContentIcon

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -16,6 +16,14 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
     message: 'Resume',
     context: 'Label for links that go to content that has been started and can be resumed',
   },
+  classesAndAssignmentsLabel: {
+    message: 'Classes and assignments',
+    context: 'Label for links that go to class or lesson content',
+  },
+  channelAndFoldersLabel: {
+    message: 'Channel and folders',
+    context: 'Label for links that go to the main channel or its subfolders',
+  },
   mostPopularLabel: {
     message: 'Most popular',
     context: 'Label for links that go to the most popular content',

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -24,6 +24,11 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
     message: 'Channel and folders',
     context: 'Label for links that go to the main channel or its subfolders',
   },
+  filterAndSearchLabel: {
+    message: 'Filter and search',
+    context:
+      'Label for a section of the page that contains options for searching and filtering content',
+  },
   mostPopularLabel: {
     message: 'Most popular',
     context: 'Label for links that go to the most popular content',

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <aside
+  <section
     :dir="languageDir"
     :class="['media-player-transcript', { showing }]"
     :style="{ background: $themeTokens.surface }"
@@ -41,7 +41,7 @@
     >
       {{ $tr('transcriptEnd') }}
     </div>
-  </aside>
+  </section>
 
 </template>
 


### PR DESCRIPTION
## Summary
This PR applies proper landmarks across the Learn plugin - the home, bookmarks, and library page, as well as the two "subpages" for the Topics view and for the content renderer. It adds `aria-label`s per @radinamatic's suggestions.

It also slightly refactors the topics page so that the tabs to toggle between "Folders" and "Search", visible in a large browser view, are now part of the side panel, rather than the `<TopicsHeader/>` component. This does require some slightly creative css, but I believe the improvements in terms of the information architecture of the page for accessibility reasons are worth it. Would appreciate any feedback or suggestions for a simpler approach. 

<img width="1063" alt="Screen Shot 2022-08-25 at 12 18 26 PM" src="https://user-images.githubusercontent.com/17235236/186717535-7d78a933-e516-4219-a448-bfae1dfcd445.png">

…

## References
Fixes #9623

## Reviewer guidance
@radinamatic will do accessibility QA testing. Radina, I have been over everything several times, and done an initial test with VoiceOver and I think I have implemented all of your recommendations, but it's definitely possible I missed something (or mis-interpreted where something was supposed to be). Let me know what improvements I can make and I will be happy to add them 😄 

For dev review, the main focus area would be the several related files of the Topics page that were changes
- `TopicsPage/index`
- `TopicsHeader`
- and the new component `ToggleHeaderTabs` which also _really_ needs a new name, open to suggestions

It was _mostly_ a move from one component into a new component (the guts of what is happening haven't changed) but the position calculation for the tabs is now... somewhat creative to get it all to work. Is this an acceptable tradeoff? I played around with many alternative structures for the side panel positions, nested divs, etc. and none of them achieved the correct combination of position, height, scroll behavior of the spec.

Also, overall, are there any regressions that this has caused?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
