### PR TITLE
Only display the completion modal on the finish event when the resource is also complete

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -209,7 +209,7 @@
         this.hideMarkAsCompleteModal();
         // Do this immediately to remove any delay
         // before the completion modal displays if appropriate.
-        this.onFinished();
+        this.displayCompletionModal();
         return this.updateProgress(1.0)
           .then(() => {
             this.$store.dispatch('createSnackbar', this.learnString('resourceCompletedLabel'));
@@ -231,8 +231,23 @@
       onFinished() {
         if (this.wasComplete) {
           this.$emit('finished');
-        } else {
+        } else if (this.complete) {
+          // Only show the completion modal if this is marked as complete
           this.displayCompletionModal();
+        } else {
+          // Otherwise, set a watch for complete changing value
+          // in case this gets updated soon after the finish event.
+          // For example the media player plugin seems to emit the finished
+          // event before the progress has been updated.
+          const watchComplete = this.$watch('complete', () => {
+            this.displayCompletionModal();
+            watchComplete();
+          });
+          // We give a 250 millisecond timeout to let this change happen.
+          // So if the completion does not update within 250 milliseconds,
+          // we clear the watcher and will require another finished event
+          // before we display the completion modal.
+          setTimeout(watchComplete, 250);
         }
       },
       displayCompletionModal() {


### PR DESCRIPTION
## Summary
* Fixes an issue where the completion modal would display even if the resource isn't complete, simply because the `finish` event was emitted.
* Does this by either checking whether complete is true, or adding a short lived watcher for complete, in case the progress update happens in a small interval after the finish event.

## References
Fixes #9983

## Reviewer guidance
Confirm the fix of #9983 PDFs
Also confirm that the completion modal still properly displays when videos complete

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
