### PR TITLE
Metadata cleanups

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCardListView.vue
@@ -53,12 +53,18 @@
               >{{ categoryAndLevelString }}</p>
               <div>
                 <img
+                  v-if="content.channel_thumbnail"
                   :src="
                     content.channel_thumbnail"
                   :alt="learnString('logo', { channelTitle: content.channel_title })"
                   class="channel-logo"
                   :style="{ color: $themePalette.grey.v_700 }"
                 >
+                <p
+                  v-else
+                  class="metadata-info"
+                  :style="{ color: $themePalette.grey.v_700, marginTop: 0 }"
+                >{{ learnString('logo', { channelTitle: content.channel_title }) }}</p>
                 <KButton
                   v-if="isLibraryPage && content.copies"
                   appearance="basic-link"

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -14,6 +14,7 @@
         <CardThumbnail
           :isMobile="isMobile"
           :contentNode="content"
+          :hideDuration="true"
         />
       </div>
       <h3 class="title">


### PR DESCRIPTION
## Summary
Two small metadata related cleanups

## References
Fixes #9823
Fixes #9826

|  Scenario | BEFORE  | AFTER  |
|---|---|---|
|  Empty image when no channel thumbnail  | <img width="1086" alt="Screen Shot 2022-11-17 at 2 54 20 PM" src="https://user-images.githubusercontent.com/17235236/202546471-c461918d-5900-4df1-ac17-e316072b8509.png"> |   <img width="1076" alt="Screen Shot 2022-11-17 at 2 53 08 PM" src="https://user-images.githubusercontent.com/17235236/202546481-ac13fa6d-0210-48f0-9a15-01835e321edb.png"> |
| Duration of activity, within lesson display | <img width="1251" alt="Screen Shot 2022-11-17 at 2 53 35 PM" src="https://user-images.githubusercontent.com/17235236/202546478-fc89bd83-9c97-49f5-a21c-7911ccee355f.png"> | <img width="1169" alt="Screen Shot 2022-11-17 at 2 53 24 PM" src="https://user-images.githubusercontent.com/17235236/202546479-9be54759-1010-42d6-80d5-04b11b71d4d8.png"> |





## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
