### PR TITLE
Category search directly

### DIFF
--- a/kolibri/plugins/learn/assets/src/constants.js
+++ b/kolibri/plugins/learn/assets/src/constants.js
@@ -44,6 +44,8 @@ export const pageNameToModuleMap = {
   [PageNames.TOPICS_TOPIC_SEARCH]: 'topicsTree',
 };
 
+export const libraryCategories = {};
+
 const availablePaths = {};
 
 plugin_data.categories.map(key => {
@@ -54,9 +56,6 @@ plugin_data.categories.map(key => {
     availablePaths[path] = true;
   }
 });
-
-export const libraryCategories = {};
-
 // Create a nested object representing the hierarchy of categories
 for (let value of Object.values(Categories)
   // Sort by the length of the key path to deal with

--- a/kolibri/plugins/learn/assets/src/constants.js
+++ b/kolibri/plugins/learn/assets/src/constants.js
@@ -48,7 +48,7 @@ export const libraryCategories = {};
 
 const availablePaths = {};
 
-plugin_data.categories.map(key => {
+(plugin_data.categories || []).map(key => {
   const paths = key.split('.');
   let path = '';
   for (let path_segment of paths) {

--- a/kolibri/plugins/learn/assets/src/constants.js
+++ b/kolibri/plugins/learn/assets/src/constants.js
@@ -1,3 +1,6 @@
+import { Categories, CategoriesLookup } from 'kolibri.coreVue.vuex.constants';
+import plugin_data from 'plugin_data';
+
 // a name for every URL pattern
 export const PageNames = {
   ROOT: 'ROOT',
@@ -40,3 +43,59 @@ export const pageNameToModuleMap = {
   [PageNames.TOPICS_TOPIC]: 'topicsTree',
   [PageNames.TOPICS_TOPIC_SEARCH]: 'topicsTree',
 };
+
+const availablePaths = {};
+
+plugin_data.categories.map(key => {
+  const paths = key.split('.');
+  let path = '';
+  for (let path_segment of paths) {
+    path = path === '' ? path_segment : path + '.' + path_segment;
+    availablePaths[path] = true;
+  }
+});
+
+export const libraryCategories = {};
+
+// Create a nested object representing the hierarchy of categories
+for (let value of Object.values(Categories)
+  // Sort by the length of the key path to deal with
+  // shorter key paths first.
+  .sort((a, b) => a.length - b.length)) {
+  // Split the value into the paths so we can build the object
+  // down the path to create the nested representation
+  const ids = value.split('.');
+  // Start with an empty path
+  let path = '';
+  // Start with the global object
+  let nested = libraryCategories;
+  for (let fragment of ids) {
+    // Add the fragment to create the path we examine
+    path += fragment;
+    // Check to see if this path is one of the paths
+    // that is available on this device
+    if (availablePaths[path]) {
+      // Lookup the human readable key for this path
+      const nestedKey = CategoriesLookup[path];
+      // Check if we have already represented this in the object
+      if (!nested[nestedKey]) {
+        // If not, add an object representing this category
+        nested[nestedKey] = {
+          // The value is the whole path to this point, so the value
+          // of the key.
+          value: path,
+          // Nested is an object that contains any subsidiary categories
+          nested: {},
+        };
+      }
+      // For the next stage of the loop the relevant object to edit is
+      // the nested object under this key.
+      nested = nested[nestedKey].nested;
+      // Add '.' to path so when we next append to the path,
+      // it is properly '.' separated.
+      path += '.';
+    } else {
+      break;
+    }
+  }
+}

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -1,45 +1,57 @@
 <template>
 
-  <KGrid
-    :style="{ margin: '24px' }"
-  >
-    <KGridItem
-      v-for="(nestedObject, key) in displaySelectedCategories"
-      :key="key"
-      :layout4="{ span: 4 }"
-      :layout8="{ span: 8 }"
-      :layout12="{ span: 4 }"
-      class="category-item"
-    >
-      <div class="filter-list-title">
-        <KIcon
-          :icon="icon(key)"
-          size="large"
-        />
-        <h2>
-          <KButton
-            :text="coreString(camelCase(key))"
-            appearance="basic-link"
-            :appearanceOverrides="appearanceOverrides"
-            :disabled="availablePaths && !availablePaths[nestedObject.value]"
-            @click="$emit('input', nestedObject.value)"
-          />
-        </h2>
+  <div>
+    <h2 class="top-category">
+      <KButton
+        :text="coreString(camelCase(selectedCategory))"
+        :appearanceOverrides="appearanceOverrides"
+        appearance="basic-link"
 
-      </div>
-      <div
-        v-for="(item, nestedKey) in nestedObject.nested"
-        :key="item.value"
+        @click="$emit('input', topLevelCategory.value)"
+      />
+    </h2>
+    <KGrid
+      :style="{ margin: '24px' }"
+    >
+      <KGridItem
+        v-for="(nestedObject, key) in displaySelectedCategories"
+        :key="key"
+        :layout4="{ span: 4 }"
+        :layout8="{ span: 8 }"
+        :layout12="{ span: 4 }"
+        class="category-item"
       >
-        <KButton
-          :text="coreString(camelCase(nestedKey))"
-          :appearanceOverrides="appearanceOverrides"
-          appearance="basic-link"
-          @click="$emit('input', item.value)"
-        />
-      </div>
-    </KGridItem>
-  </KGrid>
+        <div class="filter-list-title">
+          <KIcon
+            :icon="icon(key)"
+            size="large"
+          />
+          <h3>
+            <KButton
+              :text="coreString(camelCase(key))"
+              appearance="basic-link"
+              class="larger-text"
+              :appearanceOverrides="appearanceOverrides"
+              :disabled="availablePaths && !availablePaths[nestedObject.value]"
+              @click="$emit('input', nestedObject.value)"
+            />
+          </h3>
+
+        </div>
+        <div
+          v-for="(item, nestedKey) in nestedObject.nested"
+          :key="item.value"
+        >
+          <KButton
+            :text="coreString(camelCase(nestedKey))"
+            :appearanceOverrides="appearanceOverrides"
+            appearance="basic-link"
+            @click="$emit('input', item.value)"
+          />
+        </div>
+      </KGridItem>
+    </KGrid>
+  </div>
 
 </template>
 
@@ -81,6 +93,9 @@
           return paths;
         }
         return null;
+      },
+      topLevelCategory() {
+        return libraryCategories[this.selectedCategory];
       },
       displaySelectedCategories() {
         return libraryCategories[this.selectedCategory].nested;
@@ -124,16 +139,30 @@
 
 <style lang="scss" scoped>
 
-  h2 {
+  .top-category {
+    margin-right: 16px;
+    margin-bottom: 4px;
+    margin-left: 16px;
+    font-size: 24px;
+  }
+
+  .larger-text {
     margin-top: 4px;
     margin-bottom: 4px;
+    font-size: 20px;
   }
 
   /deep/ .link-text {
     text-decoration: none !important;
+    transition: none !important;
   }
   .category-item {
     margin-bottom: 32px;
+  }
+
+  h3 {
+    margin-top: 0;
+    margin-bottom: 8px;
   }
 
   /deep/ svg {

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -48,51 +48,8 @@
 
   import camelCase from 'lodash/camelCase';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { Categories, CategoriesLookup } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import plugin_data from 'plugin_data';
-
-  const availablePaths = {};
-
-  if (process.env.NODE_ENV !== 'production') {
-    // TODO rtibbles: remove this condition
-    Object.assign(availablePaths, CategoriesLookup);
-  } else {
-    plugin_data.categories.map(key => {
-      const paths = key.split('.');
-      let path = '';
-      for (let path_segment of paths) {
-        path = path === '' ? path_segment : path + '.' + path_segment;
-        availablePaths[path] = true;
-      }
-    });
-  }
-
-  const libraryCategories = {};
-
-  for (let subjectKey of Object.entries(Categories)
-    .sort((a, b) => a[0].length - b[0].length)
-    .map(a => a[0])) {
-    const ids = Categories[subjectKey].split('.');
-    let path = '';
-    let nested = libraryCategories;
-    for (let fragment of ids) {
-      path += fragment;
-      if (availablePaths[path]) {
-        const nestedKey = CategoriesLookup[path];
-        if (!nested[nestedKey]) {
-          nested[nestedKey] = {
-            value: path,
-            nested: {},
-          };
-        }
-        nested = nested[nestedKey].nested;
-        path += '.';
-      } else {
-        break;
-      }
-    }
-  }
+  import { libraryCategories } from '../../constants';
 
   export default {
     name: 'CategorySearchOptions',

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
@@ -35,66 +35,8 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { Categories, CategoriesLookup } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CategorySearchOptions from './CategorySearchOptions';
-  import plugin_data from 'plugin_data';
-
-  const availablePaths = {};
-
-  plugin_data.categories.map(key => {
-    const paths = key.split('.');
-    let path = '';
-    for (let path_segment of paths) {
-      path = path === '' ? path_segment : path + '.' + path_segment;
-      availablePaths[path] = true;
-    }
-  });
-
-  const libraryCategories = {};
-
-  // Create a nested object representing the hierarchy of categories
-  for (let value of Object.values(Categories)
-    // Sort by the length of the key path to deal with
-    // shorter key paths first.
-    .sort((a, b) => a.length - b.length)) {
-    // Split the value into the paths so we can build the object
-    // down the path to create the nested representation
-    const ids = value.split('.');
-    // Start with an empty path
-    let path = '';
-    // Start with the global object
-    let nested = libraryCategories;
-    for (let fragment of ids) {
-      // Add the fragment to create the path we examine
-      path += fragment;
-      // Check to see if this path is one of the paths
-      // that is available on this device
-      if (availablePaths[path]) {
-        // Lookup the human readable key for this path
-        const nestedKey = CategoriesLookup[path];
-        // Check if we have already represented this in the object
-        if (!nested[nestedKey]) {
-          // If not, add an object representing this category
-          nested[nestedKey] = {
-            // The value is the whole path to this point, so the value
-            // of the key.
-            value: path,
-            // Nested is an object that contains any subsidiary categories
-            nested: {},
-          };
-        }
-        // For the next stage of the loop the relevant object to edit is
-        // the nested object under this key.
-        nested = nested[nestedKey].nested;
-        // Add '.' to path so when we next append to the path,
-        // it is properly '.' separated.
-        path += '.';
-      } else {
-        break;
-      }
-    }
-  }
 
   export default {
     name: 'CategorySearchModal',

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/index.vue
@@ -42,19 +42,14 @@
 
   const availablePaths = {};
 
-  if (process.env.NODE_ENV !== 'production') {
-    // TODO rtibbles: remove this condition
-    Object.assign(availablePaths, CategoriesLookup);
-  } else {
-    plugin_data.categories.map(key => {
-      const paths = key.split('.');
-      let path = '';
-      for (let path_segment of paths) {
-        path = path === '' ? path_segment : path + '.' + path_segment;
-        availablePaths[path] = true;
-      }
-    });
-  }
+  plugin_data.categories.map(key => {
+    const paths = key.split('.');
+    let path = '';
+    for (let path_segment of paths) {
+      path = path === '' ? path_segment : path + '.' + path_segment;
+      availablePaths[path] = true;
+    }
+  });
 
   const libraryCategories = {};
 

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -59,7 +59,7 @@
             :disabled="availableRootCategories &&
               !availableRootCategories[key] &&
               !isKeyActive(key)"
-            :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
+            :iconAfter="hasNestedCategories(category) ? 'chevronRight' : null"
             @click="$emit('currentCategory', category)"
           />
         </div>
@@ -300,9 +300,8 @@
       noCategories() {
         this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
       },
-      hasNestedCategories(key) {
-        let object = Object.values(libraryCategories).filter(category => category.value === key)[0];
-        return Object.keys(object.nested).length > 0;
+      hasNestedCategories(category) {
+        return Object.keys(libraryCategories[category].nested).length > 0;
       },
       handleActivity(activity) {
         if (activity && !this.value.learning_activities[activity]) {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -59,7 +59,7 @@
             :disabled="availableRootCategories &&
               !availableRootCategories[key] &&
               !isKeyActive(key)"
-            iconAfter="chevronRight"
+            :iconAfter="hasNestedCategories(key) ? 'chevronRight' : null"
             @click="$emit('currentCategory', category)"
           />
         </div>
@@ -131,6 +131,7 @@
   import SearchBox from '../SearchBox';
   import commonLearnStrings from '../commonLearnStrings';
   import genContentLink from '../../utils/genContentLink';
+  import { libraryCategories } from '../../constants';
   import ActivityButtonsGroup from './ActivityButtonsGroup';
   import SelectGroup from './SelectGroup';
   import plugin_data from 'plugin_data';
@@ -140,7 +141,7 @@
   const resourcesNeeded = {};
   resourcesNeededShown.map(key => {
     const value = ResourcesNeededTypes[key];
-    if (plugin_data.learnerNeeds.includes(value) || process.env.NODE_ENV !== 'production') {
+    if (plugin_data.learnerNeeds.includes(value)) {
       resourcesNeeded[key] = value;
     }
   });
@@ -149,7 +150,7 @@
 
   availableIds = plugin_data.categories;
 
-  const libraryCategories = pick(
+  const libraryCategoriesSelection = pick(
     CategoriesLookup,
     uniq(availableIds.map(key => key.split('.')[0]))
   );
@@ -237,7 +238,7 @@
         },
       },
       libraryCategoriesList() {
-        return libraryCategories;
+        return libraryCategoriesSelection;
       },
       resourcesNeededList() {
         return resourcesNeeded;
@@ -298,6 +299,10 @@
       },
       noCategories() {
         this.$emit('input', { ...this.value, categories: { [NoCategories]: true } });
+      },
+      hasNestedCategories(key) {
+        let object = Object.values(libraryCategories).filter(category => category.value === key)[0];
+        return Object.keys(object.nested).length > 0;
       },
       handleActivity(activity) {
         if (activity && !this.value.learning_activities[activity]) {

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -148,7 +148,7 @@
 
   let availableIds;
 
-  availableIds = plugin_data.categories;
+  availableIds = plugin_data.categories || [];
 
   const libraryCategoriesSelection = pick(
     CategoriesLookup,

--- a/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/EmbeddedSidePanel/index.vue
@@ -140,7 +140,6 @@
   const resourcesNeeded = {};
   resourcesNeededShown.map(key => {
     const value = ResourcesNeededTypes[key];
-    // TODO rtibbles: remove this condition
     if (plugin_data.learnerNeeds.includes(value) || process.env.NODE_ENV !== 'production') {
       resourcesNeeded[key] = value;
     }
@@ -148,12 +147,7 @@
 
   let availableIds;
 
-  if (process.env.NODE_ENV !== 'production') {
-    // TODO rtibbles: remove this condition
-    availableIds = Object.keys(CategoriesLookup);
-  } else {
-    availableIds = plugin_data.categories;
-  }
+  availableIds = plugin_data.categories;
 
   const libraryCategories = pick(
     CategoriesLookup,

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage.vue
@@ -244,9 +244,8 @@
   import FullScreenSidePanel from 'kolibri.coreVue.components.FullScreenSidePanel';
   import FilterTextbox from 'kolibri.coreVue.components.FilterTextbox';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import { Categories, CategoriesLookup } from 'kolibri.coreVue.vuex.constants';
   import genContentLink from '../utils/genContentLink';
-  import { PageNames } from '../constants';
+  import { PageNames, libraryCategories } from '../constants';
   import useSearch from '../composables/useSearch';
   import useLearnerResources from '../composables/useLearnerResources';
   import BrowseResourceMetadata from './BrowseResourceMetadata';
@@ -257,47 +256,9 @@
   import EmbeddedSidePanel from './EmbeddedSidePanel';
   import CategorySearchModal from './CategorySearchModal';
   import SearchChips from './SearchChips';
-  import plugin_data from 'plugin_data';
 
   const mobileCarouselLimit = 3;
   const desktopCarouselLimit = 15;
-
-  const availablePaths = {};
-
-  plugin_data.categories.map(key => {
-    const paths = key.split('.');
-    let path = '';
-    for (let path_segment of paths) {
-      path = path === '' ? path_segment : path + '.' + path_segment;
-      availablePaths[path] = true;
-    }
-  });
-
-  const libraryCategories = {};
-
-  for (let subjectKey of Object.entries(Categories)
-    .sort((a, b) => a[0].length - b[0].length)
-    .map(a => a[0])) {
-    const ids = Categories[subjectKey].split('.');
-    let path = '';
-    let nested = libraryCategories;
-    for (let fragment of ids) {
-      path += fragment;
-      if (availablePaths[path]) {
-        const nestedKey = CategoriesLookup[path];
-        if (!nested[nestedKey]) {
-          nested[nestedKey] = {
-            value: path,
-            nested: {},
-          };
-        }
-        nested = nested[nestedKey].nested;
-        path += '.';
-      } else {
-        break;
-      }
-    }
-  }
 
   export default {
     name: 'LibraryPage',


### PR DESCRIPTION
## Summary

If there is a valid tagged category, but no sub-categories, clicking the category button should search directly, rather than opening an empty modal. 

This also cleans up some related display code for non-production environments. 

## References
Fixes https://github.com/learningequality/kolibri/issues/9820

## Reviewer guidance
Did I miss anything? Or, any edge cases I am not considering?

![search-category-directly](https://user-images.githubusercontent.com/17235236/202573139-cfaad391-e0e2-4cb4-870e-5bbcbc9eeb75.gif)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
