### PR TITLE
Updated resource sidebar to include currently viewed resource

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -11,9 +11,17 @@
         :key="content.id"
         :to="genContentLinkKeepCurrentBackLink(content.id, content.is_leaf)"
         class="item"
-        :class="windowIsSmall && 'small'"
+        :class="[windowIsSmall && 'small',
+                 currentResource(content.content_id) &&
+                   $computedClass(currentlyViewedItemStyle)]"
         :style="linkStyles"
       >
+        <p
+          v-if="currentResource(content.content_id)"
+          :style="currentlyViewingTextStyle"
+        >
+          {{ $tr('currentlyViewing') }}
+        </p>
         <LearningActivityIcon
           v-if="content.is_leaf"
           class="activity-icon"
@@ -141,6 +149,10 @@
         type: Boolean,
         default: false,
       },
+      currentResourceID: {
+        type: String,
+        required: true,
+      },
     },
     computed: {
       /** Overrides some default styles in KRouterLink */
@@ -148,6 +160,28 @@
         return {
           color: this.$themeTokens.text + '!important',
           fontSize: '14px',
+        };
+      },
+      currentlyViewingTextStyle() {
+        return {
+          color: this.$themePalette.grey.v_700,
+          fontSize: '12px',
+          margin: 'auto',
+        };
+      },
+      currentlyViewedItemStyle() {
+        return {
+          padding: '15px 0',
+          ':before': {
+            content: "''",
+            backgroundColor: this.$themePalette.grey.v_100,
+            position: 'absolute',
+            top: '0',
+            bottom: '0',
+            width: '200vw',
+            transform: 'translateX(-50%)',
+            zIndex: '-1',
+          },
         };
       },
       emptyMessage() {
@@ -166,6 +200,15 @@
     methods: {
       progressFor(node) {
         return this.contentNodeProgressMap[node.content_id] || 0;
+      },
+      currentResource(contentId) {
+        return contentId === this.currentResourceID || '';
+      },
+    },
+    $trs: {
+      currentlyViewing: {
+        message: 'Currently viewing',
+        context: 'Indicator of resource that is currently being viewed.',
       },
     },
   };
@@ -189,6 +232,7 @@
 
   .wrapper {
     position: relative;
+    top: -30px;
     width: 100%;
 
     /* Avoids overflow issues, aligns bottom bit */
@@ -200,7 +244,7 @@
     display: block;
     width: 100%;
     min-height: 72px;
-    margin-top: 24px;
+    padding: 20px 0;
   }
 
   .activity-icon,
@@ -215,7 +259,7 @@
 
   .activity-icon,
   .topic-icon {
-    top: 0;
+    top: auto;
   }
 
   .content-meta {
@@ -223,6 +267,7 @@
     left: calc(#{$icon-size} + 16px);
     display: inline-block;
     width: calc(100% - #{$icon-size});
+    margin-top: 5px;
   }
 
   .text-and-time {
@@ -246,6 +291,10 @@
     right: 16px;
     width: 24px;
     height: 24px;
+  }
+
+  /deep/ .link {
+    text-decoration: none;
   }
 
   /** Styles overriding the above when windowIsSmall **/

--- a/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
@@ -197,6 +197,7 @@
           'margin-top': this.fixedHeaderHeight === '0px' ? '24px' : this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
+          'overflow-x': 'hidden',
           height: `calc(100vh - ${this.fixedHeaderHeight})`,
         };
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -126,6 +126,7 @@
         :nextContent="nextContent"
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
+        :currentResourceID="currentResourceID"
       />
     </SidePanelModal>
 
@@ -297,6 +298,9 @@
       timeSpent() {
         return this.contentPageMounted ? this.$refs.contentPage.time_spent : 0;
       },
+      currentResourceID() {
+        return this.content ? this.content.content_id : '';
+      },
     },
     watch: {
       content(newContent, oldContent) {
@@ -370,7 +374,7 @@
         this.fetchLesson({ lessonId: this.lessonId }).then(lesson => {
           // Filter out this.content
           this.viewResourcesContents = lesson.resources
-            .filter(n => n.contentnode && n.contentnode_id !== this.content.id)
+            .filter(n => n.contentnode)
             .map(n => n.contentnode);
         });
       },
@@ -422,10 +426,7 @@
             nextContents = ancestor.children.results.slice(contentIndex + 1);
           }
           this.nextContent = nextContents.find(c => c.kind === ContentNodeKinds.TOPIC) || null;
-          // Filter out this.content
-          this.viewResourcesContents = parent.children.results.filter(
-            n => n.id !== this.content.id
-          );
+          this.viewResourcesContents = parent.children.results.filter(n => n.id);
         });
       },
       navigateBack() {
@@ -533,6 +534,8 @@
   }
 
   .also-in-this-side-panel {
+    overflow: hidden;
+
     /deep/ .side-panel {
       padding-bottom: 0;
     }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR updates the folder resource sidebar view in Kolibri so that users can see the currently viewed resource.

Resource sidebar view before
<img width="1440" alt="ResourceSidebarUpdateBefore" src="https://user-images.githubusercontent.com/46411498/220464196-bc555345-951f-4aa2-bd67-dc40dfc269be.png">

Resource sidebar view after
<img width="1440" alt="ResourceSidebarUpdateAfter1" src="https://user-images.githubusercontent.com/46411498/220464273-a9c6b9fc-723c-4363-81d0-149b4767d8cb.png">

<img width="1440" alt="ResourceSidebarUpdateAfter2" src="https://user-images.githubusercontent.com/46411498/220464287-b4b63e40-e5ca-495a-84f6-aafd36492553.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
[Figma specs](https://www.figma.com/file/1tQQ0Sw1yDjzO66hyjLVPM/Kolibri-UX-Fix?node-id=785%3A14773&t=lLrSajwLevr5g6JR-0)
Closes #10092 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Navigate to the Learn home page.
2. Select a resource to view.
3. Click the icon button for `View folder resources`.
4. The resource that is currently being viewed should be listed in the side panel, with the text `Currently viewing` above the resource title.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
