### PR TITLE
Create screen to be shown if the username already exists in the facility

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -12,6 +12,7 @@ import CreateAccount from './views/ChangeFacility/CreateAccount';
 
 import ToBeDone from './views/ChangeFacility/ToBeDone';
 import UsernameExists from './views/ChangeFacility/UsernameExists';
+import MergeUsernameExists from './views/ChangeFacility/MergeUsernameExists';
 
 function preload(next) {
   store.commit('CORE_SET_PAGE_LOADING', true);
@@ -118,7 +119,7 @@ export default [
       {
         path: 'merge_accounts',
         name: 'MERGE_ACCOUNTS',
-        component: ToBeDone,
+        component: MergeUsernameExists,
       },
     ],
   },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeUsernameExists.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeUsernameExists.vue
@@ -1,0 +1,123 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p data-test="line1">
+      {{ mergeAccountInfoLine1 }}
+    </p>
+    <p data-test="line2">
+      {{ mergeAccountInfoLine2 }}
+    </p>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('backAction')"
+            appearance="flat-button"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="handleContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { computed, inject } from 'kolibri.lib.vueCompositionApi';
+  import get from 'lodash/get';
+
+  export default {
+    name: 'MergeUsernameExists',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+
+    mixins: [commonCoreStrings],
+
+    setup(_, context) {
+      const changeFacilityService = inject('changeFacilityService');
+      const state = inject('state');
+      const store =
+        context.root.$store !== undefined ? context.root.$store : context.root.$children[0].$store;
+      const session = store.getters['session'];
+      const username = computed(() => session.username);
+      const mergeAccountInfoLine1 = computed({
+        get() {
+          return this.$tr('confirmMergeInfoLine1', {
+            target_facility: get(state, 'value.targetFacility.name', ''),
+            username: username.value,
+          });
+        },
+      });
+      const mergeAccountInfoLine2 = computed({
+        get() {
+          return this.$tr('confirmMergeInfoLine2', {
+            target_facility: get(state, 'value.targetFacility.name', ''),
+          });
+        },
+      });
+
+      function handleContinue() {
+        changeFacilityService.send({
+          type: 'CONTINUE',
+        });
+      }
+      function sendBack() {
+        changeFacilityService.send({
+          type: 'BACK',
+        });
+      }
+      return {
+        mergeAccountInfoLine1,
+        mergeAccountInfoLine2,
+        sendBack,
+        handleContinue,
+      };
+    },
+
+    $trs: {
+      documentTitle: {
+        message: 'Change facility',
+        context: 'Title of this step for the change facility page.',
+      },
+      confirmMergeInfoLine1: {
+        message:
+          'An account with the username ‘{username}’ already exists in the ‘{target_facility}’ learning facility.',
+        context: 'Text explaining the consequences merging will have.',
+      },
+      confirmMergeInfoLine2: {
+        message:
+          'You can merge all of your account and progress data with this account in ‘{target_facility}’ learning facility, or you can create a new account. All of your progress data will be moved to this new account.',
+        context: 'Text explaining the consequences merging will have.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .confirm {
+    margin-top: 40px;
+  }
+
+</style>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeUsernameExists.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeUsernameExists.vue
@@ -62,7 +62,7 @@
       const mergeAccountInfoLine1 = computed({
         get() {
           return this.$tr('confirmMergeInfoLine1', {
-            target_facility: get(state, 'value.targetFacility.name', ''),
+            targetFacility: get(state, 'value.targetFacility.name', ''),
             username: username.value,
           });
         },
@@ -70,7 +70,7 @@
       const mergeAccountInfoLine2 = computed({
         get() {
           return this.$tr('confirmMergeInfoLine2', {
-            target_facility: get(state, 'value.targetFacility.name', ''),
+            targetFacility: get(state, 'value.targetFacility.name', ''),
           });
         },
       });
@@ -100,12 +100,12 @@
       },
       confirmMergeInfoLine1: {
         message:
-          'An account with the username ‘{username}’ already exists in the ‘{target_facility}’ learning facility.',
+          'An account with the username ‘{username}’ already exists in the ‘{targetFacility}’ learning facility.',
         context: 'Text explaining the consequences merging will have.',
       },
       confirmMergeInfoLine2: {
         message:
-          'You can merge all of your account and progress data with this account in ‘{target_facility}’ learning facility, or you can create a new account. All of your progress data will be moved to this new account.',
+          'You can merge all of your account and progress data with this account in ‘{targetFacility}’ learning facility, or you can create a new account. All of your progress data will be moved to this new account.',
         context: 'Text explaining the consequences merging will have.',
       },
     },

--- a/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/MergeUsernameExists.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/MergeUsernameExists.spec.js
@@ -1,0 +1,75 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import MergeUsernameExists from '../../../src/views/ChangeFacility/MergeUsernameExists';
+
+const localVue = createLocalVue();
+const sendMachineEvent = jest.fn();
+
+function makeWrapper({ targetFacility, username } = {}) {
+  return mount(MergeUsernameExists, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+      state: {
+        value: {
+          targetFacility,
+        },
+      },
+    },
+    mocks: {
+      $store: {
+        getters: {
+          session: { username: username },
+        },
+      },
+    },
+    localVue,
+  });
+}
+
+const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
+const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+const clickBackButton = wrapper => getBackButton(wrapper).trigger('click');
+const clickContinueButton = wrapper => getContinueButton(wrapper).trigger('click');
+
+describe(`ChangeFacility/MergeUsernameExists`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it(`Show correct info`, () => {
+    const wrapper = makeWrapper({
+      targetFacility: { name: 'Test Facility' },
+      username: 'test1',
+    });
+    const line1_paragraph = wrapper.find('[data-test="line1"]');
+    expect(line1_paragraph.text()).toEqual(
+      'An account with the username ‘test1’ already exists in the ‘Test Facility’ learning facility.'
+    );
+    const line2_paragraph = wrapper.find('[data-test="line2"]');
+    expect(line2_paragraph.text()).toEqual(
+      'You can merge all of your account and progress data with this account in ‘Test Facility’ learning facility, or you can create a new account. All of your progress data will be moved to this new account.'
+    );
+  });
+
+  it(`clicking the continue button sends the continue event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    clickContinueButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'CONTINUE',
+    });
+  });
+
+  it(`clicking the back button sends the back event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    clickBackButton(wrapper);
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'BACK',
+    });
+  });
+});

--- a/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/MergeUsernameExists.spec.js
+++ b/kolibri/plugins/user_profile/assets/test/views/ChangeFacility/MergeUsernameExists.spec.js
@@ -47,12 +47,12 @@ describe(`ChangeFacility/MergeUsernameExists`, () => {
       targetFacility: { name: 'Test Facility' },
       username: 'test1',
     });
-    const line1_paragraph = wrapper.find('[data-test="line1"]');
-    expect(line1_paragraph.text()).toEqual(
+    const line1Paragraph = wrapper.find('[data-test="line1"]');
+    expect(line1Paragraph.text()).toEqual(
       'An account with the username ‘test1’ already exists in the ‘Test Facility’ learning facility.'
     );
-    const line2_paragraph = wrapper.find('[data-test="line2"]');
-    expect(line2_paragraph.text()).toEqual(
+    const line2Paragraph = wrapper.find('[data-test="line2"]');
+    expect(line2Paragraph.text()).toEqual(
       'You can merge all of your account and progress data with this account in ‘Test Facility’ learning facility, or you can create a new account. All of your progress data will be moved to this new account.'
     );
   });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Added screen to be shown when merge facilities is selected and there's already an account with the same username in the target facility.

![image](https://user-images.githubusercontent.com/1008178/188204576-4d32980f-907d-40d4-a29b-2de83654f478.png)


## References
Closes: https://github.com/learningequality/kolibri/issues/9671

## Reviewer guidance
In order to review any of the PR related to the Change facility after device setup project, it's useful to  have in mind the current figma design https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=611%3A9982

Also to be in context: the common use case for this will be an user who has kolibri installed (usually in a tablet o mobile device) and wants to join to a facility in a school. So two kolibri servers are needed: One kolibri server running the `target` facility where the user will merge his current profile and the kolibri server where these screens will be tested. Both servers must be running the latest code from `develop` (or a kolibri version >= 0.16 after it's released).

Depending on the screen to be tested:

After selecting the target facility (it'll have to be autodetected by the current server) ,  the first screen has two buttons, `Continue` or `Merge Accounts`. In the latter case the current user will be merged with an existing user in the target facility, in the  former case a new user will be created in the target facility. For this PR to be tested, the `Merge Account` button must be clicked.

After clicking the `Merge Account`, depending on the case,  the _target facility_ will need:
* An user created with the same _username_ the current facility has (it applies to this PR)
* An available user to be merged, but not having the same _username_ the current facility has (it applies to different PR)

If all these conditions are fulfilled, the above screen must appear to the user.



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
