### PR TITLE
fixed hidden banner on mobile view

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
@@ -16,7 +16,7 @@
       </h1>
     </KGridItem>
     <KGridItem
-      :layout4="{ span: 4 }"
+      :layout4="{ span: 1 }"
     >
       <img
         :src="topic.thumbnail"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
@@ -16,7 +16,7 @@
       </h1>
     </KGridItem>
     <KGridItem
-      :layout4="{ span: 1 }"
+      :layout4="{ span: 4 }"
     >
       <img
         :src="topic.thumbnail"
@@ -50,7 +50,8 @@
 
   .mobile-header {
     position: relative;
-    height: 100%;
+    top: 70px;
+    height: 70px;
   }
 
   .mobile-title {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -32,7 +32,7 @@
         :style="gridOffset"
       >
         <KBreadcrumbs
-          v-if="breadcrumbs.length && windowIsSmall"
+          v-if="breadcrumbs.length"
           data-test="mobile-breadcrumbs"
           :items="breadcrumbs"
         />
@@ -693,7 +693,7 @@
 <style lang="scss" scoped>
 
   $header-height: 324px;
-  $toolbar-height: 70px;
+  $toolbar-height: 50px;
   $total-height: 394px;
 
   .page {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -32,7 +32,7 @@
         :style="gridOffset"
       >
         <KBreadcrumbs
-          v-if="breadcrumbs.length"
+          v-if="breadcrumbs.length && windowIsSmall"
           data-test="mobile-breadcrumbs"
           :items="breadcrumbs"
         />
@@ -693,7 +693,7 @@
 <style lang="scss" scoped>
 
   $header-height: 324px;
-  $toolbar-height: 50px;
+  $toolbar-height: 70px;
   $total-height: 394px;
 
   .page {


### PR DESCRIPTION


## Summary
This PR fixes regression on the mobile view 

…

## References
closes #9962
Before
<img width="503" alt="Screenshot 2023-01-05 at 19 53 21" src="https://user-images.githubusercontent.com/103313919/210836402-9ecc8e2e-309d-4f01-9ac8-6f1b3af3f312.png">



After
<img width="613" alt="Screenshot 2023-01-05 at 19 41 42" src="https://user-images.githubusercontent.com/103313919/210835874-65b7090c-fa95-4b82-bbec-9593bc2ef9d4.png">


…

## Reviewer guidance
1. Go to the Library > Browse channel.
2. Reduce your screen size to mobile view and observe



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
