### PR TITLE
[Pdf_Viewer] Fix page height and width

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
@@ -87,12 +87,18 @@
         if (!this.pageReady) {
           return null;
         }
+        // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
+        // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
+        // coordinates, subtracting y2 - y1 gives the height of the page
         return this.pdfPage.view[3] - this.pdfPage.view[1];
       },
       actualWidth() {
         if (!this.pageReady) {
           return null;
         }
+        // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
+        // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
+        // coordinates, subtracting x2 - x1 gives the width of the page
         return this.pdfPage.view[2] - this.pdfPage.view[0];
       },
       heightToWidthRatio() {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
@@ -87,13 +87,13 @@
         if (!this.pageReady) {
           return null;
         }
-        return this.pdfPage.view[3];
+        return this.pdfPage.view[3] - this.pdfPage.view[1];
       },
       actualWidth() {
         if (!this.pageReady) {
           return null;
         }
-        return this.pdfPage.view[2];
+        return this.pdfPage.view[2] - this.pdfPage.view[0];
       },
       heightToWidthRatio() {
         return this.actualHeight / this.actualWidth || this.firstPageHeight / this.firstPageWidth;

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -244,8 +244,8 @@
         // Is either the first page or the saved last page visited
         const firstPageToRender = parseInt(this.getSavedPosition() * this.totalPages);
         return this.getPage(firstPageToRender + 1).then(firstPage => {
-          this.firstPageHeight = firstPage.view[3];
-          this.firstPageWidth = firstPage.view[2];
+          this.firstPageHeight = firstPage.view[3] - firstPage.view[1];
+          this.firstPageWidth = firstPage.view[2] - firstPage.view[0];
           const screenSizeMultiplier = this.windowIsLarge ? 1.25 : this.windowIsSmall ? 1 : 1.125;
           this.scale = this.elementWidth / (this.firstPageWidth * screenSizeMultiplier);
           // Set the firstPageToRender into the pdfPages object so that we do not refetch the page

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -244,8 +244,12 @@
         // Is either the first page or the saved last page visited
         const firstPageToRender = parseInt(this.getSavedPosition() * this.totalPages);
         return this.getPage(firstPageToRender + 1).then(firstPage => {
+          // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
+          // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
+          // coordinates, subtracting the two gives us the width and height of the visible page
           this.firstPageHeight = firstPage.view[3] - firstPage.view[1];
           this.firstPageWidth = firstPage.view[2] - firstPage.view[0];
+
           const screenSizeMultiplier = this.windowIsLarge ? 1.25 : this.windowIsSmall ? 1 : 1.125;
           this.scale = this.elementWidth / (this.firstPageWidth * screenSizeMultiplier);
           // Set the firstPageToRender into the pdfPages object so that we do not refetch the page


### PR DESCRIPTION
## Summary

Fix page height and width calculation. We used `page.view` array to get width and height of the page `view[2]` as width and `view[3]` as height. But investigating by the pdfjs code, the `page.view` object seems to be a viewBox array, that means that its values describe a slice value for the box that the page belongs. So `view[2]` and `view[3]` only worked for non-sliced pages as they describe the end of the width and height (with slicing starting at 0,0), but with sliced we need to consider the start of the slices which are in `view[0]` and `view[1]`.

Before:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/205269914-30a852c9-d545-43dc-aeb0-f0bdae2303b9.png">

After:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/205270159-79051997-bbb3-418f-acef-a46ec348b70b.png">

## References

Solves #5917  

## Reviewer guidance

Go to http://localhost:8000/en/learn/#/topics/c/6f7bd64fc9655bbf99122bc5df22fb9c which has cropped pages and check that all its pages are rendering with the proper width and height.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
