### PR TITLE
Fix content rendering regressions

### DIFF
--- a/kolibri/deployment/default/alt_wsgi.py
+++ b/kolibri/deployment/default/alt_wsgi.py
@@ -32,7 +32,7 @@ def generate_alt_wsgi_application():
             (alt_content_path, content_dir) for content_dir in content_dirs
         ]
         + [(paths.zip_content_static_root(), content_static_path)],
-        app_paths=paths.get_zip_content_base_path(),
+        app_paths=[paths.get_zip_content_base_path()],
     )
 
 

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -4,7 +4,7 @@
 
     <template v-if="sessionReady">
       <KContentRenderer
-        v-if="!content.assessment"
+        v-if="!content.assessmentmetadata"
         class="content-renderer"
         :kind="content.kind"
         :lang="content.lang"
@@ -54,9 +54,9 @@
         :kind="content.kind"
         :files="content.files"
         :lang="content.lang"
-        :randomize="content.randomize"
-        :masteryModel="content.masteryModel"
-        :assessmentIds="content.assessmentIds"
+        :randomize="content.assessmentmetadata.randomize"
+        :masteryModel="content.assessmentmetadata.mastery_model"
+        :assessmentIds="content.assessmentmetadata.assessment_item_ids"
         :available="content.available"
         :extraFields="extra_fields"
         :progress="progress"

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -60,7 +60,9 @@
         data-test="contentPage"
         :content="content"
         :lessonId="lessonId"
-        :style="{ backgroundColor: ( content.assessment ? '' : $themeTokens.textInverted ) }"
+        :style="{
+          backgroundColor: ( content.assessmentmetadata ? '' : $themeTokens.textInverted )
+        }"
         :allowMarkComplete="allowMarkComplete"
         @mounted="contentPageMounted = true"
         @finished="$refs.activityBar && $refs.activityBar.animateNextSteps()"


### PR DESCRIPTION
## Summary
* Properly references assessment metadata properties to ensure exercises render properly
* Pass app_paths as a list, rather than a string to ensure it is properly parsed by the Kolibri whitenoise adapter

## References
Fixes #10057 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
