### PR TITLE
[ImmersivePage] Fix content padding

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
+++ b/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
@@ -1,20 +1,24 @@
 <template>
 
-  <div :style="wrapperStyles">
-    <ImmersiveToolbar
-      ref="appBar"
-      :appBarTitle="(!loading ? appBarTitle : '')"
-      :route="route"
-      :icon="icon"
-      :isFullscreen="primary"
-    />
-    <slot></slot>
-    <KLinearLoader
-      v-if="loading"
-      class="loader"
-      type="indeterminate"
-      :delay="false"
-    />
+  <div class="main">
+    <ScrollingHeader :scrollPosition="0">
+      <ImmersiveToolbar
+        ref="appBar"
+        :appBarTitle="(!loading ? appBarTitle : '')"
+        :route="route"
+        :icon="icon"
+        :isFullscreen="primary"
+      />
+      <KLinearLoader
+        v-if="loading"
+        class="loader"
+        type="indeterminate"
+        :delay="false"
+      />
+    </ScrollingHeader>
+    <div class="main-wrapper" :style="wrapperStyles">
+      <slot></slot>
+    </div>
   </div>
 
 </template>
@@ -22,11 +26,12 @@
 
 <script>
 
+  import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import ImmersiveToolbar from '../ImmersiveToolbar';
 
   export default {
     name: 'ImmersivePage',
-    components: { ImmersiveToolbar },
+    components: { ImmersiveToolbar, ScrollingHeader },
     props: {
       appBarTitle: {
         type: String,

--- a/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
+++ b/kolibri/core/assets/src/views/CorePage/ImmersivePage.vue
@@ -11,7 +11,6 @@
       />
       <KLinearLoader
         v-if="loading"
-        class="loader"
         type="indeterminate"
         :delay="false"
       />
@@ -88,15 +87,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  .loader {
-    position: fixed;
-    top: 64px;
-    right: 0;
-    left: 0;
-  }
-
-</style>

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -8,11 +8,6 @@
       :showIcon="showIcon"
       :style="{
         height: topBarHeight + 'px',
-        position: 'fixed',
-        zIndex: 4,
-        top: 0,
-        right: 0,
-        left: 0,
         backgroundColor: isFullscreen ? $themeTokens.appBar : $themeTokens.appBarFullscreen,
       }"
       @nav-icon-click="$emit('navIconClick')"


### PR DESCRIPTION
## Summary

The main content padding-top of pages using ImmersivePage were being miscalculated because `ImmersivePage` could not detect the correct height of the appBar, this because `ImmersivePage`'s appbar (`ImmersiveToolbar`) had position: fixed, and its `clientHeight` was 0. So this PR delegates the element positioning to the `ScrollingHeader` component to help correctly calculate the height of the appBar on immersive pages.

**Before**
![image](https://user-images.githubusercontent.com/51239030/207474817-a5118b49-3bea-4ae9-8998-6a2f2906414d.png)


**After**
![image](https://user-images.githubusercontent.com/51239030/207474720-c5219ddf-9727-48fb-bf59-165df74ab949.png)

## References

Closes #9905

## Reviewer guidance

Go to any Immersive page like Add User in Facility section, or Manage Content in Device section, and check that the appbar doesn't overlap the main content.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
