### PR TITLE
Facility export usage data section design updated

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/DataPage/LearnMoreModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/LearnMoreModal.vue
@@ -1,0 +1,80 @@
+<template>
+
+  <KModal
+    :title="logType === 'summary' ? $tr('summaryLogs') : $tr('sessionLogs')"
+    :submitText="$tr('close')"
+    size="medium"
+    @cancel="closeModal"
+    @submit="closeModal"
+  >
+    <p class="description">
+      {{ getMessage() }}
+    </p>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  export default {
+    name: 'LearnMoreModal',
+    props: {
+      logType: {
+        type: String,
+        required: true,
+      },
+    },
+    methods: {
+      closeModal() {
+        this.$emit('cancel');
+      },
+      getMessage() {
+        let message = '';
+        if (this.logType === 'summary') {
+          message = this.$tr('summaryLogText');
+        } else if (this.logType === 'session') {
+          message = this.$tr('sessionLogText');
+        }
+        return message;
+      },
+    },
+    $trs: {
+      summaryLogs: {
+        message: 'Summary Logs',
+        context: 'Title for Summary logs description',
+      },
+      sessionLogs: {
+        message: 'Session Logs',
+        context: 'Title for Session logs description',
+      },
+      summaryLogText: {
+        message:
+          'A user may visit the same resource multiple times. This file records the total time and progress each user has achieved for each resource, summarized across possibly more than one visit. Anonymous usage is not included.',
+        context:
+          "Text description on the 'Learn More' pop-up window in the Facility > Data > Export usage data section.\n",
+      },
+      sessionLogText: {
+        message:
+          'When a user views a resource, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific resource. This includes anonymous usage, when no user is signed in.',
+        context:
+          "Text description on the 'Learn More' pop-up window in the Facility > Data > Export usage data section.\n",
+      },
+      close: {
+        message: 'Close',
+        context:
+          "Refers to the 'Close' button on the 'Learn More' pop-up window in the Facility > Data > Export usage data section.",
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .description {
+    margin-top: 0;
+  }
+
+</style>

--- a/kolibri/plugins/facility/assets/src/views/DataPage/LearnMoreModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/LearnMoreModal.vue
@@ -1,14 +1,14 @@
 <template>
 
   <KModal
-    :title="logType === 'summary' ? $tr('summaryLogs') : $tr('sessionLogs')"
+    :title="modalTitle"
     :submitText="$tr('close')"
     size="medium"
     @cancel="closeModal"
     @submit="closeModal"
   >
     <p class="description">
-      {{ getMessage() }}
+      {{ modalMessage }}
     </p>
   </KModal>
 
@@ -23,29 +23,31 @@
       logType: {
         type: String,
         required: true,
+        validator(value) {
+          return ['summary', 'session'].includes(value);
+        },
+      },
+    },
+    computed: {
+      modalTitle() {
+        return this.logType === 'summary' ? this.$tr('summaryLogs') : this.$tr('sessionLogs');
+      },
+      modalMessage() {
+        return this.logType === 'summary' ? this.$tr('summaryLogText') : this.$tr('sessionLogText');
       },
     },
     methods: {
       closeModal() {
         this.$emit('cancel');
       },
-      getMessage() {
-        let message = '';
-        if (this.logType === 'summary') {
-          message = this.$tr('summaryLogText');
-        } else if (this.logType === 'session') {
-          message = this.$tr('sessionLogText');
-        }
-        return message;
-      },
     },
     $trs: {
       summaryLogs: {
-        message: 'Summary Logs',
+        message: 'Summary logs',
         context: 'Title for Summary logs description',
       },
       sessionLogs: {
-        message: 'Session Logs',
+        message: 'Session logs',
         context: 'Title for Session logs description',
       },
       summaryLogText: {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -13,67 +13,80 @@
           <p>{{ $tr('pageSubHeading') }}</p>
         </KGridItem>
 
-        <KGridItem :layout8="{ span: 4 }" :layout12="{ span: 6 }">
+        <KGridItem :layout12="{ span: 8 }">
           <h2>{{ $tr('detailsHeading') }}</h2>
-          <p>{{ $tr('detailsSubHeading') }}</p>
-          <p>
-            <KButton
-              :text="$tr('download')"
-              style="margin-right: 8px;"
-              :disabled="!availableSessionCSVLog"
-              @click="downloadSessionLog"
-            />
-            <span v-if="noSessionLogs">{{ $tr('noLogsYet') }}</span>
-            <GeneratedElapsedTime v-else-if="sessionDateCreated" :date="sessionDateCreated" />
+          <p class="subheading">
+            {{ $tr('detailsSubHeading') }}
           </p>
-          <p v-if="!canUploadDownloadFiles" :style="noDlStyle">
-            {{ $tr('noDownload') }}
-          </p>
-          <p v-else-if="inSessionCSVCreation">
-            <DataPageTaskProgress>{{ $tr('generatingLog') }}</DataPageTaskProgress>
-          </p>
-          <p v-else>
-
+          <p class="subheading">
             <KButton
               appearance="basic-link"
-              :text="noSessionLogs ? $tr('generateLog') : $tr('regenerateLog')"
-              @click="generateSessionLog"
+              :text="$tr('LearnMore')"
+              @click="showLearnMoreSessionModal = true"
             />
           </p>
-          <p class="infobox">
-            <b>{{ $tr('note') }}</b> {{ $tr('detailsInfo') }}
+          <p class="generated-time">
+            <GeneratedElapsedTime v-if="sessionDateCreated" :date="sessionDateCreated" />
           </p>
         </KGridItem>
 
-        <KGridItem :layout8="{ span: 4 }" :layout12="{ span: 6 }">
-          <h2>{{ $tr('summaryHeading') }}</h2>
-          <p>{{ $tr('summarySubHeading') }}</p>
-          <p>
-            <KButton
-              :text="$tr('download')"
-              style="margin-right: 8px;"
-              :disabled="!availableSummaryCSVLog"
-              @click="downloadSummaryLog"
-            />
-            <span v-if="noSummaryLogs">{{ $tr('noLogsYet') }}</span>
-            <GeneratedElapsedTime v-else-if="summaryDateCreated" :date="summaryDateCreated" />
-          </p>
-          <p v-if="!canUploadDownloadFiles" :style="noDlStyle">
-            {{ $tr('noDownload') }}
-          </p>
-          <p v-else-if="inSummaryCSVCreation">
+        <KGridItem class="session-section-buttons" :layout12="{ span: 4, alignment: 'right' }">
+          <KButton
+            v-if="availableSessionCSVLog"
+            class="subheading-buttons"
+            appearance="flat-button"
+            :text="$tr('download')"
+            @click="downloadSessionLog"
+          />
+          <p v-if="inSessionCSVCreation">
             <DataPageTaskProgress>{{ $tr('generatingLog') }}</DataPageTaskProgress>
           </p>
-          <p v-else>
+          <KButton
+            v-else
+            class="subheading-buttons"
+            :text="$tr('generateLog')"
+            @click="generateSessionLog"
+          />
+        </KGridItem>
+
+        <KGridItem>
+          <p class="section-seperator"></p>
+        </KGridItem>
+
+        <KGridItem :layout12="{ span: 8 }">
+          <h2>{{ $tr('summaryHeading') }}</h2>
+          <p class="subheading">
+            {{ $tr('summarySubHeading') }}
+          </p>
+          <p class="subheading">
             <KButton
               appearance="basic-link"
-              :text="noSummaryLogs ? $tr('generateLog') : $tr('regenerateLog')"
-              @click="generateSummaryLog"
+              :text="$tr('LearnMore')"
+              @click="showLearnMoreSummaryModal = true"
             />
           </p>
-          <p class="infobox">
-            <b>{{ $tr('note') }}</b> {{ $tr('summaryInfo') }}
+          <p class="generated-time">
+            <GeneratedElapsedTime v-if="summaryDateCreated" :date="summaryDateCreated" />
           </p>
+        </KGridItem>
+
+        <KGridItem class="summary-section-buttons" :layout12="{ span: 4, alignment: 'right' }">
+          <KButton
+            v-if="availableSummaryCSVLog"
+            class="subheading-buttons"
+            appearance="flat-button"
+            :text="$tr('download')"
+            @click="downloadSummaryLog"
+          />
+          <p v-if="inSummaryCSVCreation">
+            <DataPageTaskProgress>{{ $tr('generatingLog') }}</DataPageTaskProgress>
+          </p>
+          <KButton
+            v-else
+            class="subheading-buttons"
+            :text="$tr('generateLog')"
+            @click="generateSummaryLog"
+          />
         </KGridItem>
 
       </KGrid>
@@ -81,6 +94,20 @@
 
     <ImportInterface v-if="canUploadDownloadFiles" />
     <SyncInterface />
+
+    <LearnMoreModal
+      v-if="showLearnMoreSummaryModal"
+      logType="summary"
+      @cancel="showLearnMoreSummaryModal = false"
+      @submit="showLearnMoreSummaryModal = false"
+    />
+
+    <LearnMoreModal
+      v-if="showLearnMoreSessionModal"
+      logType="session"
+      @cancel="showLearnMoreSessionModal = false"
+      @submit="showLearnMoreSessionModal = false"
+    />
 
   </FacilityAppBarPage>
 
@@ -100,6 +127,7 @@
   import DataPageTaskProgress from './DataPageTaskProgress';
   import SyncInterface from './SyncInterface';
   import ImportInterface from './ImportInterface';
+  import LearnMoreModal from './LearnMoreModal.vue';
 
   export default {
     name: 'DataPage',
@@ -114,16 +142,21 @@
       GeneratedElapsedTime,
       ImportInterface,
       SyncInterface,
+      LearnMoreModal,
     },
     mixins: [commonCoreStrings],
+    data() {
+      return {
+        showLearnMoreSummaryModal: false,
+        showLearnMoreSessionModal: false,
+      };
+    },
     computed: {
       ...mapGetters('manageCSV', [
         'availableSessionCSVLog',
         'availableSummaryCSVLog',
         'inSessionCSVCreation',
         'inSummaryCSVCreation',
-        'noSessionLogs',
-        'noSummaryLogs',
       ]),
       ...mapGetters(['activeFacilityId']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
@@ -134,11 +167,6 @@
       },
       pollForTasks() {
         return this.$route.name === PageNames.DATA_EXPORT_PAGE;
-      },
-      noDlStyle() {
-        return {
-          color: this.$themeTokens.annotation,
-        };
       },
     },
     watch: {
@@ -208,13 +236,8 @@
         message: 'Session logs',
         context: "'Session logs' refer to individual visits to each resource made by a user.",
       },
-      detailsInfo: {
-        message:
-          'When a user views a resource, we record how long they spend and the progress they make. Each row in this file records a single visit a user made to a specific resource. This includes anonymous usage, when no user is signed in.',
-        context: "Detailed explanation of 'Session logs'.",
-      },
       detailsSubHeading: {
-        message: 'Individual visits to each resource',
+        message: 'Individual visits to each resource.',
         context: "Description of 'Session logs'.",
       },
       documentTitle: {
@@ -226,7 +249,7 @@
         context: 'Button used to download logs contained in CSV files.',
       },
       generateLog: {
-        message: 'Generate log file',
+        message: 'Generate log',
         context:
           "Option to generate a log file which can then be downloaded in CSV format.\n\nWhen there are no logs, this string is displayed, after the user generates logs, the string is replaced with 'Generate a new log file'.",
       },
@@ -234,18 +257,6 @@
         message: 'Generating log file...',
         context:
           "Message that displays when user clicks on 'Generate a new log file'. Log files contain information about users and their interactions with the resources on the device.",
-      },
-      noDownload: {
-        message: 'Download is not supported on Android',
-        context: 'Android specific message.',
-      },
-      noLogsYet: {
-        message: 'No logs are available to download.',
-        context: "Message that displays if no logs are available yet in the user's facility.",
-      },
-      note: {
-        message: 'Note:',
-        context: 'Text that precedes the more detailed explanation of what logs are.',
       },
       pageHeading: {
         message: 'Export usage data',
@@ -256,23 +267,18 @@
           'Download CSV (comma-separated value) files containing information about users and their interactions with the resources on this device',
         context: "Description of the 'Export usage data' page.\n",
       },
-      regenerateLog: {
-        message: 'Generate a new log file',
-        context: 'Option to generate a log file which can then be downloaded in CSV format.',
-      },
       summaryHeading: {
         message: 'Summary logs',
         context:
           'Summary logs record the total time and progress each user has achieved for each resource.',
       },
       summarySubHeading: {
-        message: 'Total time/progress for each resource',
+        message: 'Total time/progress for each resource.',
         context: "Description of 'Summary logs'.",
       },
-      summaryInfo: {
-        message:
-          'A user may visit the same resource multiple times. This file records the total time and progress each user has achieved for each resource, summarized across possibly more than one visit. Anonymous usage is not included.',
-        context: "Detailed explanation of 'Summary logs'.\n",
+      LearnMore: {
+        message: 'Learn More',
+        context: 'Message that displays session or summary log information\n',
       },
     },
   };
@@ -284,12 +290,33 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .infobox {
-    padding: 8px;
-    margin-right: -8px;
-    margin-left: -8px;
-    font-size: 0.8em;
-    border-radius: $radius;
+  .subheading {
+    display: inline-block;
+    margin: 0 0.313rem 0.313rem 0;
+  }
+
+  .subheading-buttons {
+    display: inline-block;
+    margin-right: 0.313rem;
+  }
+
+  .generated-time {
+    margin: 0.313rem 0;
+    color: #616161;
+  }
+
+  .section-seperator {
+    margin: 0.313rem 0;
+    border-bottom: 1px solid rgb(222, 222, 222);
+  }
+
+  .session-section-buttons {
+    padding-top: 20px;
+    padding-bottom: 15px;
+  }
+
+  .summary-section-buttons {
+    padding-top: 20px;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -353,6 +353,7 @@
     padding-top: 20px;
   }
 
+  // conditional class to support KButton order style; based on computed prop windowSizeStyle
   /deep/ .section-buttons-flex div {
     display: flex;
   }

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -13,7 +13,7 @@
           <p>{{ $tr('pageSubHeading') }}</p>
         </KGridItem>
 
-        <KGridItem :layout12="{ span: 8 }">
+        <KGridItem :layout12="{ span: 6 }">
           <h2>{{ $tr('detailsHeading') }}</h2>
           <p class="subheading">
             {{ $tr('detailsSubHeading') }}
@@ -25,12 +25,12 @@
               @click="showLearnMoreSessionModal = true"
             />
           </p>
-          <p class="generated-time">
+          <p class="generated-time" :style="{ color: $themeTokens.annotation }">
             <GeneratedElapsedTime v-if="sessionDateCreated" :date="sessionDateCreated" />
           </p>
         </KGridItem>
 
-        <KGridItem class="session-section-buttons" :layout12="{ span: 4, alignment: 'right' }">
+        <KGridItem class="session-section-buttons" :layout12="{ span: 6, alignment: 'right' }">
           <KButton
             v-if="availableSessionCSVLog"
             class="subheading-buttons"
@@ -44,16 +44,22 @@
           <KButton
             v-else
             class="subheading-buttons"
-            :text="$tr('generateLog')"
+            :style="windowSizeStyle"
+            :text="$tr('generateLogButtonText')"
             @click="generateSessionLog"
           />
         </KGridItem>
 
         <KGridItem>
-          <p class="section-seperator"></p>
+          <p
+            class="section-seperator"
+            :style="{
+              borderBottom: `1px solid ${$themeTokens.fineLine}`,
+            }"
+          ></p>
         </KGridItem>
 
-        <KGridItem :layout12="{ span: 8 }">
+        <KGridItem :layout12="{ span: 6 }">
           <h2>{{ $tr('summaryHeading') }}</h2>
           <p class="subheading">
             {{ $tr('summarySubHeading') }}
@@ -65,12 +71,12 @@
               @click="showLearnMoreSummaryModal = true"
             />
           </p>
-          <p class="generated-time">
+          <p class="generated-time" :style="{ color: $themeTokens.annotation }">
             <GeneratedElapsedTime v-if="summaryDateCreated" :date="summaryDateCreated" />
           </p>
         </KGridItem>
 
-        <KGridItem class="summary-section-buttons" :layout12="{ span: 4, alignment: 'right' }">
+        <KGridItem class="summary-section-buttons" :layout12="{ span: 6, alignment: 'right' }">
           <KButton
             v-if="availableSummaryCSVLog"
             class="subheading-buttons"
@@ -84,7 +90,8 @@
           <KButton
             v-else
             class="subheading-buttons"
-            :text="$tr('generateLog')"
+            :style="windowSizeStyle"
+            :text="$tr('generateLogButtonText')"
             @click="generateSummaryLog"
           />
         </KGridItem>
@@ -121,6 +128,7 @@
   import urls from 'kolibri.urls';
   import { FacilityResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import { PageNames } from '../../constants';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import GeneratedElapsedTime from './GeneratedElapsedTime';
@@ -144,7 +152,7 @@
       SyncInterface,
       LearnMoreModal,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, KResponsiveWindowMixin],
     data() {
       return {
         showLearnMoreSummaryModal: false,
@@ -167,6 +175,14 @@
       },
       pollForTasks() {
         return this.$route.name === PageNames.DATA_EXPORT_PAGE;
+      },
+      windowSizeStyle() {
+        if (this.windowIsMedium || this.windowIsSmall) {
+          return {
+            float: 'left',
+          };
+        }
+        return {};
       },
     },
     watch: {
@@ -248,7 +264,7 @@
         message: 'Download',
         context: 'Button used to download logs contained in CSV files.',
       },
-      generateLog: {
+      generateLogButtonText: {
         message: 'Generate log',
         context:
           "Option to generate a log file which can then be downloaded in CSV format.\n\nWhen there are no logs, this string is displayed, after the user generates logs, the string is replaced with 'Generate a new log file'.",
@@ -302,12 +318,10 @@
 
   .generated-time {
     margin: 0.313rem 0;
-    color: #616161;
   }
 
   .section-seperator {
     margin: 0.313rem 0;
-    border-bottom: 1px solid rgb(222, 222, 222);
   }
 
   .session-section-buttons {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -14,11 +14,13 @@
         </KGridItem>
 
         <KGridItem :layout12="{ span: 6 }">
-          <h2>{{ $tr('detailsHeading') }}</h2>
-          <p class="subheading">
+          <h3 class="subheading">
+            {{ $tr('detailsHeading') }}
+          </h3>
+          <p class="subheading-desc">
             {{ $tr('detailsSubHeading') }}
           </p>
-          <p class="subheading">
+          <p class="subheading-desc">
             <KButton
               appearance="basic-link"
               :text="$tr('LearnMore')"
@@ -30,10 +32,15 @@
           </p>
         </KGridItem>
 
-        <KGridItem class="session-section-buttons" :layout12="{ span: 6, alignment: 'right' }">
+        <KGridItem
+          class="session-section-buttons"
+          :class="windowSizeStyle"
+          :layout12="{ span: 6, alignment: 'right' }"
+        >
           <KButton
             v-if="availableSessionCSVLog"
             class="subheading-buttons"
+            :style="windowIsMedium || windowIsSmall ? { order: 2 } : { order: 1 }"
             appearance="flat-button"
             :text="$tr('download')"
             @click="downloadSessionLog"
@@ -44,7 +51,6 @@
           <KButton
             v-else
             class="subheading-buttons"
-            :style="windowSizeStyle"
             :text="$tr('generateLogButtonText')"
             @click="generateSessionLog"
           />
@@ -60,11 +66,13 @@
         </KGridItem>
 
         <KGridItem :layout12="{ span: 6 }">
-          <h2>{{ $tr('summaryHeading') }}</h2>
-          <p class="subheading">
+          <h3 class="subheading">
+            {{ $tr('summaryHeading') }}
+          </h3>
+          <p class="subheading-desc">
             {{ $tr('summarySubHeading') }}
           </p>
-          <p class="subheading">
+          <p class="subheading-desc">
             <KButton
               appearance="basic-link"
               :text="$tr('LearnMore')"
@@ -76,10 +84,15 @@
           </p>
         </KGridItem>
 
-        <KGridItem class="summary-section-buttons" :layout12="{ span: 6, alignment: 'right' }">
+        <KGridItem
+          class="summary-section-buttons"
+          :class="windowSizeStyle"
+          :layout12="{ span: 6, alignment: 'right' }"
+        >
           <KButton
             v-if="availableSummaryCSVLog"
             class="subheading-buttons"
+            :style="windowIsMedium || windowIsSmall ? { order: 2 } : { order: 1 }"
             appearance="flat-button"
             :text="$tr('download')"
             @click="downloadSummaryLog"
@@ -90,7 +103,6 @@
           <KButton
             v-else
             class="subheading-buttons"
-            :style="windowSizeStyle"
             :text="$tr('generateLogButtonText')"
             @click="generateSummaryLog"
           />
@@ -178,9 +190,7 @@
       },
       windowSizeStyle() {
         if (this.windowIsMedium || this.windowIsSmall) {
-          return {
-            float: 'left',
-          };
+          return 'section-buttons-flex';
         }
         return {};
       },
@@ -306,7 +316,17 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
+  /deep/ .page-container p {
+    font-size: 0.93em;
+  }
+
   .subheading {
+    margin-top: 10px;
+    margin-bottom: 5px;
+    font-size: 0.93em;
+  }
+
+  .subheading-desc {
     display: inline-block;
     margin: 0 0.313rem 0.313rem 0;
   }
@@ -331,6 +351,10 @@
 
   .summary-section-buttons {
     padding-top: 20px;
+  }
+
+  /deep/ .section-buttons-flex div {
+    display: flex;
   }
 
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR updates the 'Export usage data' section under the Facility > Data tab. The changes include the notes being relocated to appear in modals when the "Learn More" link is clicked and a responsive design for varying viewport sizes down to mobile. The `Download` and `Generate` log buttons now wrap below when the viewport size is too small for them to appear on the same row.

Before
![image](https://user-images.githubusercontent.com/46411498/210438667-d07f6db5-0ad4-4a15-8467-1192e20280c2.png)

After
<img width="1004" alt="ExportUsageDataAfter" src="https://user-images.githubusercontent.com/46411498/210438906-733cd098-89ab-4eab-b47d-10723b0cedd2.png">

<img width="783" alt="ExportUsageDataAfterResponsive" src="https://user-images.githubusercontent.com/46411498/210439167-f8858681-0fc0-4e50-beff-db9497cb0676.png">

<img width="577" alt="ExportUsageDataAfterResponsive2" src="https://user-images.githubusercontent.com/46411498/210439181-103ec649-4642-4f43-989d-d9afcfdccf50.png">





## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
[Figma mockup](https://www.figma.com/file/SgTZugaKkES68aipU5dCk8SR/Github-issues-%26-random-fixes?node-id=1055%3A2073&t=LWDWhNNeD7A6srJo-0)
Closes #9704

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Facility > Data tab.
2. Confirm `Generate` and `Download` buttons display the expected behavior.
3. Confirm `Learn more` links open modals that contain the correct information.
4. Adjust the screen viewport to confirm that the responsive design responds as expected.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
