### PR TITLE
Show completion modal on learner marking as complete.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -207,6 +207,7 @@
         return this.updateContentSession({ progress: 1 })
           .then(() => {
             this.$store.dispatch('createSnackbar', this.learnString('resourceCompletedLabel'));
+            this.onFinished();
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);


### PR DESCRIPTION
## Summary
* Ensures the completion modal is shown when a learner marks a resource as complete

## References
Fixes #9825

## Reviewer guidance
This seemed quite a straight forward fix - I reused the `onFinished` method for this, so that if we nuance the behaviour while fixing #9824, we can do it within `onFinished` and have this remain consistent.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
