### PR TITLE
Move facility settings buttons to the page container for Android

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -1,8 +1,10 @@
 <template>
 
   <FacilityAppBarPage>
-    <KPageContainer>
-
+    <KPageContainer
+      data-test="page-container"
+      :style="{ marginBottom: '42px' }"
+    >
       <div class="mb">
         <h1>{{ $tr('pageHeader') }}</h1>
         <p>
@@ -92,9 +94,35 @@
               />
             </template>
           </KButton>
+        </div>
 
-
-
+        <div
+          v-if="isAppContext"
+          :style="{
+            marginTop: '32px',
+            borderTop: '1px solid',
+            borderTopColor: $themeTokens.fineLine
+          }"
+        >
+          <KButtonGroup
+            :style="{ marginTop: '24px', marginLeft: '-8px' }"
+          >
+            <KButton
+              :primary="true"
+              appearance="raised-button"
+              :text="coreString('saveChangesAction')"
+              name="save-settings"
+              :disabled="!settingsHaveChanged"
+              @click="saveConfig()"
+            />
+            <KButton
+              :primary="false"
+              appearance="flat-button"
+              :text="$tr('resetToDefaultSettings')"
+              name="reset-settings"
+              @click="showModal = true"
+            />
+          </KButtonGroup>
         </div>
       </template>
 
@@ -137,8 +165,11 @@
 
     </KPageContainer>
 
-    <BottomAppBar>
-      <KButtonGroup style="margin-top: 8px;">
+    <BottomAppBar data-test="bottom-bar">
+      <KButtonGroup
+        v-if="!isAppContext"
+        style="margin-top: 8px;"
+      >
         <KButton
           :primary="false"
           appearance="flat-button"
@@ -228,7 +259,7 @@
         'facilityNameSaved',
         'facilityNameError',
       ]),
-      ...mapGetters(['isSuperuser']),
+      ...mapGetters(['isAppContext', 'isSuperuser']),
       settingsList: () => settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -21,6 +21,8 @@ function getElements(wrapper) {
     saveButton: () => wrapper.find('button[name="save-settings"]'),
     confirmResetModal: () => wrapper.findComponent({ name: 'ConfirmResetModal' }),
     form: () => wrapper.find('form'),
+    bottomBar: () => wrapper.find('[data-test="bottom-bar"]'),
+    pageContainer: () => wrapper.find('[data-test="page-container"]'),
   };
 }
 
@@ -102,6 +104,50 @@ describe('facility config page view', () => {
     expect(mock).toHaveBeenCalledWith('facilityConfig/resetFacilityConfig');
     expect(mock).toHaveBeenCalledWith('createSnackbar', 'Facility settings updated');
     assertModalIsDown(wrapper);
+  });
+
+  describe(`in the browser mode`, () => {
+    let wrapper;
+    beforeAll(() => {
+      wrapper = makeWrapper();
+      wrapper.vm.$store.state.core.session.app_context = false;
+    });
+
+    it(`reset and save buttons are in the bottom bar`, () => {
+      const { bottomBar } = getElements(wrapper);
+      const { resetButton, saveButton } = getElements(bottomBar());
+      expect(resetButton().exists()).toBeTruthy();
+      expect(saveButton().exists()).toBeTruthy();
+    });
+
+    it(`reset and save buttons aren't in the page container`, () => {
+      const { pageContainer } = getElements(wrapper);
+      const { resetButton, saveButton } = getElements(pageContainer());
+      expect(resetButton().exists()).toBeFalsy();
+      expect(saveButton().exists()).toBeFalsy();
+    });
+  });
+
+  describe(`in the Android app mode`, () => {
+    let wrapper;
+    beforeAll(() => {
+      wrapper = makeWrapper();
+      wrapper.vm.$store.state.core.session.app_context = true;
+    });
+
+    it(`reset and save buttons are in the bottom bar`, () => {
+      const { bottomBar } = getElements(wrapper);
+      const { resetButton, saveButton } = getElements(bottomBar());
+      expect(resetButton().exists()).toBeFalsy();
+      expect(saveButton().exists()).toBeFalsy();
+    });
+
+    it(`reset and save buttons aren't in the page container`, () => {
+      const { pageContainer } = getElements(wrapper);
+      const { resetButton, saveButton } = getElements(pageContainer());
+      expect(resetButton().exists()).toBeTruthy();
+      expect(saveButton().exists()).toBeTruthy();
+    });
   });
   // not tested: notifications
 });


### PR DESCRIPTION
## Summary

In the Android native app, _"Save changes"_ and _"Reset to defaults"_ buttons in the facility settings are now moved to the bottom of the main page container. There are no changes in the browser app where the buttons are in the bottom bar.

| Android - before | Android - after (1/3) | Android - after (2/3) | Android - after (3/3) | Browser (no changes, for reference) |
| --------------------- | -------------------------- | -------------------------- | -------------------------- | ------------------------------------------------ |
| ![android-before](https://user-images.githubusercontent.com/13509191/219680904-d69c3a4a-c50c-474c-a95f-4d5a43ab6b3f.png) | ![android-after-large](https://user-images.githubusercontent.com/13509191/219680958-e2a9ba7c-465b-4303-a2c6-bdfcf79a8573.png) | ![android-after-medium](https://user-images.githubusercontent.com/13509191/219680994-c09b7ab9-cffa-4fc0-8c23-db726cba8783.png) | ![android-after-small](https://user-images.githubusercontent.com/13509191/219681045-0d2addb7-4856-41c1-83c8-0df1bcdd2c68.png) | ![browser](https://user-images.githubusercontent.com/13509191/219681169-7fd476e4-a607-48bd-88e2-d0d30a041ef2.png) |

## References

Closes #9794
[Figma designs](https://www.figma.com/file/MpCG7r5PULOCJsEvnTSti8/Android-Designs-2022?node-id=969%3A16669&t=Zpbks4IizxDtKuoJ-0)

## Reviewer guidance

1. Change `isAppContext` getter return value to `true` to simulate the Android environment:

https://github.com/learningequality/kolibri/blob/2b52b5b2af694afd5f8be78c22fc7673d30514f4/kolibri/core/assets/src/state/modules/session.js#L77-L79

2. Go to _"Facility"_ -> _"Settings"_
3. See the buttons

- [ ] Buttons should follow the new designs in the Android native app
- [ ] There should be no changes in the browser app

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
