### PR TITLE
Add new modal for connection testing with new strings

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/DeviceConnectingModal.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/DeviceConnectingModal.vue
@@ -1,0 +1,142 @@
+<template>
+
+  <KModal
+    :title="modalTitle"
+    :submitText="modalSubmitText"
+    :cancelText="modalCancelText"
+    size="medium"
+    :submitDisabled="attemptingToConnect"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    <UiAlert
+      v-if="!attemptingToConnect"
+      :dismissible="false"
+    >
+      {{ connectionFailureMessage }}
+    </UiAlert>
+    <KLabeledIcon
+      v-else
+      :label="loadingLabel"
+    >
+      <template #icon>
+        <KCircularLoader :size="16" :stroke="6" class="loader" />
+      </template>
+    </KLabeledIcon>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+
+  export default {
+    name: 'DeviceConnectingModal',
+    components: {
+      UiAlert,
+    },
+    mixins: [commonCoreStrings],
+    props: {
+      deviceId: {
+        type: String,
+        required: true,
+      },
+      deviceName: {
+        type: String,
+        required: true,
+      },
+      title: {
+        type: String,
+        default: null,
+      },
+    },
+    data() {
+      return {
+        attemptingToConnect: true,
+      };
+    },
+    computed: {
+      modalTitle() {
+        return this.title ? this.title : this.loadingLabel;
+      },
+      modalSubmitText() {
+        return this.attemptingToConnect ? null : this.coreString('retryAction');
+      },
+      modalCancelText() {
+        return this.attemptingToConnect
+          ? this.coreString('cancelAction')
+          : this.coreString('goBackAction');
+      },
+      loadingLabel() {
+        return this.$tr('connectingTo', { name: this.deviceName });
+      },
+      isInternetDevice() {
+        // This is fake usage of 'deviceId'
+        return ['KDP', 'Studio'].includes(this.deviceId);
+      },
+      connectionFailureMessage() {
+        const connectionStatus = '';
+        switch (connectionStatus) {
+          case 'Unknown':
+          case 'ConnectionFailure':
+            return this.isInternetDevice
+              ? this.$tr('internetDisconnected')
+              : this.$tr('connectionFailure', { name: this.deviceName });
+          case 'ResponseTimeout':
+            return this.$tr('connectionTimedOut', { name: this.deviceName });
+          case 'InvalidResponse':
+            return this.$tr('deviceIsNotKolibri', { name: this.deviceName });
+          default:
+            return this.$tr('genericConnectionError');
+        }
+      },
+    },
+    methods: {
+      handleSubmit() {
+        // TODO
+      },
+    },
+    $trs: {
+      connectingTo: {
+        message: "Connecting to '{name}'",
+        context:
+          "Shown while testing the connection to a network device, Kolibri Studio, or Kolibri Data Portal, as specified by 'name'",
+      },
+      connectionFailure: {
+        message:
+          "Unable to connect to '{name}'. Try checking if a firewall is blocking the connection.",
+        context:
+          "Error message when testing the connection to the network device specified by 'name' fails for this reason",
+      },
+      deviceIsNotKolibri: {
+        message:
+          "Another program is running at the network address on '{name}'. Please close that program, ensure Kolibri is running on the device, and try again.",
+        context:
+          "Error message when testing the connection to the network device specified by 'name' fails for this reason",
+      },
+      connectionTimedOut: {
+        message:
+          "The connection with '{name}' is taking too long to respond. Please check the connection and try again.",
+        context:
+          "Error message when testing the connection to the network device specified by 'name' fails for this reason",
+      },
+      genericConnectionError: {
+        message: 'Something went wrong. Please try again later.',
+        context:
+          'Error message when testing the connection to a network device fails for an unknown reason',
+      },
+      internetDisconnected: {
+        message: 'You must be connected to the internet.',
+        context:
+          "Error message when testing the connection to a network device fails because Kolibri isn't connected to the internet and the device address is on the internet",
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds new modal with necessary strings for giving the user feedback that the connection is being tested
- Adds necessary new strings for error cases

<img width="1665" alt="Screenshot 2023-02-24 at 12 05 46 PM" src="https://user-images.githubusercontent.com/819838/221298280-edd4c81f-cc2c-4439-b69e-24f346303633.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Connects with https://github.com/learningequality/kolibri/pull/10133
[Figma designs](https://www.figma.com/file/SgTZugaKkES68aipU5dCk8SR/Github-issues-%26-other-fixes?node-id=1721%3A4307)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
This modal is unused in this PR-- this is only for getting strings added to the codebase

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
