### PR TITLE
Add update hooks option.

### DIFF
--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -16,7 +16,9 @@ connection = SimpleLazyObject(db_connection)
 
 def __job_storage():
     return Storage(
-        connection=connection, schedule_hooks=conf.OPTIONS["Tasks"]["SCHEDULE_HOOKS"]
+        connection=connection,
+        schedule_hooks=conf.OPTIONS["Tasks"]["SCHEDULE_HOOKS"],
+        update_hooks=conf.OPTIONS["Tasks"]["UPDATE_HOOKS"],
     )
 
 

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -687,9 +687,17 @@ base_option_spec = {
         "SCHEDULE_HOOKS": {
             "type": "lazy_import_callback_list",
             "description": """
-                A lsit of module paths for function callbacks that will be called when a job is scheduled in the storage class.
+                A list of module paths for function callbacks that will be called when a job is scheduled in the storage class.
                 This is intended to allow an external task runner to be used to execute Kolibri tasks. The default is empty,
                 as the internal handling is sufficient for Kolibri's task running.
+            """,
+        },
+        "UPDATE_HOOKS": {
+            "type": "lazy_import_callback_list",
+            "description": """
+                A list of module paths for function callbacks that will be called when a job is updated in the storage class.
+                This is intended to allow an external task runner to do additional actions when the status of a kolibri Job is updated.
+                The default is empty, as the internal handling is sufficient for Kolibri's task running.
             """,
         },
     },


### PR DESCRIPTION
## Summary
Fixes oversight from #9503 where no way to add additional update_hooks to the Storage class was exposed (whereas schedule_hooks had their own option added).


## Reviewer guidance
Is this parallel to the implementation for schedule_hooks?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
