### PR TITLE
Move download string to core strings

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -84,6 +84,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     context:
       'Description of a remove task. For example, a coach can remove a user from a class if they are no longer in that class.\n',
   },
+  downloadAction: {
+    message: 'Download',
+    context: 'Label for a button used to initiate a file download.',
+  },
   saveAction: {
     message: 'Save',
     context:

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -12,8 +12,8 @@
         icon="download"
         size="mini"
         :color="$themePalette.grey.v_600"
-        :ariaLabel="$tr('downloadAction')"
-        :tooltip="$tr('downloadAction')"
+        :ariaLabel="coreString('downloadAction')"
+        :tooltip="coreString('downloadAction')"
         @click="handleDownloadRequest"
       />
       <KIconButton
@@ -201,10 +201,6 @@
       },
     },
     $trs: {
-      downloadAction: {
-        message: 'Download',
-        context: 'Label for a button used to initiate a file download.',
-      },
       removeFromMyLibraryAction: {
         message: 'Remove from my library',
         context: "Label for a button to remove a file from a learner's library",


### PR DESCRIPTION
## Summary

Moves the existing "Download" string to core strings as we will soon need it in the content renderer (see https://github.com/learningequality/kolibri/issues/9856)

## Reviewer guidance

- Is the placement of the string fine?
- Bonus points: I did this, but with the string freeze coming fast, it'd be much appreciated if you checked related references in https://github.com/learningequality/kolibri/issues/9856 and checked that this is indeed the only string we need for this issue

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
