### PR TITLE
Backport fix for number of users from #9942

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/UserTable.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserTable.vue
@@ -209,7 +209,10 @@
       selectAll(checked) {
         const currentUsers = this.users.map(user => user.id);
         if (checked) {
-          return this.$emit('input', [...this.value, ...currentUsers]);
+          return this.$emit(
+            'input',
+            this.value.concat(currentUsers.filter(item => this.value.indexOf(item) < 0))
+          );
         }
         return this.$emit('input', difference(this.value, currentUsers));
       },


### PR DESCRIPTION
## Summary
Backports #9942 to 0.15
UserTable has moved location since, so just copied code back.

## References
Backport #9942 
Should fix #9632 on 0.15

## Reviewer guidance


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
