### PR TITLE
Change Facility: Choose a new super admin screen, error state, back navigation

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -368,7 +368,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   searchForUser: {
     message: 'Search for a user...',
     context:
-      'Text which appears in the search field above the table with users from whose to choose from (e.g. when enrolling learners to a class, selecting users to sync, etc.)',
+      'Text which appears in the search field above the table with users from whom to choose from (e.g. when enrolling learners to a class, selecting users to sync, etc.)',
   },
   findSomethingToLearn: {
     message: 'Find something to learn',

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -365,6 +365,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Search',
     context: 'Test used to indicate the Kolibri search field.',
   },
+  searchForUser: {
+    message: 'Search for a user...',
+    context:
+      'Text which appears in the search field above the table with users from whose to choose from (e.g. when enrolling learners to a class, selecting users to sync, etc.)',
+  },
   findSomethingToLearn: {
     message: 'Find something to learn',
     context: 'Suggestion located inside the the keyword search field.',

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupEnrollPage/index.vue
@@ -18,7 +18,7 @@
         <div class="actions-header">
           <FilterTextbox
             v-model.trim="filterInput"
-            :placeholder="$tr('searchForUser')"
+            :placeholder="coreString('searchForUser')"
             @input="pageNum = 1"
           />
         </div>
@@ -193,10 +193,6 @@
       pageHeader: {
         message: "Enroll learners into '{className}'",
         context: 'Describes title of page where the coach enrolls learners in a new group.',
-      },
-      searchForUser: {
-        message: 'Search for a user',
-        context: 'Text in the search field.',
       },
       userTableLabel: {
         message: 'User List',

--- a/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEnrollForm.vue
@@ -10,7 +10,7 @@
       :numFilteredItems="totalLearners"
     >
       <template #filter>
-        <FilterTextbox v-model="search" :placeholder="$tr('searchForUser')" />
+        <FilterTextbox v-model="search" :placeholder="coreString('searchForUser')" />
       </template>
       <template>
         <UserTable
@@ -154,10 +154,6 @@
         message: 'All users are already enrolled in this class',
         context:
           'If all the users in a facility are already enrolled in a class, no more can be added.',
-      },
-      searchForUser: {
-        message: 'Search for a user',
-        context: 'Descriptive text which appears in the search field on the Facility > Users page.',
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/MultipleUsers.vue
@@ -9,7 +9,7 @@
     </p>
     <PaginatedListContainer
       :items="learners"
-      :filterPlaceholder="$tr('searchForUser')"
+      :filterPlaceholder="coreString('searchForUser')"
     >
       <template #default="{ items }">
         <UserTable
@@ -169,10 +169,6 @@
       imported: {
         message: 'Imported',
         context: 'Label indicating that a learner user account has already been imported.',
-      },
-      searchForUser: {
-        message: 'Search for a user',
-        context: 'Descriptive text which appears in the search field on the Facility > Users page.',
       },
       selectAUser: {
         message: 'Select a user',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -77,11 +77,12 @@ const setSourceFacilityUsers = assign({
   sourceFacilityUsers: (_, event) => event.data,
 });
 
-export const changeFacilityMachine = createMachine({
-  id: 'machine',
-  initial: 'selectFacility',
-  predictableActionArguments: true,
-  context: {
+const resetMachineContext = assign(() => {
+  return generateMachineContext();
+});
+
+const generateMachineContext = () => {
+  return {
     role: 'learner',
     username: '',
     userId: '',
@@ -99,8 +100,23 @@ export const changeFacilityMachine = createMachine({
     taskPolling: false,
     accountExists: false,
     isMerging: false,
-  },
+  };
+};
+
+export const changeFacilityMachine = createMachine({
+  id: 'machine',
+  initial: 'selectFacility',
+  predictableActionArguments: true,
+  context: generateMachineContext(),
   states: {
+    error: {
+      on: {
+        RESET: {
+          target: 'selectFacility',
+          actions: [resetMachineContext],
+        },
+      },
+    },
     profile: {
       meta: { route: 'PROFILE', path: '/' },
       on: {
@@ -198,6 +214,9 @@ export const changeFacilityMachine = createMachine({
         onDone: {
           target: 'checkNeedsNewSuperAdmin',
           actions: [setSourceFacilityUsers],
+        },
+        onError: {
+          target: 'error',
         },
       },
     },

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -178,12 +178,12 @@ export const changeFacilityMachine = createMachine({
           actions: setMerging,
         },
         {
-          target: 'confirmAccount',
+          target: 'confirmAccountUsername',
         },
       ],
     },
-    confirmAccount: {
-      meta: { route: 'CONFIRM_ACCOUNT', path: '/change_facility' },
+    confirmAccountUsername: {
+      meta: { route: 'CONFIRM_ACCOUNT_USERNAME', path: '/change_facility' },
       on: {
         NEW: {
           cond: context => context.targetFacility && context.targetFacility.learner_can_sign_up,
@@ -244,7 +244,7 @@ export const changeFacilityMachine = createMachine({
           cond: context => !!context.newSuperAdmin,
         },
         SELECTNEWSUPERADMIN: { actions: setNewSuperAdmin },
-        BACK: 'confirmAccount',
+        BACK: 'confirmAccountUsername',
       },
     },
     checkIsMerging: {
@@ -290,7 +290,7 @@ export const changeFacilityMachine = createMachine({
             target: 'changeFacility',
           },
           {
-            target: 'confirmAccount',
+            target: 'confirmAccountUsername',
           },
         ],
       },

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -175,7 +175,6 @@ export const changeFacilityMachine = createMachine({
         {
           cond: context => !!context.accountExists,
           target: 'usernameExists',
-          actions: setMerging,
         },
         {
           target: 'confirmAccountUsername',

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -77,6 +77,10 @@ const setSourceFacilityUsers = assign({
   sourceFacilityUsers: (_, event) => event.data,
 });
 
+const clearSourceFacilityUsers = assign({
+  sourceFacilityUsers: [],
+});
+
 const resetMachineContext = assign(() => {
   return generateMachineContext();
 });
@@ -274,7 +278,10 @@ const states = {
       CONTINUE: {
         target: 'checkIsMerging',
         cond: context => !!context.newSuperAdminId,
-        actions: [send({ type: 'PUSH_HISTORY', value: 'chooseAdmin' })],
+        // clear source facility users data as soon as it's not needed
+        // anymore to prevent high memory consumption as there could
+        // be many users
+        actions: [clearSourceFacilityUsers, send({ type: 'PUSH_HISTORY', value: 'chooseAdmin' })],
       },
       SELECTNEWSUPERADMIN: { actions: setNewSuperAdminId },
     },

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -103,260 +103,262 @@ const generateMachineContext = () => {
   };
 };
 
-export const changeFacilityMachine = createMachine({
-  id: 'machine',
-  initial: 'selectFacility',
-  predictableActionArguments: true,
-  context: generateMachineContext(),
-  states: {
-    error: {
-      on: {
-        RESET: {
-          target: 'selectFacility',
-          actions: [resetMachineContext],
-        },
+const states = {
+  error: {
+    on: {
+      RESET: {
+        target: 'selectFacility',
+        actions: [resetMachineContext],
       },
     },
-    profile: {
-      meta: { route: 'PROFILE', path: '/' },
-      on: {
-        CONTINUE: {
-          target: 'selectFacility',
-          cond: context => !!context.sourceFacility && !!context.username,
-        },
-        SETCONTEXT: { actions: setInitialContext },
+  },
+  profile: {
+    meta: { route: 'PROFILE', path: '/' },
+    on: {
+      CONTINUE: {
+        target: 'selectFacility',
+        cond: context => !!context.sourceFacility && !!context.username,
+      },
+      SETCONTEXT: { actions: setInitialContext },
+    },
+  },
+  selectFacility: {
+    meta: { route: 'SELECT_FACILITY', path: '/change_facility' },
+    on: {
+      CONTINUE: {
+        target: 'changeFacility',
+        cond: context => Object.keys(context.targetFacility).length > 0,
+      },
+      BACK: 'profile',
+      SETCONTEXT: { actions: setInitialContext },
+      SELECTFACILITY: {
+        actions: assign({
+          targetFacility: (_, event) => {
+            return event.value;
+          },
+        }),
+        target: 'getFacilityUsernames',
       },
     },
-    selectFacility: {
-      meta: { route: 'SELECT_FACILITY', path: '/change_facility' },
-      on: {
-        CONTINUE: {
-          target: 'changeFacility',
-          cond: context => Object.keys(context.targetFacility).length > 0,
-        },
-        BACK: 'profile',
-        SETCONTEXT: { actions: setInitialContext },
-        SELECTFACILITY: {
-          actions: assign({
-            targetFacility: (_, event) => {
-              return event.value;
-            },
-          }),
-          target: 'getFacilityUsernames',
-        },
+  },
+  getFacilityUsernames: {
+    invoke: {
+      id: 'getUserNames',
+      src: (context, event) => connectToTargetKolibri(context, event),
+      onDone: {
+        target: 'selectFacility',
+        actions: checkExists,
+      },
+      onError: {
+        target: 'selectFacility',
       },
     },
-    getFacilityUsernames: {
-      invoke: {
-        id: 'getUserNames',
-        src: (context, event) => connectToTargetKolibri(context, event),
-        onDone: {
-          target: 'selectFacility',
-          actions: checkExists,
-        },
-        onError: {
-          target: 'selectFacility',
-        },
+  },
+  changeFacility: {
+    meta: { route: 'CONFIRM_CHANGE_FACILITY', path: '/change_facility' },
+    on: {
+      MERGE: {
+        target: 'mergeAccounts',
+        actions: setMerging,
+      },
+      CONTINUE: 'checkUsernameExists',
+      BACK: 'selectFacility',
+    },
+  },
+  checkUsernameExists: {
+    always: [
+      {
+        cond: context => !!context.accountExists,
+        target: 'usernameExists',
+      },
+      {
+        target: 'confirmAccountUsername',
+      },
+    ],
+  },
+  confirmAccountUsername: {
+    meta: { route: 'CONFIRM_ACCOUNT_USERNAME', path: '/change_facility' },
+    on: {
+      NEW: {
+        cond: context => context.targetFacility && context.targetFacility.learner_can_sign_up,
+        target: 'createAccount',
+      },
+      CONTINUE: 'isAdmin',
+      BACK: 'changeFacility',
+    },
+  },
+  isAdmin: {
+    always: [
+      {
+        cond: context => context.role === 'superuser',
+        target: 'fetchSourceFacilityUsers',
+      },
+      {
+        target: 'checkIsMerging',
+      },
+    ],
+  },
+  fetchSourceFacilityUsers: {
+    invoke: {
+      src: () => {
+        return FacilityUserResource.fetchCollection().then(users => {
+          return users;
+        });
+      },
+      onDone: {
+        target: 'checkNeedsNewSuperAdmin',
+        actions: [setSourceFacilityUsers],
+      },
+      onError: {
+        target: 'error',
       },
     },
-    changeFacility: {
-      meta: { route: 'CONFIRM_CHANGE_FACILITY', path: '/change_facility' },
-      on: {
-        MERGE: {
-          target: 'mergeAccounts',
-          actions: setMerging,
+  },
+  checkNeedsNewSuperAdmin: {
+    always: [
+      {
+        cond: context => {
+          const facilityHasAnotherSuperUser =
+            context.sourceFacilityUsers.length > 0 &&
+            context.sourceFacilityUsers.find(u => u.id !== context.userId && u.is_superuser);
+          return context.role === 'superuser' && !facilityHasAnotherSuperUser;
         },
-        CONTINUE: 'checkUsernameExists',
-        BACK: 'selectFacility',
+        target: 'chooseAdmin',
       },
+      {
+        target: 'checkIsMerging',
+      },
+    ],
+  },
+  chooseAdmin: {
+    meta: { route: 'CHOOSE_ADMIN', path: '/change_facility' },
+    on: {
+      CONTINUE: {
+        target: 'checkIsMerging',
+        cond: context => !!context.newSuperAdminId,
+      },
+      SELECTNEWSUPERADMIN: { actions: setNewSuperAdminId },
     },
-    checkUsernameExists: {
-      always: [
+  },
+  checkIsMerging: {
+    always: [
+      {
+        cond: context => context.isMerging,
+        target: 'confirmMerge',
+      },
+      {
+        target: 'syncChangeFacility',
+      },
+    ],
+  },
+  confirmMerge: {
+    meta: { route: 'CONFIRM_MERGE', path: '/change_facility' },
+    on: {
+      CONTINUE: 'syncChangeFacility',
+      BACK: [
         {
-          cond: context => !!context.accountExists,
-          target: 'usernameExists',
+          cond: context => context.role === 'superuser',
+          target: 'chooseAdmin',
+        },
+        {
+          target: 'confirmAccountDetails',
+        },
+      ],
+    },
+  },
+  syncChangeFacility: {
+    meta: { route: 'SYNCING_CHANGE_FACILITY', path: '/change_facility' },
+    type: 'final',
+  },
+  createAccount: {
+    meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
+    on: {
+      CONTINUE: {
+        target: 'isAdmin',
+        actions: setTargetAccount,
+      },
+      BACK: [
+        {
+          cond: context => context.accountExists,
+          target: 'changeFacility',
         },
         {
           target: 'confirmAccountUsername',
         },
       ],
     },
-    confirmAccountUsername: {
-      meta: { route: 'CONFIRM_ACCOUNT_USERNAME', path: '/change_facility' },
-      on: {
-        NEW: {
-          cond: context => context.targetFacility && context.targetFacility.learner_can_sign_up,
-          target: 'createAccount',
-        },
-        CONTINUE: 'isAdmin',
-        BACK: 'changeFacility',
-      },
+  },
+  usernameExists: {
+    meta: { route: 'USERNAME_EXISTS', path: '/change_facility' },
+    on: {
+      MERGE: 'requireAccountCreds',
+      NEW: 'createAccount',
+      BACK: 'selectFacility',
     },
-    isAdmin: {
-      always: [
+  },
+  requireAccountCreds: {
+    meta: { route: 'REQUIRE_ACCOUNT_CREDENTIALS', path: '/change_facility' },
+    on: {
+      CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
+      USEADMIN: 'useAdminPassword',
+      BACK: 'confirmMerge',
+    },
+  },
+  useAdminPassword: {
+    meta: { route: 'ADMIN_PASSWORD', path: '/change_facility' },
+    on: {
+      CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
+      BACK: 'requireAccountCreds',
+    },
+  },
+  confirmAccountDetails: {
+    meta: { route: 'CONFIRM_DETAILS', path: '/change_facility' },
+    on: {
+      CONTINUE: 'isAdmin',
+      BACK: 'mergeAccounts',
+    },
+  },
+  mergeAccounts: {
+    meta: { route: 'MERGE_ACCOUNTS', path: '/change_facility' },
+    on: {
+      CONTINUE: [
         {
-          cond: context => context.role === 'superuser',
-          target: 'fetchSourceFacilityUsers',
+          cond: context =>
+            context.accountExists && !context.targetFacility.learner_can_login_with_no_password,
+          target: 'requireAccountCreds',
         },
         {
-          target: 'checkIsMerging',
+          cond: context =>
+            context.accountExists && context.targetFacility.learner_can_login_with_no_password,
+          target: 'getUserWithoutPasswordInfo',
         },
       ],
+      BACK: 'selectFacility',
     },
-    fetchSourceFacilityUsers: {
-      invoke: {
-        src: () => {
-          return FacilityUserResource.fetchCollection().then(users => {
-            return users;
-          });
-        },
-        onDone: {
-          target: 'checkNeedsNewSuperAdmin',
-          actions: [setSourceFacilityUsers],
-        },
-        onError: {
-          target: 'error',
-        },
-      },
-    },
-    checkNeedsNewSuperAdmin: {
-      always: [
-        {
-          cond: context => {
-            const facilityHasAnotherSuperUser =
-              context.sourceFacilityUsers.length > 0 &&
-              context.sourceFacilityUsers.find(u => u.id !== context.userId && u.is_superuser);
-            return context.role === 'superuser' && !facilityHasAnotherSuperUser;
+  },
+  getUserWithoutPasswordInfo: {
+    invoke: {
+      id: 'getPasswordlessUserInfo',
+      src: (context, event) => getUserWPasswordInfo(context, event),
+      onDone: {
+        target: 'confirmAccountDetails',
+        actions: assign({
+          targetAccount: (_, event) => {
+            return event.data;
           },
-          target: 'chooseAdmin',
-        },
-        {
-          target: 'checkIsMerging',
-        },
-      ],
-    },
-    chooseAdmin: {
-      meta: { route: 'CHOOSE_ADMIN', path: '/change_facility' },
-      on: {
-        CONTINUE: {
-          target: 'checkIsMerging',
-          cond: context => !!context.newSuperAdminId,
-        },
-        SELECTNEWSUPERADMIN: { actions: setNewSuperAdminId },
+        }),
       },
-    },
-    checkIsMerging: {
-      always: [
-        {
-          cond: context => context.isMerging,
-          target: 'confirmMerge',
-        },
-        {
-          target: 'syncChangeFacility',
-        },
-      ],
-    },
-    confirmMerge: {
-      meta: { route: 'CONFIRM_MERGE', path: '/change_facility' },
-      on: {
-        CONTINUE: 'syncChangeFacility',
-        BACK: [
-          {
-            cond: context => context.role === 'superuser',
-            target: 'chooseAdmin',
-          },
-          {
-            target: 'confirmAccountDetails',
-          },
-        ],
-      },
-    },
-    syncChangeFacility: {
-      meta: { route: 'SYNCING_CHANGE_FACILITY', path: '/change_facility' },
-      type: 'final',
-    },
-    createAccount: {
-      meta: { route: 'CREATE_ACCOUNT', path: '/change_facility' },
-      on: {
-        CONTINUE: {
-          target: 'isAdmin',
-          actions: setTargetAccount,
-        },
-        BACK: [
-          {
-            cond: context => context.accountExists,
-            target: 'changeFacility',
-          },
-          {
-            target: 'confirmAccountUsername',
-          },
-        ],
-      },
-    },
-    usernameExists: {
-      meta: { route: 'USERNAME_EXISTS', path: '/change_facility' },
-      on: {
-        MERGE: 'requireAccountCreds',
-        NEW: 'createAccount',
-        BACK: 'selectFacility',
-      },
-    },
-    requireAccountCreds: {
-      meta: { route: 'REQUIRE_ACCOUNT_CREDENTIALS', path: '/change_facility' },
-      on: {
-        CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
-        USEADMIN: 'useAdminPassword',
-        BACK: 'confirmMerge',
-      },
-    },
-    useAdminPassword: {
-      meta: { route: 'ADMIN_PASSWORD', path: '/change_facility' },
-      on: {
-        CONTINUE: { actions: setTargetAccount, target: 'confirmAccountDetails' },
-        BACK: 'requireAccountCreds',
-      },
-    },
-    confirmAccountDetails: {
-      meta: { route: 'CONFIRM_DETAILS', path: '/change_facility' },
-      on: {
-        CONTINUE: 'isAdmin',
-        BACK: 'mergeAccounts',
-      },
-    },
-    mergeAccounts: {
-      meta: { route: 'MERGE_ACCOUNTS', path: '/change_facility' },
-      on: {
-        CONTINUE: [
-          {
-            cond: context =>
-              context.accountExists && !context.targetFacility.learner_can_login_with_no_password,
-            target: 'requireAccountCreds',
-          },
-          {
-            cond: context =>
-              context.accountExists && context.targetFacility.learner_can_login_with_no_password,
-            target: 'getUserWithoutPasswordInfo',
-          },
-        ],
-        BACK: 'selectFacility',
-      },
-    },
-    getUserWithoutPasswordInfo: {
-      invoke: {
-        id: 'getPasswordlessUserInfo',
-        src: (context, event) => getUserWPasswordInfo(context, event),
-        onDone: {
-          target: 'confirmAccountDetails',
-          actions: assign({
-            targetAccount: (_, event) => {
-              return event.data;
-            },
-          }),
-        },
-        onError: {
-          target: 'mergeAccounts',
-        },
+      onError: {
+        target: 'mergeAccounts',
       },
     },
   },
+};
+
+export const changeFacilityMachine = createMachine({
+  id: 'machine',
+  initial: 'selectFacility',
+  predictableActionArguments: true,
+  context: generateMachineContext(),
+  states,
 });

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -61,8 +61,8 @@ const checkExists = assign((context, event) => {
   };
 });
 
-const setNewSuperAdmin = assign({
-  newSuperAdmin: (_, event) => event.value,
+const setNewSuperAdminId = assign({
+  newSuperAdminId: (_, event) => event.value,
 });
 
 const setTargetAccount = assign({
@@ -96,7 +96,7 @@ const generateMachineContext = () => {
     // `name`, `id`, `url`, `learner_can_sign_up` &
     // `learner_can_login_with_no_password` fields
     targetFacility: {},
-    newSuperAdmin: '',
+    newSuperAdminId: '',
     taskPolling: false,
     accountExists: false,
     isMerging: false,
@@ -241,10 +241,9 @@ export const changeFacilityMachine = createMachine({
       on: {
         CONTINUE: {
           target: 'checkIsMerging',
-          cond: context => !!context.newSuperAdmin,
+          cond: context => !!context.newSuperAdminId,
         },
-        SELECTNEWSUPERADMIN: { actions: setNewSuperAdmin },
-        BACK: 'confirmAccountUsername',
+        SELECTNEWSUPERADMIN: { actions: setNewSuperAdminId },
       },
     },
     checkIsMerging: {

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -10,7 +10,7 @@ import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility'
 import MergeAccountDialog from './views/ChangeFacility/MergeAccountDialog';
 import ConfirmAccountDetails from './views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails';
 import CreateAccount from './views/ChangeFacility/CreateAccount';
-
+import ChooseAdmin from './views/ChangeFacility/ChooseAdmin';
 import ToBeDone from './views/ChangeFacility/ToBeDone';
 import UsernameExists from './views/ChangeFacility/UsernameExists';
 import MergeUsernameExists from './views/ChangeFacility/MergeUsernameExists';
@@ -80,7 +80,7 @@ export default [
       {
         path: 'choose_admin',
         name: 'CHOOSE_ADMIN',
-        component: ToBeDone,
+        component: ChooseAdmin,
       },
       {
         path: 'confirm_merge',

--- a/kolibri/plugins/user_profile/assets/src/routes.js
+++ b/kolibri/plugins/user_profile/assets/src/routes.js
@@ -5,7 +5,7 @@ import ProfileEditPage from './views/ProfileEditPage';
 import ChangeFacility from './views/ChangeFacility';
 import ConfirmMerge from './views/ChangeFacility/ConfirmMerge';
 import SelectFacility from './views/ChangeFacility/SelectFacility';
-import ConfirmAccount from './views/ChangeFacility/ConfirmAccount';
+import ConfirmAccountUsername from './views/ChangeFacility/ConfirmAccountUsername';
 import ConfirmChangeFacility from './views/ChangeFacility/ConfirmChangeFacility';
 import MergeAccountDialog from './views/ChangeFacility/MergeAccountDialog';
 import ConfirmAccountDetails from './views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails';
@@ -74,8 +74,8 @@ export default [
 
       {
         path: 'confirm_account',
-        name: 'CONFIRM_ACCOUNT',
-        component: ConfirmAccount,
+        name: 'CONFIRM_ACCOUNT_USERNAME',
+        component: ConfirmAccountUsername,
       },
       {
         path: 'choose_admin',

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -2,18 +2,44 @@ import { shallowMount, mount } from '@vue/test-utils';
 import ChooseAdmin from '../index.vue';
 
 const sendMachineEvent = jest.fn();
-function makeWrapper() {
+function makeWrapper({ userId, sourceFacilityUsers } = {}) {
   return mount(ChooseAdmin, {
     provide: {
       changeFacilityService: {
         send: sendMachineEvent,
       },
+      state: {
+        value: {
+          userId,
+          sourceFacilityUsers,
+        },
+      },
     },
   });
 }
 
+const TEST_CURRENT_USER_ID = 'current-id';
+const TEST_FACILITY_USERS = [
+  {
+    id: TEST_CURRENT_USER_ID,
+    full_name: 'Current User',
+    username: 'currentuser',
+  },
+  {
+    id: 'learner-1',
+    full_name: 'Learner 1',
+    username: 'learner1',
+  },
+  {
+    id: 'learner-2',
+    full_name: 'Learner 2',
+    username: 'learner2',
+  },
+];
+
 const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
 const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+const getUserTable = wrapper => wrapper.find('[data-test="userTable"]');
 
 describe(`ChangeFacility/ChooseAdmin`, () => {
   beforeEach(() => {
@@ -31,14 +57,23 @@ describe(`ChangeFacility/ChooseAdmin`, () => {
     expect(wrapper.text()).toContain('Choose an account to manage channels and accounts.');
   });
 
+  it('shows a selectable table with all facility users except of a current user', () => {
+    const wrapper = makeWrapper({
+      userId: TEST_CURRENT_USER_ID,
+      sourceFacilityUsers: TEST_FACILITY_USERS,
+    });
+    const userTable = getUserTable(wrapper);
+    expect(userTable).toBeTruthy();
+    expect(userTable.text()).not.toContain('Current User');
+    const users = userTable.findAllComponents({ name: 'KRadioButton' });
+    expect(users.length).toBe(2);
+    expect(users.at(0).text()).toContain('Learner 1');
+    expect(users.at(1).text()).toContain('Learner 2');
+  });
+
   it(`shows the back button`, () => {
     const wrapper = makeWrapper();
     expect(getBackButton(wrapper).exists()).toBeTruthy();
-  });
-
-  it(`shows the continue button`, () => {
-    const wrapper = makeWrapper();
-    expect(getContinueButton(wrapper).exists()).toBeTruthy();
   });
 
   it(`clicking the back button sends the back event to the state machine`, () => {
@@ -49,11 +84,41 @@ describe(`ChangeFacility/ChooseAdmin`, () => {
     });
   });
 
-  it(`clicking the continue button sends the continue event to the state machine`, () => {
+  it(`shows the continue button`, () => {
     const wrapper = makeWrapper();
-    expect(getContinueButton(wrapper).trigger('click'));
-    expect(sendMachineEvent).toHaveBeenCalledWith({
-      type: 'CONTINUE',
+    expect(getContinueButton(wrapper).exists()).toBeTruthy();
+  });
+
+  describe(`when a new super admin is not selected`, () => {
+    it(`continue button is disabled`, () => {
+      const wrapper = makeWrapper();
+      expect(getContinueButton(wrapper).element.disabled).toBeTruthy();
+    });
+  });
+
+  describe(`when a new super admin is selected`, () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = makeWrapper({
+        userId: TEST_CURRENT_USER_ID,
+        sourceFacilityUsers: TEST_FACILITY_USERS,
+      });
+      getUserTable(wrapper)
+        .findAllComponents({ name: 'KRadioButton' })
+        .at(1)
+        .find('input')
+        .trigger('change');
+    });
+
+    it(`continue button is enabled`, () => {
+      expect(getContinueButton(wrapper).element.disabled).toBeFalsy();
+    });
+
+    it(`clicking the continue button sends the continue event to the state machine`, () => {
+      expect(getContinueButton(wrapper).trigger('click'));
+      expect(sendMachineEvent).toHaveBeenCalledWith({
+        type: 'CONTINUE',
+      });
     });
   });
 });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -1,0 +1,59 @@
+import { shallowMount, mount } from '@vue/test-utils';
+import ChooseAdmin from '../index.vue';
+
+const sendMachineEvent = jest.fn();
+function makeWrapper() {
+  return mount(ChooseAdmin, {
+    provide: {
+      changeFacilityService: {
+        send: sendMachineEvent,
+      },
+    },
+  });
+}
+
+const getBackButton = wrapper => wrapper.find('[data-test="backButton"]');
+const getContinueButton = wrapper => wrapper.find('[data-test="continueButton"]');
+
+describe(`ChangeFacility/ChooseAdmin`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`smoke test`, () => {
+    const wrapper = shallowMount(ChooseAdmin);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('shows the title and the description', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.text()).toContain('Choose a new super admin');
+    expect(wrapper.text()).toContain('Choose an account to manage channels and accounts.');
+  });
+
+  it(`shows the back button`, () => {
+    const wrapper = makeWrapper();
+    expect(getBackButton(wrapper).exists()).toBeTruthy();
+  });
+
+  it(`shows the continue button`, () => {
+    const wrapper = makeWrapper();
+    expect(getContinueButton(wrapper).exists()).toBeTruthy();
+  });
+
+  it(`clicking the back button sends the back event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    expect(getBackButton(wrapper).trigger('click'));
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'BACK',
+    });
+  });
+
+  it(`clicking the continue button sends the continue event to the state machine`, () => {
+    const wrapper = makeWrapper();
+    expect(getContinueButton(wrapper).trigger('click'));
+    expect(sendMachineEvent).toHaveBeenCalledWith({
+      type: 'CONTINUE',
+    });
+  });
+});

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -114,8 +114,12 @@ describe(`ChangeFacility/ChooseAdmin`, () => {
       expect(getContinueButton(wrapper).element.disabled).toBeFalsy();
     });
 
-    it(`clicking the continue button sends the continue event to the state machine`, () => {
+    it(`clicking the continue button sends the select new super admin and continue events to the state machine`, () => {
       expect(getContinueButton(wrapper).trigger('click'));
+      expect(sendMachineEvent).toHaveBeenCalledWith({
+        type: 'SELECTNEWSUPERADMIN',
+        value: 'learner-2',
+      });
       expect(sendMachineEvent).toHaveBeenCalledWith({
         type: 'CONTINUE',
       });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
@@ -80,6 +80,10 @@
 
       function sendContinue() {
         if (!isContinueDisabled.value) {
+          changeFacilityService.send({
+            type: 'SELECTNEWSUPERADMIN',
+            value: selectedUsers.value[0],
+          });
           changeFacilityService.send({ type: 'CONTINUE' });
         }
       }

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
@@ -4,6 +4,21 @@
     <h1>{{ $tr('documentTitle') }}</h1>
     <p>{{ $tr('description') }}</p>
 
+    <PaginatedListContainer
+      :items="usersWithoutCurrentUser"
+      :filterPlaceholder="$tr('searchForUser')"
+    >
+      <template #default="{ items }">
+        <UserTable
+          v-model="selectedUsers"
+          data-test="userTable"
+          :users="items"
+          selectable
+          :enableMultipleSelection="false"
+        />
+      </template>
+    </PaginatedListContainer>
+
     <BottomAppBar>
       <slot name="buttons">
         <KButtonGroup>
@@ -17,6 +32,7 @@
           <KButton
             :primary="true"
             :text="coreString('continueAction')"
+            :disabled="isContinueDisabled"
             data-test="continueButton"
             @click="sendContinue"
           />
@@ -30,9 +46,12 @@
 
 <script>
 
-  import { inject } from 'kolibri.lib.vueCompositionApi';
+  import get from 'lodash/get';
+  import { inject, computed, ref } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
+  import UserTable from 'kolibri.coreVue.components.UserTable';
 
   export default {
     name: 'ChooseAdmin',
@@ -41,19 +60,37 @@
         title: this.$tr('documentTitle'),
       };
     },
-    components: { BottomAppBar },
+    components: {
+      BottomAppBar,
+      PaginatedListContainer,
+      UserTable,
+    },
     mixins: [commonCoreStrings],
     setup() {
       const changeFacilityService = inject('changeFacilityService');
+      const changeFacilityContext = inject('state');
+
+      const usersWithoutCurrentUser = computed(() => {
+        const currentUserId = get(changeFacilityContext, 'value.userId');
+        const users = get(changeFacilityContext, 'value.sourceFacilityUsers', []);
+        return users.filter(user => user.id !== currentUserId);
+      });
+      const selectedUsers = ref([]);
+      const isContinueDisabled = computed(() => selectedUsers.value.length === 0);
 
       function sendContinue() {
-        changeFacilityService.send({ type: 'CONTINUE' });
+        if (!isContinueDisabled.value) {
+          changeFacilityService.send({ type: 'CONTINUE' });
+        }
       }
       function sendBack() {
         changeFacilityService.send({ type: 'BACK' });
       }
 
       return {
+        usersWithoutCurrentUser,
+        isContinueDisabled,
+        selectedUsers,
         sendContinue,
         sendBack,
       };
@@ -68,6 +105,11 @@
         message: 'Choose an account to manage channels and accounts.',
         context:
           'Description of the step for choosing a new super admin in a source facility when a user changing facilities is the only super admin of the source facility.',
+      },
+      // TODO: Move to common strings (copied from `MultipleUsers`)
+      searchForUser: {
+        message: 'Search for a user',
+        context: 'Descriptive text which appears in the search field on the Facility > Users page.',
       },
     },
   };

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
@@ -1,0 +1,75 @@
+<template>
+
+  <div>
+    <h1>{{ $tr('documentTitle') }}</h1>
+    <p>{{ $tr('description') }}</p>
+
+    <BottomAppBar>
+      <slot name="buttons">
+        <KButtonGroup>
+          <KButton
+            :primary="false"
+            :text="coreString('backAction')"
+            appearance="flat-button"
+            data-test="backButton"
+            @click="sendBack"
+          />
+          <KButton
+            :primary="true"
+            :text="coreString('continueAction')"
+            data-test="continueButton"
+            @click="sendContinue"
+          />
+        </KButtonGroup>
+      </slot>
+    </BottomAppBar>
+  </div>
+
+</template>
+
+
+<script>
+
+  import { inject } from 'kolibri.lib.vueCompositionApi';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+
+  export default {
+    name: 'ChooseAdmin',
+    metaInfo() {
+      return {
+        title: this.$tr('documentTitle'),
+      };
+    },
+    components: { BottomAppBar },
+    mixins: [commonCoreStrings],
+    setup() {
+      const changeFacilityService = inject('changeFacilityService');
+
+      function sendContinue() {
+        changeFacilityService.send({ type: 'CONTINUE' });
+      }
+      function sendBack() {
+        changeFacilityService.send({ type: 'BACK' });
+      }
+
+      return {
+        sendContinue,
+        sendBack,
+      };
+    },
+    $trs: {
+      documentTitle: {
+        message: 'Choose a new super admin',
+        context:
+          'Title of the step for choosing a new super admin in a source facility when a user changing facilities is the only super admin of the source facility.',
+      },
+      description: {
+        message: 'Choose an account to manage channels and accounts.',
+        context:
+          'Description of the step for choosing a new super admin in a source facility when a user changing facilities is the only super admin of the source facility.',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/index.vue
@@ -6,7 +6,7 @@
 
     <PaginatedListContainer
       :items="usersWithoutCurrentUser"
-      :filterPlaceholder="$tr('searchForUser')"
+      :filterPlaceholder="coreString('searchForUser')"
     >
       <template #default="{ items }">
         <UserTable
@@ -109,11 +109,6 @@
         message: 'Choose an account to manage channels and accounts.',
         context:
           'Description of the step for choosing a new super admin in a source facility when a user changing facilities is the only super admin of the source facility.',
-      },
-      // TODO: Move to common strings (copied from `MultipleUsers`)
-      searchForUser: {
-        message: 'Search for a user',
-        context: 'Descriptive text which appears in the search field on the Facility > Users page.',
       },
     },
   };

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/__tests__/index.spec.js
@@ -1,9 +1,9 @@
 import { shallowMount, mount } from '@vue/test-utils';
-import ConfirmAccount from '../index.vue';
+import ConfirmAccountUsername from '../index.vue';
 
 const sendMachineEvent = jest.fn();
 function makeWrapper({ targetFacility } = {}) {
-  return mount(ConfirmAccount, {
+  return mount(ConfirmAccountUsername, {
     provide: {
       changeFacilityService: {
         send: sendMachineEvent,
@@ -20,13 +20,13 @@ function makeWrapper({ targetFacility } = {}) {
 const getCreateNewAccountButton = wrapper => wrapper.find('[data-test="createNewAccountButton"]');
 const clickCreateNewAccountButton = wrapper => getCreateNewAccountButton(wrapper).trigger('click');
 
-describe(`ChangeFacility/ConfirmAccount`, () => {
+describe(`ChangeFacility/ConfirmAccountUsername`, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it(`smoke test`, () => {
-    const wrapper = shallowMount(ConfirmAccount);
+    const wrapper = shallowMount(ConfirmAccountUsername);
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmAccountUsername/index.vue
@@ -37,7 +37,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
 
   export default {
-    name: 'ConfirmAccount',
+    name: 'ConfirmAccountUsername',
     metaInfo() {
       return {
         title: this.$tr('documentTitle'),

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -106,6 +106,7 @@
           value: {
             facility: this.session.facility_id,
             username: this.session.username,
+            userId: this.session.user_id,
             role: this.getUserKind,
           },
         });

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -71,30 +71,25 @@
       this.service.start();
       this.service.onTransition(state => {
         if (state.value === 'error') {
-          this.$store.commit(
-            'CORE_SET_ERROR',
-            `An error occured in the '${this.previousMachineStateName}' state of the change facility machine`
-          );
-          this.service.send('RESET');
-        } else {
-          const stateID = Object.keys(state.meta)[0];
-          if (state.meta[stateID] !== undefined) {
-            let newRoute = state.meta[stateID].route;
-            if (newRoute != this.$router.currentRoute.name) {
-              if ('path' in state.meta[stateID]) {
-                this.internalNavigation = true;
-                this.$router.push(
-                  { name: newRoute, path: state.meta[stateID].path },
-                  function() {
-                    this.internalNavigation = false;
-                  }.bind(this)
-                );
-              } else this.$router.push(newRoute);
-            }
-            this.currentRoute = newRoute;
-          }
+          this.onMachineError(state);
+          return;
         }
-        this.previousMachineStateName = state.value;
+        const stateID = Object.keys(state.meta)[0];
+        if (state.meta[stateID] !== undefined) {
+          let newRoute = state.meta[stateID].route;
+          if (newRoute != this.$router.currentRoute.name) {
+            if ('path' in state.meta[stateID]) {
+              this.internalNavigation = true;
+              this.$router.push(
+                { name: newRoute, path: state.meta[stateID].path },
+                function() {
+                  this.internalNavigation = false;
+                }.bind(this)
+              );
+            } else this.$router.push(newRoute);
+          }
+          this.currentRoute = newRoute;
+        }
         this.state = state;
       });
     },
@@ -121,6 +116,16 @@
           },
         });
       }
+    },
+    methods: {
+      onMachineError(machineState) {
+        this.$store.commit(
+          'CORE_SET_ERROR',
+          `An error occured in the '${this.previousMachineStateName}' state of the change facility machine`
+        );
+        this.service.send('RESET');
+        this.previousMachineStateName = machineState.value;
+      },
     },
     $trs: {
       documentTitle: {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -45,6 +45,7 @@
     data() {
       return {
         service: interpret(changeFacilityMachine),
+        previousMachineStateName: '',
         state: changeFacilityMachine.initialState,
         currentRoute: this.$router.currentRoute.name,
         appBarHeight: 0,
@@ -69,22 +70,31 @@
     created() {
       this.service.start();
       this.service.onTransition(state => {
-        const stateID = Object.keys(state.meta)[0];
-        if (state.meta[stateID] !== undefined) {
-          let newRoute = state.meta[stateID].route;
-          if (newRoute != this.$router.currentRoute.name) {
-            if ('path' in state.meta[stateID]) {
-              this.internalNavigation = true;
-              this.$router.push(
-                { name: newRoute, path: state.meta[stateID].path },
-                function() {
-                  this.internalNavigation = false;
-                }.bind(this)
-              );
-            } else this.$router.push(newRoute);
+        if (state.value === 'error') {
+          this.$store.commit(
+            'CORE_SET_ERROR',
+            `An error occured in the '${this.previousMachineStateName}' state of the change facility machine`
+          );
+          this.service.send('RESET');
+        } else {
+          const stateID = Object.keys(state.meta)[0];
+          if (state.meta[stateID] !== undefined) {
+            let newRoute = state.meta[stateID].route;
+            if (newRoute != this.$router.currentRoute.name) {
+              if ('path' in state.meta[stateID]) {
+                this.internalNavigation = true;
+                this.$router.push(
+                  { name: newRoute, path: state.meta[stateID].path },
+                  function() {
+                    this.internalNavigation = false;
+                  }.bind(this)
+                );
+              } else this.$router.push(newRoute);
+            }
+            this.currentRoute = newRoute;
           }
-          this.currentRoute = newRoute;
         }
+        this.previousMachineStateName = state.value;
         this.state = state;
       });
     },

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -5,7 +5,7 @@
       :appBarTitle="coreString('changeLearningFacility')"
       :route="$router.getRoute('PROFILE')"
     >
-      <KPageContainer style="width: 1000px; margin: 32px auto 0;">
+      <KPageContainer style="maxWidth: 1000px; margin: 32px auto 0;">
         <router-view />
       </KPageContainer>
     </ImmersivePage>


### PR DESCRIPTION
## Summary

**Adds the _Choose a new super_ admin screen to all three main branches of the change facility flow**

<img src="https://user-images.githubusercontent.com/13509191/189899095-24846e03-4191-4d28-8171-58258ff8d5cb.png" width="400">

That created the need for the following higher-level updates that are also included:

**Adds a new error state to the machine and related logic for redirecting to the unexpected error page as well as resetting the machine when that happens**
  - **Motivation**: To avoid becoming stuck in the flow without any clues when an unexpected error occurs, typically when invoking services in between user-facing transitions
  - **Implementation**: Adds a new `error` state to the state machine and utilizes existing routing logic when transitioning between states to determine whether a user should be redirected to an unexpected error page which will be displayed thanks to our existing Vuex error logic.
 
<img src="https://user-images.githubusercontent.com/13509191/189901371-4aa41794-132d-4f7d-865a-f089315feb3e.png" width="400">

<img src="https://user-images.githubusercontent.com/13509191/189901379-869d82c2-1e5c-4a25-8941-afd2d51bdc7a.png" width="400">

**Adds history for back navigation to the state machine**
  - **Motivation**: We’ve had issues with complexity of conditions for back navigation previously which has shown to be the case for the _Choose a new super admin_ screen too in an even more complicated manner
  - **Implementation**: Adds `history` to context. States can explicitly push their name to the history. This explicitness is intentional to give us more control; for example, we don’t want to push each state name to history as some of them are not-user facing. `BACK` transition has been removed from all states in favor of one global `BACK` transition that uses `history` context. Inspired by [https://github.com/statelyai/xstate/discussions/1939#discussioncomment-381565](https://github.com/statelyai/xstate/discussions/1939#discussioncomment-381565), when implementing this `BACK` transition logic, `cond` s generated from the object containing all states were utilized.

It also contains a couple of other minor updates, see commit messages.

## References

- [Figma designs](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=194%3A2920)
- Closes https://github.com/learningequality/kolibri/issues/9326

## Reviewer guidance

- You need to have another v16 facility set up and running, the so-called target facility, to be able to access the change facility flow. You could use `kolibri start` to run it.
- At your source facility, go to *Profile* → *Change learning facility* to start testing
- The following conditions need to be satisfied for accessing
    - *(1) Default path*
        - on the target facility, there shouldn’t be a user with the same username as your current source facility user
    - *(2) Username exists*
        - on the target facility, there needs to be a user with the same username as your current source facility user
    - *(3) Merge accounts*
        - Currently, I was able to go through this path only when I had a user with the same username on the target facility as my current source facility user
- The whole change facility flow is a work in progress, so not all screens have been implemented yet. It should be possible to access the *Choose a new super admin*. Please let me know if you encounter any issues.

### Choose a new super admin

Please follow [the Figma designs](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=194%3A2920) to check the _Choose a new super admin_ page in all _(1) Default path_, _(2) Username exists_, and _(3) Merge accounts_ contexts. While navigating those paths, check:

- [ ] *Chose a new super admin* page is displayed when there are more users on the source device and the current user is the only super user
- [ ] _Choose a new super admin_ page is skipped when
  - the current user is not a super user
  - the device has more super users
  - the device has only one user
 
When _Choose a new super admin_ page is displayed
- [ ] _Continue_ button is disabled, and you can’t move to the next screen until you select a user from the table
- [ ] Keyboard navigation in the table
- [ ] After you click _Continue_ (and confirm merge if needed), the selected user ID is saved to `newSuperAdminId` state machine’s context (the whole context object is printed out at the end of the flow)

### Error state

I haven’t found a better way then to replace the state machine’s `fetchSourceFacilityUsers -> invoke -> src` by

```jsx
src: () => {
  return FacilityUserResource.fetchCollection().then(users => {
    return Promise.reject(;
  });
},
```

Then, try to navigate to the *Chose a new super admin* page.

- [ ] Check that you can see an unexpected error page

### Back navigation
Click through the change facility flow and check

- [ ] navigation back with _Back_ buttons works on pages with _Back_ buttons
- [ ] navigation back via browser's back works

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
