### PR TITLE
Fix restarting on Windows

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -640,6 +640,7 @@
             this.$store.dispatch('createSnackbar', this.$tr('saveSuccessNotification'));
             if (this.restartSetting !== null) {
               this.restart();
+              this.restartSetting = null;
             }
           })
           .catch(() => {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -521,6 +521,11 @@ class ProcessControlPlugin(Monitor):
             if command == RESTART:
                 self.bus.log("Restarting server.")
                 self.thread.cancel()
+                if installation_types.WINDOWS in installation_type().lower():
+                    # On Windows, we need to restart the server with the same executable
+                    # magicbus gets messed up trying to find a python script to run
+                    sys.executable = sys.argv[0]
+                    sys.argv = sys.argv[1:]
                 self.bus.restart()
             elif command == STOP:
                 self.bus.log("Stopping server.")


### PR DESCRIPTION
## Summary
Kolibri uses `MagicBus` to handle its restart. This library supposses applications [are launched from a python file](https://github.com/cherrypy/magicbus/blob/main/magicbus/plugins/lifecycle.py#L85) and that's not the case in Windows where `kolibri.exe` is used to launch the application.
This PR changes some system paths for magicbus to execute the right command when starting kolibri after stopping it.

## References
Closes: #9880  
@pcenov 

## Reviewer guidance

Using the new device settings feature, change the Primary Storage Location to force a restart of kolibri from the browser:
- Does it work properly on Windows?



## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
