### PR TITLE
Fix quiz completion notification regression

### DIFF
--- a/kolibri/core/logger/utils/quiz.py
+++ b/kolibri/core/logger/utils/quiz.py
@@ -1,0 +1,36 @@
+from django.db.models import Count
+from django.db.models import OuterRef
+from django.db.models import Subquery
+from django.db.models import Sum
+
+from kolibri.core.logger.models import AttemptLog
+
+
+def annotate_response_summary(queryset):
+    """
+    Accepts a MasteryLog queryset as the only argument.
+    Returns a queryset that has num_correct and num_answered
+    annotations on the queryset.
+
+    Only useful for MasteryLogs generated for quizzes.
+    """
+    return queryset.annotate(
+        num_correct=Subquery(
+            AttemptLog.objects.filter(masterylog=OuterRef("id"))
+            .order_by()
+            .values_list("item")
+            .distinct()
+            .values("masterylog")
+            .annotate(total_correct=Sum("correct"))
+            .values("total_correct")
+        ),
+        num_answered=Subquery(
+            AttemptLog.objects.filter(masterylog=OuterRef("id"))
+            .order_by()
+            .values_list("item")
+            .distinct()
+            .values("masterylog")
+            .annotate(total_complete=Count("id"))
+            .values("total_complete")
+        ),
+    )


### PR DESCRIPTION
## Summary
* Fixes a bug that was introduced during the consolidation of all progress tracking into the progress tracking endpoint
* Bug was due to a poor formed [ORM expression in the quiz completion notification generation function](https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/notifications/api.py#L568) which resulted in a query of the form:
`SELECT DISTINCT "logger_attemptlog"."correct" FROM "logger_attemptlog" WHERE "logger_attemptlog"."masterylog_id" = 4ba85343d79efb77ff3f1c53f3a27917`
* This had the effect of only counting at most 2 values, correct = 0 and correct = 1, this regression was missed in testing, because the correct calculation is being done in the class summary endpoint, so this would only happen in the ephemeral state when the data came from the notification.
* Fixes this by consolidating the logic used in the class summary endpoint and using it in both places
* Updates an existing test to act as a regression test

## References
Fixes #9255

## Reviewer guidance
See the screencast of the fix below and compare to the one in the issue.

https://user-images.githubusercontent.com/1680573/190275066-5541dc32-6fa9-46b3-80ff-e0de18ad8c9e.mp4


----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [X] If this is an important user-facing change, PR or related issue has a 'changelog' label

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
