### PR TITLE
Removes path manipulation workaround. Please see https://github.com/yarnpkg/yarn/issues/5874

### DIFF
--- a/packages/kolibri-tools/lib/read_webpack_json.js
+++ b/packages/kolibri-tools/lib/read_webpack_json.js
@@ -32,17 +32,6 @@ function readPythonPlugins({ pluginFile, plugins, pluginPath }) {
   const webpack_json_tempfile = temp.openSync({ suffix: '.json' }).path;
 
   // Extract the relevant information about the plugin configuration from the Python code.
-
-  // For reasons unknown, there is an extra /usr/bin injected into PATH while running
-  // execSync, which by-passes the virtualenv!
-
-  // Refs: https://github.com/yarnpkg/yarn/issues/5874
-  // See PR: https://github.com/learningequality/kolibri/pull/3777
-
-  // You can debug it like this:
-  //     execSync("PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')\":/usr/bin\" which python >&2 && exit 1", {env: process.env});
-  // ..hence, we have manipulated the path in the shell command to remove Node's
-  // unwanted manipulation
   let command = `python ${webpack_json} --output_file ${webpack_json_tempfile} `;
   // The plugin file takes precedence here.
   if (pluginFile) {
@@ -54,11 +43,7 @@ function readPythonPlugins({ pluginFile, plugins, pluginPath }) {
       command += ` --plugin_path ${pluginPath}`;
     }
   }
-  if (process.platform !== 'win32') {
-    execSync(`PATH=$(echo $PATH | sed 's/\\/usr\\/bin://g')":/usr/bin" ${command}`);
-  } else {
-    execSync(command);
-  }
+  execSync(command);
 
   const result = fs.readFileSync(webpack_json_tempfile);
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr removes manipulation of $PATH, a workaround used in previous versions of yarn. This seems to have been fixed as indicated in https://github.com/yarnpkg/yarn/issues/5874

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
NA

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Set up the development environment as specified in https://kolibri-dev.readthedocs.io/en/develop/getting_started.html should result in successfully running kolibri locally without returning build errors

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
