### PR TITLE
aligned finish and previous button

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -99,19 +99,30 @@
         :selectedExercises="selectedExercises"
       />
 
-      <BottomAppBar style="z-index: 1062;">
-        <KButtonGroup>
-          <KRouterLink
-            appearance="flat-button"
-            :text="$tr('previousStep')"
-            :to="toolbarRoute"
-          />
-          <KButton
-            :text="coreString('finishAction')"
-            :disabled="loadingNewQuestions"
-            primary
-            @click="submit"
-          />
+      <BottomAppBar
+        style="z-index: 1062;"
+      >
+        <KButtonGroup
+          class="align-btn"
+        >
+          <div class="align-btn">
+            <div class="div">
+              <KRouterLink
+                appearance="flat-button"
+                :text="$tr('previousStep')"
+                :to="toolbarRoute"
+              />
+            </div>
+            <div class="div">
+              <KButton
+                :text="coreString('finishAction')"
+                :disabled="loadingNewQuestions"
+                primary
+                @click="submit"
+              />
+            </div>
+          </div>
+
         </KButtonGroup>
       </BottomAppBar>
     </KPageContainer>
@@ -328,6 +339,13 @@
 
   .sortable-ghost * {
     visibility: hidden;
+  }
+  .align-btn {
+    display: flex;
+    float: right;
+  }
+  .align-btn .div {
+    margin-left: 20px;
   }
 
 </style>


### PR DESCRIPTION
## Summary
This PR fixes the previous and continue buttons that were not properly aligned

## References
Closes #9118



## Reviewer guidance

- As a Coach, navigate to Class>Plan>Quizzes
- Click the 'New quiz' > 'Create new quiz' option
- Enter a quiz title, select resources and click 'Continue'
- and observe the position of the 'Previous step' button

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
