### PR TITLE
SetupWizard - Partial provisioning, On My Own Flow

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -124,7 +124,7 @@ import coreBannerContent from '../utils/coreBannerContent';
 import CatchErrors from '../utils/CatchErrors';
 import UiToolbar from '../views/KeenUiToolbar.vue';
 import shuffled from '../utils/shuffled';
-import appCapabilities from '../utils/appCapabilities';
+import * as appCapabilities from '../utils/appCapabilities';
 import * as client from './client';
 import clientFactory from './baseClient';
 

--- a/kolibri/core/assets/src/utils/appCapabilities.js
+++ b/kolibri/core/assets/src/utils/appCapabilities.js
@@ -11,7 +11,7 @@ const appCapabilities = plugin_data.appCapabilities || {};
 // Check that we are in an appcontext, if not disable all capabilities
 // this means that consumers of this API can rely solely on the existence
 // check of methods in this API to know if they can call these or not.
-const checkCapability = key => store.getters.isAppContext && appCapabilities[key];
+export const checkCapability = key => store.getters.isAppContext && appCapabilities[key];
 
 // Use a janky getter to return a method here to only expose functions
 // that are available so that we have a single API for both existence

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -48,7 +48,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
     device_name = serializers.CharField(max_length=50, allow_null=True)
     settings = serializers.JSONField()
     allow_guest_access = serializers.BooleanField(allow_null=True)
-    is_provisioned = serializers.BooleanField(allow_null=True)
+    is_provisioned = serializers.BooleanField(default=True)
 
     class Meta:
         fields = (

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -48,6 +48,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
     device_name = serializers.CharField(max_length=50, allow_null=True)
     settings = serializers.JSONField()
     allow_guest_access = serializers.BooleanField(allow_null=True)
+    is_provisioned = serializers.BooleanField(allow_null=True)
 
     class Meta:
         fields = (
@@ -57,6 +58,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
             "settings",
             "device_name",
             "allow_guest_access",
+            "is_provisioned",
         )
 
     def validate(self, data):
@@ -109,10 +111,13 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
             # Create device settings
             language_id = validated_data.pop("language_id")
             allow_guest_access = validated_data.pop("allow_guest_access")
+
             if allow_guest_access is None:
                 allow_guest_access = preset != "formal"
+
             provision_device(
                 device_name=validated_data["device_name"],
+                is_provisioned=validated_data["is_provisioned"],
                 language_id=language_id,
                 default_facility=facility,
                 allow_guest_access=allow_guest_access,

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -55,6 +55,13 @@ class DeviceProvisionTestCase(TestCase):
         provision_device(language_id="en", default_facility=facility)
         self.assertTrue(DeviceSettings.objects.get().is_provisioned)
 
+    def test_create_device_settings_incomplete_provisioning(self):
+        facility = Facility.objects.create(name="Test")
+        provision_device(
+            language_id="en", default_facility=facility, is_provisioned=False
+        )
+        self.assertFalse(DeviceSettings.objects.get().is_provisioned)
+
     def test_create_device_settings_language(self):
         facility = Facility.objects.create(name="Test")
         provision_device(language_id="en", default_facility=facility)

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -90,13 +90,13 @@ def set_device_settings(**kwargs):
         raise DeviceNotProvisioned
 
 
-def provision_device(device_name=None, **kwargs):
+def provision_device(device_name=None, is_provisioned=True, **kwargs):
     from .models import DeviceSettings
 
     device_settings, _ = DeviceSettings.objects.get_or_create(defaults=kwargs)
     if device_name is not None:
         device_settings.name = device_name
-    device_settings.is_provisioned = True
+    device_settings.is_provisioned = is_provisioned
     device_settings.save()
 
 

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -120,6 +120,7 @@
   import some from 'lodash/some';
   import uniqBy from 'lodash/uniqBy';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -123,7 +123,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import { TransferTypes, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import ChannelPanel from '../ManageContentPage/ChannelPanel/WithImportDetails';
   import ContentWizardUiAlert from '../SelectContentPage/ContentWizardUiAlert';

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -172,6 +172,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import { FacilityResource } from 'kolibri.resources';
   import {
@@ -181,7 +182,9 @@
     SyncFacilityModalGroup,
   } from 'kolibri.coreVue.componentSets.sync';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import { deviceString } from '../commonDeviceStrings';
   import TasksBar from '../ManageContentPage/TasksBar';
+  import DeviceTopNav from '../DeviceTopNav';
   import HeaderWithOptions from '../HeaderWithOptions';
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -180,12 +180,9 @@
     ConfirmationRegisterModal,
     SyncFacilityModalGroup,
   } from 'kolibri.coreVue.componentSets.sync';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import TasksBar from '../ManageContentPage/TasksBar';
   import HeaderWithOptions from '../HeaderWithOptions';
-  import DeviceTopNav from '../DeviceTopNav';
-  import { deviceString } from '../commonDeviceStrings';
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
@@ -56,9 +56,7 @@
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import { TaskResource } from 'kolibri.resources';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
-  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
-  import { PageNames } from '../../constants';
   import DeviceChannelResource from '../../apiResources/deviceChannel';
   import useContentTasks from '../../composables/useContentTasks';
   import taskNotificationMixin from '../taskNotificationMixin';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
@@ -53,10 +53,12 @@
 
   import { mapGetters } from 'vuex';
   import find from 'lodash/find';
-  import bytesForHumans from 'kolibri.utils.bytesForHumans';
-  import { TaskResource } from 'kolibri.resources';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import bytesForHumans from 'kolibri.utils.bytesForHumans';
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
+  import { TaskResource } from 'kolibri.resources';
   import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import { PageNames } from '../../constants';
   import DeviceChannelResource from '../../apiResources/deviceChannel';
   import useContentTasks from '../../composables/useContentTasks';
   import taskNotificationMixin from '../taskNotificationMixin';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -87,6 +87,7 @@
   import get from 'lodash/get';
   import last from 'lodash/last';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import { TransferTypes } from 'kolibri.utils.syncTaskUtils';
   import useContentTasks from '../../../composables/useContentTasks';
   import ChannelContentsSummary from '../../SelectContentPage/ChannelContentsSummary';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -87,7 +87,6 @@
   import get from 'lodash/get';
   import last from 'lodash/last';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import { TransferTypes } from 'kolibri.utils.syncTaskUtils';
   import useContentTasks from '../../../composables/useContentTasks';
   import ChannelContentsSummary from '../../SelectContentPage/ChannelContentsSummary';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -121,6 +121,7 @@
   import map from 'lodash/map';
   import get from 'lodash/get';
   import { mapState } from 'vuex';
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -125,7 +125,6 @@
   import { TaskResource } from 'kolibri.resources';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import { PageNames } from '../../constants';
   import useContentTasks from '../../composables/useContentTasks';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -87,6 +87,7 @@
   import sortBy from 'lodash/sortBy';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { TaskResource } from 'kolibri.resources';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import taskNotificationMixin from '../taskNotificationMixin';

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -88,7 +88,6 @@
   import { mapState, mapGetters, mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskResource } from 'kolibri.resources';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import taskNotificationMixin from '../taskNotificationMixin';
   import useContentTasks from '../../composables/useContentTasks';

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -90,8 +90,8 @@
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import { TaskTypes, PageNames } from 'kolibri.utils.syncTaskUtils';
-  import { ContentWizardErrors } from '../../constants';
+  import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import { ContentWizardErrors, PageNames } from '../../constants';
   import TaskProgress from '../ManageContentPage/TaskProgress';
   import useContentTasks from '../../composables/useContentTasks';
   import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -89,9 +89,6 @@
   import find from 'lodash/find';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
-  import { ContentWizardErrors, PageNames } from '../../constants';
   import TaskProgress from '../ManageContentPage/TaskProgress';
   import useContentTasks from '../../composables/useContentTasks';
   import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
@@ -99,13 +96,7 @@
   import { updateTreeViewTopic } from '../../modules/wizard/handlers';
   import { getChannelWithContentSizes } from '../../modules/wizard/apiChannelMetadata';
   import NewChannelVersionBanner from '../ManageContentPage/NewChannelVersionBanner';
-  import { getChannelWithContentSizes } from '../../modules/wizard/apiChannelMetadata';
-  import { updateTreeViewTopic } from '../../modules/wizard/handlers';
-  import taskNotificationMixin from '../taskNotificationMixin';
-  import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
   import { ContentWizardPages, ContentWizardErrors } from '../../constants';
-  import useContentTasks from '../../composables/useContentTasks';
-  import TaskProgress from '../ManageContentPage/TaskProgress';
   import AvailableChannelsPage from '../AvailableChannelsPage';
   import ChannelContentsSummary from './ChannelContentsSummary';
   import ContentTreeViewer from './ContentTreeViewer';

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/index.vue
@@ -89,6 +89,15 @@
   import find from 'lodash/find';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource } from 'kolibri.resources';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import { TaskTypes, PageNames } from 'kolibri.utils.syncTaskUtils';
+  import { ContentWizardErrors } from '../../constants';
+  import TaskProgress from '../ManageContentPage/TaskProgress';
+  import useContentTasks from '../../composables/useContentTasks';
+  import SelectionBottomBar from '../ManageContentPage/SelectionBottomBar';
+  import taskNotificationMixin from '../taskNotificationMixin';
+  import { updateTreeViewTopic } from '../../modules/wizard/handlers';
+  import { getChannelWithContentSizes } from '../../modules/wizard/apiChannelMetadata';
   import NewChannelVersionBanner from '../ManageContentPage/NewChannelVersionBanner';
   import { getChannelWithContentSizes } from '../../modules/wizard/apiChannelMetadata';
   import { updateTreeViewTopic } from '../../modules/wizard/handlers';

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -86,13 +86,19 @@ class FacilityImportViewSet(ViewSet):
         Given a username, full name and password, create a superuser attached
         to the facility that was imported (or create a facility with given facility_name)
         """
+        facility_name = request.data.get("facility_name", None)
+
         # Get the imported facility (assuming its the only one at this point)
         if Facility.objects.count() == 0:
-            name = request.data.get("facility_name", "")
-            the_facility = Facility.objects.create(name=name)
+            the_facility = Facility.objects.create(name=facility_name)
         else:
             the_facility = Facility.objects.get()
+            if facility_name:
+                the_facility.name = facility_name
+                the_facility.save()
 
+        # Here we only expect and accept the on_my_own_setup extra_field and set it directly
+        # using the setter method for `on_my_own_setup` on Facility
         extra_fields = request.data.get("extra_fields", None)
         if extra_fields and extra_fields.get("on_my_own_setup"):
             the_facility.on_my_own_setup = extra_fields.get("on_my_own_setup")

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -87,11 +87,15 @@ class FacilityImportViewSet(ViewSet):
         to the facility that was imported (or create a facility with given facility_name)
         """
         # Get the imported facility (assuming its the only one at this point)
-        try:
-            the_facility = Facility.objects.get()
-        except Facility.DoesNotExist:
+        if Facility.objects.count() == 0:
             name = request.data.get("facility_name", "")
             the_facility = Facility.objects.create(name=name)
+        else:
+            the_facility = Facility.objects.get()
+
+        extra_fields = request.data.get("extra_fields", None)
+        if extra_fields and extra_fields.get("on_my_own_setup"):
+            the_facility.on_my_own_setup = extra_fields.get("on_my_own_setup")
 
         try:
             superuser = FacilityUser.objects.create_superuser(

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -103,6 +103,12 @@ class FacilityImportViewSet(ViewSet):
         if extra_fields and extra_fields.get("on_my_own_setup"):
             the_facility.on_my_own_setup = extra_fields.get("on_my_own_setup")
 
+        if extra_fields and extra_fields.get("os_user"):
+            osuser = FacilityUser.objects.get_or_create_os_user(
+                facility=the_facility, auth_token=request.data.get("auth_token")
+            )
+            return Response({"username": osuser.username})
+
         try:
             superuser = FacilityUser.objects.create_superuser(
                 request.data.get("username"),
@@ -114,6 +120,17 @@ class FacilityImportViewSet(ViewSet):
 
         except ValidationError:
             raise ValidationError(detail="duplicate", code="duplicate_username")
+
+    @decorators.action(methods=["post"], detail=False)
+    def provisionosuserdevice(self, request):
+        """
+        When we can get the OS user, this is what we'll call to provision the device
+        TODO FIXME
+        """
+
+        device_name = request.data.get("device_name", "")  # noqa
+        language_id = request.data.get("language_id", "")  # noqa
+        is_provisioned = request.data.get("is_provisioned", False)  # noqa
 
     @decorators.action(methods=["post"], detail=False)
     def provisiondevice(self, request):

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -8,8 +8,13 @@ export const FacilityImportResource = new Resource({
   grantsuperuserpermissions({ user_id, password }) {
     return this.postListEndpoint('grantsuperuserpermissions', { user_id, password });
   },
-  createsuperuser({ username, full_name, password }) {
-    return this.postListEndpoint('createsuperuser', { username, full_name, password });
+  createsuperuser({ username, full_name, password, extra_fields }) {
+    return this.postListEndpoint('createsuperuser', {
+      username,
+      full_name,
+      password,
+      extra_fields,
+    });
   },
   provisiondevice({ device_name, language_id, is_provisioned }) {
     return this.postListEndpoint('provisiondevice', { device_name, language_id, is_provisioned });

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -15,6 +15,14 @@ export const FacilityImportResource = new Resource({
       password,
       extra_fields,
       facility_name,
+      auth_token: 'ca6830b018e647fc9723561c99b6b3f0',
+    });
+  },
+  provisionosuser({ device_name, language_id, is_provisioned }) {
+    return this.postListEndpoint('provisionosuserdevice', {
+      device_name,
+      language_id,
+      is_provisioned,
     });
   },
   provisiondevice({ device_name, language_id, is_provisioned }) {

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -8,12 +8,13 @@ export const FacilityImportResource = new Resource({
   grantsuperuserpermissions({ user_id, password }) {
     return this.postListEndpoint('grantsuperuserpermissions', { user_id, password });
   },
-  createsuperuser({ username, full_name, password, extra_fields }) {
+  createsuperuser({ username, full_name, password, extra_fields, facility_name }) {
     return this.postListEndpoint('createsuperuser', {
       username,
       full_name,
       password,
       extra_fields,
+      facility_name,
     });
   },
   provisiondevice({ device_name, language_id, is_provisioned }) {

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -11,8 +11,8 @@ export const FacilityImportResource = new Resource({
   createsuperuser({ username, full_name, password }) {
     return this.postListEndpoint('createsuperuser', { username, full_name, password });
   },
-  provisiondevice({ device_name, language_id }) {
-    return this.postListEndpoint('provisiondevice', { device_name, language_id });
+  provisiondevice({ device_name, language_id, is_provisioned }) {
+    return this.postListEndpoint('provisiondevice', { device_name, language_id, is_provisioned });
   },
   facilityadmins() {
     return this.getListEndpoint('facilityadmins').then(response => {

--- a/kolibri/plugins/setup_wizard/assets/src/constants.js
+++ b/kolibri/plugins/setup_wizard/assets/src/constants.js
@@ -7,6 +7,14 @@ const Presets = Object.freeze({
   NONFORMAL: 'nonformal',
 });
 
+/**
+ * enum identifying whether the user has gone to the on my own flow or not
+ */
+const UsePresets = Object.freeze({
+  ON_MY_OWN: 'on my own',
+  GROUP: 'group',
+});
+
 const SoudQueue = 'soud_sync';
 
-export { permissionPresets, Presets, SoudQueue };
+export { permissionPresets, Presets, UsePresets, SoudQueue };

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -9,8 +9,8 @@ const isGroupSetup = context => {
   return context.individualOrGroup === 'group';
 };
 
-const isAppContext = context => {
-  return context.appContext;
+const canGetOsUser = context => {
+  return context.canGetOsUser;
 };
 
 const isNewFacility = context => {
@@ -41,8 +41,8 @@ const setFullOrLOD = assign({
   fullOrLOD: (_, event) => event.value,
 });
 
-const setAppContext = assign({
-  isAppContext: (_, event) => event.value,
+const setCanGetOsUser = assign({
+  canGetOsUser: (_, event) => event.value,
 });
 
 const setFacilityNewOrImport = assign({
@@ -67,7 +67,7 @@ const setRequirePassword = assign({
 
 const initialContext = {
   individualOrGroup: null,
-  isAppContext: false, // Must be set in the component where the machine is used
+  canGetOsUser: false, // Must be set in the component where the machine is used
   facilityNewOrImport: null,
   fullOrLOD: null,
   deviceName: null,
@@ -79,7 +79,7 @@ const initialContext = {
 
 /**
  * Assigns the machine to have the initial context again while maintaining the value of
- * isAppContext.
+ * canGetOsUser.
  *
  * This effectively resets the machine's state
  */
@@ -87,9 +87,9 @@ const resetContext = assign({
   ...reduce(
     initialContext,
     (result, value, key) => {
-      if (key === 'isAppContext') {
+      if (key === 'canGetOsUser') {
         // This won't change because of starting over
-        result[key] = context => context.isAppContext;
+        result[key] = context => context.canGetOsUser;
       } else {
         result[key] = () => value;
       }
@@ -107,10 +107,10 @@ export const wizardMachine = createMachine({
     START_OVER: { target: 'howAreYouUsingKolibri', action: resetContext },
   },
   states: {
-    // This state will be the start so the machine won't progress until the isAppContext is set
+    // This state will be the start so the machine won't progress until the canGetOsUser is set
     initializeContext: {
       on: {
-        CONTINUE: { target: 'howAreYouUsingKolibri', actions: setAppContext },
+        CONTINUE: { target: 'howAreYouUsingKolibri', actions: setCanGetOsUser },
       },
     },
     // Initial step where user selects between "On my own" (individual) or "Group learning" (group)
@@ -142,13 +142,13 @@ export const wizardMachine = createMachine({
         BACK: 'howAreYouUsingKolibri',
       },
     },
-    // A passthrough step depending on the value of context.isAppContext
+    // A passthrough step depending on the value of context.canGetOsUser
     createAccountOrFinalizeSetup: {
       always: [
         {
           // FIXME: The app needs to create a user account from the OS user in this case - to be
           // handled on the backend most likely, but just bear this in mind for now to be sure
-          cond: isAppContext,
+          cond: canGetOsUser,
           target: 'finalizeSetup',
         },
         {
@@ -285,9 +285,9 @@ if (process.env.NODE_ENV === 'development') {
   console.log('=== wizardMachine ===');
   console.log(
     'Save the following function as an object, call it and pass an object with initial context ala',
-    ' { isAppContext: Boolean } - the rest of the context should be set through events.\n',
+    ' { canGetOsUser: Boolean } - the rest of the context should be set through events.\n',
     'Usage (assuming you saved to `temp1`):\n',
-    'let machine = temp1({ isAppContext: true });\n',
+    'let machine = temp1({ canGetOsUser: true });\n',
     "machine.send({ type: 'CONTINUE', value: 'individual'});\n"
   );
   console.log((context = {}) => interpret(wizardMachine.withContext(context)).start());

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -14,6 +14,7 @@ const SetupStrings = createTranslator('SetupStrings', {
 });
 
 export default {
+  namespace: 'SetupWizard',
   state() {
     return {
       started: false,

--- a/kolibri/plugins/setup_wizard/assets/src/routes.js
+++ b/kolibri/plugins/setup_wizard/assets/src/routes.js
@@ -27,7 +27,7 @@ export default [
   },
   {
     path: '/create-account',
-    name: 'CREATE_INDIVIDUAL_ACCOUNT',
+    name: 'CREATE_SUPERUSER_AND_FACILITY',
     component: SuperuserCredentialsForm,
   },
   {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportFacilitySetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportFacilitySetup.vue
@@ -8,6 +8,7 @@
     :stepMessage.sync="currentStepMessage"
     @click_back="goToLastStep"
     @click_next="goToNextStep"
+    @start_over="startOver"
   />
 
 </template>
@@ -94,6 +95,9 @@
       }
     },
     methods: {
+      startOver() {
+        this.wizardService.send('START_OVER');
+      },
       goToNextStep({ device, facility } = {}) {
         this.device = device || this.device;
         this.facility = facility || this.facility;

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -280,4 +280,11 @@
     text-align: left;
   }
 
+  /deep/ .truncate-text {
+    /* Override KRadioButton default behavior of eliding text with ellipsis to ensure word wrap */
+
+    /* This will effect the entire onboarding experience */
+    white-space: normal;
+  }
+
 </style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -64,10 +64,14 @@
           <slot name="footer"></slot>
         </div>
 
+
         <!-- Footer for medium+ screens -->
         <KButtonGroup v-if="!windowIsSmall" class="footer-actions footer-section">
+          <!-- Allow direct override of the buttons in the footer -->
+          <slot name="buttons"></slot>
+          <!-- Default buttons, hidden when the slot is used -->
           <KButton
-            v-if="!noBackAction"
+            v-if="!noBackAction && !$slots.buttons"
             :text="coreString('goBackAction')"
             appearance="flat-button"
             :primary="false"
@@ -75,6 +79,7 @@
             @click="wizardService.send('BACK')"
           />
           <KButton
+            v-if="!$slots.buttons"
             :text="coreString('continueAction')"
             :primary="true"
             :disabled="navDisabled"
@@ -84,7 +89,10 @@
 
         <!-- Simpler to do a big button for the small screen separately -->
         <div v-if="windowIsSmall" class="mobile-footer">
+          <!-- Allow direct override of the buttons in the footer -->
+          <slot name="buttons"></slot>
           <KButton
+            v-if="!$slots.buttons"
             class="mobile-continue-button"
             :text="coreString('continueAction')"
             :primary="true"

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -80,7 +80,13 @@
 
       const synchronizeRouteAndMachine = state => {
         const { meta } = state;
-        console.log(meta);
+
+        // Dump out of here if there is nothing to resume from
+        if (!Object.keys(meta).length) {
+          this.$router.push('/');
+          return;
+        }
+
         const route = meta[Object.keys(meta)[0]].route;
         if (route) {
           // Avoid redundant navigation
@@ -88,7 +94,7 @@
             this.$router.push(route);
           }
         } else {
-          this.router.push('/');
+          this.$router.push('/');
         }
       };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -26,9 +26,10 @@
 <script>
 
   import { interpret } from 'xstate';
-  import { mapGetters, mapState } from 'vuex';
+  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import { checkCapability } from 'kolibri.utils.appCapabilities';
   import Lockr from 'lockr';
   import { wizardMachine } from '../machines/wizardMachine';
   import LoadingPage from './submission-states/LoadingPage';
@@ -57,7 +58,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext']),
       ...mapState(['loading', 'error']),
     },
     created() {
@@ -98,9 +98,10 @@
         }
       };
 
+      // Note the second arg to Lockr.get is a fallback if the first arg is not found
       const savedState = Lockr.get('savedState', 'initializeContext');
 
-      // Either the string 'initializeContext' or a valid state object
+      // Either the string 'initializeContext' or a valid state object returned from Lockr
       this.service.start(savedState);
 
       if (savedState !== 'initializeContext') {
@@ -108,7 +109,7 @@
         synchronizeRouteAndMachine(savedState);
       } else {
         // Or set the app context state on the machine and proceed to the first state
-        this.service.send({ type: 'CONTINUE', value: this.isAppContext });
+        this.service.send({ type: 'CONTINUE', value: checkCapability('get_os_user') });
       }
 
       this.service.onTransition(state => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -64,8 +64,8 @@
       /*
        * The interpreted wizardMachine is an object that lets you move between states.
        * It's current state value has no side effects or dependencies - so we can store it
-       * as data - then when we initialize the machine each time, we can pass it the previous
-       * state.
+       * as data - then when we initialize the machine each time, we can pass it that data
+       * to resume the machine as we had saved it.
        *
        * A key part of this is that we synchronize our router with the machine on every
        * transition as each state entry has a `meta` property with a route name that maps

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -102,7 +102,6 @@
       const savedState = Lockr.get('savedState', 'initializeContext');
 
       // Either the string 'initializeContext' or a valid state object returned from Lockr
-      this.service.start(savedState);
 
       if (savedState !== 'initializeContext') {
         // Update the route if there is a saved state
@@ -111,6 +110,8 @@
         // Or set the app context state on the machine and proceed to the first state
         this.service.send({ type: 'CONTINUE', value: checkCapability('get_os_user') });
       }
+
+      this.service.start(savedState);
 
       this.service.onTransition(state => {
         synchronizeRouteAndMachine(state);

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -103,11 +103,8 @@
       startOver() {
         this.isPolling = false;
         this.clearTasks().then(() => {
-          this.goToRootUrl();
+          this.$emit('start_over');
         });
-      },
-      goToRootUrl() {
-        this.$router.replace('/');
       },
       clearTasks() {
         return TaskResource.clearAll();

--- a/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importFacility/LoadingTaskPage.vue
@@ -18,18 +18,16 @@
         @click="handleClickContinue"
       />
       <template v-else-if="loadingTask.status === 'FAILED'">
-        <KButtonGroup>
-          <KButton
-            primary
-            :text="coreString('retryAction')"
-            @click="retryImport"
-          />
-          <KButton
-            :text="coreString('startOverAction')"
-            appearance="flat-button"
-            @click="startOver"
-          />
-        </KButtonGroup>
+        <KButton
+          :text="coreString('startOverAction')"
+          appearance="flat-button"
+          @click="startOver"
+        />
+        <KButton
+          primary
+          :text="coreString('retryAction')"
+          @click="retryImport"
+        />
       </template>
       <span v-else></span>
     </template>

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -9,13 +9,13 @@
     <KRadioButton
       v-model="selected"
       style="margin-bottom: 1em"
-      :value="Options.INDIVIDUAL"
+      :value="UsePresets.ON_MY_OWN"
       :label="$tr('onMyOwnLabel')"
       :description="$tr('onMyOwnDescription')"
     />
     <KRadioButton
       v-model="selected"
-      :value="Options.GROUP"
+      :value="UsePresets.GROUP"
       :label="$tr('groupLearningLabel')"
       :description="$tr('groupLearningDescription')"
     />
@@ -27,11 +27,7 @@
 <script>
 
   import OnboardingStepBase from '../OnboardingStepBase';
-
-  const Options = Object.freeze({
-    INDIVIDUAL: 'individual',
-    GROUP: 'group',
-  });
+  import { Presets, UsePresets } from '../../constants';
 
   export default {
     name: 'HowAreYouUsingKolibri',
@@ -39,20 +35,24 @@
     inject: ['wizardService'],
     data() {
       return {
-        selected: Options.INDIVIDUAL,
+        selected: UsePresets.ON_MY_OWN,
       };
     },
     computed: {
-      isIndividualSetup() {
-        return this.selected === Options.INDIVIDUAL;
+      isOnMyOwnSetup() {
+        return this.selected === UsePresets.ON_MY_OWN;
       },
-      Options() {
-        return Options;
+      UsePresets() {
+        return UsePresets;
       },
     },
     methods: {
       handleContinue() {
-        this.$store.commit('SET_FACILITY_PRESET', this.isIndividualSetup ? Options.INDIVIDUAL : '');
+        if (this.isOnMyOwnSetup) {
+          // If the user is on their own, set the preset to personal here
+          // If not then the user will set it using a form later on
+          this.$store.commit('SET_FACILITY_PRESET', Presets.PERSONAL);
+        }
         this.goToNextStep();
       },
       goToNextStep() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -1,14 +1,107 @@
 <template>
 
-  <p>~INTERSTITIAL~ </p>
+  <div class="full-page">
+    <CoreLogo class="logo" />
+    <h1 class="page-title">
+      {{ $tr('pageTitle') }}
+    </h1>
+    <p class="message">
+      {{ $tr('pleaseWaitMessage') }}
+    </p>
+  </div>
 
 </template>
 
 
 <script>
 
+  import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
+  import { FacilityImportResource } from '../../api';
+  import { UsePresets } from '../../constants';
+
   export default {
     name: 'SettingUpKolibri',
+    components: { CoreLogo },
+    inject: ['wizardService'],
+    mounted() {
+      // If we're in app mode
+      if (this.wizardService.state.context.canGetOsUser) {
+        const facilityUserData = {
+          facility_name: this.$store.state.onboardingData.facility.name,
+          extra_fields: {
+            on_my_own_setup: this.isOnMyOwnSetup(),
+            os_user: true,
+          },
+        };
+        FacilityImportResource.createsuperuser(facilityUserData)
+          .then(
+            () => (window.location = window.urls['kolibri:kolibri.plugins.user_auth:user_auth']())
+          )
+          .catch(err => console.log(err));
+      } else {
+        window.location = window.urls['kolibri:kolibri.plugins.user_auth:user_auth']();
+      }
+    },
+    methods: {
+      isOnMyOwnSetup() {
+        return this.wizardService.state.context.onMyOwnOrGroup == UsePresets.ON_MY_OWN;
+      },
+    },
+    $trs: {
+      pageTitle: {
+        message: 'Setting up Kolibri',
+        context: 'The title of the page',
+      },
+      pleaseWaitMessage: {
+        message: 'This may take several minutes',
+        context: 'Kolibri is working in the background and the user may need to wait',
+      },
+    },
   };
 
 </script>
+
+
+<style scoped lang="scss">
+
+  .full-page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+  }
+
+  .logo {
+    display: block;
+    max-width: 400px;
+    padding: 0 2em;
+    margin: 12em auto 0;
+
+    /* TODO Replace this with animated logo */
+    animation-name: spin;
+    animation-duration: 400ms;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .page-title,
+  .message {
+    padding: 0 1em;
+    text-align: center;
+  }
+
+  .page-title {
+    font-size: 1.5em;
+  }
+
+</style>

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -110,15 +110,30 @@
     },
     methods: {
       handleContinue() {
-        const data = {
+        /**
+         * Partially provision the device
+         * Create SuperUser
+         * Continue
+         * TODO: Not sure "Facility" and "Device" are the best default names here -- will need to
+         * get the OS user's info I think.
+         */
+        const facilityUserData = {
           fullName: this.fullName,
           username: this.username,
           password: this.password,
+          facility_name: 'Facility',
         };
         if (this.formIsValid) {
-          return FacilityImportResource.createsuperuser(data)
+          return FacilityImportResource.createsuperuser(facilityUserData)
             .then(() => {
-              //this.updateSuperuserAndClickNext(data.username, data.password);
+              const deviceProvisioningData = {
+                device_name: 'Device',
+                language_id: this.$store.state.onboardingData.language_id,
+                is_provisioned: true,
+              };
+              FacilityImportResource.provisiondevice(deviceProvisioningData).then(() =>
+                this.wizardService.send('CONTINUE')
+              );
             })
             .catch(e => {
               throw new Error(`Error creating superuser: ${e}`);
@@ -127,35 +142,6 @@
           this.focusOnInvalidField();
         }
       },
-      // FIXME this breaks because the facility isn't created yet, this bit of the logic
-      // is TBD -- the old method kept as some functionality may be preserved
-      // Note that the process is currently gathering deferring the actual provisioning of
-      // everything to the end, hence why no facility here yet. Not sure how we'll proceed here yet
-      /*
-      handleSubmit() {
-        if (!this.$refs.fullNameTextbox) {
-          return this.$emit('click_next');
-        }
-        this.formSubmitted = true;
-        // Have to wait a tick to let inputs react to this.formSubmitted
-        this.$nextTick().then(() => {
-          if (this.formIsValid) {
-            this.$store.commit('SET_SUPERUSER_CREDENTIALS', {
-              full_name: this.fullName,
-              username: this.username,
-              password: this.password,
-            });
-            this.$emit('click_next', {
-              full_name: this.fullName,
-              username: this.username,
-              password: this.password,
-            });
-          } else {
-            this.focusOnInvalidField();
-          }
-        });
-      },
-      */
       focusOnInvalidField() {
         this.$nextTick().then(() => {
           if (!this.fullNameValid) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -68,6 +68,7 @@
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
   import OnboardingStepBase from '../OnboardingStepBase';
+  import { UsePresets } from '../../constants';
   import { FacilityImportResource } from '../../api';
 
   export default {
@@ -110,7 +111,7 @@
     },
     methods: {
       isOnMyOwnSetup() {
-        return this.wizardService.state.context.individualOrGroup == 'individual';
+        return this.wizardService.state.context.onMyOwnOrGroup == UsePresets.ON_MY_OWN;
       },
       handleContinue() {
         /**
@@ -133,7 +134,7 @@
           return FacilityImportResource.createsuperuser(facilityUserData)
             .then(() => {
               const deviceProvisioningData = {
-                device_name: 'Device',
+                device_name: this.wizardService.state.context.deviceName,
                 language_id: this.$store.state.onboardingData.language_id,
                 is_provisioned: true,
               };

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -122,6 +122,9 @@
           username: this.username,
           password: this.password,
           facility_name: 'Facility',
+          extra_fields: {
+            on_my_own_setup: this.wizardService.state.context.individualOrGroup == 'individual',
+          },
         };
         if (this.formIsValid) {
           return FacilityImportResource.createsuperuser(facilityUserData)

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SuperuserCredentialsForm.vue
@@ -109,6 +109,9 @@
       },
     },
     methods: {
+      isOnMyOwnSetup() {
+        return this.wizardService.state.context.individualOrGroup == 'individual';
+      },
       handleContinue() {
         /**
          * Partially provision the device
@@ -121,9 +124,9 @@
           fullName: this.fullName,
           username: this.username,
           password: this.password,
-          facility_name: 'Facility',
+          facility_name: this.$store.state.onboardingData.facility.name,
           extra_fields: {
-            on_my_own_setup: this.wizardService.state.context.individualOrGroup == 'individual',
+            on_my_own_setup: this.isOnMyOwnSetup(),
           },
         };
         if (this.formIsValid) {

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -27,7 +27,11 @@ class SetupWizardPlugin(KolibriPluginBase):
 
     @property
     def plugin_data(self):
-        return {"canUseOSUser": GET_OS_USER in interface}
+        return {
+            "appCapabilities": {
+                "canGetOsUser": GET_OS_USER in interface,
+            }
+        }
 
 
 @register_hook

--- a/kolibri/plugins/setup_wizard/kolibri_plugin.py
+++ b/kolibri/plugins/setup_wizard/kolibri_plugin.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 from kolibri.core.device.hooks import SetupHook
 from kolibri.core.webpack import hooks as webpack_hooks
 from kolibri.plugins import KolibriPluginBase
-from kolibri.plugins.app.utils import GET_OS_USER
-from kolibri.plugins.app.utils import interface
 from kolibri.plugins.hooks import register_hook
 from kolibri.utils import translation
 from kolibri.utils.translation import ugettext as _
@@ -27,11 +25,7 @@ class SetupWizardPlugin(KolibriPluginBase):
 
     @property
     def plugin_data(self):
-        return {
-            "appCapabilities": {
-                "canGetOsUser": GET_OS_USER in interface,
-            }
-        }
+        return {}
 
 
 @register_hook


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Prepares SetupWizard flow so that it can be partially provisioned (ie, a Facility can have been created/imported without the DeviceSettings.is_provisioned flag being set to True) -- this covers the edge case of a user not completing the process of importing users one by one and returning to it without ever saying "Okay I'm done onboarding"
- The FacilityImportResource / FacilityImportViewSet were both set to use the new `is_provisioned` flag when given in a request - it defaults to `False` **honestly not sure what default to use, as is evidenced by it defaulting to True in device settings**
- The same two were also changed so that `createsuperuser` will create a facility with a given `facility_name`.

**Outstanding issues (follow-up things)**

The following is what, at a high level, remains for the Setup Wizard. I will create a new set of issues and add them to the backlog following up on this when approved and before merging.

- Only the "On My Own" flow is setup to work properly here, other flows need work still (high effort)
- The "Step X of Y" logic is not yet implemented (medium effort)
- Wiring up bits around the user's device name and such needs to be implemented when creating facilities and devices (medium effort)
- The Interstitial needs to be designed (low effort)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Can you go from start to finish through the On My Own flow?
- Thoughts on what the sane default for "is_provisioned" should be end to end?
- Any concerns with creating the facility inside the "createsuperuser" method?
- Does your language selection during Onboarding get reflected properly? (refresh on the page that says "-- INTERSTITIAL --")

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
