### PR TITLE
Anroid bottom nav bar

### DIFF
--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -35,6 +35,7 @@ import ProgressIcon from '../views/ProgressIcon';
 import PermissionsIcon from '../views/PermissionsIcon';
 import AppBarPage from '../views/CorePage/AppBarPage';
 import AppBar from '../views/AppBar';
+import AppBottomBar from '../views/AppBottomBar';
 import ImmersivePage from '../views/CorePage/ImmersivePage';
 import ScrollingHeader from '../views/ScrollingHeader';
 import SideNav from '../views/SideNav';
@@ -156,6 +157,7 @@ export default {
       ProgressIcon,
       PermissionsIcon,
       AppBar,
+      AppBottomBar,
       AppBarPage,
       ImmersivePage,
       SideNav,

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -227,6 +227,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       "A topic is marked as 'Completed' when a learner finishes that specific topic within an educational resource. A topic could be a video, audio, document file or interactive app.",
   },
+  deviceManagementTitle: {
+    message: 'Device',
+    context:
+      'The device is the physical or virtual machine that has the Kolibri server installed on it.',
+  },
   deviceNameLabel: {
     message: 'Device name',
     context:
@@ -278,6 +283,16 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Home',
     context:
       "Home page is a place for learners containing summary of their activities and suggestions for what to do next. For example, they can see a list of classess they're enrolled in, their recent lessons and quizess, and they can directly navigate to resources to continue learning from.",
+  },
+  learnLabel: {
+    message: 'Learn',
+    context:
+      "Each time a learner signs in to Kolibri, the first thing they see is the  'Learn' page with the list of all the classes they are enrolled to.",
+  },
+  libraryLabel: {
+    message: 'Library',
+    context:
+      "The 'Library' section displays channels available on Kolibri server, and allows learners to browse, explore and filter topics and resources on their own.",
   },
   identifierLabel: {
     message: 'Identifier',
@@ -355,6 +370,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Quizzes',
     context:
       'A quiz is a summative assessment made up of questions taken from exercises. Quizzes are created by coaches and then assigned to learners in a class.\n\nWe intentionally renamed "exam" to "quiz" in order to encourage use as an informal diagnostic tool for teachers.',
+  },
+  reportsLabel: {
+    message: 'Reports',
+    context:
+      'Reports are representations of learner progress and performance data shown to coaches in a class.',
   },
   resourcesLabel: {
     message: 'Resources',
@@ -766,6 +786,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Lesson plans',
     context:
       'Category label in the Kolibri resources library; refers to lesson planning materials for teachers.',
+  },
+  plan: {
+    message: 'Plan',
+    context:
+      "Translate as a VERB. Refers to the 'Plan' tab where coaches manage lessons, quizzes, and groups.",
   },
 
   // Resources Needed Categories = {

--- a/kolibri/core/assets/src/views/AndroidNavigationNestedMenu.vue
+++ b/kolibri/core/assets/src/views/AndroidNavigationNestedMenu.vue
@@ -1,0 +1,207 @@
+<template>
+
+  <div class="wrapper">
+    <div
+      v-for="(nestedObject, key) in navigationOptions"
+      :key="key"
+      class="container"
+    >
+      <KButton
+        :icon="nestedObject.icon"
+        class="inline"
+        :text="coreString(nestedObject.text)"
+        appearance="flat-button"
+        :iconAfter="visibleSubMenu === key ? 'chevronUp' : 'chevronDown'"
+        @click="manageDisplay(key)"
+      />
+      <div v-if="visibleSubMenu === key">
+        <div
+          v-for="(nestedKey, item) in nestedObject.subNavigation"
+          :key="item.value"
+          class="link-container"
+        >
+          <router-link
+            v-if="nestedKey.condition ? nestedKey.condition : true"
+            :to="nestedKey.route"
+            class="link"
+          >
+            {{ coreString(nestedKey.text) }}
+          </router-link>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  // import commonLearnStrings from 'kolibri.coreVue.mixins.commonLearnStrings';
+  import { mapState } from 'vuex';
+  import { PageNames as LearnPageNames } from './../../../../plugins/learn/assets/src/constants';
+  import { PageNames as FacilityPageNames } from './../../../../plugins/facility/assets/src/constants';
+  import { PageNames as CoachPageNames } from './../../../../plugins/coach/assets/src/constants';
+
+  export default {
+    name: 'AndroidNavigationNestedMenu',
+    mixins: [commonCoreStrings],
+    data() {
+      return {
+        visibleSubMenu: null,
+      };
+    },
+    computed: {
+      ...mapState('classSummary', { classId: 'id' }),
+      navigationOptions() {
+        return {
+          learnSubnav: {
+            icon: 'home',
+            text: 'learnLabel',
+            subNavigation: {
+              home: {
+                text: 'homeLabel',
+                route: this.$router.getRoute(LearnPageNames.HOME),
+              },
+              library: {
+                text: 'libraryLabel',
+                route: this.$router.getRoute(LearnPageNames.LIBRARY),
+              },
+              bookmarks: {
+                text: 'bookmarksLabel',
+                route: this.$router.getRoute(LearnPageNames.BOOKMARKS),
+              },
+            },
+          },
+          coachSubnav: {
+            icon: 'coach',
+            text: 'coachLabel',
+            subNavigation: {
+              classHome: {
+                text: 'classHome',
+                route: this.coachRoute('HomePage'),
+              },
+              reports: {
+                condition: Boolean(this.classId),
+                text: 'reportsLabel',
+                route: this.coachRoute(CoachPageNames.REPORTS_PAGE),
+              },
+              plan: {
+                condition: Boolean(this.classId),
+                text: 'plan',
+                route: this.coachRoute(CoachPageNames.PLAN_PAGE),
+              },
+            },
+          },
+          facilitySubnav: {
+            icon: 'facility',
+            text: 'facilityLabel',
+            subNavigation: {
+              facilityClasses: {
+                text: 'classesLabel',
+                link: this.$router.getRoute(FacilityPageNames.CLASS_MGMT_PAGE),
+              },
+              facilityUsers: {
+                text: 'usersLabel',
+                link: this.$router.getRoute(FacilityPageNames.USER_MGMT_PAGE),
+              },
+              facilitySettings: {
+                text: 'settings',
+                link: this.$router.getRoute(FacilityPageNames.FACILITY_CONFIG_PAGE),
+              },
+              facilityData: {
+                text: 'data',
+                link: this.$router.getRoute(FacilityPageNames.DATA_EXPORT_PAGE),
+              },
+            },
+          },
+          deviceSubnav: {
+            icon: 'device',
+            text: 'deviceManagementTitle',
+            subNavigation: {
+              channels: {
+                text: this.coreString('channelsLabel'),
+                link: this.$router.getRoute('MANAGE_CONTENT_PAGE'),
+              },
+              permissions: {
+                text: this.$tr('permissionsLabel'),
+                link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
+              },
+              facilities: {
+                text: this.coreString('facilitiesLabel'),
+                link: this.$router.getRoute('FACILITIES_PAGE'),
+              },
+              info: {
+                text: this.$tr('infoLabel'),
+                link: this.$router.getRoute('DEVICE_INFO_PAGE'),
+              },
+              settings: {
+                text: this.$tr('settingsLabel'),
+                link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
+              },
+            },
+          },
+        };
+      },
+    },
+    methods: {
+      manageDisplay(key) {
+        if (this.visibleSubMenu !== key) {
+          this.visibleSubMenu = key;
+        } else {
+          this.visibleSubMenu = null;
+        }
+      },
+      coachRoute(name) {
+        return { name, params: { classId: this.classId } };
+      },
+    },
+    $trs: {
+      permissionsLabel: {
+        message: 'Permissions',
+        context: 'Refers to the Device > Permissions tab.',
+      },
+      infoLabel: {
+        message: 'Info',
+        context: 'Refers to the Device > Info tab.',
+      },
+      settingsLabel: {
+        message: 'Settings',
+        context: 'Refers to the Device > Settings tab.\n',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .wrapper {
+    margin-top: 100px;
+  }
+
+  .container {
+    margin: 24px 100px;
+  }
+
+  .inline {
+    display: inline-block;
+    margin: 0 4px;
+  }
+
+  .link-container {
+    margin: 20px;
+  }
+
+  .link {
+    padding: 10px;
+    margin: 20px 44px;
+    text-decoration: none;
+    border: 1px solid;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/AndroidNavigationNestedMenu.vue
+++ b/kolibri/core/assets/src/views/AndroidNavigationNestedMenu.vue
@@ -1,224 +1,395 @@
 <template>
 
-  <FocusTrap
-    @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
-    @shouldFocusLastEl="$emit('shouldFocusLastEl')"
-  >
-    <div class="wrapper">
-
+  <div>
+    <FocusTrap
+      @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
+      @shouldFocusLastEl="$emit('shouldFocusLastEl')"
+    >
       <div
-        v-for="(nestedObject, key) in navigationOptions"
-        :key="key"
-        class="container"
+        class="side-nav-scrollable-area"
+        :style="{
+          top: `${topBarHeight}px`,
+          width: '100%',
+          backgroundColor: $themeTokens.surface,
+        }"
       >
-        <KButton
-          ref="menuItem"
-          :icon="nestedObject.icon"
-          class="inline"
-          :text="coreString(nestedObject.text)"
-          appearance="flat-button"
-          :appearanceOverrides="menuPluginStyles"
-          :iconAfter="visibleSubMenu === key ? 'chevronUp' : 'chevronDown'"
-          @click="manageDisplay(key)"
-        />
-        <div v-if="visibleSubMenu === key">
-          <div
-            v-for="(nestedKey, item) in nestedObject.subNavigation"
-            :key="item.value"
-            class="link-container"
+        <img
+          v-if="themeConfig.sideNav.topLogo"
+          class="logo"
+          :src="themeConfig.sideNav.topLogo.src"
+          :alt="themeConfig.sideNav.topLogo.alt"
+          :style="themeConfig.sideNav.topLogo.style"
+        >
+
+        <div v-if="userIsLearner" class="user-information">
+          <!-- display user details -->
+          <TotalPoints class="points" />
+          <b>{{ fullName }}</b>
+          <p
+            :style="{
+              color: $themeTokens.annotation,
+              fontSize: '12px',
+              marginTop: '8px',
+              marginBottom: 0,
+            }"
           >
-            <!-- <router-link
-            v-if="nestedKey.condition ? nestedKey.condition : true"
-            :to="nestedKey.route"
-            class="link"
-          >
-            {{ coreString(nestedKey.text) }}
-          </router-link> -->
-            <a
-              :href="url()"
-              class="core-menu-option"
-              role="menuitem"
+            {{ username }}
+          </p>
+          <p :style="{ color: $themeTokens.annotation, fontSize: '12px', marginTop: 0 }">
+            {{ getUserKind }}
+          </p>
+          <!-- display sync status, when relevant -->
+          <div v-if="isSubsetOfUsersDevice" data-test="syncStatusInDropdown">
+            <div class="sync-status">
+              {{ $tr('deviceStatus') }}
+            </div>
+            <SyncStatusDisplay :syncStatus="mapSyncStatusOptionToLearner" displaySize="small" />
+          </div>
+        </div>
+        <SideNavDivider v-if="userIsLearner" :style="{ listStyleType: 'none' }" />
+        <CoreMenu
+          ref="coreMenu"
+          role="navigation"
+          :style="{ backgroundColor: $themeTokens.surface }"
+          :aria-label="$tr('navigationLabel')"
+        >
+          <template #options>
+            <component :is="component" v-for="component in menuOptions" :key="component.name" />
+            <CoreMenuOption
+              :label="$tr('languageSwitchMenuOption')"
+              icon="language"
+              class="pointer"
+              @select="handleShowLanguageModal()"
+            />
+            <SideNavDivider />
+          </template>
+        </CoreMenu>
+
+        <div v-if="showSoudNotice" style="padding: 16px">
+          <LearnOnlyDeviceNotice />
+        </div>
+
+        <div class="side-nav-scrollable-area-footer" :style="{ color: $themeTokens.annotation }">
+          <!-- custom branded footer logo + text -->
+          <template v-if="themeConfig.sideNav.brandedFooter">
+            <img
+              v-if="themeConfig.sideNav.brandedFooter.logo"
+              class="side-nav-scrollable-area-footer-logo"
+              :src="themeConfig.sideNav.brandedFooter.logo.src"
+              :alt="themeConfig.sideNav.brandedFooter.logo.alt"
+              :style="themeConfig.sideNav.brandedFooter.logo.style"
             >
-              {{ url() }}
-              {{ coreString(nestedKey.text) }}
-            </a>
+            <div
+              v-if="
+                themeConfig.sideNav.brandedFooter.paragraphArray &&
+                  themeConfig.sideNav.brandedFooter.paragraphArray.length
+              "
+              class="side-nav-scrollable-area-footer-info"
+            >
+              <p
+                v-for="(line, index) in themeConfig.sideNav.brandedFooter.paragraphArray"
+                :key="index"
+              >
+                {{ line }}
+              </p>
+            </div>
+          </template>
+          <!-- Kolibri footer logo -->
+          <CoreLogo
+            v-if="themeConfig.sideNav.showKolibriFooterLogo"
+            class="side-nav-scrollable-area-footer-logo"
+          />
+          <div class="side-nav-scrollable-area-footer-info">
+            <p>{{ footerMsg }}</p>
+            <!-- Not translated -->
+            <p>© {{ copyrightYear }} Learning Equality</p>
+            <p>
+              <KButton
+                ref="privacyLink"
+                :text="coreString('usageAndPrivacyLabel')"
+                class="privacy-link"
+                appearance="basic-link"
+                @click="handleClickPrivacyLink"
+              />
+            </p>
           </div>
         </div>
       </div>
-    </div>
-  </FocusTrap>
+      <div
+        class="side-nav-header"
+        :class="!isAppContext ? 'side-nav-header-dropshadow' : ''"
+        :style="{
+          height: topBarHeight + 'px',
+          width: '100%',
+          paddingTop: windowIsSmall ? '4px' : '8px',
+          backgroundColor: isAppContext ? $themeTokens.surface : $themeTokens.appBar,
+        }"
+      >
+        <KIconButton
+          ref="closeButton"
+          tabindex="0"
+          icon="close"
+          :color="isAppContext ? $themeTokens.text : $themeTokens.textInverted"
+          class="side-nav-header-icon"
+          :ariaLabel="$tr('closeNav')"
+          size="large"
+          @click="toggleNav"
+        />
+        <span class="side-nav-header-name" :style="{ color: $themeTokens.textInverted }">{{
+          sideNavTitleText
+        }}</span>
+      </div>
+    </FocusTrap>
+
+    <PrivacyInfoModal
+      v-if="privacyModalVisible"
+      @cancel="privacyModalVisible = false"
+      @submit="privacyModalVisible = false"
+    />
+
+    <LanguageSwitcherModal
+      v-if="languageModalShown"
+      ref="languageSwitcherModal"
+      :style="{ color: $themeTokens.text }"
+      @cancel="languageModalShown = false"
+    />
+  </div>
 
 </template>
 
 
 <script>
 
+  import { mapGetters, mapState, mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import FocusTrap from 'kolibri.coreVue.components.FocusTrap';
-  // import commonLearnStrings from 'kolibri.coreVue.mixins.commonLearnStrings';
-  import urls from 'kolibri.urls';
-  import { PageNames as LearnPageNames } from './../../../../plugins/learn/assets/src/constants';
-  import { PageNames as FacilityPageNames } from './../../../../plugins/facility/assets/src/constants';
-  import { PageNames as CoachPageNames } from './../../../../plugins/coach/assets/src/constants';
+  import { UserKinds, SyncStatus, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
+  import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
+  import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
+  import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
+  import LearnOnlyDeviceNotice from 'kolibri.coreVue.components.LearnOnlyDeviceNotice';
+  import navComponents from 'kolibri.utils.navComponents';
+  import PrivacyInfoModal from 'kolibri.coreVue.components.PrivacyInfoModal';
+  import themeConfig from 'kolibri.themeConfig';
+  import Backdrop from 'kolibri.coreVue.components.Backdrop';
+  import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
+  import navComponentsMixin from '../mixins/nav-components';
+  import TotalPoints from '../../../../plugins/learn/assets/src/views/TotalPoints.vue';
+  import SyncStatusDisplay from './SyncStatusDisplay';
+  import logout from './LogoutSideNavEntry';
+  import SideNavDivider from './SideNavDivider';
+  import FocusTrap from './FocusTrap.vue';
+  import plugin_data from 'plugin_data';
+
+  // Explicit ordered list of roles for nav item sorting
+  const navComponentRoleOrder = [
+    UserKinds.ANONYMOUS,
+    UserKinds.LEARNER,
+    UserKinds.COACH,
+    UserKinds.ADMIN,
+    UserKinds.CAN_MANAGE_CONTENT,
+    UserKinds.SUPERUSER,
+  ];
 
   export default {
     name: 'AndroidNavigationNestedMenu',
-    components: { FocusTrap },
-    mixins: [commonCoreStrings],
+    components: {
+      Backdrop,
+      CoreMenu,
+      CoreMenuOption,
+      CoreLogo,
+      LearnOnlyDeviceNotice,
+      SyncStatusDisplay,
+      SideNavDivider,
+      PrivacyInfoModal,
+      FocusTrap,
+      TotalPoints,
+      LanguageSwitcherModal,
+    },
+    mixins: [commonCoreStrings, responsiveWindowMixin, responsiveElementMixin, navComponentsMixin],
+    setup() {
+      return { themeConfig };
+    },
+    props: {
+      navShown: {
+        type: Boolean,
+        required: true,
+      },
+    },
     data() {
       return {
-        visibleSubMenu: null,
+        // __copyrightYear is injected by Webpack DefinePlugin
+        copyrightYear: __copyrightYear,
+        privacyModalVisible: false,
+        languageModalShown: false,
+        isSubsetOfUsersDevice: plugin_data.isSubsetOfUsersDevice,
+        userSyncStatus: null,
+        isPolling: false,
+        // poll every 10 seconds
+        pollingInterval: 10000,
       };
     },
     computed: {
-      // ...mapState('classSummary', { classId: 'id' }),
-      menuPluginStyles() {
-        console.log(this.$router);
-        return {
-          color: this.$themeTokens.text,
-          width: '99%',
-          height: '48px',
-          textAlign: 'left',
-          padding: '0px 4px',
-          border: 'none',
-          textTransform: 'capitalize',
-          fontWeight: 'normal',
-          ':hover': this.menuPluginActiveStyles,
-        };
+      ...mapGetters(['isAdmin', 'isCoach', 'getUserKind', 'isAppContext']),
+      ...mapState({
+        username: state => state.core.session.username,
+        fullName: state => state.core.session.full_name,
+      }),
+      showSoudNotice() {
+        return this.isSubsetOfUsersDevice && (this.isAdmin || this.isCoach);
       },
-      menuPluginActiveStyles() {
-        return {
-          backgroundColor: this.$themeBrand.primary.v_50,
-          color: this.$themeBrand.primary,
-          fontWeight: 'bold',
-          padding: '0px 4px',
-          borderRadius: '4px',
-        };
+      footerMsg() {
+        return this.$tr('poweredBy', { version: __version });
       },
-      navigationOptions() {
-        return {
-          learnSubnav: {
-            icon: 'home',
-            text: 'learnLabel',
-            subNavigation: {
-              home: {
-                text: 'homeLabel',
-                route: this.$router.getRoute(LearnPageNames.HOME),
-              },
-              library: {
-                text: 'libraryLabel',
-                route: this.$router.getRoute(LearnPageNames.LIBRARY),
-              },
-              bookmarks: {
-                text: 'bookmarksLabel',
-                route: this.$router.getRoute(LearnPageNames.BOOKMARKS),
-              },
-            },
-          },
-          coachSubnav: {
-            icon: 'coach',
-            text: 'coachLabel',
-            subNavigation: {
-              classHome: {
-                text: 'classes',
-                route: this.coachRoute('ClassesPage'),
-              },
-              reports: {
-                condition: Boolean(this.classId),
-                text: 'reportsLabel',
-                route: this.coachRoute(CoachPageNames.REPORTS_PAGE),
-              },
-              plan: {
-                condition: Boolean(this.classId),
-                text: 'plan',
-                route: this.coachRoute(CoachPageNames.PLAN_PAGE),
-              },
-            },
-          },
-          facilitySubnav: {
-            icon: 'facility',
-            text: 'facilityLabel',
-            test: this.$router,
-            subNavigation: {
-              facilityClasses: {
-                text: this.coreString('classesLabel'),
-                route: this.facilityRoute(FacilityPageNames.CLASS_MGMT_PAGE),
-              },
-              facilityUsers: {
-                text: this.coreString('usersLabel'),
-                route: this.facilityRoute(FacilityPageNames.USER_MGMT_PAGE),
-              },
-              facilitySettings: {
-                text: this.coreString('settings'),
-                route: this.facilityRoute(FacilityPageNames.FACILITY_CONFIG_PAGE),
-              },
-              facilityData: {
-                text: this.coreString('data'),
-                route: this.facilityRoute(FacilityPageNames.DATA_EXPORT_PAGE),
-              },
-            },
-          },
-          deviceSubnav: {
-            icon: 'device',
-            text: 'deviceManagementTitle',
-            subNavigation: {
-              channels: {
-                text: this.coreString('channelsLabel'),
-                route: this.deviceRoute('MANAGE_CONTENT_PAGE'),
-              },
-              permissions: {
-                text: this.$tr('permissionsLabel'),
-                route: this.deviceRoute('MANAGE_PERMISSIONS_PAGE'),
-              },
-              facilities: {
-                text: this.coreString('facilitiesLabel'),
-                route: this.deviceRoute('FACILITIES_PAGE'),
-              },
-              info: {
-                text: this.$tr('infoLabel'),
-                route: this.deviceRoute('DEVICE_INFO_PAGE'),
-              },
-              settings: {
-                text: this.$tr('settingsLabel'),
-                route: this.deviceRoute('DEVICE_SETTINGS_PAGE'),
-              },
-            },
-          },
-        };
+      menuOptions() {
+        const topComponents = navComponents
+          .filter(component => component.section !== NavComponentSections.ACCOUNT)
+          .sort(this.compareMenuComponents);
+        const accountComponents = navComponents
+          .filter(component => component.section === NavComponentSections.ACCOUNT)
+          .sort(this.compareMenuComponents);
+        return [...topComponents, SideNavDivider, ...accountComponents, logout].filter(
+          this.filterByRole
+        );
+      },
+      sideNavTitleText() {
+        if (this.themeConfig.sideNav.title) {
+          return this.themeConfig.sideNav.title;
+        }
+        return this.coreString('kolibriLabel');
+      },
+      userIsLearner() {
+        return this.getUserKind == UserKinds.LEARNER;
+      },
+      mapSyncStatusOptionToLearner() {
+        if (this.userSyncStatus) {
+          return this.userSyncStatus.status;
+        }
+        return SyncStatus.NOT_CONNECTED;
       },
     },
-    methods: {
-      url() {
-        return urls['kolibri:kolibri.plugins.device:device_management']();
+    watch: {
+      navShown(isShown) {
+        this.$nextTick(() => {
+          if (isShown) {
+            this.isPolling = true;
+            this.pollUserSyncStatusTask();
+            this.focusFirstEl();
+          } else {
+            this.isPolling = false;
+          }
+        });
       },
-      manageDisplay(key) {
-        if (this.visibleSubMenu !== key) {
-          this.visibleSubMenu = key;
-        } else {
-          this.visibleSubMenu = null;
+    },
+    mounted() {
+      this.$nextTick(() => {
+        this.$emit('shouldFocusFirstEl');
+      });
+    },
+    created() {
+      window.addEventListener('click', this.handleWindowClick);
+    },
+    beforeDestroy() {
+      window.removeEventListener('click', this.handleWindowClick);
+      this.isPolling = false;
+    },
+    methods: {
+      ...mapActions(['fetchUserSyncStatus']),
+      toggleNav() {
+        this.$emit('toggleSideNav');
+      },
+      handleShowLanguageModal() {
+        this.languageModalShown = true;
+      },
+      pollUserSyncStatusTask() {
+        if (this.navShown) {
+          this.fetchUserSyncStatus({ user: this.userId }).then(syncData => {
+            if (syncData && syncData[0]) {
+              this.userSyncStatus = syncData[0];
+              this.setPollingInterval(this.userSyncStatus.status);
+            }
+          });
+          if (this.isPolling && this.isSubsetOfUsersDevice) {
+            setTimeout(() => {
+              this.pollUserSyncStatusTask();
+            }, this.pollingInterval);
+          }
         }
       },
-      coachRoute(name) {
-        return { name, params: { classId: this.classId } };
+      setPollingInterval(status) {
+        if (status === SyncStatus.QUEUED) {
+          // check more frequently for updates if the user is waiting to sync,
+          // so that the sync isn't missed
+          this.pollingInterval = 1000;
+        } else {
+          this.pollingInterval = 10000;
+        }
       },
-      deviceRoute(name) {
-        let url = urls['kolibri:kolibri.plugins.device:device_management'];
-        this.$router.push(url);
-        this.$router.push(this.router.getRoute(name));
+      handleClickPrivacyLink() {
+        this.privacyModalVisible = true;
+      },
+      compareMenuComponents(navComponentA, navComponentB) {
+        // Compare menu items to allow sorting by the following priority:
+        // Sort by role
+        // Nav items with no roles will be placed first
+        // as index will be -1
+        if (navComponentA.role !== navComponentB.role) {
+          return (
+            navComponentRoleOrder.indexOf(navComponentA.role) -
+            navComponentRoleOrder.indexOf(navComponentB.role)
+          );
+        }
+        // Next sort by priority
+        if (navComponentA.priority !== navComponentB.priority) {
+          return navComponentA.priority - navComponentB.priority;
+        }
+        // Still no difference?
+        // There is no difference!
+        return 0;
+      },
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap.
+       */
+      focusFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.coreMenu.focusFirstEl();
+        });
+      },
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap.
+       */
+      focusLastEl() {
+        this.$refs.closeButton.$el.focus();
       },
     },
     $trs: {
-      permissionsLabel: {
-        message: 'Permissions',
-        context: 'Refers to the Device > Permissions tab.',
+      navigationLabel: {
+        message: 'Main user menu',
+        context:
+          'Refers to the main side navigation bar. The message is providing additional context to the screen-reader users, but is not visible in the Kolibri UI.',
       },
-      infoLabel: {
-        message: 'Info',
-        context: 'Refers to the Device > Info tab.',
+      closeNav: {
+        message: 'Close navigation',
+        context:
+          "This message is providing additional context to the screen-reader users, but is not visible in the Kolibri UI.\n\nIn this case the screen-reader will announce the message when user navigates to the 'X' button with the keyboard, to indicate that it allows them to close the sidebar navigation menu. (Note that the sidebar needs to have been previously opened)",
       },
-      settingsLabel: {
-        message: 'Settings',
-        context: 'Refers to the Device > Settings tab.\n',
+      poweredBy: {
+        message: 'Kolibri {version}',
+        context:
+          'Indicates the current version of Kolibri.\n\nFor languages with non-latin scripts, Kolibri should be transcribed phonetically into the target language, similar to a person\'s name. It should not be translated as "hummingbird".',
+      },
+      deviceStatus: {
+        message: 'Device status',
+        context:
+          "Label in the side navigation menu. Indicates the status of an individual learner's device.",
+      },
+      languageSwitchMenuOption: {
+        message: 'Change language',
+        context:
+          'General user setting where a user can choose the language they want to view the Kolibri interface in.',
       },
     },
   };
@@ -230,48 +401,145 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .wrapper {
-    margin-top: 100px;
+  // Matches the Keen-UI/UiToolbar box-shadow property
+  %ui-toolbar-box-shadow {
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 2px rgba(0, 0, 0, 0.2);
   }
 
-  .container {
-    margin: 8px;
+  .side-nav-wrapper {
+    overflow-x: hidden;
+    overflow-y: scroll;
   }
 
-  .inline {
-    display: inline-block;
-    margin: 0 4px;
+  .side-nav {
+    position: fixed;
+    top: 0;
+    bottom: 48px;
+    left: 0;
+    z-index: 24;
   }
 
-  .link-container {
-    height: 44px;
+  .side-nav-enter {
+    transform: translate3d(-100%, 0, 0);
   }
 
-  .link {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    height: 44px;
-    margin-left: 40px;
-    font-size: 12px;
-    text-decoration: none;
+  .side-nav-enter-active {
+    transition: all 0.2s ease-in-out;
   }
 
-  /deep/ .button {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
+  .side-nav-enter-to {
+    transform: translate3d(0, 0, 0);
   }
 
-  /deep/ .prop-icon:last-child {
-    margin-right: 8px;
-    margin-bottom: 4px;
-    margin-left: auto;
+  .side-nav-leave {
+    transform: translate3d(0, 0, 0);
   }
 
-  /deep/ .prop-icon:first-child {
+  .side-nav-leave-active {
+    transition: all 0.2s ease-in-out;
+  }
+
+  .side-nav-leave-to {
+    transform: translate3d(-100%, 0, 0);
+  }
+
+  .side-nav-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 17;
+    font-size: 14px;
+  }
+
+  .side-nav-header-dropshadow {
+    @extend %ui-toolbar-box-shadow;
+  }
+
+  .side-nav-header-icon {
+    margin-left: 5px; /* align with a toolbar icon below */
+  }
+
+  .side-nav-header-name {
+    margin-left: 8px;
+    font-size: 18px;
+    font-weight: bold;
+    vertical-align: middle;
+  }
+
+  .side-nav-scrollable-area {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    padding-top: 4px;
+    overflow: auto;
+  }
+
+  .side-nav-scrollable-area-footer {
+    padding: 16px;
+  }
+
+  .side-nav-scrollable-area-footer-logo {
+    max-width: 100%;
+    height: 77px;
+  }
+
+  .pointer {
+    cursor: pointer;
+  }
+
+  .user-information {
+    position: relative;
+    margin-left: 24px;
+    font-size: 14px;
+  }
+
+  .sync-status {
     margin-bottom: 8px;
-    margin-left: 4px;
+    font-size: small;
+    font-weight: bold;
+  }
+
+  .points {
+    float: right;
+    margin-top: -5px;
+    margin-right: 16px;
+    margin-left: auto;
+
+    .description {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .side-nav-scrollable-area-footer-info {
+    margin-top: 8px;
+    font-size: 12px;
+    line-height: 16px;
+
+    p {
+      margin: 0;
+    }
+  }
+
+  .side-nav-backdrop {
+    z-index: 15;
+  }
+
+  /* keen menu */
+  /deep/ .ui-menu {
+    max-width: none;
+    max-height: none;
+    padding: 0;
+    border: 0;
+  }
+
+  .privacy-link {
+    text-align: left;
+  }
+
+  .logo {
+    max-width: 100%;
+    height: auto;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -121,6 +121,8 @@
     data() {
       return {
         pointsDisplayed: false,
+        width: window.innerWidth,
+        appBarItems: [],
         userSyncStatus: null,
         isPolling: false,
         // poll every 10 seconds
@@ -191,6 +193,33 @@
         } else {
           this.pollingInterval = 10000;
         }
+      },
+      onResize() {
+        this.width = window.innerWidth;
+        this.updateAppBarItems();
+      },
+      updateAppBarItems() {
+        console.log('updating');
+        const navItems = document.getElementsByClassName('list-item-navigation');
+        // console.log(navItems);
+        let index = 0;
+        let spaceTakenUp = 0;
+        this.appBarItems = [];
+        if (navItems && navItems.length > 0) {
+          while (index < navItems.length) {
+            spaceTakenUp = spaceTakenUp + navItems.item(index).offsetWidth;
+            if (spaceTakenUp < this.width - 40) {
+              this.appBarItems.push(navItems[index]);
+              index = index + 1;
+              console.log(index, navItems.length);
+              console.log(this.appBarItems);
+            } else {
+              return this.appBarItems;
+            }
+          }
+          return this.appBarItems;
+        }
+        return null;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -121,8 +121,6 @@
     data() {
       return {
         pointsDisplayed: false,
-        width: window.innerWidth,
-        appBarItems: [],
         userSyncStatus: null,
         isPolling: false,
         // poll every 10 seconds
@@ -193,33 +191,6 @@
         } else {
           this.pollingInterval = 10000;
         }
-      },
-      onResize() {
-        this.width = window.innerWidth;
-        this.updateAppBarItems();
-      },
-      updateAppBarItems() {
-        console.log('updating');
-        const navItems = document.getElementsByClassName('list-item-navigation');
-        // console.log(navItems);
-        let index = 0;
-        let spaceTakenUp = 0;
-        this.appBarItems = [];
-        if (navItems && navItems.length > 0) {
-          while (index < navItems.length) {
-            spaceTakenUp = spaceTakenUp + navItems.item(index).offsetWidth;
-            if (spaceTakenUp < this.width - 40) {
-              this.appBarItems.push(navItems[index]);
-              index = index + 1;
-              console.log(index, navItems.length);
-              console.log(this.appBarItems);
-            } else {
-              return this.appBarItems;
-            }
-          }
-          return this.appBarItems;
-        }
-        return null;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -14,7 +14,7 @@
         :raised="false"
         :removeBrandDivider="true"
       >
-        <template #icon>
+        <template v-if="!isAppContext" #icon>
           <KIconButton
             icon="menu"
             :color="$themeTokens.textInverted"
@@ -33,7 +33,7 @@
           >
         </template>
 
-        <template v-if="windowIsLarge" #navigation>
+        <template v-if="windowIsLarge && !isAppContext" #navigation>
           <slot name="sub-nav"></slot>
         </template>
 
@@ -129,7 +129,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'totalPoints', 'isLearner']),
+      ...mapGetters(['isUserLoggedIn', 'totalPoints', 'isLearner', 'isAppContext']),
       ...mapState({
         username: state => state.core.session.username,
         fullName: state => state.core.session.full_name,

--- a/kolibri/core/assets/src/views/AppBottomBar.vue
+++ b/kolibri/core/assets/src/views/AppBottomBar.vue
@@ -17,7 +17,7 @@
           class="icon-box"
           :activeClasses="activeClasses"
         >
-          <a :href="link.link">
+          <a :href="link.link" tabindex="-1">
             <KIconButton
               :icon="link.icon"
               :color="link.color"

--- a/kolibri/core/assets/src/views/AppBottomBar.vue
+++ b/kolibri/core/assets/src/views/AppBottomBar.vue
@@ -1,0 +1,87 @@
+<template>
+
+  <div class="bottom-bar">
+    <div class="icons">
+      <span
+        v-for="(link, index) in navigationLinks"
+        :key="index"
+        class="icon-box"
+        :activeClass="activeClasses"
+      >
+        <router-link
+          ref="btn"
+          :to="link.link"
+        >
+          <KIconButton
+            :icon="link.icon"
+            :color="link.color"
+            :ariaLabel="link.title"
+          />
+        </router-link>
+
+
+      </span>
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'AppBottomBar',
+    mixins: [commonCoreStrings],
+    props: {
+      navigationLinks: {
+        type: Array,
+        default: () => [],
+        required: true,
+      },
+    },
+    computed: {
+      activeClasses() {
+        // return both fixed and dynamic classes
+        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .bottom-bar {
+    @extend %dropshadow-4dp;
+
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 24;
+    height: 48px;
+    background-color: white;
+  }
+
+  .icons {
+    //  margin-top: 4px;
+    display: flex;
+    justify-content: space-around;
+  }
+
+  .router-link-active {
+    padding-top: 6px;
+    border-top: 4px solid;
+  }
+
+  .icon-box {
+    width: 48px;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/AppBottomBar.vue
+++ b/kolibri/core/assets/src/views/AppBottomBar.vue
@@ -1,13 +1,14 @@
 <template>
 
   <div>
-    <div v-if="navigationIsOpen" class="menu">
-      <AndroidNavigationNestedMenu
-        ref="menu"
-        @shouldFocusFirstEl="focusFirstEl"
-        @shouldFocusLastEl="focusLastEl"
-      />
-    </div>
+    <AndroidNavigationNestedMenu
+      v-if="navigationIsOpen"
+      ref="sideNav"
+      :navShown="navigationIsOpen"
+      @toggleSideNav="navigationIsOpen = !navigationIsOpen"
+      @shouldFocusFirstEl="findFirstEl()"
+    />
+
     <div class="bottom-bar">
       <div class="icons">
         <span
@@ -16,23 +17,22 @@
           class="icon-box"
           :activeClasses="activeClasses"
         >
-          <KIconButton
-            :icon="link.icon"
-            :color="link.color"
-            :ariaLabel="link.title"
-            @click="navigateToRoute(link.link)"
-          />
+          <a :href="link.link">
+            <KIconButton
+              :icon="link.icon"
+              :color="link.color"
+              :ariaLabel="link.title"
+            />
+          </a>
           <p class="label" :style="{ color: $themeTokens.primary }">{{ link.title }}</p>
         </span>
         <KIconButton
-          v-if="isAdmin || isCoach"
           icon="menu"
           :color="$themeTokens.primary"
           :ariaLabel="$tr('openNav')"
           @click="toggleBottomNav"
         />
       </div>
-
     </div>
   </div>
 
@@ -42,7 +42,6 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { mapGetters } from 'vuex';
   import AndroidNavigationNestedMenu from './AndroidNavigationNestedMenu';
 
   export default {
@@ -62,7 +61,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isAdmin', 'isCoach']),
       activeClasses() {
         // return both fixed and dynamic classes
         return `router-link-active ${this.$computedClass({
@@ -74,7 +72,7 @@
       navigationIsOpen(navigationIsOpen) {
         this.$nextTick(() => {
           if (navigationIsOpen) {
-            this.focusFirstEl();
+            this.findFirstEl();
           }
         });
       },
@@ -83,23 +81,11 @@
       toggleBottomNav() {
         this.navigationIsOpen = !this.navigationIsOpen;
       },
-      navigateToRoute(link) {
-        console.log(link);
-        this.$router.redirectTo(link);
-      },
-      /**
-       * @public
-       * Focuses on correct first element for FocusTrap.
-       */
-      focusFirstEl() {
+      findFirstEl() {
         this.$nextTick(() => {
-          if (this.$refs && this.$refs.menu && this.$refs.menu.$refs) {
-            this.$refs.menu.$refs.menuItem[0].$el.focus();
-          }
+          console.log(this.$refs);
+          this.$refs.sideNav.focusFirstEl();
         });
-      },
-      focusLastEl() {
-        this.$refs.menu.$refs.menuItem[this.$refs.menu.$refs.menuItem.length - 1].focus();
       },
     },
     $trs: {
@@ -125,19 +111,14 @@
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 24;
+    z-index: 12;
     height: 48px;
     background-color: white;
   }
 
   .menu {
-    position: fixed;
-    right: 0;
-    bottom: 48px;
-    left: 0;
     z-index: 24;
-    width: 100%;
-    height: 100%;
+    overflow-y: scroll;
     background-color: white;
     transition: background-color $core-time ease;
   }

--- a/kolibri/core/assets/src/views/AppBottomBar.vue
+++ b/kolibri/core/assets/src/views/AppBottomBar.vue
@@ -1,28 +1,41 @@
 <template>
 
-  <div class="bottom-bar">
-    <div class="icons">
-      <span
-        v-for="(link, index) in navigationLinks"
-        :key="index"
-        class="icon-box"
-        :activeClass="activeClasses"
-      >
-        <router-link
-          ref="btn"
-          :to="link.link"
-        >
-          <KIconButton
-            :icon="link.icon"
-            :color="link.color"
-            :ariaLabel="link.title"
-          />
-        </router-link>
-
-
-      </span>
+  <div>
+    <div v-if="navigationIsOpen" class="menu">
+      <AndroidNavigationNestedMenu />
     </div>
+    <div class="bottom-bar">
+      <div class="icons">
+        <span
+          v-for="(link, index) in navigationLinks"
+          :key="index"
+          class="icon-box"
+          :activeClasses="activeClasses"
+        >
+          <router-link
+            ref="btn"
+            :to="link.link"
+          >
+            <KIconButton
+              :icon="link.icon"
+              :color="link.color"
+              :ariaLabel="link.title"
+            />
 
+          </router-link>
+          <p class="label" :style="{ color: $themeTokens.primary }">{{ link.title }}</p>
+
+        </span>
+        <KIconButton
+          v-if="isAdmin || isCoach"
+          icon="menu"
+          :color="$themeTokens.primary"
+          :ariaLabel="$tr('openNav')"
+          @click="toggleBottomNav"
+        />
+      </div>
+
+    </div>
   </div>
 
 </template>
@@ -31,9 +44,12 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { mapGetters } from 'vuex';
+  import AndroidNavigationNestedMenu from './AndroidNavigationNestedMenu';
 
   export default {
     name: 'AppBottomBar',
+    components: { AndroidNavigationNestedMenu },
     mixins: [commonCoreStrings],
     props: {
       navigationLinks: {
@@ -42,10 +58,30 @@
         required: true,
       },
     },
+    data() {
+      return {
+        navigationIsOpen: false,
+      };
+    },
     computed: {
+      ...mapGetters(['isAdmin', 'isCoach']),
       activeClasses() {
         // return both fixed and dynamic classes
-        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
+        return `router-link-active ${this.$computedClass({
+          borderTop: this.$themeTokens.primary,
+        })}`;
+      },
+    },
+    methods: {
+      toggleBottomNav() {
+        this.navigationIsOpen = !this.navigationIsOpen;
+      },
+    },
+    $trs: {
+      openNav: {
+        message: 'Open site navigation',
+        context:
+          "This message is providing additional context to the screen-reader users, but is not visible in the Kolibri UI.\n\nIn this case the screen-reader will announce the message when user navigates to the 'hamburger' button with the keyboard, to indicate that it allows them to open the sidebar navigation menu.",
       },
     },
   };
@@ -69,19 +105,41 @@
     background-color: white;
   }
 
+  .menu {
+    position: fixed;
+    right: 0;
+    bottom: 48px;
+    left: 0;
+    z-index: 24;
+    width: 100%;
+    height: 100%;
+    background-color: white;
+    transition: background-color $core-time ease;
+  }
+
   .icons {
     //  margin-top: 4px;
     display: flex;
     justify-content: space-around;
   }
 
-  .router-link-active {
-    padding-top: 6px;
-    border-top: 4px solid;
-  }
-
   .icon-box {
     width: 48px;
+  }
+
+  .router-link-active {
+    padding-top: 6px;
+  }
+
+  .button {
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+
+  .label {
+    padding: 0;
+    margin-top: -8px;
+    font-size: 12px;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/AppBottomBar.vue
+++ b/kolibri/core/assets/src/views/AppBottomBar.vue
@@ -2,7 +2,11 @@
 
   <div>
     <div v-if="navigationIsOpen" class="menu">
-      <AndroidNavigationNestedMenu />
+      <AndroidNavigationNestedMenu
+        ref="menu"
+        @shouldFocusFirstEl="focusFirstEl"
+        @shouldFocusLastEl="focusLastEl"
+      />
     </div>
     <div class="bottom-bar">
       <div class="icons">
@@ -12,19 +16,13 @@
           class="icon-box"
           :activeClasses="activeClasses"
         >
-          <router-link
-            ref="btn"
-            :to="link.link"
-          >
-            <KIconButton
-              :icon="link.icon"
-              :color="link.color"
-              :ariaLabel="link.title"
-            />
-
-          </router-link>
+          <KIconButton
+            :icon="link.icon"
+            :color="link.color"
+            :ariaLabel="link.title"
+            @click="navigateToRoute(link.link)"
+          />
           <p class="label" :style="{ color: $themeTokens.primary }">{{ link.title }}</p>
-
         </span>
         <KIconButton
           v-if="isAdmin || isCoach"
@@ -72,9 +70,36 @@
         })}`;
       },
     },
+    watch: {
+      navigationIsOpen(navigationIsOpen) {
+        this.$nextTick(() => {
+          if (navigationIsOpen) {
+            this.focusFirstEl();
+          }
+        });
+      },
+    },
     methods: {
       toggleBottomNav() {
         this.navigationIsOpen = !this.navigationIsOpen;
+      },
+      navigateToRoute(link) {
+        console.log(link);
+        this.$router.redirectTo(link);
+      },
+      /**
+       * @public
+       * Focuses on correct first element for FocusTrap.
+       */
+      focusFirstEl() {
+        this.$nextTick(() => {
+          if (this.$refs && this.$refs.menu && this.$refs.menu.$refs) {
+            this.$refs.menu.$refs.menuItem[0].$el.focus();
+          }
+        });
+      },
+      focusLastEl() {
+        this.$refs.menu.$refs.menuItem[this.$refs.menu.$refs.menuItem.length - 1].focus();
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/CoreAppMenuItem.vue
+++ b/kolibri/core/assets/src/views/CoreAppMenuItem.vue
@@ -1,0 +1,30 @@
+<template>
+
+  <li>
+    <a
+      :href="link"
+      class="core-menu-option"
+      role="menuitem"
+      :class="$computedClass(optionStyle)"
+      :tabindex="link ? false : '0'"
+      @click="conditionalEmit"
+      @keydown.enter="conditionalEmit"
+    >
+      <slot>
+        <KLabeledIcon>
+          <template v-if="icon" #icon>
+            <KIcon
+              :icon="icon"
+              :color="optionIconColor"
+            />
+          </template>
+          <div v-if="label">{{ label }}</div>
+        </KLabeledIcon>
+        <div
+          v-if="secondaryText"
+        >{{ secondaryText }}</div>
+      </slot>
+    </a>
+  </li>
+
+</template>

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -1,0 +1,676 @@
+<template>
+
+  <div
+    ref="mainWrapper"
+    class="main-wrapper"
+    :style="mainWrapperStyles"
+  >
+
+    <div v-if="blockDoubleClicks" class="click-mask"></div>
+
+    <ScrollingHeader
+      :scrollPosition="scrollPosition"
+      :alwaysVisible="fixedAppBar"
+      :mainWrapperScrollHeight="mainWrapperScrollHeight"
+      :isHidden.sync="headerIsHidden"
+      :skipNextUpdate.sync="headerSkipNextUpdate"
+    >
+      <ImmersiveToolbar
+        v-if="immersivePage && !fullScreen"
+        :appBarTitle="toolbarTitle || appBarTitle"
+        :icon="immersivePageIcon"
+        :route="immersivePageRoute"
+        :isFullscreen="!immersivePagePrimary"
+        :height="topBarHeight"
+        @nav-icon-click="$emit('navIconClick')"
+      />
+      <AppBar
+        v-else-if="!immersivePage && !fullScreen"
+        ref="appBar"
+        class="app-bar"
+        :title="toolbarTitle || appBarTitle"
+        :height="topBarHeight"
+        :navShown="navShown"
+        @toggleSideNav="navShown = !navShown"
+        @showLanguageModal="languageModalShown = true"
+      >
+        <template #totalPointsMenuItem>
+          <slot name="totalPointsMenuItem"></slot>
+        </template>
+        <template #app-bar-actions>
+          <div class="app-bar-actions">
+            <slot name="app-bar-actions"></slot>
+          </div>
+        </template>
+        <template v-if="showSubNav" #sub-nav>
+          <slot name="sub-nav"></slot>
+        </template>
+      </AppBar>
+      <KLinearLoader
+        v-if="loading && !fullScreen"
+        class="loader"
+        :style="{ top: `${appbarHeight}px` }"
+        type="indeterminate"
+        :delay="false"
+      />
+    </ScrollingHeader>
+
+    <SideNav
+      ref="sideNav"
+      :navShown="navShown"
+      @toggleSideNav="navShown = !navShown"
+      @shouldFocusFirstEl="findFirstEl()"
+    />
+
+    <div
+      v-if="!loading"
+      :class="fullScreen ? 'scrolling-pane' : 'content'"
+      :style="contentStyles"
+    >
+      <CoreBanner v-if="coreBannerComponent && showDemoBanner">
+        <template #default="props">
+          <component :is="coreBannerComponent" :bannerClosed="props.bannerClosed" />
+        </template>
+      </CoreBanner>
+
+      <div v-if="debug" class="debug">
+        <div>{{ contentComponentName }}</div>
+        <div>{{ routePath }}</div>
+      </div>
+
+      <KPageContainer v-if="notAuthorized">
+        <AuthMessage
+          :authorizedRole="authorizedRole"
+          :header="authorizationErrorHeader"
+          :details="authorizationErrorDetails"
+        />
+      </KPageContainer>
+      <KPageContainer v-else-if="error">
+        <AppError />
+      </KPageContainer>
+
+      <div
+        v-else
+        id="main"
+        role="main"
+        tabindex="-1"
+        class="main"
+        :style="mainStyles"
+      >
+        <slot></slot>
+      </div>
+    </div>
+
+
+    <div aria-live="polite">
+      <GlobalSnackbar />
+    </div>
+    <UpdateNotification
+      v-if="!loading && showNotification && mostRecentNotification"
+      :id="mostRecentNotification.id"
+      :title="mostRecentNotification.title"
+      :msg="mostRecentNotification.msg"
+      :linkText="mostRecentNotification.linkText"
+      :linkUrl="mostRecentNotification.linkUrl"
+      @submit="dismissUpdateModal"
+    />
+    <LanguageSwitcherModal
+      v-if="languageModalShown"
+      :style="{ color: $themeTokens.text }"
+      @cancel="languageModalShown = false"
+    />
+    <AppBottomBar class="bottom-bar" :navigationLinks="links" />
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import { mapState, mapGetters } from 'vuex';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import AppBar from 'kolibri.coreVue.components.AppBar';
+  import AppBottomBar from 'kolibri.coreVue.components.AppBottomBar';
+  import SideNav from 'kolibri.coreVue.components.SideNav';
+  import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
+  import { throttle } from 'frame-throttle';
+  import Lockr from 'lockr';
+  import { UPDATE_MODAL_DISMISSED } from 'kolibri.coreVue.vuex.constants';
+  import { currentLanguage, defaultLanguage } from 'kolibri.utils.i18n';
+  import coreBannerContent from 'kolibri.utils.coreBannerContent';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AppError from 'kolibri-common/components/AppError';
+  import GlobalSnackbar from 'kolibri-common/components/GlobalSnackbar';
+  import navComponentsMixin from '../../mixins/nav-components';
+  import ImmersiveToolbar from '../ImmersiveToolbar';
+  import UpdateNotification from '../UpdateNotification';
+  import LanguageSwitcherModal from '../language-switcher/LanguageSwitcherModal';
+  import CoreBanner from '../CoreBanner';
+  import { PageNames } from './../../../../../plugins/learn/assets/src/constants';
+  import ScrollingHeader from './ScrollingHeader';
+
+  // NOTE: there is a new useScrollPosition composable in kolibri.core
+  // that can be used when CoreBase is refactored
+  // This version should be depricated
+  const scrollPositions = {
+    _scrollPositions: {},
+    getScrollPosition() {
+      // Use key set by Vue Router on the history state.
+      const key = (window.history.state || {}).key;
+      const defaultPos = { x: 0, y: 0 };
+      if (key && this._scrollPositions[key]) {
+        return this._scrollPositions[key];
+      }
+      return defaultPos;
+    },
+    setScrollPosition({ x, y }) {
+      const key = (window.history.state || {}).key;
+      // Only set if we have a vue router key on the state,
+      // otherwise we don't do anything.
+      if (key) {
+        this._scrollPositions[window.history.state.key] = { x, y };
+      }
+    },
+  };
+
+  export default {
+    name: 'CoreBase',
+    metaInfo() {
+      return {
+        // Use arrow function to bind $tr to this component
+        titleTemplate: title => {
+          if (this.error) {
+            return this.$tr('kolibriTitleMessage', { title: this.$tr('errorPageTitle') });
+          }
+          if (!title) {
+            // If no child component sets title, it reads 'Kolibri'
+            return this.coreString('kolibriLabel');
+          }
+          // If child component sets title, it reads 'Child Title - Kolibri'
+          return this.$tr('kolibriTitleMessage', { title });
+        },
+        title: this.pageTitle,
+      };
+    },
+    components: {
+      AppBar,
+      AppBottomBar,
+      AppError,
+      CoreBanner,
+      ImmersiveToolbar,
+      SideNav,
+      AuthMessage,
+      GlobalSnackbar,
+      ScrollingHeader,
+      UpdateNotification,
+      LanguageSwitcherModal,
+    },
+    mixins: [navComponentsMixin, responsiveWindowMixin, commonCoreStrings],
+    props: {
+      appBarTitle: {
+        type: String,
+        required: false,
+        default: '',
+      },
+      // Prop that determines whether to show nav components and provide margins
+      fullScreen: {
+        type: Boolean,
+        default: false,
+      },
+      // Prop that determines if the page contains an embedded sidebar
+      hasSidebar: {
+        type: Boolean,
+        default: false,
+      },
+      // reserve space at the bottom for floating widgets
+      marginBottom: {
+        type: Number,
+        default: 0,
+      },
+      // AUTHORIZATION SPECIFIC
+      authorized: {
+        type: Boolean,
+        required: false,
+        default: true,
+      },
+      authorizedRole: {
+        type: String,
+        default: null,
+      },
+      authorizationErrorHeader: {
+        type: String,
+        default: null,
+      },
+      authorizationErrorDetails: {
+        type: String,
+        default: null,
+      },
+      // IMMERSIVE-SPECIFIC
+      immersivePage: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      // generally a 'back' or 'close' icon
+      immersivePageIcon: {
+        type: String,
+        required: false,
+        default: 'close',
+      },
+      // link to where the 'back' button should go
+      immersivePageRoute: {
+        type: Object,
+        required: false,
+        default: null,
+      },
+      // determines the color, primary being the classic kolibri appbar color
+      immersivePagePrimary: {
+        type: Boolean,
+        required: false,
+      },
+      toolbarTitle: {
+        type: String,
+        required: false,
+        default: '',
+      },
+      // Alternative to using metaInfo in a top level component to set the
+      // title of the HTML Document
+      pageTitle: {
+        type: String,
+        required: false,
+        default: '',
+      },
+      // If true, will render the component in the "sub-nav" slot and add 48px
+      // to AppBody's top offset.
+      showSubNav: {
+        type: Boolean,
+        default: false,
+      },
+      debug: {
+        type: Boolean,
+        default: false,
+      },
+      maxMainWidth: {
+        type: Number,
+        required: false,
+        default: 1000,
+      },
+      showDemoBanner: {
+        type: Boolean,
+        default: false,
+        required: false,
+      },
+    },
+    data() {
+      return {
+        navShown: false,
+        scrollPosition: 0,
+        unwatchScrollHeight: undefined,
+        notificationModalShown: true,
+        languageModalShown: false,
+        headerIsHidden: false,
+        headerSkipNextUpdate: false,
+        mainWrapperScrollHeight: 0,
+      };
+    },
+    computed: {
+      ...mapGetters(['isAdmin', 'isSuperuser']),
+      ...mapState({
+        error: state => state.core.error,
+        loading: state => state.core.loading,
+        blockDoubleClicks: state => state.core.blockDoubleClicks,
+        notifications: state => state.core.notifications,
+      }),
+      appbarHeight() {
+        if (this.showSubNav) {
+          // Adds the height of KNavBar
+          return this.topBarHeight + 48;
+        }
+        return this.topBarHeight;
+      },
+      notAuthorized() {
+        // catch "not authorized" error, display AuthMessage
+        if (
+          this.error &&
+          this.error.response &&
+          this.error.response.status &&
+          this.error.response.status == 403
+        ) {
+          return true;
+        }
+        return !this.authorized;
+      },
+      mainWrapperStyles() {
+        if (this.$isPrint) {
+          return {};
+        }
+
+        return {
+          width: '100vw',
+          backgroundColor: this.$themePalette.grey.v_100,
+          paddingTop: `${this.appbarHeight}px`,
+          paddingBottom: `${this.marginBottom}px`,
+        };
+      },
+      contentStyles() {
+        if (this.fullScreen || this.$isPrint || this.hasSidebar) {
+          return {
+            marginTop: '0px',
+            marginBottom: '0px',
+            padding: '0px',
+          };
+        }
+        return {
+          top: this.fixedAppBar ? `${this.appbarHeight}px` : 0,
+          padding: `32px ${this.windowIsSmall ? 16 : 32}px`,
+        };
+      },
+      mainStyles() {
+        let styles = {
+          marginLeft: 'auto',
+          marginRight: 'auto',
+        };
+        if (!this.fullScreen) {
+          styles['maxWidth'] = this.maxMainWidth + 'px';
+        }
+        if (this.hasSidebar) {
+          styles = {
+            marginLeft: '0',
+            marginRight: '0',
+          };
+        }
+        return styles;
+      },
+      fixedAppBar() {
+        return this.windowIsLarge && !this.windowIsShort;
+      },
+      links() {
+        const links = [
+          {
+            condition: this.isUserLoggedIn,
+            title: this.coreString('homeLabel'),
+            link: this.$router.getRoute(PageNames.HOME),
+            icon: 'dashboard',
+            color: this.$themeTokens.primary,
+          },
+          {
+            condition: this.canAccessUnassignedContent,
+            title: this.coreString('libraryLabel'),
+            link: this.$router.getRoute(PageNames.LIBRARY),
+            icon: 'library',
+            color: this.$themeTokens.primary,
+          },
+          {
+            condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
+            title: this.coreString('bookmarksLabel'),
+            link: this.$router.getRoute(PageNames.BOOKMARKS),
+            icon: 'bookmark',
+            color: this.$themeTokens.primary,
+          },
+        ];
+        return links;
+      },
+      // calls handleScroll no more than every 17ms
+      throttledHandleScroll() {
+        return throttle(this.handleScroll);
+      },
+      showNotification() {
+        if (
+          (this.isAdmin || this.isSuperuser) &&
+          !Lockr.get(UPDATE_MODAL_DISMISSED) &&
+          this.notificationModalShown &&
+          this.notifications.length !== 0
+        ) {
+          return true;
+        }
+        return false;
+      },
+      mostRecentNotification() {
+        let languageCode = defaultLanguage.id;
+        // notifications should already be ordered by timestamp
+        const notification = this.notifications[0];
+        if (notification) {
+          // check if translated message is available for current language
+          if (notification.i18n[currentLanguage] !== undefined) {
+            languageCode = currentLanguage;
+          }
+          // i18n data structure generated by nutritionfacts_i18n.py
+          return {
+            id: notification.id,
+            title: notification.i18n[languageCode].title,
+            msg: notification.i18n[languageCode].msg,
+            linkText: notification.i18n[languageCode].link_text,
+            linkUrl: notification.link_url,
+          };
+        }
+        return null;
+      },
+      contentComponentName() {
+        return this.$slots.default[0].context.$options.name;
+      },
+      routePath() {
+        if (this.$router.getRouteDefinition(this.contentComponentName)) {
+          return this.$router.getRouteDefinition(this.contentComponentName).path;
+        }
+        return '';
+      },
+      coreBannerComponent() {
+        return coreBannerContent[0];
+      },
+    },
+    watch: {
+      $route() {
+        // If there's a scrollTo parameter, it will be handled by
+        // the vue-router via `scrollBehavior`.
+        if (this.$route.params.scrollTo) {
+          // Show the header by default when navigating with a scrollTo parameter.
+          this.showHeader();
+          return;
+        }
+        // Set a watcher so that if the router sets a new
+        // route, we update our scroll position based on the ones
+        // we have tracked in the scrollPosition object above.
+        if (this.unwatchScrollHeight) {
+          this.unwatchScrollHeight();
+        }
+        if (this.loading) {
+          // Don't set scroll position until the main content
+          // of coreBase is shown in the DOM.
+          // Create a watcher to monitor changes in loading
+          // to try to set the scrollHeight after the contents
+          // have loaded.
+          this.unwatchScrollHeight = this.$watch('loading', () => {
+            this.unwatchScrollHeight();
+            this.$nextTick(() => {
+              // Set the scroll in next tick for safety, to ensure
+              // that the child components have finished mounting
+              this.setScroll();
+            });
+          });
+        } else {
+          this.setScroll();
+        }
+      },
+      windowWidth() {
+        if (this.fixedAppBar && this.headerIsHidden) {
+          this.headerIsHidden = false;
+        }
+        this.updateScrollHeight();
+      },
+      links() {
+        const links = [
+          {
+            condition: this.isUserLoggedIn,
+            title: this.coreString('homeLabel'),
+            link: this.$router.getRoute(PageNames.HOME),
+            icon: 'dashboard',
+            color: this.$themeTokens.primary,
+          },
+          {
+            condition: this.canAccessUnassignedContent,
+            title: this.learnString('libraryLabel'),
+            link: this.$router.getRoute(PageNames.LIBRARY),
+            icon: 'library',
+            color: this.$themeTokens.primary,
+          },
+          {
+            condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
+            title: this.coreString('bookmarksLabel'),
+            link: this.$router.getRoute(PageNames.BOOKMARKS),
+            icon: 'bookmark',
+            color: this.$themeTokens.primary,
+          },
+        ];
+        return links;
+      },
+    },
+    beforeRouteUpdate() {
+      this.recordScroll();
+    },
+    beforeRouteLeave() {
+      this.recordScroll();
+    },
+    mounted() {
+      window.addEventListener('scroll', this.throttledHandleScroll, { passive: true });
+      this.setScroll();
+    },
+    beforeDestroy() {
+      window.removeEventListener('scroll', this.throttledHandleScroll);
+    },
+    methods: {
+      handleScroll() {
+        this.scrollPosition = window.pageYOffset;
+        this.recordScroll();
+      },
+      recordScroll() {
+        scrollPositions.setScrollPosition({ y: window.pageYOffset });
+      },
+      dismissUpdateModal() {
+        if (this.notifications.length === 0) {
+          this.notificationModalShown = false;
+          Lockr.set(UPDATE_MODAL_DISMISSED, true);
+        }
+      },
+      updateScrollHeight() {
+        this.mainWrapperScrollHeight = Math.max(
+          this.$refs.mainWrapper.offsetHeight,
+          this.$refs.mainWrapper.scrollHeight
+        );
+      },
+      updateHeaderHidden(isHidden) {
+        // This provides a mechanism to tell the `ScrollingHeader` component to
+        // ignore scroll changes triggered here in `CoreBase` e.g. during usage of
+        // the forward/back buttons.
+
+        this.headerSkipNextUpdate = true;
+        this.headerIsHidden = isHidden;
+      },
+      showHeader() {
+        this.updateHeaderHidden(false);
+      },
+      setScroll() {
+        this.updateScrollHeight();
+        window.scrollTo(0, scrollPositions.getScrollPosition().y);
+        this.scrollPosition = window.pageYOffset;
+        // If recorded scroll is applied, immediately un-hide the header
+        if (this.scrollPosition > 0) {
+          this.$nextTick().then(this.showHeader);
+        }
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.sideNav.focusFirstEl();
+        });
+      },
+    },
+    $trs: {
+      kolibriTitleMessage: {
+        message: '{ title } - Kolibri',
+        context: 'DO NOT TRANSLATE\nCopy the source string.',
+      },
+      errorPageTitle: {
+        message: 'Error',
+        context:
+          "When Kolibri throws an error, this is the text that's used as the title of the error page. The description of the error follows below.",
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  @import '~kolibri-design-system/lib/styles/definitions';
+
+  .main-wrapper {
+    display: inline-block;
+    width: 100vw;
+
+    @media print {
+      /* Without this, things won't print correctly
+         *  - Firefox: Tables will get cutoff
+         *  - Chrome: Table header won't repeat correctly on each page
+         */
+      display: block;
+    }
+  }
+
+  .main {
+    height: 100%;
+  }
+
+  // When focused by SkipNavigationLink, don't outline non-buttons/links
+  /deep/ [tabindex='-1'] {
+    outline-style: none !important;
+  }
+
+  .scrolling-pane {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow-x: auto;
+  }
+
+  .click-mask {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 24;
+    width: 100%;
+    height: 100%;
+  }
+
+  .app-bar {
+    @extend %dropshadow-4dp;
+
+    width: 100%;
+  }
+
+  .app-bar-actions {
+    display: inline-block;
+  }
+
+  .loader {
+    position: fixed;
+    right: 0;
+    left: 0;
+  }
+
+  .content {
+    margin-right: auto;
+    margin-bottom: 128px;
+    margin-left: auto;
+  }
+
+  .debug {
+    font-family: monospace;
+    font-size: large;
+    font-weight: bold;
+    line-height: 2em;
+  }
+
+</style>

--- a/kolibri/core/assets/src/views/CoreBase/index.vue
+++ b/kolibri/core/assets/src/views/CoreBase/index.vue
@@ -147,8 +147,8 @@
   import UpdateNotification from '../UpdateNotification';
   import LanguageSwitcherModal from '../language-switcher/LanguageSwitcherModal';
   import CoreBanner from '../CoreBanner';
+  import ScrollingHeader from '../ScrollingHeader';
   import { PageNames } from './../../../../../plugins/learn/assets/src/constants';
-  import ScrollingHeader from './ScrollingHeader';
 
   // NOTE: there is a new useScrollPosition composable in kolibri.core
   // that can be used when CoreBase is refactored

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -2,6 +2,7 @@
 
   <li>
     <a
+      ref="menuItem"
       :href="link"
       class="core-menu-option"
       role="menuitem"
@@ -11,18 +12,13 @@
       @keydown.enter="conditionalEmit"
     >
       <slot>
-        <KLabeledIcon>
+        <KLabeledIcon :iconAfter="iconAfter">
           <template v-if="icon" #icon>
-            <KIcon
-              :icon="icon"
-              :color="optionIconColor"
-            />
+            <KIcon :icon="icon" :color="optionIconColor" />
           </template>
           <div v-if="label">{{ label }}</div>
         </KLabeledIcon>
-        <div
-          v-if="secondaryText"
-        >{{ secondaryText }}</div>
+        <div v-if="secondaryText">{{ secondaryText }}</div>
       </slot>
     </a>
   </li>
@@ -49,6 +45,11 @@
         default: null,
       },
       icon: {
+        type: String,
+        required: false,
+        default: '',
+      },
+      iconAfter: {
         type: String,
         required: false,
         default: '',

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -38,6 +38,9 @@
       :style="{ color: $themeTokens.text }"
       @cancel="languageModalShown = false"
     />
+
+    <AppBottomBar class="bottom-bar" :navigationLinks="links" />
+
   </div>
 
 </template>
@@ -48,11 +51,16 @@
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import SideNav from 'kolibri.coreVue.components.SideNav';
+  import AppBottomBar from 'kolibri.coreVue.components.AppBottomBar';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AppBar from '../AppBar';
+  import { PageNames } from './../../../../../plugins/learn/assets/src/constants';
+  import commonLearnStrings from './../../../../../plugins/learn/assets/src/views/commonLearnStrings';
 
   export default {
     name: 'AppBarPage',
-    components: { AppBar, LanguageSwitcherModal, ScrollingHeader, SideNav },
+    components: { AppBar, AppBottomBar, LanguageSwitcherModal, ScrollingHeader, SideNav },
+    mixins: [commonCoreStrings, commonLearnStrings],
     props: {
       title: {
         type: String,
@@ -91,6 +99,32 @@
               marginTop: 0,
             };
       },
+      links() {
+        const links = [
+          {
+            condition: this.isUserLoggedIn,
+            title: this.coreString('homeLabel'),
+            link: this.$router.getRoute(PageNames.HOME),
+            icon: 'dashboard',
+            color: this.$themeTokens.annotation,
+          },
+          {
+            condition: this.canAccessUnassignedContent,
+            title: this.learnString('libraryLabel'),
+            link: this.$router.getRoute(PageNames.LIBRARY),
+            icon: 'library',
+            color: this.$themeTokens.annotation,
+          },
+          {
+            condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
+            title: this.coreString('bookmarksLabel'),
+            link: this.$router.getRoute(PageNames.BOOKMARKS),
+            icon: 'bookmark',
+            color: this.$themeTokens.annotation,
+          },
+        ];
+        return links;
+      },
     },
     mounted() {
       this.$nextTick(() => {
@@ -107,7 +141,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
 
   .app-bar {
-    @extend %dropshadow-4dp;
+    @extend %dropshadow-8dp;
 
     width: 100%;
   }

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -41,6 +41,7 @@
     />
 
     <AppBottomBar
+      v-if="isAppContext"
       class="bottom-bar"
       :navigationLinks="links"
     />
@@ -52,6 +53,7 @@
 
 <script>
 
+  import { mapGetters } from 'vuex';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import SideNav from 'kolibri.coreVue.components.SideNav';
@@ -90,6 +92,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isAppContext']),
       url() {
         return urls['kolibri:kolibri.plugins.learn:learn']();
       },

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -11,7 +11,7 @@
         @toggleSideNav="navShown = !navShown"
         @showLanguageModal="languageModalShown = true"
       >
-        <template #sub-nav>
+        <template v-if="!isAppContext" #sub-nav>
           <slot name="subNav"></slot>
         </template>
       </AppBar>

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -30,6 +30,7 @@
       ref="sideNav"
       :navShown="navShown"
       @toggleSideNav="navShown = !navShown"
+      @shouldFocusFirstEl="findFirstEl()"
     />
 
     <LanguageSwitcherModal
@@ -39,7 +40,10 @@
       @cancel="languageModalShown = false"
     />
 
-    <AppBottomBar class="bottom-bar" :navigationLinks="links" />
+    <AppBottomBar
+      class="bottom-bar"
+      :navigationLinks="links"
+    />
 
   </div>
 
@@ -54,6 +58,7 @@
   import AppBottomBar from 'kolibri.coreVue.components.AppBottomBar';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
+  import generateSideNavRoute from '../../../../../plugins/learn/assets/src/appNavigationRoutes';
   import AppBar from '../AppBar';
   import { PageNames } from './../../../../../plugins/learn/assets/src/constants';
   import commonLearnStrings from './../../../../../plugins/learn/assets/src/views/commonLearnStrings';
@@ -85,6 +90,9 @@
       };
     },
     computed: {
+      url() {
+        return urls['kolibri:kolibri.plugins.learn:learn']();
+      },
       wrapperStyles() {
         return this.appearanceOverrides
           ? this.appearanceOverrides
@@ -105,21 +113,21 @@
           {
             condition: this.isUserLoggedIn,
             title: this.coreString('homeLabel'),
-            link: this.baseLink(PageNames.HOME),
+            link: this.generateBottomBarRoute(PageNames.HOME),
             icon: 'dashboard',
             color: this.$themeTokens.primary,
           },
           {
             condition: this.canAccessUnassignedContent,
             title: this.learnString('libraryLabel'),
-            link: this.baseLink(PageNames.LIBRARY),
+            link: this.generateBottomBarRoute(PageNames.LIBRARY),
             icon: 'library',
             color: this.$themeTokens.primary,
           },
           {
             condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
             title: this.coreString('bookmarksLabel'),
-            link: this.baseLink(PageNames.BOOKMARKS),
+            link: this.generateBottomBarRoute(PageNames.BOOKMARKS),
             icon: 'bookmark',
             color: this.$themeTokens.primary,
           },
@@ -133,10 +141,13 @@
       });
     },
     methods: {
-      baseLink(link) {
-        const url = urls['kolibri:kolibri.plugins.learn:learn']();
-        const path = this.$router.getRoute(link).name.toLowerCase();
-        return `${url}#/${path}`;
+      generateBottomBarRoute(route) {
+        return generateSideNavRoute(this.url, route);
+      },
+      findFirstEl() {
+        this.$nextTick(() => {
+          this.$refs.sideNav.focusFirstEl();
+        });
       },
     },
   };

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -53,6 +53,7 @@
   import SideNav from 'kolibri.coreVue.components.SideNav';
   import AppBottomBar from 'kolibri.coreVue.components.AppBottomBar';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import urls from 'kolibri.urls';
   import AppBar from '../AppBar';
   import { PageNames } from './../../../../../plugins/learn/assets/src/constants';
   import commonLearnStrings from './../../../../../plugins/learn/assets/src/views/commonLearnStrings';
@@ -104,21 +105,21 @@
           {
             condition: this.isUserLoggedIn,
             title: this.coreString('homeLabel'),
-            link: this.$router.getRoute(PageNames.HOME),
+            link: this.baseLink(PageNames.HOME),
             icon: 'dashboard',
             color: this.$themeTokens.primary,
           },
           {
             condition: this.canAccessUnassignedContent,
             title: this.learnString('libraryLabel'),
-            link: this.$router.getRoute(PageNames.LIBRARY),
+            link: this.baseLink(PageNames.LIBRARY),
             icon: 'library',
             color: this.$themeTokens.primary,
           },
           {
             condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
             title: this.coreString('bookmarksLabel'),
-            link: this.$router.getRoute(PageNames.BOOKMARKS),
+            link: this.baseLink(PageNames.BOOKMARKS),
             icon: 'bookmark',
             color: this.$themeTokens.primary,
           },
@@ -130,6 +131,13 @@
       this.$nextTick(() => {
         this.appBarHeight = this.$refs.appBar.$el.scrollHeight || 0;
       });
+    },
+    methods: {
+      baseLink(link) {
+        const url = urls['kolibri:kolibri.plugins.learn:learn']();
+        const path = this.$router.getRoute(link).name.toLowerCase();
+        return `${url}#/${path}`;
+      },
     },
   };
 

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -106,21 +106,21 @@
             title: this.coreString('homeLabel'),
             link: this.$router.getRoute(PageNames.HOME),
             icon: 'dashboard',
-            color: this.$themeTokens.annotation,
+            color: this.$themeTokens.primary,
           },
           {
             condition: this.canAccessUnassignedContent,
             title: this.learnString('libraryLabel'),
             link: this.$router.getRoute(PageNames.LIBRARY),
             icon: 'library',
-            color: this.$themeTokens.annotation,
+            color: this.$themeTokens.primary,
           },
           {
             condition: this.isUserLoggedIn && this.canAccessUnassignedContent,
             title: this.coreString('bookmarksLabel'),
             link: this.$router.getRoute(PageNames.BOOKMARKS),
             icon: 'bookmark',
-            color: this.$themeTokens.annotation,
+            color: this.$themeTokens.primary,
           },
         ];
         return links;

--- a/kolibri/plugins/coach/assets/src/appNavigationRoutes.js
+++ b/kolibri/plugins/coach/assets/src/appNavigationRoutes.js
@@ -1,0 +1,40 @@
+import routes from './routes/reportRoutes';
+import planRoutes from './routes/planRoutes';
+
+// let pathMap = {};
+
+// const createPathMap = () => {
+//     Object.keys(routes).forEach(key => {
+//         let pathName = routes[key].name;
+//         let pathRoute = routes[key].path;
+//         if (pathName) {
+//             pathMap[`${pathName}`] = pathRoute;
+//         }
+//     });
+// };
+
+// createPathMap();
+
+export function generateSideNavReportRoute(id, classId) {
+  let route = routes.find(item => item.name === id);
+  let query = {};
+  if (classId) {
+    query.class_id = classId;
+  }
+  return {
+    ...route,
+    query,
+  };
+}
+
+export function generateSideNavPlanRoute(id, classId) {
+  let route = planRoutes.find(item => item.name === id);
+  let query = {};
+  if (classId) {
+    query.class_id = classId;
+  }
+  return {
+    ...route,
+    query,
+  };
+}

--- a/kolibri/plugins/coach/assets/src/views/CoachAppBarPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachAppBarPage.vue
@@ -6,7 +6,7 @@
   >
     <AppBarPage :title="appBarTitle || defaultAppBarTitle">
       <template
-        v-if="showSubNav"
+        v-if="showSubNav && !isAppContext"
         #subNav
       >
         <TopNavbar />
@@ -24,7 +24,7 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -88,6 +88,7 @@
       ...mapState({
         error: state => state.core.error,
       }),
+      ...mapGetters(['isAppContext']),
     },
     $trs: {
       kolibriTitleMessage: {

--- a/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.vue
@@ -1,10 +1,25 @@
 <template>
 
-  <CoreMenuOption
-    :label="coreString('coachLabel')"
-    :link="url"
-    icon="coach"
-  />
+  <div>
+    <CoreMenuOption
+      :label="coreString('coachLabel')"
+      :iconAfter="iconAfter"
+      icon="coach"
+      @select="handleMenu()"
+    />
+    <div v-if="isAppContext && visibleSubMenu">
+      <a
+        href="#"
+        class="link"
+        :class="$computedClass(optionStyle)"
+      > {{ coachString('plan') }} </a>
+      <a
+        href="#"
+        class="link"
+        :class="$computedClass(optionStyle)"
+      > {{ coachString('reportsLabel') }} </a>
+    </div>
+  </div>
 
 </template>
 
@@ -12,20 +27,63 @@
 <script>
 
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+  import { mapGetters } from 'vuex';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
+  import { generateSideNavReportRoute, generateSideNavPlanRoute } from '../appNavigationRoutes.js';
+  import { coachStringsMixin } from './common/commonCoachStrings';
+  import commonCoach from './common.js';
 
   const component = {
     name: 'CoachSideNavEntry',
     components: {
       CoreMenuOption,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoach, commonCoreStrings, coachStringsMixin],
+    data() {
+      return {
+        visibleSubMenu: false,
+      };
+    },
     computed: {
+      ...mapGetters(['isAppContext']),
       url() {
         return urls['kolibri:kolibri.plugins.coach:coach']();
+      },
+      optionStyle() {
+        return {
+          color: this.$themeTokens.text,
+          textDecoration: 'none',
+          ':hover': {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+          },
+          ':focus': this.$coreOutline,
+        };
+      },
+      iconAfter() {
+        if (this.isAppContext) {
+          return this.visibleSubMenu ? 'chevronUp' : 'chevronDown';
+        }
+      },
+    },
+    methods: {
+      generateSideNavPlanRoute(route) {
+        return generateSideNavPlanRoute(route);
+      },
+      generateSideNavReportRoute(route) {
+        return generateSideNavReportRoute(route);
+      },
+      redirectToRoute() {
+        window.location = this.url;
+      },
+      handleMenu() {
+        // in the app, and there is an active class ID
+        if (this.isAppContext) {
+          this.visibleSubMenu = !this.visibleSubMenu;
+        }
       },
     },
     role: UserKinds.COACH,
@@ -37,3 +95,22 @@
   export default component;
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .link-container {
+    height: 44px;
+  }
+
+  .link {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 44px;
+    margin-left: 40px;
+    font-size: 12px;
+    text-decoration: none;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -31,6 +31,11 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       "In the Plan > Quizzes section, coaches can create new quizzes using the 'New quiz' button.",
   },
+  plan: {
+    message: 'Plan',
+    context:
+      "Translate as a VERB. Refers to the 'Plan' tab where coaches manage lessons, quizzes, and groups.",
+  },
   previewAction: {
     message: 'Preview',
     context:

--- a/kolibri/plugins/device/assets/src/appNavigationRoutes.js
+++ b/kolibri/plugins/device/assets/src/appNavigationRoutes.js
@@ -1,0 +1,19 @@
+import routes from './routes';
+
+let pathMap = {};
+
+const createPathMap = () => {
+  Object.keys(routes).forEach(key => {
+    let pathName = routes[key].name;
+    let pathRoute = routes[key].path;
+    if (pathName) {
+      pathMap[`${pathName}`] = pathRoute;
+    }
+  });
+};
+
+createPathMap();
+
+export default function generateSideNavRoute(rootUrl, pathReference) {
+  return `${rootUrl}#${pathMap[pathReference]}`;
+}

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -63,6 +63,38 @@
         window.sessionStorage.setItem(welcomeDimissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
+      // numberOfNavigationTabsToDisplay() {
+      //   let navItems = document.getElementsByClassName('list-item-navigation');
+      //   navItems = [].slice.call(navItems);
+      //   let index = 0;
+      //   let viewportWidthTakenUp = 0;
+      //   let numberOfItemsToDisplayAsTabs;
+      //   if (navItems && navItems.length > 0) {
+      //     while (index < navItems.length) {
+      //       viewportWidthTakenUp = viewportWidthTakenUp + navItems[index].offsetWidth;
+      //       if (viewportWidthTakenUp < window.innerWidth - 40) {
+      //         navItems[index].classList.add('visible');
+      //         numberOfItemsToDisplayAsTabs = index + 1;
+      //       } else {
+      //         navItems[index].classList.remove('visible');
+      //       }
+      //       index = index + 1;
+      //     }
+      //   }
+      //   return numberOfItemsToDisplayAsTabs;
+      // },
+    },
+    $trs: {
+      deviceManagementTitle: {
+        message: 'Device',
+        context:
+          'The device is the physical or virtual machine that has the Kolibri server installed on it.',
+      },
+      permissionsLabel: {
+        message: 'Permissions',
+        context:
+          'Indicates the Device > Permissions tab. Permissions refer to what users can manage on the device.',
+      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -63,38 +63,6 @@
         window.sessionStorage.setItem(welcomeDimissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
-      // numberOfNavigationTabsToDisplay() {
-      //   let navItems = document.getElementsByClassName('list-item-navigation');
-      //   navItems = [].slice.call(navItems);
-      //   let index = 0;
-      //   let viewportWidthTakenUp = 0;
-      //   let numberOfItemsToDisplayAsTabs;
-      //   if (navItems && navItems.length > 0) {
-      //     while (index < navItems.length) {
-      //       viewportWidthTakenUp = viewportWidthTakenUp + navItems[index].offsetWidth;
-      //       if (viewportWidthTakenUp < window.innerWidth - 40) {
-      //         navItems[index].classList.add('visible');
-      //         numberOfItemsToDisplayAsTabs = index + 1;
-      //       } else {
-      //         navItems[index].classList.remove('visible');
-      //       }
-      //       index = index + 1;
-      //     }
-      //   }
-      //   return numberOfItemsToDisplayAsTabs;
-      // },
-    },
-    $trs: {
-      deviceManagementTitle: {
-        message: 'Device',
-        context:
-          'The device is the physical or virtual machine that has the Kolibri server installed on it.',
-      },
-      permissionsLabel: {
-        message: 'Permissions',
-        context:
-          'Indicates the Device > Permissions tab. Permissions refer to what users can manage on the device.',
-      },
     },
   };
 

--- a/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.vue
@@ -1,10 +1,21 @@
 <template>
 
-  <CoreMenuOption
-    :label="$tr('device')"
-    :link="url"
-    icon="device"
-  />
+  <div>
+    <CoreMenuOption
+      :label="$tr('device')"
+      :iconAfter="iconAfter"
+      :link="isAppContext ? null : url"
+      icon="device"
+      @select="visibleSubMenu = !visibleSubMenu"
+    />
+    <div v-if="isAppContext && visibleSubMenu">
+      <div v-for="(nestedObject, key) in routes" :key="key" class="link-container">
+        <a :href="nestedObject.route" class="link" :class="$computedClass(optionStyle)">
+          {{ nestedObject.text }}
+        </a>
+      </div>
+    </div>
+  </div>
 
 </template>
 
@@ -12,14 +23,75 @@
 <script>
 
   import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+  import { mapGetters } from 'vuex';
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import generateSideNavRoute from '../appNavigationRoutes.js';
+  import { PageNames as DevicePageNames } from '../constants';
 
   const component = {
     name: 'DeviceManagementSideNavEntry',
     components: {
       CoreMenuOption,
+    },
+    mixins: [commonCoreStrings],
+    data() {
+      return {
+        visibleSubMenu: false,
+      };
+    },
+    computed: {
+      ...mapGetters(['isAppContext']),
+      url() {
+        return urls['kolibri:kolibri.plugins.device:device_management']();
+      },
+      routes() {
+        return {
+          channels: {
+            text: this.coreString('channelsLabel'),
+            route: this.generateSideNavRoute(DevicePageNames.MANAGE_CONTENT_PAGE),
+          },
+          permissions: {
+            text: this.$tr('permissionsLabel'),
+            route: this.generateSideNavRoute(DevicePageNames.MANAGE_PERMISSIONS_PAGE),
+          },
+          facilities: {
+            text: this.coreString('facilitiesLabel'),
+            route: this.generateSideNavRoute(DevicePageNames.FACILITIES_PAGE),
+          },
+          info: {
+            text: this.$tr('infoLabel'),
+            route: this.generateSideNavRoute(DevicePageNames.DEVICE_INFO_PAGE),
+          },
+          settings: {
+            text: this.$tr('settingsLabel'),
+            route: this.generateSideNavRoute(DevicePageNames.DEVICE_SETTINGS_PAGE),
+          },
+        };
+      },
+      optionStyle() {
+        return {
+          color: this.$themeTokens.text,
+          textDecoration: 'none',
+          ':hover': {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+          },
+          ':focus': this.$coreOutline,
+        };
+      },
+      iconAfter() {
+        if (this.isAppContext) {
+          return this.visibleSubMenu ? 'chevronUp' : 'chevronDown';
+        }
+      },
+    },
+    methods: {
+      generateSideNavRoute(route) {
+        return generateSideNavRoute(this.url, route);
+      },
     },
     $trs: {
       device: {
@@ -27,10 +99,17 @@
         context:
           'The device is the physical or virtual machine that has the Kolibri server installed on it.',
       },
-    },
-    computed: {
-      url() {
-        return urls['kolibri:kolibri.plugins.device:device_management']();
+      permissionsLabel: {
+        message: 'Permissions',
+        context: 'Refers to the Device > Permissions tab.',
+      },
+      infoLabel: {
+        message: 'Info',
+        context: 'Refers to the Device > Info tab.',
+      },
+      settingsLabel: {
+        message: 'Settings',
+        context: 'Refers to the Device > Settings tab.\n',
       },
     },
     role: UserKinds.CAN_MANAGE_CONTENT,
@@ -42,3 +121,25 @@
   export default component;
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .link-container {
+    height: 44px;
+  }
+
+  .link {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 44px;
+    margin-left: 40px;
+    font-size: 12px;
+  }
+
+  .link-text {
+    text-decoration: none;
+  }
+
+</style>

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -19,49 +19,50 @@
     components: {
       HorizontalNavBarWithOverflowMenu,
     },
-    mixins: [commonCoreStrings],
-    computed: {
-      ...mapGetters(['canManageContent', 'isSuperuser']),
-      links() {
-        let list = [];
-        if (this.canManageContent) {
-          list.push({
+    mixins: [commonCoreStrings, responsiveWindowMixin],
+    data() {
+      return {
+        links: [
+          {
+            condition: this.canManageContent,
             title: this.coreString('channelsLabel'),
             link: this.$router.getRoute('MANAGE_CONTENT_PAGE'),
             icon: 'channel',
             color: this.$themeTokens.textInverted,
-          });
-        }
-        if (this.isSuperuser) {
-          list.push([
-            {
-              title: this.$tr('permissionsLabel'),
-              link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
-              icon: 'permissions',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.coreString('facilitiesLabel'),
-              link: this.$router.getRoute('FACILITIES_PAGE'),
-              icon: 'facility',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.$tr('infoLabel'),
-              link: this.$router.getRoute('DEVICE_INFO_PAGE'),
-              icon: 'deviceInfo',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.$tr('settingsLabel'),
-              link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
-              icon: 'settings',
-              color: this.$themeTokens.textInverted,
-            },
-          ]);
-        }
-        return list.flat();
-      },
+          },
+          {
+            condition: this.isSuperuser,
+            title: this.$tr('permissionsLabel'),
+            link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
+            icon: 'permissions',
+            color: this.$themeTokens.textInverted,
+          },
+          {
+            condition: this.isSuperuser,
+            title: this.coreString('facilitiesLabel'),
+            link: this.$router.getRoute('FACILITIES_PAGE'),
+            icon: 'facility',
+            color: this.$themeTokens.textInverted,
+          },
+          {
+            condition: this.isSuperuser,
+            title: this.$tr('infoLabel'),
+            link: this.$router.getRoute('DEVICE_INFO_PAGE'),
+            icon: 'deviceInfo',
+            color: this.$themeTokens.textInverted,
+          },
+          {
+            condition: this.isSuperuser,
+            title: this.$tr('settingsLabel'),
+            link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
+            icon: 'settings',
+            color: this.$themeTokens.textInverted,
+          },
+        ],
+      };
+    },
+    computed: {
+      ...mapGetters(['canManageContent', 'isSuperuser']),
     },
 
     $trs: {

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <HorizontalNavBarWithOverflowMenu
-    v-if="links.length > 0"
-    :navigationLinks="links"
-  />
+  <HorizontalNavBarWithOverflowMenu v-if="links.length > 0" :navigationLinks="links" />
 
 </template>
 
@@ -19,7 +16,7 @@
     components: {
       HorizontalNavBarWithOverflowMenu,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     data() {
       return {
         links: [

--- a/kolibri/plugins/facility/assets/src/appNavigationRoutes.js
+++ b/kolibri/plugins/facility/assets/src/appNavigationRoutes.js
@@ -1,0 +1,20 @@
+import routes from './routes';
+
+let pathMap = {};
+
+const createPathMap = () => {
+  Object.keys(routes).forEach(key => {
+    let pathName = routes[key].name;
+    let pathRoute = routes[key].path;
+    if (pathName) {
+      pathMap[`${pathName}`] = pathRoute;
+    }
+  });
+};
+
+createPathMap();
+
+export default function generateSideNavRoute(rootUrl, pathReference) {
+  const cleanPath = pathMap[pathReference].replace(':facility_id?/', '');
+  return `${rootUrl}#${cleanPath}`;
+}

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -117,6 +117,7 @@ export default [
     path: '/',
     // Redirect to AllFacilitiesPage if a superuser and device has > 1 facility
     beforeEnter(to, from, next) {
+      console.log(window.location);
       if (store.getters.userIsMultiFacilityAdmin) {
         next(store.getters.facilityPageLinks.AllFacilitiesPage);
       } else {

--- a/kolibri/plugins/facility/assets/src/views/FacilityManagementSideNavEntry.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityManagementSideNavEntry.vue
@@ -1,10 +1,21 @@
 <template>
 
-  <CoreMenuOption
-    :label="coreString('facilityLabel')"
-    :link="url"
-    icon="facility"
-  />
+  <div>
+    <CoreMenuOption
+      :label="coreString('facilityLabel')"
+      :link="isAppContext ? null : url"
+      :iconAfter="iconAfter"
+      icon="facility"
+      @select="visibleSubMenu = !visibleSubMenu"
+    />
+    <div v-if="isAppContext && visibleSubMenu">
+      <div v-for="(nestedObject, key) in routes" :key="key" class="link-container">
+        <a :href="nestedObject.route" class="link" :class="$computedClass(optionStyle)">
+          {{ nestedObject.text }}
+        </a>
+      </div>
+    </div>
+  </div>
 
 </template>
 
@@ -16,6 +27,9 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
+  import { mapGetters } from 'vuex';
+  import generateSideNavRoute from '../appNavigationRoutes.js';
+  import { PageNames as FacilityPageNames } from '../constants';
 
   const component = {
     name: 'FacilityManagementSideNavEntry',
@@ -23,13 +37,70 @@
     components: {
       CoreMenuOption,
     },
+    data() {
+      return {
+        visibleSubMenu: false,
+      };
+    },
     computed: {
+      ...mapGetters(['isAppContext']),
       url() {
         return urls['kolibri:kolibri.plugins.facility:facility_management']();
+      },
+      routes() {
+        return {
+          facilityClasses: {
+            text: this.coreString('classesLabel'),
+            route: this.generateSideNavRoute(FacilityPageNames.CLASS_MGMT_PAGE),
+          },
+          facilityUsers: {
+            text: this.coreString('usersLabel'),
+            route: this.generateSideNavRoute(FacilityPageNames.USER_MGMT_PAGE),
+          },
+          facilitySettings: {
+            text: this.$tr('settingsLabel'),
+            route: this.generateSideNavRoute(FacilityPageNames.FACILITY_CONFIG_PAGE),
+          },
+          facilityData: {
+            text: this.$tr('data'),
+            route: this.generateSideNavRoute(FacilityPageNames.DATA_EXPORT_PAGE),
+          },
+        };
+      },
+      optionStyle() {
+        return {
+          color: this.$themeTokens.text,
+          textDecoration: 'none',
+          ':hover': {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+          },
+          ':focus': this.$coreOutline,
+        };
+      },
+      iconAfter() {
+        if (this.isAppContext) {
+          return this.visibleSubMenu ? 'chevronUp' : 'chevronDown';
+        }
+      },
+    },
+    methods: {
+      generateSideNavRoute(route) {
+        return generateSideNavRoute(this.url, route);
       },
     },
     role: UserKinds.ADMIN,
     priority: 10,
+    $trs: {
+      data: {
+        message: 'Data',
+        context: "Title of tab in 'Facility' section.",
+      },
+      settingsLabel: {
+        message: 'Settings',
+        context: "Title of tab in 'Facility' section.",
+      },
+    },
   };
 
   navComponents.register(component);
@@ -37,3 +108,22 @@
   export default component;
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .link-container {
+    height: 44px;
+  }
+
+  .link {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 44px;
+    margin-left: 40px;
+    font-size: 12px;
+    text-decoration: none;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
@@ -1,8 +1,6 @@
 <template>
 
-  <HorizontalNavBarWithOverflowMenu
-    :navigationLinks="links"
-  />
+  <HorizontalNavBarWithOverflowMenu :navigationLinks="links" />
 
 </template>
 

--- a/kolibri/plugins/learn/assets/src/appNavigationRoutes.js
+++ b/kolibri/plugins/learn/assets/src/appNavigationRoutes.js
@@ -1,0 +1,19 @@
+import routes from './routes';
+
+let pathMap = {};
+
+const createPathMap = () => {
+  Object.keys(routes).forEach(key => {
+    let pathName = routes[key].name;
+    let pathRoute = routes[key].path;
+    if (pathName) {
+      pathMap[`${pathName}`] = pathRoute;
+    }
+  });
+};
+
+createPathMap();
+
+export default function generateSideNavRoute(rootUrl, pathReference) {
+  return `${rootUrl}#${pathMap[pathReference]}`;
+}

--- a/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
@@ -1,10 +1,23 @@
 <template>
 
-  <CoreMenuOption
-    :label="learnString('learnLabel')"
-    :link="url"
-    icon="learn"
-  />
+  <div>
+    <CoreMenuOption
+      ref="firstMenu"
+      :label="learnString('learnLabel')"
+      :iconAfter="iconAfter"
+      icon="learn"
+      :link="isAppContext ? null : url"
+      @select="visibleSubMenu = !visibleSubMenu"
+    />
+
+    <div v-if="isAppContext && visibleSubMenu">
+      <div v-for="(nestedObject, key) in routes" :key="key" class="link-container">
+        <a :href="nestedObject.route" class="link" :styles="menuPluginStyles">
+          {{ nestedObject.text }}
+        </a>
+      </div>
+    </div>
+  </div>
 
 </template>
 
@@ -14,6 +27,9 @@
   import CoreMenuOption from 'kolibri.coreVue.components.CoreMenuOption';
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
+  import { mapGetters } from 'vuex';
+  import { PageNames as LearnPageNames } from '../constants';
+  import generateSideNavRoute from '../appNavigationRoutes.js';
   import commonLearnStrings from './commonLearnStrings';
 
   const component = {
@@ -22,9 +38,63 @@
     components: {
       CoreMenuOption,
     },
+    data() {
+      return {
+        visibleSubMenu: false,
+      };
+    },
     computed: {
+      ...mapGetters(['isAppContext']),
       url() {
         return urls['kolibri:kolibri.plugins.learn:learn']();
+      },
+      routes() {
+        return {
+          home: {
+            text: 'homeLabel',
+            route: this.generateSideNavRoute(LearnPageNames.HOME),
+          },
+          library: {
+            text: 'libraryLabel',
+            route: this.generateSideNavRoute(LearnPageNames.LIBRARY),
+          },
+          bookmarks: {
+            text: 'bookmarksLabel',
+            route: this.generateSideNavRoute(LearnPageNames.BOOKMARKS),
+          },
+        };
+      },
+      menuPluginStyles() {
+        return {
+          color: this.$themeTokens.text,
+          width: '99%',
+          height: '48px',
+          textAlign: 'left',
+          padding: '0px 4px',
+          border: 'none',
+          textTransform: 'capitalize',
+          fontWeight: 'normal',
+          ':hover': this.menuPluginActiveStyles,
+        };
+      },
+      menuPluginActiveStyles() {
+        return {
+          backgroundColor: this.$themeBrand.primary.v_50,
+          color: this.$themeBrand.primary,
+          fontWeight: 'bold',
+          padding: '0px 4px',
+          borderRadius: '4px',
+        };
+      },
+      iconAfter() {
+        if (this.isAppContext) {
+          return this.visibleSubMenu ? 'chevronUp' : 'chevronDown';
+        }
+      },
+    },
+    methods: {
+      generateSideNavRoute(route) {
+        return generateSideNavRoute(this.url, route);
       },
     },
     priority: 10,
@@ -35,3 +105,22 @@
   export default component;
 
 </script>
+
+
+<style lang="scss" scoped>
+
+  .link-container {
+    height: 44px;
+  }
+
+  .link {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 44px;
+    margin-left: 40px;
+    font-size: 12px;
+    text-decoration: none;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.vue
@@ -12,7 +12,7 @@
 
     <div v-if="isAppContext && visibleSubMenu">
       <div v-for="(nestedObject, key) in routes" :key="key" class="link-container">
-        <a :href="nestedObject.route" class="link" :styles="menuPluginStyles">
+        <a :href="nestedObject.route" class="link" :class="$computedClass(optionStyle)">
           {{ nestedObject.text }}
         </a>
       </div>
@@ -28,13 +28,14 @@
   import navComponents from 'kolibri.utils.navComponents';
   import urls from 'kolibri.urls';
   import { mapGetters } from 'vuex';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames as LearnPageNames } from '../constants';
   import generateSideNavRoute from '../appNavigationRoutes.js';
   import commonLearnStrings from './commonLearnStrings';
 
   const component = {
     name: 'LearnSideNavEntry',
-    mixins: [commonLearnStrings],
+    mixins: [commonLearnStrings, commonCoreStrings],
     components: {
       CoreMenuOption,
     },
@@ -51,39 +52,28 @@
       routes() {
         return {
           home: {
-            text: 'homeLabel',
+            text: this.coreString('homeLabel'),
             route: this.generateSideNavRoute(LearnPageNames.HOME),
           },
           library: {
-            text: 'libraryLabel',
+            text: this.coreString('libraryLabel'),
             route: this.generateSideNavRoute(LearnPageNames.LIBRARY),
           },
           bookmarks: {
-            text: 'bookmarksLabel',
+            text: this.coreString('bookmarksLabel'),
             route: this.generateSideNavRoute(LearnPageNames.BOOKMARKS),
           },
         };
       },
-      menuPluginStyles() {
+      optionStyle() {
         return {
           color: this.$themeTokens.text,
-          width: '99%',
-          height: '48px',
-          textAlign: 'left',
-          padding: '0px 4px',
-          border: 'none',
-          textTransform: 'capitalize',
-          fontWeight: 'normal',
-          ':hover': this.menuPluginActiveStyles,
-        };
-      },
-      menuPluginActiveStyles() {
-        return {
-          backgroundColor: this.$themeBrand.primary.v_50,
-          color: this.$themeBrand.primary,
-          fontWeight: 'bold',
-          padding: '0px 4px',
-          borderRadius: '4px',
+          textDecoration: 'none',
+          ':hover': {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+          },
+          ':focus': this.$coreOutline,
         };
       },
       iconAfter() {

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -3,6 +3,7 @@
   <HorizontalNavBarWithOverflowMenu
     ref="navigation"
     :ariaLabel="$tr('learnPageMenuLabel')"
+    v-if="isAppContext"
     :navigationLinks="links"
   />
 
@@ -69,4 +70,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .bottom-bar {
+    position: relative;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnTopNav.vue
@@ -3,7 +3,6 @@
   <HorizontalNavBarWithOverflowMenu
     ref="navigation"
     :ariaLabel="$tr('learnPageMenuLabel')"
-    v-if="isAppContext"
     :navigationLinks="links"
   />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8085,14 +8085,27 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4"
+  resolved "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
-    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0":
+  version "1.3.0"
+  resolved "https://github.com/learningequality/kolibri-design-system#26c0c302d548afa63aaff32d4539c510c3351f82"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8085,23 +8085,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3":
+"kolibri-design-system@https://github.com/marcellamaki/kolibri-design-system#14eafae9f30d8611c02fdb5178b68c0d8dbd1553":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3"
-  dependencies:
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "^3.0.21"
-    css-element-queries "^1.2.0"
-    fuzzysearch "^1.0.3"
-    keen-ui "^1.3.0"
-    lodash "^4.17.15"
-    popper.js "^1.14.6"
-    purecss "^0.6.2"
-    tippy.js "^4.2.1"
-
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0":
-  version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#26c0c302d548afa63aaff32d4539c510c3351f82"
+  resolved "https://github.com/marcellamaki/kolibri-design-system#14eafae9f30d8611c02fdb5178b68c0d8dbd1553"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8085,9 +8085,23 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/marcellamaki/kolibri-design-system#14eafae9f30d8611c02fdb5178b68c0d8dbd1553":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3":
   version "1.3.0"
-  resolved "https://github.com/marcellamaki/kolibri-design-system#14eafae9f30d8611c02fdb5178b68c0d8dbd1553"
+  resolved "https://github.com/learningequality/kolibri-design-system#269b294bf562dd7d0e3a616aaace97bf0d3433c3"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.3.1-beta0":
+  version "1.3.0"
+  resolved "https://github.com/learningequality/kolibri-design-system#26c0c302d548afa63aaff32d4539c510c3351f82"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary

@radinamatic and @pcenov - thank you for taking a first look through these changes! I have a few last hiccups with coach routing that I still have not sorted out, but I think a first pass would be very helpful. I promise I will have proper gherkins written up when the PR is ready for final review, and I've done my best to outline testing scenarios clearly below for what the _currently expected_ functionality should be based on what I've done so far. There will also be some slight visual/UI updates to make this to-spec to the figma that I'll brush up early next week.

### Current changes ready for initial manual QA 

#### Regression testing
- These changes should ONLY affect the "app context", probably best tested on a physical device, as I have been mocking the changes for development 
- Therefore, testing of the "usual" browser-based workflow should be done to ensure that there have been no regressions
- Key areas of focus would be all things navigation - the side navigation panel, and the routing for the tabs within each plugin. All should function normally and have no visual changes

#### New feature testing
While the new feature is not 100% complete yet, there are some key pieces of functionality that are ready for testing

**Bottom bar for the learner:**
- In the App Context, the bottom bar for learner should be functional
- bottom bar should only appear in the app context 
- learner/user should be able to navigate with any of the bottom icon buttons
-  learner/user should be able to navigate with any of the bottom icon buttons using TAB key, and focus outline should be present
- the MENU icon, should open an overlay that contains learner information (very similar to the current browser sidebar) 
- within this overlay menu, the "LEARN" button should open and close, to reveal that same navigation tab options (home, library, bookmarks)
- these options should work for navigation
- all other menu options should also work
- the menu should be keyboard navigable, with the focus outline visible, and the focus trapped (contained within the menu while open, not disappearing across the page)

| Descption  | Screenshot |
|---|---|
| Bottom bar is present  | <img width="319" alt="Screenshot 2023-01-06 at 6 59 38 PM" src="https://user-images.githubusercontent.com/17235236/211119163-bca6a700-bd5d-4a25-adfc-da8020b90621.png"> |
|  Overlay menu is visible | <img width="344" alt="Screenshot 2023-01-06 at 6 44 08 PM" src="https://user-images.githubusercontent.com/17235236/211118355-aa35f709-c657-48cb-ab0b-02943de72d9c.png"> |
| Overlay menu has an option open | <img width="332" alt="Screenshot 2023-01-06 at 6 49 35 PM" src="https://user-images.githubusercontent.com/17235236/211118402-8904eddd-0011-481f-9adc-5ab82fe3fec3.png"> |

**Bottom bar for the non-learner**:
- In the App Context, the bottom bar for learner should be functional
- bottom bar should only appear in the app context 
- For all functioning navigation routes, no matter what plugin they are currently in (For example, if currently on the device page, "Home" on the bottom bar should bring to the LEARN home page, "Library" to the Library page, etc. If in the learn plugin an ")
-  user should be able to navigate with any of the bottom icon buttons using TAB key, and focus outline should be present
- the MENU icon, should open an overlay that plugin information (very similar to the current browser sidebar) 
- within this overlay menu, the "LEARN" button should open and close, to reveal that same navigation tab options (home, library, bookmarks). These options should work for navigation
- within this overlay menu, the "COACH" button should open and close, to reveal that same navigation tab options (home, library, bookmarks). _These options currently DO NOT work for navigation_, although they should be visually correct
- within this overlay menu, the "DEVICE" button should open and close, to reveal that same navigation tab options (home, library, bookmarks). These options should work for navigation
- within this overlay menu, the "FACILITY" button should open and close, to reveal that same navigation tab options (home, library, bookmarks). If the user only has one facility, these options should work. If they have multiple facilities, it will NOT work.
- The menu should be keyboard navigable, with the focus outline visible, and the focus trapped (contained within the menu while open, not disappearing across the page)

| Descption  | Screenshot |
|---|---|
| Bottom bar is present  |  <img width="287" alt="Screenshot 2023-01-06 at 6 59 23 PM" src="https://user-images.githubusercontent.com/17235236/211119212-c8ea8e2e-16a5-48ca-9e94-9d1fad1e6eef.png"> |
| Overlay menu has an option open | <img width="285" alt="Screenshot 2023-01-06 at 6 59 17 PM" src="https://user-images.githubusercontent.com/17235236/211119209-f48718c2-e3b5-42db-8bf4-376986be95c1.png"> |


## References



<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
