### PR TITLE
Use colorlog.TTYColoredFormatter

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -8,11 +8,11 @@ try:
     # during build, when dependencies are not
     # installed.
     # TODO: Move version tools to build tools, so we don't have to do this
-    from colorlog import ColoredFormatter
+    from colorlog import TTYColoredFormatter
     from colorlog import getLogger
 except ImportError:
     getLogger = None
-    ColoredFormatter = None
+    TTYColoredFormatter = None
 
 from .logger import LOG_COLORS
 from .logger import EncodingStreamHandler as StreamHandler
@@ -23,10 +23,10 @@ from kolibri.utils.compat import monkey_patch_translation
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 logging.StreamHandler(sys.stdout)
 
-if StreamHandler and getLogger and ColoredFormatter:
+if StreamHandler and getLogger and TTYColoredFormatter:
     handler = StreamHandler(stream=sys.stdout)
     handler.setFormatter(
-        ColoredFormatter(
+        TTYColoredFormatter(
             fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
         )
     )

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -197,7 +197,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
             "simple_date": {"format": "%(levelname)s %(asctime)s %(name)s %(message)s"},
             "color": {
-                "()": "colorlog.ColoredFormatter",
+                "()": "colorlog.TTYColoredFormatter",
                 "format": "%(log_color)s%(levelname)-8s %(asctime)s %(message)s",
                 "log_colors": LOG_COLORS,
             },


### PR DESCRIPTION
Unlike colorlog.ColoredFormatter, this log formatter only outputs color codes if Kolibri is running under a TTY. In newer versions of colorlog, TTYColoredFormatter is the same as ColoredFormatter.

-----

## Summary

This resolves an issue where log output from Kolibri's stdout / stderr contains ANSI escape sequences in environments where these can be problematic, such as `adb logcat`. It means that log output from Kolibri will appear unformatted when piped to a file, for example by running:

```
kolibri manage listchannels 2>&1 > out.txt
cat out.txt
```

## Reviewer guidance

Kolibri debug log output should be unchanged when running interactively. In addition, log files written by Kolibri itself should be the same. When viewing a log file generated from Kolibri's output to stdout / stderr, the resulting file should be in plain text with no ANSI escape sequences.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
