### PR TITLE
theme links in navbar fixed

### DIFF
--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -71,7 +71,7 @@
       },
       activeClasses() {
         // return both fixed and dynamic classes
-        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
+        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.textInverted })}`;
       },
     },
   };

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -71,7 +71,9 @@
       },
       activeClasses() {
         // return both fixed and dynamic classes
-        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.textInverted })}`;
+        return `router-link-active ${this.$computedClass({
+          color: this.$themeTokens.textInverted,
+        })}`;
       },
     },
   };

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -2,6 +2,7 @@
 
   <li class="list-item-navigation visible">
     <router-link
+      :active="isActive"
       class="tab"
       :class="$computedClass(tabStyles)"
       :style="windowIsSmall ? smallScreenOverrides : {}"
@@ -51,7 +52,8 @@
     computed: {
       tabStyles() {
         return {
-          color: this.$themePalette.grey.v_50,
+          color:this.isActive? this.$themeTokens.textInverted: this.$themePalette.grey.v_50,
+          'border-bottom-color':this.isActive? this.$themeTokens.textInverted: 'none',
           ':hover': {
             'background-color': this.$themeTokens.appBarDark,
           },
@@ -67,6 +69,9 @@
           fontSize: '14px',
           borderBottomWidth: '2px',
         };
+      },
+      isActive() { 
+        return this.$route.path === `/${this.link.name.toLowerCase()}`;
       },
     },
   };
@@ -116,8 +121,6 @@
   //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
     font-weight: bold;
-    color: white;
-    border-bottom-color: white;
     border-bottom-style: solid;
     border-bottom-width: 4px;
 

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -1,15 +1,20 @@
 <template>
 
-  <li class="list-item-navigation visible">
+  <li class="list-item">
     <router-link
-      :active="isActive"
       class="tab"
       :class="$computedClass(tabStyles)"
-      :style="windowIsSmall ? smallScreenOverrides : {}"
       :to="link"
+      :activeClass="activeClasses"
     >
       <div class="dimmable tab-icon">
-        <slot></slot>
+        <UiIcon
+          class="icon"
+          tabindex="-1"
+        >
+          <!--The icon svg-->
+          <slot></slot>
+        </UiIcon>
       </div>
 
       <div class="dimmable tab-title" tabindex="-1">
@@ -22,16 +27,14 @@
 
 
 <script>
-
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-
+  import UiIcon from 'kolibri-design-system/lib/keen/UiIcon';
   /**
    Links for use inside the Navbar
    */
   export default {
     name: 'NavbarLink',
-    mixins: [responsiveWindowMixin],
+    components: { UiIcon },
     props: {
       /**
        * The text
@@ -52,8 +55,7 @@
     computed: {
       tabStyles() {
         return {
-          color:this.isActive? this.$themeTokens.textInverted: this.$themePalette.grey.v_50,
-          'border-bottom-color':this.isActive? this.$themeTokens.textInverted: 'none',
+          color: this.$themePalette.grey.v_100,
           ':hover': {
             'background-color': this.$themeTokens.appBarDark,
           },
@@ -63,42 +65,27 @@
           },
         };
       },
-      smallScreenOverrides() {
-        return {
-          padding: '0 8px',
-          fontSize: '14px',
-          borderBottomWidth: '2px',
-        };
-      },
-      isActive() { 
-        return this.$route.path === `/${this.link.name.toLowerCase()}`;
+      activeClasses() {
+        // return both fixed and dynamic classes
+        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.textInverted })}`;
       },
     },
   };
-
 </script>
 
 
 <style lang="scss" scoped>
-
   @import '~kolibri-design-system/lib/styles/definitions';
-
-  .list-item-navigation {
+  .list-item {
     display: inline-block;
     text-align: center;
-    visibility: hidden;
   }
-
-  .visible {
-    visibility: visible;
-  }
-
   .tab {
     display: inline-block;
     min-width: 72px;
     max-width: 264px;
-    padding: 0 16px;
-    padding-bottom: 6px;
+    padding: 0 18px;
+    padding-bottom: 3px;
     margin: 0;
     font-size: 14px;
     text-decoration: none;
@@ -107,12 +94,10 @@
     border-top-left-radius: $radius;
     border-top-right-radius: $radius;
     transition: background-color $core-time ease;
-
     .dimmable {
-      opacity: 1;
+      opacity: 0.6;
     }
   }
-
   // Getting this class to work correctly with our theme system is not currently
   // possible. Some options:
   //  1. Update vueAphrodite to handle nested classes (to handle .dimmable)
@@ -120,33 +105,26 @@
   //     https://github.com/vuejs/rfcs/pull/34
   //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
-    font-weight: bold;
+    padding-bottom: 2px;
     border-bottom-style: solid;
-    border-bottom-width: 4px;
-
+    border-bottom-width: 2px;
     .dimmable {
       opacity: 1;
     }
   }
-
   .icon {
-    top: 0;
+    font-size: 24px;
   }
-
-  svg {
-    width: 14px;
-    height: 14px;
-  }
-
   .tab-icon {
     display: inline-block;
     padding: 10px 0;
     margin-right: 4px;
   }
-
   .tab-title {
     display: inline-block;
+    font-weight: bold;
     text-overflow: ellipsis;
+    text-transform: uppercase;
+    vertical-align: middle;
   }
-
 </style>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -1,20 +1,15 @@
 <template>
 
-  <li class="list-item">
+  <li class="list-item-navigation visible">
     <router-link
       class="tab"
       :class="$computedClass(tabStyles)"
+      :style="windowIsSmall ? smallScreenOverrides : {}"
       :to="link"
       :activeClass="activeClasses"
     >
       <div class="dimmable tab-icon">
-        <UiIcon
-          class="icon"
-          tabindex="-1"
-        >
-          <!--The icon svg-->
-          <slot></slot>
-        </UiIcon>
+        <slot></slot>
       </div>
 
       <div class="dimmable tab-title" tabindex="-1">
@@ -27,14 +22,16 @@
 
 
 <script>
+
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import UiIcon from 'kolibri-design-system/lib/keen/UiIcon';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+
   /**
    Links for use inside the Navbar
    */
   export default {
     name: 'NavbarLink',
-    components: { UiIcon },
+    mixins: [responsiveWindowMixin],
     props: {
       /**
        * The text
@@ -55,7 +52,7 @@
     computed: {
       tabStyles() {
         return {
-          color: this.$themePalette.grey.v_100,
+          color: this.$themePalette.grey.v_50,
           ':hover': {
             'background-color': this.$themeTokens.appBarDark,
           },
@@ -65,27 +62,43 @@
           },
         };
       },
+      smallScreenOverrides() {
+        return {
+          padding: '0 8px',
+          fontSize: '14px',
+          borderBottomWidth: '2px',
+        };
+      },
       activeClasses() {
         // return both fixed and dynamic classes
-        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.textInverted })}`;
+        return `router-link-active ${this.$computedClass({ color: this.$themeTokens.primary })}`;
       },
     },
   };
+
 </script>
 
 
 <style lang="scss" scoped>
+
   @import '~kolibri-design-system/lib/styles/definitions';
-  .list-item {
+
+  .list-item-navigation {
     display: inline-block;
     text-align: center;
+    visibility: hidden;
   }
+
+  .visible {
+    visibility: visible;
+  }
+
   .tab {
     display: inline-block;
     min-width: 72px;
     max-width: 264px;
-    padding: 0 18px;
-    padding-bottom: 3px;
+    padding: 0 16px;
+    padding-bottom: 6px;
     margin: 0;
     font-size: 14px;
     text-decoration: none;
@@ -94,10 +107,12 @@
     border-top-left-radius: $radius;
     border-top-right-radius: $radius;
     transition: background-color $core-time ease;
+
     .dimmable {
-      opacity: 0.6;
+      opacity: 1;
     }
   }
+
   // Getting this class to work correctly with our theme system is not currently
   // possible. Some options:
   //  1. Update vueAphrodite to handle nested classes (to handle .dimmable)
@@ -105,26 +120,33 @@
   //     https://github.com/vuejs/rfcs/pull/34
   //  3. Somehow refactor the tab styling to not require nested active classes
   .router-link-active {
-    padding-bottom: 2px;
+    font-weight: bold;
     border-bottom-style: solid;
-    border-bottom-width: 2px;
+    border-bottom-width: 4px;
+
     .dimmable {
       opacity: 1;
     }
   }
+
   .icon {
-    font-size: 24px;
+    top: 0;
   }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+
   .tab-icon {
     display: inline-block;
     padding: 10px 0;
     margin-right: 4px;
   }
+
   .tab-title {
     display: inline-block;
-    font-weight: bold;
     text-overflow: ellipsis;
-    text-transform: uppercase;
-    vertical-align: middle;
   }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
replaces hardcoded colors with theme tokens 

Noticeable UI changes


before changes:

![old](https://user-images.githubusercontent.com/64302444/209099666-30d9c0e9-05fb-4907-996a-f8377450d103.png)

After changes:
![new](https://user-images.githubusercontent.com/64302444/209099659-a8cd222b-d265-4c5b-8022-e68f11c6932e.png)



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
resolve #9019 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
@marcellamaki 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
