### PR TITLE
Fix facility name in Import Facility

### DIFF
--- a/kolibri/core/assets/src/mixins/commonSyncElements.js
+++ b/kolibri/core/assets/src/mixins/commonSyncElements.js
@@ -87,11 +87,12 @@ export default {
         device_id,
       });
     },
-    startPeerImportTask({ facility, username, password, device_id }) {
+    startPeerImportTask({ facility, username, facility_name, password, device_id }) {
       return TaskResource.startTask({
         type: 'kolibri.core.auth.tasks.peerfacilityimport',
         device_id,
         facility,
+        facility_name,
         username,
         password,
       });

--- a/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityAdminCredentialsForm.vue
@@ -103,6 +103,7 @@
           return this.startPeerImportTask({
             device_id: this.device.id,
             facility: this.facility.id,
+            facility_name: this.facility.name,
             username: this.username,
             password: this.password,
           })

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -353,7 +353,7 @@ def peerfacilitysync(command, **kwargs):
 
 class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     facility = HexOnlyUUIDField()
-    facility_name = serializers.CharField()
+    facility_name = serializers.CharField(default="")
     username = serializers.CharField()
     password = serializers.CharField(default=NOT_SPECIFIED, required=False)
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -241,7 +241,7 @@ class SyncJobValidator(JobValidator):
             facility_name = facility.name
         else:
             facility_id = facility
-            facility_name = ""
+            facility_name = data["facility_name"]
         return {
             "extra_metadata": dict(
                 facility_id=facility_id,
@@ -353,6 +353,7 @@ def peerfacilitysync(command, **kwargs):
 
 class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     facility = HexOnlyUUIDField()
+    facility_name = serializers.CharField()
     username = serializers.CharField()
     password = serializers.CharField(default=NOT_SPECIFIED, required=False)
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The facility name was always getting set to an empty string " " in the core/auth/tasks.py file, so I replaced it with the facility name, by passing it in the request.
![kolibri](https://user-images.githubusercontent.com/99071926/210075028-d8fddd67-fe10-4c21-a173-f52d2dfb7f5d.png)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9494 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Go to Device>Facilities.
Import a facility.
In the Facility Tasks Page, see the facility name displayed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
