### PR TITLE
Clean up of sign in and sign up

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -172,6 +172,7 @@ export function kolibriLogin(store, sessionPayload) {
         ERROR_CONSTANTS.INVALID_CREDENTIALS,
         ERROR_CONSTANTS.MISSING_PASSWORD,
         ERROR_CONSTANTS.PASSWORD_NOT_SPECIFIED,
+        ERROR_CONSTANTS.NOT_FOUND,
       ]);
       if (errorsCaught) {
         if (errorsCaught.includes(ERROR_CONSTANTS.INVALID_CREDENTIALS)) {
@@ -180,6 +181,8 @@ export function kolibriLogin(store, sessionPayload) {
           return LoginErrors.PASSWORD_MISSING;
         } else if (errorsCaught.includes(ERROR_CONSTANTS.PASSWORD_NOT_SPECIFIED)) {
           return LoginErrors.PASSWORD_NOT_SPECIFIED;
+        } else if (errorsCaught.includes(ERROR_CONSTANTS.NOT_FOUND)) {
+          return LoginErrors.USER_NOT_FOUND;
         }
       } else {
         store.dispatch('handleApiError', error);

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -359,10 +359,10 @@ class FacilityUserViewSet(ValuesViewset):
             update_session_auth_hash(self.request, instance)
 
 
-class ExistingUsernameView(views.APIView):
-    def get(self, request):
-        username = request.GET.get("username")
-        facility_id = request.GET.get("facility")
+class UsernameAvailableView(views.APIView):
+    def post(self, request):
+        username = request.data.get("username")
+        facility_id = request.data.get("facility")
 
         if not username or not facility_id:
             return Response(
@@ -380,9 +380,20 @@ class ExistingUsernameView(views.APIView):
 
         try:
             FacilityUser.objects.get(username__iexact=username, facility=facility_id)
-            return Response({"username_exists": True}, status=status.HTTP_200_OK)
+            return Response(
+                [
+                    {
+                        "id": error_constants.USERNAME_ALREADY_EXISTS,
+                        "metadata": {
+                            "field": "username",
+                            "message": "Username already exists.",
+                        },
+                    }
+                ],
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except ObjectDoesNotExist:
-            return Response({"username_exists": False}, status=status.HTTP_200_OK)
+            return Response(True, status=status.HTTP_200_OK)
 
 
 class FacilityUsernameViewSet(ReadOnlyValuesViewset):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -777,7 +777,18 @@ class SessionViewSet(viewsets.ViewSet):
                 username__iexact=username, facility=facility_id
             )
         except ObjectDoesNotExist:
-            unauthenticated_user = None
+            return Response(
+                [
+                    {
+                        "id": error_constants.NOT_FOUND,
+                        "metadata": {
+                            "field": "username",
+                            "message": "Username not found.",
+                        },
+                    }
+                ],
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         user = authenticate(username=username, password=password, facility=facility_id)
         if user is not None and user.is_active:
@@ -785,10 +796,7 @@ class SessionViewSet(viewsets.ViewSet):
             login(request, user)
             # Success!
             return self.get_session_response(request)
-        if (
-            unauthenticated_user is not None
-            and unauthenticated_user.password == NOT_SPECIFIED
-        ):
+        if unauthenticated_user.password == NOT_SPECIFIED:
             # Here - we have a Learner whose password is "NOT_SPECIFIED" because they were created
             # while the "Require learners to log in with password" setting was disabled - but now
             # it is enabled again.

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -2,7 +2,6 @@ from django.conf.urls import url
 from rest_framework import routers
 
 from .api import ClassroomViewSet
-from .api import ExistingUsernameView
 from .api import FacilityDatasetViewSet
 from .api import FacilityUsernameViewSet
 from .api import FacilityUserViewSet
@@ -13,6 +12,7 @@ from .api import RoleViewSet
 from .api import SessionViewSet
 from .api import SetNonSpecifiedPasswordView
 from .api import SignUpViewSet
+from .api import UsernameAvailableView
 from kolibri.core.api import KolibriDataPortalViewSet
 from kolibri.core.routers import BulkDeleteRouter
 
@@ -45,9 +45,9 @@ urlpatterns = (
             name="setnonspecifiedpassword",
         ),
         url(
-            r"^usernameexists$",
-            ExistingUsernameView.as_view(),
-            name="usernameexists",
+            r"^usernameavailable$",
+            UsernameAvailableView.as_view(),
+            name="usernameavailable",
         ),
     ]
 )

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1612,33 +1612,33 @@ class DuplicateUsernameTestCase(APITestCase):
     def setUpTestData(cls):
         cls.facility = FacilityFactory.create()
         cls.user = FacilityUserFactory.create(facility=cls.facility, username="user")
-        cls.url = reverse("kolibri:core:usernameexists")
+        cls.url = reverse("kolibri:core:usernameavailable")
         provision_device()
 
     def test_check_duplicate_username_with_unique_username(self):
-        response = self.client.get(
+        response = self.client.post(
             self.url,
-            {"username": "new_user", "facility": self.facility.id},
+            data={"username": "new_user", "facility": self.facility.id},
             format="json",
         )
-        expected = {"username_exists": False}
-        self.assertDictEqual(response.data, expected)
+        self.assertEqual(response.data, True)
 
     def test_check_duplicate_username_with_existing_username(self):
-        response = self.client.get(
+        response = self.client.post(
             self.url,
-            {"username": self.user.username, "facility": self.facility.id},
+            data={"username": self.user.username, "facility": self.facility.id},
             format="json",
         )
-        expected = {"username_exists": True}
-        self.assertDictEqual(response.data, expected)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.data[0]["id"], error_constants.USERNAME_ALREADY_EXISTS
+        )
 
     def test_check_duplicate_username_with_existing_username_other_facility(self):
         other_facility = FacilityFactory.create()
-        response = self.client.get(
+        response = self.client.post(
             self.url,
-            {"username": self.user.username, "facility": other_facility.id},
+            data={"username": self.user.username, "facility": other_facility.id},
             format="json",
         )
-        expected = {"username_exists": False}
-        self.assertDictEqual(response.data, expected)
+        self.assertEqual(response.data, True)

--- a/kolibri/plugins/user_auth/assets/src/apiResource.js
+++ b/kolibri/plugins/user_auth/assets/src/apiResource.js
@@ -1,26 +1,5 @@
 import { Resource } from 'kolibri.lib.apiResource';
-import urls from 'kolibri.urls';
-import client from 'kolibri.client';
 
 export const SignUpResource = new Resource({
   name: 'signup',
 });
-
-// Returns Promise<Boolean>
-export function getUsernameExists({ facilityId, username }) {
-  return client({
-    url: urls['kolibri:core:usernameexists'](),
-    method: 'GET',
-    params: {
-      facility: facilityId,
-      username: username,
-    },
-  })
-    .then(response => {
-      return response.data.username_exists;
-    })
-    .catch(() => {
-      // Just fail silently
-      return false;
-    });
-}

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -169,7 +169,6 @@
   import AuthBase from '../AuthBase';
   import UsersList from '../UsersList';
   import commonUserStrings from '../commonUserStrings';
-  import { getUsernameExists } from '../../apiResource';
   import SignInHeading from './SignInHeading';
 
   const MAX_USERS_FOR_LISTING_VIEW = 16;
@@ -450,20 +449,7 @@
         if (!this.isNextButtonEnabled) {
           return;
         }
-
-        // Check if user is in the facility
-        return getUsernameExists({
-          username: this.username,
-          facilityId: this.selectedFacility.id,
-        }).then(usernameExists => {
-          if (usernameExists) {
-            this.createSession();
-          } else {
-            // If username is not found, focus and select the field so user can try again
-            this.loginError = LoginErrors.USER_NOT_FOUND;
-            this.$refs.username.$refs.textbox.$refs.input.select();
-          }
-        });
+        return this.createSession();
       },
       createSession() {
         this.busy = true;
@@ -486,10 +472,10 @@
                   name: ComponentMap.NEW_PASSWORD,
                   query: sessionPayload,
                 });
+              } else if (err === LoginErrors.PASSWORD_MISSING) {
+                this.usernameSubmittedWithoutPassword = true;
               } else {
-                // Otherwise, only show errors when we've submitted a password
-                this.usernameSubmittedWithoutPassword = !this.password;
-                this.loginError = this.usernameSubmittedWithoutPassword ? null : err;
+                this.loginError = err;
               }
             }
 


### PR DESCRIPTION
## Summary
* Allows sign in endpoint to return an error indicating the user was not found to prevent an extra request
* Simplify error handling accordingly in SignIn/index.vue
* Changes logic of UsernameExistsView to UsernameAvailableView to return a 200 with response `True` if available, return an error otherwise, with semantic error constant USERNAME_ALREADY_EXISTS
* Changes to accepting only POST requests to prevent usernames being encoded in URL parameters which was noted as a slight vulnerability during penetration testing

## References
Done while implementing #10160, but spun out into separate PR to not interfere with string freeze.

## Reviewer guidance
Error handling still working correctly for username not found:
![Screenshot from 2023-02-28 19-20-53](https://user-images.githubusercontent.com/1680573/222038036-29cdb2ed-a05f-4c05-8603-169be3683028.png)

Duplicate username detection working appropriately during sign up flow:
[Screencast from 02-28-2023 07:21:11 PM.webm](https://user-images.githubusercontent.com/1680573/222038077-4f23fa30-7006-4bf3-905e-b6ec3874675c.webm)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
