### PR TITLE
Fix show more bug for resources that are at the top level

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -84,7 +84,7 @@
               v-if="resources.length"
               :gridType="2"
               data-test="search-results"
-              :contents="resources"
+              :contents="resourcesDisplayed"
               :numCols="numCols"
               :genContentLink="genContentLink"
               currentCardViewStyle="card"
@@ -688,6 +688,9 @@
         this.loadMoreTopics().then(() => {
           this.topicMoreLoading = false;
         });
+      },
+      handleShowMoreResources() {
+        this.showMoreResources = true;
       },
       findFirstEl() {
         if (this.$refs.embeddedPanel) {


### PR DESCRIPTION
## Summary
Follow up to https://github.com/learningequality/kolibri/pull/9555
Fixes #9553 in `develop` 

## References

### Logged in user when there is both a folder and top level resources
https://user-images.githubusercontent.com/17235236/195942363-50238ac8-739d-4738-8792-eb7e2b14626b.mp4


### Guest user, previewing relevant resources at top level

https://user-images.githubusercontent.com/17235236/195942443-894844b3-1afa-454c-98c1-b5c7ecd1b696.mp4



## Reviewer guidance
### Steps to reproduce
Navigate to a folder where there are more than 4 resources at the top level (not nested within other folders)

Should be aligned with feedback and decisions in https://github.com/learningequality/kolibri/pull/9555

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
