### PR TITLE
Updated to flush saveAnswer debounced function

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -390,7 +390,10 @@
         return Promise.resolve();
       },
       goToQuestion(questionNumber) {
-        const promise = this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve();
+        const saveAnswerPromise = this.debouncedSaveAnswer.flush() || Promise.resolve();
+        const promise = saveAnswerPromise.then(
+          () => this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve()
+        );
         promise.then(() => {
           this.$router.push({
             name: ClassesPageNames.EXAM_VIEWER,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Updated to flush `saveAnswer`  debounce function that was previously added to fix the incorrect number of attempts shown. Responses that were not counted previously should now be saved.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Follow up to #9723 
Addresses [the issue of responses not being saved or cut in half](https://github.com/learningequality/kolibri/pull/9723#issuecomment-1266770009)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. On Kolibri 0.15.2, import Khan Academy's (English - US curriculum) > Math by grade > 3rd grade > Represent and interpret data > Picture graphs
2. Create a quiz for 'Read picture graphs (multi-step problems)'
3. Complete the quiz
4. As a Coach go to Coach>Reports>Quiz score
5. Confirm that all answers were recorded and within one attempt.
----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
