### PR TITLE
Added screen to confirm merge

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -206,7 +206,15 @@ export const changeFacilityMachine = createMachine({
       meta: { route: 'CONFIRM_MERGE', path: '/change_facility' },
       on: {
         CONTINUE: 'syncChangeFacility',
-        BACK: 'confirmAccountDetails',
+        BACK: [
+          {
+            cond: context => context.role === 'superuser',
+            target: 'chooseAdmin',
+          },
+          {
+            target: 'confirmAccountDetails',
+          },
+        ],
       },
     },
     syncChangeFacility: {

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -206,7 +206,7 @@ export const changeFacilityMachine = createMachine({
       meta: { route: 'CONFIRM_MERGE', path: '/change_facility' },
       on: {
         CONTINUE: 'syncChangeFacility',
-        BACK: 'changeFacility',
+        BACK: 'confirmAccountDetails',
       },
     },
     syncChangeFacility: {

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -3,6 +3,7 @@ import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import ProfilePage from './views/ProfilePage';
 import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';
+import ConfirmMerge from './views/ChangeFacility/ConfirmMerge';
 import SelectFacility from './views/ChangeFacility/SelectFacility';
 import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
 import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
@@ -83,7 +84,7 @@ export default [
       {
         path: 'confirm_merge',
         name: 'CONFIRM_MERGE',
-        component: ToBeDone,
+        component: ConfirmMerge,
       },
       {
         path: 'syncing_change_facility',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmMerge.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmMerge.vue
@@ -61,10 +61,11 @@
       const isConfirmed = ref(false);
 
       function handleContinue() {
-        if (isConfirmed.value)
+        if (isConfirmed.value) {
           changeFacilityService.send({
             type: 'CONTINUE',
           });
+        }
       }
       function sendBack() {
         changeFacilityService.send({

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmMerge.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmMerge.vue
@@ -1,0 +1,107 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p>{{ $tr('confirmMergeInfoLine') }}</p>
+    <div class="confirm">
+      <KCheckbox
+        ref="kCheckbox"
+        :label="$tr('consequences')"
+        :checked="false"
+        @change="isConfirmed = !isConfirmed"
+        @keydown.enter="handleContinue"
+      />
+    </div>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('backAction')"
+            appearance="flat-button"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :disabled="!isConfirmed"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="handleContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { inject, ref } from 'kolibri.lib.vueCompositionApi';
+
+  export default {
+    name: 'ConfirmMerge',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+
+    setup() {
+      const changeFacilityService = inject('changeFacilityService');
+      const isConfirmed = ref(false);
+
+      function handleContinue() {
+        if (isConfirmed.value)
+          changeFacilityService.send({
+            type: 'CONTINUE',
+          });
+      }
+      function sendBack() {
+        changeFacilityService.send({
+          type: 'BACK',
+        });
+      }
+      return {
+        isConfirmed,
+        sendBack,
+        handleContinue,
+      };
+    },
+
+    $trs: {
+      documentTitle: {
+        message: 'Merge accounts',
+        context: 'Title of this step for the change facility page.',
+      },
+      confirmMergeInfoLine: {
+        message:
+          'You are about to merge all progress data from two different accounts. Progress data includes your interactions with resources, time spent, and points. This cannot be undone.',
+        context: 'Text explaining the consequences merging will have.',
+      },
+      consequences: {
+        message: 'I understand the consequences of merging accounts',
+        context: 'Button to confirm the acceptance of merging.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .confirm {
+    margin-top: 40px;
+  }
+
+</style>

--- a/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/ConfirmMerge.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/ConfirmMerge.spec.js
@@ -38,6 +38,16 @@ describe(`ChangeFacility/ConfirmMerge`, () => {
     checkbox.trigger('click');
     await wrapper.vm.$nextTick();
     expect(continueButton.vm.disabled).toBeFalsy();
+  });
+
+  it(`clicking continue button sends the continue event to the state machine`, async () => {
+    const wrapper = makeWrapper();
+    clickContinueButton(wrapper);
+    expect(sendMachineEvent).not.toHaveBeenCalled();
+
+    const checkbox = wrapper.find('input[class="k-checkbox-input"]');
+    checkbox.trigger('click');
+    await wrapper.vm.$nextTick();
     clickContinueButton(wrapper);
     expect(sendMachineEvent).toHaveBeenCalledWith({
       type: 'CONTINUE',

--- a/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/ConfirmMerge.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/ConfirmMerge.spec.js
@@ -1,0 +1,54 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import ConfirmMerge from '../../../src/views/ChangeFacility/ConfirmMerge';
+
+const localVue = createLocalVue();
+const sendMachineEvent = jest.fn();
+
+function makeWrapper() {
+  return mount(ConfirmMerge, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+    },
+    localVue,
+  });
+}
+
+const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
+const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+const clickBackButton = wrapper => getBackButton(wrapper).trigger('click');
+const clickContinueButton = wrapper => getContinueButton(wrapper).trigger('click');
+
+describe(`ChangeFacility/ConfirmMerge`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('continue is disabled until merging is accepted', async () => {
+    const wrapper = makeWrapper();
+    const checkbox = wrapper.find('input[class="k-checkbox-input"]');
+    const continueButton = wrapper.find('[data-test="continueButton"]');
+    expect(continueButton.vm.disabled).toBeTruthy();
+    checkbox.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(continueButton.vm.disabled).toBeFalsy();
+    clickContinueButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'CONTINUE',
+    });
+  });
+
+  it(`clicking the back button sends the back event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    clickBackButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'BACK',
+    });
+  });
+});


### PR DESCRIPTION


## Summary

![confirmMerge](https://user-images.githubusercontent.com/1008178/187280608-1dd1b95f-f537-4b01-a1d6-e6f3ae140516.gif)

## References
Closes: #9331 

## Reviewer guidance
Following the "merge" path in the change facility setup this screen should appear almost at the end.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
