### PR TITLE
set max width on library page main grid container

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -470,6 +470,8 @@
 <style lang="scss" scoped>
 
   .main-grid {
+    // after 1700px, just left align, per design spec
+    max-width: 1700px;
     margin-top: 40px;
     margin-right: 24px;
   }


### PR DESCRIPTION
## Summary
Fixes [9498](https://github.com/learningequality/kolibri/issues/9498)
Adds a max width to the main grid per spec (an oversight that this wasn't originally implemented)


## References
Very hard to tell from my laptop screen size 😂 but I have stretched the window and you can see the cards are towards the left with excess space.
https://user-images.githubusercontent.com/17235236/195928277-561d157c-abc9-42c5-ab43-e2b40c45157f.mp4



## Reviewer guidance

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
