### PR TITLE
Upgrade morango and lower default sync chunk size through CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ test-all:
 	export KOLIBRI_DATABASE_USER=postgres; \
 	export KOLIBRI_DATABASE_PASSWORD=postgres; \
 	export KOLIBRI_DATABASE_HOST=127.0.0.1; \
-	export KOLIBRI_DATABASE_PORT=5432; \
+	export KOLIBRI_DATABASE_PORT=15432; \
 	set -ex; \
 	function _on_interrupt() { docker-compose down; }; \
 	trap _on_interrupt SIGINT SIGTERM SIGKILL ERR; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:12
     ports:
-      - "5432:5432"
+      - "15432:5432"
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/kolibri/core/auth/management/commands/sync.py
+++ b/kolibri/core/auth/management/commands/sync.py
@@ -29,7 +29,7 @@ class Command(MorangoSyncCommand):
         parser.add_argument(
             "--chunk-size",
             type=int,
-            default=500,
+            default=200,
             help="Chunk size of records to send/retrieve per request",
         )
         parser.add_argument(

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -241,8 +241,8 @@ class multiple_kolibri_servers(object):
                     "USER": "postgres",
                     "PASSWORD": "postgres",
                     "NAME": server.env["KOLIBRI_DATABASE_NAME"],
-                    "HOST": "localhost",
-                    "PORT": "5432",
+                    "HOST": server.env["KOLIBRI_DATABASE_HOST"],
+                    "PORT": server.env["KOLIBRI_DATABASE_PORT"],
                     "TEST": {"NAME": server.env["KOLIBRI_DATABASE_NAME"]},
                 }
 

--- a/kolibri/utils/tests/test_cli.py
+++ b/kolibri/utils/tests/test_cli.py
@@ -164,7 +164,7 @@ def test_kolibri_listen_port_env(monkeypatch):
 
         test_port = 1234
 
-        test_zip_port = 5432
+        test_zip_port = 1432
 
         os.environ["KOLIBRI_HTTP_PORT"] = str(test_port)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.1.37
 jsonfield==2.0.2
 requests-toolbelt==0.8.0
-morango==0.6.14
+morango==0.6.15
 tzlocal==2.1
 pytz==2020.5
 python-dateutil==2.7.5


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Decreases the default chunk size for the sync command to keep memory usage a bit more stable over time; this value matches the value used when syncing through the UI
- Upgrades `morango` to 0.6.15, which includes a fix for the syncing error https://github.com/learningequality/morango/issues/173
- If you were syncing more than 511,500 records (like @nucleogenesis), it was much more likely you'd run into the above overflow error while transferring with a chunk size of 500. An option is to increase the chunk size but that could cause heavy memory usage. So decreasing the chunk size needed the overflow fix
- Updates `make test-with-postgres` to use the port 15432 for postgres to avoid conflicts with host services based off feedback at last demo
  - And some related changes to support this update

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes https://github.com/learningequality/kolibri/issues/9677

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I ran
```
make test-with-postgres INTEGRATION_TEST=1
```

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
