### PR TITLE
Implement folder skip logic to avoid navigation down single child folders

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -940,27 +940,46 @@ class TreeQueryMixin(object):
 
         return depth, next__gt
 
+    def _get_gc_by_parent(self, child_ids):
+        # Use this to keep track of how many grand children we have accumulated per child of the parent node
+        gc_by_parent = {}
+        # Iterate through the grand children of the parent node in lft order so we follow the tree traversal order
+        for gc in (
+            self.filter_queryset(self.get_queryset())
+            .filter(parent_id__in=child_ids)
+            .values("id", "parent_id")
+            .order_by("lft")
+        ):
+            # If we have not already added a list of nodes to the gc_by_parent map, initialize it here
+            if gc["parent_id"] not in gc_by_parent:
+                gc_by_parent[gc["parent_id"]] = []
+            gc_by_parent[gc["parent_id"]].append(gc["id"])
+        return gc_by_parent
+
     def get_grandchild_ids(self, child_ids, depth, page_size):
+        grandchild_ids = []
         if depth == 2:
             # Use this to keep track of how many grand children we have accumulated per child of the parent node
-            gc_by_parent = {}
-            # Iterate through the grand children of the parent node in lft order so we follow the tree traversal order
-            for gc in (
-                self.filter_queryset(self.get_queryset())
-                .filter(parent_id__in=child_ids)
-                .values("id", "parent_id")
-                .order_by("lft")
-            ):
-                # If we have not already added a list of nodes to the gc_by_parent map, initialize it here
-                if gc["parent_id"] not in gc_by_parent:
-                    gc_by_parent[gc["parent_id"]] = []
-                # If the number of grand children for a specific child node is less than the page size
-                # then we keep on adding them to both lists
-                # If not, we just skip this node, as we have already hit the page limit for the node that is
-                # its parent.
-                if len(gc_by_parent[gc["parent_id"]]) < page_size:
-                    gc_by_parent[gc["parent_id"]].append(gc["id"])
-                    yield gc["id"]
+            gc_by_parent = self._get_gc_by_parent(child_ids)
+            singletons = []
+            for child_id in gc_by_parent:
+                gc_ids = gc_by_parent[child_id]
+                if len(gc_ids) == 1:
+                    singletons.append(gc_ids[0])
+                # Only add up to the page size to the list
+                grandchild_ids.extend(gc_ids[:page_size])
+            if singletons:
+                grandchild_ids.extend(
+                    self.get_grandchild_ids(singletons, depth, page_size)
+                )
+        return grandchild_ids
+
+    def get_child_ids(self, parent_id, next__gt):
+        # Get a list of child_ids of the parent node up to the pagination limit
+        child_qs = self.get_queryset().filter(parent_id=parent_id)
+        if next__gt is not None:
+            child_qs = child_qs.filter(lft__gt=next__gt)
+        return child_qs.values_list("id", flat=True).order_by("lft")[0:NUM_CHILDREN]
 
     def get_tree_queryset(self, request, pk):
         # Get the model for the parent node here - we do this so that we trigger a 404 immediately if the node
@@ -975,18 +994,21 @@ class TreeQueryMixin(object):
             raise Http404
         depth, next__gt = self.validate_and_return_params(request)
 
-        # Get a list of child_ids of the parent node up to the pagination limit
-        child_qs = self.get_queryset().filter(parent_id=parent_id)
-        if next__gt is not None:
-            child_qs = child_qs.filter(lft__gt=next__gt)
-        child_ids = child_qs.values_list("id", flat=True).order_by("lft")[
-            0:NUM_CHILDREN
-        ]
+        child_ids = self.get_child_ids(parent_id, next__gt)
+
+        ancestor_ids = []
+
+        while next__gt is None and len(child_ids) == 1:
+            ancestor_ids.extend(child_ids)
+            child_ids = self.get_child_ids(child_ids[0], next__gt)
 
         # Get a flat list of ids for grandchildren we will be returning
         gc_ids = self.get_grandchild_ids(child_ids, depth, NUM_GRANDCHILDREN_PER_CHILD)
         return self.filter_queryset(self.get_queryset()).filter(
-            Q(id=parent_id) | Q(id__in=child_ids) | Q(id__in=gc_ids)
+            Q(id=parent_id)
+            | Q(id__in=ancestor_ids)
+            | Q(id__in=child_ids)
+            | Q(id__in=gc_ids)
         )
 
 
@@ -1026,19 +1048,19 @@ class BaseContentNodeTreeViewset(
         # The serialized parent representation is the first node in the lft order
         parent = nodes[0]
 
-        # Use this to keep track of direct children of the parent node
-        # this will allow us to do lookups for the grandchildren, in order
+        # Use this to keep track of descendants of the parent node
+        # this will allow us to do lookups for any further descendants, in order
         # to insert them into the "children" property
-        children_by_id = {}
+        descendants_by_id = {}
 
         # Iterate through all the descendants that we have serialized
         for desc in nodes[1:]:
+            # Add them to the descendants_by_id map so that
+            # descendants can reference them later
+            descendants_by_id[desc["id"]] = desc
             # First check to see whether it is a direct child of the
             # parent node that we initially queried
             if desc["parent"] == pk:
-                # If so add them to the children_by_id map so that
-                # grandchildren descendants can reference them later
-                children_by_id[desc["id"]] = desc
                 # The parent of this descendant is the parent node
                 # for this query
                 desc_parent = parent
@@ -1048,11 +1070,11 @@ class BaseContentNodeTreeViewset(
                 # For the parent node the page size is the maximum number of children
                 # we are returning (regardless of whether they have a full representation)
                 page_size = NUM_CHILDREN
-            elif desc["parent"] in children_by_id:
+            elif desc["parent"] in descendants_by_id:
                 # Otherwise, check to see if our descendant's parent is in the
-                # children_by_id map - if it failed the first condition,
+                # descendants_by_id map - if it failed the first condition,
                 # it really should not fail this
-                desc_parent = children_by_id[desc["parent"]]
+                desc_parent = descendants_by_id[desc["parent"]]
                 # When we request more results for pagination, we only want to return
                 # nodes at this level, and not any of its children
                 more_depth = 1

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -962,6 +962,10 @@ class TreeQueryMixin(object):
             # Use this to keep track of how many grand children we have accumulated per child of the parent node
             gc_by_parent = self._get_gc_by_parent(child_ids)
             singletons = []
+            # Now loop through each of the child_ids we passed in
+            # that have any children, check if any of them have only one
+            # child, and also add up to the page size to the list of
+            # grandchild_ids.
             for child_id in gc_by_parent:
                 gc_ids = gc_by_parent[child_id]
                 if len(gc_ids) == 1:

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -66,7 +66,7 @@ export function showTopicsTopic(store, { id, pageName, query }) {
           }
           let children = topic.children.results || [];
           // If there is only one child, and that child is a topic, then display that instead
-          if (children.length === 1 && !children[0].is_leaf) {
+          while (children.length === 1 && !children[0].is_leaf) {
             topic = children[0];
             children = topic.children.results || [];
           }

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -64,7 +64,12 @@ export function showTopicsTopic(store, { id, pageName, query }) {
             topic.tagline = currentChannel.tagline;
             topic.thumbnail = currentChannel.thumbnail;
           }
-          const children = topic.children.results || [];
+          let children = topic.children.results || [];
+          // If there is only one child, and that child is a topic, then display that instead
+          if (children.length === 1 && !children[0].is_leaf) {
+            topic = children[0];
+            children = topic.children.results || [];
+          }
 
           // if there are no children which are not leaf nodes (i.e. they have children themselves)
           // then redirect to search results

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -37,6 +37,7 @@ export function showTopicsContent(store, id) {
 }
 
 export function showTopicsTopic(store, { id, pageName, query }) {
+  const skip = query && query.skip === 'true';
   return store.dispatch('loading').then(() => {
     store.commit('SET_PAGE_NAME', pageName);
     const params = {
@@ -65,10 +66,13 @@ export function showTopicsTopic(store, { id, pageName, query }) {
             topic.thumbnail = currentChannel.thumbnail;
           }
           let children = topic.children.results || [];
+          let skipped = false;
           // If there is only one child, and that child is a topic, then display that instead
-          while (children.length === 1 && !children[0].is_leaf) {
+          while (skip && children.length === 1 && !children[0].is_leaf) {
             topic = children[0];
             children = topic.children.results || [];
+            skipped = true;
+            id = topic.id;
           }
 
           // if there are no children which are not leaf nodes (i.e. they have children themselves)
@@ -76,6 +80,8 @@ export function showTopicsTopic(store, { id, pageName, query }) {
           if (!children.some(c => !c.is_leaf) && pageName !== PageNames.TOPICS_TOPIC_SEARCH) {
             router.replace({ name: PageNames.TOPICS_TOPIC_SEARCH, params: { id }, query });
             store.commit('SET_PAGE_NAME', PageNames.TOPICS_TOPIC_SEARCH);
+          } else if (skipped) {
+            router.replace({ name: pageName, params: { id }, query });
           }
 
           store.commit('topicsTree/SET_STATE', {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -3,6 +3,17 @@
   <div>
     <!-- header link to folder -->
     <h2>
+      <template v-for="prefixTitle in (topic.prefixTitles || [])">
+        <span :key="prefixTitle" :style="{ color: $themeTokens.annotation }">
+          {{ prefixTitle }}
+        </span>
+        <KIcon
+          :key="prefixTitle"
+          icon="chevronRight"
+          :color="$themeTokens.annotation"
+          :style="{ top: '4px' }"
+        />
+      </template>
       <KRouterLink
         :text="topic.title"
         :to="genContentLinkKeepCurrentBackLink(topic.id, false)"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -8,7 +8,7 @@
           {{ prefixTitle }}
         </span>
         <KIcon
-          :key="prefixTitle"
+          :key="topic.title + prefixTitle"
           icon="chevronRight"
           :color="$themeTokens.annotation"
           :style="{ top: '4px' }"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -264,6 +264,7 @@
 
   import { mapActions, mapState } from 'vuex';
   import isEqual from 'lodash/isEqual';
+  import set from 'lodash/set';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
   import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
@@ -395,17 +396,18 @@
           return [];
         }
         return [
-          ...this.topic.ancestors.map(({ title, id }, index) => ({
-            // Use the channel name just in case the root node does not have a title.
-            text: index === 0 ? this.channelTitle : title,
-            // If we are operating under skip logic, then we could already be on the page
-            // for one of the ancestors, in that case, do not include a link to avoid
-            // a redundant link.
-            link:
-              id === this.$route.params.id
-                ? null
-                : this.genContentLinkKeepCurrentBackLink(id, false),
-          })),
+          ...this.topic.ancestors.map(({ title, id }, index) => {
+            const link = this.genContentLinkKeepCurrentBackLink(id, false);
+            // To allow navigating to a specific topic under the breadcrumb
+            // without following the normal skip logic, add a special query
+            // parameter to signal that we do not want to skip.
+            set(link, ['query', 'skip'], 'false');
+            return {
+              // Use the channel name just in case the root node does not have a title.
+              text: index === 0 ? this.channelTitle : title,
+              link,
+            };
+          }),
           { text: this.topic.ancestors.length ? this.topic.title : this.channelTitle },
         ];
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -456,7 +456,7 @@
           .filter(content => content.kind === ContentNodeKinds.TOPIC)
           .filter(t => t.children && t.children.results.length)
           .map(t => {
-            let topicChildren = t.children ? t.children.results : [];
+            let topicChildren = t.children.results;
             const prefixTitles = [];
             while (topicChildren.length === 1 && !topicChildren[0].is_leaf) {
               // If the topic has only one child, and that child is also a topic

--- a/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
@@ -138,7 +138,28 @@ describe('TopicsPage', () => {
   describe('showing cards', () => {
     let wrapper;
     beforeEach(() => {
-      store.state.topicsTree.contents = [{ kind: ContentNodeKinds.TOPIC }];
+      store.state.topicsTree.contents = [
+        {
+          kind: ContentNodeKinds.TOPIC,
+          is_leaf: false,
+          children: {
+            results: [
+              { kind: ContentNodeKinds.VIDEO, is_leaf: true },
+              { kind: ContentNodeKinds.VIDEO, is_leaf: true },
+            ],
+          },
+        },
+        {
+          kind: ContentNodeKinds.TOPIC,
+          is_leaf: false,
+          children: {
+            results: [
+              { kind: ContentNodeKinds.VIDEO, is_leaf: true },
+              { kind: ContentNodeKinds.VIDEO, is_leaf: true },
+            ],
+          },
+        },
+      ];
       wrapper = shallowMount(TopicsPage, {
         store: store,
         localVue,

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8036,9 +8036,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#d24d3d590c6fe82ca8c475c722511ed9410a1da4"
+  resolved "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary
* Updates the backend topic tree endpoint to allow recursive filling out of tree data in the case where there is only a single descendant
* Updates tests
* Updates the frontend to skip topics retrieved from the backend when they only have a single topic child and recurse through the descendants until it finds either multiple topic children or a resource

## References
Fixes #9860

## Reviewer guidance
Import a resource in a channel with some nested paths, with only 1 available resource in a deeply nested folder.
Import multiple resources in the deeply nested path.
Remove one resource, and import another in a parallel nested path.

Breadcrumb link is no longer disabled when showing '3rd grade' but skipping to the child folder, but rather has a `noSkip` query parameter to allow navigation to avoid the skipping:
![Screenshot from 2022-12-14 18-17-59](https://user-images.githubusercontent.com/1680573/207758683-78816017-3fbc-4af6-840f-a962e73fa06a.png)

Collapsed child folders within a parent:
![Screenshot from 2022-12-14 18-18-12](https://user-images.githubusercontent.com/1680573/207758841-3a8bfce9-7062-46fa-aa7e-4db0b08f311a.png)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [x] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
