### PR TITLE
Prevent excessive completion modals

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -420,6 +420,14 @@ describe('useProgressTracking composable', () => {
       // even though current progress can only increase by 0.5
       expect(client.mock.calls[0][0].data.progress_delta).toEqual(1);
     });
+    it('should max progress and max progress_delta if progressDelta is updated twice to be over max value', async () => {
+      const { updateContentSession, progress } = await initStore({ progress: 0 });
+      await updateContentSession({ progressDelta: 0.023 });
+      await updateContentSession({ progressDelta: 1 });
+      expect(get(progress)).toEqual(1);
+      // Will store the maximum possible value for progress_delta which is 1,
+      expect(client.mock.calls[0][0].data.progress_delta).toEqual(1);
+    });
     it('should update extra_fields and store if contentState is updated', async () => {
       const { updateContentSession, extra_fields } = await initStore();
       await updateContentSession({ contentState: { newState: 0.2 } });

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -870,13 +870,15 @@ describe('useProgressTracking composable', () => {
     });
     it('should debounce requests', async () => {
       const { updateContentSession } = await initStore();
-      updateContentSession({ progress: 1 });
-      updateContentSession({ contentState: { yes: 'no' } });
-      updateContentSession({ progressDelta: 1 });
-      updateContentSession({ progress: 1 });
-      updateContentSession({ contentState: { yes: 'no' } });
-      updateContentSession({ progressDelta: 1 });
+      const promises = [];
+      promises.push(updateContentSession({ progress: 0.6 }));
+      promises.push(updateContentSession({ contentState: { yes: 'no' } }));
+      promises.push(updateContentSession({ progressDelta: 0.1 }));
+      promises.push(updateContentSession({ progress: 0.8 }));
+      promises.push(updateContentSession({ contentState: { yes: 'no' } }));
+      promises.push(updateContentSession({ progressDelta: 0.9 }));
       await updateContentSession({ progress: 1 });
+      await Promise.all(promises);
       expect(client).toHaveBeenCalledTimes(1);
     });
     it('should retry 5 times if it receives a 503', async () => {

--- a/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
@@ -13,7 +13,13 @@ import { ContentNodeProgressResource } from 'kolibri.resources';
 const contentNodeProgressMap = reactive({});
 
 export function setContentNodeProgress(progress) {
-  set(contentNodeProgressMap, progress.content_id, progress.progress);
+  // Avoid setting stale progress data - assume that progress increases monotonically
+  if (
+    !contentNodeProgressMap[progress.content_id] ||
+    progress.progress > contentNodeProgressMap[progress.content_id]
+  ) {
+    set(contentNodeProgressMap, progress.content_id, progress.progress);
+  }
 }
 
 export default function useContentNodeProgress() {

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -336,6 +336,7 @@ export default function useProgressTracking(store) {
     // Used to ensure state is always saved when a session closes.
     force = false,
   } = {}) {
+    const wasComplete = get(progress_state) >= 1;
     if (get(session_id) === null) {
       throw ReferenceError(noSessionErrorText);
     }
@@ -411,7 +412,8 @@ export default function useProgressTracking(store) {
       set(time_spent_delta, threeDecimalPlaceRoundup(get(time_spent_delta) + elapsedTime));
     }
 
-    immediate = (!isUndefined(interaction) && !interaction.id) || immediate;
+    const completed = !wasComplete && get(progress_state) >= 1;
+    immediate = (!isUndefined(interaction) && !interaction.id) || completed || immediate;
     forceSessionUpdate = forceSessionUpdate || force;
     // Logic for promise returning debounce vendored and modified from:
     // https://github.com/sindresorhus/p-debounce/blob/main/index.js

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -362,7 +362,10 @@ export default function useProgressTracking(store) {
       }
       progressDelta = _zeroToOne(progressDelta);
       progressDelta = threeDecimalPlaceRoundup(progressDelta);
-      set(progress_delta, threeDecimalPlaceRoundup(get(progress_delta) + progressDelta));
+      set(
+        progress_delta,
+        _zeroToOne(threeDecimalPlaceRoundup(get(progress_delta) + progressDelta))
+      );
       set(
         progress_state,
         Math.min(threeDecimalPlaceRoundup(get(progress_state) + progressDelta), 1)

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -55,7 +55,7 @@
               {{ $tr('signIn') }}
             </UiAlert>
             <div
-              v-else
+              v-else-if="!wasComplete"
               class="stats"
             >
               <div class="points">
@@ -201,6 +201,10 @@
       lessonId: {
         type: String,
         default: null,
+      },
+      wasComplete: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -61,7 +61,8 @@
       :isUserLoggedIn="isUserLoggedIn"
       :contentNodeId="content.id"
       :lessonId="lessonId"
-      @close="showCompletionModal = false"
+      :wasComplete="wasComplete"
+      @close="hideCompletionModal"
       @shouldFocusFirstEl="findFirstEl()"
     />
 
@@ -231,12 +232,15 @@
         if (this.wasComplete) {
           this.$emit('finished');
         } else {
-          this.wasComplete = true;
           this.displayCompletionModal();
         }
       },
       displayCompletionModal() {
         this.showCompletionModal = true;
+      },
+      hideCompletionModal() {
+        this.showCompletionModal = false;
+        this.wasComplete = true;
       },
       onError(error) {
         this.$store.dispatch('handleApiError', error);

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -156,6 +156,7 @@
     data() {
       return {
         showCompletionModal: false,
+        wasComplete: false,
         sessionReady: false,
       };
     },
@@ -174,6 +175,7 @@
         lessonId: this.lessonId,
       }).then(() => {
         this.sessionReady = true;
+        this.wasComplete = this.progress >= 1;
         // Set progress into the content node progress store in case it was not already loaded
         this.cacheProgress();
       });
@@ -223,7 +225,12 @@
           });
       },
       onFinished() {
-        this.displayCompletionModal();
+        if (this.wasComplete) {
+          this.$emit('finished');
+        } else {
+          this.wasComplete = true;
+          this.displayCompletionModal();
+        }
       },
       displayCompletionModal() {
         this.showCompletionModal = this.progress >= 1;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -206,6 +206,9 @@
       },
       handleMarkAsComplete() {
         this.hideMarkAsCompleteModal();
+        // Do this immediately to remove any delay
+        // before the completion modal displays if appropriate.
+        this.onFinished();
         return this.updateProgress(1.0)
           .then(() => {
             this.$store.dispatch('createSnackbar', this.learnString('resourceCompletedLabel'));

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -223,6 +223,9 @@
           });
       },
       onFinished() {
+        this.displayCompletionModal();
+      },
+      displayCompletionModal() {
         this.showCompletionModal = this.progress >= 1;
       },
       onError(error) {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -236,7 +236,7 @@
         }
       },
       displayCompletionModal() {
-        this.showCompletionModal = this.progress >= 1;
+        this.showCompletionModal = true;
       },
       onError(error) {
         this.$store.dispatch('handleApiError', error);

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -9,6 +9,7 @@
     <div v-if="blockDoubleClicks" class="click-mask"></div>
     <SkipNavigationLink />
     <LearningActivityBar
+      ref="activityBar"
       :resourceTitle="resourceTitle"
       :learningActivities="content.learning_activities"
       :isLessonContext="lessonContext"
@@ -56,6 +57,7 @@
         :content="content"
         :lessonId="lessonId"
         :allowMarkComplete="allowMarkComplete"
+        @finished="$refs.activityBar && $refs.activityBar.animateNextSteps()"
       />
     </div>
 

--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -23,6 +23,7 @@
       @toggleBookmark="toggleBookmark"
       @viewResourceList="toggleResourceList"
       @viewInfo="openSidePanel"
+      @completionModal="openCompletionModal"
     />
     <KLinearLoader
       v-if="loading"
@@ -49,6 +50,7 @@
       class="main"
     >
       <ContentPage
+        ref="contentPage"
         class="content"
         data-test="contentPage"
         :content="content"
@@ -420,6 +422,11 @@
           this.$refs.embeddedPanel.focusFirstEl();
         } else {
           this.$refs.resourcePanel.focusFirstEl();
+        }
+      },
+      openCompletionModal() {
+        if (this.$refs.contentPage) {
+          this.$refs.contentPage.displayCompletionModal();
         }
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -40,6 +40,7 @@
         :tooltip="action.label"
         :ariaLabel="action.label"
         :disabled="action.disabled"
+        :class="action.id === 'next-steps' && nextStepsAnimate ? 'bounce' : ''"
         @click="onActionClick(action.event)"
       />
 
@@ -205,6 +206,7 @@
     data() {
       return {
         isMenuOpen: false,
+        nextStepsAnimate: false,
       };
     },
     computed: {
@@ -341,6 +343,15 @@
           this.$refs.menu.focusFirstEl();
         });
       },
+      /*
+       * @public
+       */
+      animateNextSteps() {
+        this.nextStepsAnimate = true;
+        setTimeout(() => {
+          this.nextStepsAnimate = false;
+        }, 1500);
+      },
     },
     $trs: {
       goBack: {
@@ -406,6 +417,49 @@
       width: 18px;
       height: 18px;
     }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bounce {
+      transition-delay: 0s;
+      transition-duration: 0s;
+      animation-duration: 1ms;
+      animation-delay: -1ms;
+      animation-iteration-count: 1;
+    }
+  }
+
+  @keyframes bounce {
+    0% {
+      transform: scale(1, 1) translateY(0);
+    }
+    10% {
+      transform: scale(1.1, 0.9) translateY(0);
+    }
+    30% {
+      transform: scale(0.9, 1.1) translateY(-0.5em);
+    }
+    50% {
+      transform: scale(1.05, 0.95) translateY(0);
+    }
+    57% {
+      transform: scale(1, 1) translateY(-0.125em);
+    }
+    64% {
+      transform: scale(1, 1) translateY(0);
+    }
+    100% {
+      transform: scale(1, 1) translateY(0);
+    }
+  }
+
+  .bounce {
+    animation-name: bounce;
+    animation-duration: 1s;
+    animation-timing-function: cubic-bezier(0.28, 0.84, 0.42, 1);
+    animation-delay: 0s;
+    animation-iteration-count: infinite;
+    animation-direction: normal;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/completion-modal.spec.js
@@ -72,7 +72,7 @@ describe('CompletionModal', () => {
     });
 
     it("doesn't display obtained points", () => {
-      expect(wrapper.text()).not.toContain('+500 points');
+      expect(wrapper.text()).not.toContain('+ 500 points');
     });
   });
 
@@ -93,6 +93,16 @@ describe('CompletionModal', () => {
 
     it('displays obtained points', () => {
       expect(wrapper.text()).toContain('+ 500 points');
+    });
+
+    it('does not display obtained points if wasComplete is true', () => {
+      wrapper = makeWrapper({
+        propsData: {
+          isUserLoggedIn: true,
+          wasComplete: true,
+        },
+      });
+      expect(wrapper.text()).not.toContain('+ 500 points');
     });
 
     it("displays 'Stay and practice' section with 'Stay here' button", async () => {


### PR DESCRIPTION
## Summary
* Reverts a previous change that caused completion modals to pop up whenever a user finished a piece of content, and not just on first completion
* Adds a next steps button which will reopen the completion modal
* Add an animation (which gets turned off for users with a reduced motion setting) which emphasizes the next steps button when a finish event is fired again
* Ensures the completion modal is shown when a learner marks a resource as complete

## References
Fixes https://github.com/learningequality/kolibri/issues/9825
Fixes #9824
Fixes https://github.com/learningequality/kolibri/issues/9840

This was discussed with @jtamiace before implementation

## Reviewer guidance
Does this resolve the issue above? Does the new button function as intended? Is the cleanup of the action bar logic in the learning activity bar sensible?

Will this be easy to migrate into develop across the refactor?

[Screencast from 11-10-2022 05:18:18 PM.webm](https://user-images.githubusercontent.com/1680573/201239976-fff85bf4-df32-48a1-86d6-78fe69b21f70.webm)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
