### PR TITLE
Fix bookmark failure to load data

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnImmersiveLayout.vue
@@ -282,7 +282,22 @@
     watch: {
       content(newContent, oldContent) {
         if ((newContent && !oldContent) || newContent.id !== oldContent.id) {
-          this.resetSidebarInfo();
+          this.initializeState();
+        }
+      },
+      showViewResourcesSidePanel(newVal, oldVal) {
+        if (newVal && !oldVal) {
+          this.getSidebarInfo();
+        }
+      },
+    },
+    created() {
+      this.initializeState();
+    },
+    methods: {
+      initializeState() {
+        this.resetSidebarInfo();
+        if (this.content) {
           client({
             method: 'get',
             url: urls['kolibri:core:bookmarks-list'](),
@@ -292,13 +307,6 @@
           });
         }
       },
-      showViewResourcesSidePanel(newVal, oldVal) {
-        if (newVal && !oldVal) {
-          this.getSidebarInfo();
-        }
-      },
-    },
-    methods: {
       resetSidebarInfo() {
         this.showViewResourcesSidePanel = false;
         this.nextContent = null;


### PR DESCRIPTION
## Summary
* Handle case where content data is loaded before component is initialized, and fetch bookmark data.

## References
Fixes #9864

## Reviewer guidance
Go to a resource.
Press back.
Go back to the resource.
See that the bookmark button is not disabled.
[Screencast from 11-22-2022 09:29:06 AM.webm](https://user-images.githubusercontent.com/1680573/203381682-c01d7209-d75d-4280-967b-d63efbfc17c2.webm)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
