### PR TITLE
Use $formatNumber instead of dummy string.

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1059,10 +1059,6 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Score obtained by a learner on a quiz, indicated by the percentage of correct answers given.',
   },
-  percentage: {
-    message: '{value, number, percent}',
-    context: 'Formatting a number into a percentage',
-  },
   // TODO - move these into diff sections as we make this a full feature in 0.16
   // Past Papers Project (12/2021) strings
   timeSpentLabel: {

--- a/kolibri/plugins/coach/assets/src/csv/fields.js
+++ b/kolibri/plugins/coach/assets/src/csv/fields.js
@@ -1,7 +1,7 @@
 import pad from 'lodash/padStart';
 import get from 'lodash/get';
 import { createTranslator, formatList } from 'kolibri.utils.i18n';
-import coreStringsMixin from 'kolibri.coreVue.mixins.commonCoreStrings';
+import coreStrings from 'kolibri.utils.coreStrings';
 import { STATUSES } from '../modules/classSummary/constants';
 import { VERBS } from '../views/common/status/constants';
 import { learnerProgressTranslators } from '../views/common/status/statusStrings';
@@ -46,8 +46,6 @@ const VERB_MAP = {
   [STATUSES.completed]: VERBS.completed,
 };
 
-const coreStrings = coreStringsMixin.methods.coreString;
-
 /*
  * Common CSV export fields and formats
  */
@@ -70,7 +68,7 @@ export function avgScore() {
           return '';
         }
 
-        return coreStrings('percentage', { value: row.avgScore });
+        return coreStrings.$formatNumber(row.avgScore, { style: 'percent' });
       },
     },
   ];
@@ -110,7 +108,7 @@ export function lastActivity() {
 export function learnerProgress(key = 'status') {
   return [
     {
-      name: coreStrings('progressLabel'),
+      name: coreStrings.$tr('progressLabel'),
       key,
       format(row) {
         const value = get(row, key);
@@ -184,14 +182,14 @@ export function recipients(className) {
 export function score() {
   return [
     {
-      name: coreStrings('scoreLabel'),
+      name: coreStrings.$tr('scoreLabel'),
       key: 'score',
       format: row => {
         if (!row.statusObj.score && row.statusObj.score !== 0) {
           return '';
         }
 
-        return coreStrings('percentage', { value: row.statusObj.score });
+        return coreStrings.$formatNumber(row.statusObj.score, { style: 'percent' });
       },
     },
   ];
@@ -200,7 +198,7 @@ export function score() {
 export function tally() {
   return [
     {
-      name: coreStrings('notStartedLabel'),
+      name: coreStrings.$tr('notStartedLabel'),
       key: 'tally.notStarted',
     },
     {
@@ -208,7 +206,7 @@ export function tally() {
       key: 'tally.started',
     },
     {
-      name: coreStrings('completedLabel'),
+      name: coreStrings.$tr('completedLabel'),
       key: 'tally.completed',
     },
     {


### PR DESCRIPTION
## Summary
* Uses FormatJS APIs instead of creating dummy strings for i18n of numbers

## References
Cleanup from #9941


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
