### PR TITLE
Fixes Version logic not handling non-tripartite version strings

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -450,9 +450,9 @@ class TestKolibriVersion(unittest.TestCase):
     def test_normalize_version_to_semver_bipartite(self):
         self.assertEqual(
             version.normalize_version_to_semver(
-                "1.10.0",
+                "1.10",
             ),
-            "1.10.0-c",
+            "1.10-c",
         )
 
     def test_normalize_version_to_semver_alpa(self):

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -458,9 +458,9 @@ class TestKolibriVersion(unittest.TestCase):
     def test_normalize_version_to_semver_alpa(self):
         self.assertEqual(
             version.normalize_version_to_semver(
-                "0.14",
+                "0.14a1",
             ),
-            "0.14-c",
+            "0.14-a.1.c",
         )
 
     def test_normalize_version_to_semver_beta(self):

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -450,9 +450,9 @@ class TestKolibriVersion(unittest.TestCase):
     def test_normalize_version_to_semver_bipartite(self):
         self.assertEqual(
             version.normalize_version_to_semver(
-                "0.1",
+                "1.10.0",
             ),
-            "0.1-c",
+            "1.10.0-c",
         )
 
     def test_normalize_version_to_semver_alpa(self):
@@ -460,13 +460,13 @@ class TestKolibriVersion(unittest.TestCase):
             version.normalize_version_to_semver(
                 "0.14",
             ),
-            "0.1a.4-a.0",
+            "0.14-c",
         )
 
     def test_normalize_version_to_semver_beta(self):
         self.assertEqual(
             version.normalize_version_to_semver(
-                "0.16",
+                "0.16b1",
             ),
-            "0.1.0-b.6",
+            "0.16-b.1.c",
         )

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -430,3 +430,43 @@ class TestKolibriVersion(unittest.TestCase):
             "1.0.0",
             version.truncate_version("1.15.1", truncation_level=version.MAJOR_VERSION),
         )
+
+    def test_normalize_version_to_semver_dev(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.15.0a5.dev0+git.682.g0be46de2",
+            ),
+            "0.15.0-a.5.dev0.git.682.g0be46de2",
+        )
+
+    def test_normalize_version_to_semver_tripartite(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.15.0",
+            ),
+            "0.15.0-c",
+        )
+
+    def test_normalize_version_to_semver_bipartite(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.1",
+            ),
+            "0.1-c",
+        )
+
+    def test_normalize_version_to_semver_alpa(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.14",
+            ),
+            "0.1a.4-a.0",
+        )
+
+    def test_normalize_version_to_semver_beta(self):
+        self.assertEqual(
+            version.normalize_version_to_semver(
+                "0.16",
+            ),
+            "0.1.0-b.6",
+        )

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -466,11 +466,15 @@ def version_matches_range(version, version_range):
 
 
 def normalize_version_to_semver(version):
+    # dev = re.match(r"(.*?)(\.dev.*)?$", version).group()
+    dev_match = re.match(r"(.*?)(\.dev.*)?$", version)
 
-    _, dev = re.match(r"(.*?)(\.dev.*)?$", version).groups()
+    dev = dev_match.group(2)
 
     # extract the numeric semver component and the stuff that comes after
-    numeric, after = re.match(r"(\d+\.\d+\.\d+)([^\d].*)?", version).groups()
+    numeric, after = re.match(
+        r"(^\d+\.\d+[0-9]*\.?[0-9]*)([a-z0-9.+]*)", version
+    ).groups()
 
     # clean up the different variations of the post-numeric component to ease checking
     after = (after or "").strip("-").strip("+").strip(".").split("+")[0]

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -482,7 +482,7 @@ def normalize_version_to_semver(version):
     # split up the alpha/beta letters from the numbers, to sort numerically not alphabetically
     after_pieces = re.match(r"([a-z])(\d+)", after)
     if after_pieces:
-        after = ".".join([piece for piece in after_pieces.groups() if piece])
+        after = ".".join([piece for piece in after_pieces.group() if piece])
 
     # position final releases between alphas, betas, and further dev
     if not dev:


### PR DESCRIPTION

## Summary

This PR fixes Version logic not handling non-tripartite version strings
…

## References

#7683
…

## Reviewer guidance
Does the code look okay? Is it working as intended?



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- [ ] Automated test coverage is satisfactory
- [ ] PR is fully functional
- [ ] PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- [ ] External dependency files were updated if necessary (`yarn` and `pip`)
- [ ] Documentation is updated
- [ ] Contributor is in AUTHORS.md
