### PR TITLE
Disable forward/back buttons until locations are properly loaded.

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -104,6 +104,7 @@
           <NextButton
             v-if="contentIsRtl"
             v-show="!isAtEnd"
+            :disabled="!locationsAreReady"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"
             :style="{ backgroundColor }"
@@ -112,6 +113,7 @@
           <PreviousButton
             v-else
             v-show="!isAtStart"
+            :disabled="!locationsAreReady"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"
             :style="{ backgroundColor }"
@@ -130,6 +132,7 @@
           <PreviousButton
             v-if="contentIsRtl"
             v-show="!isAtStart"
+            :disabled="!locationsAreReady"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"
             :style="{ backgroundColor }"
@@ -138,6 +141,7 @@
           <NextButton
             v-else
             v-show="!isAtEnd"
+            :disabled="!locationsAreReady"
             :color="navigationButtonColor"
             :isRtl="contentIsRtl"
             :style="{ backgroundColor }"
@@ -148,7 +152,7 @@
 
       <BottomBar
         class="bottom-bar"
-        :locationsAreReady="locations.length > 0"
+        :locationsAreReady="locationsAreReady"
         :heading="bottomBarHeading"
         :sliderValue="sliderValue"
         :sliderStep="sliderStep"
@@ -367,6 +371,9 @@
         return seconds;
       },
       /* eslint-enable kolibri/vue-no-unused-properties */
+      locationsAreReady() {
+        return this.locations && this.locations.length > 0;
+      },
     },
     watch: {
       sideBarOpen(newSideBar, oldSideBar) {

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -382,6 +382,16 @@ describe('useProgressTracking composable', () => {
       expect(get(progress)).toEqual(1);
       expect(client.mock.calls[0][0].data.progress_delta).toEqual(1);
     });
+    it('should max progress and store progress_delta if progress is asymptotically updated to 1', async () => {
+      const progress_delta_value = 0.5 / 999;
+      const { updateContentSession, progress } = await initStore();
+      for (let i = 999; i > 0; i--) {
+        updateContentSession({ progress: 1 - progress_delta_value * i });
+      }
+      await updateContentSession({ progress: 1 });
+      expect(get(progress)).toEqual(1);
+      expect(client.mock.calls[0][0].data.progress_delta).toBeGreaterThanOrEqual(0.5);
+    });
     it('should not update progress and store progress_delta if progress is updated under current value', async () => {
       const { updateContentSession, progress, progress_delta } = await initStore();
       await updateContentSession({ progress: 0.4 });

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -351,7 +351,7 @@ export default function useProgressTracking(store) {
       progress = threeDecimalPlaceRoundup(progress);
       if (get(progress_state) < progress) {
         const newProgressDelta = _zeroToOne(
-          get(progress_delta) + threeDecimalPlaceRoundup(progress - get(progress_state))
+          threeDecimalPlaceRoundup(get(progress_delta) + progress - get(progress_state))
         );
         set(progress_delta, newProgressDelta);
         set(progress_state, progress);


### PR DESCRIPTION
## Summary
* If the forward button is pressed before the locations have finished loading, the location for the first page will not be properly set in the `visitedPages` object, and so the progress will not complete.
* This fixes this by disabling the forward and back buttons until the locations are loaded.

## References
Fixes #9745 as far as I am able to replicate it

## Reviewer guidance
Are there any other ways of reproducing #9745 that I am missing?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
