### PR TITLE
Clean up strings and labels for PDF side bar.

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -28,7 +28,8 @@
             <KIconButton
               v-if="outline && outline.length > 0"
               class="controls"
-              :ariaLabel="coreString('menu')"
+              :ariaLabel="coreString('bookmarksLabel')"
+              :tooltip="coreString('bookmarksLabel')"
               aria-controls="sidebar-container"
               icon="menu"
               @click="toggleSideBar"

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
@@ -7,7 +7,7 @@
     }"
   >
     <nav :style="{ height: '100%' }">
-      <div :style="{ display: 'flex' }">
+      <div v-if="tabs.filter(t => !t.disabled).length > 1" :style="{ display: 'flex' }">
         <div
           v-for="tab in tabs"
           :key="tab.name"
@@ -30,7 +30,7 @@
           <div
             class="tab"
             :tabindex="tab.disabled ? -1 : 0"
-            :aria-label="tab.name"
+            :aria-label="tab.label"
             role="button"
             @click="selectTab(tab.name)"
             @keydown.enter="selectTab(tab.name)"
@@ -64,10 +64,10 @@
           />
         </template>
         <template v-if="selectedTab === 'preview'">
-          <span> Preview </span>
+          <span></span>
         </template>
         <template v-if="selectedTab === 'annotations'">
-          <span> Annotations </span>
+          <span></span>
         </template>
       </div>
     </nav>
@@ -78,6 +78,7 @@
 
 <script>
 
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import Bookmarks from './Bookmarks';
 
   export default {
@@ -85,6 +86,7 @@
     components: {
       Bookmarks,
     },
+    mixins: [commonCoreStrings],
     props: {
       outline: {
         type: Array,
@@ -105,19 +107,19 @@
         tabs: [
           {
             name: 'bookmarks',
-            label: 'Bookmarks',
+            label: this.coreString('bookmarksLabel'),
             icon: 'list',
             disabled: false,
           },
           {
             name: 'preview',
-            label: 'Preview',
+            label: '',
             icon: 'channel',
             disabled: true,
           },
           {
             name: 'annotations',
-            label: 'Annotations',
+            label: '',
             icon: 'edit',
             disabled: true,
           },


### PR DESCRIPTION
## Summary
* Removes unwrapped string references.
* Hides PDF side bar navigation elements while there is only one enabled
* Adds `Bookmarks` aria-label and tooltip to side nav element until more than one menu item is available

## Reviewer guidance
![image](https://user-images.githubusercontent.com/1680573/213009959-2359a05f-4f54-4f58-abf2-732e7aad8478.png)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
