### PR TITLE
changed _init_.py  from 5 tuple to 3.

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -15,12 +15,15 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 15, 8, "final", 0)
+VERSION = (
+    0,
+    15,
+    8,
+)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"
 __version__ = str(get_version(VERSION))
-
 
 #: A list of all available plugins defined within the Kolibri repo
 #: Define it here to avoid introspection malarkey, and to allow for

--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -15,11 +15,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (
-    0,
-    15,
-    8,
-)
+VERSION = (0, 15, 8)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -28,7 +28,10 @@ class TestKolibriVersion(unittest.TestCase):
 
     @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)
     @mock.patch("kolibri.utils.version.get_version_file", return_value=None)
-    def test_no_tag_no_file_version(self, file_mock, describe_mock):
+    @mock.patch("kolibri.utils.version.get_git_changeset", return_value=None)
+    def test_no_tag_no_file_version_no_git_changeset(
+        self, get_git_changeset_mock, file_mock, describe_mock
+    ):
         """
         Test that when doing something with a 0th alpha doesn't provoke any
         hickups with ``git describe --tag``.
@@ -36,7 +39,24 @@ class TestKolibriVersion(unittest.TestCase):
         then get_prerelease_version should return 0.15.8.dev0
         """
         v = get_version((0, 1, 0))
-        self.assertIn("0.1.0.dev0", v)
+        self.assertEqual("0.1.0.dev0", v)
+
+    @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)
+    @mock.patch("kolibri.utils.version.get_version_file", return_value=None)
+    @mock.patch(
+        "kolibri.utils.version.get_git_changeset", return_value="+git.1234567890"
+    )
+    def test_no_tag_no_file_version_git_changeset(
+        self, get_git_changeset_mock, file_mock, describe_mock
+    ):
+        """
+        Test that when doing something with a 0th alpha doesn't provoke any
+        hickups with ``git describe --tag``.
+        If the version file returns nothing, and get_git_describe returns nothing,
+        then get_prerelease_version should return 0.15.8.dev0
+        """
+        v = get_version((0, 1, 0))
+        self.assertEqual("0.1.0.dev0+git.1234567890", v)
 
     @mock.patch("kolibri.utils.version.get_git_describe", return_value="v0.1.0-alpha1")
     @mock.patch("kolibri.utils.version.get_version_file", return_value=None)

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -470,3 +470,19 @@ class TestKolibriVersion(unittest.TestCase):
             ),
             "0.16-b.1.c",
         )
+
+    @mock.patch("kolibri.utils.version.get_git_describe", return_value="v0.15.8")
+    def test_get_version(self, describe_mock):
+        self.assertEqual(
+            version.get_version((0, 15, 8)),
+            "0.15.8",
+        )
+        assert describe_mock.call_count == 1
+
+    @mock.patch("kolibri.utils.version.get_version_file", return_value="0.15.8")
+    def test_get_version_from_file(self, describe_mock):
+        self.assertEqual(
+            version.get_version((0, 15, 8)),
+            "0.15.8",
+        )
+        assert describe_mock.call_count == 1

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -254,6 +254,28 @@ class TestKolibriVersion(unittest.TestCase):
         self.assertEqual(v, "0.1.1")
         assert describe_mock.call_count == 0
 
+    @mock.patch("kolibri.utils.version.get_git_describe", return_value="v0.1.1")
+    @mock.patch("kolibri.utils.version.get_version_file", return_value=None)
+    def test_final_tag(self, file_mock, describe_mock):
+        """
+        Test that the major version is set as expected on a final release tag
+        """
+        v = get_version((0, 1, 1))
+        self.assertEqual(v, "0.1.1")
+        assert describe_mock.call_count == 1
+
+    @mock.patch(
+        "kolibri.utils.version.get_git_describe", return_value="v0.1.1-6-gdef09150"
+    )
+    @mock.patch("kolibri.utils.version.get_version_file", return_value=None)
+    def test_after_final_tag(self, file_mock, describe_mock):
+        """
+        Test that the version is set as the next patch alpha when we are beyond the final release tag
+        """
+        v = get_version((0, 1, 1))
+        self.assertEqual(v, "0.1.1a0.dev0+git.6.gdef09150")
+        assert describe_mock.call_count == 1
+
     def test_version_compat(self):
         """
         Test that our version glue works for some really old releases of

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -34,9 +34,12 @@ class TestKolibriVersion(unittest.TestCase):
     ):
         """
         Test that when doing something with a 0th alpha doesn't provoke any
-        hickups with ``git describe --tag``.
+        hiccups with ``git describe --tag``.
         If the version file returns nothing, and get_git_describe returns nothing,
-        then get_prerelease_version should return 0.15.8.dev0
+        and get_git_changeset returns nothing,
+        then get_prerelease_version should return x.y.z.dev0
+        as we are not on a final release, but we can't determine any more information
+        beyond that, so we can only say this is a dev0 release and nothing more.
         """
         v = get_version((0, 1, 0))
         self.assertEqual("0.1.0.dev0", v)
@@ -51,9 +54,11 @@ class TestKolibriVersion(unittest.TestCase):
     ):
         """
         Test that when doing something with a 0th alpha doesn't provoke any
-        hickups with ``git describe --tag``.
+        hiccups with ``git describe --tag``.
         If the version file returns nothing, and get_git_describe returns nothing,
-        then get_prerelease_version should return 0.15.8.dev0
+        then get_prerelease_version should return x.y.z.dev0 and the output of
+        get_git_changeset to give an incrementing version number in absence of any
+        other relevant tag information.
         """
         v = get_version((0, 1, 0))
         self.assertEqual("0.1.0.dev0+git.1234567890", v)
@@ -228,7 +233,10 @@ class TestKolibriVersion(unittest.TestCase):
     def test_git_random_tag(self, file_mock, popen_mock):
         """
         Test that we don't fail if some random tag appears
-        Always fallback to .dev0 if the tag data is unparseable.
+        Always fallback to .dev0 to give some indication that
+        this is not a final release, even if we can discern nothing else.
+        Noting that the subprocess.Popen mock also causes get_git_changeset
+        to return nothing meaningful either, so we don't even get that additional information.
         """
         process_mock = mock.Mock()
         attrs = {"communicate.return_value": ("foobar", "")}

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -159,8 +159,12 @@ class TestKolibriVersion(unittest.TestCase):
         """
         assert get_version((0, 1, 0)) == "0.1.0"
 
+    @mock.patch(
+        "kolibri.utils.version.get_version_file",
+        return_value=None,
+    )
     @mock.patch("kolibri.utils.version.get_git_describe")
-    def test_alpha_1_inconsistent_git_tag(self, describe_mock):
+    def test_alpha_1_inconsistent_git_tag(self, describe_mock, file_mock):
         """
         Test that we fail when git returns inconsistent data
         Only when the returned tag is a greater major, minor, patch

--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -392,7 +392,7 @@ class TestKolibriVersion(unittest.TestCase):
     @mock.patch("kolibri.utils.version.get_version_file", return_value=None)
     def test_get_version(self, file_mock, describe_mock):
         self.assertEqual(
-            version.get_version((0, 15, 8)),
+            get_version((0, 15, 8)),
             "0.15.8",
         )
         assert describe_mock.call_count == 1
@@ -400,7 +400,7 @@ class TestKolibriVersion(unittest.TestCase):
     @mock.patch("kolibri.utils.version.get_version_file", return_value="0.15.8")
     def test_get_version_from_file(self, describe_mock):
         self.assertEqual(
-            version.get_version((0, 15, 8)),
+            get_version((0, 15, 8)),
             "0.15.8",
         )
-        assert describe_mock.call_count == 0
+        assert describe_mock.call_count == 1

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -338,7 +338,7 @@ def get_prerelease_version(version):
                 + suffix
             )
 
-    return major + ".dev0"
+    return major + ".dev0" + (get_git_changeset() or "")
 
 
 def get_version_from_file(version):

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -117,30 +117,6 @@ def get_major_version(version):
     return major
 
 
-def get_complete_version(version=None):
-    """
-    :returns: A tuple of the version. If version argument is non-empty, then
-              checks for correctness of the tuple provided.
-    """
-    if version is None:
-        from kolibri import VERSION as version
-    else:
-        if len(version) != 3:
-            raise AssertionError
-
-    return version
-
-
-def get_docs_version(version=None):
-    """
-    :returns: Version string for use in Sphinx docs
-    """
-    version = get_complete_version(version)
-    if version[3] != "final":
-        return "dev"
-    return "%d.%d" % version[:2]
-
-
 def get_git_changeset():
     """
     Returns a numeric identifier of the latest git changeset.
@@ -292,9 +268,9 @@ def get_prerelease_version(version):
     if tag_describe:
 
         git_version, suffix = get_version_from_git(tag_describe)
-        # We will check  if the git_tag and version strings are the same length,
-        # and compare it  the first three characters of each string to see if they matches.
-        # if not, we then  raise an AssertionError.
+        # We will check if the git_tag and version strings are the same length,
+        # and compare it the first three characters of each string to see if they matches.
+        # if not, we then raise an AssertionError.
         if not suffix:
             if not git_version[:3] == version[:3]:
                 raise AssertionError(
@@ -372,10 +348,7 @@ def get_version_from_file(version):
 
 
 @lru_cache()
-def get_version(version=None):
-    if version is None:
-        from kolibri import VERSION as version
-
+def get_version(version):
     version_str = get_version_from_file(version)
     if version_str:
         return version_str

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -324,14 +324,14 @@ def get_prerelease_version(version):
         if git_version[:3] == version[:3]:
             if git_version[3] == "final":
                 return major
-        # If the tag was of a final version, we will use it.
+            # If the tag was of a final version, we will use it.
 
-        return (
-            get_major_version(git_version)
-            + mapping[git_version[3]]
-            + str(git_version[4])
-            + suffix
-        )
+            return (
+                get_major_version(git_version)
+                + mapping[git_version[3]]
+                + str(git_version[4])
+                + suffix
+            )
 
     # In all cirrcumstances, return the initial findings
     return major + ".dev0"

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -297,23 +297,25 @@ def get_prerelease_version(version):
     tag_describe = get_git_describe(version)
 
     # If the detected git describe data is not valid, then either respect
-    # that we are in alpha-0 mode or raise an error
+
     if tag_describe:
 
         git_version, suffix = get_version_from_git(tag_describe)
+        # We will check  if the git_tag and version strings are the same length,
+        # and compare it  the first three characters of each string to see if they matches.
+        # if not, we then  raise an AssertionError.
         if not suffix:
             if not git_version[:3] == version[:3]:
-                # If it's the 0th alpha, load suffix info from git changeset
-                # if version[4] == 0 and version[3] == "alpha":
-                # Throw away the description from git
-                suffix = get_git_changeset()
-
-                # Replace 'alpha' with .dev
-                return major + ".dev0" + suffix
-
-                # # If the tag was not of a final version, we will fail.
+                raise AssertionError(
+                    (
+                        "Version detected from git describe --tags, but it's "
+                        "inconsistent with kolibri.__version__."
+                        "__version__ is: {}, tag says: {}."
+                    ).format(str(version), git_version)
+                )
+        # checks if the version number in git_version is greater than the version number in version.
+        # If it is, the code raises an AssertionError
         if git_version[:3] > version[:3]:
-            # If the tag was of a final version, we will use it.
             raise AssertionError(
                 (
                     "Version detected from git describe --tags, but it's "
@@ -321,10 +323,13 @@ def get_prerelease_version(version):
                     "__version__ is: {}, tag says: {}."
                 ).format(str(version), git_version)
             )
+        # checks if the tag in git_version is the same to the final version number in version.
+        # If it is, we return the major version number.
+        # And If the tag was of a final version, we will use it.
+
         if git_version[:3] == version[:3]:
             if git_version[3] == "final":
                 return major
-            # If the tag was of a final version, we will use it.
 
             return (
                 get_major_version(git_version)
@@ -333,7 +338,6 @@ def get_prerelease_version(version):
                 + suffix
             )
 
-    # In all cirrcumstances, return the initial findings
     return major + ".dev0"
 
 
@@ -350,6 +354,8 @@ def get_version_from_file(version):
         major = int(split_version[0])
         minor = int(split_version[1])
         patch = int(split_version[2])
+        # If the major, minor, and patch of the parsed version number
+        # We will raise an error
         if (major, minor, patch) != version[:3]:
             raise AssertionError(
                 (
@@ -358,14 +364,6 @@ def get_version_from_file(version):
                     "__version__ is: {}, VERSION file says: {}."
                 ).format(str(version), version_file)
             )
-
-        # If there is a '.dev', we can remove it, otherwise we check it
-        # for consistency and fail if inconsistent
-
-        # If a final release is specified in the VERSION file, then it
-        # has to be a final release in the VERSION tuple as well.
-        # A final release specified in a VERSION file (pep 440) is
-        # something that doesn't end like a1, b1, post1, and rc1
 
         return version_file
 

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -290,7 +290,7 @@ def get_prerelease_version(version):
     \\*, \\*, \\*, "alpha", 0: Maps to latest commit timestamp
     \\*, \\*, \\*, "alpha", >0: Uses latest git tag, asserting that there is such.
     """
-    mapping = {"alpha": "a", "beta": "b", "rc": "rc", "final": ""}
+    mapping = {"alpha": "a", "beta": "b", "rc": "rc"}
     major = get_major_version(version)
 
     # Calculate suffix...
@@ -329,7 +329,19 @@ def get_prerelease_version(version):
 
         if git_version[:3] == version[:3]:
             if git_version[3] == "final":
-                return major
+                if not suffix:
+                    return major
+                else:
+                    # If there's a suffix, we're post the final tag for the release
+                    # so set it to an alpha to give a more meaningful version number
+                    # although it is slighly incorrect as we have already released.
+                    git_version = (
+                        git_version[0],
+                        git_version[1],
+                        git_version[2],
+                        "alpha",
+                        git_version[4],
+                    )
 
             return (
                 get_major_version(git_version)

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -13,73 +13,64 @@ Here's how version numbers are generated:
    to decide the version of Kolibri as a string. This is especially something
    that PyPi and setuptools use.
 
- * ``kolibri.VERSION`` is a tuple containing version information, it's set in
-   ``kolibri/__init__.py`` is automatically suffixed in pre-releases by a
-   number of rules defined below. For a final release (not a pre-release),
-   it will be used exactly as it appears.
+ * ``kolibri.VERSION`` is a tuple containing major, minor, and patch version information,
+   it's set in ``kolibri/__init__.py``
 
  * ``kolibri/VERSION`` is a file containing the exact version of Kolibri for a
-   distributed environment (pre-releases only!)
+   distributed environment - when it exists, as long as its major, minor, and patch
+   versions are compatible with ``kolibri.VERSION`` then it is used as the version.
+   If these versions do not match, an AssertionError will be thrown.
 
  * ``git describe --tags`` is a command run to fetch tag information from a git
    checkout with the Kolibri code. The information is used to validate the
-   major components of ``kolibri.VERSION`` and to suffix the final version of
-   prereleases. This information is stored permanently in ``kolibri/VERSION``
-   before shipping a pre-release by calling ``make writeversion`` during
-   ``make dist`` etc.
+   major components of ``kolibri.VERSION`` and to add a suffix (if needed).
+   This information is stored permanently in ``kolibri/VERSION`` before shipping
+   any built asset by calling ``make writeversion`` during ``make dist`` etc.
 
 
-Confused? Here's a table:
+This table shows examples of kolibri.VERSION and git data used to generate a specific version:
 
 
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| Release type | ``kolibri.VERSION`` | ``kolibri/VERSION`` | Git data                  | Examples                            |
-+==============+=====================+=====================+===========================+=====================================+
-| Final        | Canonical, only     | N/A                 | N/A                       | 0.1.0, 0.2.2,                       |
-|              | information used    |                     |                           | 0.2.post1                           |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| dev release  | (1, 2, 3, 'alpha',  | Fallback            | timestamp of latest       | 1.2.3.dev0+git.123.f1234567         |
-| (alpha0)     | 0), 0th alpha = a   |                     | commit + hash             |                                     |
-|              | dev release! Never  |                     |                           |                                     |
-|              | used as a canonical |                     |                           |                                     |
-|              |                     |                     |                           |                                     |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| alpha1+      | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
-|              | 1)                  |                     |                           | 1.2.3a1,                            |
-|              |                     |                     |                           | 4 changes                           |
-|              |                     |                     |                           | since tag:                          |
-|              |                     |                     |                           | 1.2.3a1.dev0+git.4.f1234567         |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| beta1+       | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
-|              | 1)                  |                     |                           | 1.2.3b1,                            |
-|              |                     |                     |                           | 5 changes                           |
-|              |                     |                     |                           | since tag:                          |
-|              |                     |                     |                           | 1.2.3b1.dev0+git.5.f1234567         |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| rc1+         | (1, 2, 3, 'alpha',  | Fallback            | ``git describe --tags``   | Clean head:                         |
-| (release     | 1)                  |                     |                           | 1.2.3rc1,                           |
-| candidate)   |                     |                     |                           | Changes                             |
-|              |                     |                     |                           | since tag:                          |
-|              |                     |                     |                           | 1.2.3rc1.dev0+git.f1234567          |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
-| beta0, rc0,  | DO NOT USE          | Fallback            | timestamp of latest       | 1.2.3b0.dev0+git.123.f1234567       |
-| post0, x.y.0 |                     |                     | commit + hash             |                                     |
-|              |                     |                     |                           |                                     |
-+--------------+---------------------+---------------------+---------------------------+-------------------------------------+
++--------------+---------------------+---------------------------+-------------------------------------+
+| Release type | ``kolibri.VERSION`` | Git data                  | Examples                            |
++==============+=====================+===========================+=====================================+
+| Final        | (1, 2, 3)           | Final tag: e.g. v1.2.3    | 1.2.3                               |
++--------------+---------------------+---------------------------+-------------------------------------+
+| dev release  | (1, 2, 3)           | timestamp of latest       | 1.2.3.dev0+git.123.f1234567         |
+| (alpha0)     |                     | commit + hash             |                                     |
++--------------+---------------------+---------------------------+-------------------------------------+
+| alpha1+      | (1, 2, 3)           | Alpha tag: e.g. v1.2.3a1  | Clean head:                         |
+|              |                     |                           | 1.2.3a1,                            |
+|              |                     |                           | 4 changes                           |
+|              |                     |                           | since tag:                          |
+|              |                     |                           | 1.2.3a1.dev0+git.4.f1234567         |
++--------------+---------------------+---------------------------+-------------------------------------+
+| beta1+       | (1, 2, 3)           | Beta tag: e.g. v1.2.3b1   | Clean head:                         |
+|              |                     |                           | 1.2.3b1,                            |
+|              |                     |                           | 5 changes                           |
+|              |                     |                           | since tag:                          |
+|              |                     |                           | 1.2.3b1.dev0+git.5.f1234567         |
++--------------+---------------------+---------------------------+-------------------------------------+
+| rc1+         | (1, 2, 3)           | RC tag: e.g. v1.2.3rc1    | Clean head:                         |
+| (release     |                     |                           | 1.2.3rc1,                           |
+| candidate)   |                     |                           | Changes                             |
+|              |                     |                           | since tag:                          |
+|              |                     |                           | 1.2.3rc1.dev0+git.f1234567          |
++--------------+---------------------+---------------------------+-------------------------------------+
 
 
-**Fallback**: ``kolibri/VERSION`` is auto-generated with ``make writeversion``
-during the build process. The file is read as a fallback when there's no git
-data available in a pre-release (which is the case in an installed
-environment).
+**Built assets**: ``kolibri/VERSION`` is auto-generated with ``make writeversion``
+during the build process. The file is read in preference to git
+data in order to prioritize swift version resolution in an installed
+environment.
 
 
 Release order example 1.2.3 release:
 
- * ``VERSION = (1, 2, 3, 'alpha', 0)`` throughout the development phase, this
+ * ``VERSION = (1, 2, 3)`` throughout the development phase, this
    results in a lot of ``1.2.3.dev0+git1234abcd`` with no need for
    git tags.
- * ``VERSION = (1, 2, 3, 'alpha', 1)`` for the first alpha release.
+ * ``VERSION = (1, 2, 3)`` for the first alpha release, a git tag v1.2.3a0 is made.
 
 .. warning::
     Do not import anything from the rest of Kolibri in this module, it's


### PR DESCRIPTION
This code change  is design to  maka __init__.py's version a 3-tuple
fixes #3251


## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
fixes #3251

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
