### PR TITLE
Add @rtibbles' script to run kolibri in app mode, yarn scripts

### DIFF
--- a/docs/manual_testing/app_plugin/index.rst
+++ b/docs/manual_testing/app_plugin/index.rst
@@ -1,0 +1,11 @@
+Testing Kolibri with app plugin enabled
+=============
+
+The Kolibri app plugin
+----------------------------
+
+The Kolibri app plugin is designed to provide features and behavior with the mobile app user in mind. In order to test or develop Kolibri in this mode, there are commands that can be used to initialize Kolibri as needed.
+
+By running the command: `yarn app-python-devserver` you will start Kolibri in development mode. You can also run `yarn app-devserver` to run the frontend devserver in parallel.
+
+When you start the server with these commands, you will see a message with a URL pointing to `http://127.0.0.1:8000/app/api/initialize/<some token>` - visiting this URL will set your browser so that it can interact with Kolibri as it runs with the app plugin. **You will only have to do this once unless you clear your browser storage.**

--- a/docs/manual_testing/app_plugin/index.rst
+++ b/docs/manual_testing/app_plugin/index.rst
@@ -1,8 +1,8 @@
 Testing Kolibri with app plugin enabled
-=============
+=======================================
 
 The Kolibri app plugin
-----------------------------
+----------------------
 
 The Kolibri app plugin is designed to provide features and behavior with the mobile app user in mind. In order to test or develop Kolibri in this mode, there are commands that can be used to initialize Kolibri as needed.
 

--- a/docs/manual_testing/index.rst
+++ b/docs/manual_testing/index.rst
@@ -8,4 +8,5 @@ Manual testing & QA
 
    general_notes/index
    testing_with_vms/index
+   app_plugin/index
    a11y_resources/index

--- a/integration_testing/scripts/run_kolibri_app_mode.py
+++ b/integration_testing/scripts/run_kolibri_app_mode.py
@@ -36,7 +36,7 @@ initialize()
 # start kolibri server
 logging.info("Starting kolibri server.")
 
-kolibri_bus = KolibriProcessBus()
+kolibri_bus = KolibriProcessBus(port=8000)
 app_plugin = AppPlugin(kolibri_bus)
 app_plugin.subscribe()
 kolibri_bus.run()

--- a/integration_testing/scripts/run_kolibri_app_mode.py
+++ b/integration_testing/scripts/run_kolibri_app_mode.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import logging
+
+from magicbus.plugins import SimplePlugin
+
+from kolibri.main import enable_plugin
+from kolibri.plugins.app.utils import interface
+from kolibri.utils.cli import initialize
+from kolibri.utils.server import KolibriProcessBus
+
+
+class AppPlugin(SimplePlugin):
+    def __init__(self, bus):
+        self.bus = bus
+        self.bus.subscribe("SERVING", self.SERVING)
+
+    def SERVING(self, port):
+        self.port = port
+
+    def RUN(self):
+        start_url = (
+            "http://127.0.0.1:{port}".format(port=self.port)
+            + interface.get_initialize_url()
+        )
+        print("Kolibri running at: {start_url}".format(start_url=start_url))
+
+
+logging.info("Initializing Kolibri and running any upgrade routines")
+
+# activate app mode
+enable_plugin("kolibri.plugins.app")
+
+# we need to initialize Kolibri to allow us to access the app key
+initialize()
+
+# start kolibri server
+logging.info("Starting kolibri server.")
+
+kolibri_bus = KolibriProcessBus()
+app_plugin = AppPlugin(kolibri_bus)
+app_plugin.subscribe()
+kolibri_bus.run()

--- a/kolibri/plugins/app/utils.py
+++ b/kolibri/plugins/app/utils.py
@@ -47,7 +47,7 @@ class AppInterface(object):
         if next_url is not None:
             query_dict["next"] = next_url
         query_string = query_dict.urlencode()
-        return url + "?" + query_string if query_string else ""
+        return url + ("?" + query_string if query_string else "")
 
     @property
     def enabled(self):

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "transfercontext": "kolibri-tools i18n-transfer-context --pluginFile ./build_tools/build_plugins.txt",
     "watch": "kolibri-tools build dev --file ./build_tools/build_plugins.txt --cache",
     "watch-hot": "yarn run watch --hot",
+    "app-python-devserver": "DJANGO_SETTINGS_MODULE=kolibri.deployment.default.settings.dev python ./integration_testing/scripts/run_kolibri_app_mode.py",
     "python-devserver": "kolibri start --debug --foreground --port=8000 --settings=kolibri.deployment.default.settings.dev",
     "python-devserver-no-update": "kolibri start --debug --skip-update --foreground --port=8000 --settings=kolibri.deployment.default.settings.dev",
     "frontend-devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:hashi-dev --",
+    "app-devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:app-python-devserver yarn:hashi-dev --",
     "devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
     "devserver-hot": "concurrently --passthrough-arguments --kill-others \"yarn:watch-hot --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt --transpile",
@@ -62,5 +64,8 @@
   "browserslist": [
     "extends browserslist-config-kolibri"
   ],
-  "dependencies": {}
+  "dependencies": {},
+  "volta": {
+    "node": "16.18.0"
+  }
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Bootstrapping Kolibri to run in app mode w/ the app plugin enabled w/ dev settings.

Provides `yarn app-python-devserver` which runs the script and `yarn app-devserver` which runs the frontend devserver in parallel.

Additionally fixes issue w/ `get_initialize_url` returning an empty string.


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Should we have a dev server version and a non devserver version? Would QA need a proper dev server?
 
