### PR TITLE
Remove all options from filters

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/ActivityButtonsGroup.vue
@@ -4,17 +4,6 @@
     <h2 class="title">
       {{ $tr('activities') }}
     </h2>
-    <KButton
-      appearance="flat-button"
-      :appearanceOverrides="activityStyles"
-      :disabled="activeKeys.length === 0"
-      @click="$emit('input', null)"
-    >
-      <KIcon icon="allActivities" class="activity-icon" />
-      <p class="activity-button-text">
-        {{ coreString('all') }}
-      </p>
-    </KButton>
     <span
       v-for="(key, activity) in learningActivitiesList"
       :key="key"

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -45,20 +45,6 @@
         </h2>
         <!-- list of category metadata - clicking prompts a filter modal -->
         <div
-          span="4"
-          class="category-list-item"
-        >
-          <KButton
-            :text="$tr('allCategories')"
-            appearance="flat-button"
-            :appearanceOverrides="isKeyActive('all_categories')
-              ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
-              : categoryListItemStyles"
-            @click="allCategories"
-          />
-        </div>
-
-        <div
           v-for="(category, key) in libraryCategoriesList"
           :key="category"
           span="4"
@@ -137,7 +123,6 @@
   import pick from 'lodash/pick';
   import uniq from 'lodash/uniq';
   import {
-    AllCategories,
     CategoriesLookup,
     NoCategories,
     ResourcesNeededTypes,
@@ -317,17 +302,11 @@
       isKeyActive(key) {
         return !!this.activeKeys.filter(k => k.includes(key)).length;
       },
-      allCategories() {
-        this.$emit('input', { ...this.value, categories: { [AllCategories]: true } });
-      },
       noCategories() {
         this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
       },
       handleActivity(activity) {
-        if (activity === null) {
-          const learning_activities = {};
-          this.$emit('input', { ...this.value, learning_activities });
-        } else if (activity && !this.value.learning_activities[activity]) {
+        if (activity && !this.value.learning_activities[activity]) {
           const learning_activities = {
             [activity]: true,
             ...this.value.learning_activities,
@@ -376,10 +355,6 @@
       categories: {
         message: 'Categories',
         context: 'Section header label in the Library page sidebar.',
-      },
-      allCategories: {
-        message: 'All categories',
-        context: 'Option in the Library page sidebar.',
       },
     },
   };


### PR DESCRIPTION
## Summary
Removes all categories section from _Categories_ and _All_ icon from the _Activities_ list
according to the design at 
<img width="1821" alt="Screen Shot 2022-10-04 at 10 37 46 AM" src="https://user-images.githubusercontent.com/6668144/193888270-101612f9-c175-40e5-9ac9-4e7bc8e5d14f.png">

## References
Fixes: #8871 

## Reviewer guidance
According to the decided design, this gherking scenarios must happen:
```
  Scenario: Clear filters from Categories
    When I click the *Clear* button next to the Categories label in the filter panel
    Then I see <filter option> is no longer selected in the filter panel
      And I see the search results matching <filter options> are no longer included
      And I see the chips for <filter option> are removed from the header
      And I see <filter option> is no longer selected in the filter panel
```

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
