### PR TITLE
[Pdf_Viewer] Backport changes from develop to 0.15.x

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/utils/event_utils.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/event_utils.js
@@ -1,0 +1,43 @@
+import Vue from 'vue';
+
+class EventBus {
+  constructor() {
+    this._eventDispatcher = new Vue();
+  }
+
+  /**
+   * Proxy to the Vue object that is the global dispatcher.
+   * @param {string} eventName
+   * @param {...any} args
+   */
+  emit(eventName, ...args) {
+    this._eventDispatcher.$emit(eventName, ...args);
+  }
+  /**
+   * Proxy to the Vue object that is the global dispatcher.
+   * @param {string} event
+   * @param {function} callback
+   */
+  on(event, callback) {
+    this._eventDispatcher.$on(event, callback);
+  }
+  /**
+   * Proxy to the Vue object that is the global dispatcher.
+   * Takes any arguments and passes them on.
+   * @param {string} event
+   * @param {function} callback
+   */
+  once(event, callback) {
+    this._eventDispatcher.$once(event, callback);
+  }
+  /**
+   * Proxy to the Vue object that is the global dispatcher.
+   * @param {string} event
+   * @param {function} callback
+   */
+  off(event, callback) {
+    this._eventDispatcher.$off(event, callback);
+  }
+}
+
+export { EventBus };

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/struct_tree_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/struct_tree_layer_builder.js
@@ -1,0 +1,176 @@
+/* Copyright 2021 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/struct_tree_layer_builder.js
+ */
+
+// Modified: typedef imports deleted
+// Original line: 16
+
+const PDF_ROLE_TO_HTML_ROLE = {
+  // Document level structure types
+  Document: null, // There's a "document" role, but it doesn't make sense here.
+  DocumentFragment: null,
+  // Grouping level structure types
+  Part: 'group',
+  Sect: 'group', // XXX: There's a "section" role, but it's abstract.
+  Div: 'group',
+  Aside: 'note',
+  NonStruct: 'none',
+  // Block level structure types
+  P: null,
+  // H<n>,
+  H: 'heading',
+  Title: null,
+  FENote: 'note',
+  // Sub-block level structure type
+  Sub: 'group',
+  // General inline level structure types
+  Lbl: null,
+  Span: null,
+  Em: null,
+  Strong: null,
+  Link: 'link',
+  Annot: 'note',
+  Form: 'form',
+  // Ruby and Warichu structure types
+  Ruby: null,
+  RB: null,
+  RT: null,
+  RP: null,
+  Warichu: null,
+  WT: null,
+  WP: null,
+  // List standard structure types
+  L: 'list',
+  LI: 'listitem',
+  LBody: null,
+  // Table standard structure types
+  Table: 'table',
+  TR: 'row',
+  TH: 'columnheader',
+  TD: 'cell',
+  THead: 'columnheader',
+  TBody: null,
+  TFoot: null,
+  // Standard structure type Caption
+  Caption: null,
+  // Standard structure type Figure
+  Figure: 'img',
+  // Standard structure type Formula
+  Formula: null,
+  // standard structure type Artifact
+  Artifact: null,
+};
+
+const HEADING_PATTERN = /^H(\d+)$/;
+
+// Modified: unused "options" props deleted and constructor definition deleted
+//           Making use of the textLayer ref for taking into account just non-blank text
+// Original line: 85
+
+class StructTreeLayerBuilder {
+  constructor(textLayer) {
+    this.textLayer = textLayer;
+  }
+  render(structTree) {
+    // Modified: Extracting ids of available nodes in textLayer
+    // Original line: 90
+    const availableNodes = [];
+    for (let i = 0; i < this.textLayer.children.length; i++) {
+      const node = this.textLayer.children[i];
+      if (node.id !== undefined) {
+        availableNodes.push(node.id);
+      }
+    }
+    this.availableNodes = availableNodes;
+    return this._walk(structTree);
+  }
+
+  _setAttributes(structElement, htmlElement) {
+    if (structElement.alt !== undefined) {
+      htmlElement.setAttribute('aria-label', structElement.alt);
+    }
+    if (structElement.id !== undefined) {
+      htmlElement.setAttribute('aria-owns', structElement.id);
+    }
+    if (structElement.lang !== undefined) {
+      htmlElement.setAttribute('lang', structElement.lang);
+    }
+  }
+
+  _isNodeNotAvailable(node) {
+    return (
+      node.id !== undefined && node.id.startsWith('page') && !this.availableNodes.includes(node.id)
+    );
+  }
+
+  _walk(node) {
+    // Modified: Just take into account non-blank text
+    // Original line: 106
+    if (!node || this._isNodeNotAvailable(node)) {
+      return null;
+    }
+    const element = document.createElement('span');
+    if ('role' in node) {
+      const { role } = node;
+      const match = role.match(HEADING_PATTERN);
+      if (match) {
+        element.setAttribute('role', 'heading');
+        element.setAttribute('aria-level', match[1]);
+      } else if (PDF_ROLE_TO_HTML_ROLE[role]) {
+        element.setAttribute('role', PDF_ROLE_TO_HTML_ROLE[role]);
+      }
+    }
+
+    this._setAttributes(node, element);
+
+    if (node.children) {
+      if (node.children.length === 1 && 'id' in node.children[0]) {
+        // Often there is only one content node so just set the values on the
+        // parent node to avoid creating an extra span.
+        if (!this._isNodeNotAvailable(node.children[0])) {
+          this._setAttributes(node.children[0], element);
+        }
+      } else {
+        for (const kid of node.children) {
+          const node = this._walk(kid);
+          // Modified: Validate that the node is not null
+          // Original line: 131
+          if (node) {
+            element.appendChild(node);
+          }
+        }
+      }
+    }
+    // Modified: Just take into account non-blank elements
+    // Original line: 135
+    if (
+      element.innerHTML === '' &&
+      element.getAttribute('aria-owns') == undefined &&
+      element.getAttribute('role') == undefined
+    ) {
+      return null;
+    }
+    return element;
+  }
+}
+
+// Modified: Exporting TextLayerBuilder as a default export
+// Original line: 139
+export default StructTreeLayerBuilder;

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -1,0 +1,261 @@
+/* Copyright 2012 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/text_layer_builder.js
+ */
+
+// Modified: typedef imports deleted
+// Original line: 17
+
+import { renderTextLayer } from 'pdfjs-dist/legacy/build/pdf';
+
+const EXPAND_DIVS_TIMEOUT = 300; // ms
+
+/**
+ * @typedef {Object} TextLayerBuilderOptions
+ * @property {HTMLDivElement} textLayerDiv - The text layer container.
+ * @property {number} pageIndex - The page index.
+ * @property {PageViewport} viewport - The viewport of the text layer.
+ * @property {TextHighlighter} highlighter - Optional object that will handle
+ *   highlighting text from the find controller.
+ * @property {boolean} enhanceTextSelection - Option to turn on improved
+ *   text selection.
+ */
+
+/**
+ * The text layer builder provides text selection functionality for the PDF.
+ * It does this by creating overlay divs over the PDF's text. These divs
+ * contain text that matches the PDF text they are overlaying.
+ */
+class TextLayerBuilder {
+  constructor({
+    textLayerDiv,
+    eventBus,
+    pageIndex,
+    viewport,
+    highlighter = null,
+    enhanceTextSelection = false,
+  }) {
+    this.textLayerDiv = textLayerDiv;
+    this.eventBus = eventBus;
+    this.textContent = null;
+    this.textContentItemsStr = [];
+    this.textContentStream = null;
+    this.renderingDone = false;
+    this.pageNumber = pageIndex + 1;
+    this.viewport = viewport;
+    this.textDivs = [];
+    this.textLayerRenderTask = null;
+    this.highlighter = highlighter;
+    this.enhanceTextSelection = enhanceTextSelection;
+
+    this._bindMouse();
+  }
+
+  /**
+   * @private
+   */
+  _finishRendering() {
+    this.renderingDone = true;
+
+    if (!this.enhanceTextSelection) {
+      const endOfContent = document.createElement('div');
+      endOfContent.className = 'endOfContent';
+      this.textLayerDiv.append(endOfContent);
+    }
+
+    // Modified: Validate eventBus is defined
+    // Original line: 79
+    if (this.eventBus) {
+      this.eventBus.emit('textlayerrendered', {
+        source: this,
+        pageNumber: this.pageNumber,
+        numTextDivs: this.textDivs.length,
+      });
+    }
+  }
+
+  /**
+   * Renders the text layer.
+   *
+   * @param {number} [timeout] - Wait for a specified amount of milliseconds
+   *                             before rendering.
+   */
+  render(timeout = 0) {
+    if (!(this.textContent || this.textContentStream) || this.renderingDone) {
+      return;
+    }
+    this.cancel();
+
+    this.textDivs.length = 0;
+
+    // Modified: Validate highlighter is defined instead of using optional chain operator
+    // Original line: 99
+    if (this.highlighter) {
+      this.highlighter.setTextMapping(this.textDivs, this.textContentItemsStr);
+    }
+
+    const textLayerFrag = document.createDocumentFragment();
+    this.textLayerRenderTask = renderTextLayer({
+      textContent: this.textContent,
+      textContentStream: this.textContentStream,
+      container: textLayerFrag,
+      viewport: this.viewport,
+      textDivs: this.textDivs,
+      textContentItemsStr: this.textContentItemsStr,
+      timeout,
+      enhanceTextSelection: this.enhanceTextSelection,
+    });
+    this.textLayerRenderTask.promise.then(
+      () => {
+        // Modified: Removing blank lines
+        // Original line: 114
+        const childsToRemove = [];
+        for (let i = 0; i < textLayerFrag.children.length; i++) {
+          const child = textLayerFrag.children[i];
+          if (
+            child.className.includes('markedContent') &&
+            child.id !== undefined &&
+            child.innerHTML === ''
+          ) {
+            childsToRemove.push(child);
+          }
+        }
+        for (let i = 0; i < childsToRemove.length; i++) {
+          textLayerFrag.removeChild(childsToRemove[i]);
+        }
+        this.textLayerDiv.append(textLayerFrag);
+        this._finishRendering();
+        // Modified: Validate highlighter is defined instead of using optional chain operator
+        // Original line: 116
+        if (this.highlighter) {
+          this.highlighter.enable();
+        }
+      },
+      // Modified: Logging errors
+      // Original line: 118
+      err => {
+        console.error('Error rendering text layer: ', err);
+      }
+    );
+  }
+
+  /**
+   * Cancel rendering of the text layer.
+   */
+  cancel() {
+    if (this.textLayerRenderTask) {
+      this.textLayerRenderTask.cancel();
+      this.textLayerRenderTask = null;
+      // Modified: Removing content from text layer to avoid multiple layers rendering on zoom
+      // Original line: 131
+      this.textLayerDiv.textContent = '';
+    }
+    // Modified: Validate highlighter is defined instead of using optional chain operator
+    // Original line: 132
+    if (this.highlighter) {
+      this.highlighter.disable();
+    }
+  }
+
+  setTextContentStream(readableStream) {
+    this.cancel();
+    this.textContentStream = readableStream;
+  }
+
+  setTextContent(textContent) {
+    this.cancel();
+    this.textContent = textContent;
+  }
+
+  /**
+   * Improves text selection by adding an additional div where the mouse was
+   * clicked. This reduces flickering of the content if the mouse is slowly
+   * dragged up or down.
+   *
+   * @private
+   */
+  _bindMouse() {
+    const div = this.textLayerDiv;
+    let expandDivsTimer = null;
+
+    div.addEventListener('mousedown', evt => {
+      if (this.enhanceTextSelection && this.textLayerRenderTask) {
+        this.textLayerRenderTask.expandTextDivs(true);
+        // Modified: Delete PDFJS Dev global variables references
+        // Original line: 159
+        if (expandDivsTimer) {
+          clearTimeout(expandDivsTimer);
+          expandDivsTimer = null;
+        }
+        return;
+      }
+
+      const end = div.querySelector('.endOfContent');
+      if (!end) {
+        return;
+      }
+      // Modified: Delete PDFJS Dev global variables references
+      // Original line: 173
+
+      // On non-Firefox browsers, the selection will feel better if the height
+      // of the `endOfContent` div is adjusted to start at mouse click
+      // location. This avoids flickering when the selection moves up.
+      // However it does not work when selection is started on empty space.
+
+      // Modified: Refactor simplified code for deleting PDFJS Dev global variables references
+      // Original line: 178
+      let adjustTop =
+        evt.target !== div &&
+        window.getComputedStyle(end).getPropertyValue('-moz-user-select') !== 'none';
+      if (adjustTop) {
+        const divBounds = div.getBoundingClientRect();
+        const r = Math.max(0, (evt.pageY - divBounds.top) / divBounds.height);
+        end.style.top = (r * 100).toFixed(2) + '%';
+      }
+      end.classList.add('active');
+    });
+
+    div.addEventListener('mouseup', () => {
+      if (this.enhanceTextSelection && this.textLayerRenderTask) {
+        // Modified: Delete PDFJS Dev global variables references
+        // Original line: 197
+        expandDivsTimer = setTimeout(() => {
+          if (this.textLayerRenderTask) {
+            this.textLayerRenderTask.expandTextDivs(false);
+          }
+          expandDivsTimer = null;
+        }, EXPAND_DIVS_TIMEOUT);
+        return;
+      }
+
+      const end = div.querySelector('.endOfContent');
+      if (!end) {
+        return;
+      }
+      // Modified: Delete PDFJS Dev global variables references
+      // Original line: 214
+      end.style.top = '';
+      end.classList.remove('active');
+    });
+  }
+}
+
+// Modified: Exporting TextLayerBuilder as a default export
+// Original line: 222
+export default TextLayerBuilder;

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -119,7 +119,6 @@ class TextLayerBuilder {
       textDivs: this.textDivs,
       textContentItemsStr: this.textContentItemsStr,
       timeout,
-      enhanceTextSelection: this.enhanceTextSelection,
     });
     this.textLayerRenderTask.promise.then(
       () => {

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.scss
@@ -1,0 +1,118 @@
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/text_layer_builder.css
+ */
+
+.text-layer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  line-height: 1;
+  text-align: initial;
+
+  /* Modified: specifiying letter-spacing as normal to avoid kolibri's default letter-spacing
+   * misaligning text-layer with the canvas.
+   * Original line: 28 */
+  letter-spacing: normal;
+  opacity: 0.2;
+  text-size-adjust: none;
+
+  /* stylelint-disable */
+  forced-color-adjust: none;
+  /* stylelint-enable */
+}
+
+.text-layer span,
+.text-layer br {
+  position: absolute;
+  color: transparent;
+  white-space: pre;
+  cursor: text;
+  user-select: text;
+  transform-origin: 0% 0%;
+}
+
+/* Only necessary in Google Chrome, see issue 14205, and most unfortunately
+ * the problem doesn't show up in "text" reference tests. */
+.text-layer span.markedContent {
+  top: 0;
+  height: 0;
+}
+
+.text-layer .highlight {
+  padding: 1px;
+  margin: -1px;
+
+  /* TODO Manage with Kolibri standards */
+  background-color: rgba(180, 0, 170, 1);
+  border-radius: 4px;
+}
+
+.text-layer .highlight.appended {
+  position: initial;
+}
+
+.text-layer .highlight.begin {
+  border-radius: 4px 0 0 4px;
+}
+
+.text-layer .highlight.end {
+  border-radius: 0 4px 4px 0;
+}
+
+.text-layer .highlight.middle {
+  border-radius: 0;
+}
+
+.text-layer .highlight.selected {
+  /* TODO Manage with Kolibri standards */
+  background-color: rgba(0, 100, 0, 1);
+}
+
+.text-layer ::selection {
+  /* Modified: selection color.
+   * Original line: 74 */
+
+  /* TODO Manage with Kolibri standards */
+  background: rgb(0, 168, 255);
+}
+
+/* Avoids https://github.com/mozilla/pdf.js/issues/13840 in Chrome */
+.text-layer br::selection {
+  background: transparent;
+}
+
+.text-layer .endOfContent {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+  display: block;
+  cursor: default;
+  user-select: none;
+}
+
+.text-layer .endOfContent.active {
+  top: 0;
+}

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -129,10 +129,6 @@
   import PdfPage from './PdfPage';
   import SideBar from './SideBar';
 
-  // Source from which PDFJS loads its service worker, this is based on the __publicPath
-  // global that is defined in the Kolibri webpack pipeline, and the additional entry in the PDF
-  // renderer's own webpack config
-  PDFJSLib.GlobalWorkerOptions.workerSrc = __webpack_public_path__ + `pdfJSWorker-${__version}.js`;
   // How often should we respond to changes in scrolling to render new pages?
   const renderDebounceTime = 300;
   const scaleIncrement = 0.25;
@@ -249,6 +245,10 @@
           this.debounceForceUpdateRecycleList();
         }
       },
+    },
+    beforeCreate() {
+      PDFJSLib.GlobalWorkerOptions.workerSrc =
+        __webpack_public_path__ + `pdfJSWorker-${__version}.js`;
     },
     destroyed() {
       // Reset the overflow on the HTML tag that we set to hidden in created()

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -3,6 +3,10 @@
   <CoreFullscreen
     ref="pdfRenderer"
     class="pdf-renderer"
+    :class="{
+      'pdf-controls-open': showControls,
+      'pdf-full-screen': isInFullscreen
+    }"
     :style="{ backgroundColor: $themeTokens.text }"
     @changeFullscreen="isInFullscreen = $event"
   >
@@ -17,54 +21,90 @@
     <template v-else>
       <transition name="slide">
         <div
-          class="fullscreen-header"
+          class="fullscreen-header pdf-controls-container"
           :style="{ backgroundColor: this.$themePalette.grey.v_100 }"
         >
-          <KIconButton
-            class="button-zoom-in controls"
-            aria-controls="pdf-container"
-            icon="add"
-            @click="zoomIn"
-          />
-          <KIconButton
-            class="button-zoom-out controls"
-            aria-controls="pdf-container"
-            icon="remove"
-            @click="zoomOut"
-          />
-          <KButton
-            class="fullscreen-button"
-            :primary="false"
-            appearance="flat-button"
-            :icon="isInFullscreen ? 'fullscreen_exit' : 'fullscreen'"
-            @click="$refs.pdfRenderer.toggleFullscreen()"
-          >
-            {{ fullscreenText }}
-          </KButton>
+          <div>
+            <KIconButton
+              v-if="outline && outline.length > 0"
+              class="controls"
+              :ariaLabel="coreString('menu')"
+              aria-controls="sidebar-container"
+              icon="menu"
+              @click="toggleSideBar"
+            />
+          </div>
+          <div>
+            <KIconButton
+              class="button-zoom-in controls"
+              :ariaLabel="coreString('zoomIn')"
+              aria-controls="pdf-container"
+              icon="add"
+              @click="zoomIn"
+            />
+            <KIconButton
+              class="button-zoom-out controls"
+              :ariaLabel="coreString('zoomOut')"
+              aria-controls="pdf-container"
+              icon="remove"
+              @click="zoomOut"
+            />
+            <KButton
+              class="fullscreen-button"
+              :primary="false"
+              appearance="flat-button"
+              :icon="isInFullscreen ? 'fullscreen_exit' : 'fullscreen'"
+              @click="$refs.pdfRenderer.toggleFullscreen()"
+            >
+              {{ fullscreenText }}
+            </KButton>
+          </div>
         </div>
       </transition>
-      <RecycleList
-        ref="recycleList"
-        :items="pdfPages"
-        :itemHeight="itemHeight"
-        :emitUpdate="true"
-        :style="{ height: `${elementHeight}px` }"
-        class="pdf-container"
-        keyField="index"
-        @update="handleUpdate"
-      >
-        <template #default="{ item }">
-          <PdfPage
-            :key="item.index"
-            :pageNum="item.index + 1"
-            :pdfPage="pdfPages[item.index].page"
-            :pageReady="pdfPages[item.index].resolved"
-            :firstPageHeight="firstPageHeight || 0"
-            :firstPageWidth="firstPageWidth || 0"
-            :scale="scale || 1"
+      <KGrid gutter="0">
+        <KGridItem
+          v-if="showSideBar"
+          :layout8="{ span: 2 }"
+          :layout12="{ span: 3 }"
+          class="sidebar-container"
+          :class="{ 'mt-40': showControls }"
+        >
+          <SideBar
+            :outline="outline || []"
+            :goToDestination="goToDestination"
+            :focusDestPage="focusDestPage"
           />
-        </template>
-      </RecycleList>
+        </KGridItem>
+        <KGridItem
+          :layout8="{ span: showSideBar ? 6 : 8 }"
+          :layout12="{ span: showSideBar ? 9 : 12 }"
+        >
+          <RecycleList
+            ref="recycleList"
+            :items="pdfPages"
+            :itemHeight="itemHeight"
+            :emitUpdate="true"
+            :style="{ height: `${elementHeight}px` }"
+            class="pdf-container"
+            keyField="index"
+            @update="handleUpdate"
+          >
+            <template #default="{ item }">
+              <PdfPage
+                :key="item.index"
+                :pageNum="item.index + 1"
+                :pdfPage="pdfPages[item.index].page"
+                :pageReady="pdfPages[item.index].resolved"
+                :firstPageHeight="firstPageHeight || 0"
+                :firstPageWidth="firstPageWidth || 0"
+                :scale="scale || 1"
+                :totalPages="pdfPages.length"
+                :eventBus="eventBus"
+              />
+            </template>
+          </RecycleList>
+        </KGridItem>
+      </KGrid>
     </template>
   </CoreFullscreen>
 
@@ -73,7 +113,7 @@
 
 <script>
 
-  import PDFJSLib from 'pdfjs-dist';
+  import * as PDFJSLib from 'pdfjs-dist/legacy/build/pdf';
   import Hammer from 'hammerjs';
   import throttle from 'lodash/throttle';
   import debounce from 'lodash/debounce';
@@ -81,15 +121,18 @@
   import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
   // polyfill necessary for recycle list
   import 'intersection-observer';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
-  import urls from 'kolibri.urls';
+  import { EventBus } from '../utils/event_utils';
   import PdfPage from './PdfPage';
+  import SideBar from './SideBar';
+
   // Source from which PDFJS loads its service worker, this is based on the __publicPath
   // global that is defined in the Kolibri webpack pipeline, and the additional entry in the PDF
   // renderer's own webpack config
-  PDFJSLib.PDFJS.workerSrc = urls.static(`${__kolibriModuleName}/pdfJSWorker-${__version}.js`);
+  PDFJSLib.GlobalWorkerOptions.workerSrc = __webpack_public_path__ + `pdfJSWorker-${__version}.js`;
   // How often should we respond to changes in scrolling to render new pages?
   const renderDebounceTime = 300;
   const scaleIncrement = 0.25;
@@ -97,11 +140,12 @@
   export default {
     name: 'PdfRendererIndex',
     components: {
+      SideBar,
       PdfPage,
       RecycleList,
       CoreFullscreen,
     },
-    mixins: [responsiveWindowMixin, responsiveElementMixin],
+    mixins: [responsiveWindowMixin, responsiveElementMixin, commonCoreStrings],
     data: () => ({
       progress: null,
       scale: null,
@@ -114,7 +158,11 @@
       isInFullscreen: false,
       currentLocation: 0,
       updateContentStateInterval: null,
+      showControls: true,
+      showSideBar: false,
       visitedPages: {},
+      eventBus: null,
+      outline: null,
     }),
     computed: {
       // Returns whether or not the current device is iOS.
@@ -212,12 +260,13 @@
       window.document.getElementsByTagName('html')[0].style.overflow = 'hidden';
 
       this.currentLocation = this.savedLocation;
-      const loadPdfPromise = PDFJSLib.getDocument(this.defaultFile.storage_url);
+      const loadingPdf = PDFJSLib.getDocument(this.defaultFile.storage_url);
       // pass callback to update loading bar
-      loadPdfPromise.onProgress = loadingProgress => {
+      loadingPdf.onProgress = loadingProgress => {
         this.progress = loadingProgress.loaded / loadingProgress.total;
       };
-      this.prepComponentData = loadPdfPromise.then(pdfDocument => {
+      this.eventBus = new EventBus();
+      this.prepComponentData = loadingPdf.promise.then(pdfDocument => {
         // Get initial info from the loaded pdf document
         this.pdfDocument = pdfDocument;
         this.totalPages = this.pdfDocument.numPages;
@@ -232,8 +281,10 @@
         // Is either the first page or the saved last page visited
         const firstPageToRender = parseInt(this.getSavedPosition() * this.totalPages);
         return this.getPage(firstPageToRender + 1).then(firstPage => {
-          this.firstPageHeight = firstPage.view[3];
-          this.firstPageWidth = firstPage.view[2];
+          const viewPort = firstPage.getViewport({ scale: 1 });
+          this.firstPageHeight = viewPort.height;
+          this.firstPageWidth = viewPort.width;
+
           const screenSizeMultiplier = this.windowIsLarge ? 1.25 : this.windowIsSmall ? 1 : 1.125;
           this.scale = this.elementWidth / (this.firstPageWidth * screenSizeMultiplier);
           // Set the firstPageToRender into the pdfPages object so that we do not refetch the page
@@ -243,6 +294,10 @@
             ...this.pdfPages[firstPageToRender],
             page: firstPage,
             resolved: true,
+          });
+          pdfDocument.getOutline().then(outline => {
+            this.outline = outline;
+            this.showSideBar = outline && outline.length > 0; // Remove if other tabs are already implemented
           });
         });
       });
@@ -353,6 +408,9 @@
       setScale: throttle(function(scaleValue) {
         this.scale = scaleValue;
       }, 500),
+      toggleSideBar() {
+        this.showSideBar = !this.showSideBar;
+      },
       calculatePosition() {
         return this.$refs.recycleList.$el.scrollTop / this.$refs.recycleList.$el.scrollHeight;
       },
@@ -409,6 +467,125 @@
         }
         this.$emit('updateContentState', contentState);
       },
+      /**
+       * Handle bookmark items click.
+       * Adaptation of the original functions from pdf.js:
+       * - https://github.com/mozilla/pdf.js/blob/v2.14.305/web/pdf_link_service.js#L237
+       * - https://github.com/mozilla/pdf.js/blob/v2.14.305/web/pdf_link_service.js#L176
+       * - https://github.com/mozilla/pdf.js/blob/v2.14.305/web/base_viewer.js#L1175
+       */
+      async goToDestination(dest) {
+        if (!this.pdfDocument) {
+          return;
+        }
+        let explicitDest;
+        if (typeof dest === 'string') {
+          explicitDest = await this.pdfDocument.getDestination(dest);
+        } else {
+          explicitDest = await dest;
+        }
+        if (!Array.isArray(explicitDest)) {
+          console.error('Error getting destination');
+          return;
+        }
+
+        const pageNumber = await this.getDestinationPageNumber(explicitDest);
+        if (!pageNumber || pageNumber < 1 || pageNumber > this.pagesCount) {
+          console.error('Invalid destination page');
+          return;
+        }
+
+        let position = (pageNumber - 1) / this.totalPages; // relative page position
+
+        // add relative y offset of the destination on the page
+        if (explicitDest[1].name === 'XYZ') {
+          // XYZ is a dest name value from pdfjs
+          const y = this.firstPageHeight - explicitDest[3];
+          const relativeYPage = y / this.firstPageHeight;
+          // This isnt taking into account the padding between pages
+          // but it gives it a good little space
+          position += relativeYPage * (1 / this.totalPages);
+        }
+
+        this.scrollTo(position);
+      },
+      async focusDestPage(dest, event) {
+        if (!this.pdfDocument) {
+          return;
+        }
+        let explicitDest;
+        if (typeof dest === 'string') {
+          explicitDest = await this.pdfDocument.getDestination(dest);
+        } else {
+          explicitDest = await dest;
+        }
+        if (!Array.isArray(explicitDest)) {
+          console.error('Error getting destination');
+          return;
+        }
+
+        const pageNumber = await this.getDestinationPageNumber(explicitDest);
+        if (!pageNumber || pageNumber < 1 || pageNumber > this.pagesCount) {
+          console.error('Invalid destination page');
+          return;
+        }
+        const isFocused = this.focusPage(pageNumber, event.target);
+        if (!isFocused) {
+          let position = (pageNumber - 1) / this.totalPages;
+          this.scrollTo(position); // scroll to page so the virtual list can render it
+          const onPageRendered = e => {
+            if (e.pageNumber === pageNumber) {
+              this.focusPage(pageNumber, event.target);
+              this.eventBus.off('pageRendered', onPageRendered);
+            }
+          };
+          this.eventBus.on('pageRendered', onPageRendered);
+        }
+      },
+      /**
+       * Focus a given pdf page and return true if the page was already rendered
+       */
+      focusPage(pageNumber, bookmark) {
+        const page = document.querySelector('#pdf-page-' + pageNumber);
+        if (page) {
+          page.setAttribute('tabindex', 0);
+          page.focus({
+            preventScroll: true,
+          });
+          const backToBookmark = e => {
+            if (e.key === 'Enter' && e.shiftKey) {
+              page.removeAttribute('tabindex');
+              window.removeEventListener('keydown', backToBookmark);
+              bookmark.focus();
+            }
+          };
+          window.addEventListener('keydown', backToBookmark);
+          return true;
+        }
+        return false;
+      },
+      /**
+       * Get the page number from the explicit destination array.
+       * Adaptation of the original function from pdf.js:
+       * - https://github.com/mozilla/pdf.js/blob/v2.14.305/web/pdf_link_service.js#L181
+       */
+      async getDestinationPageNumber(explicitDest) {
+        try {
+          const destRef = explicitDest[0];
+          if (typeof destRef === 'object' && destRef !== null) {
+            const pageIndex = await this.pdfDocument.getPageIndex(destRef);
+            return pageIndex + 1;
+          }
+          if (Number.isInteger(destRef)) {
+            return destRef + 1;
+          }
+          console.error('Invalid destination reference');
+          return null;
+        } catch (e) {
+          console.error('Error getting destination page number', e);
+          return null;
+        }
+      },
     },
     $trs: {
       exitFullscreen: {
@@ -432,6 +609,7 @@
   @import '~kolibri-design-system/lib/styles/definitions';
   $controls-height: 40px;
   $top-bar-height: 32px;
+  $tool-bar-height: 56px;
 
   .pdf-renderer {
     @extend %momentum-scroll;
@@ -446,11 +624,20 @@
     position: relative;
     top: $controls-height;
   }
+
   .controls {
     position: relative;
     z-index: 0; // Hide icons with transition
     margin: 0 4px;
   }
+
+  .pdf-controls-container {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 8px;
+  }
+
   .progress-bar {
     top: 50%;
     max-width: 200px;
@@ -462,13 +649,16 @@
       overflow-x: auto;
     }
   }
+
   .fullscreen-button {
     margin: 0;
+
     svg {
       position: relative;
       top: 8px;
     }
   }
+
   .fullscreen-header {
     position: absolute;
     top: 0;
@@ -476,22 +666,48 @@
     left: 0;
     z-index: 7;
     display: flex;
-    justify-content: flex-end;
     height: $controls-height;
   }
+
   .slide-enter-active {
     @extend %md-accelerate-func;
 
     transition: all 0.3s;
   }
+
   .slide-leave-active {
     @extend %md-decelerate-func;
 
     transition: all 0.3s;
   }
+
   .slide-enter,
   .slide-leave-to {
     transform: translateY(-40px);
+  }
+
+  .mt-40 {
+    margin-top: 40px;
+  }
+
+  .sidebar-container {
+    height: calc(100vh - #{$tool-bar-height});
+  }
+
+  .pdf-renderer.pdf-controls-open .sidebar-container {
+    height: calc(100vh - #{$tool-bar-height} - #{$controls-height});
+  }
+
+  .pdf-renderer.pdf-full-screen .sidebar-container {
+    height: 100vh;
+  }
+
+  .pdf-renderer.pdf-full-screen.pdf-controls-open .sidebar-container {
+    height: calc(100vh - #{$controls-height});
+  }
+
+  /deep/ .sidebar-container > div {
+    height: 100%;
   }
 
 </style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -84,7 +84,7 @@
             :items="pdfPages"
             :itemHeight="itemHeight"
             :emitUpdate="true"
-            :style="{ height: `${elementHeight}px` }"
+            :style="{ height: `${elementHeight - 40}px` }"
             class="pdf-container"
             keyField="index"
             @update="handleUpdate"
@@ -297,7 +297,7 @@
           });
           pdfDocument.getOutline().then(outline => {
             this.outline = outline;
-            this.showSideBar = outline && outline.length > 0; // Remove if other tabs are already implemented
+            this.showSideBar = outline && outline.length > 0 && this.windowIsLarge; // Remove if other tabs are already implemented
           });
         });
       });
@@ -504,6 +504,9 @@
               }
 
               this.scrollTo(position);
+              if (this.windowIsSmall) {
+                this.showSideBar = false;
+              }
             });
           }
         );
@@ -524,6 +527,7 @@
                 console.error('Invalid destination page');
                 return;
               }
+
               const isFocused = this.focusPage(pageNumber, event.target);
               if (!isFocused) {
                 let position = (pageNumber - 1) / this.totalPages;
@@ -535,6 +539,9 @@
                   }
                 };
                 this.eventBus.on('pageRendered', onPageRendered);
+              }
+              if (this.windowIsSmall) {
+                this.showSideBar = false;
               }
             });
           }

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/Bookmarks/BookmarkItem.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/Bookmarks/BookmarkItem.vue
@@ -1,0 +1,127 @@
+<template>
+
+  <li class="bookmark-item">
+    <div class="bookmark-item-title-container">
+      <span
+        v-if="item.items && item.items.length > 0"
+        class="dropdown-icon-container"
+        tabindex="0"
+        role="button"
+        :aria-label="$tr('expand')"
+        aria-controls="pdf-container"
+        @click="toggleExpanded"
+        @keydown.enter="toggleExpanded"
+        @keydown.space="toggleExpanded"
+      >
+        <KIcon
+          icon="chevronRight"
+          class="dropdown-icon"
+          :class="{ 'expanded': expanded }"
+        />
+      </span>
+      <span
+        tabindex="0"
+        class="bookmark-item-title"
+        role="button"
+        @click="goToDestination(item.dest)"
+        @keydown.shift.enter="focusDestPage(item.dest, $event)"
+        @keydown.enter.exact="goToDestination(item.dest)"
+        @keydown.space="goToDestination(item.dest)"
+      >
+        {{ item.title }}
+      </span>
+    </div>
+    <ul v-if="expanded" class="bookmark-children">
+      <BookmarkItem
+        v-for="(child, index) in item.items"
+        :key="index"
+        :item="child"
+        :goToDestination="goToDestination"
+        :focusDestPage="focusDestPage"
+      />
+    </ul>
+  </li>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'BookmarkItem',
+    props: {
+      item: {
+        type: Object,
+        required: true,
+      },
+      goToDestination: {
+        type: Function,
+        required: true,
+      },
+      focusDestPage: {
+        type: Function,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        expanded: false,
+      };
+    },
+    methods: {
+      toggleExpanded() {
+        this.expanded = !this.expanded;
+      },
+    },
+    $trs: {
+      expand: 'Expand bookmark',
+    },
+  };
+
+</script>
+
+
+<style scoped lang="scss">
+
+  .bookmark-item {
+    position: relative;
+    font-size: 12px;
+    list-style: none;
+
+    .bookmark-item-title-container {
+      display: flex;
+      margin-bottom: 16px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+
+    .bookmark-item-title:focus-visible,
+    .dropdown-icon-container:focus-visible {
+      outline-width: 3px;
+      outline-style: solid;
+      outline-color: #8dc5b6;
+      outline-offset: 4px;
+    }
+
+    .dropdown-icon-container {
+      position: relative;
+      top: 2px;
+      padding-right: 16px;
+      font-size: 16px;
+
+      .dropdown-icon {
+        transition: transform 0.2s ease-in-out;
+        transform: rotate(0deg);
+
+        &.expanded {
+          transform: rotate(90deg);
+        }
+      }
+    }
+
+    .bookmark-children {
+      padding-left: 48px;
+    }
+  }
+
+</style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/Bookmarks/index.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/Bookmarks/index.vue
@@ -1,0 +1,58 @@
+<template>
+
+  <ul
+    class="bookmarks-wrapper"
+    :aria-label="$tr('bookmarksSection')"
+  >
+    <BookmarkItem
+      v-for="(item, index) in outline"
+      :key="index"
+      :item="item"
+      :goToDestination="goToDestination"
+      :focusDestPage="focusDestPage"
+    />
+  </ul>
+
+</template>
+
+
+<script>
+
+  import BookmarkItem from './BookmarkItem';
+
+  export default {
+    name: 'Bookmarks',
+    components: {
+      BookmarkItem,
+    },
+    props: {
+      outline: {
+        type: Array,
+        required: true,
+      },
+      goToDestination: {
+        type: Function,
+        required: true,
+      },
+      focusDestPage: {
+        type: Function,
+        required: true,
+      },
+    },
+    $trs: {
+      bookmarksSection:
+        'Bookmarks section. You can switch between the pdf document and bookmarks section pressing shift + enter.',
+    },
+  };
+
+</script>
+
+
+<style scoped lang="scss">
+
+  .bookmarks-wrapper {
+    padding: 32px 16px;
+    margin: 0;
+  }
+
+</style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
@@ -1,0 +1,164 @@
+<template>
+
+  <aside
+    class="pdf-sidebar"
+    :style="{
+      background: $themeTokens.surface,
+    }"
+  >
+    <nav :style="{ height: '100%' }">
+      <KGrid gutter="0">
+        <KGridItem
+          v-for="tab in tabs"
+          :key="tab.name"
+          :ref="tab.name"
+          :layout12="{ span: 4, alignment: 'center' }"
+          :style="{
+            background: selectedTab === tab.name ?
+              $themeTokens.annotation :
+              $themeTokens.transparent,
+            cursor: 'pointer',
+            borderRadius: '2px',
+            opacity: tab.disabled ? 0.5 : 1,
+            pointerEvents: tab.disabled ? 'none' : 'auto',
+            height: '48px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }"
+        >
+          <div
+            class="tab"
+            :tabindex="tab.disabled ? -1 : 0"
+            :aria-label="tab.name"
+            role="button"
+            @click="selectTab(tab.name)"
+            @keydown.enter="selectTab(tab.name)"
+            @keydown.space="selectTab(tab.name)"
+          >
+            <KIcon
+              :icon="tab.icon"
+              :style="{
+                fill: selectedTab === tab.name ?
+                  $themeTokens.textInverted :
+                  $themeTokens.text,
+                height: '24px',
+                width: '24px',
+              }"
+            />
+            <KTooltip
+              :reference="tab.name"
+              :refs="$refs"
+            >
+              {{ tab.label }}
+            </KTooltip>
+          </div>
+        </KGridItem>
+      </KGrid>
+      <div class="sidebar-content">
+        <template v-if="selectedTab === 'bookmarks'">
+          <Bookmarks
+            :outline="outline"
+            :goToDestination="goToDestination"
+            :focusDestPage="focusDestPage"
+          />
+        </template>
+        <template v-if="selectedTab === 'preview'">
+          <span> Preview </span>
+        </template>
+        <template v-if="selectedTab === 'annotations'">
+          <span> Annotations </span>
+        </template>
+      </div>
+    </nav>
+  </aside>
+
+</template>
+
+
+<script>
+
+  import Bookmarks from './Bookmarks';
+
+  export default {
+    name: 'SideBar',
+    components: {
+      Bookmarks,
+    },
+    props: {
+      outline: {
+        type: Array,
+        required: true,
+      },
+      goToDestination: {
+        type: Function,
+        required: true,
+      },
+      focusDestPage: {
+        type: Function,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        selectedTab: 'bookmarks',
+        tabs: [
+          {
+            name: 'bookmarks',
+            label: 'Bookmarks',
+            icon: 'list',
+            disabled: false,
+          },
+          {
+            name: 'preview',
+            label: 'Preview',
+            icon: 'channel',
+            disabled: true,
+          },
+          {
+            name: 'annotations',
+            label: 'Annotations',
+            icon: 'edit',
+            disabled: true,
+          },
+        ],
+      };
+    },
+    watch: {
+      outline() {
+        this.tabs[0].disabled = !this.outline || !this.outline.length;
+        this.selectedTab = this.outline && this.outline.length ? 'bookmarks' : 'preview';
+      },
+    },
+    methods: {
+      selectTab(tabName) {
+        this.selectedTab = tabName;
+      },
+    },
+  };
+
+</script>
+
+
+<style scoped lang="scss">
+
+  $sidebar-nav-height: 48px;
+
+  .pdf-sidebar {
+    height: 100%;
+    box-shadow: inset -1px 2px 8px rgba(0, 0, 0, 0.16);
+  }
+
+  .tab:focus-visible {
+    outline-width: 3px;
+    outline-style: solid;
+    outline-color: #8dc5b6;
+    outline-offset: 4px;
+  }
+
+  .sidebar-content {
+    height: calc(100% - #{$sidebar-nav-height});
+    overflow-y: auto;
+  }
+
+</style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
@@ -7,12 +7,11 @@
     }"
   >
     <nav :style="{ height: '100%' }">
-      <KGrid gutter="0">
-        <KGridItem
+      <div :style="{ display: 'flex' }">
+        <div
           v-for="tab in tabs"
           :key="tab.name"
           :ref="tab.name"
-          :layout12="{ span: 4, alignment: 'center' }"
           :style="{
             background: selectedTab === tab.name ?
               $themeTokens.annotation :
@@ -25,6 +24,7 @@
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
+            width: '100%'
           }"
         >
           <div
@@ -53,8 +53,8 @@
               {{ tab.label }}
             </KTooltip>
           </div>
-        </KGridItem>
-      </KGrid>
+        </div>
+      </div>
       <div class="sidebar-content">
         <template v-if="selectedTab === 'bookmarks'">
           <Bookmarks

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfPage.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfPage.spec.js
@@ -1,0 +1,124 @@
+import { shallowMount } from '@vue/test-utils';
+import PdfPage from '../src/views/PdfPage';
+import { EventBus } from '../src/utils/event_utils';
+import * as mockPDFJS from './mocks/pdfjsMock';
+
+jest.mock('pdfjs-dist/legacy/build/pdf', () => require('./mocks/pdfjsMock'));
+
+function makeWrapper(options = {}) {
+  return shallowMount(PdfPage, {
+    ...options,
+    propsData: {
+      pageNumber: 1,
+      pdfPage: mockPDFJS.PdfPage,
+      pageReady: false,
+      scale: 1,
+      firstPageHeight: 600,
+      firstPageWidth: 800,
+      ...options.propsData,
+      eventBus: new EventBus(),
+    },
+  });
+}
+
+describe('PdfPage', () => {
+  beforeAll(() => {
+    HTMLCanvasElement.prototype.getContext = () => {};
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    HTMLCanvasElement.prototype.getContext = undefined;
+  });
+
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe('canvas pdf page', () => {
+    it('Should render the page if the page is loaded', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: true,
+        },
+      });
+      await global.flushPromises();
+      expect(pdfPage.render).toHaveBeenCalled();
+    });
+
+    it('Should not render the page if the page is not loaded', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: false,
+        },
+      });
+      await global.flushPromises();
+      expect(pdfPage.render).not.toHaveBeenCalled();
+    });
+
+    it('Should render the page after the page is loaded', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      const wrapper = makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: false,
+        },
+      });
+      await global.flushPromises();
+
+      wrapper.setProps({ pageReady: true });
+      await global.flushPromises();
+      expect(pdfPage.render).toHaveBeenCalled();
+    });
+
+    it('Should show the canvas just after page rendering is complete', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      const wrapper = makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: false,
+        },
+      });
+      await global.flushPromises();
+      expect(wrapper.find('canvas').attributes('style')).toBe('display: none;');
+
+      wrapper.setProps({ pageReady: true });
+      await global.flushPromises();
+      expect(wrapper.find('canvas').attributes('style')).not.toBe('display: none;');
+    });
+  });
+
+  describe('Text layer', () => {
+    it('Should render the text layer if the page is loaded', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: true,
+        },
+      });
+      await global.flushPromises();
+      expect(mockPDFJS.renderTextLayer).toHaveBeenCalled();
+    });
+
+    it('Should not render the text layer if the page is not loaded', async () => {
+      const pdfPage = mockPDFJS.PdfPage;
+      makeWrapper({
+        propsData: {
+          pdfPage,
+          pageReady: false,
+        },
+      });
+      await global.flushPromises();
+      expect(mockPDFJS.renderTextLayer).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
@@ -1,40 +1,257 @@
+import { shallowMount } from '@vue/test-utils';
 import PdfRendererIndex from '../src/views/PdfRendererIndex';
+import * as mockPDFJS from './mocks/pdfjsMock';
 
 const { methods } = PdfRendererIndex;
 
 jest.mock('kolibri.urls');
 
-describe('updateProgress', () => {
-  let context = {};
+jest.mock('pdfjs-dist/legacy/build/pdf', () => require('./mocks/pdfjsMock'));
 
-  beforeEach(() => {
-    context = {
+jest.mock('lodash/debounce', () => fn => fn);
+
+jest.mock('lodash/throttle', () => fn => fn);
+
+const DUMMY_PDF_URL = 'http://localhost:8000/test.pdf';
+
+function makeWrapper(options = {}) {
+  return shallowMount(PdfRendererIndex, {
+    ...options,
+    data: () => ({
+      defaultFile: { storage_url: DUMMY_PDF_URL },
       forceDurationBasedProgress: null,
       $emit: jest.fn(),
-      durationBasedProgress: 0.1,
-      savedVisitedPages: { 1: 'true', 2: 'true', 3: 'true' },
-      totalPages: 9,
-    };
+      ...options.data,
+    }),
+  });
+}
+
+async function loadPdfContainer(options) {
+  const wrapper = makeWrapper(options);
+  mockPDFJS.loadingDocument.onProgress({ loaded: 10, total: 10 });
+  await global.flushPromises();
+
+  wrapper.vm.handleUpdate(); // First recyle list update call on mount
+  await global.flushPromises();
+  return wrapper;
+}
+
+describe('PdfRendererIndex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('updateProgress', () => {
+    let context = {};
+
+    beforeEach(() => {
+      context = {
+        forceDurationBasedProgress: null,
+        $emit: jest.fn(),
+        durationBasedProgress: 0.1,
+        savedVisitedPages: { 1: 'true', 2: 'true', 3: 'true' },
+        totalPages: 9,
+      };
+    });
+
+    it('should be able to calculate progress using "pages visited/total" by default', () => {
+      methods.updateProgress.call(context);
+
+      expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+      expect(context.$emit.mock.calls[0][1]).toEqual(
+        Object.keys(context.savedVisitedPages).length / context.totalPages
+      );
+      expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
+    });
+
+    it('should have option of using time-based tracking for progress calculation when forceDurationBasedProgress is true', () => {
+      context.forceDurationBasedProgress = true;
+      methods.updateProgress.call(context);
+
+      expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
+      expect(context.$emit.mock.calls[0][1]).toBe(0.1);
+      expect(context.$emit.mock.calls[0][1]).not.toEqual(
+        Object.keys(context.savedVisitedPages).length / context.totalPages
+      );
+    });
   });
 
-  it('should be able to calculate progress using "pages visited/total" by default', () => {
-    methods.updateProgress.call(context);
+  describe('First render', () => {
+    it('smoke test', () => {
+      const wrapper = makeWrapper();
+      expect(wrapper.exists()).toBe(true);
+    });
 
-    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
-    expect(context.$emit.mock.calls[0][1]).toEqual(
-      Object.keys(context.savedVisitedPages).length / context.totalPages
-    );
-    expect(context.$emit.mock.calls[0][1]).not.toBe(context.durationBasedProgress);
+    it('should get the pdf Document', () => {
+      makeWrapper({
+        data: { defaultFile: { storage_url: DUMMY_PDF_URL } },
+      });
+      expect(mockPDFJS.getDocument).toHaveBeenCalledWith(DUMMY_PDF_URL);
+    });
+
+    it('should get the pdf Document Outline', async () => {
+      const wrapper = await loadPdfContainer();
+      expect(wrapper.vm.outline).toBeDefined();
+    });
+
+    describe('Document loading progress', () => {
+      it('should update the loading progress when pdf Document is loading', () => {
+        const wrapper = makeWrapper();
+        expect(mockPDFJS.loadingDocument.onProgress).toBeDefined();
+        mockPDFJS.loadingDocument.onProgress({ loaded: 1, total: 10 });
+        expect(wrapper.vm.progress).toBe(0.1);
+      });
+
+      it('should show Loading component while pdf Document is loading', () => {
+        const wrapper = makeWrapper();
+        expect(wrapper.find('.progress-bar').exists()).toBe(true);
+        mockPDFJS.loadingDocument.onProgress({ loaded: 1, total: 10 });
+        expect(wrapper.find('.progress-bar').exists()).toBe(true);
+        expect(wrapper.find('.pdf-container').exists()).toBe(false);
+      });
+
+      it('should hide Loading component when pdf Document is loaded', async () => {
+        const wrapper = await loadPdfContainer();
+        expect(wrapper.find('.progress-bar').exists()).toBe(false);
+        expect(wrapper.find('.pdf-container').exists()).toBe(true);
+      });
+    });
+
+    describe('Pdf Pages loading', () => {
+      it('should load first the page one if there is the first time opening the pdf and there is no saved Location', async () => {
+        await loadPdfContainer();
+        expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledWith(1);
+      });
+
+      it('should load the proper page when there is a saved location', async () => {
+        const savedLocation = 0.2;
+        mockPDFJS.PdfDocument.numPages = 10;
+        await loadPdfContainer({
+          data: {
+            extraFields: {
+              contentState: { savedLocation },
+            },
+          },
+        });
+        // 0.2 * 10 = 2 Means that the user already passed the second page so the user
+        // will be on the third page
+        expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledWith(3);
+      });
+    });
   });
 
-  it('should have option of using time-based tracking for progress calculation when forceDurationBasedProgress is true', () => {
-    context.forceDurationBasedProgress = true;
-    methods.updateProgress.call(context);
+  describe('Pdf Pages loading on user scroll', () => {
+    it('should load required pages on user scroll', async () => {
+      const wrapper = await loadPdfContainer();
 
-    expect(context.$emit.mock.calls[0][0]).toBe('updateProgress');
-    expect(context.$emit.mock.calls[0][1]).toBe(0.1);
-    expect(context.$emit.mock.calls[0][1]).not.toEqual(
-      Object.keys(context.savedVisitedPages).length / context.totalPages
-    );
+      // Avoid first render reset
+      mockPDFJS.PdfDocument.getPage.mockClear();
+
+      // User has scrolled and can see from the second to the four page so
+      // that many pages should be loaded
+      const startIndex = 1;
+      const endIndex = 3;
+      wrapper.vm.handleUpdate(startIndex, endIndex);
+      await global.flushPromises();
+      expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledTimes(endIndex - startIndex + 1);
+      for (let i = startIndex; i <= endIndex; i++) {
+        expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledWith(i + 1);
+      }
+    });
+
+    it('should cache the proper loaded pages', async () => {
+      mockPDFJS.PdfDocument.numPages = 5;
+      const wrapper = await loadPdfContainer();
+
+      // user scrolls
+      const startIndex = 2;
+      const endIndex = 3;
+      wrapper.vm.handleUpdate(startIndex, endIndex);
+      await global.flushPromises();
+
+      // First, third and fourth pages are loaded
+      const expectedLoadedPages = [true, false, true, true, false];
+
+      wrapper.vm.pdfPages.forEach((page, index) => {
+        expect(page.resolved).toBe(expectedLoadedPages[index]);
+        if (page.resolved) {
+          expect(page.page).not.toBeNull();
+        }
+      });
+    });
+
+    it('should not load pages that are already loaded', async () => {
+      const wrapper = await loadPdfContainer();
+
+      // user scrolls a bit through the first page already loaded
+      const startIndex = 0;
+      const endIndex = 0;
+      wrapper.vm.handleUpdate(startIndex, endIndex);
+      await global.flushPromises();
+
+      expect(mockPDFJS.PdfDocument.getPage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Stored visited pages', () => {
+    it('Should set the first page as visited on mount', async () => {
+      const wrapper = makeWrapper();
+      await global.flushPromises();
+      expect(wrapper.vm.savedVisitedPages[1]).toBe(true);
+    });
+
+    it('Should set the proper page visited when user scrolls', async () => {
+      mockPDFJS.PdfDocument.numPages = 10;
+      const wrapper = await loadPdfContainer();
+
+      wrapper.vm.calculatePosition = () => 0.15;
+      wrapper.vm.handleUpdate(1, 2);
+      await global.flushPromises();
+
+      // 15% of 10 pages, so the user has visited the second page
+      expect(wrapper.vm.savedVisitedPages[2]).toBe(true);
+    });
+  });
+
+  describe('Pdf controls', () => {
+    it('should show the pdf controls on mount', async () => {
+      const wrapper = await loadPdfContainer();
+      expect(wrapper.find('.pdf-controls-container').exists()).toBe(true);
+    });
+
+    it('Should increase the scale when the user clicks on the zoom in button', async () => {
+      const mockUpdateVisibleItems = jest.fn();
+      const wrapper = await loadPdfContainer({
+        stubs: {
+          RecycleList: {
+            template: '<div />',
+            methods: {
+              updateVisibleItems: mockUpdateVisibleItems,
+            },
+          },
+        },
+      });
+      wrapper.vm.scale = 1;
+      const initialScale = wrapper.vm.scale;
+      wrapper.vm.zoomIn();
+      expect(wrapper.vm.scale > initialScale).toBe(true);
+    });
+
+    it('Should decrease the scale when the user clicks on the zoom out button', async () => {
+      const mockUpdateVisibleItems = jest.fn();
+      const wrapper = await loadPdfContainer({
+        stubs: {
+          RecycleList: {
+            template: '<div />',
+            methods: {
+              updateVisibleItems: mockUpdateVisibleItems,
+            },
+          },
+        },
+      });
+      wrapper.vm.scale = 1;
+      const initialScale = wrapper.vm.scale;
+      wrapper.vm.zoomOut();
+      expect(wrapper.vm.scale < initialScale).toBe(true);
+    });
   });
 });

--- a/kolibri/plugins/pdf_viewer/assets/tests/SideBar/Bookmarks.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/SideBar/Bookmarks.spec.js
@@ -1,0 +1,160 @@
+import { mount } from '@vue/test-utils';
+import Bookmarks from '../../src/views/SideBar/Bookmarks/index.vue';
+import BookmarkItem from '../../src/views/SideBar/Bookmarks/BookmarkItem.vue';
+
+function withWrapperArray(wrapperArray) {
+  return {
+    hasText: str => wrapperArray.filter(i => i.text().match(str)),
+    not: {
+      hasText: str => wrapperArray.filter(i => !i.text().match(str)),
+    },
+  };
+}
+
+const outline = [
+  {
+    dest: [{ num: 89, gen: 0 }, { name: 'XYZ' }, 70, 621, 0],
+    url: null,
+    title: 'Local Connection',
+    items: [
+      {
+        dest: [{ num: 1, gen: 0 }, { name: 'XYZ' }, 70, 720, 0],
+        url: null,
+        title: 'Power source asdfasdf',
+        items: [],
+      },
+      {
+        dest: [{ num: 1, gen: 0 }, { name: 'XYZ' }, 70, 577, 0],
+        url: null,
+        title: 'Inner Local network connection',
+        items: [],
+      },
+      {
+        dest: [{ num: 1, gen: 0 }, { name: 'XYZ' }, 70, 450, 0],
+        url: null,
+        title: 'Server devices',
+        items: [],
+      },
+      {
+        dest: [{ num: 1, gen: 0 }, { name: 'XYZ' }, 70, 260, 0],
+        url: null,
+        title: 'Client devices',
+        items: [],
+      },
+    ],
+  },
+  {
+    dest: [{ num: 3, gen: 0 }, { name: 'XYZ' }, 70, 621, 0],
+    url: null,
+    title: 'Network Connection 2',
+    items: [],
+  },
+];
+
+function makeWrapper(options = {}) {
+  return mount(Bookmarks, {
+    ...options,
+    propsData: {
+      outline,
+      goToDestination: jest.fn(),
+      ...options.propsData,
+    },
+  });
+}
+
+describe('Pdf Bookmarks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('smoke test', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should render the root bookmarks', () => {
+    const wrapper = makeWrapper();
+    expect(wrapper.findAllComponents(BookmarkItem)).toHaveLength(outline.length);
+    outline.forEach(bookmark => {
+      expect(
+        withWrapperArray(wrapper.findAllComponents(BookmarkItem)).hasText(bookmark.title)
+      ).toHaveLength(1);
+    });
+  });
+
+  it('should render dropdown-icon for bookmarks with children', () => {
+    const wrapper = makeWrapper();
+    outline.forEach(bookmark => {
+      const bookmarkItem = withWrapperArray(wrapper.findAllComponents(BookmarkItem))
+        .hasText(bookmark.title)
+        .at(0);
+      if (bookmark.items.length) {
+        expect(bookmarkItem.find('.dropdown-icon').exists()).toBe(true);
+      } else {
+        expect(bookmarkItem.find('.dropdown-icon').exists()).toBe(false);
+      }
+    });
+  });
+
+  it('should render children bookmarks when click on dropdown', async () => {
+    const wrapper = makeWrapper();
+    for (const bookmark of outline) {
+      if (!bookmark.items.length) continue;
+      const bookmarkItem = withWrapperArray(wrapper.findAllComponents(BookmarkItem))
+        .hasText(bookmark.title)
+        .at(0);
+
+      // check that children are not rendered before click
+      expect(
+        withWrapperArray(bookmarkItem.findAllComponents(BookmarkItem)).hasText(
+          bookmark.items[0].title
+        )
+      ).toHaveLength(0);
+
+      bookmarkItem.find('.dropdown-icon-container').trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(
+        withWrapperArray(bookmarkItem.findAllComponents(BookmarkItem))
+          .hasText(bookmark.items[0].title)
+          // filter leaf nodes
+          .filter(i => i.findAllComponents(BookmarkItem).length === 1)
+      ).toHaveLength(1);
+    }
+  });
+
+  it('should hide children bookmarks when double click on dropdown', async () => {
+    const wrapper = makeWrapper();
+    for (const bookmark of outline) {
+      if (!bookmark.items.length) continue;
+      const bookmarkItem = withWrapperArray(wrapper.findAllComponents(BookmarkItem))
+        .hasText(bookmark.title)
+        .at(0);
+
+      bookmarkItem.find('.dropdown-icon-container').trigger('click');
+      await wrapper.vm.$nextTick();
+      bookmarkItem.find('.dropdown-icon-container').trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(
+        withWrapperArray(bookmarkItem.findAllComponents(BookmarkItem)).hasText(
+          bookmark.items[0].title
+        )
+      ).toHaveLength(0);
+    }
+  });
+
+  it('should call goToDestination when click on bookmark', async () => {
+    const goToDestination = jest.fn();
+    const wrapper = makeWrapper({
+      propsData: { goToDestination },
+    });
+    for (const bookmark of outline) {
+      const bookmarkItem = withWrapperArray(wrapper.findAllComponents(BookmarkItem))
+        .hasText(bookmark.title)
+        .at(0);
+      bookmarkItem.find('.bookmark-item-title').trigger('click');
+      await wrapper.vm.$nextTick();
+      expect(goToDestination).toHaveBeenCalledWith(bookmark.dest);
+    }
+  });
+});

--- a/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-undef */
+
+export const GlobalWorkerOptions = {
+  workerSrc: '',
+};
+
+export const PdfPage = {
+  view: [0, 0, 595.276, 841.89],
+  getViewport: jest.fn(() => ({})),
+  render: jest.fn(() => ({
+    promise: Promise.resolve(),
+    cancel: jest.fn(),
+  })),
+  streamTextContent: jest.fn(() => ({})),
+};
+
+export const PdfDocument = {
+  numPages: 1,
+  getPage: jest.fn(() => Promise.resolve(PdfPage)),
+  cleanup: jest.fn(),
+  destroy: jest.fn(),
+  getOutline: jest.fn(() => Promise.resolve([])),
+  getPageIndex: jest.fn(() => Promise.resolve(1)),
+  getDestination: jest.fn(() => Promise.resolve([])),
+};
+
+export const loadingDocument = {
+  onProgress: null,
+  promise: Promise.resolve(PdfDocument),
+};
+
+export const getDocument = jest.fn(() => loadingDocument);
+
+export const renderTextLayer = jest.fn(() => ({
+  promise: Promise.resolve(),
+  expandTextDivs: jest.fn(),
+  cancel: jest.fn(),
+}));
+
+/* eslint-enable */

--- a/kolibri/plugins/pdf_viewer/buildConfig.js
+++ b/kolibri/plugins/pdf_viewer/buildConfig.js
@@ -3,7 +3,7 @@ module.exports = {
   webpack_config: {
     entry: {
       main: './assets/src/module.js',
-      pdfJSWorker: 'pdfjs-dist/build/pdf.worker.entry',
+      pdfJSWorker: 'pdfjs-dist/legacy/build/pdf.worker.entry',
     },
   },
 };

--- a/kolibri/plugins/pdf_viewer/package.json
+++ b/kolibri/plugins/pdf_viewer/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
-    "pdfjs-dist": "^1.9.426",
     "intersection-observer": "0.5.0",
+    "pdfjs-dist": "^2.14.305",
     "vue-virtual-scroller": "0.12.0"
   }
 }

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
     __filename: true,
     __copyrightYear: true,
     __kolibriModuleName: true,
+    __webpack_public_path__: true,
   },
   extends: [
     'eslint:recommended',

--- a/packages/kolibri-tools/jest.conf/index.js
+++ b/packages/kolibri-tools/jest.conf/index.js
@@ -19,6 +19,7 @@ module.exports = {
     __kolibriModuleName: 'testmodule',
     __version: 'testversion',
     __copyrightYear: '2018',
+    __webpack_public_path__: 'webpack_public_path',
     'vue-jest': {
       babelConfig,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14453,7 +14453,7 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-web-streams-polyfill@^3.2.0, web-streams-polyfill@^3.2.1:
+web-streams-polyfill@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5395,6 +5395,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dommatrix@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dommatrix/-/dommatrix-1.0.3.tgz#e7c18e8d6f3abdd1fef3dd4aa74c4d2e620a0525"
+  integrity sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==
+
 domutils@1.5:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -9018,7 +9023,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@^1.0.0, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9841,11 +9846,6 @@ node-cache@^4.1.1:
     clone "2.x"
     lodash "^4.17.15"
 
-node-ensure@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/node-ensure/-/node-ensure-0.0.0.tgz#ecae764150de99861ec5c810fd5d096b183932a7"
-  integrity sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=
-
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -10603,13 +10603,13 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pdfjs-dist@^1.9.426:
-  version "1.10.100"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-1.10.100.tgz#d5a250b42482ab6e41d763a795ce7cdebe6b1894"
-  integrity sha512-aCfONGqlBeazYxik3rjd7xaoCKMRYECwZSCC3EC3weqibF2V1Bp/v9WZbF7Lyy5Q6UE4NqOYu126r7U+Le4Uhg==
+pdfjs-dist@^2.14.305:
+  version "2.16.105"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz#937b9c4a918f03f3979c88209d84c1ce90122c2a"
+  integrity sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==
   dependencies:
-    node-ensure "^0.0.0"
-    worker-loader "^1.0.0"
+    dommatrix "^1.0.3"
+    web-streams-polyfill "^3.2.1"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -12333,14 +12333,6 @@ sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-schema-utils@^0.4.0:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
-  integrity sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==
-  dependencies:
-    ajv "^6.1.0"
-    ajv-keywords "^3.1.0"
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -14461,6 +14453,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
+web-streams-polyfill@^3.2.0, web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
+
 webfontloader@^1.6.24:
   version "1.6.28"
   resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
@@ -14765,14 +14762,6 @@ worker-farm@^1.7.0:
   integrity sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==
   dependencies:
     errno "~0.1.7"
-
-worker-loader@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/worker-loader/-/worker-loader-1.1.1.tgz#920d74ddac6816fc635392653ed8b4af1929fd92"
-  integrity sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==
-  dependencies:
-    loader-utils "^1.0.0"
-    schema-utils "^0.4.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## Summary

Backport develop changes of pdf_viewer from develop to 0.15.x.

## References

Backported changes:

* Update PDFJs version to 2.14 #9526 
* Rendering PDF text layer #9536 
* Rendering PDF struct tree layer #9585 
* Add unit tests #9586 
* Render SidePanel with PDF Bookmarks #9743 
* Fix page height and width calculations #9888 
* Support for rotated PDFs #9907 

## Reviewer guidance

Test everything with pdfs rendering works ok in release-v0.15.x. 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
