### PR TITLE
Fixes truncated text and missing header section in mobile view

### DIFF
--- a/kolibri/core/assets/src/views/KeenUiToolbar.vue
+++ b/kolibri/core/assets/src/views/KeenUiToolbar.vue
@@ -14,7 +14,7 @@
 
   /deep/ .ui-toolbar__title {
     overflow: hidden;
-    white-space: nowrap;
+    white-space: normal;
   }
 
   /deep/ .ui-toolbar__left {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
@@ -48,9 +48,15 @@
 
 <style lang="scss" scoped>
 
+  $mobile-header-height: 100px;
+  $toolbar-height: 70px;
+
   .mobile-header {
     position: relative;
-    height: 100%;
+    top: $toolbar-height;
+    height: $mobile-header-height;
+    padding-right: 16px;
+    padding-left: 16px;
   }
 
   .mobile-title {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixed truncated title and header issue in mobile view.
![Kolibri](https://user-images.githubusercontent.com/99071926/209627447-1148a39e-e7f6-4b0c-b276-95959582eb98.png)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9624 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to Learn>Library
Select any channel and turn into mobile view to see the changes.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
