### PR TITLE
Read missing `percentage` string; fix CSV export messages

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1059,7 +1059,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Score obtained by a learner on a quiz, indicated by the percentage of correct answers given.',
   },
-
+  percentage: {
+    message: '{value, number, percent}',
+    context: 'Formatting a number into a percentage',
+  },
   // TODO - move these into diff sections as we make this a full feature in 0.16
   // Past Papers Project (12/2021) strings
   timeSpentLabel: {
@@ -1142,6 +1145,7 @@ const MetadataLookup = invert(
     METADATA.ResourcesNeededTypes
   )
 );
+
 /**
  * Return translated string for key defined in the coreStrings translator. Will map
  * ID keys generated in the kolibri-constants library to their appropriate translations

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -45,6 +45,7 @@ const VERB_MAP = {
   [STATUSES.helpNeeded]: VERBS.needHelp,
   [STATUSES.completed]: VERBS.completed,
 };
+
 const coreStrings = coreStringsMixin.methods.coreString;
 
 /*
@@ -69,7 +70,7 @@ export function avgScore() {
           return '';
         }
 
-        return coachStrings.$tr('percentage', { value: row.avgScore });
+        return coreStrings('percentage', { value: row.avgScore });
       },
     },
   ];
@@ -183,14 +184,14 @@ export function recipients(className) {
 export function score() {
   return [
     {
-      name: coreStrings.$tr('scoreLabel'),
+      name: coreStrings('scoreLabel'),
       key: 'score',
       format: row => {
         if (!row.statusObj.score && row.statusObj.score !== 0) {
           return '';
         }
 
-        return coachStrings.$tr('percentage', { value: row.statusObj.score });
+        return coreStrings('percentage', { value: row.statusObj.score });
       },
     },
   ];


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Noted by a partner, they were getting a broken `CommonCoachStrings.percentage` value in the percentage column of a quiz report. The percentage string was missing both from the coach and core strings so I added it in there and updated the code that generates the messages in the CSV fields.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

[Slack conversation](https://learningequality.slack.com/archives/CB37UM23A/p1671741765466159)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

If you print out a CSV report for a quiz do you see a percentage in the percentage column? (On Develop!)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
