### PR TITLE
By default don't initialize hooks when enabling and disabling plugins programmatically

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -131,7 +131,7 @@ def initialize_kolibri_plugin(plugin_name, initialize_hooks=True):
     In so doing, it will instantiate the KolibriPlugin object if it
     exists, and also register any hooks found in the module.
 
-    Use the initialize_hooks argument to just retrieve the kolibri plugin without registering
+    Set the initialize_hooks argument to False to just retrieve the kolibri plugin without registering
     its hooks.
 
     :returns: the KolibriPlugin object for the module

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -89,7 +89,7 @@ def _import_python_module(plugin_name):
             raise
 
 
-def initialize_plugins_and_hooks(all_classes, plugin_name):
+def initialize_plugins_and_hooks(all_classes, plugin_name, initialize_hooks=True):
     was_configured = django_settings.configured
     plugin_objects = []
     for class_definition in all_classes:
@@ -102,7 +102,7 @@ def initialize_plugins_and_hooks(all_classes, plugin_name):
                         class_definition.__name__, plugin_name
                     )
                 )
-        elif issubclass(class_definition, KolibriHook):
+        elif issubclass(class_definition, KolibriHook) and initialize_hooks:
             class_definition.add_hook_to_registries()
             if not was_configured and django_settings.configured:
                 raise PluginLoadsApp(
@@ -125,11 +125,14 @@ def initialize_plugins_and_hooks(all_classes, plugin_name):
         raise MultiplePlugins("More than one plugin defined in kolibri_plugin module")
 
 
-def initialize_kolibri_plugin(plugin_name):
+def initialize_kolibri_plugin(plugin_name, initialize_hooks=True):
     """
     Try to load kolibri_plugin from given plugin module identifier
     In so doing, it will instantiate the KolibriPlugin object if it
     exists, and also register any hooks found in the module.
+
+    Use the initialize_hooks argument to just retrieve the kolibri plugin without registering
+    its hooks.
 
     :returns: the KolibriPlugin object for the module
     """
@@ -170,7 +173,9 @@ def initialize_kolibri_plugin(plugin_name):
             for cls in plugin_module.__dict__.values()
             if is_plugin_module(cls) and isinstance(cls, type)
         ]
-        return initialize_plugins_and_hooks(all_classes, plugin_name)
+        return initialize_plugins_and_hooks(
+            all_classes, plugin_name, initialize_hooks=initialize_hooks
+        )
 
     except ImportError as e:
         # Python 2: message, Python 3: msg
@@ -190,9 +195,9 @@ def initialize_kolibri_plugin(plugin_name):
         raise PluginLoadsApp(msg)
 
 
-def enable_plugin(plugin_name):
+def enable_plugin(plugin_name, initialize_hooks=False):
     try:
-        obj = initialize_kolibri_plugin(plugin_name)
+        obj = initialize_kolibri_plugin(plugin_name, initialize_hooks=initialize_hooks)
         if obj:
             obj.enable()
             return True
@@ -200,9 +205,9 @@ def enable_plugin(plugin_name):
         logger.error(str(e))
 
 
-def disable_plugin(plugin_name):
+def disable_plugin(plugin_name, initialize_hooks=False):
     try:
-        obj = initialize_kolibri_plugin(plugin_name)
+        obj = initialize_kolibri_plugin(plugin_name, initialize_hooks=initialize_hooks)
         if obj:
             obj.disable()
             return True

--- a/kolibri/utils/cli.py
+++ b/kolibri/utils/cli.py
@@ -394,7 +394,7 @@ def enable(plugin_names, default_plugins):
     for name in plugin_names:
         try:
             logger.info("Enabling plugin '{}'".format(name))
-            error = error or not enable_plugin(name)
+            error = error or not enable_plugin(name, initialize_hooks=True)
         except Exception as e:
             error = True
             logger.error("Error enabling plugin '{}', error was: {}".format(name, e))


### PR DESCRIPTION
## Summary
* To do a full disable or enabling of a plugin, we also register all the hooks.
* This is appropriate from the CLI as it gives us warning of whether a hook registration does forbidden calls and initialization
* When enabling and disabling plugins programmatically, it can prematurely register a hook within the life cycle of an application using Kolibri
* Adds an extra argument to toggle hook initialization, which defaults to True
* Turns it off by default for the `enable_plugin` and `disable_plugin` functions
* Turns it on by default for the CLI invocation of `enable_plugin`

## References
Fixes https://github.com/learningequality/kolibri/issues/9696

## Reviewer guidance
Open a python shell and do the following:
```
from kolibri.core.hooks import RoleBasedRedirectHook
print(list(RoleBasedRedirectHook.registered_hooks))

from kolibri.main import disable_plugin
disable_plugin("kolibri.plugins.learn")

print(list(RoleBasedRedirectHook.registered_hooks))
```

With this PR, both print statements will produce empty lists. Without it, the second will produce a list like this: `[<kolibri.plugins.learn.kolibri_plugin.LearnRedirect at 0x7feaa74dd8d0>]`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
