### PR TITLE
Fix learn UI regressions

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -296,6 +296,11 @@
     align-items: center;
   }
 
+  /deep/ .ui-toolbar__left {
+    display: flex;
+    align-items: center;
+  }
+
   .brand-logo {
     max-width: 48px;
     max-height: 48px;

--- a/kolibri/core/assets/src/views/KeenUiToolbar.vue
+++ b/kolibri/core/assets/src/views/KeenUiToolbar.vue
@@ -18,6 +18,8 @@
   }
 
   /deep/ .ui-toolbar__left {
+    display: flex;
+    align-items: center;
     margin-left: 16px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/CardList.vue
+++ b/kolibri/plugins/learn/assets/src/views/CardList.vue
@@ -183,6 +183,7 @@
     width: 100%;
     min-height: 246px;
     padding: $v-padding $h-padding;
+    margin-top: $h-padding;
     text-decoration: none;
     vertical-align: top;
     border-radius: 8px;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -499,7 +499,7 @@
   }
 
   /deep/ .progress-icon .ui-icon {
-    margin-top: -2px;
+    margin-top: -1px;
     margin-left: 16px;
 
     svg {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -118,6 +118,7 @@
     width: 100%;
     height: $header-height;
     padding-top: 16px;
+    padding-right: 32px;
     padding-bottom: 0;
     padding-left: 32px;
   }

--- a/kolibri/plugins/learn/assets/src/views/cards/BaseCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/BaseCard.vue
@@ -130,6 +130,7 @@
   }
 
   .title {
+    height: 44px;
     margin-top: 2px;
     font-size: $font-size-normal;
   }


### PR DESCRIPTION
## Summary
Fixes #9726

…

## References
| Issue  | Before  | After  |
|---|---|---|
| Library > Recent - The ‘View as list’ view is broken in all supported browsers  | ![image](https://user-images.githubusercontent.com/17235236/195922000-8cb8bce0-fd6a-46b8-b98e-90c49bc81e12.png) | <img width="1440" alt="Screen Shot 2022-10-14 at 3 01 32 PM" src="https://user-images.githubusercontent.com/17235236/195922495-6f2bc4aa-fe51-417e-98b4-6341fadb7c99.png"> |
| Bookmarks - Same as above  | ![image](https://user-images.githubusercontent.com/17235236/195922036-57a2a88a-67c2-43fd-bfcf-e138870d1fda.png) |  <img width="1428" alt="Screen Shot 2022-10-14 at 3 01 36 PM" src="https://user-images.githubusercontent.com/17235236/195922472-b4375308-d774-40d9-84d1-37e0aa42850c.png"> |
|  Learn > Home > Continue learning on your own - Misaligned cards | ![image](https://user-images.githubusercontent.com/17235236/195922111-e0f5a298-5f61-4714-a70a-a7999bf8b744.png) | <img width="1435" alt="Screen Shot 2022-10-14 at 3 01 51 PM" src="https://user-images.githubusercontent.com/17235236/195922446-099e2f82-f645-491a-b38d-d72a7d8613c5.png"> |
| Library > Channel - Misaligned channel title and x icon and Uncaught error in the console  | ![image](https://user-images.githubusercontent.com/17235236/195922132-fd25c77a-9769-47e2-a19d-9f436962ec36.png) | <img width="1418" alt="Screen Shot 2022-10-14 at 3 02 01 PM" src="https://user-images.githubusercontent.com/17235236/195922396-e6cddc7b-ca1f-4caa-9188-636d506ab113.png"> |
| Library > Channel with Arabic - Padding issues (2/2) | ![image](https://user-images.githubusercontent.com/17235236/195922172-4705480c-fb54-4642-b2e8-7c4f202ed628.png). | <img width="1436" alt="Screen Shot 2022-10-14 at 3 02 30 PM" src="https://user-images.githubusercontent.com/17235236/195922341-21361413-1fed-4a07-b2b4-ad5cbbf1af3b.png"> |
| Library > Channel with Arabic - Padding issues  (2/2) | ![image](https://user-images.githubusercontent.com/17235236/195922172-4705480c-fb54-4642-b2e8-7c4f202ed628.png) | <img width="1423" alt="Screen Shot 2022-10-14 at 3 02 21 PM" src="https://user-images.githubusercontent.com/17235236/195922360-e4ffc5bb-8712-44b3-b5b2-d6616f44142a.png"> |
| Learn > Resource - Misaligned icon | ![image](https://user-images.githubusercontent.com/17235236/195922215-f467226b-c90f-457e-8f61-1987acc573a3.png) | <img width="1436" alt="Screen Shot 2022-10-14 at 3 03 06 PM" src="https://user-images.githubusercontent.com/17235236/195922281-9e6d29c2-f54c-4e24-aabd-6a09fd6e76e5.png"> |

…

## Reviewer guidance

Do all page layouts listed above have the corrected spacing/alignment?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
