### PR TITLE
Fixes failure to save facility name

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -77,7 +77,10 @@
           <h2>{{ $tr('deviceManagementPin') }}</h2>
 
           <p>{{ $tr('deviceManagementDescription') }}</p>
-          <KButton v-show="!isPinSet" @click="handleCreatePin">
+          <KButton
+            v-show="!isPinSet"
+            @click="handleCreatePin"
+          >
             {{ $tr('createPinBtn') }}
           </KButton>
 
@@ -104,9 +107,7 @@
             borderTopColor: $themeTokens.fineLine
           }"
         >
-          <KButtonGroup
-            :style="{ marginTop: '24px', marginLeft: '-8px' }"
-          >
+          <KButtonGroup :style="{ marginTop: '24px', marginLeft: '-8px' }">
             <KButton
               :primary="true"
               appearance="raised-button"
@@ -315,6 +316,7 @@
     },
     methods: {
       camelCase,
+      ...mapActions('facilityConfig', ['saveFacilityName']),
       ...mapActions(['createSnackbar']),
       updateSettingValue(settingName, newValue) {
         this.$store.commit('facilityConfig/CONFIG_PAGE_MODIFY_SETTING', {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the failure to save facility name on the facility configuration page as picked up during manual QA.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/pull/10135

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Go to `/facility/#/settings`
- Click on **Edit**  facility name

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
