### PR TITLE
Properly set language direction as string rather than bidi boolean.

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -58,16 +58,7 @@ export let currentLanguage = defaultLocale;
 export let languageDirection = languageDirections.LTR;
 
 export function getLangDir(id) {
-  /*
-    The lang_direction property is returned as a boolean and not as a string.
-    The previous logic would fail for non strings thus the change to allow for both
-    string and non string to work as values of lang_direction.
-  */
-  let langDirection = (availableLanguages[id] || {}).lang_direction || languageDirections.LTR;
-  if (typeof langDirection !== 'string' && langDirection) {
-    langDirection = languageDirections.RTL;
-  }
-  return langDirection;
+  return (availableLanguages[id] || {}).lang_direction || languageDirections.LTR;
 }
 
 export function isRtl(id) {

--- a/kolibri/core/kolibri_plugin.py
+++ b/kolibri/core/kolibri_plugin.py
@@ -147,7 +147,7 @@ class FrontEndCoreAppAssetHook(WebpackBundleHook):
                 "english_name": lang_info["english_name"]
                 if lang_info
                 else get_language_info(code)["name"],
-                "lang_direction": get_language_info(code)["bidi"],
+                "lang_direction": "rtl" if get_language_info(code)["bidi"] else "ltr",
             }
         return {
             "coreLanguageMessages": self.frontend_messages(),


### PR DESCRIPTION
## Summary
* Corrects what seems to be a 5 year (maybe more) old bug that improperly sets the language_direction attribute onto the available languages object
* Probable that this does not get noticed previously because the `isRtl` Vue prototype method uses the top level `lang_dir` variable, rather than using the available languages.

## References
Fixes #9887

## Reviewer guidance
This reverts the previous update to the `getLangDir` function but should retain the same overall behaviour.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
