### PR TITLE
Only update learning activities for imported channel

### DIFF
--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -6,6 +6,7 @@ from itertools import islice
 
 from django.apps import apps
 from django.db.models.fields.related import ForeignKey
+from sqlalchemy import and_
 from sqlalchemy import or_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import OperationalError
@@ -951,7 +952,12 @@ class NoLearningActivitiesChannelImport(ChannelImport):
         for kind, la in kind_activity_map.items():
             self.destination.execute(
                 ContentNodeTable.update()
-                .where(ContentNodeTable.c.kind == kind)
+                .where(
+                    and_(
+                        ContentNodeTable.c.kind == kind,
+                        ContentNodeTable.c.channel_id == self.channel_id,
+                    )
+                )
                 .values(learning_activities=la)
             )
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Changes the query that updates content nodes' learning activity when importing a channel to only apply to the channel that was imported
- Adds tests to ensure the above behavior

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/9873

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1) Import a channel and verify there are no regressions
2) Look through the new tests and run them

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
