### PR TITLE
Do not set as readonly a property of a reactive object

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/ClassDeleteModal.vue
@@ -17,7 +17,6 @@
 
 <script>
 
-  import { readonly } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useDeleteClass from './useDeleteClass';
 
@@ -28,7 +27,7 @@
       const { deleteSelectedClassModel } = useDeleteClass(props.classToDelete);
       const { name } = props.classToDelete;
       return {
-        className: readonly(name),
+        className: name,
         deleteSelectedClassModel,
       };
     },


### PR DESCRIPTION
## Summary
Deleting a class was failing, as described in #9935.
The problem was in the frontend as one of the attributes of the class was being marked as readonly. This was breaking the reacivity of the whole class object.

This PR solves the problem

## References
Closes #9935 

## Reviewer guidance
Check the problem described in #9935 is fixed @pcenov 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
