### PR TITLE
Return Android specific system value from public device info endpoint.

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -61,6 +61,7 @@ from kolibri.core.utils.urls import reverse_remote
 from kolibri.plugins.utils import initialize_kolibri_plugin
 from kolibri.plugins.utils import iterate_plugins
 from kolibri.plugins.utils import PluginDoesNotExist
+from kolibri.utils.android import ANDROID_PLATFORM_SYSTEM_VALUE
 from kolibri.utils.android import on_android
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.filesystem import check_is_directory
@@ -152,7 +153,9 @@ class DeviceInfoView(views.APIView):
         instance_model = InstanceIDModel.get_or_create_current_instance()[0]
 
         info["device_id"] = instance_model.id
-        info["os"] = "Android" if on_android() else instance_model.platform
+        info["os"] = (
+            ANDROID_PLATFORM_SYSTEM_VALUE if on_android() else instance_model.platform
+        )
 
         info["content_storage_free_space"] = get_free_space(
             OPTIONS["Paths"]["CONTENT_DIR"]

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -15,6 +15,8 @@ from django.db.utils import ProgrammingError
 
 import kolibri
 from kolibri.core.auth.constants.facility_presets import mappings
+from kolibri.utils.android import ANDROID_PLATFORM_SYSTEM_VALUE
+from kolibri.utils.android import on_android
 
 logger = logging.getLogger(__name__)
 
@@ -422,7 +424,9 @@ def get_device_info(version=DEVICE_INFO_VERSION):
         "kolibri_version": kolibri.__version__,
         "instance_id": instance_model.id,
         "device_name": device_name,
-        "operating_system": platform.system(),
+        "operating_system": ANDROID_PLATFORM_SYSTEM_VALUE
+        if on_android()
+        else platform.system(),
         "subset_of_users_device": subset_of_users_device,
     }
 

--- a/kolibri/utils/android.py
+++ b/kolibri/utils/android.py
@@ -1,6 +1,11 @@
 from os import environ
 
 
+# A constant to be used in place of Python's platform.system()
+# when we know we are on an Android system.
+ANDROID_PLATFORM_SYSTEM_VALUE = "Android"
+
+
 # Android is based on the Linux kernel, but due to security issues, we cannot
 # run the /proc command there, so we need a way to distinguish between the two.
 # Python for Android always sets some Android environment variables, so we check


### PR DESCRIPTION
## Summary
* Creates a constant to return in place of `platform.system` when we are on an android device
* Returns it from the public device info endpoint
