### PR TITLE
Cleans up some issues in the sidepanel component

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/SidePanel.vue
@@ -49,10 +49,9 @@
         v-if="currentCategory && (windowIsSmall || windowIsMedium)"
         ref="searchModal"
         :selectedCategory="currentCategory"
-        :numCols="numCols"
         position="fullscreen"
         @cancel="currentCategory = null"
-        @input="category => $emit('setCategory', category)"
+        @input="selectCategory"
       />
     </SidePanelModal>
 
@@ -62,10 +61,9 @@
       v-if="windowIsLarge && currentCategory"
       ref="searchModal"
       :selectedCategory="currentCategory"
-      :numCols="numCols"
       position="modal"
       @cancel="currentCategory = null"
-      @input="category => $emit('setCategory', category)"
+      @input="selectCategory"
     />
   </div>
 
@@ -165,6 +163,12 @@
     watch: {
       searchTerms(val) {
         this.$emit('searchTerms', val);
+      },
+    },
+    methods: {
+      selectCategory(category) {
+        this.$emit('setCategory', category);
+        this.currentCategory = null;
       },
     },
   };


### PR DESCRIPTION
## Summary
* Removed unused numcols.
* Close modal when category selected.


## References
Noticed while reviewing #10145 

## Reviewer guidance
Screencast of modal closing properly (please ignore the disconnected popup.. I had shut down the server when I took the screencast).
[Screencast from 02-28-2023 09:35:23 AM.webm](https://user-images.githubusercontent.com/1680573/221932700-f17fc19c-72e1-491d-9bc4-9905cbb7a296.webm)

Check that there's no `numCols was referenced during render` error in the console when loading the library page.


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
