### PR TITLE
Added function handler to delay SaveAnswer function

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -38,7 +38,7 @@
               :assessment="true"
               :allowHints="false"
               :answerState="currentAttempt.answer"
-              @interaction="saveAnswer"
+              @interaction="debouncedSaveAnswer"
             />
             <UiAlert v-else :dismissible="false" type="error">
               {{ $tr('noItemId') }}
@@ -297,6 +297,15 @@
         return this.displayNavigationButtonLabel
           ? { position: 'relative', top: '3px', left: '-4px' }
           : {};
+      },
+      debouncedSaveAnswer() {
+        // So as not to share debounced functions between instances of the same component
+        // and also to allow access to the cancel method of the debounced function
+        // best practice seems to be to do it as a computed property and not a method:
+        // https://github.com/vuejs/vue/issues/2870#issuecomment-219096773
+        // 750ms chosen through trial and error designed to allow users to input relatively
+        // slowly while producing one single answer
+        return debounce(this.saveAnswer, 750);
       },
     },
     watch: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR adds a debounce function handler for the saveAnswer method, which previously saved incomplete inputs and showed multiple inputs on a completed quiz when the user intended to have one single answer.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #9444 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Note: *Multiple answers might still be recorded if a user takes more than a second to input the complete answer.*
1. On Kolibri 0.15.2, import Khan Academy's (English - US curriculum) > Math by grade > 3rd grade > Represent and interpret data > Picture graphs
2. Create a quiz for 'Read picture graphs (multi-step problems)'
3. Complete the quiz 
4. As a Coach go to Coach>Reports>Quiz score

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
