### PR TITLE
Update Progress Tracking API and frontend composable to send complete context via API

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -86,29 +86,31 @@ class StartSessionSerializer(serializers.Serializer):
         if "node_id" not in data and "quiz_id" not in data:
             raise ValidationError("node_id is required if not a coach assigned quiz")
         if "node_id" in data:
-            errors = []
+            errors = {}
             if "kind" not in data:
-                errors.append(ValidationError("kind is required for any node_id"))
+                errors["kind"] = ValidationError("kind is required for any node_id")
             else:
                 if (
                     data["kind"] == content_kinds.EXERCISE
                     and "mastery_model" not in data
                 ):
-                    errors.append(
-                        ValidationError(
-                            "mastery model must be specified for exercise kinds"
-                        )
+                    errors["mastery_model"] = ValidationError(
+                        "mastery model must be specified for exercise kinds"
                     )
                 elif data["kind"] != content_kinds.EXERCISE and "mastery_model" in data:
-                    errors.append(
-                        ValidationError(
-                            "mastery model must not be specified for non-exercise kinds"
-                        )
+                    errors["mastery_model"] = ValidationError(
+                        "mastery model must not be specified for non-exercise kinds"
                     )
             if "content_id" not in data:
-                errors.append(ValidationError("content_id is required for any node_id"))
+                errors["content_id"] = ValidationError(
+                    "content_id is required for any node_id"
+                )
             if "channel_id" not in data:
-                errors.append(ValidationError("channel_id is required for any node_id"))
+                errors["channel_id"] = ValidationError(
+                    "channel_id is required for any node_id"
+                )
+            if errors:
+                raise ValidationError(errors)
         return data
 
 

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -6,9 +6,7 @@ from random import randint
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import IntegerField
-from django.db.models import OuterRef
 from django.db.models import Q
-from django.db.models import Subquery
 from django.db.models import Sum
 from django.db.models import Value
 from django.db.models.functions import Coalesce
@@ -21,7 +19,6 @@ from django_filters.rest_framework import NumberFilter
 from django_filters.rest_framework import UUIDFilter
 from le_utils.constants import content_kinds
 from le_utils.constants import exercises
-from le_utils.constants import modalities
 from rest_framework import serializers
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -37,8 +34,6 @@ from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
 from kolibri.core.auth.models import dataset_cache
 from kolibri.core.content.api import OptionalPageNumberPagination
-from kolibri.core.content.models import AssessmentMetaData
-from kolibri.core.content.models import ContentNode
 from kolibri.core.decorators import query_params_required
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
@@ -67,9 +62,19 @@ class HexStringUUIDField(serializers.UUIDField):
         return super(HexStringUUIDField, self).to_internal_value(data).hex
 
 
+class MasteryModelSerializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=exercises.MASTERY_MODELS)
+    m = serializers.IntegerField(required=False)
+    n = serializers.IntegerField(required=False)
+
+
 class StartSessionSerializer(serializers.Serializer):
     lesson_id = HexStringUUIDField(required=False)
     node_id = HexStringUUIDField(required=False)
+    content_id = HexStringUUIDField(required=False)
+    channel_id = HexStringUUIDField(required=False)
+    kind = serializers.ChoiceField(choices=content_kinds.choices, required=False)
+    mastery_model = MasteryModelSerializer(required=False)
     # Do this as a special way of handling our coach generated quizzes
     quiz_id = HexStringUUIDField(required=False)
     # A flag to indicate whether to start the session over again
@@ -80,6 +85,30 @@ class StartSessionSerializer(serializers.Serializer):
             raise ValidationError("quiz_id must not be mixed with other context")
         if "node_id" not in data and "quiz_id" not in data:
             raise ValidationError("node_id is required if not a coach assigned quiz")
+        if "node_id" in data:
+            errors = []
+            if "kind" not in data:
+                errors.append(ValidationError("kind is required for any node_id"))
+            else:
+                if (
+                    data["kind"] == content_kinds.EXERCISE
+                    and "mastery_model" not in data
+                ):
+                    errors.append(
+                        ValidationError(
+                            "mastery model must be specified for exercise kinds"
+                        )
+                    )
+                elif data["kind"] != content_kinds.EXERCISE and "mastery_model" in data:
+                    errors.append(
+                        ValidationError(
+                            "mastery model must not be specified for non-exercise kinds"
+                        )
+                    )
+            if "content_id" not in data:
+                errors.append(ValidationError("content_id is required for any node_id"))
+            if "channel_id" not in data:
+                errors.append(ValidationError("channel_id is required for any node_id"))
         return data
 
 
@@ -228,35 +257,14 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
         context = LogContext()
 
         if node_id is not None:
-            try:
-                node = (
-                    ContentNode.objects.annotate(
-                        mastery_model=Subquery(
-                            AssessmentMetaData.objects.filter(
-                                contentnode_id=OuterRef("id")
-                            ).values_list("mastery_model", flat=True)[:1]
-                        )
-                    )
-                    .values(
-                        "content_id", "channel_id", "kind", "mastery_model", "options"
-                    )
-                    .get(id=node_id)
-                )
-                mastery_model = node["mastery_model"]
-                content_id = node["content_id"]
-                channel_id = node["channel_id"]
-                kind = node["kind"]
-                context["node_id"] = node_id
-                if lesson_id:
-                    self._check_lesson_permissions(user, lesson_id)
-                    context["lesson_id"] = lesson_id
-                if (
-                    node["options"]
-                    and node["options"].get("modality") == modalities.QUIZ
-                ):
-                    mastery_model = {"type": exercises.QUIZ}
-            except ContentNode.DoesNotExist:
-                raise ValidationError("Invalid node_id")
+            mastery_model = validated_data.get("mastery_model")
+            content_id = validated_data.get("content_id")
+            channel_id = validated_data.get("channel_id")
+            kind = validated_data.get("kind")
+            context["node_id"] = node_id
+            if lesson_id:
+                self._check_lesson_permissions(user, lesson_id)
+                context["lesson_id"] = lesson_id
         elif quiz_id is not None:
             self._check_quiz_permissions(user, quiz_id)
             mastery_model = {"type": exercises.QUIZ, "coach_assigned": True}

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -84,6 +84,9 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
     def _make_request(self, data):
         post_data = {
             "node_id": self.node.id,
+            "content_id": self.node.content_id,
+            "channel_id": self.node.channel_id,
+            "kind": self.node.kind,
         }
         post_data.update(data)
         return self.client.post(
@@ -218,7 +221,11 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
             password=DUMMY_PASSWORD,
             facility=self.facility,
         )
-        response = self._make_request({})
+        response = self._make_request(
+            {
+                "mastery_model": mastery_model,
+            }
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["mastery_criterion"], mastery_model)
@@ -377,7 +384,11 @@ class ProgressTrackingViewSetStartSessionFreshTestCase(APITestCase):
             password=DUMMY_PASSWORD,
             facility=self.facility,
         )
-        response = self._make_request({})
+        response = self._make_request(
+            {
+                "mastery_model": {"type": exercises.QUIZ},
+            }
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["mastery_criterion"], {"type": exercises.QUIZ})
@@ -449,7 +460,12 @@ class ProgressTrackingViewSetStartSessionResumeTestCase(APITestCase):
         )
 
     def _make_request(self, data):
-        post_data = {"node_id": self.node.id}
+        post_data = {
+            "node_id": self.node.id,
+            "content_id": self.node.content_id,
+            "channel_id": self.node.channel_id,
+            "kind": self.node.kind,
+        }
         post_data.update(data)
         return self.client.post(
             reverse("kolibri:core:trackprogress-list"),
@@ -548,7 +564,13 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
         )
 
     def _make_request(self, data):
-        post_data = {"node_id": self.node.id}
+        post_data = {
+            "node_id": self.node.id,
+            "content_id": self.node.content_id,
+            "channel_id": self.node.channel_id,
+            "kind": self.node.kind,
+            "mastery_model": self.assessmentmetadata.mastery_model,
+        }
         post_data.update(data)
         return self.client.post(
             reverse("kolibri:core:trackprogress-list"),
@@ -596,7 +618,11 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
         self.mastery_log.mastery_level = -10
         self.mastery_log.mastery_criterion = {"type": exercises.QUIZ}
         self.mastery_log.save()
-        response = self._make_request({})
+        response = self._make_request(
+            {
+                "mastery_model": {"type": exercises.QUIZ},
+            }
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["mastery_criterion"], {"type": exercises.QUIZ})
@@ -653,7 +679,7 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
         self.mastery_log.mastery_criterion = {"type": exercises.QUIZ}
         self.mastery_log.complete = True
         self.mastery_log.save()
-        response = self._make_request({})
+        response = self._make_request({"mastery_model": {"type": exercises.QUIZ}})
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MasteryLog.objects.all().count(), 1)
@@ -698,6 +724,7 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
         self.mastery_log.save()
         response = self._make_request(
             {
+                "mastery_model": {"type": exercises.QUIZ},
                 "repeat": True,
             }
         )
@@ -809,7 +836,7 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
                 answer=interaction["answer"],
                 interaction_history=[interaction],
             )
-        response = self._make_request({})
+        response = self._make_request({"mastery_model": {"type": exercises.QUIZ}})
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["totalattempts"], 15)
@@ -861,7 +888,7 @@ class ProgressTrackingViewSetStartSessionAssessmentResumeTestCase(APITestCase):
                 answer=interaction["answer"],
                 interaction_history=[interaction],
             )
-        response = self._make_request({})
+        response = self._make_request({"mastery_model": {"type": exercises.QUIZ}})
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["totalattempts"], 15)

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -133,9 +133,6 @@
           totalattempts: this.totalattempts,
         };
       },
-      contentNodeId() {
-        return this.contentNode.id;
-      },
       assessment() {
         if (this.contentNode.kind !== ContentNodeKinds.EXERCISE) {
           return null;
@@ -146,7 +143,7 @@
     },
     created() {
       return this.initContentSession({
-        nodeId: this.contentNodeId,
+        node: this.contentNode,
       }).then(() => {
         this.sessionReady = true;
         this.setWasIncomplete();

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -285,7 +285,7 @@
         this.hideMarkAsCompleteModal();
         this.sessionReady = false;
         return this.initContentSession({
-          nodeId: this.content.id,
+          node: this.content,
           lessonId: this.lessonId,
           repeat,
         }).then(() => {


### PR DESCRIPTION
## Summary
* Updates the progress tracking API to take all context data from the frontend API call rather than relying on reading from the database
* Does this to allow progress tracking for resources that are not locally present (i.e. for remote browsing)
* Updates the frontend composable that communicates with the backend to handle this
* Updates all uses of the frontend composable that pass nodeId to instead pass a whole node object to give all the metadata

## References
Fixes #9892

## Reviewer guidance
Confirm that progress tracking still works as intended.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
