### PR TITLE
Improve import workflow for collections

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -587,6 +587,7 @@ export class Resource {
     idKey = 'id',
     namespace = 'core',
     useContentCacheKey = false,
+    cacheBust = true,
     ...options
   } = {}) {
     if (!name) {
@@ -595,6 +596,7 @@ export class Resource {
     this.name = `kolibri:${namespace}:${name}`;
     this.idKey = idKey;
     this.useContentCacheKey = useContentCacheKey;
+    this.cacheBust = cacheBust;
     const optionsDefinitions = Object.getOwnPropertyDescriptors(options);
     Object.keys(optionsDefinitions).forEach(key => {
       Object.defineProperty(this, key, optionsDefinitions[key]);
@@ -980,6 +982,7 @@ export class Resource {
 
   client(options) {
     const client = require('./core-app/client').default;
+    options.cacheBust = this.cacheBust;
     // Add in content cache parameter if relevant
     if (this.useContentCacheKey && !options.data) {
       options.params = options.params || {};

--- a/kolibri/core/assets/src/api-resources/remoteChannel.js
+++ b/kolibri/core/assets/src/api-resources/remoteChannel.js
@@ -2,10 +2,8 @@ import { Resource } from 'kolibri.lib.apiResource';
 
 export default new Resource({
   name: 'remotechannel',
+  cacheBust: false,
   getKolibriStudioStatus() {
     return this.getListEndpoint('kolibri_studio_status');
-  },
-  fetchChannelList(id) {
-    return this.fetchDetailCollection('retrieve_list', id);
   },
 });

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1719,14 +1719,6 @@ class KolibriStudioAPITestCase(APITestCase):
         self.assertEqual(response.data[0]["id"], 1)
 
     @mock_patch_decorator
-    def test_channel_retrieve_list(self):
-        response = self.client.get(
-            reverse("kolibri:core:remotechannel-retrieve-list", kwargs={"pk": 1}),
-            format="json",
-        )
-        self.assertEqual(response.data[0]["id"], 1)
-
-    @mock_patch_decorator
     def test_no_permission_non_superuser_channel_list(self):
         user = FacilityUser.objects.create(username="user", facility=self.facility)
         user.set_password(DUMMY_PASSWORD)

--- a/kolibri/plugins/device/assets/src/modules/manageContent/actions/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/actions/index.js
@@ -7,11 +7,13 @@ function refreshChannelList(store) {
   return ChannelResource.fetchCollection({
     getParams: { include_fields: 'on_device_file_size' },
     force: true,
-  }).then(channels => {
-    store.commit('SET_CHANNEL_LIST', [...channels]);
-    store.commit('SET_CHANNEL_LIST_LOADING', false);
-    return [...channels];
-  });
+  })
+    .then(channels => {
+      store.commit('SET_CHANNEL_LIST', [...channels]);
+      store.commit('SET_CHANNEL_LIST_LOADING', false);
+      return [...channels];
+    })
+    .catch(() => []);
 }
 
 function startImportWorkflow(store, channel) {

--- a/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/actions/availableChannelsActions.js
@@ -1,6 +1,6 @@
 import differenceBy from 'lodash/differenceBy';
 import find from 'lodash/find';
-import { getRemoteChannelByToken, getRemoteChannelBundleByToken } from '../utils';
+import { getRemoteChannelByToken } from '../utils';
 
 /**
  * HACK: Makes a request to Kolibri Studio to get info on unlisted channels, then appends
@@ -46,7 +46,4 @@ export function getAllDriveChannels(store, drive) {
       latest_version: c.version,
     };
   });
-}
-export function fetchUnlistedChannelInfo(store, channelId) {
-  return getRemoteChannelBundleByToken(channelId).then(channels => Array(channels));
 }

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -103,11 +103,14 @@ export function showAvailableChannelsPage(store, params) {
     selectedDrivePromise = Promise.resolve({});
     availableChannelsPromise = new Promise((resolve, reject) => {
       getInstalledChannelsPromise(store).then(() => {
-        return RemoteChannelResource.fetchCollection()
+        return RemoteChannelResource.fetchCollection({ getParams: { token: params.token } })
           .then(remoteChannels => {
-            return store
-              .dispatch('manageContent/wizard/getAllRemoteChannels', remoteChannels)
-              .then(allChannels => resolve(allChannels));
+            if (!params.token) {
+              return store
+                .dispatch('manageContent/wizard/getAllRemoteChannels', remoteChannels)
+                .then(allChannels => resolve(allChannels));
+            }
+            resolve(remoteChannels);
           })
           .catch(() => reject({ error: ContentWizardErrors.KOLIBRI_STUDIO_UNAVAILABLE }));
       });

--- a/kolibri/plugins/device/assets/src/modules/wizard/utils.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/utils.js
@@ -16,7 +16,7 @@ export function getRemoteChannelByToken(token) {
 }
 
 export function getRemoteChannelBundleByToken(token) {
-  return RemoteChannelResource.fetchChannelList(token);
+  return RemoteChannelResource.fetchCollection({ getParams: { token } });
 }
 
 /**

--- a/kolibri/plugins/device/assets/src/routes/wizardTransitionRoutes.js
+++ b/kolibri/plugins/device/assets/src/routes/wizardTransitionRoutes.js
@@ -21,6 +21,7 @@ export default [
       return showAvailableChannelsPage(store, {
         address_id: query.address_id,
         drive_id: query.drive_id,
+        token: query.token,
       });
     },
   },

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/ChannelTokenModal.vue
@@ -72,13 +72,7 @@
           this.formIsDisabled = true;
           return this.lookupToken(this.token)
             .then(channels => {
-              // tokens can return one or more channels
-              if (channels.length > 1) {
-                this.$store.commit('manageContent/wizard/SET_AVAILABLE_CHANNELS', channels);
-                this.$emit('cancel');
-              } else {
-                this.$emit('submit', channels[0]);
-              }
+              this.$emit('submit', { token: this.token, channels });
             })
             .catch(error => {
               if (error.response.status === 404) {

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -325,14 +325,18 @@
       },
       handleSubmitToken({ token, channels }) {
         if (channels.length > 1) {
-          this.disableModal = true;
-          this.$router.push({
-            ...this.$route,
-            query: {
-              ...this.$route.query,
-              token,
-            },
-          });
+          if (this.$route.query.token !== token) {
+            this.disableModal = true;
+            this.$router.push({
+              ...this.$route,
+              query: {
+                ...this.$route.query,
+                token,
+              },
+            });
+          } else {
+            this.showTokenModal = false;
+          }
         } else {
           this.goToSelectContentPageForChannel(channels[0]);
         }

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -27,15 +27,29 @@
             @click="toggleMultipleMode"
           />
         </p>
-        <p v-if="showUnlistedChannels">
-          <KButton
-            data-test="token-button"
-            :text="$tr('channelTokenButtonLabel')"
-            appearance="raised-button"
-            name="showtokenmodal"
-            @click="showTokenModal = true"
-          />
-        </p>
+        <KButton
+          v-if="showUnlistedChannels"
+          data-test="token-button"
+          :text="$tr('channelTokenButtonLabel')"
+          appearance="raised-button"
+          name="showtokenmodal"
+          @click="showTokenModal = true"
+        />
+        <div
+          v-if="$route.query.token"
+          class="token-chip"
+          :style="{ backgroundColor: $themePalette.grey.v_300 }"
+        >
+          <span>
+            <p class="token-chip-text">{{ $route.query.token }}</p>
+            <KIconButton
+              icon="delete"
+              size="mini"
+              class="token-chip-button"
+              @click="clearToken"
+            />
+          </span>
+        </div>
         <p>
           <UiAlert
             v-show="notEnoughFreeSpace"
@@ -309,26 +323,30 @@
         }
         return this.$router.push({ query: newQuery });
       },
-      handleSubmitToken(channel) {
-        if (this.multipleMode) {
+      handleSubmitToken({ token, channels }) {
+        if (channels.length > 1) {
           this.disableModal = true;
-          this.$store
-            .dispatch('manageContent/wizard/fetchUnlistedChannelInfo', channel.id)
-            .then(channels => {
-              const newChannels = channels.map(x => Object.assign(x, { newUnlistedChannel: true }));
-              // Need to de-duplicate channels in case user enters same token twice, etc.
-              this.newUnlistedChannels = uniqBy(
-                [...newChannels, ...this.newUnlistedChannels],
-                'id'
-              );
-              this.showTokenModal = false;
-              this.disableModal = false;
-            })
-            .catch(error => {
-              this.$store.dispatch('handleApiError', error);
-            });
+          this.$router.push({
+            ...this.$route,
+            query: {
+              ...this.$route.query,
+              token,
+            },
+          });
         } else {
-          this.goToSelectContentPageForChannel(channel);
+          this.goToSelectContentPageForChannel(channels[0]);
+        }
+      },
+      clearToken() {
+        if (this.$route.query.token) {
+          const query = {
+            ...this.$route.query,
+          };
+          delete query.token;
+          this.$router.push({
+            ...this.$route,
+            query,
+          });
         }
       },
       goToSelectContentPageForChannel(channel) {
@@ -478,6 +496,26 @@
   .channel-list-header {
     padding: 16px 0;
     font-size: 14px;
+  }
+
+  .token-chip {
+    display: inline-block;
+    margin-left: 8px;
+    font-size: 14px;
+    vertical-align: middle;
+    border-radius: 34px;
+  }
+
+  .token-chip-text {
+    display: inline-block;
+    margin: 4px 0 4px 8px;
+    font-size: 14px;
+  }
+
+  .token-chip-button {
+    min-width: 24px !important;
+    margin: 2px;
+    vertical-align: middle;
   }
 
 </style>

--- a/kolibri/plugins/device/assets/test/views/ChannelTokenModal.spec.js
+++ b/kolibri/plugins/device/assets/test/views/ChannelTokenModal.spec.js
@@ -76,10 +76,10 @@ describe('channelTokenModal component', () => {
     });
 
     it('emits a "submit" event if token lookup is successful', () => {
-      const tokenPayload = { id: 'toka-toka-token' };
+      const tokenPayload = { token: 'toka-toka-token', channels: [{ id: 'toka-toka-token' }] };
       const { lookupTokenStub } = getElements(wrapper);
       const lookupStub = lookupTokenStub();
-      lookupStub.mockResolvedValue([tokenPayload]);
+      lookupStub.mockResolvedValue(tokenPayload.channels);
       return inputToken(wrapper, 'toka-toka-token')
         .then(() => {
           wrapper.vm.submitForm();


### PR DESCRIPTION
## Summary
* Adds some caching and removes cache busting when fetching from the remote channels endpoint
* Removes pointless additional endpoint from remote channels endpoint
* Persists entered token as query parameter in URL
* Allows entered token to be removed using a clearable chip

## References
Fixes #8536

## Reviewer guidance
Fixes the first problem identified in #8536 by persisting the token in the URL when it is a token that denotes more than one channel, and so loading token channels on page load.


https://user-images.githubusercontent.com/1680573/190832429-e71e4269-285b-4805-bf69-e2f188eaac66.mp4

Fixes the second problem identified in the issue, by dint of relying on page navigation to set and unset the token, so the vuex state for selected channels gets cleared upon navigation.


https://user-images.githubusercontent.com/1680573/190832458-efca7fa2-e89b-491d-a81d-ed22e49d7da7.mp4



----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
