### PR TITLE
Add regression test and fix for multiple worker processes duplicating jobs.

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -47,6 +47,9 @@ class State(object):
     QUEUED means the Job has been sent to the workers for running, but has not
     been run yet (to our knowledge).
 
+    SELECTED means the Job has been picked up by the worker controller as a next
+    job to pass to its workers, but that it has not actually started running yet.
+
     RUNNING means that one of the workers has started running the job, but is not
     complete yet. If the job has been set to track progress, then the job's progress
     and total_progress fields should be continuously updated.
@@ -66,6 +69,7 @@ class State(object):
     PENDING = "PENDING"
     SCHEDULED = "SCHEDULED"
     QUEUED = "QUEUED"
+    SELECTED = "SELECTED"
     RUNNING = "RUNNING"
     FAILED = "FAILED"
     CANCELING = "CANCELING"

--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -7,6 +7,7 @@ from mock import patch
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.test.base import connection
+from kolibri.core.tasks.test.taskrunner.test_job_running import EventProxy
 from kolibri.core.tasks.worker import Worker
 
 QUEUE = "pytest"
@@ -24,7 +25,32 @@ def error_func():
 
 
 @pytest.fixture
+def flag():
+    e = EventProxy()
+    yield e
+    e.clear()
+
+
+def toggle_flag(flag_id):
+    evt = EventProxy(event_id=flag_id)
+    if evt.is_set():
+        evt.clear()
+    else:
+        evt.set()
+
+
+@pytest.fixture
 def worker():
+    with connection() as c:
+        b = Worker(c, regular_workers=1, high_workers=1)
+        b.storage.clear(force=True)
+        yield b
+        b.storage.clear(force=True)
+        b.shutdown()
+
+
+@pytest.fixture
+def worker2():
     with connection() as c:
         b = Worker(c, regular_workers=1, high_workers=1)
         b.storage.clear(force=True)
@@ -51,6 +77,25 @@ class TestWorker:
             pass
 
         assert job.state == State.COMPLETED
+
+    def test_enqueue_job_runs_job_once(self, worker, worker2, flag):
+
+        job = Job(toggle_flag, flag.event_id)
+        worker.storage.enqueue_job(job, QUEUE)
+
+        while job.state != State.COMPLETED:
+            job = worker.storage.get_job(job.job_id)
+            time.sleep(0.5)
+        try:
+            # Get the future, or pass if it has already been cleaned up.
+            future = worker.future_job_mapping[job.job_id]
+
+            future.result()
+        except KeyError:
+            pass
+
+        assert job.state == State.COMPLETED
+        assert flag.is_set()
 
     def test_can_handle_unicode_exceptions(self, worker):
         # Make sure task exception info is not an object, but is either a string or None.


### PR DESCRIPTION
## Summary
* Adds a new job status for when a job has been selected to be run next by the task runner but has not been sent to a worker yet
* Updates to this status upon finding a new job for SQLite
* Adds a row locking query that also skips locked rows for PostgreSQL to ensure that multiple worker processes will not select the same job for running
* Adds a regression test with two workers to ensure this is the case

## References
Fixes #9641

## Reviewer guidance
Are the queries clear enough in terms of what they are doing? Does the test sufficiently cover the concern?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
