### PR TITLE
Adds job storage sanity check

### DIFF
--- a/kolibri/core/tasks/scheduler.py
+++ b/kolibri/core/tasks/scheduler.py
@@ -182,6 +182,13 @@ class Scheduler(StorageMixin):
             scheduled_jobs = self._ns_query(s).all()
             return [Job.from_json(o.saved_job) for o in scheduled_jobs]
 
+    def test_table_readable(self):
+        """
+        Do a quick query to raise errors if the database is unusable.
+        """
+        with self.session_scope() as s:
+            self._ns_query(s).first()
+
     def count(self):
         with self.session_scope() as s:
             return self._ns_query(s).count()

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -246,6 +246,15 @@ class Storage(StorageMixin):
 
             return [self._orm_to_job(o) for o in orm_jobs]
 
+    def test_table_readable(self):
+        """
+        Do a quick query to raise errors if the database is unusable.
+        """
+        with self.session_scope() as s:
+            q = s.query(ORMJob)
+
+            q.first()
+
     def count_all_jobs(self, queue=None):
         with self.session_scope() as s:
             q = s.query(ORMJob)

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -42,6 +42,7 @@ from kolibri.utils.sanity_checks import check_django_stack_ready
 from kolibri.utils.sanity_checks import check_log_file_location
 from kolibri.utils.sanity_checks import DatabaseInaccessible
 from kolibri.utils.sanity_checks import DatabaseNotMigrated
+from kolibri.utils.sanity_checks import ensure_job_tables_created
 from kolibri.utils.server import get_status
 from kolibri.utils.server import NotRunning
 
@@ -255,14 +256,14 @@ def _upgrades_after_django_setup(updated, version):
             logging.error(e)
 
 
-def initialize(
+def initialize(  # noqa C901
     skip_update=False,
     settings=None,
     debug=False,
     debug_database=False,
     no_input=False,
     pythonpath=None,
-):  # noqa: max-complexity=12
+):
     """
     This should be called before starting the Kolibri app, it initializes Kolibri plugins
     and sets up Django.
@@ -306,6 +307,16 @@ def initialize(
         run_plugin_updates()
 
         check_django_stack_ready()
+
+        try:
+            ensure_job_tables_created()
+        except Exception as e:
+            logging.error(
+                "The job tables were not fully migrated. Tried to "
+                "create them in the database and an error occurred: "
+                "{}".format(e)
+            )
+            raise
 
         try:
             check_database_is_migrated()

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -6,6 +6,8 @@ import sys
 from django.apps import apps
 from django.db.utils import OperationalError
 from django.db.utils import ProgrammingError
+from sqlalchemy.exc import OperationalError as SQLAlchemyOperationalError
+from sqlalchemy.exc import ProgrammingError as SQLAlchemyProgrammingError
 
 from .conf import KOLIBRI_HOME
 from .conf import OPTIONS
@@ -112,6 +114,29 @@ def check_database_is_migrated():
         return
     except (OperationalError, ProgrammingError) as e:
         raise DatabaseNotMigrated(db_exception=e)
+    except Exception as e:
+        raise DatabaseInaccessible(db_exception=e)
+
+
+def ensure_job_tables_created():
+    from kolibri.core.tasks.main import job_storage
+    from kolibri.core.tasks.main import scheduler
+
+    try:
+        job_storage.test_table_readable()
+    except (SQLAlchemyOperationalError, SQLAlchemyProgrammingError):
+        logger.warning("Database table for job storage was not accessible, recreating.")
+        job_storage.recreate_tables()
+    except Exception as e:
+        raise DatabaseInaccessible(db_exception=e)
+
+    try:
+        scheduler.test_table_readable()
+    except (SQLAlchemyOperationalError, SQLAlchemyProgrammingError):
+        logger.warning(
+            "Database table for scheduled jobs was not accessible, recreating."
+        )
+        scheduler.recreate_tables()
     except Exception as e:
         raise DatabaseInaccessible(db_exception=e)
 


### PR DESCRIPTION
## Summary
* Ensures that job storage tables can be read from, and recreates them if they throw an error
* Adds a test for this behaviour
* Only does this if updates are enabled to prevent competing processes attempting to do this, similar to Django migration checks.

## References
Fixes #9613

## Reviewer guidance
Does it provide adequate coverage?
To manually confirm the fix, use SQLite browser or similar to drop a column from one the job or scheduler tables in the `job_storage.sqlite3`, then run Kolibri and confirm that it does not error and that upon inspection the table is now whole again.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
