### PR TITLE
Remove reference to no longer existing and helper.

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/useSavedAddresses.js
@@ -1,5 +1,5 @@
 import { ref, computed, onBeforeMount } from 'kolibri.lib.vueCompositionApi';
-import { get, set, and } from '@vueuse/core';
+import { get, set } from '@vueuse/core';
 import { deleteAddress, fetchStaticAddresses } from './api';
 
 const Stages = Object.freeze({
@@ -81,7 +81,7 @@ export default function useSavedAddresses(props, context) {
   });
 
   const requestsFailed = computed(() => {
-    return and(fetchingFailed, deletingFailed);
+    return get(fetchingFailed) && get(deletingFailed);
   });
 
   return {


### PR DESCRIPTION
## Summary
 *Upgrading @vueuse/core meant that the `and` helper we were referencing was migrated to `@vueuse/math` and renamed as `logicAnd`
* Rather than install a whole other package for this one helper, this replaces the single instance of it

