### PR TITLE
Update PID file when the zipcontent server starts

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -321,6 +321,8 @@ class PIDPlugin(SimplePlugin):
 
         :param: status: status of the process
         """
+        if status is None:
+            _, _, _, status = _read_pid_file(self.bus.pid_file)
         with open(self.bus.pid_file, "w") as f:
             f.write(
                 "{}\n{}\n{}\n{}\n".format(
@@ -334,6 +336,7 @@ class PIDPlugin(SimplePlugin):
 
     def ZIP_SERVING(self, zip_port):
         self.bus.zip_port = zip_port or self.bus.zip_port
+        self.set_pid_file(None)
 
     def EXIT(self):
         try:


### PR DESCRIPTION
The PID file must be updated with the zipcontent server's assigned port number. However, as in #9372, the status field should be unchanged.

## Reviewer guidance

* Please cherry-pick this into the release-v0.15.x branch if possible :)

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
