### PR TITLE
[PdfViewer] Add annotation layer

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
@@ -172,13 +172,6 @@ class AnnotationLayerBuilder {
         AnnotationLayer.render(parameters);
         this.l10n.translate(this.div);
       }
-
-      // Modified: Code added to get external links with _blank target
-      const linkAnnotations = this.div.querySelectorAll('.linkAnnotation a');
-      for (let i = 0; i < linkAnnotations.length; i++) {
-        const linkAnnotation = linkAnnotations[i];
-        linkAnnotation.setAttribute('target', '_blank');
-      }
     });
   }
 

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
@@ -1,0 +1,197 @@
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/annotation_layer_builder.js
+ */
+
+// Modified: typedef imports deleted
+// Original line: 16
+
+/* eslint-disable */
+
+import { AnnotationLayer } from 'pdfjs-dist/legacy/build/pdf';
+
+function getL10nFallback(key, args) {
+  switch (key) {
+    case 'find_match_count':
+      key = `find_match_count[${args.total === 1 ? 'one' : 'other'}]`;
+      break;
+    case 'find_match_count_limit':
+      key = `find_match_count_limit[${args.limit === 1 ? 'one' : 'other'}]`;
+      break;
+  }
+  return DEFAULT_L10N_STRINGS[key] || '';
+}
+
+// Replaces {{arguments}} with their values.
+function formatL10nValue(text, args) {
+  if (!args) {
+    return text;
+  }
+  return text.replace(/\{\{\s*(\w+)\s*\}\}/g, (all, name) => {
+    return name in args ? args[name] : '{{' + name + '}}';
+  });
+}
+
+/**
+ * No-op implementation of the localization service.
+ * @implements {IL10n}
+ */
+const NullL10n = {
+  async getLanguage() {
+    return 'en-us';
+  },
+
+  async getDirection() {
+    return 'ltr';
+  },
+
+  async get(key, args = null, fallback = getL10nFallback(key, args)) {
+    return formatL10nValue(fallback, args);
+  },
+
+  async translate(element) {},
+};
+
+/**
+ * @typedef {Object} AnnotationLayerBuilderOptions
+ * @property {HTMLDivElement} pageDiv
+ * @property {PDFPageProxy} pdfPage
+ * @property {AnnotationStorage} [annotationStorage]
+ * @property {string} [imageResourcesPath] - Path for image resources, mainly
+ *   for annotation icons. Include trailing slash.
+ * @property {boolean} renderForms
+ * @property {IPDFLinkService} linkService
+ * @property {IDownloadManager} downloadManager
+ * @property {IL10n} l10n - Localization service.
+ * @property {boolean} [enableScripting]
+ * @property {Promise<boolean>} [hasJSActionsPromise]
+ * @property {Promise<Object<string, Array<Object>> | null>}
+ *   [fieldObjectsPromise]
+ * @property {Object} [mouseState]
+ * @property {Map<string, HTMLCanvasElement>} [annotationCanvasMap]
+ */
+
+class AnnotationLayerBuilder {
+  /**
+   * @param {AnnotationLayerBuilderOptions} options
+   */
+  constructor({
+    pageDiv,
+    pdfPage,
+    linkService,
+    downloadManager,
+    annotationStorage = null,
+    imageResourcesPath = '',
+    renderForms = true,
+    l10n = NullL10n,
+    enableScripting = false,
+    hasJSActionsPromise = null,
+    fieldObjectsPromise = null,
+    mouseState = null,
+    annotationCanvasMap = null,
+  }) {
+    this.pageDiv = pageDiv;
+    this.pdfPage = pdfPage;
+    this.linkService = linkService;
+    this.downloadManager = downloadManager;
+    this.imageResourcesPath = imageResourcesPath;
+    this.renderForms = renderForms;
+    this.l10n = l10n;
+    this.annotationStorage = annotationStorage;
+    this.enableScripting = enableScripting;
+    this._hasJSActionsPromise = hasJSActionsPromise;
+    this._fieldObjectsPromise = fieldObjectsPromise;
+    this._mouseState = mouseState;
+    this._annotationCanvasMap = annotationCanvasMap;
+
+    this.div = null;
+    this._cancelled = false;
+  }
+
+  /**
+   * @param {PageViewport} viewport
+   * @param {string} intent (default value is 'display')
+   * @returns {Promise<void>} A promise that is resolved when rendering of the
+   *   annotations is complete.
+   */
+  render(viewport, intent = 'display') {
+    Promise.all([
+      this.pdfPage.getAnnotations({ intent }),
+      this._hasJSActionsPromise,
+      this._fieldObjectsPromise,
+    ]).then(([annotations, hasJSActions, fieldObjects]) => {
+      if (this._cancelled || annotations.length === 0) {
+        return;
+      }
+
+      const parameters = {
+        viewport: viewport.clone({ dontFlip: true }),
+        div: this.div,
+        annotations,
+        page: this.pdfPage,
+        imageResourcesPath: this.imageResourcesPath,
+        renderForms: this.renderForms,
+        linkService: this.linkService,
+        downloadManager: this.downloadManager,
+        annotationStorage: this.annotationStorage,
+        enableScripting: this.enableScripting,
+        hasJSActions,
+        fieldObjects,
+        mouseState: this._mouseState,
+        annotationCanvasMap: this._annotationCanvasMap,
+      };
+
+      if (this.div) {
+        // If an annotationLayer already exists, refresh its children's
+        // transformation matrices.
+        AnnotationLayer.update(parameters);
+      } else {
+        // Create an annotation layer div and render the annotations
+        // if there is at least one annotation.
+        this.div = document.createElement('div');
+        this.div.className = 'annotationLayer';
+        this.pageDiv.appendChild(this.div);
+        parameters.div = this.div;
+
+        AnnotationLayer.render(parameters);
+        this.l10n.translate(this.div);
+      }
+
+      // Modified: Code added to get external links with _blank target
+      const linkAnnotations = this.div.querySelectorAll('.linkAnnotation a');
+      for (let i = 0; i < linkAnnotations.length; i++) {
+        const linkAnnotation = linkAnnotations[i];
+        linkAnnotation.setAttribute('target', '_blank');
+      }
+    });
+  }
+
+  cancel() {
+    this._cancelled = true;
+  }
+
+  hide() {
+    if (!this.div) {
+      return;
+    }
+    this.div.hidden = true;
+  }
+}
+
+export { AnnotationLayerBuilder };

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.js
@@ -53,19 +53,19 @@ function formatL10nValue(text, args) {
  * @implements {IL10n}
  */
 const NullL10n = {
-  async getLanguage() {
+  getLanguage() {
     return 'en-us';
   },
 
-  async getDirection() {
+  getDirection() {
     return 'ltr';
   },
 
-  async get(key, args = null, fallback = getL10nFallback(key, args)) {
+  get(key, args = null, fallback = getL10nFallback(key, args)) {
     return formatL10nValue(fallback, args);
   },
 
-  async translate(element) {},
+  translate(element) {},
 };
 
 /**

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.scss
@@ -1,0 +1,238 @@
+/* Copyright 2014 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/annotation_layer_builder.css
+ */
+
+:root {
+  --annotation-unfocused-field-background: url("data:image/svg+xml;charset=UTF-8,<svg width='1px' height='1px' xmlns='http://www.w3.org/2000/svg'><rect width='100%' height='100%' style='fill:rgba(0, 54, 255, 0.13);'/></svg>");
+}
+
+.annotationLayer section {
+  position: absolute;
+  text-align: initial;
+}
+
+.annotationLayer .linkAnnotation > a,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  font-size: 1em;
+}
+
+.annotationLayer .buttonWidgetAnnotation.pushButton > canvas {
+  position: relative;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
+.annotationLayer .linkAnnotation > a:hover,
+.annotationLayer .buttonWidgetAnnotation.pushButton > a:hover {
+  background: rgba(255, 255, 0, 1);
+  box-shadow: 0 2px 10px rgba(255, 255, 0, 1);
+  opacity: 0.2;
+}
+
+.annotationLayer .textAnnotation img {
+  position: absolute;
+  cursor: pointer;
+}
+
+.annotationLayer .textWidgetAnnotation input,
+.annotationLayer .textWidgetAnnotation textarea,
+.annotationLayer .choiceWidgetAnnotation select,
+.annotationLayer .buttonWidgetAnnotation.checkBox input,
+.annotationLayer .buttonWidgetAnnotation.radioButton input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 0 3px;
+  margin: 0;
+  font-size: 9px;
+  vertical-align: top;
+  background-image: var(--annotation-unfocused-field-background);
+  border: 1px solid transparent;
+}
+
+.annotationLayer .choiceWidgetAnnotation select option {
+  padding: 0;
+}
+
+.annotationLayer .buttonWidgetAnnotation.radioButton input {
+  border-radius: 50%;
+}
+
+.annotationLayer .textWidgetAnnotation textarea {
+  font: message-box;
+  font-size: 9px;
+  resize: none;
+}
+
+.annotationLayer .textWidgetAnnotation input[disabled],
+.annotationLayer .textWidgetAnnotation textarea[disabled],
+.annotationLayer .choiceWidgetAnnotation select[disabled],
+.annotationLayer .buttonWidgetAnnotation.checkBox input[disabled],
+.annotationLayer .buttonWidgetAnnotation.radioButton input[disabled] {
+  cursor: not-allowed;
+  background: none;
+  border: 1px solid transparent;
+}
+
+.annotationLayer .textWidgetAnnotation input:hover,
+.annotationLayer .textWidgetAnnotation textarea:hover,
+.annotationLayer .choiceWidgetAnnotation select:hover,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:hover,
+.annotationLayer .buttonWidgetAnnotation.radioButton input:hover {
+  border: 1px solid rgba(0, 0, 0, 1);
+}
+
+.annotationLayer .textWidgetAnnotation input:focus,
+.annotationLayer .textWidgetAnnotation textarea:focus,
+.annotationLayer .choiceWidgetAnnotation select:focus {
+  background: none;
+  border: 1px solid transparent;
+}
+
+.annotationLayer .textWidgetAnnotation input :focus,
+.annotationLayer .textWidgetAnnotation textarea :focus,
+.annotationLayer .choiceWidgetAnnotation select :focus,
+.annotationLayer .buttonWidgetAnnotation.checkBox :focus,
+.annotationLayer .buttonWidgetAnnotation.radioButton :focus {
+  background-color: transparent;
+  background-image: none;
+  outline: auto;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::after,
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked::before {
+  position: absolute;
+  display: block;
+  content: '';
+  background-color: rgba(0, 0, 0, 1);
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::before,
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::after {
+  left: 45%;
+  width: 1px;
+  height: 80%;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::before {
+  transform: rotate(45deg);
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input:checked::after {
+  transform: rotate(-45deg);
+}
+
+.annotationLayer .buttonWidgetAnnotation.radioButton input:checked::before {
+  top: 20%;
+  left: 30%;
+  width: 50%;
+  height: 50%;
+  border-radius: 50%;
+}
+
+.annotationLayer .textWidgetAnnotation input.comb {
+  padding-right: 0;
+  padding-left: 2px;
+  font-family: monospace;
+}
+
+.annotationLayer .textWidgetAnnotation input.comb:focus {
+  /*
+   * Letter spacing is placed on the right side of each character. Hence, the
+   * letter spacing of the last character may be placed outside the visible
+   * area, causing horizontal scrolling. We avoid this by extending the width
+   * when the element has focus and revert this when it loses focus.
+   */
+  width: 103%;
+}
+
+.annotationLayer .buttonWidgetAnnotation.checkBox input,
+.annotationLayer .buttonWidgetAnnotation.radioButton input {
+  appearance: none;
+  padding: 0;
+}
+
+.annotationLayer .popupWrapper {
+  position: absolute;
+  width: 20em;
+}
+
+.annotationLayer .popup {
+  position: absolute;
+  z-index: 200;
+  max-width: 20em;
+  padding: 6px;
+  margin-left: 5px;
+  font: message-box;
+  font-size: 9px;
+  word-wrap: break-word;
+  white-space: normal;
+  cursor: pointer;
+  background-color: rgba(255, 255, 153, 1);
+  border-radius: 2px;
+  box-shadow: 0 2px 5px rgba(136, 136, 136, 1);
+}
+
+.annotationLayer .popup > * {
+  font-size: 9px;
+}
+
+.annotationLayer .popup h1 {
+  display: inline-block;
+}
+
+.annotationLayer .popupDate {
+  display: inline-block;
+  margin-left: 5px;
+}
+
+.annotationLayer .popupContent {
+  padding-top: 2px;
+  margin-top: 2px;
+  border-top: 1px solid rgba(51, 51, 51, 1);
+}
+
+.annotationLayer .richText > * {
+  white-space: pre-wrap;
+}
+
+.annotationLayer .highlightAnnotation,
+.annotationLayer .underlineAnnotation,
+.annotationLayer .squigglyAnnotation,
+.annotationLayer .strikeoutAnnotation,
+.annotationLayer .freeTextAnnotation,
+.annotationLayer .lineAnnotation svg line,
+.annotationLayer .squareAnnotation svg rect,
+.annotationLayer .circleAnnotation svg ellipse,
+.annotationLayer .polylineAnnotation svg polyline,
+.annotationLayer .polygonAnnotation svg polygon,
+.annotationLayer .caretAnnotation,
+.annotationLayer .inkAnnotation svg polyline,
+.annotationLayer .stampAnnotation,
+.annotationLayer .fileAttachmentAnnotation {
+  cursor: pointer;
+}

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.scss
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/annotation_layer_builder.scss
@@ -14,9 +14,7 @@
  */
 
 /*
- * This file has been modified to adapt the component to the needs of Kolibri
- * The original file is available at:
- * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/annotation_layer_builder.css
+ * The original file is available at: https://github.com/mozilla/pdf.js/blob/v2.14.305/web/annotation_layer_builder.css
  */
 
 :root {

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
@@ -1,0 +1,203 @@
+/* Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file has been modified to adapt the component to the needs of Kolibri
+ * The original file is available at:
+ * https://github.com/mozilla/pdf.js/blob/v2.14.305/web/pdf_link_service.js
+ */
+
+// Modified: typedef imports deleted
+// Original line: 16
+
+/* eslint-disable */
+
+const DEFAULT_LINK_REL = 'noopener noreferrer nofollow';
+
+const LinkTarget = {
+  NONE: 0, // Default value.
+  SELF: 1,
+  BLANK: 2,
+  PARENT: 3,
+  TOP: 4,
+};
+
+const NullCharactersRegExp = /\x00/g;
+const InvisibleCharactersRegExp = /[\x01-\x1F]/g;
+
+/**
+ * @param {string} str
+ * @param {boolean} [replaceInvisible]
+ */
+function removeNullCharacters(str, replaceInvisible = false) {
+  if (typeof str !== 'string') {
+    console.error(`The argument must be a string.`);
+    return str;
+  }
+  if (replaceInvisible) {
+    str = str.replace(InvisibleCharactersRegExp, ' ');
+  }
+  return str.replace(NullCharactersRegExp, '');
+}
+
+/**
+ * Adds various attributes (href, title, target, rel) to hyperlinks.
+ * @param {HTMLAnchorElement} link - The link element.
+ * @param {ExternalLinkParameters} params
+ */
+function addLinkAttributes(link, { url, target, rel, enabled = true } = {}) {
+  if (!url || typeof url !== 'string') {
+    throw new Error('A valid "url" parameter must provided.');
+  }
+
+  const urlNullRemoved = removeNullCharacters(url);
+  if (enabled) {
+    link.href = link.title = urlNullRemoved;
+  } else {
+    link.href = '';
+    link.title = `Disabled: ${urlNullRemoved}`;
+    link.onclick = () => {
+      return false;
+    };
+  }
+
+  let targetStr = ''; // LinkTarget.NONE
+  switch (target) {
+    case LinkTarget.NONE:
+      break;
+    case LinkTarget.SELF:
+      targetStr = '_self';
+      break;
+    case LinkTarget.BLANK:
+      targetStr = '_blank';
+      break;
+    case LinkTarget.PARENT:
+      targetStr = '_parent';
+      break;
+    case LinkTarget.TOP:
+      targetStr = '_top';
+      break;
+  }
+  link.target = targetStr;
+
+  link.rel = typeof rel === 'string' ? rel : DEFAULT_LINK_REL;
+}
+
+/**
+ * @implements {IPDFLinkService}
+ */
+class SimpleLinkService {
+  constructor() {
+    this.externalLinkEnabled = true;
+  }
+
+  /**
+   * @type {number}
+   */
+  get pagesCount() {
+    return 0;
+  }
+
+  /**
+   * @type {number}
+   */
+  get page() {
+    return 0;
+  }
+
+  /**
+   * @param {number} value
+   */
+  set page(value) {}
+
+  /**
+   * @type {number}
+   */
+  get rotation() {
+    return 0;
+  }
+
+  /**
+   * @param {number} value
+   */
+  set rotation(value) {}
+
+  /**
+   * @param {string|Array} dest - The named, or explicit, PDF destination.
+   */
+  async goToDestination(dest) {}
+
+  /**
+   * @param {number|string} val - The page number, or page label.
+   */
+  goToPage(val) {}
+
+  /**
+   * @param {HTMLAnchorElement} link
+   * @param {string} url
+   * @param {boolean} [newWindow]
+   */
+  addLinkAttributes(link, url, newWindow = false) {
+    addLinkAttributes(link, { url, enabled: this.externalLinkEnabled });
+  }
+
+  /**
+   * @param dest - The PDF destination object.
+   * @returns {string} The hyperlink to the PDF object.
+   */
+  getDestinationHash(dest) {
+    return '#';
+  }
+
+  /**
+   * @param hash - The PDF parameters/hash.
+   * @returns {string} The hyperlink to the PDF object.
+   */
+  getAnchorUrl(hash) {
+    return '#';
+  }
+
+  /**
+   * @param {string} hash
+   */
+  setHash(hash) {}
+
+  /**
+   * @param {string} action
+   */
+  executeNamedAction(action) {}
+
+  /**
+   * @param {number} pageNum - page number.
+   * @param {Object} pageRef - reference to the page.
+   */
+  cachePageRef(pageNum, pageRef) {}
+
+  /**
+   * @param {number} pageNumber
+   */
+  isPageVisible(pageNumber) {
+    return true;
+  }
+
+  /**
+   * @param {number} pageNumber
+   */
+  isPageCached(pageNumber) {
+    return true;
+  }
+}
+
+export { LinkTarget, SimpleLinkService };

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
@@ -142,7 +142,7 @@ class SimpleLinkService {
   /**
    * @param {string|Array} dest - The named, or explicit, PDF destination.
    */
-  async goToDestination(dest) {}
+  goToDestination(dest) {}
 
   /**
    * @param {number|string} val - The page number, or page label.

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/pdf_link_service.js
@@ -74,8 +74,11 @@ function addLinkAttributes(link, { url, target, rel, enabled = true } = {}) {
   }
 
   let targetStr = ''; // LinkTarget.NONE
+  // Modified: default targets as _blank
+  // Original line: 16
   switch (target) {
     case LinkTarget.NONE:
+      targetStr = '_blank';
       break;
     case LinkTarget.SELF:
       targetStr = '_self';
@@ -89,6 +92,8 @@ function addLinkAttributes(link, { url, target, rel, enabled = true } = {}) {
     case LinkTarget.TOP:
       targetStr = '_top';
       break;
+    default:
+      targetStr = '_blank';
   }
   link.target = targetStr;
 

--- a/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
@@ -12,6 +12,7 @@ export const PdfPage = {
     cancel: jest.fn(),
   })),
   streamTextContent: jest.fn(() => ({})),
+  getAnnotations: jest.fn(() => Promise.resolve([])),
 };
 
 export const PdfDocument = {
@@ -36,5 +37,9 @@ export const renderTextLayer = jest.fn(() => ({
   expandTextDivs: jest.fn(),
   cancel: jest.fn(),
 }));
+
+export const AnnotationMode = {
+  ENABLE_FORMS: 'ENABLE_FORMS',
+};
 
 /* eslint-enable */


### PR DESCRIPTION
## Summary

This PR adds a new layer to the PDF Viewer to allow pdf annotations like external links based on how pdf.js does.

A different implementation in contrast to pdf.js links is that if there is no target specified, the links open in a different tab, instead of opening them in the same tab as mozilla's pdf renderer does.


https://user-images.githubusercontent.com/51239030/218927754-d9b19603-88bf-4329-95bd-238e4bc99268.mov



## Reviewer guidance

Go to any pdf resource that has links and try clicking on them. They should work as expected.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
