### PR TITLE
Fix PDF completion issues

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -1,4 +1,4 @@
-import { get } from '@vueuse/core';
+import { get, set } from '@vueuse/core';
 import client from 'kolibri.client';
 import { coreStoreFactory as makeStore } from 'kolibri.coreVue.vuex.store';
 import useProgressTracking from '../useProgressTracking';
@@ -372,6 +372,15 @@ describe('useProgressTracking composable', () => {
       await updateContentSession({ progress: 2 });
       expect(get(progress)).toEqual(1);
       expect(client.mock.calls[0][0].data.progress_delta).toEqual(0.5);
+    });
+    it('should max progress and store progress_delta if progress is updated over threshold and over max value and progress_delta is greater than 0', async () => {
+      const { updateContentSession, progress, progress_delta } = await initStore({
+        progress: 0.167,
+      });
+      set(progress_delta, 0.5);
+      await updateContentSession({ progress: 1 });
+      expect(get(progress)).toEqual(1);
+      expect(client.mock.calls[0][0].data.progress_delta).toEqual(1);
     });
     it('should not update progress and store progress_delta if progress is updated under current value', async () => {
       const { updateContentSession, progress, progress_delta } = await initStore();

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -350,8 +350,9 @@ export default function useProgressTracking(store) {
       progress = _zeroToOne(progress);
       progress = threeDecimalPlaceRoundup(progress);
       if (get(progress_state) < progress) {
-        const newProgressDelta =
-          get(progress_delta) + threeDecimalPlaceRoundup(progress - get(progress_state));
+        const newProgressDelta = _zeroToOne(
+          get(progress_delta) + threeDecimalPlaceRoundup(progress - get(progress_state))
+        );
         set(progress_delta, newProgressDelta);
         set(progress_state, progress);
       }

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -17,7 +17,6 @@
     <template v-else>
       <transition name="slide">
         <div
-          v-if="showControls"
           class="fullscreen-header"
           :style="{ backgroundColor: this.$themePalette.grey.v_100 }"
         >
@@ -115,7 +114,6 @@
       isInFullscreen: false,
       currentLocation: 0,
       updateContentStateInterval: null,
-      showControls: true,
       visitedPages: {},
     }),
     computed: {
@@ -203,14 +201,6 @@
           this.debounceForceUpdateRecycleList();
         }
       },
-      // Listen to change in scroll position to determine whether we show top control bar or not
-      currentLocation(newPos, oldPos) {
-        if (newPos > oldPos) {
-          this.showControls = false;
-        } else {
-          this.showControls = true;
-        }
-      },
     },
     destroyed() {
       // Reset the overflow on the HTML tag that we set to hidden in created()
@@ -222,7 +212,6 @@
       window.document.getElementsByTagName('html')[0].style.overflow = 'hidden';
 
       this.currentLocation = this.savedLocation;
-      this.showControls = true; // Ensures it shows on load even if we're scrolled
       const loadPdfPromise = PDFJSLib.getDocument(this.defaultFile.storage_url);
       // pass callback to update loading bar
       loadPdfPromise.onProgress = loadingProgress => {


### PR DESCRIPTION
## Summary
* Removes debounce of all handling of the `RecycleList` `update` event, and instead just debounces the PDF page rendering which is the expensive call.
* This allows the currently scrolled to position to be more frequently updated, preventing the error that would occur where visiting entire pages would fail to get recorded.
* Generalizes the previous fix for 2 page PDFs to the case where the `scrollTop` is still on the second to last page, but the browser cannot scroll any further. Does this by checking to see if we are on the second to last page, but the browser viewport cannot scroll any further. In this case, we mark both the second to last and last pages as viewed.
* Removes the PDF control panel autohiding, which is now superfluous following #9439
* Fixes an issue that @AllanOXDi and I occasionally saw in testing, whereby the `progress_delta` being sent to the backend could inadvertently be summed to a value greater than 1.
* Adds a regression test for the above.

## References
Fixes #8868

## Reviewer guidance
Continually scroll without stopping from the beginning of a PDF until the end. See that it properly marks as complete.

Zoom out slightly so that more than one page of a PDF is rendered at once. Continually scroll without stopping until the end of the PDF. See that as long as no more than 2 pages are visible on the screen at once, it properly marks as complete.

(This is an edge case where if someone were reading through the PDF in a way that allowed for three or more pages to be visible at once, completion would not be marked - someone would probably need a monitor with an aspect ratio with the height about three times the width at least for this to happen, so I think it's not something to be concerned about).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
