### PR TITLE
fix too much empty space

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -103,7 +103,7 @@
 <style lang="scss" scoped>
 
   .folder-header-link {
-    margin-top: 15px;
+    margin-top: 25px;
 
     /deep/ .link-text {
       text-decoration: none !important;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -103,6 +103,8 @@
 <style lang="scss" scoped>
 
   .folder-header-link {
+    margin-top: 15px;
+
     /deep/ .link-text {
       text-decoration: none !important;
     }

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -38,26 +38,49 @@
         />
 
         <div class="card-grid">
-          <!-- Filter buttons - shown when not sidebar not visible -->
-          <div v-if="!windowIsLarge" data-test="tab-buttons">
+
+          <!-- catering for a more smaller screen  -->
+          <div v-if="windowIsSmall" data-test="tab-buttons">
             <KButton
               v-if="topics.length"
               icon="topic"
               data-test="folders-button"
-              class="overlay-toggle-button"
+              class="btn-space-mobile-1"
               :text="coreString('folders')"
               :primary="false"
               @click="toggleFolderSearchSidePanel('folder')"
             />
             <KButton
               icon="filter"
-              class="overlay-toggle-button"
+              class="btn-space-mobile-1"
               data-test="filter-button"
               :text="filterTranslator.$tr('filter')"
               :primary="false"
               @click="toggleFolderSearchSidePanel('search')"
             />
           </div>
+
+          <!-- Filter buttons - shown when not sidebar not visible -->
+          <div v-else-if="!windowIsLarge" data-test="tab-buttons">
+            <KButton
+              v-if="topics.length"
+              icon="topic"
+              data-test="folders-button"
+              class="btn-space-mobile-2"
+              :text="coreString('folders')"
+              :primary="false"
+              @click="toggleFolderSearchSidePanel('folder')"
+            />
+            <KButton
+              icon="filter"
+              class="btn-space-mobile-2"
+              data-test="filter-button"
+              :text="filterTranslator.$tr('filter')"
+              :primary="false"
+              @click="toggleFolderSearchSidePanel('search')"
+            />
+          </div>
+
 
           <!-- default/preview display of nested folder structure, not search -->
           <div v-if="!displayingSearchResults" data-test="topics">
@@ -650,6 +673,7 @@
           [topicId]: true,
         };
       },
+
       handleLoadMoreInSubtopic(topicId) {
         this.subTopicLoading = topicId;
         this.loadMoreContents(topicId).then(() => {
@@ -714,6 +738,14 @@
     margin: 24px;
   }
 
+  .btn-space-mobile-1 {
+    margin: 0 16px 16px 0;
+  }
+
+  .btn-space-mobile-2 {
+    margin: 16px 16px 16px 0;
+  }
+
   .text {
     max-width: 920px;
   }
@@ -736,10 +768,6 @@
     display: inline-block;
     margin: 4px;
     margin-left: 8px;
-  }
-
-  .overlay-toggle-button {
-    margin: 16px 16px 16px 0;
   }
 
   .full-screen-side-panel {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -693,7 +693,7 @@
 <style lang="scss" scoped>
 
   $header-height: 324px;
-  $toolbar-height: 70px;
+  $toolbar-height: 45px;
   $total-height: 394px;
 
   .page {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -109,6 +109,7 @@
               :numCols="numCols"
               :genContentLink="genContentLink"
               currentCardViewStyle="card"
+              style="padding-top:20px"
               @toggleInfoPanel="toggleInfoPanel"
             />
             <KButton

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -109,7 +109,7 @@
               :numCols="numCols"
               :genContentLink="genContentLink"
               currentCardViewStyle="card"
-              style="padding-top:20px"
+              style="padding-top:35px"
               @toggleInfoPanel="toggleInfoPanel"
             />
             <KButton


### PR DESCRIPTION

## Summary
This PR fixes too much space on the mobile view when browsing through the channel.


## References
Closes #9500
Before
![image](https://user-images.githubusercontent.com/103313919/204870897-01c0d55b-9b35-482b-83f5-3ef02114147d.png)
After


![Screenshot 2022-11-30 at 20 23 37](https://user-images.githubusercontent.com/103313919/204871061-416615cc-a7e4-4b53-a66d-c55077142baa.png)



## Reviewer guidance

1. Go to the Library > Browse channel.
2. Reduce your screen size to mobile view and observe

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
