### PR TITLE
String cleanup for learn library interface

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -689,7 +689,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Numeracy',
     context: 'Category type. See https://en.wikipedia.org/wiki/Numeracy',
   },
-  digitialLiteracy: {
+  digitalLiteracy: {
     message: 'Digital literacy',
     context: 'Category type. See https://en.wikipedia.org/wiki/Digital_literacy',
   },
@@ -711,7 +711,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
 
   //  VocationalSubcategories
-  softwareToolsAndTraining: {
+  toolsAndSoftwareTraining: {
     message: 'Software tools and training',
     context: 'Subcategory type for technical and vocational training.',
   },
@@ -777,24 +777,33 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
 
   // Resources Needed Categories = {
-  ForBeginners: {
+  forBeginners: {
     message: 'For beginners',
     context: 'Filter option and a label for the resources in the Kolibri Library.',
   },
-  ToUseWithTeachersAndPeers: {
-    message: 'To use with teachers and peers',
+  toUseWithPeers: {
+    message: 'To use with peers',
     context:
       "'Peers' in this context refers to classmates or other learners who are interacting with Kolibri.",
   },
-  ToUseWithPaperAndPencil: {
+  toUseWithTeachers: {
+    message: 'To use with teachers',
+    context:
+      'To use with a subject matter or pedagogical expert who is helping to guide the learner.',
+  },
+  toUseWithPaperAndPencil: {
     message: 'To use with paper and pencil',
     context: 'Refers to a filter for resources.\n',
   },
-  NeedsInternet: {
+  needsInternet: {
     message: 'That need internet connection',
     context: 'Refers to a filter for resources.',
   },
-  NeedsMaterials: {
+  needsSpecialSoftware: {
+    message: 'That need special software',
+    context: 'Refers to a filter for resources.',
+  },
+  needsMaterials: {
     message: 'That need other materials',
     context: 'Refers to a filter for resources.\n',
   },
@@ -1102,16 +1111,17 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
  * - Keys which, when _.camelCase()'ed will not result in a valid key, requiring manual mapping
  */
 const nonconformingKeys = {
-  PEOPLE: 'ToUseWithTeachersAndPeers',
-  PAPER_PENCIL: 'ToUseWithPaperAndPencil',
-  INTERNET: 'NeedsInternet',
-  MATERIALS: 'NeedsMaterials',
-  FOR_BEGINNERS: 'ForBeginners',
-  digitalLiteracy: 'digitialLiteracy',
+  PEERS: 'toUseWithPeers',
+  TEACHER: 'toUseWithTeachers',
+  PAPER_PENCIL: 'toUseWithPaperAndPencil',
+  INTERNET: 'needsInternet',
+  SPECIAL_SOFTWARE: 'needsSpecialSoftware',
+  MATERIALS: 'needsMaterials',
+  OTHER_SUPPLIES: 'needsMaterials',
+  FOR_BEGINNERS: 'forBeginners',
   BASIC_SKILLS: 'allLevelsBasicSkills',
   FOUNDATIONS: 'basicSkills',
   foundations: 'basicSkills',
-  toolsAndSoftwareTraining: 'softwareToolsAndTraining',
   foundationsLogicAndCriticalThinking: 'logicAndCriticalThinking',
 };
 

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -417,6 +417,9 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'A user is any person who has access to a facility in Kolibri. There are  four main types of users in Kolibri: Learners, Coaches, Admins and Super admins.',
   },
+  uncountedAdditionalResults: {
+    message: 'More than { num, number } results',
+  },
   viewMoreAction: {
     message: 'View more',
     context:
@@ -1089,17 +1092,6 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
 });
 
-// We forgot another string, so we are using one from the EPubRenderer SearchSideBar namespace
-// do not do this, do as I say, not as I do, etc. etc.
-// TODO: 0.16 - remove this and put a proper string in place
-const overResultsTranslator = createTranslator('SearchSideBar', {
-  overCertainNumberOfSearchResults: {
-    message: 'Over {num, number, integer} {num, plural, one {result} other {results}}',
-    context:
-      'Refers to number of search results when there are over a specified amount. Only translate "over", "result" and "results".\n',
-  },
-});
-
 /**
  * An object mapping ad hoc keys (like those to be passed to coreString()) which do not
  * conform to the expectations. Examples:
@@ -1151,10 +1143,6 @@ const MetadataLookup = invert(
  * string mapping to the values to be passed for those arguments.
  */
 export function coreString(key, args) {
-  if (key === 'overCertainNumberOfSearchResults') {
-    return overResultsTranslator.$tr(key, args);
-  }
-
   const metadataKey = get(MetadataLookup, key, null);
   key = metadataKey ? camelCase(metadataKey) : key;
 

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -768,6 +768,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
       'Category label in the Kolibri resources library; refers to lesson planning materials for teachers.',
   },
 
+  uncategorized: {
+    message: 'Uncategorized',
+    context: 'A label to indicate that no category label has been applied to the resource.',
+  },
+
   // Resources Needed Categories = {
   ForBeginners: {
     message: 'For beginners',
@@ -1084,13 +1089,6 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
 });
 
-// We forgot a string, so we are using one from the PerseusInternalMessages namespace
-// do not do this, do as I say, not as I do, etc. etc.
-// TODO: 0.16 - remove this and put a proper string in place
-const noneOfTheAboveTranslator = createTranslator('PerseusInternalMessages', {
-  'None of the above': 'None of the above',
-});
-
 // We forgot another string, so we are using one from the EPubRenderer SearchSideBar namespace
 // do not do this, do as I say, not as I do, etc. etc.
 // TODO: 0.16 - remove this and put a proper string in place
@@ -1153,10 +1151,6 @@ const MetadataLookup = invert(
  * string mapping to the values to be passed for those arguments.
  */
 export function coreString(key, args) {
-  if (key === 'None of the above' || key === METADATA.NoCategories) {
-    return noneOfTheAboveTranslator.$tr('None of the above', args);
-  }
-
   if (key === 'overCertainNumberOfSearchResults') {
     return overResultsTranslator.$tr(key, args);
   }

--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -36,7 +36,15 @@ function _generateLearningActivitiesShown(learningActivities) {
   return learningActivitiesShown;
 }
 
-const resourcesNeededShown = ['FOR_BEGINNERS', 'PEOPLE', 'PAPER_PENCIL', 'INTERNET', 'MATERIALS'];
+const resourcesNeededShown = [
+  'FOR_BEGINNERS',
+  'PEERS',
+  'TEACHER',
+  'SPECIAL_SOFTWARE',
+  'PAPER_PENCIL',
+  'INTERNET',
+  'OTHER_SUPPLIES',
+];
 
 function _generateResourcesNeeded(learnerNeeds) {
   const resourcesNeeded = {};

--- a/kolibri/plugins/learn/assets/src/views/SearchChips.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchChips.vue
@@ -33,10 +33,9 @@
   import flatMap from 'lodash/flatMap';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import { AllCategories } from 'kolibri.coreVue.vuex.constants';
+  import { NoCategories } from 'kolibri.coreVue.vuex.constants';
   import useChannels from '../composables/useChannels';
   import useLanguages from '../composables/useLanguages';
-  import SearchFiltersPanel from './SearchFiltersPanel';
 
   export default {
     name: 'SearchChips',
@@ -77,7 +76,6 @@
     created() {
       const LibraryPageComponent = require('./LibraryPage').default;
       this.translator = crossComponentTranslator(LibraryPageComponent);
-      this.allCategoriesTranslator = crossComponentTranslator(SearchFiltersPanel);
     },
     methods: {
       clearAllString() {
@@ -90,8 +88,8 @@
         if (key === 'channels') {
           return this.channelsMap[value].name;
         }
-        if (key === 'categories' && value === AllCategories) {
-          return this.allCategoriesTranslator.$tr('allCategories'); // eslint-disable-line kolibri/vue-no-undefined-string-uses
+        if (key === 'categories' && value === NoCategories) {
+          return this.coreString('uncategorized');
         }
         return this.coreString(value);
       },

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -70,7 +70,7 @@
           class="category-list-item"
         >
           <KButton
-            :text="coreString('None of the above')"
+            :text="coreString('uncategorized')"
             appearance="flat-button"
             :appearanceOverrides="isKeyActive('no_categories')
               ? { ...categoryListItemStyles, ...categoryListItemActiveStyles }

--- a/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
@@ -5,7 +5,7 @@
     <!-- for interacting or updating the results   -->
     <h2 class="results-title" data-test="search-results-title">
       {{ more ?
-        coreString('overCertainNumberOfSearchResults', { num: results.length }) :
+        coreString('uncountedAdditionalResults', { num: results.length }) :
         $tr('results', { results: results.length })
       }}
     </h2>

--- a/kolibri/plugins/learn/assets/test/views/search-results-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/search-results-grid.spec.js
@@ -24,7 +24,7 @@ describe('when search results are loaded', () => {
         },
       });
       expect(wrapper.find('[data-test="search-results-title"]').element).toHaveTextContent(
-        coreStrings('overCertainNumberOfSearchResults', { num: 1 })
+        coreStrings('uncountedAdditionalResults', { num: 1 })
       );
     });
   });


### PR DESCRIPTION
## Summary
* Replace none of the above with uncategorized.
* Update string for uncounted additional search results.
* Adds search strings and search categories for needs to conform to selectable options on Kolibri Studio.
* Cleans up non-camelcased translation keys.

## References
Fixes https://github.com/learningequality/kolibri/issues/9245
![Screenshot from 2023-02-14 10-51-12](https://user-images.githubusercontent.com/1680573/218830948-8f6532fa-b15a-4286-976f-c019ee3de908.png)

Resolves https://github.com/learningequality/kolibri/issues/8872
![Screenshot from 2023-02-14 10-09-51](https://user-images.githubusercontent.com/1680573/218831007-fb7512c2-ee57-43f4-a0f8-0ded58b33744.png)

Closes https://github.com/learningequality/kolibri/issues/8845
![Screenshot from 2023-02-14 10-20-16](https://user-images.githubusercontent.com/1680573/218831173-d807bcac-9b40-4a49-8ff9-fa47479dc5e4.png)


## Reviewer guidance
Verify each of the fixes. Ensure that none of the translation key cleanup has caused regressions.

NEW STRING ADDED: `That need special software` for special software filter. Everything else is just a slight reworking of what was there before.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
