### PR TITLE
Adjust thumbnail and column width and padding for consistent layout across channel management pages

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/ChannelDetails.vue
@@ -118,9 +118,7 @@
   .col-1 {
     display: flex;
     flex-grow: 0;
-    width: $thumbside;
     height: $thumbside;
-    margin-right: 16px;
 
     .checkbox {
       align-self: center;
@@ -128,16 +126,18 @@
     }
 
     .thumbnail {
-      width: auto;
+      width: $thumbside;
       max-width: $thumbside;
       height: auto;
       max-height: $thumbside;
       object-fit: contain;
+      margin-right: 16px;
     }
 
     .thumbnail-svg {
       width: $thumbside;
       height: $thumbside;
+      margin-right: 16px;
     }
   }
 


### PR DESCRIPTION
## Summary

Slightly adjusts styling for thumbnails and columns across channel management pages - to ensure changes are applied consistently.


## References
Follow up to #9658
Addresses @pcenov's [finding that this change was not applied to all pages](https://github.com/learningequality/kolibri/pull/9658#issuecomment-1267049559)

|   |   |
|---|---|
| Deleting Channels |  ![delete-channels](https://user-images.githubusercontent.com/17235236/194353186-2cee3545-8230-4c5a-bd33-ec515114428e.gif) | 
| Exporting Channels | ![export-channels](https://user-images.githubusercontent.com/17235236/194353213-55b7f7cd-bd0d-4788-a7c5-5e6d10e36415.gif) |
| Importing Channels | ![import-channels](https://user-images.githubusercontent.com/17235236/194353227-2cce118e-03ae-4d2e-818c-c9f7132bc8e6.gif) |






## Reviewer guidance
On Import, Export, and Delete Channels pages:
1. Are thumbnails and text not overlapping?
2. Are thumbnails centered within their space, whether or not they fill it?
3. Do all thumbnails have some space to their right hand side, between the thumbnail and the text?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
