### PR TITLE
Restore task types that had been deleted

### DIFF
--- a/kolibri/core/assets/src/utils/syncTaskUtils.js
+++ b/kolibri/core/assets/src/utils/syncTaskUtils.js
@@ -19,6 +19,10 @@ export const TaskTypes = {
   SYNCPEERFULL: 'kolibri.core.auth.tasks.peerfacilitysync',
   SYNCPEERPULL: 'kolibri.core.auth.tasks.peerfacilityimport',
   DELETEFACILITY: 'kolibri.core.auth.tasks.deletefacility',
+  EXPORTSESSIONLOGCSV: 'kolibri.core.logger.tasks.exportsessionlogcsv',
+  EXPORTSUMMARYLOGCSV: 'kolibri.core.logger.tasks.exportsummarylogcsv',
+  IMPORTUSERSFROMCSV: 'kolibri.core.auth.tasks.importusersfromcsv',
+  EXPORTUSERSTOCSV: 'kolibri.core.auth.tasks.exportuserstocsv',
 };
 
 // identical to facility constants.js


### PR DESCRIPTION
## Summary
In a [refactoring made in June ](https://github.com/learningequality/kolibri/pull/9534) some tasktypes had been deleted. They are needed to export facility data.
This PR restores them

## References
Closes #9933

## Reviewer guidance
Check problems described in #9933 are fixed @pcenov 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
