### PR TITLE
added modal for setting PIN

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1082,6 +1082,14 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Change learning facility',
     context: 'Menu or screen used for the user to move to a different learning facility',
   },
+  enterPinPlaceholder: {
+    message: 'Enter PIN',
+    context: 'Placholder text for the enter pin textbox',
+  },
+  removePinPlacholder: {
+    message: 'REMOVE PIN',
+    context: 'Placholder text for the remove pin textbox',
+  },
 });
 
 // We forgot a string, so we are using one from the PerseusInternalMessages namespace

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -110,6 +110,19 @@ export default createTranslator('NotificationStrings', {
     message: 'Group deleted',
     context: 'A confirmation message indicating that the user has deleted a new group of learners.',
   },
+  pinCreated: {
+    message: 'New PIN created',
+    context: 'A confirmation message for creating a new a pin',
+  },
+  pinUpadeted: {
+    message: 'PIN updated',
+    context: 'A confimation message for updating a pin',
+  },
+  pinRemove: {
+    message: 'PIN removed',
+    context: 'A confirmation message for removing a pin',
+  },
+
   // TODO move more messages into this namespace:
   // - "Quiz started"
   // - "Quiz Ended"

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -13,7 +13,7 @@
 
       <KTextbox
         v-model="name"
-        type="number"
+        input="number"
         :label="$tr('enterPinLabel')"
         :maxlength="4"
         @blur="nameBlurred = true"

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -2,8 +2,8 @@
 
   <KModal
     :title="$tr('title')"
-    :submitText="$tr('save')"
-    :cancelText="$tr('cancel')"
+    :submitText="coreString('saveAction')"
+    :cancelText="coreString('cancelAction')"
     @submit="submit"
     @cancel="$emit('cancel')"
   >
@@ -12,10 +12,10 @@
       <p>{{ $tr('setPin') }}</p>
 
       <KTextbox
-        ref="myfocus"
+        ref="pinFocus"
         v-model="pin"
         input="number"
-        :label="$tr('enterPinLabel')"
+        :label="coreString('enterPinPlaceholder')"
         :maxlength="4"
         :invalid="true"
         :invalidText="pinError"
@@ -61,7 +61,7 @@
         this.showSnackbarNotification('pinUpadeted');
       },
       focus: function() {
-        this.$refs.myfocus.focus();
+        this.$refs.pinFocus.focus();
       },
     },
     $trs: {
@@ -77,18 +77,6 @@
       setPin: {
         message: 'Choose four numbers to set as your new PIN.',
         context: 'Label to allow user to choose numbers to set PIN',
-      },
-      cancel: {
-        message: 'cancel',
-        context: 'cancel btn text',
-      },
-      save: {
-        message: 'save',
-        context: 'Text for save button',
-      },
-      enterPinLabel: {
-        message: 'Enter PIN',
-        context: 'Enter PIN label',
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -1,0 +1,65 @@
+<template>
+
+  <KModal
+    :title="$tr('title')"
+    :submitText="$tr('save')"
+    :cancelText="$tr('cancel')"
+    @submit="$emit('submit')"
+    @cancel="$emit('cancel')"
+  >
+    <div>
+      <p>{{ $tr('needToSync') }}</p>
+      <p>{{ $tr('setPin') }}</p>
+
+      <KTextbox
+        v-model="name"
+        type="number"
+        :label="$tr('enterPinLabel')"
+        :maxlength="4"
+        @blur="nameBlurred = true"
+      />
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'ChangePinModal',
+    mixins: [commonCoreStrings],
+    methods: {},
+
+    $trs: {
+      title: {
+        message: 'Change device management PIN',
+        context: 'Title for the change pin modal.',
+      },
+      needToSync: {
+        message:
+          'You will need to sync this device with other devices that share this facility in order to use this PIN.',
+        context: 'Reminder to sync devices',
+      },
+      setPin: {
+        message: 'Choose four numbers to set as your new PIN.',
+        context: 'Label to allow user to choose numbers to set PIN',
+      },
+      cancel: {
+        message: 'cancel',
+        context: 'cancel btn text',
+      },
+      save: {
+        message: 'save',
+        context: 'Text for save button',
+      },
+      enterPinLabel: {
+        message: 'Enter PIN',
+        context: 'Enter PIN label',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -4,7 +4,7 @@
     :title="$tr('title')"
     :submitText="$tr('save')"
     :cancelText="$tr('cancel')"
-    @submit="$emit('submit')"
+    @submit="submit"
     @cancel="$emit('cancel')"
   >
     <div>
@@ -12,11 +12,14 @@
       <p>{{ $tr('setPin') }}</p>
 
       <KTextbox
-        v-model="name"
+        ref="myfocus"
+        v-model="pin"
         input="number"
         :label="$tr('enterPinLabel')"
         :maxlength="4"
-        @blur="nameBlurred = true"
+        :invalid="true"
+        :invalidText="pinError"
+        :showInvalidText="showErrorText"
       />
     </div>
   </KModal>
@@ -31,8 +34,36 @@
   export default {
     name: 'ChangePinModal',
     mixins: [commonCoreStrings],
-    methods: {},
-
+    data() {
+      return {
+        pin: '',
+        pinPattern: /^[0-9]{4}$/,
+        pinError: null,
+        showErrorText: false,
+      };
+    },
+    computed: {},
+    methods: {
+      submit() {
+        if (!this.pin) {
+          this.showErrorText = true;
+          this.pinError = 'This field cannot be empty';
+          this.focus();
+        } else {
+          if (this.pinPattern.test(this.pin)) {
+            this.pinError = '';
+            this.$emit('submit');
+          } else {
+            this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
+            this.focus();
+          }
+        }
+        this.showSnackbarNotification('pinUpadeted');
+      },
+      focus: function() {
+        this.$refs.myfocus.focus();
+      },
+    },
     $trs: {
       title: {
         message: 'Change device management PIN',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -46,7 +46,7 @@
       submit() {
         if (!this.pin) {
           this.showErrorText = true;
-          this.pinError = 'This feild cannot be empty';
+          this.pinError = 'This field cannot be empty';
         } else {
           if (this.pinPattern.test(this.pin)) {
             this.pinError = '';

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -58,6 +58,7 @@
             this.focus();
           }
         }
+        this.showSnackbarNotification('pinCreated');
       },
       focus: function() {
         this.$refs.myfocus.focus();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -2,8 +2,8 @@
 
   <KModal
     :title="$tr('title')"
-    :submitText="$tr('save')"
-    :cancelText="$tr('cancel')"
+    :submitText="coreString('saveAction')"
+    :cancelText="coreString('cancelAction')"
     @submit="submit"
     @cancel="$emit('cancel')"
   >
@@ -12,10 +12,10 @@
       <p>{{ $tr('enterPin') }}</p>
 
       <KTextbox
-        ref="myfocus"
+        ref="pinFocus"
         v-model="pin"
         input="number"
-        :label="$tr('enterPinLabel')"
+        :label="coreString('enterPinPlaceholder')"
         :maxlength="4"
         :invalid="true"
         :invalidText="pinError"
@@ -61,7 +61,7 @@
         this.showSnackbarNotification('pinCreated');
       },
       focus: function() {
-        this.$refs.myfocus.focus();
+        this.$refs.pinFocus.focus();
       },
     },
     $trs: {
@@ -77,18 +77,6 @@
       enterPin: {
         message: 'Enter four numbers to set as your new PIN',
         context: 'Label to allow user to enter PIN',
-      },
-      cancel: {
-        message: 'cancel',
-        context: 'cancel btn text',
-      },
-      save: {
-        message: 'save',
-        context: 'Text for save button',
-      },
-      enterPinLabel: {
-        message: 'Enter PIN',
-        context: 'Enter PIN label',
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -12,6 +12,7 @@
       <p>{{ $tr('enterPin') }}</p>
 
       <KTextbox
+        ref="myfocus"
         v-model="pin"
         input="number"
         :label="$tr('enterPinLabel')"
@@ -47,14 +48,19 @@
         if (!this.pin) {
           this.showErrorText = true;
           this.pinError = 'This field cannot be empty';
+          this.focus();
         } else {
           if (this.pinPattern.test(this.pin)) {
             this.pinError = '';
             this.$emit('submit');
           } else {
             this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
+            this.focus();
           }
         }
+      },
+      focus: function() {
+        this.$refs.myfocus.focus();
       },
     },
     $trs: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -1,0 +1,65 @@
+<template>
+
+  <KModal
+    :title="$tr('title')"
+    :submitText="$tr('save')"
+    :cancelText="$tr('cancel')"
+    @submit="$emit('submit')"
+    @cancel="$emit('cancel')"
+  >
+    <div>
+      <p>{{ $tr('newToSync') }}</p>
+      <p>{{ $tr('enterPin') }}</p>
+
+      <KTextbox
+        v-model="name"
+        type="number"
+        :label="$tr('enterPinLabel')"
+        :maxlength="4"
+        @blur="nameBlurred = true"
+      />
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'CreateManagementPinModal',
+    mixins: [commonCoreStrings],
+    methods: {},
+
+    $trs: {
+      title: {
+        message: 'Create device management PIN',
+        context: 'Title for the create management modal.',
+      },
+      newToSync: {
+        message:
+          'You will need to sync this device with other devices with the same facility in order to use this PIN.',
+        context: 'Reminder to sync devices',
+      },
+      enterPin: {
+        message: 'Enter four numbers to set as your new PIN',
+        context: 'Label to allow user to enter PIN',
+      },
+      cancel: {
+        message: 'cancel',
+        context: 'cancel btn text',
+      },
+      save: {
+        message: 'save',
+        context: 'Text for save button',
+      },
+      enterPinLabel: {
+        message: 'Enter PIN',
+        context: 'Enter PIN label',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -4,7 +4,7 @@
     :title="$tr('title')"
     :submitText="$tr('save')"
     :cancelText="$tr('cancel')"
-    @submit="$emit('submit')"
+    @submit="submit"
     @cancel="$emit('cancel')"
   >
     <div>
@@ -12,11 +12,13 @@
       <p>{{ $tr('enterPin') }}</p>
 
       <KTextbox
-        v-model="name"
-        type="number"
+        v-model="pin"
+        input="number"
         :label="$tr('enterPinLabel')"
         :maxlength="4"
-        @blur="nameBlurred = true"
+        :invalid="true"
+        :invalidText="pinError"
+        :showInvalidText="showErrorText"
       />
     </div>
   </KModal>
@@ -31,8 +33,30 @@
   export default {
     name: 'CreateManagementPinModal',
     mixins: [commonCoreStrings],
-    methods: {},
-
+    data() {
+      return {
+        pin: '',
+        pinPattern: /^[0-9]{4}$/,
+        pinError: null,
+        showErrorText: false,
+      };
+    },
+    computed: {},
+    methods: {
+      submit() {
+        if (!this.pin) {
+          this.showErrorText = true;
+          this.pinError = 'This feild cannot be empty';
+        } else {
+          if (this.pinPattern.test(this.pin)) {
+            this.pinError = '';
+            this.$emit('submit');
+          } else {
+            this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
+          }
+        }
+      },
+    },
     $trs: {
       title: {
         message: 'Create device management PIN',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
@@ -2,8 +2,8 @@
 
   <KModal
     :title="$tr('title')"
-    :submitText="$tr('removePin')"
-    :cancelText="$tr('cancel')"
+    :submitText="coreString('removePinPlacholder')"
+    :cancelText="coreString('cancelAction')"
     @submit="removePin"
     @cancel="$emit('cancel')"
   >
@@ -37,14 +37,6 @@
         message:
           'You will need to sync this device with other devices that share this facility in order to use this PIN.',
         context: 'Reminder to sync devices',
-      },
-      cancel: {
-        message: 'cancel',
-        context: 'label for the cancel button',
-      },
-      removePin: {
-        message: 'REMOVE PIN',
-        context: 'label for the remove pin button',
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
@@ -1,0 +1,48 @@
+<template>
+
+  <KModal
+    :title="$tr('title')"
+    :submitText="$tr('removePin')"
+    :cancelText="$tr('cancel')"
+    @submit="$emit('submit')"
+    @cancel="$emit('cancel')"
+  >
+    <div>
+      <p>{{ $tr('warningToSync') }}</p>
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'RemovePinModal',
+    mixins: [commonCoreStrings],
+    methods: {},
+
+    $trs: {
+      title: {
+        message: 'Remove device management PIN',
+        context: 'Title for the remove pin modal.',
+      },
+      warningToSync: {
+        message:
+          'You will need to sync this device with other devices that share this facility in order to use this PIN.',
+        context: 'Reminder to sync devices',
+      },
+      cancel: {
+        message: 'cancel',
+        context: 'label for the cancel button',
+      },
+      removePin: {
+        message: 'REMOVE PIN',
+        context: 'label for the remove pin button',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
@@ -4,7 +4,7 @@
     :title="$tr('title')"
     :submitText="$tr('removePin')"
     :cancelText="$tr('cancel')"
-    @submit="$emit('submit')"
+    @submit="removePin"
     @cancel="$emit('cancel')"
   >
     <div>
@@ -22,8 +22,12 @@
   export default {
     name: 'RemovePinModal',
     mixins: [commonCoreStrings],
-    methods: {},
-
+    methods: {
+      removePin() {
+        this.$emit('submit');
+        this.showSnackbarNotification('pinRemove');
+      },
+    },
     $trs: {
       title: {
         message: 'Remove device management PIN',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
@@ -6,7 +6,7 @@
     @cancel="$emit('cancel')"
   >
     <div>
-      <p>{{ $tr('pin') }}</p>
+      <p>{{ userPinNumber }}</p>
 
     </div>
   </KModal>
@@ -21,16 +21,17 @@
   export default {
     name: 'ViewPinModal',
     mixins: [commonCoreStrings],
+    computed: {
+      userPinNumber() {
+        return 123;
+      },
+    },
     methods: {},
 
     $trs: {
       title: {
         message: 'Device management PIN',
         context: 'Title for the view pin modal.',
-      },
-      pin: {
-        message: '123',
-        context: 'user pin',
       },
       close: {
         message: 'close',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
@@ -1,0 +1,42 @@
+<template>
+
+  <KModal
+    :title="$tr('title')"
+    :cancelText="$tr('close')"
+    @cancel="$emit('cancel')"
+  >
+    <div>
+      <p>{{ $tr('pin') }}</p>
+
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'ViewPinModal',
+    mixins: [commonCoreStrings],
+    methods: {},
+
+    $trs: {
+      title: {
+        message: 'Device management PIN',
+        context: 'Title for the view pin modal.',
+      },
+      pin: {
+        message: '123',
+        context: 'user pin',
+      },
+      close: {
+        message: 'close',
+        context: 'close button for the modal',
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -114,9 +114,9 @@
       />
 
       <CreateManagementPinModal
-        v-if="CreatePinShow"
-        @submit="CreatePinShow = false"
-        @cancel="CreatePinShow = false"
+        v-if="createPinShow"
+        @submit="createPinShow = false"
+        @cancel="createPinShow = false"
       />
 
       <ViewPinModal
@@ -214,7 +214,7 @@
         showModal: false,
         showEditFacilityModal: false,
         settingsCopy: {},
-        CreatePinShow: false,
+        createPinShow: false,
         handleViewModal: false,
         handleChangePinModal: false,
         handleRemovePinModal: false,
@@ -320,7 +320,7 @@
         this.settingsCopy = Object.assign({}, this.settings);
       },
       handlecreatePin() {
-        this.CreatePinShow = true;
+        this.createPinShow = true;
       },
       handleSelect(option) {
         if (option.value === 'VIEW') {
@@ -393,7 +393,7 @@
         context: 'Description for the device management',
       },
       createPinBtn: {
-        message: 'CREATE PIN',
+        message: 'create pin',
         context: 'Button for the create pin',
       },
       optionBtn: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -82,6 +82,7 @@
           <KButton
             hasDropdown
             :text="$tr('optionBtn')"
+            style="marginLeft:15px"
           >
             <template #menu>
               <KDropdownMenu

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -78,6 +78,22 @@
           <KButton @click="handlecreatePin">
             {{ $tr('createPinBtn') }}
           </KButton>
+
+          <KButton
+            hasDropdown
+            :text="$tr('optionBtn')"
+          >
+            <template #menu>
+              <KDropdownMenu
+                :options="dropdownOption"
+                class="options-btn"
+                @select="handleSelect"
+              />
+            </template>
+          </KButton>
+
+
+
         </div>
       </template>
 
@@ -100,6 +116,22 @@
         v-if="CreatePinShow"
         @submit="CreatePinShow = false"
         @cancel="CreatePinShow = false"
+      />
+
+      <ViewPinModal
+        v-if="handleViewModal"
+        @cancel="handleViewModal = false"
+      />
+      <ChangePinModal
+        v-if="handleChangePinModal"
+        @submit="handleChangePinModal = false"
+        @cancel="handleChangePinModal = false"
+      />
+
+      <RemovePinModal
+        v-if="handleRemovePinModal"
+        @submit="handleRemovePinModal = false"
+        @cancel="handleRemovePinModal = false"
       />
 
     </KPageContainer>
@@ -144,6 +176,9 @@
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
   import CreateManagementPinModal from './CreateManagementPinModal';
+  import ViewPinModal from './ViewPinModal';
+  import ChangePinModal from './ChangePinModal';
+  import RemovePinModal from './RemovePinModal';
 
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
@@ -168,6 +203,9 @@
       EditFacilityNameModal,
       BottomAppBar,
       CreateManagementPinModal,
+      ViewPinModal,
+      ChangePinModal,
+      RemovePinModal,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     data() {
@@ -176,6 +214,9 @@
         showEditFacilityModal: false,
         settingsCopy: {},
         CreatePinShow: false,
+        handleViewModal: false,
+        handleChangePinModal: false,
+        handleRemovePinModal: false,
       };
     },
     computed: {
@@ -203,6 +244,13 @@
       },
       enableChangePassword() {
         return this.settings['learner_can_login_with_no_password'];
+      },
+      dropdownOption() {
+        return [
+          { label: 'View PIN', value: 'VIEW' },
+          { label: 'Change PIN', value: 'CHANGE' },
+          { label: 'Remove PIN', value: 'REMOVE' },
+        ];
       },
     },
     watch: {
@@ -273,6 +321,15 @@
       handlecreatePin() {
         this.CreatePinShow = true;
       },
+      handleSelect(option) {
+        if (option.value === 'VIEW') {
+          this.handleViewModal = true;
+        } else if (option.value === 'CHANGE') {
+          this.handleChangePinModal = true;
+        } else if (option.value === 'REMOVE') {
+          this.handleRemovePinModal = true;
+        }
+      },
     },
     $trs: {
       // These are not going to be picked up by the linter because snake cased versions
@@ -337,6 +394,10 @@
       createPinBtn: {
         message: 'CREATE PIN',
         context: 'Button for the create pin',
+      },
+      optionBtn: {
+        message: 'option',
+        context: 'Options button for the create pin page',
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -75,7 +75,7 @@
           <h2>{{ $tr('deviceManagementPin') }}</h2>
 
           <p>{{ $tr('deviceManagementDescription') }}</p>
-          <KButton @click="handlecreatePin">
+          <KButton @click="handleCreatePin">
             {{ $tr('createPinBtn') }}
           </KButton>
 
@@ -319,7 +319,7 @@
       copySettings() {
         this.settingsCopy = Object.assign({}, this.settings);
       },
-      handlecreatePin() {
+      handleCreatePin() {
         this.createPinShow = true;
       },
       handleSelect(option) {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -67,28 +67,17 @@
           </div>
 
           <div>
-            <KButtonGroup style="margin-top: 8px;">
-              <KButton
-                :primary="false"
-                appearance="raised-button"
-                :text="$tr('resetToDefaultSettings')"
 
-                name="reset-settings"
-                @click="showModal = true"
-              />
-
-              <KButton
-                :primary="true"
-                :class="windowIsSmall ? 'mobile-button' : ''"
-                appearance="raised-button"
-                :text="coreString('saveChangesAction')"
-                name="save-settings"
-
-                :disabled="!settingsHaveChanged"
-                @click="saveConfig()"
-              />
-            </KButtonGroup>
           </div>
+        </div>
+
+        <div class="">
+          <h2>{{ $tr('deviceManagementPin') }}</h2>
+
+          <p>{{ $tr('deviceManagementDescription') }}</p>
+          <KButton @click="handlecreatePin">
+            {{ $tr('createPinBtn') }}
+          </KButton>
         </div>
       </template>
 
@@ -106,7 +95,36 @@
         @submit="sendFacilityName"
         @cancel="showEditFacilityModal = false"
       />
+
+      <CreateManagementPinModal
+        v-if="CreatePinShow"
+        @submit="CreatePinShow = false"
+        @cancel="CreatePinShow = false"
+      />
+
     </KPageContainer>
+
+    <BottomAppBar>
+      <KButtonGroup style="margin-top: 8px;">
+        <KButton
+          :primary="false"
+          appearance="flat-button"
+          :text="$tr('resetToDefaultSettings')"
+          name="reset-settings"
+          @click="showModal = true"
+        />
+
+        <KButton
+          :primary="true"
+          :class="windowIsSmall ? 'mobile-button' : ''"
+          appearance="raised-button"
+          :text="coreString('saveChangesAction')"
+          name="save-settings"
+          :disabled="!settingsHaveChanged"
+          @click="saveConfig()"
+        />
+      </KButtonGroup>
+    </BottomAppBar>
   </FacilityAppBarPage>
 
 </template>
@@ -121,9 +139,11 @@
   import isEqual from 'lodash/isEqual';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
+  import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
+  import CreateManagementPinModal from './CreateManagementPinModal';
 
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
@@ -146,6 +166,8 @@
       FacilityAppBarPage,
       ConfirmResetModal,
       EditFacilityNameModal,
+      BottomAppBar,
+      CreateManagementPinModal,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],
     data() {
@@ -153,6 +175,7 @@
         showModal: false,
         showEditFacilityModal: false,
         settingsCopy: {},
+        CreatePinShow: false,
       };
     },
     computed: {
@@ -247,6 +270,9 @@
       copySettings() {
         this.settingsCopy = Object.assign({}, this.settings);
       },
+      handlecreatePin() {
+        this.CreatePinShow = true;
+      },
     },
     $trs: {
       // These are not going to be picked up by the linter because snake cased versions
@@ -298,6 +324,19 @@
       documentTitle: {
         message: 'Facility Settings',
         context: 'Title of page where user can configure facility settings.',
+      },
+      deviceManagementPin: {
+        message: 'Device management PIN',
+        context: 'The title for the device management pin',
+      },
+      deviceManagementDescription: {
+        message:
+          'This 4-digit PIN allows users to manage content and other settings on learn-only devices',
+        context: 'Description for the device management',
+      },
+      createPinBtn: {
+        message: 'CREATE PIN',
+        context: 'Button for the create pin',
       },
     },
   };


### PR DESCRIPTION
## Summary
This PR introduces a modal to handle  PIN creating on the device facility setting page
## References
Closes #9992
## Reviewer guidance
Navigate to the facility  setting page, locate the button to create PIN, click and observe the behaviour

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
