### PR TITLE
Adds translated string for user kind in the user table

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -49,6 +49,7 @@ import commonCoreStrings from '../mixins/commonCoreStrings'; // eslint-disable-l
 import { coreStrings } from '../mixins/commonCoreStrings'; // eslint-disable-line import/no-duplicates
 import commonTaskStrings from '../mixins/taskStrings';
 import commonSyncElements from '../mixins/commonSyncElements';
+import translatedUserKinds from '../mixins/userKinds';
 import CoreFullscreen from '../views/CoreFullscreen';
 import * as exams from '../exams/utils';
 import * as validators from '../validators';
@@ -212,6 +213,7 @@ export default {
       commonCoreStrings,
       commonTaskStrings,
       commonSyncElements,
+      translatedUserKinds,
     },
   },
   resources,

--- a/kolibri/core/assets/src/mixins/userKinds.js
+++ b/kolibri/core/assets/src/mixins/userKinds.js
@@ -1,0 +1,38 @@
+import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+import { crossComponentTranslator } from 'kolibri.utils.i18n';
+import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+import UserTypeDisplay from 'kolibri.coreVue.components.UserTypeDisplay';
+
+export default {
+  data() {
+    return {
+      translator: crossComponentTranslator(UserTypeDisplay),
+    };
+  },
+  mixins: [commonCoreStrings],
+  props: {
+    distinguishCoachTypes: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    omitLearner: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  computed: {
+    typeDisplayMap() {
+      return {
+        [UserKinds.SUPERUSER]: this.translator.$tr('superUserLabel'),
+        [UserKinds.ADMIN]: this.coreString('adminLabel'),
+        [UserKinds.COACH]: this.distinguishCoachTypes
+          ? this.coreString('facilityCoachLabel')
+          : this.coreString('coachLabel'),
+        [UserKinds.ASSIGNABLE_COACH]: this.coreString('coachLabel'),
+        [UserKinds.LEARNER]: this.omitLearner ? '' : this.coreString('learnerLabel'),
+      };
+    },
+  },
+};

--- a/kolibri/core/assets/src/views/UserTypeDisplay.vue
+++ b/kolibri/core/assets/src/views/UserTypeDisplay.vue
@@ -33,6 +33,10 @@
     },
     $trs: {
       /* eslint-disable kolibri/vue-no-unused-translations */
+      /*
+        Translation should not be removed as it's being used
+        by the crossComponentTranslator in the userKinds mixin
+      */
       superUserLabel: {
         message: 'Super admin',
         context:

--- a/kolibri/core/assets/src/views/UserTypeDisplay.vue
+++ b/kolibri/core/assets/src/views/UserTypeDisplay.vue
@@ -12,40 +12,18 @@
 
 <script>
 
-  import { UserKinds } from 'kolibri.coreVue.vuex.constants';
-  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import translatedUserKinds from 'kolibri.coreVue.mixins.translatedUserKinds';
 
   export default {
     name: 'UserTypeDisplay',
-    mixins: [commonCoreStrings],
+    mixins: [translatedUserKinds],
     props: {
       userType: {
         type: String,
         default: null,
       },
-      distinguishCoachTypes: {
-        type: Boolean,
-        required: false,
-        default: true,
-      },
-      omitLearner: {
-        type: Boolean,
-        required: false,
-        default: false,
-      },
     },
     computed: {
-      typeDisplayMap() {
-        return {
-          [UserKinds.SUPERUSER]: this.$tr('superUserLabel'),
-          [UserKinds.ADMIN]: this.coreString('adminLabel'),
-          [UserKinds.COACH]: this.distinguishCoachTypes
-            ? this.coreString('facilityCoachLabel')
-            : this.coreString('coachLabel'),
-          [UserKinds.ASSIGNABLE_COACH]: this.coreString('coachLabel'),
-          [UserKinds.LEARNER]: this.omitLearner ? '' : this.coreString('learnerLabel'),
-        };
-      },
       typeDisplay() {
         if (this.userType) {
           return this.typeDisplayMap[this.userType];
@@ -54,11 +32,13 @@
       },
     },
     $trs: {
+      /* eslint-disable kolibri/vue-no-unused-translations */
       superUserLabel: {
         message: 'Super admin',
         context:
           'An account type that can manage the device. Super admin accounts also have permission to do everything that admins, coaches, and learners can do.',
       },
+      /* eslint-enable */
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserTable.vue
@@ -87,7 +87,7 @@
               />
             </td>
             <td class="visuallyhidden">
-              {{ user.kind }}
+              {{ typeDisplayMap[user.kind] }}
             </td>
             <td>
               <span dir="auto">
@@ -140,6 +140,7 @@
   import GenderDisplayText from 'kolibri.coreVue.components.GenderDisplayText';
   import BirthYearDisplayText from 'kolibri.coreVue.components.BirthYearDisplayText';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import translatedUserKinds from 'kolibri.coreVue.mixins.translatedUserKinds';
 
   export default {
     name: 'UserTable',
@@ -150,7 +151,7 @@
       GenderDisplayText,
       BirthYearDisplayText,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, translatedUserKinds],
     props: {
       users: {
         type: Array,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In the users table under _Facility_, we render a visually hidden `<td>` with a user kind value for assistive technologies. However, it shows an untranslated constant (e.g. superuser). This PR resolves this issue by rendering the translated, constant equivalent string into the  visually hidden `<td>` (e.g. Super admin), the same as the one displayed in the badge.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/9600

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Navigate to _Facility_ menu option, and select the _Users_ tab ie. _facility/#/users_
- Check any of the rows markup in the Users table.
- There should be a `<td>` with a class `visuallyHidden`, containing the same [translated] string as that displayed in the badge for that particular row.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
