### PR TITLE
Ports remaining 0.15 fixes from corebase to AppBarPage to ensure focusTrap works correctly

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/index.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div tabindex="0" @keyup.esc="$emit('close')">
+  <div @keyup.esc="$emit('close')">
     <ul
       role="menu"
       class="ui-menu"

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -132,9 +132,7 @@
     methods: {
       findFirstEl() {
         this.$nextTick(() => {
-          if (this.navShown) {
-            this.$refs.menuNav.focusFirstEl();
-          }
+          this.$refs.sideNav.focusFirstEl();
         });
       },
     },


### PR DESCRIPTION
## Summary
Due to the corebase refactor + focusTrap fixes in 0.15, a few lines of code were lost in the shuffle, preventing the focusTrap from being a closed loop on the SideNav. This adds the missing listener and function.


## Reviewer guidance
Using tab, does focus now stay trapped in the side nav once it is opened?
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
