### PR TITLE
[PDF_Viewer] Support for rotated PDFs

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfPage.vue
@@ -84,35 +84,19 @@
       };
     },
     computed: {
-      actualHeight() {
-        if (!this.pageReady) {
-          return null;
-        }
-        // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
-        // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
-        // coordinates, subtracting y2 - y1 gives the height of the page
-        return this.pdfPage.view[3] - this.pdfPage.view[1];
-      },
-      actualWidth() {
-        if (!this.pageReady) {
-          return null;
-        }
-        // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
-        // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
-        // coordinates, subtracting x2 - x1 gives the width of the page
-        return this.pdfPage.view[2] - this.pdfPage.view[0];
-      },
-      heightToWidthRatio() {
-        return this.actualHeight / this.actualWidth || this.firstPageHeight / this.firstPageWidth;
-      },
       scaledHeight() {
-        return this.firstPageHeight * this.scale;
+        if (!this.pdfPage) {
+          return this.firstPageHeight * this.scale;
+        }
+        const viewport = this.getViewport();
+        return viewport.height;
       },
       scaledWidth() {
-        return this.scaledHeight / this.heightToWidthRatio;
-      },
-      pageScale() {
-        return this.scaledHeight / this.actualHeight || this.scale;
+        if (!this.pdfPage) {
+          return this.firstPageWidth * this.scale;
+        }
+        const viewport = this.getViewport();
+        return viewport.width;
       },
     },
     watch: {
@@ -132,7 +116,7 @@
     methods: {
       getViewport() {
         // Get viewport, which contains directions to be passed into render function
-        return this.pdfPage.getViewport({ scale: this.pageScale });
+        return this.pdfPage.getViewport({ scale: this.scale || 1 });
       },
       renderPage(newVal, oldVal) {
         if (typeof newVal === 'number' && typeof oldVal === 'number' && newVal !== oldVal) {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -281,11 +281,9 @@
         // Is either the first page or the saved last page visited
         const firstPageToRender = parseInt(this.getSavedPosition() * this.totalPages);
         return this.getPage(firstPageToRender + 1).then(firstPage => {
-          // page.view is a viewbox array of [x1, y1, x2, y2] coordinates where x1, y1 is the
-          // top left corner and x2, y2 is the bottom right corner of the visible page in PDF
-          // coordinates, subtracting the two gives us the width and height of the visible page
-          this.firstPageHeight = firstPage.view[3] - firstPage.view[1];
-          this.firstPageWidth = firstPage.view[2] - firstPage.view[0];
+          const viewPort = firstPage.getViewport({ scale: 1 });
+          this.firstPageHeight = viewPort.height;
+          this.firstPageWidth = viewPort.width;
 
           const screenSizeMultiplier = this.windowIsLarge ? 1.25 : this.windowIsSmall ? 1 : 1.125;
           this.scale = this.elementWidth / (this.firstPageWidth * screenSizeMultiplier);


### PR DESCRIPTION
## Summary

PDFs pages can be saved with a rotation value (0, 90, 180, 270). So the pages width/height values will also depend on its rotation. This PR delegates the task of calculating the width and height of the pages to the native PDFJs viewport object.

UI changes in a rotated pdf example:

**Before**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/206918455-4eb1043f-6bf2-4e74-a0cc-5531ad5218e8.png">

**After**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/206918425-235ab8fc-6589-447f-ab45-c6758cf04a2e.png">

## References

Closes #7759 

## Reviewer guidance

Go to SIB Level 5 (Grade 8) `kifaz-vifal` `channel > English > Language > Parts of speech: the noun > Introduction to nouns > Introduction to singular and plural nouns` which is an example of a PDF that has rotated pages and check that the pages are rendering Ok.

Also try any other PDF resources just to make sure it doesn't break non-rotated PDFs.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
