### PR TITLE
Make learner ids unique when assigned from groups and adhoc groups.

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/dataHelpers.js
@@ -103,7 +103,7 @@ export default {
         // If exam.groups is empty, getLearnersForGroups returns the whole class
         // so only concat it if we're getting learners from specified groups
         return exam.groups.length
-          ? individuallyAssignedLearners.concat(this.getLearnersForGroups(exam.groups))
+          ? uniq(individuallyAssignedLearners.concat(this.getLearnersForGroups(exam.groups)))
           : individuallyAssignedLearners;
       } else {
         if (exam.assignments.length) {
@@ -127,7 +127,7 @@ export default {
         // If lesson.groups is empty, getLearnersForGroups returns the whole class
         // so only concat it if we're getting learners from specified groups
         return lesson.groups.length
-          ? individuallyAssignedLearners.concat(this.getLearnersForGroups(lesson.groups))
+          ? uniq(individuallyAssignedLearners.concat(this.getLearnersForGroups(lesson.groups)))
           : individuallyAssignedLearners;
       } else {
         if (lesson.assignments.length) {


### PR DESCRIPTION
## Summary
* Ensures that returned learner ids are made unique, to prevent double counting of learners assigned both as individual assignments and through groups of which they are members.
* Does this for both lessons and quizzes.

## References
Fixes #7667 (which was only reported for lessons, but the same bug exists for quizzes).

## Reviewer guidance
Follow the steps to reproduce in the issue.
Confirm that this is indeed no longer the case for this.

Screenshots before:
![Screenshot from 2022-09-16 15-23-07](https://user-images.githubusercontent.com/1680573/190826955-b96f990a-4035-4279-b2cf-fb67b913d6a7.png)
![Screenshot from 2022-09-16 15-23-19](https://user-images.githubusercontent.com/1680573/190826957-1775f8c0-5752-40b0-8def-151bbc7fe3bb.png)

Screenshots after:
![Screenshot from 2022-09-16 15-36-46](https://user-images.githubusercontent.com/1680573/190827022-9492e326-1c90-4dde-a05b-73d2c66b1e5e.png)

![Screenshot from 2022-09-16 15-36-53](https://user-images.githubusercontent.com/1680573/190826982-aad69b62-3332-401d-8d1f-33fbfaeb89bb.png)


----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical user journeys are covered by Gherkin stories


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
