### PR TITLE
Disable some elements depending on kolibri options

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
@@ -1,5 +1,6 @@
 import urls from 'kolibri.urls';
 import client from 'kolibri.client';
+import plugin_data from 'plugin_data';
 
 export default {
   namespaced: true,
@@ -23,6 +24,12 @@ export default {
   getters: {
     getDeviceOS(state) {
       return state.deviceInfo.os;
+    },
+    canRestart() {
+      return plugin_data.canRestart;
+    },
+    isRemoteContent() {
+      return plugin_data.isRemoteContent;
     },
   },
   actions: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
@@ -101,7 +101,7 @@
       },
       newPluginsState: {
         message:
-          'Changing the state of the enabled plugins will restart this server. This page has to be refrehed to see the changes.',
+          'When you enable or disable a page, Kolibri will restart, and you must refresh the browser to see the changes.',
         context: 'Description for restarting the server.',
       },
       selectedPath: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -6,7 +6,14 @@
       <DeviceTopNav />
     </template>
     <KPageContainer class="device-container">
+      <UiAlert
+        v-if="showDisabledAlert && alertDismissed"
+        type="warning"
+        @dismiss="alertDismissed = false"
+      >
+        {{ disabledAlertText }}
 
+      </UiAlert>
       <section>
         <h1>
           {{ $tr('pageHeader') }}
@@ -136,7 +143,7 @@
               :text="$tr('changeLocation')"
               :primary="true"
               appearance="basic-link"
-              :disabled="!multipleWritablePaths"
+              :disabled="!multipleWritablePaths || isRemoteContent"
               :class="{ 'disabled': !multipleWritablePaths }"
               @click="showChangePrimaryLocationModal = true"
             />
@@ -144,6 +151,7 @@
           <KButton
             v-if="browserLocationMatchesServerURL && (secondaryStorageLocations.length === 0)"
             :text="$tr('addLocation')"
+            :disabled="isRemoteContent"
             appearance="raised-button"
             secondary
             @click="showAddStorageLocationModal = true"
@@ -164,6 +172,7 @@
             hasDropdown
             secondary
             appearance="raised-button"
+            :disabled="isRemoteContent"
             :text="coreString('optionsLabel')"
           >
             <template #menu>
@@ -180,6 +189,7 @@
             :label="$tr('enableAutoDownload')"
             :checked="enableAutomaticDownload"
             :description="$tr('enableAutoDownloadDescription')"
+            :disabled="isRemoteContent"
             @change="handleCheckAutodownload('enableAutomaticDownload', $event)"
           />
           <div class="fieldset left-margin">
@@ -187,23 +197,26 @@
               :label="$tr('allowLearnersDownloadResources')"
               :checked="allowLearnerDownloadResources"
               :description="$tr('allowLearnersDownloadDescription')"
+              :disabled="isRemoteContent"
               @change="handleCheckAutodownload('allowLearnerDownloadResources', $event)"
             />
             <KCheckbox
               :label="$tr('setStorageLimit')"
               :checked="setLimitForAutodownload"
               :description="$tr('setStorageLimitDescription')"
+              :disabled="isRemoteContent"
               @change="handleCheckAutodownload('setLimitForAutodownload', $event)"
             />
             <div
               v-show="setLimitForAutodownload"
               class="left-margin"
+              :disabled="isRemoteContent"
             >
               <KTextbox
                 ref="autoDownloadLimit"
                 v-model="limitForAutodownload"
                 class="download-limit-textbox"
-                :disabled="notEnoughFreeSpace"
+                :disabled="notEnoughFreeSpace || isRemoteContent"
                 type="number"
                 label="GB"
                 :min="0"
@@ -216,7 +229,7 @@
                   id="slider"
                   v-model="limitForAutodownload"
                   :class="$computedClass(sliderStyle)"
-                  :disabled="notEnoughFreeSpace"
+                  :disabled="notEnoughFreeSpace || isRemoteContent"
                   type="range"
                   min="0"
                   :max="freeSpace"
@@ -248,6 +261,7 @@
             :key="plugin.id"
             :label="plugin.name"
             :checked="plugin.enabled"
+            :disabled="!canRestart"
             @change="plugin.enabled = $event"
           />
         </div>
@@ -334,6 +348,7 @@
   import urls from 'kolibri.urls';
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
@@ -372,6 +387,7 @@
       AddStorageLocationModal,
       RemoveStorageLocationModal,
       ServerRestartModal,
+      UiAlert,
     },
     mixins: [commonCoreStrings],
     setup() {
@@ -438,11 +454,12 @@
         showRestartModal: false,
         writablePaths: 0,
         readOnlyPaths: 0,
+        alertDismissed: true,
       };
     },
     computed: {
       ...mapGetters(['isAppContext']),
-      ...mapGetters('deviceInfo', ['getDeviceOS']),
+      ...mapGetters('deviceInfo', ['getDeviceOS', 'canRestart', 'isRemoteContent']),
       pageTitle() {
         return deviceString('deviceManagementTitle');
       },
@@ -524,6 +541,22 @@
           return true;
         }
         return this.getDeviceOS.includes('Android');
+      },
+
+      showDisabledAlert() {
+        return this.isRemoteContent || !this.canRestart;
+      },
+      disabledAlertText() {
+        if (!this.canRestart && this.isRemoteContent) {
+          return this.$tr('alertDisabledOptions');
+        }
+        if (!this.canRestart) {
+          return this.$tr('alertDisabledPlugins');
+        }
+        if (this.isRemoteContent) {
+          return this.$tr('alertDisabledPaths');
+        }
+        return this.$tr('alertDisabledOptions');
       },
     },
     created() {
@@ -1013,6 +1046,20 @@
         message: 'Unselect a page to hide it even if the user has permission to access it.',
         context: "Description for the 'Enabled pages' section.",
       },
+      alertDisabledOptions: {
+        message:
+          'Some configuration options have been disabled due to the way Kolibri has been set up.',
+        context: 'Alert text that is provided if some options are disabled',
+      },
+      alertDisabledPaths: {
+        message: 'This Kolibri is not set up to manage its own resource files locally.',
+        context: 'Alert text that is provided if some storage locations are disabled',
+      },
+      alertDisabledPlugins: {
+        message:
+          'This Kolibri is not able to initiate a restart from the user interface - any plugin management will have to happen from the command line, and Kolibri will have to be restarted manually.',
+        context: 'Alert text that is provided if some plugins are disabled',
+      },
     },
   };
 
@@ -1115,6 +1162,10 @@
   .android-bar {
     padding-top: 10px;
     border-top: 1px solid rgb(222, 222, 222);
+  }
+
+  /deep/ .ui-alert--type-warning .ui-alert__body {
+    background-color: rgba(255, 253, 231, 1) !important;
   }
 
 </style>


### PR DESCRIPTION
## Summary
Added to the Device page settings some rules to disable some elements, depending on Kolibri options/envvars:
- If `REMOTE_CONTENT` is true,  autodownload and the settings to change the content paths should be disable.
- If `RESTART_HOOKS` is empty, no restart is possible, so the settings to disable plugins should be disabled.
- Metered connection settings are hidden unless being on Android

![disabled](https://user-images.githubusercontent.com/1008178/218185352-1183ea76-d35f-44e3-9bd0-0e63fb055cf4.png)

It also shows a dismissable banner if any of these options are disabled
![disabled2](https://user-images.githubusercontent.com/1008178/218185453-2be82e39-231c-40e0-bbcc-1768bce320b4.png)


## References
Closes: #9783

@radinamatic added the string mentioned in this comment https://github.com/learningequality/kolibri/pull/10025#issuecomment-1426232179

## Reviewer guidance
Change in options.ini, the above options (or use them in a terminal when starting kolibri, as in this example:
`KOLIBRI_RESTART_HOOKS="" KOLIBRI_REMOTE_CONTENT=true kolibri start --foreground` 
`KOLIBRI_RESTART_HOOKS="" kolibri start --foreground` 
`KOLIBRI_REMOTE_CONTENT=true kolibri start --foreground` 
to see the different banner messages

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
