### PR TITLE
adds additional output to linting tool for formatting failure case

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -346,6 +346,9 @@ program
                 if (!patternCheck || patternCheck.match(globbedFile)) {
                   return runLinting(globbedFile)
                     .then(formatted => {
+                      if (formatted.code) {
+                        logging.error(`Formatting issue in file: ${globbedFile}`);
+                      }
                       return formatted.code;
                     })
                     .catch(error => {


### PR DESCRIPTION
## Summary

While working on https://github.com/learningequality/kolibri-design-system/pull/358 I was confused why sometimes linting would fail without any actionable error:

```
~/Projects/le/design-system main* ⇡ 6s
❯ yarn lint
yarn run v1.22.18
$ kolibri-tools lint --pattern '**/*.vue' -i ,'**/node_modules/**','**/.nuxt/**','**/dist/**','**/lib/KIcon/precompiled-icons/**','**/lib/keen/**','**/docs/environment.js','**/docs/jsdocs.js'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Running `yarn lint-fix` ended up reformatting a file, so it was something to do with prettier or eslint.

I believe this output should give more actionable information about why the lint command might be failing.

## Reviewer guidance

* Modify a file such that it might be reformatted by prettier, e.g. `<   div    >hello</div>`
* Run `lint-frontend` without and without this patch
* With the patch it should show what file is causing issues

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
