### PR TITLE
Pins ubuntu versions to ubuntu-20.04 for any task needing Python 2.7.

### DIFF
--- a/.github/workflows/build_pex.yml
+++ b/.github/workflows/build_pex.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build_pex:
     name: Build PEX
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       pex-file-name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
     steps:

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build_whl:
     name: Build WHL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       whl-file-name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
       tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}

--- a/.github/workflows/c_extensions.yml
+++ b/.github/workflows/c_extensions.yml
@@ -27,7 +27,7 @@ jobs:
     name: C Extensions
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -65,7 +65,7 @@ jobs:
     name: No C Extensions
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: '3.11'
     - name: pip cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   postgres:
     name: Python postgres unit tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
@@ -33,10 +33,10 @@ jobs:
           - 5432:5432
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6 for Postgres
+    - name: Set up Python 3.9 for Postgres
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Install tox
       run: |
         python -m pip install --upgrade pip
@@ -44,7 +44,7 @@ jobs:
     - name: tox env cache
       uses: actions/cache@v2
       with:
-        path: ${{ github.workspace }}/.tox/py3.6
-        key: ${{ runner.os }}-tox-py3.6-${{ hashFiles('requirements/*.txt') }}
+        path: ${{ github.workspace }}/.tox/py3.9
+        key: ${{ runner.os }}-tox-py3.9-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       run: tox -e postgres

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/python2lint.yml
+++ b/.github/workflows/python2lint.yml
@@ -27,7 +27,7 @@ jobs:
     name: Python 2 syntax checking
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 2.7

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -26,7 +26,7 @@ jobs:
   unit_test:
     name: Python unit tests
     needs: pre_job
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 5
       matrix:
@@ -78,11 +78,11 @@ jobs:
           - 5432:5432
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6 for Postgres
+    - name: Set up Python 3.9 for Postgres
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Install tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
@@ -92,8 +92,8 @@ jobs:
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v2
       with:
-        path: ${{ github.workspace }}/.tox/py3.6
-        key: ${{ runner.os }}-tox-py3.6-${{ hashFiles('requirements/*.txt') }}
+        path: ${{ github.workspace }}/.tox/py3.9
+        key: ${{ runner.os }}-tox-py3.9-${{ hashFiles('requirements/*.txt') }}
     - name: Test with tox
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e postgres

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,2 +1,2 @@
 # Additional reqs for running kolibri with a postgres db layer
-psycopg2==2.7.5
+psycopg2-binary==2.8.6

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     KOLIBRI_DATABASE_PORT = 5432
     KOLIBRI_RUN_MODE = tox
 basepython =
-    postgres: python3.6
+    postgres: python3.9
 deps =
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/base.txt


### PR DESCRIPTION
## Summary
`ubuntu-latest` is now `ubuntu-22.04`
The `setup/python` action does not have assets for Python 2.7 or 3.6 for Ubuntu 22.04
This pins any actions needing those two Python versions to 20.04, and upgrades Python 3.6 to 3.9 for postgres tests.