### PR TITLE
 Resume content  by last interaction

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,7 +5,7 @@ Kolibri is copyrighted by Learning Equality under the MIT License.
 If you have contributed to Kolibri, feel free to add your name and Github account to this list:
 
 | Name | Github user |
-|------|-------------|
+|--|-------------|
 | Eli Dai | 66eli77 |
 | Adam Stasiw | AdamStasiw |
 | Akshay Mahajan | akshaymahajans |
@@ -84,3 +84,4 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Carol Willing | willingc |
 | Yash Jipkate | YashJipkate |
 | Yixuan Liu | yil039 |
+| Allan Otodi | AllanOXDi |

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1391,12 +1391,7 @@ class UserContentNodeViewset(BaseContentNodeMixin, BaseValuesViewset, ListModelM
 
     def get_queryset(self):
         user = self.request.user
-        # if user is anonymous, don't return any nodes
-        # if person requesting is not the data they are requesting for, also return no nodes
         queryset = models.ContentNode.objects.filter(available=True)
-        if not user.is_facility_user:
-            user = None
-
         queryset = queryset.annotate(
             last_interacted=Subquery(
                 ContentSummaryLog.objects.filter(
@@ -1435,11 +1430,7 @@ class ContentNodeProgressViewset(
 
     def get_queryset(self):
         user = self.request.user
-
         queryset = models.ContentNode.objects.filter(available=True)
-        if not user.is_facility_user:
-            user = None
-
         queryset = queryset.annotate(
             last_interacted=Subquery(
                 ContentSummaryLog.objects.filter(

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1391,7 +1391,11 @@ class UserContentNodeViewset(BaseContentNodeMixin, BaseValuesViewset, ListModelM
 
     def get_queryset(self):
         user = self.request.user
+
         queryset = models.ContentNode.objects.filter(available=True)
+        if not user.is_facility_user:
+            user = None
+
         queryset = queryset.annotate(
             last_interacted=Subquery(
                 ContentSummaryLog.objects.filter(
@@ -1430,7 +1434,11 @@ class ContentNodeProgressViewset(
 
     def get_queryset(self):
         user = self.request.user
+
         queryset = models.ContentNode.objects.filter(available=True)
+        if not user.is_facility_user:
+            user = None
+
         queryset = queryset.annotate(
             last_interacted=Subquery(
                 ContentSummaryLog.objects.filter(

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -114,7 +114,6 @@ class UpdateSessionSerializer(serializers.Serializer):
 # in a Django IntegerField across all backends
 MIN_INTEGER = -2147483648
 
-
 attemptlog_fields = [
     "id",
     "correct",
@@ -359,7 +358,6 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
         )
 
         with transaction.atomic(), dataset_cache:
-
             user = None if request.user.is_anonymous() else request.user
 
             self._precache_dataset_id(user)

--- a/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
@@ -321,7 +321,7 @@ export default function useLearnerResources() {
    * @public
    */
   function fetchResumableContentNodes() {
-    const params = { resume: true, max_results: 12 };
+    const params = { resume: true, max_results: 12, ordering: '-last_interacted' };
     fetchContentNodeProgress(params);
     return ContentNodeResource.fetchResume(params).then(({ results, more }) => {
       if (!results || !results.length) {

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -226,11 +226,17 @@ class LearnHomePageHydrationView(APIView):
             classrooms = learner_classroom_viewset.serialize_list(request)
             if not classrooms or not any(_resumable_resources(classrooms)):
                 resumable_resources = user_contentnode_viewset.serialize_list(
-                    request, {"resume": True, "max_results": 12}
+                    request,
+                    {"resume": True, "max_results": 12, "ordering": "-last_interacted"},
                 )
                 resumable_resources_progress = (
                     contentnode_progress_viewset.serialize_list(
-                        request, {"resume": True, "max_results": 12}
+                        request,
+                        {
+                            "resume": True,
+                            "max_results": 12,
+                            "ordering": "-last_interacted",
+                        },
                     )
                 )
 


### PR DESCRIPTION

## Summary
This fix allow resumable content node to be ordered by the last interacted one first.

fixes #8649

[screen-capture.webm](https://user-images.githubusercontent.com/103313919/186770772-9a6c3991-8b70-41b4-9d32-97a7e351d8a5.webm)







## Reviewer guidance

 * Log on to Kolibri 
 * View at least 3 content and log-out
 * Log on again


…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
