### PR TITLE
Backport changes from to fix title spacing in app bar

### DIFF
--- a/kolibri/core/assets/src/views/KeenUiToolbar.vue
+++ b/kolibri/core/assets/src/views/KeenUiToolbar.vue
@@ -18,6 +18,8 @@
   }
 
   /deep/ .ui-toolbar__left {
+    display: flex;
+    align-items: center;
     margin-left: 16px;
   }
 


### PR DESCRIPTION
## Summary
KDS updates made for App bar changes (which should have been targeting KDS `develop`, but, alas, apparently past Marcella did not consider this) caused a regression when these changes were now applied to 0.15. 

This updates the Keen UI toolbar spacing to be align with the changes in Kolibri `develop` (these changes already exist in develop and it's just backporting them)

## References
Fixes #9815 

| **BEFORE** | **AFTER** |
|---|---|
| <img width="1440" alt="Screen Shot 2022-11-08 at 2 02 37 PM" src="https://user-images.githubusercontent.com/17235236/200653447-83fae5c2-ca69-4ab2-ac3e-aeb93d6e52e6.png"> | <img width="1440" alt="Screen Shot 2022-11-08 at 2 01 21 PM" src="https://user-images.githubusercontent.com/17235236/200653450-f17d8111-3371-4ecf-9f70-516b82d59514.png"> |
| <img width="1436" alt="Screen Shot 2022-11-08 at 2 02 42 PM" src="https://user-images.githubusercontent.com/17235236/200653443-ba11439b-fea9-400a-ae4d-7e05de1b22c0.png"> | <img width="1430" alt="Screen Shot 2022-11-08 at 2 01 16 PM" src="https://user-images.githubusercontent.com/17235236/200653455-89e9d413-2f03-4375-9959-260803592d1b.png"> | 


## Reviewer guidance
Does this look good on all pages?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
