### PR TITLE
Reverts change that was disabling categories in Library Search.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -58,7 +58,8 @@
             :appearanceOverrides="isKeyActive(key)
               ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }
               : categoryListItemStyles"
-            :disabled="!availableRootCategories[key] &&
+            :disabled="availableRootCategories &&
+              !availableRootCategories[key] &&
               !isKeyActive(key)"
             :iconAfter="hasNestedCategories(category) ? 'chevronRight' : null"
             @click="handleCategory(category)"
@@ -275,7 +276,7 @@
           }
           return roots;
         }
-        return {};
+        return null;
       },
       availableNeeds() {
         if (this.availableLabels) {


### PR DESCRIPTION
## Summary
* Reverts change from #9230 that prevented categories from being properly displayed in the case where no search labels had been retrieved from the `useSearch` composable, because no search had been performed yet (i.e. at the root of the Library Page).

## References
Fixes #9893

## Reviewer guidance
On the base library page, categories should now display.

![image](https://user-images.githubusercontent.com/1680573/207180400-42fbd8d6-2d67-4577-9ad6-18a5e6437241.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
