### PR TITLE
Add coach strings

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -112,10 +112,15 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     message: 'No description',
     context: 'Indicates when a lesson does not have a description.',
   },
+  generalInformationLabel: {
+    message: 'General information',
+    context:
+      'Used as a visually hidden label for the section on quiz and lesson pages that contains general information about a lesson or a quizz',
+  },
   detailsLabel: {
     message: 'Details',
     context:
-      'Can refer to the details of the quiz that the coach is creating. For example, the title and the number of questions.',
+      'General label describing some details about a lesson or a quiz. For example, the quiz title and the number of questions, or title of the section with reports on the lesson page.',
   },
   difficultQuestionsLabel: {
     message: 'Difficult questions',

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -120,7 +120,7 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   detailsLabel: {
     message: 'Details',
     context:
-      'General label describing some details about a lesson or a quiz. For example, the quiz title and the number of questions, or title of the section with reports on the lesson page.',
+      'Visually hidden label for the section that contains detailed interaction reports for each resource in the lesson or a quiz.',
   },
   difficultQuestionsLabel: {
     message: 'Difficult questions',


### PR DESCRIPTION
## Summary

Prepares strings for issue #9849

## Reviewer guidance

Please see the acceptance criteria of #9849 and linked Figma designs and check that all strings needed are here.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
