### PR TITLE
Some string rearranging to support app bar updates

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -240,6 +240,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       "A topic is marked as 'Completed' when a learner finishes that specific topic within an educational resource. A topic could be a video, audio, document file or interactive app.",
   },
+  dataLabel: {
+    message: 'Data',
+    context: "Title of tab in 'Facility' section.",
+  },
   deviceNameLabel: {
     message: 'Device name',
     context:
@@ -296,6 +300,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Identifier',
     context:
       "An 'Identifier' could be a student ID number or an existing user identification number. This is an optional field in the user create/edit screen.",
+  },
+  infoLabel: {
+    message: 'Info',
+    context: 'Refers to the Device > Info tab.',
   },
   inProgressLabel: {
     message: 'In progress',
@@ -382,6 +390,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Search for a user...',
     context:
       'Text which appears in the search field above the table with users from whom to choose from (e.g. when enrolling learners to a class, selecting users to sync, etc.)',
+  },
+  settingsLabel: {
+    message: 'Settings',
+    context: "Title of tab used in 'Facility' and 'Device' sections.",
   },
   findSomethingToLearn: {
     message: 'Find something to learn',

--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -303,7 +303,7 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
   infoLabel: {
     message: 'Info',
-    context: 'Refers to the Device > Info tab.',
+    context: "Title of tab in 'Device' section.",
   },
   inProgressLabel: {
     message: 'In progress',
@@ -338,9 +338,19 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'A lesson is a linear learning pathway defined by a coach. The coach can select resources from any channel, add them to the lesson, define the ordering, and assign the lesson to learners in their class.',
   },
+  libraryLabel: {
+    message: 'Library',
+    context:
+      "The 'Library' section displays channels available on Kolibri server, and allows learners to browse, explore and filter topics and resources on their own.",
+  },
   loadingLabel: {
     message: 'Loading…',
     context: 'Message displayed when a resource is loading indicating that the user should wait.',
+  },
+  menuLabel: {
+    message: 'Menu',
+    context:
+      'Label that indicates a list of options. May be a button label, or a reference to the menu itself',
   },
   nameLabel: {
     message: 'Name',

--- a/kolibri/plugins/coach/assets/src/views/TopNavbar.vue
+++ b/kolibri/plugins/coach/assets/src/views/TopNavbar.vue
@@ -40,7 +40,7 @@
             color: this.$themeTokens.textInverted,
           },
           {
-            title: this.$tr('plan'),
+            title: this.coachString('planLabel'),
             link: this.navRoute(PageNames.PLAN_PAGE),
             icon: 'edit',
             color: this.$themeTokens.textInverted,
@@ -51,13 +51,6 @@
     methods: {
       navRoute(name) {
         return this.classId ? { name, params: { classId: this.classId } } : { name };
-      },
-    },
-    $trs: {
-      plan: {
-        message: 'Plan',
-        context:
-          "Translate as a VERB. Refers to the 'Plan' tab where coaches manage lessons, quizzes, and groups.",
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -249,6 +249,11 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       "Coaches can choose between 'Randomized' and 'Fixed' question order when they create quizzes.\n\nThis text is a description of the 'Randomized' question order.",
   },
+  planLabel: {
+    message: 'Plan',
+    context:
+      "Translate as a VERB. Refers to the 'Plan' tab where coaches manage lessons, quizzes, and groups.",
+  },
   previewLabel: {
     message: 'Preview',
     context:

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -13,13 +13,14 @@
   import { mapGetters } from 'vuex';
   import HorizontalNavBarWithOverflowMenu from 'kolibri.coreVue.components.HorizontalNavBarWithOverflowMenu';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonDeviceStrings from './commonDeviceStrings';
 
   export default {
     name: 'DeviceTopNav',
     components: {
       HorizontalNavBarWithOverflowMenu,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonDeviceStrings],
     computed: {
       ...mapGetters(['canManageContent', 'isSuperuser']),
       links() {
@@ -35,7 +36,7 @@
         if (this.isSuperuser) {
           list.push([
             {
-              title: this.$tr('permissionsLabel'),
+              title: this.deviceString('permissionsLabel'),
               link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
               icon: 'permissions',
               color: this.$themeTokens.textInverted,
@@ -47,13 +48,13 @@
               color: this.$themeTokens.textInverted,
             },
             {
-              title: this.$tr('infoLabel'),
+              title: this.coreString('infoLabel'),
               link: this.$router.getRoute('DEVICE_INFO_PAGE'),
               icon: 'deviceInfo',
               color: this.$themeTokens.textInverted,
             },
             {
-              title: this.$tr('settingsLabel'),
+              title: this.coreString('settingsLabel'),
               link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
               icon: 'settings',
               color: this.$themeTokens.textInverted,
@@ -61,21 +62,6 @@
           ]);
         }
         return list.flat();
-      },
-    },
-
-    $trs: {
-      permissionsLabel: {
-        message: 'Permissions',
-        context: 'Refers to the Device > Permissions tab.',
-      },
-      infoLabel: {
-        message: 'Info',
-        context: 'Refers to the Device > Info tab.',
-      },
-      settingsLabel: {
-        message: 'Settings',
-        context: 'Refers to the Device > Settings tab.\n',
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
+++ b/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
@@ -32,7 +32,7 @@ const deviceStrings = createTranslator('CommonDeviceStrings', {
   },
   permissionsLabel: {
     message: 'Permissions',
-    context: 'Refers to the Device > Permissions tab.',
+    context: "Title of tab in 'Device' section.",
   },
 });
 

--- a/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
+++ b/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
@@ -30,6 +30,10 @@ const deviceStrings = createTranslator('CommonDeviceStrings', {
     context:
       'Warning that appears when there is not enough space on the user’s device for the selected resources',
   },
+  permissionsLabel: {
+    message: 'Permissions',
+    context: 'Refers to the Device > Permissions tab.',
+  },
 });
 
 /**

--- a/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
@@ -35,28 +35,18 @@
             color: this.$themeTokens.textInverted,
           },
           {
-            title: this.$tr('settings'),
+            title: this.coreString('settingsLabel'),
             link: this.$router.getRoute(PageNames.FACILITY_CONFIG_PAGE),
             icon: 'settings',
             color: this.$themeTokens.textInverted,
           },
           {
-            title: this.$tr('data'),
+            title: this.coreString('dataLabel'),
             link: this.$router.getRoute(PageNames.DATA_EXPORT_PAGE),
             icon: 'save',
             color: this.$themeTokens.textInverted,
           },
         ];
-      },
-    },
-    $trs: {
-      data: {
-        message: 'Data',
-        context: "Title of tab in 'Facility' section.",
-      },
-      settings: {
-        message: 'Settings',
-        context: "Title of tab in 'Facility' section.",
       },
     },
   };


### PR DESCRIPTION
This is to reduce duplication across components related to navigation and the app bar, before string freeze, per @rtibbles suggestions


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
