### PR TITLE
[PDF_Viewer] Recalculate pdf scale on sidebar toggle

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -76,6 +76,7 @@
           />
         </KGridItem>
         <KGridItem
+          ref="pdfContainer"
           :layout8="{ span: showSideBar ? 6 : 8 }"
           :layout12="{ span: showSideBar ? 9 : 12 }"
         >
@@ -215,6 +216,15 @@
         // https://github.com/vuejs/vue/issues/2870#issuecomment-219096773
         return debounce(this.showVisiblePages, renderDebounceTime);
       },
+      screenSizeMultiplier() {
+        if (this.windowIsLarge) {
+          return 1.25;
+        }
+        if (this.windowIsSmall) {
+          return 1;
+        }
+        return 1.125;
+      },
     },
     watch: {
       recycleListIsMounted(newVal) {
@@ -244,6 +254,15 @@
         if (this.recycleListIsMounted) {
           this.debounceForceUpdateRecycleList();
         }
+      },
+      showSideBar() {
+        this.$nextTick(() => {
+          if (!this.$refs.pdfContainer || !this.$refs.pdfContainer.$el) {
+            return;
+          }
+          const containerWidth = this.$refs.pdfContainer.$el.clientWidth;
+          this.scale = containerWidth / (this.firstPageWidth * this.screenSizeMultiplier);
+        });
       },
     },
     beforeCreate() {
@@ -284,9 +303,8 @@
           const viewPort = firstPage.getViewport({ scale: 1 });
           this.firstPageHeight = viewPort.height;
           this.firstPageWidth = viewPort.width;
+          this.scale = this.elementWidth / (this.firstPageWidth * this.screenSizeMultiplier);
 
-          const screenSizeMultiplier = this.windowIsLarge ? 1.25 : this.windowIsSmall ? 1 : 1.125;
-          this.scale = this.elementWidth / (this.firstPageWidth * screenSizeMultiplier);
           // Set the firstPageToRender into the pdfPages object so that we do not refetch the page
           // from PDFJS when we do our initial render
           // splice so changes are detected


### PR DESCRIPTION
## Summary

Recalculate pdf page scale on sidebar toggle.

| Before | After |
| :-----: | :----: |
| <img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/212475093-7cca9a4a-eff9-461b-800a-25162b14b3a0.png"> First render of a pdf with bookmarks | <img width="1440" alt="image" src="https://user-images.githubusercontent.com/51239030/212475016-879d1e34-1bab-457c-9279-b32e9ba566bf.png"> First render of a pdf with bookmarks |


## Reviewer guidance

Go to any pdf resource that has bookmarks and toggle the sidebar on and off, the page should resize to cover the available width without any scrollbars.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
