### PR TITLE
Remove unnecessary translation strings in favour of number i18n method.

### DIFF
--- a/kolibri/core/assets/src/views/ProgressBar.vue
+++ b/kolibri/core/assets/src/views/ProgressBar.vue
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div v-if="showPercentage" class="progress-bar-text">
-      {{ $tr('pct', [progress]) }}
+      {{ $formatNumber(progress, { style: 'percent' }) }}
     </div>
   </div>
 
@@ -55,12 +55,6 @@
     computed: {
       percent() {
         return Math.max(Math.min(this.progress * 100, 100), 0);
-      },
-    },
-    $trs: {
-      pct: {
-        message: '{0, number, percent}',
-        context: 'DO NOT TRANSLATE\nCopy the source string.',
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ChannelContentsSummary.vue
@@ -55,17 +55,17 @@
       </tr>
       <tr>
         <th>{{ $tr('totalSizeRow') }}</th>
-        <td>{{ $tr('resourceCount', { count: channel.total_resources || 0 }) }}</td>
+        <td>{{ $formatNumber(channel.total_resources || 0, { useGrouping: true }) }}</td>
         <td>{{ bytesForHumans(channel.total_file_size || 0) }}</td>
       </tr>
       <tr>
         <th>{{ $tr('onDeviceRow') }}</th>
-        <td>{{ $tr('resourceCount', { count: channel.on_device_resources || 0 }) }}</td>
+        <td>{{ $formatNumber(channel.on_device_resources || 0, { useGrouping: true }) }}</td>
         <td>{{ bytesForHumans(channel.on_device_file_size || 0) }}</td>
       </tr>
       <tr v-if="channel.new_resource_count !== null">
         <th>{{ $tr('newOrUpdatedLabel') }}</th>
-        <td>{{ $tr('resourceCount', { count: channel.new_resource_count || 0 }) }}</td>
+        <td>{{ $formatNumber(channel.new_resource_count || 0, { useGrouping: true }) }}</td>
         <td>{{ bytesForHumans(channel.new_resource_total_size || 0) }}</td>
       </tr>
       <tr v-if="!remoteContentEnabled && freeSpace !== null">
@@ -132,10 +132,6 @@
       onDeviceRow: {
         message: 'On your device',
         context: "Indicates resources that are on the user's device.",
-      },
-      resourceCount: {
-        message: '{count, number, useGrouping}',
-        context: 'DO NOT TRANSLATE\nCopy the source string.',
       },
       sizeCol: {
         message: 'Size',

--- a/kolibri/plugins/epub_viewer/assets/src/views/BottomBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/BottomBar.vue
@@ -12,7 +12,7 @@
           <div class="d-t-r">
             <div class="bottom-bar-progress-container d-t-c">
               <div class="bottom-bar-progress">
-                {{ $tr('progress', { progress: sliderValue / 100 }) }}
+                {{ $formatNumber(sliderValue / 100, { style: 'percent' }) }}
               </div>
             </div>
             <div class="d-t-c full-width">
@@ -75,10 +75,6 @@
       },
     },
     $trs: {
-      progress: {
-        message: `{progress, number, percent}`,
-        context: 'DO NOT TRANSLATE\nCopy the source string.',
-      },
       jumpToPositionInBook: {
         message: 'Jump to position in book',
         context:


### PR DESCRIPTION
## Summary
* Removes translation strings that have been created simply to render a number, that can be directly rendered in an i18n friendly way using the `$formatNumber` method.

## References
https://github.com/learningequality/vue-intl#formatnumber

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
