### PR TITLE
Add prefer-const linting rule to kolibri-tools

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -91,3 +91,4 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Liana Harris | LianaHarris360 |
 | Rishi Kejriwal | Kej-r03 |
 | Siddhanth Rathod | siddhanthrathod |
+| Akila Induranga | akila-i |

--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -1063,7 +1063,7 @@ export class Resource {
       console.log(`Route name: ${store.state.route.name}`);
       if (Object.keys(store.state.route.params).length) {
         console.group('Vue router params');
-        for (let [k, v] of Object.entries(store.state.route.params)) {
+        for (const [k, v] of Object.entries(store.state.route.params)) {
           console.log(`${k}: ${v}`);
         }
         console.groupEnd();
@@ -1072,7 +1072,7 @@ export class Resource {
     }
     if (Object.keys(err.config.params).length) {
       console.group('Query parameters');
-      for (let [k, v] of Object.entries(err.config.params)) {
+      for (const [k, v] of Object.entries(err.config.params)) {
         console.log(`${k}: ${v}`);
       }
       console.groupEnd();
@@ -1082,7 +1082,7 @@ export class Resource {
         const data = JSON.parse(err.config.data);
         if (Object.keys(data).length) {
           console.group('Data');
-          for (let [k, v] of Object.entries(data)) {
+          for (const [k, v] of Object.entries(data)) {
             console.log(`${k}: ${v}`);
           }
           console.groupEnd();
@@ -1091,7 +1091,7 @@ export class Resource {
     }
     if (Object.keys(err.config.headers).length) {
       console.group('Headers');
-      for (let [k, v] of Object.entries(err.config.headers)) {
+      for (const [k, v] of Object.entries(err.config.headers)) {
         console.log(`${k}: ${v}`);
       }
       console.groupEnd();

--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -129,7 +129,7 @@ export default new Resource({
   },
   cacheData(data) {
     if (Array.isArray(data)) {
-      for (let model of data) {
+      for (const model of data) {
         this.cacheData(model);
       }
     } else if (isPlainObject(data)) {
@@ -142,7 +142,7 @@ export default new Resource({
           this.cacheData(data.children);
         }
       } else if (data.results) {
-        for (let model of data.results) {
+        for (const model of data.results) {
           this.cacheData(model);
         }
       }

--- a/kolibri/core/assets/src/composables/useScrollPosition.js
+++ b/kolibri/core/assets/src/composables/useScrollPosition.js
@@ -2,7 +2,7 @@ import { computed } from 'kolibri.lib.vueCompositionApi';
 import { get } from '@vueuse/core';
 
 export default function useScrollPosition() {
-  let _scrollPositions = {};
+  const _scrollPositions = {};
 
   const scrollPosition = computed({
     get() {

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1180,7 +1180,7 @@ export default {
      * `CORE_CREATE_SNACKBAR` mutation.
      */
     showSnackbarNotification(key, args, coreCreateSnackbarArgs) {
-      let text = notificationStrings.$tr(key, args || {});
+      const text = notificationStrings.$tr(key, args || {});
       if (coreCreateSnackbarArgs) {
         this.$store.commit('CORE_CREATE_SNACKBAR', {
           ...coreCreateSnackbarArgs,

--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -236,7 +236,7 @@ export function getFacilities(store) {
 
 export function getFacilityConfig(store, facilityId) {
   const { currentFacilityId, selectedFacility } = store.getters;
-  let facId = facilityId || currentFacilityId;
+  const facId = facilityId || currentFacilityId;
   if (!facId) {
     // No facility Id, so nothing good is going to happen here.
     // Redirect and let Kolibri sort it out.

--- a/kolibri/core/assets/src/utils/sortLanguages.js
+++ b/kolibri/core/assets/src/utils/sortLanguages.js
@@ -15,7 +15,7 @@ export default function sortLanguages(availableLanguages, currentLanguageId) {
     return language.id == currentLanguageId;
   });
 
-  let sortedLanguages = availableLanguages
+  const sortedLanguages = availableLanguages
     .sort(compareLanguages)
     .filter(language => language.id != currentLanguageId);
 

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -35,7 +35,7 @@
     },
     computed: {
       fileOptions() {
-        let options = this.files.map(file => {
+        const options = this.files.map(file => {
           const label = getFilePresetString(file);
           return {
             label,

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -57,7 +57,7 @@
     inject: ['showActive'],
     computed: {
       active() {
-        let showActive = typeof this.showActive !== 'undefined' ? this.showActive : true;
+        const showActive = typeof this.showActive !== 'undefined' ? this.showActive : true;
         return showActive && window.location.pathname.startsWith(this.link);
       },
       optionStyle() {

--- a/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
+++ b/kolibri/core/assets/src/views/language-switcher/LanguageSwitcherModal.vue
@@ -60,8 +60,8 @@
     },
     computed: {
       splitLanguageOptions() {
-        let secondCol = this.languageOptions;
-        let firstCol = secondCol.splice(0, Math.ceil(secondCol.length / 2));
+        const secondCol = this.languageOptions;
+        const firstCol = secondCol.splice(0, Math.ceil(secondCol.length / 2));
 
         return [firstCol, secondCol];
       },

--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -91,7 +91,7 @@
         return '';
       },
       valid() {
-        let passwordValid = this.passwordInvalidText === '';
+        const passwordValid = this.passwordInvalidText === '';
         if (this.showConfirmationInput) {
           return this.confirmationInvalidText === '' && passwordValid;
         }

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/actions.js
@@ -9,7 +9,7 @@ export function updateWithNotifications(store, notifications) {
   const contentLearnerStatusMapUpdates = [];
   const { learnerMap, examMap, contentNodeMap, lessonMap } = store.state;
 
-  for (let nIdx in notifications) {
+  for (const nIdx in notifications) {
     const notification = notifications[nIdx];
     const { object } = notification;
 

--- a/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
+++ b/kolibri/plugins/coach/assets/src/modules/coachNotifications/getters.js
@@ -137,7 +137,7 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
     }
   );
 
-  for (let groupCode in groupedNotifications) {
+  for (const groupCode in groupedNotifications) {
     // Filter out all bust the most recent event for each user
     const allEvents = sortedUniqBy(groupedNotifications[groupCode], 'user_id');
 
@@ -145,12 +145,12 @@ export function summarizedNotifications(state, getters, rootState, rootGetters) 
 
     // Iterate through each of the assignee collections and create one
     // summarizing notification for each event type in the collection.
-    for (let collIdx in eventsByCollection) {
+    for (const collIdx in eventsByCollection) {
       const collectionEvents = eventsByCollection[collIdx];
 
       const eventTypeEvents = groupBy(collectionEvents, 'event');
 
-      for (let eventType in eventTypeEvents) {
+      for (const eventType in eventTypeEvents) {
         const orderedEvents = eventTypeEvents[eventType];
 
         const firstEvent = orderedEvents.slice(-1)[0];

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -45,9 +45,7 @@ function showResourceSelectionPage(store, params) {
 
         const ancestorCounts = {};
 
-        let resourceAncestors;
-
-        resourceAncestors = store.state.lessonSummary.workingResources.map(
+        const resourceAncestors = store.state.lessonSummary.workingResources.map(
           resource => (cache[resource.contentnode_id] || {}).ancestors || []
         );
         // store ancestor ids to get their descendants later

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -122,7 +122,7 @@
         return this.$store.state.classSummary.name;
       },
       syncStatusOptions() {
-        let options = [];
+        const options = [];
         for (const [value] of Object.entries(SyncStatus)) {
           // skip displaying the "not recently synced" "unable to sync"
           // so they can be as separate option, per Figma design
@@ -177,7 +177,7 @@
       pollClassListSyncStatuses() {
         this.fetchUserSyncStatus({ member_of: this.$route.params.classId }).then(data => {
           const statuses = {};
-          for (let status of data) {
+          for (const status of data) {
             statuses[status.user] = status;
           }
           this.classSyncStatusList = statuses;

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -114,7 +114,7 @@
           ? this.coachString('lessonVisibleToLearnersLabel')
           : this.coachString('lessonNotVisibleToLearnersLabel');
 
-        let promise = LessonResource.saveModel({
+        const promise = LessonResource.saveModel({
           id: this.lesson.id,
           data: {
             is_active: newActiveState,

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -277,7 +277,7 @@
     },
     methods: {
       handleOpenQuiz() {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: this.$route.params.quizId,
           data: {
             active: true,
@@ -297,7 +297,7 @@
           });
       },
       handleCloseQuiz() {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: this.$route.params.quizId,
           data: {
             archive: true,
@@ -322,7 +322,7 @@
           ? this.coachString('quizVisibleToLearners')
           : this.coachString('quizNotVisibleToLearners');
 
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: this.$route.params.quizId,
           data: {
             active: newActiveState,

--- a/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/notifications/notificationStrings.js
@@ -82,7 +82,7 @@ const nStringsMixin = {
 function cardTextForNotification(notification) {
   const { collection, resource, learnerSummary, object, event } = notification;
   let stringType;
-  let stringDetails = {
+  const stringDetails = {
     learnerName: learnerSummary.firstUserName,
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -241,7 +241,7 @@
     },
     methods: {
       handleOpenQuiz(quizId) {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: quizId,
           data: {
             active: true,
@@ -261,7 +261,7 @@
           });
       },
       handleCloseQuiz(quizId) {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: quizId,
           data: {
             archive: true,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreatePracticeQuizPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreatePracticeQuizPage.vue
@@ -91,7 +91,7 @@
           };
         }
 
-        let value = content.assessmentmetadata.assessment_item_ids.length;
+        const value = content.assessmentmetadata.assessment_item_ids.length;
         this.$store.commit('examCreation/SET_NUMBER_OF_QUESTIONS', value);
 
         return {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/PracticeQuizContentPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/PracticeQuizContentPreviewPage.vue
@@ -162,14 +162,14 @@
         );
       },
       newTitle() {
-        let currentPracticeQuizName = this.content.title;
-        let practiceQuizNameAlreadyExists = this.exams.filter(exam =>
+        const currentPracticeQuizName = this.content.title;
+        const practiceQuizNameAlreadyExists = this.exams.filter(exam =>
           exam.title.includes(currentPracticeQuizName)
         );
 
         if (practiceQuizNameAlreadyExists.length >= 1) {
           // Set the new (#) for additional copies based on how many copies exist
-          let newCopyNum = practiceQuizNameAlreadyExists.length;
+          const newCopyNum = practiceQuizNameAlreadyExists.length;
           return this.$tr('duplicateTitle', {
             copyNum: newCopyNum,
             originalTitle: this.content.title,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -215,7 +215,7 @@
           ? this.coachString('lessonVisibleToLearnersLabel')
           : this.coachString('lessonNotVisibleToLearnersLabel');
 
-        let promise = LessonResource.saveModel({
+        const promise = LessonResource.saveModel({
           id: lesson.id,
           data: {
             is_active: newActiveState,

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/IndividualLearnerSelector.vue
@@ -192,7 +192,7 @@
       fetchOutsideClassroom() {
         this.fetchingOutside = true;
         ClassSummaryResource.fetchModel({ id: this.targetClassId, force: true }).then(summary => {
-          let summaryGroupMap = {};
+          const summaryGroupMap = {};
           summary.groups.forEach(group => {
             summaryGroupMap[group.id] = group;
           });
@@ -212,7 +212,7 @@
         this.$emit('update:selectedLearnerIds', newLearnerIds);
       },
       selectVisiblePage() {
-        let newIds = [...this.selectedLearnerIds];
+        const newIds = [...this.selectedLearnerIds];
         const isWholePageSelected = every(this.currentPageLearners, learner =>
           this.selectedLearnerIds.includes(learner.id)
         );

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -162,7 +162,7 @@
           ? this.coachString('lessonVisibleToLearnersLabel')
           : this.coachString('lessonNotVisibleToLearnersLabel');
 
-        let promise = LessonResource.saveModel({
+        const promise = LessonResource.saveModel({
           id: lesson.id,
           data: {
             is_active: newActiveState,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -222,7 +222,7 @@
     },
     methods: {
       handleOpenQuiz(quizId) {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: quizId,
           data: {
             active: true,
@@ -242,7 +242,7 @@
           });
       },
       handleCloseQuiz(quizId) {
-        let promise = ExamResource.saveModel({
+        const promise = ExamResource.saveModel({
           id: quizId,
           data: {
             archive: true,

--- a/kolibri/plugins/device/assets/src/composables/__mocks__/usePlugins.js
+++ b/kolibri/plugins/device/assets/src/composables/__mocks__/usePlugins.js
@@ -1,4 +1,4 @@
-export let plugins = [];
+export const plugins = [];
 
 const MOCK_DEFAULTS = {
   plugins: { value: [] },

--- a/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
@@ -11,8 +11,7 @@ const logging = logger.getLogger(__filename);
 
 export function cancelTask(store, taskId) {
   return new Promise(resolve => {
-    let cancelWatch;
-    cancelWatch = coreStore.watch(
+    const cancelWatch = coreStore.watch(
       state =>
         (state.manageContent.taskList.find(task => task.id === taskId) || {}).status ===
         TaskStatuses.CANCELED,

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
@@ -54,8 +54,8 @@ export function getPathPermissions(path) {
 }
 
 export function getPathsPermissions(paths) {
-  let pathsInfo = [];
-  for (let path of paths) {
+  const pathsInfo = [];
+  for (const path of paths) {
     getPathPermissions(path).then(permissions => {
       pathsInfo.push({ path, writable: permissions.data.writable });
     });

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -470,7 +470,7 @@
         return this.$store.getters.isSuperuser && this.facilities.length > 1;
       },
       languageOptions() {
-        let languages = sortLanguages(Object.values(availableLanguages), currentLanguage).map(
+        const languages = sortLanguages(Object.values(availableLanguages), currentLanguage).map(
           language => {
             return {
               value: language.id,

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -23,7 +23,7 @@
     computed: {
       ...mapGetters(['canManageContent', 'isSuperuser']),
       links() {
-        let list = [];
+        const list = [];
         if (this.canManageContent) {
           list.push({
             title: this.coreString('channelsLabel'),

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -239,7 +239,7 @@
     watch: {
       // Update facilities whenever a watched task completes
       facilityTasks(newTasks) {
-        for (let index in newTasks) {
+        for (const index in newTasks) {
           const task = newTasks[index];
           if (this.taskIdsToWatch.includes(task.id)) {
             if (task.status === TaskStatuses.COMPLETED) {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -87,7 +87,7 @@
           }
         } else if (this.step === Steps.SELECT_SOURCE_FACILITY_PEER) {
           this.$emit('cancel');
-          let newRoute = availableChannelsPageLink({ addressId: data.id });
+          const newRoute = availableChannelsPageLink({ addressId: data.id });
           newRoute.query.setup = true;
           this.$router.push(newRoute);
         }

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/ContentTreeViewer.vue
@@ -123,12 +123,12 @@
       breadcrumbs() {
         if (this.manageMode) {
           return this.path.map(x => {
-            let query = {};
+            const query = {};
             if (x.id !== this.$route.params.channel_id) {
               query.node = x.id;
             }
 
-            let params = { scrollTo: '.content-tree-viewer' };
+            const params = { scrollTo: '.content-tree-viewer' };
 
             return {
               text: x.title,

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -519,7 +519,7 @@
       },
       storeVisitedPage(currentLocation) {
         if (currentLocation) {
-          let visited = this.savedVisitedPages;
+          const visited = this.savedVisitedPages;
           visited[currentLocation] = true;
           this.savedVisitedPages = visited;
         }

--- a/kolibri/plugins/learn/assets/src/composables/__mocks__/useCoreLearn.js
+++ b/kolibri/plugins/learn/assets/src/composables/__mocks__/useCoreLearn.js
@@ -31,8 +31,8 @@
  * ```
  */
 
-export let inClasses = false;
-export let canDownload = true;
+export const inClasses = false;
+export const canDownload = true;
 
 const MOCK_DEFAULTS = {
   inClasses,

--- a/kolibri/plugins/learn/assets/src/composables/useChannels.js
+++ b/kolibri/plugins/learn/assets/src/composables/useChannels.js
@@ -10,7 +10,7 @@ import plugin_data from 'plugin_data';
 const channelsArray = plugin_data.channels ? plugin_data.channels : [];
 const chanMap = {};
 
-for (let channel of channelsArray) {
+for (const channel of channelsArray) {
   chanMap[channel.id] = channel;
 }
 
@@ -20,7 +20,7 @@ const channelsMap = reactive(chanMap);
 
 function fetchChannels(params) {
   return ChannelResource.list(params).then(channels => {
-    for (let channel of channels) {
+    for (const channel of channels) {
       set(channelsMap, channel.id, channel);
     }
     return channels;

--- a/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentNodeProgress.js
@@ -38,7 +38,7 @@ export default function useContentNodeProgress() {
       force: true,
     }).then(progressData => {
       const progresses = progressData ? progressData : [];
-      for (let progress of progresses) {
+      for (const progress of progresses) {
         setContentNodeProgress(progress);
       }
     });
@@ -59,7 +59,7 @@ export default function useContentNodeProgress() {
       id,
     }).then(progressData => {
       const progresses = progressData ? progressData : [];
-      for (let progress of progresses) {
+      for (const progress of progresses) {
         setContentNodeProgress(progress);
       }
     });

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -43,7 +43,7 @@ export default function useDownloadRequests(store) {
         node_id: '2ea9bda8703241be89b5b9fd87f88815',
       },
     ];
-    for (let req of dummyDownloadRequests) {
+    for (const req of dummyDownloadRequests) {
       set(downloadRequestMap, req.node_id, req);
     }
   }

--- a/kolibri/plugins/learn/assets/src/composables/useLanguages.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLanguages.js
@@ -10,7 +10,7 @@ import plugin_data from 'plugin_data';
 const langArray = plugin_data.languages ? plugin_data.languages : [];
 const langMap = {};
 
-for (let lang of langArray) {
+for (const lang of langArray) {
   langMap[lang.id] = lang;
 }
 

--- a/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearnerResources.js
@@ -35,7 +35,7 @@ function addResumableContentNodes(nodes, more = null) {
 }
 
 function _cacheLessonResources(lesson) {
-  for (let resource of lesson.resources) {
+  for (const resource of lesson.resources) {
     if (resource.contentnode && resource.contentnode.content_id) {
       ContentNodeResource.cacheData(resource.contentnode);
       setContentNodeProgress({
@@ -47,14 +47,14 @@ function _cacheLessonResources(lesson) {
 }
 
 function setClassData(classroom) {
-  for (let lesson of classroom.assignments.lessons) {
+  for (const lesson of classroom.assignments.lessons) {
     _cacheLessonResources(lesson);
   }
 }
 
 export function setClasses(classData) {
   set(classes, classData);
-  for (let classroom of classData) {
+  for (const classroom of classData) {
     setClassData(classroom);
   }
 }

--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -63,7 +63,7 @@ const replaceBlocklist = {
 };
 
 function clearObject(obj) {
-  for (let key in obj) {
+  for (const key in obj) {
     delete obj[key];
   }
 }
@@ -263,7 +263,7 @@ export default function useProgressTracking(store) {
         Object.assign(nowSavedInteraction, interaction);
         pastattemptMap[nowSavedInteraction.id] = nowSavedInteraction;
       } else {
-        for (let key in interaction) {
+        for (const key in interaction) {
           if (!blocklist[key]) {
             pastattemptMap[interaction.id][key] = interaction[key];
           }
@@ -280,7 +280,7 @@ export default function useProgressTracking(store) {
       data,
     }).then(response => {
       if (response.data.attempts) {
-        for (let attempt of response.data.attempts) {
+        for (const attempt of response.data.attempts) {
           updateAttempt(attempt);
         }
       }
@@ -362,7 +362,7 @@ export default function useProgressTracking(store) {
         // If it is successful call all of the resolve functions that we have stored
         // from all the Promises that have been returned while this specific debounce
         // has been active.
-        for (let [resolve] of updateContentSessionResolveRejectStack) {
+        for (const [resolve] of updateContentSessionResolveRejectStack) {
           resolve(result);
         }
         // Reset the stack for resolve/reject functions, so that future invocations
@@ -371,7 +371,7 @@ export default function useProgressTracking(store) {
       })
       .catch(err => {
         // If there is an error call reject for all previously returned promises.
-        for (let [, reject] of updateContentSessionResolveRejectStack) {
+        for (const [, reject] of updateContentSessionResolveRejectStack) {
           reject(err);
         }
         // Likewise reset the stack.
@@ -449,7 +449,7 @@ export default function useProgressTracking(store) {
           a => !a.id && a.item === interaction.item
         );
         if (unsavedInteraction) {
-          for (let key in interaction) {
+          for (const key in interaction) {
             set(unsavedInteraction, key, interaction[key]);
           }
         } else {

--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -79,13 +79,13 @@ function _generateLibraryCategoriesLookup(categories) {
   (categories || []).map(key => {
     const paths = key.split('.');
     let path = '';
-    for (let path_segment of paths) {
+    for (const path_segment of paths) {
       path = path === '' ? path_segment : path + '.' + path_segment;
       availablePaths[path] = true;
     }
   });
   // Create a nested object representing the hierarchy of categories
-  for (let value of Object.values(Categories)
+  for (const value of Object.values(Categories)
     // Sort by the length of the key path to deal with
     // shorter key paths first.
     .sort((a, b) => a.length - b.length)) {
@@ -96,7 +96,7 @@ function _generateLibraryCategoriesLookup(categories) {
     let path = '';
     // Start with the global object
     let nested = libraryCategories;
-    for (let fragment of ids) {
+    for (const fragment of ids) {
       // Add the fragment to create the path we examine
       path += fragment;
       // Check to see if this path is one of the paths
@@ -171,10 +171,10 @@ export default function useSearch(descendant, store, router) {
     get() {
       const searchTerms = {};
       const query = get(route).query;
-      for (let key of searchKeys) {
+      for (const key of searchKeys) {
         const obj = {};
         if (query[key]) {
-          for (let value of query[key].split(',')) {
+          for (const value of query[key].split(',')) {
             obj[value] = true;
           }
         }
@@ -185,7 +185,7 @@ export default function useSearch(descendant, store, router) {
     },
     set(value) {
       const query = { ...get(route).query };
-      for (let key of searchKeys) {
+      for (const key of searchKeys) {
         const val = Object.keys(value[key] || {})
           .filter(Boolean)
           .join(',');
@@ -239,7 +239,7 @@ export default function useSearch(descendant, store, router) {
       getParams.max_results = 25;
       const terms = get(searchTerms);
       set(searchLoading, true);
-      for (let key of searchKeys) {
+      for (const key of searchKeys) {
         if (key === 'categories') {
           if (terms[key][AllCategories]) {
             getParams['categories__isnull'] = false;

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -73,7 +73,7 @@ export function showExam(store, params, alreadyOnQuiz) {
 
                 const contentNodeMap = {};
 
-                for (let node of contentNodes) {
+                for (const node of contentNodes) {
                   contentNodeMap[node.id] = node;
                 }
 

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -38,7 +38,7 @@ function hydrateHomePage() {
       response.data.resumable_resources.results || [],
       response.data.resumable_resources.more || null
     );
-    for (let progress of response.data.resumable_resources_progress) {
+    for (const progress of response.data.resumable_resources_progress) {
       setContentNodeProgress(progress);
     }
   });

--- a/kolibri/plugins/learn/assets/src/utils/validateChannelTheme.js
+++ b/kolibri/plugins/learn/assets/src/utils/validateChannelTheme.js
@@ -16,7 +16,7 @@ export function validateChannelTheme(theme) {
   const updatedTheme = {
     ...defaultTheme,
   };
-  for (let key in theme) {
+  for (const key in theme) {
     const color = theme[key];
     if (!color) {
       continue;

--- a/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/CategorySearchModal/CategorySearchOptions.vue
@@ -85,10 +85,10 @@
       availablePaths() {
         if (this.searchableLabels) {
           const paths = {};
-          for (let key of this.searchableLabels.categories) {
+          for (const key of this.searchableLabels.categories) {
             const keyPaths = key.split('.');
             let path = '';
-            for (let keyPath of keyPaths) {
+            for (const keyPath of keyPaths) {
               path = path === '' ? keyPath : path + '.' + keyPath;
               paths[path] = true;
             }

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/CustomContentRenderer.vue
@@ -263,8 +263,8 @@
       },
 
       navigateTo(message) {
-        let id = message.nodeId;
-        let context = {};
+        const id = message.nodeId;
+        const context = {};
         return ContentNodeResource.fetchModel({ id })
           .then(contentNode => {
             if (contentNode && contentNode.kind === 'topic') {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -263,7 +263,7 @@
           });
       },
       navigateTo(message) {
-        let id = message.nodeId;
+        const id = message.nodeId;
         return ContentNodeResource.fetchModel({ id })
           .then(contentNode => {
             router.push(

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/ActivityButtonsGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/ActivityButtonsGroup.vue
@@ -73,7 +73,7 @@
       availableActivities() {
         if (this.searchableLabels) {
           const activities = {};
-          for (let key of this.searchableLabels.learning_activities) {
+          for (const key of this.searchableLabels.learning_activities) {
             activities[key] = true;
           }
           return activities;

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -236,7 +236,7 @@
       availableRootCategories() {
         if (this.searchableLabels) {
           const roots = {};
-          for (let key of this.searchableLabels.categories) {
+          for (const key of this.searchableLabels.categories) {
             const root = key.split('.')[0];
             roots[root] = true;
           }
@@ -247,7 +247,7 @@
       availableNeeds() {
         if (this.searchableLabels) {
           const needs = {};
-          for (let key of this.searchableLabels.learner_needs) {
+          for (const key of this.searchableLabels.learner_needs) {
             const root = key.split('.')[0];
             needs[root] = true;
             needs[key] = true;
@@ -286,7 +286,7 @@
       handleNeed(need) {
         if (this.value.learner_needs[need]) {
           const learner_needs = {};
-          for (let n in this.value.learner_needs) {
+          for (const n in this.value.learner_needs) {
             if (n !== need) {
               learner_needs[n] = true;
             }

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -470,7 +470,7 @@
           .filter(t => (this.subTopicId ? t.id === this.subTopicId : true))
           .map(t => {
             let childrenToDisplay;
-            let topicChildren = t.children ? t.children.results : [];
+            const topicChildren = t.children ? t.children.results : [];
             if (this.subTopicId || this.topics.length === 1) {
               // If we are in a subtopic display, we should only be displaying this topic
               // so don't bother checking if the ids match.

--- a/kolibri/plugins/learn/assets/test/bookmark-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/bookmark-page.spec.js
@@ -53,7 +53,7 @@ describe('Bookmark Page', () => {
       expect(wrapper.find("[data-test='load-more-button']")).toBeTruthy();
     });
     it('clicking the load more button calls the load more function', async () => {
-      let mockFetchBookmarks = ContentNodeResource.fetchBookmarks.mockResolvedValue({
+      const mockFetchBookmarks = ContentNodeResource.fetchBookmarks.mockResolvedValue({
         results: fakeBookmarks,
       });
       await wrapper.find("[data-test='load-more-button']").vm.$emit('click');

--- a/kolibri/plugins/media_player/assets/src/modules/captions/index.js
+++ b/kolibri/plugins/media_player/assets/src/modules/captions/index.js
@@ -153,7 +153,7 @@ export default {
       );
     },
     setTrackList(store, trackList) {
-      let { language } = store.state;
+      const { language } = store.state;
 
       if (store.state.trackList) {
         store.state.trackListeners.forEach(({ trackId, event, listener }) => {
@@ -235,7 +235,7 @@ export default {
     },
     synchronizeTrackList(store) {
       const { subtitles, transcript } = store.state;
-      let { language } = store.state;
+      const { language } = store.state;
       const settings = new Settings(defaultSettings());
       settings.captionSubtitles = subtitles;
       settings.captionTranscript = transcript;

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerFullscreen/mimicFullscreenToggle.js
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerFullscreen/mimicFullscreenToggle.js
@@ -19,8 +19,8 @@ class MimicFullscreenToggle extends FullscreenToggle {
   }
 
   handleChangeFullscreen(isFullscreen) {
-    let el = this.$('.vjs-icon-placeholder'),
-      addClass = MimicFullscreenToggle.INACTIVE_CLASS,
+    const el = this.$('.vjs-icon-placeholder');
+    let addClass = MimicFullscreenToggle.INACTIVE_CLASS,
       removeClass = MimicFullscreenToggle.ACTIVE_CLASS,
       controlText = 'Fullscreen';
 

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/text_layer_builder.js
@@ -220,7 +220,7 @@ class TextLayerBuilder {
 
       // Modified: Refactor simplified code for deleting PDFJS Dev global variables references
       // Original line: 178
-      let adjustTop =
+      const adjustTop =
         evt.target !== div &&
         window.getComputedStyle(end).getPropertyValue('-moz-user-select') !== 'none';
       if (adjustTop) {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -366,7 +366,7 @@
         }
       },
       storeVisitedPage(currentPageNum) {
-        let visited = this.savedVisitedPages;
+        const visited = this.savedVisitedPages;
         visited[currentPageNum] = true;
         this.savedVisitedPages = visited;
       },
@@ -549,7 +549,7 @@
 
               const isFocused = this.focusPage(pageNumber, event.target);
               if (!isFocused) {
-                let position = (pageNumber - 1) / this.totalPages;
+                const position = (pageNumber - 1) / this.totalPages;
                 this.scrollTo(position); // scroll to page so the virtual list can render it
                 const onPageRendered = e => {
                   if (e.pageNumber === pageNumber) {

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -310,7 +310,7 @@
         } catch (e) {
           logging.debug('Error during unmounting of item renderer', e);
         }
-        for (let key in this.imageUrls) {
+        for (const key in this.imageUrls) {
           if (this.imageUrls[key].indexOf('blob:') === 0) {
             URL.revokeObjectURL(this.imageUrls[key]);
           }

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -50,10 +50,9 @@
       OnboardingStepBase,
     },
     data() {
-      let selected;
       const preset = this.wizardService.state.context['formalOrNonformal'];
       // preset inits to null, so either it'll be what the user selected or default to nonformal
-      selected = preset || Presets.NONFORMAL;
+      const selected = preset || Presets.NONFORMAL;
 
       const facilityName = this.wizardService.state.context['facilityName'] || '';
       return {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -38,7 +38,7 @@
     },
     inject: ['wizardService'],
     data() {
-      let selected = get(this, 'wizardService.context.setupType', Options.FULL);
+      const selected = get(this, 'wizardService.context.setupType', Options.FULL);
       return {
         Options,
         selected,

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -125,7 +125,7 @@
           learner_can_sign_up: this.wizardContext('learnerCanCreateAccount'),
         };
 
-        let payload = {
+        const payload = {
           ...this.facilityData,
           superuser,
           settings: omitBy(settings, v => v === null),

--- a/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
+++ b/kolibri/plugins/slideshow_viewer/assets/src/views/SlideshowRendererComponent.vue
@@ -240,7 +240,7 @@
         return 'descriptive-text-' + id;
       },
       storeVisitedSlide(currentSlideNum) {
-        let visited = this.savedVisitedSlides;
+        const visited = this.savedVisitedSlides;
         visited[currentSlideNum] = true;
         this.savedVisitedSlides = visited;
       },

--- a/kolibri/plugins/user_profile/assets/src/composables/__mocks__/useOnMyOwnSetup.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/__mocks__/useOnMyOwnSetup.js
@@ -1,4 +1,4 @@
-export let onMyOwnSetup = false;
+export const onMyOwnSetup = false;
 
 const MOCK_DEFAULTS = {
   onMyOwnSetup,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -75,7 +75,7 @@
         }
         const stateID = Object.keys(state.meta)[0];
         if (state.meta[stateID] !== undefined) {
-          let newRoute = state.meta[stateID].route;
+          const newRoute = state.meta[stateID].route;
           if (newRoute != this.$router.currentRoute.name) {
             if ('path' in state.meta[stateID]) {
               this.internalNavigation = true;

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-undefined-string-uses.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-undefined-string-uses.js
@@ -13,8 +13,8 @@ const $TR_FUNCTION = '$tr';
 
 const create = context => {
   let hasTemplate;
-  let definitionNodes = [];
-  let usedStringNodes = [];
+  const definitionNodes = [];
+  const usedStringNodes = [];
 
   const initialize = {
     Program(node) {

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-methods.js
@@ -13,9 +13,9 @@ const { GROUP_METHODS } = require('../constants');
 const create = context => {
   let hasTemplate;
   let unusedProperties = [];
-  let thisExpressionsVariablesNames = [];
-  let befoureRouteEnterInstanceProperties = [];
-  let watchStringMethods = [];
+  const thisExpressionsVariablesNames = [];
+  const befoureRouteEnterInstanceProperties = [];
+  const watchStringMethods = [];
 
   const sourceCode = context.getSourceCode();
   const comments = sourceCode.getAllComments();

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-properties.js
@@ -15,8 +15,8 @@ const { GROUP_PROPS, GROUP_DATA, GROUP_COMPUTED } = constants;
 const create = context => {
   let hasTemplate;
   let unusedProperties = [];
-  let thisExpressionsVariablesNames = [];
-  let befoureRouteEnterInstanceProperties = [];
+  const thisExpressionsVariablesNames = [];
+  const befoureRouteEnterInstanceProperties = [];
 
   const initialize = {
     Program(node) {

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-translations.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-translations.js
@@ -17,7 +17,7 @@ const $TR_FUNCTION = '$tr';
 const create = context => {
   let hasTemplate;
   let definitionNodes = [];
-  let usedStrings = [];
+  const usedStrings = [];
 
   const initialize = {
     Program(node) {

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-methods.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-methods.js
@@ -12,10 +12,10 @@ const { VUEX_MUTATION, VUEX_ACTION } = require('../constants');
 
 const create = context => {
   let hasTemplate;
-  let unusedVuexProperties = [];
-  let thisExpressionsVariablesNames = [];
-  let befoureRouteEnterInstanceProperties = [];
-  let watchStringMethods = [];
+  const unusedVuexProperties = [];
+  const thisExpressionsVariablesNames = [];
+  const befoureRouteEnterInstanceProperties = [];
+  const watchStringMethods = [];
 
   const initialize = {
     Program(node) {

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-no-unused-vuex-properties.js
@@ -12,9 +12,9 @@ const { VUEX_STATE, VUEX_GETTER } = require('../constants');
 
 const create = context => {
   let hasTemplate;
-  let unusedVuexProperties = [];
-  let thisExpressionsVariablesNames = [];
-  let befoureRouteEnterInstanceProperties = [];
+  const unusedVuexProperties = [];
+  const thisExpressionsVariablesNames = [];
+  const befoureRouteEnterInstanceProperties = [];
 
   const initialize = {
     Program(node) {

--- a/packages/hashi/generateH5PMimeTypeDB.js
+++ b/packages/hashi/generateH5PMimeTypeDB.js
@@ -49,9 +49,9 @@ const allowedFileExtensions = new Set([
 
 const output = {};
 
-for (let key in mimeDB) {
+for (const key in mimeDB) {
   if (mimeDB[key].extensions) {
-    for (let ext of mimeDB[key].extensions) {
+    for (const ext of mimeDB[key].extensions) {
       if (allowedFileExtensions.has(ext)) {
         output[ext] = key;
       }

--- a/packages/hashi/src/H5P/H5PRunner.js
+++ b/packages/hashi/src/H5P/H5PRunner.js
@@ -48,7 +48,7 @@ const doNotLogVerbs = [
   'accessed-copyright',
 ];
 const doNotLogVerbMap = {};
-for (let doNotLogVerb of doNotLogVerbs) {
+for (const doNotLogVerb of doNotLogVerbs) {
   doNotLogVerbMap[XAPIVerbMap[doNotLogVerb]] = true;
 }
 // These verbs are reported too much by H5P leading to spammy responses,
@@ -61,7 +61,7 @@ const maxDelay = 30;
 
 const completionVerbs = ['completed', 'mastered', 'passed'];
 const completionVerbMap = {};
-for (let completionVerb of completionVerbs) {
+for (const completionVerb of completionVerbs) {
   completionVerbMap[XAPIVerbMap[completionVerb]] = true;
 }
 
@@ -268,7 +268,7 @@ export default class H5PRunner {
           this.iframe.contentWindow.H5P.init();
           this.loaded();
           setTimeout(() => {
-            for (let instance of this.iframe.contentWindow.H5P.instances) {
+            for (const instance of this.iframe.contentWindow.H5P.instances) {
               this.iframe.contentWindow.H5P.trigger(instance, 'resize');
             }
           }, 0);
@@ -376,7 +376,7 @@ export default class H5PRunner {
       }
     };
     const debouncedHandlers = {};
-    for (let debouncedVerb of debounceVerbs) {
+    for (const debouncedVerb of debounceVerbs) {
       const verb = XAPIVerbMap[debouncedVerb];
       debouncedHandlers[verb] = debounce(
         function(statement) {
@@ -523,7 +523,7 @@ export default class H5PRunner {
   setDependencies() {
     const dependencySorter = new Toposort();
 
-    for (let dependency of this.dependencies) {
+    for (const dependency of this.dependencies) {
       this.packageFiles[dependency.packagePath] = {};
       dependencySorter.add(dependency.packagePath, dependency.dependencies);
 

--- a/packages/hashi/src/h5pBundle.js
+++ b/packages/hashi/src/h5pBundle.js
@@ -31,7 +31,7 @@ window.H5P.jQuery.fn.load = function(url) {
    */
   if (typeof url === 'function') {
     console.warn('You are using a deprecated H5P library. Please upgrade!');
-    let args = Array.prototype.slice.call(arguments);
+    const args = Array.prototype.slice.call(arguments);
     args.unshift('load');
     return window.H5P.jQuery.fn.on.apply(this, args);
   }

--- a/packages/hashi/src/mediator.js
+++ b/packages/hashi/src/mediator.js
@@ -52,7 +52,7 @@ class Mediator {
   sendMessageAwaitReply({ event, data, nameSpace }) {
     return new Promise((resolve, reject) => {
       const msgId = uuidv4();
-      let self = this;
+      const self = this;
       function handler(message) {
         if (message.message_id === msgId && message.type === 'response') {
           if (message.status == MessageStatuses.SUCCESS) {

--- a/packages/hashi/src/xAPI/xAPISchema.js
+++ b/packages/hashi/src/xAPI/xAPISchema.js
@@ -526,7 +526,7 @@ class Schema {
   }
   clean(obj) {
     const output = {};
-    for (let key in this.spec) {
+    for (const key in this.spec) {
       const keySpec = this.spec[key];
       let required = keySpec.required;
       if (isFunction(required)) {

--- a/packages/hashi/test/kolibri.spec.js
+++ b/packages/hashi/test/kolibri.spec.js
@@ -53,7 +53,7 @@ describe('the kolibri hashi shim', () => {
   });
 
   describe('getContentByFilter method', () => {
-    let options = { page: 1, pageSize: 50, parent: 'self' };
+    const options = { page: 1, pageSize: 50, parent: 'self' };
     response = { page: 1, pageSize: 50, results: [{ id: 'abc123' }, { id: 'def456' }] };
     beforeEach(function() {
       mockMessage = {

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -218,5 +218,10 @@ module.exports = {
     'kolibri/vue-watch-no-string': ERROR,
     'kolibri/vue-no-unused-translations': ERROR,
     'kolibri/vue-no-undefined-string-uses': ERROR,
+
+    'prefer-const': [ERROR, {
+      destructuring: 'any',
+      ignoreReadBeforeAssign: false
+    }]
   },
 };

--- a/packages/kolibri-tools/lib/alias_import_resolver.js
+++ b/packages/kolibri-tools/lib/alias_import_resolver.js
@@ -43,7 +43,7 @@ exports.addAliases = function(aliases) {
 };
 
 exports.resetAliases = function() {
-  for (let key in moduleAliases) {
+  for (const key in moduleAliases) {
     delete moduleAliases[key];
   }
 };

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -155,7 +155,7 @@ function runWebpackBuild(mode, bundleData, devServer, options, cb = null) {
           performance: true, // info about oversized assets
         });
         mkdirp.sync('./.stats');
-        for (let stat of statsJson.children) {
+        for (const stat of statsJson.children) {
           fs.writeFileSync(`.stats/${stat.name}.json`, JSON.stringify(stat, null, 2), {
             encoding: 'utf-8',
           });
@@ -653,7 +653,7 @@ try {
 
     for (const packageName of Object.keys(results.versions)) {
       if (!results.versions[packageName].isSatisfied) {
-        let required = engines[packageName];
+        const required = engines[packageName];
         cliLogging.break();
         cliLogging.error(`Incorrect version of ${packageName}.`);
         cliLogging.error(`${packageName} ${required} is required.`);

--- a/packages/kolibri-tools/lib/i18n/ProfileStrings.js
+++ b/packages/kolibri-tools/lib/i18n/ProfileStrings.js
@@ -61,9 +61,9 @@ function profileToCSV(profile) {
   return reduce(
     profile,
     (csv, data, $tr) => {
-      let definitions = data.definitions;
-      let uses = data.uses;
-      let dataRows = [];
+      const definitions = data.definitions;
+      const uses = data.uses;
+      const dataRows = [];
       definitions.forEach(def => {
         dataRows.push({
           string: $tr,
@@ -74,7 +74,7 @@ function profileToCSV(profile) {
         });
       });
       uses.forEach(use => {
-        let newUse = {
+        const newUse = {
           string: '',
           definition: 'No',
           namespace: use.namespace,
@@ -163,12 +163,12 @@ function profileVueScript(profile, ast, pathname, namespace, allMessages) {
                 common = true;
               }
 
-              let currentNamespace = common
+              const currentNamespace = common
                 ? COMMON_NAMESPACES[node.callee.property.name]
                 : namespace;
 
               if (key && currentNamespace) {
-                let $tring = getStringFromNamespaceKey(allMessages, currentNamespace, key);
+                const $tring = getStringFromNamespaceKey(allMessages, currentNamespace, key);
 
                 if ($tring) {
                   profile[$tring].uses.push({
@@ -215,10 +215,10 @@ function profileVueTemplate(profile, ast, pathname, namespace, allMessages) {
               common = true;
             }
 
-            let currentNamespace = common ? COMMON_NAMESPACES[node.callee.name] : namespace;
+            const currentNamespace = common ? COMMON_NAMESPACES[node.callee.name] : namespace;
 
             if (key && currentNamespace) {
-              let $tring = getStringFromNamespaceKey(allMessages, currentNamespace, key);
+              const $tring = getStringFromNamespaceKey(allMessages, currentNamespace, key);
 
               if ($tring) {
                 profile[$tring].uses.push({
@@ -241,9 +241,9 @@ function profileVueTemplate(profile, ast, pathname, namespace, allMessages) {
 }
 
 function profileJSFile(profile, ast, pathname, allMessages) {
-  let common = false;
-  let varDeclarations = {};
-  let $trUses = {};
+  const common = false;
+  const varDeclarations = {};
+  const $trUses = {};
 
   // Process the AST
   try {
@@ -267,7 +267,7 @@ function profileJSFile(profile, ast, pathname, allMessages) {
           if (node.callee && node.callee.type === 'MemberExpression') {
             if (node.callee.property && node.callee.property.name === '$tr') {
               if (node.arguments && node.arguments.length > 0) {
-                let varName = node.callee.object.name;
+                const varName = node.callee.object.name;
                 // Profile all $tr() calls (ie, uses of the key)
                 // storing the key (variableName) => value (key)
                 if (Object.keys($trUses).includes(varName)) {
@@ -359,7 +359,7 @@ module.exports = function(pathInfo, ignore, outputFile, verbose) {
     } else {
       bundleMessages = getAllMessagesFromFilePath(moduleFilePath, ignore, verbose);
     }
-    for (let id in bundleMessages) {
+    for (const id in bundleMessages) {
       const message = bundleMessages[id]['message'];
       const [namespace, key] = id.split('.');
       if (!definitions[message]) {
@@ -384,7 +384,7 @@ module.exports = function(pathInfo, ignore, outputFile, verbose) {
     } else {
       files = getFilesFromFilePath(moduleFilePath, ignore);
     }
-    for (let filePath of files) {
+    for (const filePath of files) {
       const scriptAST = getAstFromFile(filePath);
       if (filePath.endsWith('.vue')) {
         const namespace = getVueSFCName(scriptAST);

--- a/packages/kolibri-tools/lib/i18n/SyncContext.js
+++ b/packages/kolibri-tools/lib/i18n/SyncContext.js
@@ -33,7 +33,7 @@ function findObjectsWith$trs(scriptAST) {
   traverse(scriptAST, {
     pre: node => {
       if (node.type === 'ObjectExpression') {
-        for (let property of node.properties) {
+        for (const property of node.properties) {
           if (is$trs(property)) {
             objects.push(node);
             break;
@@ -109,7 +109,7 @@ function modifyVueComponent$trs(vueComponent, definitions) {
     pre: node => {
       if (is$trs(node)) {
         // node.value.properties is the object passed to $trs
-        for (let property of node.value.properties) {
+        for (const property of node.value.properties) {
           fileHasChanged =
             modifyTranslationObjectNode(property, namespace, definitions) || fileHasChanged;
         }
@@ -139,7 +139,7 @@ function modifyCreateTranslatorASTNodes(ast, definitions) {
         );
         if (namespace && node.arguments[1].properties) {
           // Go through all of the properties and update the nodes as needed.
-          for (let property of node.arguments[1].properties) {
+          for (const property of node.arguments[1].properties) {
             fileHasChanged =
               modifyTranslationObjectNode(property, namespace, translatorDefinitions) ||
               fileHasChanged;
@@ -162,7 +162,7 @@ function processVueFiles(files, definitions) {
         whitespace: 'preserve',
       });
 
-      let scriptContent = get(vueSFC, 'script.content');
+      const scriptContent = get(vueSFC, 'script.content');
 
       // If we don't have a script, nothing to modify so stop here.
       if (!scriptContent) {

--- a/packages/kolibri-tools/lib/i18n/astUtils.js
+++ b/packages/kolibri-tools/lib/i18n/astUtils.js
@@ -349,7 +349,7 @@ function generateMessagesFromASTNode(messageNodeProperties, messageNamespace, as
   const results = {};
   if (messageNodeProperties && messageNamespace) {
     // Now that we have the properties we care about, let's do the thing we're here to do!
-    for (let $trProperty of messageNodeProperties) {
+    for (const $trProperty of messageNodeProperties) {
       results[
         `${messageNamespace}.${getPropertyKey($trProperty, ast, filePath)}`
       ] = getObjectifiedValue($trProperty.value);
@@ -536,7 +536,7 @@ function recurseForStrings(entryFile, ignore, visited, verbose) {
   const outputStrings = {};
   if (!visited.has(entryFile)) {
     Object.assign(outputStrings, getMessagesFromFile(entryFile, verbose));
-    for (let filePath of getImportFileNames(entryFile, ignore)) {
+    for (const filePath of getImportFileNames(entryFile, ignore)) {
       Object.assign(outputStrings, recurseForStrings(filePath, ignore, visited, verbose));
     }
     visited.add(entryFile);

--- a/packages/kolibri-tools/lib/i18n/csvToJSON.js
+++ b/packages/kolibri-tools/lib/i18n/csvToJSON.js
@@ -26,7 +26,7 @@ module.exports = function(pathInfo, ignore, langInfo, localeDataFolder, verbose)
     Object.assign(allDefaultMessages, messages);
     logging.info(`Gathered ${requiredMessages[name].length} required string ids for ${name}`);
   });
-  for (let langObject of languageInfo) {
+  for (const langObject of languageInfo) {
     const crowdinCode = langObject['crowdin_code'];
     const intlCode = langObject['intl_code'];
     logging.info(
@@ -35,10 +35,10 @@ module.exports = function(pathInfo, ignore, langInfo, localeDataFolder, verbose)
     const csvDefinitions = parseCSVDefinitions(localeDataFolder, intlCode);
     let messagesExist = false;
     const localeFolder = path.join(localeDataFolder, toLocale(intlCode), 'LC_MESSAGES');
-    for (let name in requiredMessages) {
+    for (const name in requiredMessages) {
       // An object for storing our messages.
       const messages = {};
-      for (let msg of requiredMessages[name]) {
+      for (const msg of requiredMessages[name]) {
         const definition = csvDefinitions.find(o => o['Identifier'] === msg);
         if (intlCode === 'en') {
           messages[msg] = allDefaultMessages[msg].message;

--- a/packages/kolibri-tools/lib/i18n/untranslatedMessages.js
+++ b/packages/kolibri-tools/lib/i18n/untranslatedMessages.js
@@ -25,14 +25,14 @@ module.exports = function(pathInfo, ignore, langInfo, localeDataFolder, verbose)
   const table = new Table({
     head: ['Crowdin Code', 'Intl Code', '# Untranslated Messages', 'Untranslated Word Count'],
   });
-  for (let langObject of languageInfo) {
+  for (const langObject of languageInfo) {
     const crowdinCode = langObject['crowdin_code'];
     const intlCode = langObject['intl_code'];
     const csvDefinitions = parseCSVDefinitions(localeDataFolder, intlCode);
     // An object for storing missing messages.
     const missingMessages = {};
-    for (let name in requiredMessages) {
-      for (let msg in requiredMessages[name]) {
+    for (const name in requiredMessages) {
+      for (const msg in requiredMessages[name]) {
         const definition = csvDefinitions.find(o => o['Identifier'] === msg);
         if (!definition) {
           missingMessages[msg] = requiredMessages[name][msg]['message'];

--- a/packages/kolibri-tools/lib/i18n/utils.js
+++ b/packages/kolibri-tools/lib/i18n/utils.js
@@ -33,8 +33,8 @@ function parseCSVDefinitions(dir, intlLangCode = null) {
 // Turn a language name (en-us) into a locale name (en_US).
 // This is converted from the equivalent Django function.
 function toLocale(language) {
-  let [lang, ...country] = language.toLowerCase().split('-');
-  country = country.join('-');
+  const [lang, ...countryFromLanguage] = language.toLowerCase().split('-');
+  let country = countryFromLanguage.join('-');
   if (!country) {
     return language.slice(0, 3).toLowerCase() + language.slice(3);
   }
@@ -57,7 +57,7 @@ function toLocale(language) {
 }
 
 function forEachPathInfo(pathInfo, callback) {
-  for (let pathData of pathInfo) {
+  for (const pathData of pathInfo) {
     if (pathData.aliases) {
       addAliases(pathData.aliases);
     }

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -13,7 +13,7 @@ const { insertContent } = require('./vueTools');
 require('./htmlhint_custom');
 
 // check for host project's linting configs, otherwise use defaults
-let hostProjectDir = process.cwd();
+const hostProjectDir = process.cwd();
 
 let esLintConfig;
 try {
@@ -78,10 +78,10 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
       let formatted = source;
       let messages = [];
       // Array of promises that we need to let resolve before finishing up.
-      let promises = [];
+      const promises = [];
       // Array of callbacks to call to apply changes to style blocks.
       // Store for application after linting has completed to prevent race conditions.
-      let styleCodeUpdates = [];
+      const styleCodeUpdates = [];
       let notSoPretty = false;
       let lineOffset;
       function eslint(code) {
@@ -162,7 +162,7 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
                   stylinted = output.output;
                 }
               }
-              let linted = prettierFormat(stylinted || code, style, vue);
+              const linted = prettierFormat(stylinted || code, style, vue);
 
               if (linted.trim() !== (stylinted || code).trim()) {
                 notSoPretty = true;
@@ -210,7 +210,7 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
           }
 
           // Now run htmlhint on the whole vue component
-          let htmlMessages = HTMLHint.verify(formatted, htmlHintConfig);
+          const htmlMessages = HTMLHint.verify(formatted, htmlHintConfig);
           if (htmlMessages.length) {
             messages.push(...HTMLHint.format(htmlMessages, { colors: true }));
           }
@@ -220,7 +220,7 @@ function lint({ file, write, encoding = 'utf-8', silent = false } = {}) {
             block = vueComponent.script;
 
             const js = block.content;
-            let formattedJs = prettierFormat(js, 'babel', true);
+            const formattedJs = prettierFormat(js, 'babel', true);
             formatted = insertContent(formatted, block, formattedJs);
             if (formattedJs.trim() !== js.trim()) {
               notSoPretty = true;

--- a/packages/kolibri-tools/lib/webpackBundleTracker.js
+++ b/packages/kolibri-tools/lib/webpackBundleTracker.js
@@ -195,8 +195,8 @@ class BundleTrackerPlugin {
     // Should probably try to fix this within the context of the RTL plugin,
     // but the webpack API is a bit too opaque to understand how to add the RTL asset
     // to the chunk group as well as to the emitted assets.
-    for (let chunkGroupName in cssFilesInChunks) {
-      for (let cssFile of cssFilesInChunks[chunkGroupName]) {
+    for (const chunkGroupName in cssFilesInChunks) {
+      for (const cssFile of cssFilesInChunks[chunkGroupName]) {
         const rtlCssFile = cssFile.replace('.css', '.rtl.css');
         if (output.assets[rtlCssFile]) {
           output.chunks[chunkGroupName].push(output.assets[rtlCssFile]);

--- a/packages/kolibri-tools/lib/webpackRtlPlugin.js
+++ b/packages/kolibri-tools/lib/webpackRtlPlugin.js
@@ -38,7 +38,7 @@ class WebpackRTLPlugin {
           additionalAssets: true,
         },
         assets => {
-          for (let asset in assets) {
+          for (const asset in assets) {
             if (asset.endsWith('.css') && !asset.endsWith('.rtl.css')) {
               const baseSource = assets[asset].source();
               const rtlSource = rtlcss.process(


### PR DESCRIPTION
## Summary

- New ESLint rule (prefer-const) added
- Errors prompted by prefer-const lint rule are fixed
- performed `npm run lint-frontend`. No errors found.
- PR does not affect the UI

## References

- Issue #9867 
- ESLint documentation : [prefer-const](https://eslint.org/docs/latest/rules/prefer-const)

## Reviewer guidance

- `npm run lint-frontend` to check ESLint rules compliance.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
