### PR TITLE
Add message to indicate that deletion is being prepared for a channel.

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/TaskPanel.vue
@@ -193,6 +193,13 @@
           return this.$tr('cancelSize', {
             bytesText: bytesForHumans(file_size),
           });
+        } else if (
+          this.task.type === TaskTypes.DELETECHANNEL ||
+          this.task.type === TaskTypes.DELETECONTENT
+        ) {
+          return this.$tr('deletePreparing', {
+            channelName: this.task.extra_metadata.channel_name || this.$tr('unknownChannelName'),
+          });
         }
         return '';
       },
@@ -313,6 +320,10 @@
       deleteChannelWhole: {
         message: `Delete '{channelName}'`,
         context: 'Refers to deleting an entire channel.',
+      },
+      deletePreparing: {
+        message: `Preparing to delete resources for '{channelName}'`,
+        context: 'Indicates that deletion has started but no status can be reported yet.',
       },
       deleteChannelPartial: {
         message: `Delete resources from '{channelName}'`,


### PR DESCRIPTION
## Summary
* Adds a status message before we have received information from the backend of how many resources are being deleted
* Uses this message for both complete channel deletion and partial channel deletion

## References
Fixes #8797

## Reviewer guidance
Full channel deletion
![Screenshot from 2023-02-28 18-27-37](https://user-images.githubusercontent.com/1680573/222029877-a9e95149-7f35-4d86-ac98-4581b7600f65.png)

Partial channel deletion
![Screenshot from 2023-02-28 18-28-10](https://user-images.githubusercontent.com/1680573/222029923-1c78731c-c2ed-4d0e-a866-51fe017d3df8.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
