### PR TITLE
Update KDS so that `:disabled` works properly on `KButtons`

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.36",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.4.0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.4.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
+++ b/kolibri/plugins/coach/assets/test/views/reports/__snapshots__/ReportsExerciseLearners.spec.js.snap
@@ -14,7 +14,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_qhgpwa link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
+        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_1jjc9c8 link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
               <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
             </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
             <!----></a></td>
@@ -32,7 +32,7 @@ exports[`ReportsExerciseLearners doesn't render groups information when show gro
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_qhgpwa link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
+        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_1jjc9c8 link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
               <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
             </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
             <!----></a></td>
@@ -70,7 +70,7 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
     </thead>
     <transition-group-stub tag="tbody" name="list">
       <tr data-test="entry">
-        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_qhgpwa link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
+        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_1jjc9c8 link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
               <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
             </svg> <span class="link-text" style="margin-left: 8px;">learner1</span>
             <!----></a></td>
@@ -92,7 +92,7 @@ exports[`ReportsExerciseLearners renders all entries 1`] = `
 </span></td>
       </tr>
       <tr data-test="entry">
-        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_qhgpwa link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
+        <td><a data-test="exercise-learner-link" dir="auto" class="KRouterLink-noKey-0_1jjc9c8 link"><svg viewBox="0 0 24 24" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="" style="fill: #996189; top: 4px;" data-test="icon-before">
               <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"></path>
             </svg> <span class="link-text" style="margin-left: 8px;">learner2</span>
             <!----></a></td>

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -6,7 +6,7 @@
         :text="coreString(camelCase(selectedCategory))"
         :appearanceOverrides="appearanceOverrides"
         appearance="basic-link"
-        :disabled="availablePaths && !availablePaths[nestedObject.value]"
+        :disabled="availablePaths && !availablePaths[topLevelCategory.value]"
         @click="$emit('input', topLevelCategory.value)"
       />
     </h2>

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -46,6 +46,7 @@
             :text="coreString(camelCase(nestedKey))"
             :appearanceOverrides="appearanceOverrides"
             appearance="basic-link"
+            :disabled="availablePaths && !availablePaths[nestedObject.value]"
             @click="$emit('input', item.value)"
           />
         </div>

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -6,7 +6,7 @@
         :text="coreString(camelCase(selectedCategory))"
         :appearanceOverrides="appearanceOverrides"
         appearance="basic-link"
-
+        :disabled="availablePaths && !availablePaths[nestedObject.value]"
         @click="$emit('input', topLevelCategory.value)"
       />
     </h2>

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.36",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.4.0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v1.4.1",
     "lockr": "0.8.4",
     "lodash": "^4.17.21",
     "loglevel": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8888,9 +8888,9 @@ kolibri-constants@0.1.36:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.36.tgz#c9ab07305dc6e052547b830a91e61a58757bb1ee"
   integrity sha512-61FoLBFjOXoBu7lsAKFltkZCwwzVO/Cwmgq+wBqkoTmLw92ma6shLP/ZYaNrzYNhuEn4gHfCC6zWZoLoC1hp/w==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.4.0":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v1.4.1":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#b82120fb662e4949c59320488380246514e12a2a"
+  resolved "https://github.com/learningequality/kolibri-design-system#94babf2a8c35ac0bd86036dfb67a3e720e3b49d2"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary
Bumps KDS version to latest, which includes a fix for `:disabled` on link-style `KButtons`

Small UI tweak to also included `:disabled` on nested subclasses.

## References
Fixes #9872

<img width="1409" alt="Screen Shot 2022-11-28 at 7 04 39 PM" src="https://user-images.githubusercontent.com/17235236/204406854-390d7b37-ea8a-4aa9-af44-b680ff246342.png">

## Reviewer guidance

Within a channel, open the search modal. Categories that would yield 0 results (i.e. the category exists within the library as a whole, but not within the current scope of the channel) should be disabled. 

This should also be the result on either the library or the channel page if you have already selected one filter (i.e. "Read") and then go to search categories. Those categories that are excluded by the parameters of the search should now be disabled and not clickable.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
