### PR TITLE
Switch display of the completion modal to require both completed progress and the 'finished' event

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -742,6 +742,9 @@
         ) {
           this.storeVisitedPage(this.locations[locationIndex]);
         }
+        if (location.end.percentage >= 1) {
+          this.finish();
+        }
         this.updateProgress();
         this.updateContentState();
       },
@@ -767,6 +770,9 @@
           };
         }
         this.$emit('updateContentState', contentState);
+      },
+      finish() {
+        this.$emit('finished');
       },
     },
   };

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -182,14 +182,16 @@
     },
     methods: {
       recordProgress() {
+        let progress;
         if (this.forceDurationBasedProgress) {
-          this.$emit('updateProgress', this.durationBasedProgress);
+          progress = this.durationBasedProgress;
         } else {
           const hashiProgress = this.hashi ? this.hashi.getProgress() : null;
-          this.$emit(
-            'updateProgress',
-            hashiProgress === null ? this.durationBasedProgress : hashiProgress
-          );
+          progress = hashiProgress === null ? this.durationBasedProgress : hashiProgress;
+        }
+        this.$emit('updateProgress', progress);
+        if (progress >= 1) {
+          this.$emit('finished');
         }
         this.pollProgress();
       },

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -338,6 +338,13 @@ oriented data synchronization.
         return (this.renderer && this.renderer.totalHints) || 0;
       },
     },
+    watch: {
+      success(newValue, oldValue) {
+        if (newValue && !oldValue) {
+          this.$emit('finished');
+        }
+      },
+    },
     created() {
       this.nextQuestion();
     },

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -24,6 +24,7 @@
         @updateContentState="updateContentState"
         @navigateTo="navigateTo"
         @error="onError"
+        @finished="onFinished"
       />
 
       <AssessmentWrapper
@@ -49,17 +50,18 @@
         @updateInteraction="updateInteraction"
         @updateProgress="updateProgress"
         @updateContentState="updateContentState"
+        @finished="onFinished"
       />
     </template>
     <KCircularLoader v-else />
 
     <CompletionModal
-      v-if="progress >= 1 && wasIncomplete"
+      v-if="showCompletionModal"
       ref="completionModal"
       :isUserLoggedIn="isUserLoggedIn"
       :contentNodeId="content.id"
       :lessonId="lessonId"
-      @close="markAsComplete"
+      @close="showCompletionModal = false"
       @shouldFocusFirstEl="findFirstEl()"
     />
 
@@ -153,7 +155,7 @@
     },
     data() {
       return {
-        wasIncomplete: false,
+        showCompletionModal: false,
         sessionReady: false,
       };
     },
@@ -172,15 +174,11 @@
         lessonId: this.lessonId,
       }).then(() => {
         this.sessionReady = true;
-        this.setWasIncomplete();
         // Set progress into the content node progress store in case it was not already loaded
         this.cacheProgress();
       });
     },
     methods: {
-      setWasIncomplete() {
-        this.wasIncomplete = this.progress < 1;
-      },
       /*
        * Update the progress of the content node in the shared progress store
        * in the useContentNodeProgress composable. Do this to have a single
@@ -224,8 +222,8 @@
             this.$store.dispatch('handleApiError', error);
           });
       },
-      markAsComplete() {
-        this.wasIncomplete = false;
+      onFinished() {
+        this.showCompletionModal = this.progress >= 1;
       },
       onError(error) {
         this.$store.dispatch('handleApiError', error);

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -338,7 +338,10 @@
         this.player.on('seeking', this.handleSeek);
         this.player.on('volumechange', this.throttledUpdateVolume);
         this.player.on('ratechange', this.updateRate);
-        this.player.on('ended', () => this.setPlayState(false));
+        this.player.on('ended', () => {
+          this.setPlayState(false);
+          this.$emit('finished');
+        });
         this.$watch('elementWidth', this.updatePlayerSizeClass);
         this.updatePlayerSizeClass();
         this.resizePlayer();

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -331,6 +331,9 @@
           this.storeVisitedPage(currentPage);
           this.updateProgress();
           this.updateContentState();
+          if (this.scrolledToEnd()) {
+            this.$emit('finished');
+          }
         }
         this.debouncedShowVisiblePages(start, end);
       },

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -232,6 +232,9 @@
         this.storeVisitedSlide(this.currentSlideIndex);
         this.updateProgress();
         this.updateContentState();
+        if (this.currentSlideIndex >= this.slides.length - 1) {
+          this.$emit('finished');
+        }
       },
       slideTextId(id) {
         return 'descriptive-text-' + id;


### PR DESCRIPTION
## Summary
* Prevents premature display of the completion modal by waiting for the new `finished` event to be emitted by the resource renderer.
* Adds emission of the `finished` event to all non-perseus renderers and to the AssessmentItemWrapper component.

## References
Fixes #9348

Requires https://github.com/learningequality/kolibri-design-system/releases/tag/v1.4.0-beta0

## Reviewer guidance
Does this cover the use cases, does the completion modal display under the new circumstances?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
