### PR TITLE
Fix progress tracking edge case where float rounding issues prevent progress reaching 1

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from itertools import groupby
+from math import ceil
 from random import randint
 
 from django.core.exceptions import PermissionDenied
@@ -699,6 +700,9 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
             )
 
     def _normalize_progress(self, progress):
+        # Round progress to three decimal places
+        # but always rounding up.
+        progress = ceil(progress * 1000) / float(1000)
         return max(0, min(1.0, progress))
 
     def _update_content_log(self, log, end_timestamp, validated_data):

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -882,6 +882,17 @@ class UpdateSessionBase(object):
         self.assertEqual(response.status_code, 200)
         self._assert_logs_value("progress", 1.0)
 
+    def test_update_session_progress_delta_asymptotic_succeeds(self):
+        self._update_logs("progress", 0.666)
+        response = self._make_request(
+            {
+                "progress_delta": 0.3331,
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self._assert_logs_value("progress", 1.0)
+
     def test_update_session_absolute_progress_succeeds(self):
         self._update_logs("progress", 0.3)
         response = self._make_request(

--- a/kolibri/core/logger/upgrade.py
+++ b/kolibri/core/logger/upgrade.py
@@ -1,8 +1,11 @@
 """
 A file to contain specific logic to handle version upgrades in Kolibri.
 """
+from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import ExamLog
 from kolibri.core.logger.utils.exam_log_migration import migrate_from_exam_logs
+from kolibri.core.notifications.api import parse_summarylog
+from kolibri.core.notifications.api import quiz_completed_notification
 from kolibri.core.upgrade import version_upgrade
 
 
@@ -13,3 +16,31 @@ def migrate_examlog_and_examattemptlogs():
     data structures.
     """
     migrate_from_exam_logs(ExamLog.objects.all())
+
+
+@version_upgrade(old_version="<0.15.11")
+def fix_asymptotic_progress():
+    """
+    Migrate any ContentSummaryLogs that have erroneously had their progress set to >0.999 but not to 1
+    """
+    for summarylog in ContentSummaryLog.objects.filter(
+        progress__gt=0.999, progress__lt=1
+    ):
+        # Do this in a for loop rather than trying to minimize write queries, as it's a one time event
+        # and the queries for finding any correlated mastery log would be quite complex joins.
+        summarylog.progress = 1
+        summarylog.completion_timestamp = summarylog.end_timestamp
+        masterylog = summarylog.masterylogs.all().order_by("-end_timestamp").first()
+        quiz = False
+        if masterylog:
+            masterylog.complete = True
+            masterylog.completion_timestamp = masterylog.end_timestamp
+            masterylog.save()
+            if masterylog.mastery_level < 0:
+                # This is a quiz, so we need to generate a quiz notification
+                quiz_completed_notification(masterylog, summarylog.content_id)
+                quiz = True
+        summarylog.save()
+        if not quiz:
+            # If this isn't a quiz generate the appropriate completion notification for the resource.
+            parse_summarylog(summarylog)

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -392,6 +392,12 @@ describe('useProgressTracking composable', () => {
       expect(get(progress)).toEqual(1);
       expect(client.mock.calls[0][0].data.progress_delta).toBeGreaterThanOrEqual(0.5);
     });
+    it('should max progress and store progress_delta if progress starts at 0.9999999999999999 and is updated to 1', async () => {
+      const { updateContentSession, progress } = await initStore({ progress: 0.9999999999999999 });
+      await updateContentSession({ progress: 1 });
+      expect(get(progress)).toEqual(1);
+      expect(client.mock.calls[0][0].data.progress_delta).toBeGreaterThanOrEqual(0.001);
+    });
     it('should not update progress and store progress_delta if progress is updated under current value', async () => {
       const { updateContentSession, progress, progress_delta } = await initStore();
       await updateContentSession({ progress: 0.4 });

--- a/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
+++ b/kolibri/plugins/learn/assets/src/composables/__tests__/useProgressTracking.spec.js
@@ -337,6 +337,14 @@ describe('useProgressTracking composable', () => {
       await updateContentSession({ contentState: { test: 'test' } });
       expect(store.state.core.totalProgress).toEqual(1);
     });
+    it('should update progress_state if the backend returns complete', async () => {
+      const { updateContentSession, progress } = await initStore();
+      client.__setPayload({
+        complete: true,
+      });
+      await updateContentSession({ contentState: { test: 'test' } });
+      expect(get(progress)).toEqual(1);
+    });
     it('should not update total progress if the backend returns complete and was already complete', async () => {
       const { updateContentSession, store } = await initStore({ complete: true });
       store.commit('CORE_SET_SESSION', { kind: ['learner'] });

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -145,7 +145,7 @@ export default function useProgressTracking(store) {
       const data = response.data;
       set(context, valOrNull(data.context));
       set(complete, valOrNull(data.complete));
-      set(progress_state, threeDecimalPlaceRoundup(valOrNull(data.progress)));
+      set(progress_state, valOrNull(data.progress));
       set(progress_delta, 0);
       set(time_spent, valOrNull(data.time_spent));
       set(time_spent_delta, 0);

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -231,6 +231,7 @@ export default function useProgressTracking(store) {
       }
       if (response.data.complete) {
         set(complete, true);
+        set(progress_state, 1);
         if (store.getters.isUserLoggedIn && !wasComplete) {
           store.commit('INCREMENT_TOTAL_PROGRESS', 1);
         }

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -168,6 +168,12 @@
       }),
       ...mapState(['showCompleteContentModal']),
     },
+    watch: {
+      progress() {
+        // Ensure that our cached progress and tracked progress always stay up to date
+        this.cacheProgress();
+      },
+    },
     created() {
       /* Always be sure that this is hidden before the component renders */
       this.hideMarkAsCompleteModal();
@@ -191,13 +197,13 @@
         setContentNodeProgress({ content_id: this.content.content_id, progress: this.progress });
       },
       updateInteraction({ progress, interaction }) {
-        this.updateContentSession({ progress, interaction }).then(this.cacheProgress);
+        this.updateContentSession({ progress, interaction });
       },
       updateProgress(progress) {
-        return this.updateContentSession({ progress }).then(this.cacheProgress);
+        return this.updateContentSession({ progress });
       },
       addProgress(progressDelta) {
-        this.updateContentSession({ progressDelta }).then(this.cacheProgress);
+        this.updateContentSession({ progressDelta });
       },
       updateContentState(contentState) {
         this.updateContentSession({ contentState });


### PR DESCRIPTION
## Summary
* Somehow progress on some exercises managed to get set to `0.9999999999999999` - frontend code cause this to be rounded to 1 when loaded into the frontend, leading to no progress update being recorded for exercises specifically (because exercises record absolute progress, rather than the change in progress).
* Fixes this by removing the rounding on the progress value loaded from the backend
* Adds rounding up to 3 decimal places on progress values on the backend to try to prevent a similar occurrence in future
* Ensures that any such completion registered by the backend is propagated to frontend state
* Adds a data migration upgrade step to ensure that existing instances of `0.9999999999999999` are marked as complete, completion timestamps are set, masterylogs are updated, and any completion notifications are generated

## References
Fixes #10065 (although there are additional aspects of interest worth looking into there, this is the principal bug)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
