### PR TITLE
[EPub_Viewer] Fix createMarks

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SearchSideBar.vue
@@ -62,7 +62,7 @@
     </transition>
 
     <ol
-      v-show="searchHasBeenMade && !searchIsLoading && searchResults.length > 0"
+      v-if="searchHasBeenMade && !searchIsLoading && searchResults.length > 0"
       ref="searchResultsList"
       class="search-results-list"
     >
@@ -153,7 +153,6 @@
       searchIsLoading: false,
       maxSearchResultsExceeded: false,
       searchHasBeenMade: false,
-      markInstance: null,
     }),
     computed: {
       numberOfSearchResults() {
@@ -187,29 +186,20 @@
                 this.maxSearchResultsExceeded = true;
               }
               this.searchResults = searchResults.slice(0, MAX_SEARCH_RESULTS);
-
+              this.$emit('newSearchQuery', searchQuery);
+              this.searchIsLoading = false;
               // Wait for list to be updated
               this.$nextTick().then(() => {
-                if (this.markInstance) {
-                  this.markInstance.unmark({
-                    done: () => this.createMarks(searchQuery),
-                  });
-                } else {
-                  this.createMarks(searchQuery);
-                }
+                this.createMarks(searchQuery);
               });
             }
           );
         }
       },
       createMarks(searchQuery) {
-        this.markInstance = new Mark(this.$refs.searchResultsList);
-        this.markInstance.mark(searchQuery, {
+        const markInstance = new Mark(this.$refs.searchResultsList);
+        markInstance.mark(searchQuery, {
           separateWordSearch: false,
-          done: () => {
-            this.$emit('newSearchQuery', searchQuery);
-            this.searchIsLoading = false;
-          },
         });
       },
     },

--- a/kolibri/plugins/epub_viewer/assets/tests/SearchSideBar.spec.js
+++ b/kolibri/plugins/epub_viewer/assets/tests/SearchSideBar.spec.js
@@ -3,6 +3,11 @@ import store from 'kolibri.coreVue.vuex.store';
 import SearchSideBar from '../src/views/SearchSideBar';
 import SampleSearchResults from './SampleSearchResults';
 
+const mockMark = {
+  mark: jest.fn(),
+};
+jest.mock('mark.js', () => jest.fn().mockImplementation(() => mockMark));
+
 function createWrapper() {
   const node = document.createElement('app');
   document.body.appendChild(node);
@@ -33,9 +38,6 @@ describe('Search side bar', () => {
     wrapper.vm.searchQuery = 'biology';
     wrapper.vm.searchResults = SampleSearchResults;
     wrapper.vm.createMarks(wrapper.vm.searchQuery);
-    // const allMarks = wrapper.findAll('mark');
-    // expect(allMarks.length).toBeGreaterThanOrEqual(wrapper.vm.searchResults.length);
-    // Listen for event as a proxy for Mark to have done the highlighting
-    expect(wrapper.emitted().newSearchQuery[0]).toEqual(['biology']);
+    expect(mockMark.mark).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

There are wrong behaviors in the EPub search in specific situations like the one described in #10048. These behaviors are probably due to some incompatibility between Mark.js's way of marking DOM content and Vue's way of tracking DOM updates, which causes these DOM updates to sometimes fail with inconsistent results.

This PR changes the way of displaying the list of results from v-show to v-if so that vue does not set the `display: none` property but instead recognizes the rendering changes of the new results as a completely new DOM component and Mark .js always mark the results over a "clean" component.

## References

closes #10048

## Reviewer guidance

Perform the steps described in #10048 and check that those inconsistent results doesn't appear anymore.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
