### PR TITLE
Adds Metered connection notification modal to kolibri-common

### DIFF
--- a/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
+++ b/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
@@ -1,0 +1,76 @@
+<template>
+
+  <KModal
+    v-if="displayMeteredConnectionWarning"
+    :title="$tr('modalTitle')"
+    :submitText="coreString('continueAction')"
+    @submit="$emit('submit')"
+  >
+    <div>
+      <p>{{ $tr('modalDescription') }}</p>
+      <KRadioButton
+        v-model="selected"
+        :label="$tr('doNotUseMetered')"
+        :value="Options.DO_NOT_USE_METERED"
+        class="radio-button"
+      />
+      <KRadioButton
+        v-model="selected"
+        :label="$tr('useMetered')"
+        :value="Options.USE_METERED"
+        class="radio-button"
+      />
+    </div>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  const Options = Object.freeze({
+    DO_NOT_USE_METERED: 'DO_NOT_USE_METERED',
+    USE_METERED: 'USE_METERED',
+  });
+
+  export default {
+    name: 'MeteredConnectionNotificationModal',
+    mixins: [commonCoreStrings],
+
+    data() {
+      return {
+        Options,
+        selected: Options.DO_NOT_USE_METERED,
+      };
+    },
+    computed: {
+      displayMeteredConnectionWarning() {
+        return true;
+      },
+    },
+    $trs: {
+      /* Second-person perspective: "You ..." */
+      modalTitle: {
+        message: 'Use metered data?',
+        context:
+          'Title of a modal that permits a user to continue with or without using a metered data connection',
+      },
+      modalDescription: {
+        message:
+          'You are using a metered connection. If you are on a limited data plan, you may have to pay extra charges.',
+        context: 'Information in a modal informing a user about their connection status.',
+      },
+      doNotUseMetered: {
+        message: 'No, do not use metered data',
+        context: 'An option that a user can select in a form',
+      },
+      useMetered: {
+        message: 'Yes, use metered data',
+        context: 'An option that a user can select in a form',
+      },
+    },
+  };
+
+</script>


### PR DESCRIPTION
## Summary
Front end only issue that adds metered connection notification modal to kolibri-common. My thinking was that it may need to be reused outside of learn, but I can also move it into the learn plugin for now. Currently, it is not integrated into any pages. Just the modal for string freeze. 


Follow up issue is assigned to me and opened here: https://github.com/learningequality/kolibri/issues/10142

## References
Fixes #9845 

## Reviewer guidance
Please review strings to figma comparison. 

<img width="955" alt="Screenshot 2023-02-24 at 7 12 47 PM" src="https://user-images.githubusercontent.com/17235236/221324582-344d6d71-ebb1-4936-8a99-0bfda87b9f8c.png">

For in-code manual testing, devs can import this anywhere. Right now, the default display is "true" (temporarily), so it will pop up immediately for review where referenced. 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
