### PR TITLE
Fix issue that causes learners to skip every other question in an exercise

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -207,7 +207,6 @@ export default function useProgressTracking(store) {
         );
         Object.assign(nowSavedInteraction, interaction);
         pastattemptMap[nowSavedInteraction.id] = nowSavedInteraction;
-        set(totalattempts, get(totalattempts) + 1);
       } else {
         for (let key in interaction) {
           if (!blocklist[key]) {


### PR DESCRIPTION
## Summary
* During testing of Studio hotfixes, an issue became apparent that Kolibri was only displaying every other question of an exercise when the questions were not randomized
* It became apparent that this was caused by the `totalattempts` being incremented twice on the client side when an attempt was submitted, which is then used to determine the next question to display - which was then skipping every other question, as it was going up by 2 at a time instead of 1.

## Reviewer guidance
* Verify that questions are now displayed in proper order

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
