### PR TITLE
Add Python3.11 to supported python versions.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/kolibri/utils/compat.py
+++ b/kolibri/utils/compat.py
@@ -101,3 +101,49 @@ def monkey_patch_collections():
     for name in dir(abc):
         if not hasattr(collections, name):
             setattr(collections, name, getattr(abc, name))
+
+
+def monkey_patch_translation():
+    """
+    Monkey-patching for the gettext module is required for Python 3.11
+    and above.
+    Prior to 3.11, the gettext module classes still had the deprecated set_output_charset
+    This can be removed when we upgrade to a version of Django that no longer relies
+    on this deprecated Python 2.7 only call.
+    """
+    if sys.version_info < (3, 11):
+        return
+
+    import gettext
+
+    def set_output_charset(*args, **kwargs):
+        pass
+
+    gettext.NullTranslations.set_output_charset = set_output_charset
+
+    original_translation = gettext.translation
+
+    def translation(
+        domain,
+        localedir=None,
+        languages=None,
+        class_=None,
+        fallback=False,
+        codeset=None,
+    ):
+        return original_translation(
+            domain,
+            localedir=localedir,
+            languages=languages,
+            class_=class_,
+            fallback=fallback,
+        )
+
+    gettext.translation = translation
+
+    original_install = gettext.install
+
+    def install(domain, localedir=None, codeset=None, names=None):
+        return original_install(domain, localedir=localedir, names=names)
+
+    gettext.install = install

--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -18,6 +18,7 @@ except ImportError:
 from .logger import LOG_COLORS
 from .logger import EncodingStreamHandler as StreamHandler
 from kolibri.utils.compat import monkey_patch_collections
+from kolibri.utils.compat import monkey_patch_translation
 
 
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
@@ -125,6 +126,8 @@ def set_env():
     check_python_versions()
 
     monkey_patch_collections()
+
+    monkey_patch_translation()
 
     sys.path = [os.path.realpath(os.path.dirname(kolibri_dist.__file__))] + sys.path
 

--- a/setup.py
+++ b/setup.py
@@ -104,8 +104,11 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     cmdclass={"install_scripts": gen_windows_batch_files},
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <3.11",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <3.12",
 )

--- a/test/patch_pytest.py
+++ b/test/patch_pytest.py
@@ -4,35 +4,52 @@ in order to allow pytest to run in Python 3.10 without upgrading to version 6.2.
 """
 import os
 import subprocess
+import sys
 
 import pytest
 
-site_packages_dir = os.path.dirname(pytest.__file__)
 
-patch_file = os.path.join(os.path.dirname(__file__), "pytest_3.10.patch")
+def patch():
+    site_packages_dir = os.path.dirname(pytest.__file__)
 
-print("Applying patch: " + str(patch_file))
+    patch_file = os.path.join(os.path.dirname(__file__), "pytest_3.10.patch")
 
-# -N: insist this is FORWARD patch, don't reverse apply
-# -p1: strip first path component
-# -t: batch mode, don't ask questions
-patch_command = ["patch", "-N", "-p1", "-d", site_packages_dir, "-t", "-i", patch_file]
-print(" ".join(patch_command))
-try:
-    # Use a dry run to establish whether the patch is already applied.
-    # If we don't check this, the patch may be partially applied (which is bad!)
-    subprocess.check_output(patch_command + ["--dry-run"])
-except subprocess.CalledProcessError as e:
-    if e.returncode == 1:
-        # Return code 1 means not all hunks could be applied, this usually
-        # means the patch is already applied.
-        print(
-            "Warning: failed to apply patch (exit code 1), "
-            "assuming it is already applied: ",
-            str(patch_file),
-        )
+    print("Applying patch: " + str(patch_file))
+
+    # -N: insist this is FORWARD patch, don't reverse apply
+    # -p1: strip first path component
+    # -t: batch mode, don't ask questions
+    patch_command = [
+        "patch",
+        "-N",
+        "-p1",
+        "-d",
+        site_packages_dir,
+        "-t",
+        "-i",
+        patch_file,
+    ]
+    print(" ".join(patch_command))
+    try:
+        # Use a dry run to establish whether the patch is already applied.
+        # If we don't check this, the patch may be partially applied (which is bad!)
+        subprocess.check_output(patch_command + ["--dry-run"])
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 1:
+            # Return code 1 means not all hunks could be applied, this usually
+            # means the patch is already applied.
+            print(
+                "Warning: failed to apply patch (exit code 1), "
+                "assuming it is already applied: ",
+                str(patch_file),
+            )
+        else:
+            raise e
     else:
-        raise e
-else:
-    # The dry run worked, so do the real thing
-    subprocess.check_output(patch_command)
+        # The dry run worked, so do the real thing
+        subprocess.check_output(patch_command)
+
+
+if __name__ == "__main__":
+    if sys.version_info >= (3, 10):
+        patch()

--- a/tox.ini
+++ b/tox.ini
@@ -28,22 +28,12 @@ deps =
     -r{toxinidir}/requirements/cext.txt
 commands =
     sh -c 'kolibri manage makemigrations --check'
-    # Run the actual tests
-    python -O -m pytest {posargs:--cov=kolibri --cov-report= --cov-append --color=no} kolibri
-    python -O -m pytest {posargs:--cov=kolibri --cov-report= --cov-append --color=no} -p no:django test
-    # Fail if the log is longer than 200 lines (something erroring or very noisy got added)
-    sh -c "if [ `cat {env:KOLIBRI_HOME}/logs/kolibri.txt | wc -l` -gt 200 ] ; then echo 'Log too long' && echo '' && tail -n 20 {env:KOLIBRI_HOME}/logs/kolibri.txt && exit 1 ; fi"
-
-[testenv:py3.10]
-commands =
-    sh -c 'kolibri manage makemigrations --check'
     python test/patch_pytest.py
     # Run the actual tests
     python -O -m pytest {posargs:--cov=kolibri --cov-report= --cov-append --color=no} kolibri
     python -O -m pytest {posargs:--cov=kolibri --cov-report= --cov-append --color=no} -p no:django test
     # Fail if the log is longer than 200 lines (something erroring or very noisy got added)
     sh -c "if [ `cat {env:KOLIBRI_HOME}/logs/kolibri.txt | wc -l` -gt 200 ] ; then echo 'Log too long' && echo '' && tail -n 20 {env:KOLIBRI_HOME}/logs/kolibri.txt && exit 1 ; fi"
-
 
 [testenv:postgres]
 passenv = TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{2.7,3.4,3.5,3.6,3.7,3.8,3.9,3.10}, postgres
+envlist = py{2.7,3.4,3.5,3.6,3.7,3.8,3.9,3.10,3.11}, postgres
 
 [testenv]
 usedevelop = True
@@ -21,6 +21,7 @@ basepython =
     py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
+    py3.11: python3.11
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
## Summary
* Add Python 3.11 compatibility

## Testing checklist

- [X] Critical and brittle code paths are covered by unit tests

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [x] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
