### PR TITLE
Pin setup integration

### DIFF
--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -114,7 +114,7 @@ export default createTranslator('NotificationStrings', {
     message: 'New PIN created',
     context: 'A confirmation message for creating a new a pin',
   },
-  pinUpadeted: {
+  pinUpdated: {
     message: 'PIN updated',
     context: 'A confimation message for updating a pin',
   },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -56,7 +56,7 @@
             this.pinError = '';
             this.setPin({ pin_code: this.pin });
             this.$emit('submit');
-            this.showSnackbarNotification('pinUpadeted');
+            this.showSnackbarNotification('pinUpdated');
           } else {
             this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
             this.focus();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -30,6 +30,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { mapActions } from 'vuex';
 
   export default {
     name: 'ChangePinModal',
@@ -44,6 +45,7 @@
     },
     computed: {},
     methods: {
+      ...mapActions('facilityConfig', ['setPin']),
       submit() {
         if (!this.pin) {
           this.showErrorText = true;
@@ -52,13 +54,14 @@
         } else {
           if (this.pinPattern.test(this.pin)) {
             this.pinError = '';
+            this.setPin({ pin_code: this.pin });
             this.$emit('submit');
+            this.showSnackbarNotification('pinUpadeted');
           } else {
             this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
             this.focus();
           }
         }
-        this.showSnackbarNotification('pinUpadeted');
       },
       focus: function() {
         this.$refs.pinFocus.focus();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfirmResetModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfirmResetModal.vue
@@ -30,7 +30,8 @@
           "Confirmation message on the 'Reset to defaults' window accessed via the Facility > Settings page.",
       },
       reconfirmation: {
-        message: 'Any custom changes will be lost.',
+        message:
+          'Your device management PIN will not be affected, but any other custom changes will be lost.',
         context:
           "Description on the 'Reset to defaults' window accessed via the Facility > Settings page.",
       },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -30,6 +30,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { mapActions } from 'vuex';
 
   export default {
     name: 'CreateManagementPinModal',
@@ -44,6 +45,7 @@
     },
     computed: {},
     methods: {
+      ...mapActions('facilityConfig', ['setPin']),
       submit() {
         if (!this.pin) {
           this.showErrorText = true;
@@ -52,13 +54,14 @@
         } else {
           if (this.pinPattern.test(this.pin)) {
             this.pinError = '';
+            this.setPin({ pin_code: this.pin });
+            this.showSnackbarNotification('pinCreated');
             this.$emit('submit');
           } else {
             this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
             this.focus();
           }
         }
-        this.showSnackbarNotification('pinCreated');
       },
       focus: function() {
         this.$refs.pinFocus.focus();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/RemovePinModal.vue
@@ -18,12 +18,16 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { mapActions } from 'vuex';
 
   export default {
     name: 'RemovePinModal',
     mixins: [commonCoreStrings],
+    computed: {},
     methods: {
+      ...mapActions('facilityConfig', ['unsetPin']),
       removePin() {
+        this.unsetPin();
         this.$emit('submit');
         this.showSnackbarNotification('pinRemove');
       },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ViewPinModal.vue
@@ -7,7 +7,6 @@
   >
     <div>
       <p>{{ userPinNumber }}</p>
-
     </div>
   </KModal>
 
@@ -16,14 +15,16 @@
 
 <script>
 
+  import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'ViewPinModal',
     mixins: [commonCoreStrings],
     computed: {
+      ...mapState('facilityConfig', ['settings']),
       userPinNumber() {
-        return 123;
+        return this.settings['extra_fields']['pin_code'];
       },
     },
     methods: {},

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -234,7 +234,11 @@
         return !isEqual(this.settings, this.settingsCopy);
       },
       isPinSet() {
-        if (this.settings['extra_fields']['pin_code']) {
+        if (
+          this.settings &&
+          this.settings['extra_fields'] &&
+          this.settings['extra_fields']['pin_code']
+        ) {
           return this.settings['extra_fields']['pin_code'];
         } else {
           return null;

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -75,14 +75,14 @@
           <h2>{{ $tr('deviceManagementPin') }}</h2>
 
           <p>{{ $tr('deviceManagementDescription') }}</p>
-          <KButton @click="handleCreatePin">
+          <KButton v-show="!isPinSet" @click="handleCreatePin">
             {{ $tr('createPinBtn') }}
           </KButton>
 
           <KButton
+            v-show="isPinSet"
             hasDropdown
             :text="$tr('optionBtn')"
-            style="marginLeft:15px"
           >
             <template #menu>
               <KDropdownMenu
@@ -233,6 +233,13 @@
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);
       },
+      isPinSet() {
+        if (this.settings['extra_fields']['pin_code']) {
+          return this.settings['extra_fields']['pin_code'];
+        } else {
+          return null;
+        }
+      },
       deviceSettingsUrl() {
         const getUrl = urls['kolibri:kolibri.plugins.device:device_management'];
         if (getUrl) {
@@ -273,7 +280,6 @@
     },
     methods: {
       camelCase,
-      ...mapActions('facilityConfig', ['saveFacilityName']),
       ...mapActions(['createSnackbar']),
       updateSettingValue(settingName, newValue) {
         this.$store.commit('facilityConfig/CONFIG_PAGE_MODIFY_SETTING', {


### PR DESCRIPTION

## Summary
This pull request integrates the front-end with the back-end to allow the creation, update and deflation of pins on the facility setting page.

## Reviewer guidance
 Navigate to facility> settings >create pin
## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
