### PR TITLE
Fix progress calculation when importing a facility

### DIFF
--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -665,7 +665,7 @@ class MorangoSyncCommand(AsyncCommand):
                 progress = 100
 
             tracker.update_progress(
-                increment=math.ceil(progress - tracker.progress),
+                increment=math.ceil(progress - tracker.job.progress),
                 message=stats_msg(transfer_session),
                 extra_data=dict(
                     bytes_sent=transfer_session.bytes_sent,


### PR DESCRIPTION
## Summary
Progress calculation when running MorangoSyncCommand was broken. This PR fixes it

## References

Closes: #9934 

## Reviewer guidance
Do tests pass?
Is facility importing working now? @pcenov  

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
