### PR TITLE
Add linting for tests to ensure forwards compatibility.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -43,7 +43,7 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v2
@@ -87,7 +87,7 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v2
@@ -117,7 +117,7 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v2
@@ -147,7 +147,7 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
-        pip install tox
+        pip install "tox<4"
     - name: Test with tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e py${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,12 @@ repos:
         kolibri/core/logger/migrations/0003_auto_20170531_1140\.py|
         kolibri/core/logger/migrations/0005_auto_20180514_1419\.py|
       )$
+-   repo: https://github.com/isidentical/teyit
+    rev: 0.4.3
+    hooks:
+    -   id: teyit
+        language_version: '3.9'
+# Always keep black as the final hook so it reformats any other reformatting.
 -   repo: https://github.com/python/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,7 +69,7 @@ repos:
     rev: 0.4.3
     hooks:
     -   id: teyit
-        language_version: '3.9'
+        language_version: '3.10'
 # Always keep black as the final hook so it reformats any other reformatting.
 -   repo: https://github.com/python/black
     rev: 20.8b1

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1114,7 +1114,7 @@ class LoginLogoutTestCase(APITestCase):
             reverse("kolibri:core:session-detail", kwargs={"pk": "current"})
         )
         new_expire_date = self.client.session.get_expiry_date()
-        self.assertTrue(expire_date < new_expire_date)
+        self.assertLess(expire_date, new_expire_date)
 
 
 class SignUpBase(object):

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -57,7 +57,7 @@ class FacilityDatasetTestCase(TestCase):
         )
 
     def test_datasets_equal(self):
-        self.assertTrue(self.facility.dataset is not None)
+        self.assertIsNotNone(self.facility.dataset)
         self.assertEqual(self.facility.dataset, self.classroom.dataset)
         self.assertEqual(self.classroom.dataset, self.learner_group.dataset)
         self.assertEqual(self.learner_group.dataset, self.facility_user.dataset)
@@ -105,7 +105,7 @@ class FacilityDatasetTestCase(TestCase):
         self.assertEqual(str(new_dataset), "FacilityDataset (no associated Facility)")
 
     def test_exam_lesson_dataset(self):
-        self.assertTrue(self.facility.dataset is not None)
+        self.assertIsNotNone(self.facility.dataset)
         self.assertEqual(self.exam.infer_dataset(), self.lesson.infer_dataset())
 
         # Check current implementation of infer_dataset on Lesson and Exam

--- a/kolibri/core/auth/test/test_user_export.py
+++ b/kolibri/core/auth/test/test_user_export.py
@@ -85,7 +85,7 @@ class UserCSVExportTestCase(TestCase):
         self.assertEqual(len(results), expected_count)
         for demo_field in DEMO_FIELDS:
             label = labels[demo_field]
-            self.assertTrue(label in results[0])
+            self.assertIn(label, results[0])
 
     def test_csv_export_no_demographics(self):
         facility, superuser = setup_device()
@@ -103,7 +103,7 @@ class UserCSVExportTestCase(TestCase):
         self.assertEqual(len(results), expected_count)
         for demo_field in DEMO_FIELDS:
             label = labels[demo_field]
-            self.assertFalse(label in results[0])
+            self.assertNotIn(label, results[0])
 
     def test_csv_export_user_in_multiple_classes(self):
         facility, superuser = setup_device()

--- a/kolibri/core/bookmarks/test/test_bookmark_api.py
+++ b/kolibri/core/bookmarks/test/test_bookmark_api.py
@@ -100,7 +100,7 @@ class BookmarkAPITestCase(APITestCase):
         # Make sure there actually are more than just what we're getting back
         # so we're sure the permissions are applied as expected
         users_bookmarks = Bookmark.objects.filter(user=self.user)
-        self.assertTrue(len(Bookmark.objects.all()) > len(users_bookmarks))
+        self.assertGreater(len(Bookmark.objects.all()), len(users_bookmarks))
         for bookmark_entry in response.data:
             # We're going to filter the users_bookmarks QuerySet over and over
             # to be sure that everything we get from the API exists there which

--- a/kolibri/core/content/test/test_enumerate_channel.py
+++ b/kolibri/core/content/test/test_enumerate_channel.py
@@ -27,7 +27,7 @@ class EnumerateChannelTestCase(TestCase):
         os.symlink(src_db_file, dst_db_file)
 
         channel_ids = get_channel_ids_for_content_database_dir(dst_dir)
-        self.assertTrue("6199dde695db4ee4ab392222d5af1e5c" not in channel_ids)
+        self.assertNotIn("6199dde695db4ee4ab392222d5af1e5c", channel_ids)
 
     # Helper function
     def create_corrupted_database_file(self, db_dir):
@@ -45,7 +45,7 @@ class EnumerateChannelTestCase(TestCase):
         import_external_content_dbs()
         message_list = [message[0][0] for message in logger_mock.call_args_list]
         error_message = "Tried to import channel 6199dde695db4ee4ab392222d5af1e5c, but database file was corrupted."
-        self.assertTrue(error_message in message_list)
+        self.assertIn(error_message, message_list)
         os.remove(db_file)  # Remove database file for future tests
 
     def test_corrupted_database_file_local_import(self):
@@ -56,5 +56,5 @@ class EnumerateChannelTestCase(TestCase):
         channels = get_channels_for_data_folder(datafolder)
 
         # Make sure that the corrupted database file is not going to be listed
-        self.assertTrue("6199dde695db4ee4ab392222d5af1e5c" not in channels)
+        self.assertNotIn("6199dde695db4ee4ab392222d5af1e5c", channels)
         os.remove(db_file)  # Remove database file for future tests

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -842,7 +842,7 @@ class ImportContentTestCase(TestCase):
             renderable_only=False,
         )
         logger_mock.assert_called_once()
-        self.assertTrue("3 files are skipped" in logger_mock.call_args_list[0][0][0])
+        self.assertIn("3 files are skipped", logger_mock.call_args_list[0][0][0])
         annotation_mock.set_content_visibility.assert_called_with(
             self.the_channel_id,
             [],
@@ -1097,7 +1097,7 @@ class ImportContentTestCase(TestCase):
             10,
         )
         call_command("importcontent", "disk", self.the_channel_id, "destination")
-        self.assertTrue("1 files are skipped" in logger_mock.call_args_list[0][0][0])
+        self.assertIn("1 files are skipped", logger_mock.call_args_list[0][0][0])
         annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.core.content.management.commands.importcontent.logger.error")
@@ -1125,7 +1125,7 @@ class ImportContentTestCase(TestCase):
         )
         with self.assertRaises(OSError):
             call_command("importcontent", "disk", self.the_channel_id, "destination")
-            self.assertTrue("Permission denied" in logger_mock.call_args_list[0][0][0])
+            self.assertIn("Permission denied", logger_mock.call_args_list[0][0][0])
             annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.core.content.management.commands.importcontent.os.remove")

--- a/kolibri/core/content/test/test_redirectcontent.py
+++ b/kolibri/core/content/test/test_redirectcontent.py
@@ -32,7 +32,7 @@ class RedirectContentTestCase(TestCase):
         response = self.client.get(self._get_url(node_id=node_id))
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
-        self.assertTrue(node_id in response.url)
+        self.assertIn(node_id, response.url)
 
     def test_node_id_only_invalid(self):
         response = self.client.get(self._get_url(node_id="rubbish"))
@@ -45,7 +45,7 @@ class RedirectContentTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_and_content_id_and_channel_id_valid(self):
         node = ContentNode.objects.first()
@@ -56,7 +56,7 @@ class RedirectContentTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_missing_and_content_id_and_channel_id_valid(self):
         node = ContentNode.objects.first()
@@ -70,7 +70,7 @@ class RedirectContentTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_missing_and_content_id_valid_and_channel_id_missing(self):
         node = ContentNode.objects.first()
@@ -84,7 +84,7 @@ class RedirectContentTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_missing_and_content_id_missing_and_channel_id_missing(self):
         response = self.client.get(
@@ -108,7 +108,7 @@ class RedirectContentTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_invalid_and_content_id_valid_and_channel_id_invalid(self):
         node = ContentNode.objects.first()
@@ -120,7 +120,7 @@ class RedirectContentTestCase(TestCase):
         self.assertEqual(response.status_code, 302)
         # This is true for our default learn urls for now.
         # Can make this assertion because this node is unique
-        self.assertTrue(node.id in response.url)
+        self.assertIn(node.id, response.url)
 
     def test_node_id_invalid_and_content_id_invalid_and_channel_id_invalid(self):
         response = self.client.get(

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -369,7 +369,7 @@ class DeviceInfoTestCase(APITestCase):
 
     def test_urls(self):
         response = self.client.get(reverse("kolibri:core:deviceinfo"), format="json")
-        self.assertFalse(len(response.data["urls"]) == 0)
+        self.assertNotEqual(len(response.data["urls"]), 0)
         for url in response.data["urls"]:
             # Make sure each url is a valid link
             self.assertTrue(url.startswith("http://"))

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -157,8 +157,8 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], create_summarylog)
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][1], ContentSummaryLog)
+            self.assertIsInstance(
+                save_queue_mock.mock_calls[0][1][1], ContentSummaryLog
             )
 
         self.assertEqual(response.status_code, 200)
@@ -304,10 +304,8 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
             self.assertEqual(
                 save_queue_mock.mock_calls[0][1][0], quiz_started_notification
             )
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], MasteryLog))
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][2], string_types)
-            )
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], MasteryLog)
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][2], string_types)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -1248,8 +1246,8 @@ class ProgressTrackingViewSetLoggedInUpdateSessionTestCase(
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], parse_summarylog)
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][1], ContentSummaryLog)
+            self.assertIsInstance(
+                save_queue_mock.mock_calls[0][1][1], ContentSummaryLog
             )
 
         self.assertEqual(response.status_code, 200)
@@ -2120,7 +2118,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentTestCase(
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], parse_attemptslog)
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
 
         self.assertEqual(response.status_code, 200)
         attempt_id = response.json().get("attempts", [{}])[0].get("id")
@@ -2177,7 +2175,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentTestCase(
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], parse_attemptslog)
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
 
         self.assertEqual(response.status_code, 200)
         attempt_id = response.json().get("attempts", [{}])[0].get("id")
@@ -2283,10 +2281,8 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
             self.assertEqual(
                 save_queue_mock.mock_calls[0][1][0], quiz_answered_notification
             )
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][2], string_types)
-            )
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][2], string_types)
 
     def test_update_assessment_session_create_errored_attempt_succeeds(self):
         with patch("kolibri.core.logger.api.wrap_to_save_queue") as save_queue_mock:
@@ -2297,10 +2293,8 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
             self.assertEqual(
                 save_queue_mock.mock_calls[0][1][0], quiz_answered_notification
             )
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][2], string_types)
-            )
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][2], string_types)
 
     def test_update_assessment_session_create_hinted_attempt_succeeds(self):
         with patch("kolibri.core.logger.api.wrap_to_save_queue") as save_queue_mock:
@@ -2311,10 +2305,8 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
             self.assertEqual(
                 save_queue_mock.mock_calls[0][1][0], quiz_answered_notification
             )
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][2], string_types)
-            )
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][2], string_types)
 
     def test_update_session_absolute_progress_triggers_completion(self):
         with patch("kolibri.core.logger.api.wrap_to_save_queue") as save_queue_mock:
@@ -2339,10 +2331,8 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
             self.assertEqual(
                 save_queue_mock.mock_calls[0][1][0], quiz_completed_notification
             )
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], MasteryLog))
-            self.assertTrue(
-                isinstance(save_queue_mock.mock_calls[0][1][2], string_types)
-            )
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], MasteryLog)
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][2], string_types)
 
     def test_update_assessment_session_update_attempt_submitted_quiz_fails(self):
         timestamp = local_now()
@@ -2525,7 +2515,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentPracticeQuizTestCase
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], parse_attemptslog)
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
 
         self.assertEqual(response.status_code, 200)
         attempt_id = response.json().get("attempts", [{}])[0].get("id")
@@ -2582,7 +2572,7 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentPracticeQuizTestCase
             )
             save_queue_mock.assert_called()
             self.assertEqual(save_queue_mock.mock_calls[0][1][0], parse_attemptslog)
-            self.assertTrue(isinstance(save_queue_mock.mock_calls[0][1][1], AttemptLog))
+            self.assertIsInstance(save_queue_mock.mock_calls[0][1][1], AttemptLog)
 
         self.assertEqual(response.status_code, 200)
         attempt_id = response.json().get("attempts", [{}])[0].get("id")

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -70,7 +70,7 @@ class TestRegisteredTask(TestCase):
         self.assertEqual(self.registered_task.func, int)
         self.assertEqual(self.registered_task.validator, JobValidator)
         self.assertEqual(self.registered_task.priority, Priority.HIGH)
-        self.assertTrue(isinstance(self.registered_task.permissions[0], IsSuperAdmin))
+        self.assertIsInstance(self.registered_task.permissions[0], IsSuperAdmin)
         self.assertEqual(self.registered_task.job_id, "test")
         self.assertEqual(self.registered_task.queue, "test")
         self.assertEqual(self.registered_task.cancellable, True)

--- a/kolibri/core/test/test_key_urls.py
+++ b/kolibri/core/test/test_key_urls.py
@@ -216,13 +216,13 @@ class LogoutLanguagePersistenceTest(APITestCase):
         for lang_code in [lang[0] for lang in settings.LANGUAGES]:
             self.client.login(**self.credentials)
             response = self.client.post("/{}/logout".format(lang_code))
-            self.assertTrue(lang_code in response.url)
+            self.assertIn(lang_code, response.url)
 
     def test_default_language_without_namespaced_logout(self):
         # Test /logout without any in-path language code. Expect default language setting.
         self.client.login(**self.credentials)
         response = self.client.get("/logout")
-        self.assertTrue(get_settings_language() in response.url)
+        self.assertIn(get_settings_language(), response.url)
 
     def test_persistent_session_language_setting_on_logout(self):
         # Test when set on a session.
@@ -234,4 +234,4 @@ class LogoutLanguagePersistenceTest(APITestCase):
         session[LANGUAGE_SESSION_KEY] = test_lang
         session.save()
         response = self.client.post("/logout")
-        self.assertTrue(test_lang in response.url)
+        self.assertIn(test_lang, response.url)

--- a/kolibri/core/test/test_setlanguage.py
+++ b/kolibri/core/test/test_setlanguage.py
@@ -88,7 +88,7 @@ class I18NTests(TestCase):
             response.content.decode("utf-8"),
             translate_url(reverse("kolibri:core:redirect_user"), "en"),
         )
-        self.assertFalse(LANGUAGE_SESSION_KEY in self.client.session)
+        self.assertNotIn(LANGUAGE_SESSION_KEY, self.client.session)
 
     def test_setlang_null_next_valid(self):
         """
@@ -112,7 +112,7 @@ class I18NTests(TestCase):
             response.content.decode("utf-8"),
             translate_url(reverse("kolibri:kolibri.plugins.learn:learn"), "en"),
         )
-        self.assertFalse(LANGUAGE_SESSION_KEY in self.client.session)
+        self.assertNotIn(LANGUAGE_SESSION_KEY, self.client.session)
 
     def test_setlang_null_next_invalid(self):
         """
@@ -136,7 +136,7 @@ class I18NTests(TestCase):
             response.content.decode("utf-8"),
             translate_url(reverse("kolibri:core:redirect_user"), "en"),
         )
-        self.assertFalse(LANGUAGE_SESSION_KEY in self.client.session)
+        self.assertNotIn(LANGUAGE_SESSION_KEY, self.client.session)
 
     def test_setlang_get(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{2.7,3.6,3.7,3.8,3.9,3.10,3.11}, postgres
 
 [testenv]
 usedevelop = True
-whitelist_externals=
+allowlist_externals=
     rm
     make
     sh


### PR DESCRIPTION
## Summary
* Adds a pre-commit hook to ensure we use modern unittest `TestCase` methods, as they will be removed in Python 3.12
* Follows advice here: https://docs.python.org/3.12/whatsnew/3.12.html#removed

## Reviewer guidance
Do all tests still pass?
Does linting pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
