### PR TITLE
Learner facing duration indicators

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1065,6 +1065,7 @@ const nonconformingKeys = {
   digitalLiteracy: 'digitialLiteracy',
   BASIC_SKILLS: 'allLevelsBasicSkills',
   FOUNDATIONS: 'basicSkills',
+  foundations: 'basicSkills',
   toolsAndSoftwareTraining: 'softwareToolsAndTraining',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
 };

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -7,7 +7,7 @@ import { computed } from 'kolibri.lib.vueCompositionApi';
 import { get } from '@vueuse/core';
 import CompletionCriteria from 'kolibri-constants/CompletionCriteria';
 import lodashGet from 'lodash/get';
-import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
+import { LearningActivities, ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import coreStrings from 'kolibri.utils.coreStrings';
 
 const DURATION_THRESHOLD = 60 * 30; // 30 minutes in seconds
@@ -78,6 +78,7 @@ export default function useLearningActivities(contentNode) {
     return (
       contentNode &&
       contentNode.duration &&
+      (contentNode.kind == ContentNodeKinds.AUDIO || contentNode.kind == ContentNodeKinds.VIDEO) &&
       lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
         CompletionCriteria.TIME
     );
@@ -93,8 +94,11 @@ export default function useLearningActivities(contentNode) {
     return (
       contentNode &&
       contentNode.duration &&
-      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
-        CompletionCriteria.APPROX_TIME
+      !(contentNode.kind == ContentNodeKinds.AUDIO || contentNode.kind == ContentNodeKinds.VIDEO) &&
+      (lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
+        CompletionCriteria.APPROX_TIME ||
+        lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
+          CompletionCriteria.TIME)
     );
   });
 

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -78,9 +78,7 @@ export default function useLearningActivities(contentNode) {
     return (
       contentNode &&
       contentNode.duration &&
-      (contentNode.kind == ContentNodeKinds.AUDIO || contentNode.kind == ContentNodeKinds.VIDEO) &&
-      lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
-        CompletionCriteria.TIME
+      (contentNode.kind == ContentNodeKinds.AUDIO || contentNode.kind == ContentNodeKinds.VIDEO)
     );
   });
 

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -92,7 +92,8 @@ export default function useLearningActivities(contentNode) {
     return (
       contentNode &&
       contentNode.duration &&
-      !(contentNode.kind == ContentNodeKinds.AUDIO || contentNode.kind == ContentNodeKinds.VIDEO) &&
+      contentNode.kind !== ContentNodeKinds.AUDIO &&
+      contentNode.kind !== ContentNodeKinds.VIDEO &&
       (lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===
         CompletionCriteria.APPROX_TIME ||
         lodashGet(contentNode, ['options', 'completion_criteria', 'model']) ===

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -5,7 +5,7 @@
   >
     <template #labels>
       <LearningActivityDuration
-        v-if="!isMobile"
+        v-if="displayDurationChip"
         :contentNode="contentNode"
         appearance="chip"
         class="duration"
@@ -37,6 +37,22 @@
       contentNode: {
         type: Object,
         required: true,
+      },
+      // Override to hide the tag used based on thumbnail proportions
+      // should be TRUE when medium sized screen and list view of cards
+      hideDuration: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    computed: {
+      displayDurationChip() {
+        if (this.hideDuration) {
+          return false;
+        } else if (this.isMobile) {
+          return false;
+        }
+        return true;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -42,7 +42,7 @@
               <LearningActivityDuration
                 v-if="!windowIsLarge"
                 :contentNode="content"
-                class="duration"
+                :class="categoryAndLevelString ? 'duration prepends' : 'duration'"
                 condensed
                 :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
               />
@@ -283,7 +283,9 @@
     display: inline-block;
     margin-top: 4px;
     font-size: 13px;
+  }
 
+  .prepends {
     &::after {
       content: ' | ';
     }

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -47,10 +47,10 @@
                 :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
               />
               <p
-                v-if="categoryAndLevelString(content)"
+                v-if="categoryAndLevelString"
                 class="metadata-info"
                 :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
-              >{{ categoryAndLevelString(content) }}</p>
+              >{{ categoryAndLevelString }}</p>
               <div>
                 <img
                   :src="
@@ -174,23 +174,24 @@
         const time = this.$formatRelative(this.ceilingDate, { now: this.now });
         return this.coreString('bookmarkedTimeAgoLabel', { time });
       },
-    },
-    methods: {
-      categoryAndLevelString(content) {
-        if (this.levels(content.grade_levels) && this.category(content.categories)) {
-          return this.category(content.categories) + ' | ' + this.levels(content.grade_levels);
-        } else if (this.category(content.categories)) {
-          return this.category(content.categories);
-        } else if (this.levels(content.grade_levels)) {
-          return this.levels(content.grade_levels);
+      categoryAndLevelString() {
+        if (this.levels(this.content.grade_levels) && this.category(this.content.categories)) {
+          return (
+            this.category(this.content.categories) + ' | ' + this.levels(this.content.grade_levels)
+          );
+        } else if (this.category(this.content.categories)) {
+          return this.category(this.content.categories);
+        } else if (this.levels(this.content.grade_levels)) {
+          return this.levels(this.content.grade_levels);
         }
         return null;
       },
+    },
+    methods: {
       levels(levels) {
-        const levelsNonReactive = JSON.parse(JSON.stringify(levels));
         const matches = Object.keys(ContentLevels)
           .sort()
-          .filter(k => levelsNonReactive.includes(ContentLevels[k]));
+          .filter(k => levels.includes(ContentLevels[k]));
         if (matches && matches.length > 0) {
           let adjustedMatches = [];
           matches.map(key => {
@@ -211,10 +212,9 @@
         }
       },
       category(options) {
-        const optionsNonReactive = JSON.parse(JSON.stringify(options));
         const matches = Object.keys(Categories)
           .sort()
-          .filter(k => optionsNonReactive.includes(Categories[k]));
+          .filter(k => options.includes(Categories[k]));
         if (matches && matches.length > 0) {
           return matches.map(m => this.coreString(camelCase(m))).join(', ');
         }

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -57,6 +57,7 @@
                     content.channel_thumbnail"
                   :alt="learnString('logo', { channelTitle: content.channel_title })"
                   class="channel-logo"
+                  :style="{ color: $themePalette.grey.v_700 }"
                 >
                 <KButton
                   v-if="isLibraryPage && content.copies"
@@ -269,6 +270,7 @@
     display: inline-block;
     height: 24px;
     margin-right: 8px;
+    font-size: 13px;
   }
 
   .copies {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -8,7 +8,7 @@
     >
       <KFixedGrid numCols="4">
         <KFixedGridItem :span="isMobile ? 4 : 1" class="thumb-area">
-          <CardThumbnail :contentNode="content" />
+          <CardThumbnail :contentNode="content" :hideDuration="!windowIsLarge" />
           <p
             v-if="isBookmarksPage && !isMobile"
             class="created-info"
@@ -22,29 +22,51 @@
         <KFixedGridItem :span="isMobile ? 4 : 3" class="text-area">
           <span :style="{ color: $themeTokens.text }">
             <div class="metadata-info" :style="{ color: $themePalette.grey.v_700 }">
-              <LearningActivityLabel :contentNode="content" labelAfter condensed />
+              <LearningActivityLabel
+                :contentNode="content"
+                :hideDuration="true"
+                labelAfter
+                condensed
+              />
             </div>
-            <h3>
+            <h3 :style="{ marginTop: '4px', marginBottom: '4px' }">
               <TextTruncatorCss :text="content.title" :maxLines="1" />
             </h3>
-            <p v-if="content.description" style="font-size: 14px;">
-              <TextTruncatorCss :text="content.description" :maxLines="4" />
+            <p
+              v-if="content.description"
+              style="font-size: 14px; marginTop: 4px; marginBottom: 4px;"
+            >
+              <TextTruncatorCss :text="content.description" :maxLines="2" />
             </p>
             <div v-if="!isMobile" class="bottom-items">
-              <p v-if="categoryAndLevelString">{{ categoryAndLevelString }}</p>
-              <img
-                :src="content.channel_thumbnail"
-                :alt="learnString('logo', { channelTitle: content.channel_title })"
-                class="channel-logo"
-              >
-              <KButton
-                v-if="isLibraryPage && content.copies"
-                appearance="basic-link"
-                class="copies"
-                :style="{ color: $themeTokens.text }"
-                :text="coreString('copies', { num: content.copies.length })"
-                @click.prevent="$emit('openCopiesModal', content.copies)"
+              <LearningActivityDuration
+                v-if="!windowIsLarge"
+                :contentNode="content"
+                class="duration"
+                condensed
+                :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
               />
+              <p
+                v-if="categoryAndLevelString(content)"
+                class="metadata-info"
+                :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
+              >{{ categoryAndLevelString(content) }}</p>
+              <div>
+                <img
+                  :src="
+                    content.channel_thumbnail"
+                  :alt="learnString('logo', { channelTitle: content.channel_title })"
+                  class="channel-logo"
+                >
+                <KButton
+                  v-if="isLibraryPage && content.copies"
+                  appearance="basic-link"
+                  class="copies"
+                  :style="{ color: $themeTokens.text }"
+                  :text="coreString('copies', { num: content.copies.length })"
+                  @click.prevent="$emit('openCopiesModal', content.copies)"
+                />
+              </div>
             </div>
           </span>
         </KFixedGridItem>
@@ -85,9 +107,13 @@
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { now } from 'kolibri.utils.serverClock';
+  import { ContentLevels, Categories } from 'kolibri.coreVue.vuex.constants';
+  import camelCase from 'lodash/camelCase';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { PageNames } from '../constants';
   import ProgressBar from './ProgressBar';
   import LearningActivityLabel from './LearningActivityLabel';
+  import LearningActivityDuration from './LearningActivityDuration';
   import commonLearnStrings from './commonLearnStrings';
   import CardThumbnail from './HybridLearningContentCard/CardThumbnail';
 
@@ -97,9 +123,10 @@
       CardThumbnail,
       TextTruncatorCss,
       LearningActivityLabel,
+      LearningActivityDuration,
       ProgressBar,
     },
-    mixins: [commonLearnStrings, commonCoreStrings],
+    mixins: [responsiveWindowMixin, commonLearnStrings, commonCoreStrings],
     props: {
       createdDate: {
         type: String,
@@ -131,16 +158,6 @@
       now: now(),
     }),
     computed: {
-      categoryAndLevelString() {
-        if (this.category && this.level) {
-          return this.coreString(this.category) + ' | ' + this.coreString(this.level);
-        } else if (this.category) {
-          return this.coreString(this.category);
-        } else if (this.level) {
-          return this.coreString(this.level);
-        }
-        return null;
-      },
       isBookmarksPage() {
         return this.currentPage === PageNames.BOOKMARKS;
       },
@@ -156,6 +173,51 @@
       bookmarkCreated() {
         const time = this.$formatRelative(this.ceilingDate, { now: this.now });
         return this.coreString('bookmarkedTimeAgoLabel', { time });
+      },
+    },
+    methods: {
+      categoryAndLevelString(content) {
+        if (this.levels(content.grade_levels) && this.category(content.categories)) {
+          return this.category(content.categories) + ' | ' + this.levels(content.grade_levels);
+        } else if (this.category(content.categories)) {
+          return this.category(content.categories);
+        } else if (this.levels(content.grade_levels)) {
+          return this.levels(content.grade_levels);
+        }
+        return null;
+      },
+      levels(levels) {
+        const levelsNonReactive = JSON.parse(JSON.stringify(levels));
+        const matches = Object.keys(ContentLevels)
+          .sort()
+          .filter(k => levelsNonReactive.includes(ContentLevels[k]));
+        if (matches && matches.length > 0) {
+          let adjustedMatches = [];
+          matches.map(key => {
+            let translationKey;
+            if (key === 'PROFESSIONAL') {
+              translationKey = 'specializedProfessionalTraining';
+            } else if (key === 'WORK_SKILLS') {
+              translationKey = 'allLevelsWorkSkills';
+            } else if (key === 'BASIC_SKILLS') {
+              translationKey = 'allLevelsBasicSkills';
+            } else {
+              translationKey = camelCase(key);
+            }
+            adjustedMatches.push(translationKey);
+          });
+          adjustedMatches = adjustedMatches.map(m => this.coreString(m)).join(', ');
+          return adjustedMatches;
+        }
+      },
+      category(options) {
+        const optionsNonReactive = JSON.parse(JSON.stringify(options));
+        const matches = Object.keys(Categories)
+          .sort()
+          .filter(k => optionsNonReactive.includes(Categories[k]));
+        if (matches && matches.length > 0) {
+          return matches.map(m => this.coreString(camelCase(m))).join(', ');
+        }
       },
     },
   };
@@ -198,7 +260,9 @@
   }
 
   .metadata-info {
-    font-size: 14px;
+    display: inline-block;
+    padding-left: 2px;
+    font-size: 13px;
   }
 
   .channel-logo {
@@ -213,6 +277,16 @@
     font-size: 13px;
     text-decoration: none;
     vertical-align: top;
+  }
+
+  .duration {
+    display: inline-block;
+    margin-top: 4px;
+    font-size: 13px;
+
+    &::after {
+      content: ' | ';
+    }
   }
 
   .footer {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/__tests__/index.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/__tests__/index.spec.js
@@ -26,10 +26,11 @@ describe(`LearningActivityDuration`, () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('displays time duration for exact time', () => {
+  it('displays time duration for exact time for audio/video resources', () => {
     const wrapper = makeWrapper({
       contentNode: {
         duration: 322,
+        kind: 'audio',
         options: {
           completion_criteria: {
             model: CompletionCriteria.TIME,
@@ -38,6 +39,21 @@ describe(`LearningActivityDuration`, () => {
       },
     });
     expect(wrapper.text()).toBe('5 minutes');
+  });
+
+  it('displays time duration as a short or long activity for non-audio/video resources with an exact time set', () => {
+    const wrapper = makeWrapper({
+      contentNode: {
+        duration: 300,
+        kind: 'document',
+        options: {
+          completion_criteria: {
+            model: CompletionCriteria.TIME,
+          },
+        },
+      },
+    });
+    expect(wrapper.text()).toBe('Short activity');
   });
 
   it(`displays 'Short activity' as duration for approximate time


### PR DESCRIPTION
## Summary
Updates learner-facing duration indicators on content cards and does general metadata cleanup and ensuring correct display.

## References
Now: 

Category, Level and time metadata is displaying on list view content cards 
<img width="1430" alt="Screen Shot 2022-11-04 at 10 26 36 AM" src="https://user-images.githubusercontent.com/17235236/199999361-e07ce3ae-3f2a-4d0d-bc2e-701469f1c1e6.png">
<img width="583" alt="Screen Shot 2022-11-04 at 10 28 51 AM" src="https://user-images.githubusercontent.com/17235236/199999767-f3d0ccea-878f-46fd-8539-bb6797c52a3e.png">

Duration labels display exact time only for audio and video resources, otherwise "short" or "long" activity
<img width="1426" alt="Screen Shot 2022-11-04 at 10 27 57 AM" src="https://user-images.githubusercontent.com/17235236/199999578-22008079-bb7f-4df7-8051-45b894095509.png">

## Reviewer guidance
This was what I found so far.... anything else you come across?

Recommend testing with hotfixes, and importing channel `dolok-jajiv` which I created with metadata for testing

Probably needs more robust test cases of all possible labels....But perhaps okay to start

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
