### PR TITLE
Add constants for download requests status and reason

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -114,6 +114,18 @@ export const SyncStatus = {
   NOT_CONNECTED: 'NOT_CONNECTED',
 };
 
+export const DownloadRequestStatus = {
+  QUEUED: 'QUEUED',
+  DOWNLOADED: 'DOWNLOADED',
+  FAILED: 'FAILED',
+};
+
+export const DownloadRequestReason = {
+  USER_INITIATED: 'USER_INITIATED',
+  DOWNLOADED_BY_ADMIN: 'DOWNLOADED_BY_ADMIN',
+  AUTO_SYNCED: 'AUTO_SYNCED',
+};
+
 export const ERROR_CONSTANTS = {
   // These are an exact copy of the python module kolibri.core.error_constants
   // and should be kept in sync.


### PR DESCRIPTION
## Summary
Adds: 

`const DownloadRequestStatus`
and 
`const DownloadRequestReason`

to support download and autos-yncing management UIs. Added now so the will be in place early in this iteration as the remote browsing and automatic syncing frontend work is put into place.

## References

## Reviewer guidance

Are there additional scenarios we should add? Or, should we structure this differently?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
