### PR TITLE
Tests uKResponsiveWindow composable and Updates KDS Package to latest develop

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -17,6 +17,7 @@ import vuex from 'vuex';
 import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
 import responsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
 import responsiveElementMixin from 'kolibri-design-system/lib/KResponsiveElementMixin';
+import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 import scriptLoader from 'kolibri-design-system/lib/utils/scriptLoader';
 import UiIconButton from 'kolibri-design-system/lib/keen/UiIconButton'; // temp hack
 import * as vueCompositionApi from '@vue/composition-api';
@@ -225,6 +226,9 @@ export default {
       commonCoreStrings,
       commonTaskStrings,
       commonSyncElements,
+    },
+    composables: {
+      useKResponsiveWindow,
     },
   },
   resources,

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4",
+    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,11 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
+<<<<<<< HEAD
     "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66",
+=======
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4",
+>>>>>>> parent of 1dcede93f0 (References fork for testing purposes. To be reverted before merge)
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998",
+    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#5940c7668b64e1083bd5166db89077ed34eccff1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98",
+    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#5940c7668b64e1083bd5166db89077ed34eccff1",
+    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78",
+    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,11 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-<<<<<<< HEAD
-    "kolibri-design-system": "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66",
-=======
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4",
->>>>>>> parent of 1dcede93f0 (References fork for testing purposes. To be reverted before merge)
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#29122c4b42e57f627713532611217f7f111b0add",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
@@ -85,7 +85,7 @@
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import SidePanelModal from 'kolibri.coreVue.components.SidePanelModal';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import CategorySearchModal from '../CategorySearchModal';
   import SearchFiltersPanel from '../SearchFiltersPanel';
   import commonLearnStrings from './../commonLearnStrings';
@@ -97,7 +97,7 @@
       SearchFiltersPanel,
       SidePanelModal,
     },
-    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings],
     /* eslint-disable-next-line no-unused-vars */
     setup(props, context) {
       var currentCategory = ref(null);
@@ -119,6 +119,13 @@
         }
       };
 
+      const {
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsMedium,
+        windowIsSmall,
+      } = useKResponsiveWindow();
+
       return {
         closeCategoryModal,
         currentCategory,
@@ -126,6 +133,10 @@
         searchModal,
         findFirstEl,
         handleCategory,
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsMedium,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -118,11 +118,11 @@
   import { mapState } from 'vuex';
 
   import { onMounted } from 'kolibri.lib.vueCompositionApi';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
   import SidePanelModal from 'kolibri.coreVue.components.SidePanelModal';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import useSearch from '../../composables/useSearch';
   import useLearnerResources from '../../composables/useLearnerResources';
   import BrowseResourceMetadata from '../BrowseResourceMetadata';
@@ -151,7 +151,7 @@
       SidePanel,
       LearnAppBarPage,
     },
-    mixins: [commonLearnStrings, commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const {
         searchTerms,
@@ -173,6 +173,12 @@
         moreResumableContentNodes,
         fetchMoreResumableContentNodes,
       } = useLearnerResources();
+      const {
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsMedium,
+        windowIsSmall,
+      } = useKResponsiveWindow();
 
       onMounted(() => {
         const keywords = currentRoute().query.keywords;
@@ -197,6 +203,10 @@
         resumableContentNodes,
         moreResumableContentNodes,
         fetchMoreResumableContentNodes,
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsMedium,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/test/views/library-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/library-page.spec.js
@@ -2,6 +2,7 @@ import { mount, shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';
 import KCircularLoader from 'kolibri-design-system/lib/loaders/KCircularLoader';
+import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 import { PageNames } from '../../src/constants';
 import LibraryPage from '../../src/views/LibraryPage';
 /* eslint-disable import/named */
@@ -23,26 +24,38 @@ const router = new VueRouter({
 // rootNodes used when showing default view, should always have length
 const mockStore = new Vuex.Store({
   state: { rootNodes: ['length'], core: { loading: false } },
-  getters: { isUserLoggedIn: jest.fn(), isLearner: jest.fn() },
+  getters: {
+    isUserLoggedIn: jest.fn(),
+    isLearner: jest.fn(),
+    isSuperuser: jest.fn(),
+    isAdmin: jest.fn(),
+    isCoach: jest.fn(),
+    getUserKind: jest.fn(),
+  },
 });
 
 jest.mock('../../src/composables/useSearch');
 jest.mock('../../src/composables/useLearnerResources');
 jest.mock('../../src/composables/useLearningActivities');
+jest.mock('kolibri-design-system/lib/useKResponsiveWindow');
 
 describe('LibraryPage', () => {
   describe('filters button', () => {
     it('is visible when the page is not large', () => {
+      useKResponsiveWindow.mockImplementation(() => ({
+        windowIsLarge: false,
+      }));
       const wrapper = shallowMount(LibraryPage, {
-        computed: { windowIsLarge: () => false },
         localVue,
         store: mockStore,
       });
       expect(wrapper.find('[data-test="filter-button"').element).toBeTruthy();
     });
     it('is hidden when the page is large', () => {
+      useKResponsiveWindow.mockImplementation(() => ({
+        windowIsLarge: true,
+      }));
       const wrapper = shallowMount(LibraryPage, {
-        computed: { windowIsLarge: () => true },
         localVue,
         store: mockStore,
       });
@@ -52,9 +65,11 @@ describe('LibraryPage', () => {
 
   describe('when user clicks the filters button', () => {
     it('displays the filters side panel, which is not displayed by default', async () => {
+      useKResponsiveWindow.mockImplementation(() => ({
+        windowIsLarge: false,
+      }));
       // mount to ensure we can click the button
       const wrapper = mount(LibraryPage, {
-        computed: { windowIsLarge: () => false }, // ensure filters button shown
         localVue,
         router,
         store: mockStore,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,9 +8147,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98":
+"kolibri-design-system@https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78":
   version "1.3.0"
-  resolved "https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98"
+  resolved "https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,6 +8147,7 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
+<<<<<<< HEAD
 "kolibri-design-system@https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66":
   version "1.3.0"
   resolved "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66"
@@ -8162,6 +8163,8 @@ kolibri-constants@0.1.41:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
 
+=======
+>>>>>>> parent of 1dcede93f0 (References fork for testing purposes. To be reverted before merge)
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4"
@@ -8169,7 +8172,6 @@ kolibri-constants@0.1.41:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
-    frame-throttle "^3.0.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,9 +8147,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78":
+"kolibri-design-system@https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66":
   version "1.3.0"
-  resolved "https://github.com/akolson/kolibri-design-system#445c740501581935094c7ca9fa48bce1a0281b78"
+  resolved "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,9 +8147,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998":
+"kolibri-design-system@https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98":
   version "1.3.0"
-  resolved "https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998"
+  resolved "https://github.com/akolson/kolibri-design-system#b16c125c4413e628afb66eb50bd25d9d3e607e98"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,6 +8147,21 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
+"kolibri-design-system@https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998":
+  version "1.3.0"
+  resolved "https://github.com/akolson/kolibri-design-system#b0fc2051119373ba1ce05e977c59d4504e55b998"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4"
@@ -8154,6 +8169,7 @@ kolibri-constants@0.1.41:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,10 +8147,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-<<<<<<< HEAD
-"kolibri-design-system@https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#29122c4b42e57f627713532611217f7f111b0add":
   version "1.3.0"
-  resolved "https://github.com/akolson/kolibri-design-system#794ac2a6b62d8dd7aa810eecfde7465086204c66"
+  resolved "https://github.com/learningequality/kolibri-design-system#29122c4b42e57f627713532611217f7f111b0add"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
@@ -8163,8 +8162,6 @@ kolibri-constants@0.1.41:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
 
-=======
->>>>>>> parent of 1dcede93f0 (References fork for testing purposes. To be reverted before merge)
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#4f07455efca105044ff964efcda3e3e9b96233b4"
@@ -8172,6 +8169,7 @@ kolibri-constants@0.1.41:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pr implements the `useKResponsiveWindow` composable in areas where its mixin equivalent(`KResponsiveWindowMixin`) is used particularly in `kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue` and `kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue` as a test.

Please note that my KDS fork has been referenced for testing purposes. This will be reverted once KDS PR https://github.com/learningequality/kolibri-design-system/pull/377 gets merged

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri-design-system/pull/377


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to  `http://localhost:8000/en/learn/#/library`
2. Test the window for responsiveness. It should behave as before when using the mixin

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
