### PR TITLE
Separate request logging

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -67,6 +67,12 @@ ENVIRONMENT_VARIABLES = {
             used to detect whether running under socket activation under Debian.
         """,
     },
+    "KOLIBRI_DISABLE_REQUEST_LOGGING": {
+        "description": """
+            Disable request logging. Set the variable to True/False to turn off/on
+            cherrypy.access logs.
+        """,
+    },
 }
 
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -179,11 +179,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
         if NO_FILE_BASED_LOGGING
         else ["file", "console", "console-error", "file_debug"]
     )
-    REQUEST_HANDLERS = (
-        []
-        if DISABLE_REQUEST_LOGGING
-        else ["requests"]
-    )
+    REQUEST_HANDLERS = [] if DISABLE_REQUEST_LOGGING else ["requests"]
 
     # This is the general level
     DEFAULT_LEVEL = "INFO" if not debug else "DEBUG"

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -179,7 +179,6 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
         if NO_FILE_BASED_LOGGING
         else ["file", "console", "console-error", "file_debug"]
     )
-    REQUEST_HANDLERS = [] if DISABLE_REQUEST_LOGGING else ["requests"]
 
     # This is the general level
     DEFAULT_LEVEL = "INFO" if not debug else "DEBUG"
@@ -236,14 +235,6 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "formatter": "simple_date",
                 "encoding": "utf-8",
             },
-            "requests": {
-                "level": "INFO",
-                "filters": [],
-                "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
-                "filename": os.path.join(LOG_ROOT, "request.txt"),
-                "formatter": "simple_date",
-                "encoding": "utf-8",
-            },
         },
         "loggers": {
             "": {
@@ -256,7 +247,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "propagate": False,
             },
             "cherrypy.access": {
-                "handlers": REQUEST_HANDLERS,
+                "handlers": [] if DISABLE_REQUEST_LOGGING else [DEFAULT_HANDLERS],
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -7,6 +7,7 @@ GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
 
 NO_FILE_BASED_LOGGING = os.environ.get("KOLIBRI_NO_FILE_BASED_LOGGING", False)
+DISABLE_REQUEST_LOGGING = os.environ.get("KOLIBRI_DISABLE_REQUEST_LOGGING", False)
 
 LOG_COLORS = {
     "DEBUG": "blue",
@@ -178,6 +179,11 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
         if NO_FILE_BASED_LOGGING
         else ["file", "console", "console-error", "file_debug"]
     )
+    REQUEST_HANDLERS = (
+        []
+        if DISABLE_REQUEST_LOGGING
+        else ["requests"]
+    )
 
     # This is the general level
     DEFAULT_LEVEL = "INFO" if not debug else "DEBUG"
@@ -234,6 +240,14 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "formatter": "simple_date",
                 "encoding": "utf-8",
             },
+            "requests": {
+                "level": "INFO",
+                "filters": [],
+                "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
+                "filename": os.path.join(LOG_ROOT, "request.txt"),
+                "formatter": "simple_date",
+                "encoding": "utf-8",
+            },
         },
         "loggers": {
             "": {
@@ -242,6 +256,11 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
             "kolibri": {
                 "handlers": DEFAULT_HANDLERS,
+                "level": DEFAULT_LEVEL,
+                "propagate": False,
+            },
+            "cherrypy.access": {
+                "handlers": REQUEST_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -247,7 +247,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "propagate": False,
             },
             "cherrypy.access": {
-                "handlers": [] if DISABLE_REQUEST_LOGGING else [DEFAULT_HANDLERS],
+                "handlers": [] if DISABLE_REQUEST_LOGGING else DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
                 "propagate": False,
             },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
Signed-off-by: Jaideep Sharma [sharmajaideep1906@gmail.com](mailto:sharmajaideep1906@gmail.com)

## Summary
Previously request were logged into `$KOLIBRI_HOME/logs/kolibri.txt` after `kolibri start --debug`.
I made a new logger for `cherrypy.access` along with a new environment variable `KOLIBRI_DISABLE_REQUEST_LOGGING` such that when this variable is set, requests are not logged at all, and in case it is not set, the requests get logged into `$KOLIBRI_HOME/logs/request.txt`.

## References
fixes: #9505

## Reviewer guidance

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
