### PR TITLE
bump kds to latest develop commit

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -20,7 +20,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#e203de2141dd9c8e807a1285a9d695a083576fc8",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -23,7 +23,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.41",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#e203de2141dd9c8e807a1285a9d695a083576fc8",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8077,9 +8077,9 @@ kolibri-constants@0.1.41:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.41.tgz#7acf8118bc4ab2ceb3e28b807e391d46bb563ed9"
   integrity sha512-cykNfZvnW8FZlpYnk3SvTUuCOGlYGwgmQbor91dpWe9z8Tb4jcZKYzIY+ZBCsjgsU1azb+R+gdqLxrdw9LgGLg==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#e203de2141dd9c8e807a1285a9d695a083576fc8":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#043f9dec00e1926a55b819a0105a60dd1b4472d0"
+  resolved "https://github.com/learningequality/kolibri-design-system#e203de2141dd9c8e807a1285a9d695a083576fc8"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary
Supersedes #9775 
Fixes https://github.com/learningequality/kolibri/issues/9754

## References
Bumps KDS version to the latest `develop` commit, which will fix the regression above and also make available updates including @LianaHarris360 KDatePicker component and more robust icon handling.