### PR TITLE
Revert debouncing updates to saveAnswer for release

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -38,7 +38,7 @@
               :assessment="true"
               :allowHints="false"
               :answerState="currentAttempt.answer"
-              @interaction="debouncedSaveAnswer"
+              @interaction="saveAnswer"
             />
             <UiAlert v-else :dismissible="false" type="error">
               {{ $tr('noItemId') }}
@@ -298,15 +298,6 @@
           ? { position: 'relative', top: '3px', left: '-4px' }
           : {};
       },
-      debouncedSaveAnswer() {
-        // So as not to share debounced functions between instances of the same component
-        // and also to allow access to the cancel method of the debounced function
-        // best practice seems to be to do it as a computed property and not a method:
-        // https://github.com/vuejs/vue/issues/2870#issuecomment-219096773
-        // 750ms chosen through trial and error designed to allow users to input relatively
-        // slowly while producing one single answer
-        return debounce(this.saveAnswer, 750);
-      },
     },
     watch: {
       attemptLogItemValue(newVal, oldVal) {
@@ -390,10 +381,7 @@
         return Promise.resolve();
       },
       goToQuestion(questionNumber) {
-        const saveAnswerPromise = this.debouncedSaveAnswer.flush() || Promise.resolve();
-        const promise = saveAnswerPromise.then(
-          () => this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve()
-        );
+        const promise = this.debouncedSetAndSaveCurrentExamAttemptLog.flush() || Promise.resolve();
         promise.then(() => {
           this.$router.push({
             name: ClassesPageNames.EXAM_VIEWER,


### PR DESCRIPTION
## Summary
Temporarily reverts changes for debouncing answer saves in quizzes - can be re-implemented with further testing after release.

…

## References
Reverts 9723, 9765

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
