### PR TITLE
Task notifications

### DIFF
--- a/integration_testing/scripts/run_kolibri_app_mode.py
+++ b/integration_testing/scripts/run_kolibri_app_mode.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
+import atexit
 import logging
+import os
 
 from magicbus.plugins import SimplePlugin
 
+from kolibri.main import disable_plugin
 from kolibri.main import enable_plugin
 from kolibri.plugins.app.utils import interface
 from kolibri.utils.cli import initialize
@@ -29,6 +32,10 @@ logging.info("Initializing Kolibri and running any upgrade routines")
 
 # activate app mode
 enable_plugin("kolibri.plugins.app")
+atexit.register(disable_plugin, "kolibri.plugins.app")
+
+# Add a task update hook
+os.environ["KOLIBRI_UPDATE_HOOKS"] = "kolibri.core.tasks.job.log_status"
 
 # we need to initialize Kolibri to allow us to access the app key
 initialize()

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -239,7 +239,6 @@ def exportuserstocsv(facility=None, locale=None):
 
 class SyncJobValidator(JobValidator):
     facility = serializers.PrimaryKeyRelatedField(queryset=Facility.objects.all())
-    facility_name = serializers.CharField(default="")
     command = serializers.ChoiceField(choices=["sync", "resumesync"], default="sync")
     sync_session_id = HexOnlyUUIDField(format="hex", required=False, allow_null=True)
 
@@ -370,6 +369,7 @@ def peerfacilitysync(command, **kwargs):
 
 class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     facility = HexOnlyUUIDField()
+    facility_name = serializers.CharField(default="")
     username = serializers.CharField()
     password = serializers.CharField(default=NOT_SPECIFIED, required=False)
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -42,6 +42,7 @@ from kolibri.core.public.constants.user_sync_statuses import QUEUED
 from kolibri.core.public.constants.user_sync_statuses import SYNC
 from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.tasks.decorators import register_task
+from kolibri.core.tasks.job import JobStatus
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.permissions import IsAdminForJob
@@ -51,9 +52,20 @@ from kolibri.core.tasks.validation import JobValidator
 from kolibri.core.utils.urls import reverse_remote
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.conf import OPTIONS
+from kolibri.utils.translation import ugettext as _
 
 
 logger = logging.getLogger(__name__)
+
+
+def status_fn(job):
+    # Translators: A notification title shown to users when their Kolibri device is syncing data to another Kolibri instance
+    data_syncing_in_progress = _("Data syncing in progress")
+
+    # Translators: Notification text shown to users when their Kolibri device is syncing data to another Kolibri instance
+    # to encourage them to stay connected to their network to ensure a successful sync.
+    do_not_disconnect = _("Do not disconnect your device from the network.")
+    return JobStatus(data_syncing_in_progress, do_not_disconnect)
 
 
 class LocaleChoiceField(serializers.ChoiceField):
@@ -227,6 +239,7 @@ def exportuserstocsv(facility=None, locale=None):
 
 class SyncJobValidator(JobValidator):
     facility = serializers.PrimaryKeyRelatedField(queryset=Facility.objects.all())
+    facility_name = serializers.CharField(default="")
     command = serializers.ChoiceField(choices=["sync", "resumesync"], default="sync")
     sync_session_id = HexOnlyUUIDField(format="hex", required=False, allow_null=True)
 
@@ -270,6 +283,8 @@ facility_task_queue = "facility_task"
     track_progress=True,
     cancellable=False,
     queue=facility_task_queue,
+    long_running=True,
+    status_fn=status_fn,
 )
 def dataportalsync(command, **kwargs):
     """
@@ -343,6 +358,8 @@ class PeerFacilitySyncJobValidator(PeerSyncJobValidator):
     track_progress=True,
     cancellable=False,
     queue=facility_task_queue,
+    long_running=True,
+    status_fn=status_fn,
 )
 def peerfacilitysync(command, **kwargs):
     """
@@ -353,7 +370,6 @@ def peerfacilitysync(command, **kwargs):
 
 class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     facility = HexOnlyUUIDField()
-    facility_name = serializers.CharField(default="")
     username = serializers.CharField()
     password = serializers.CharField(default=NOT_SPECIFIED, required=False)
 
@@ -374,6 +390,8 @@ class PeerFacilityImportJobValidator(PeerFacilitySyncJobValidator):
     track_progress=True,
     cancellable=False,
     queue=facility_task_queue,
+    long_running=True,
+    status_fn=status_fn,
 )
 def peerfacilityimport(command, **kwargs):
     """
@@ -429,6 +447,7 @@ soud_sync_queue = "soud_sync"
 @register_task(
     validator=PeerRepeatingSingleSyncJobValidator,
     queue=soud_sync_queue,
+    status_fn=status_fn,
 )
 def peerusersync(command, **kwargs):
     cleanup = False
@@ -808,6 +827,7 @@ class PeerImportSingleSyncJobValidator(PeerSyncJobValidator):
     track_progress=True,
     queue=soud_sync_queue,
     permission_classes=[IsSuperAdmin() | NotProvisioned()],
+    status_fn=status_fn,
 )
 def peeruserimport(**kwargs):
     call_command("sync", **kwargs)

--- a/kolibri/core/device/task_notifications.py
+++ b/kolibri/core/device/task_notifications.py
@@ -1,0 +1,14 @@
+"""
+Tiny module to store strings for task notifications for device tasks.
+TODO: This can be migrated into kolibri/core/device/tasks.py in 0.17
+"""
+from kolibri.core.tasks.job import JobStatus
+from kolibri.utils.translation import ugettext as _
+
+
+def status_fn(job):
+    # Translators: A notification title shown to users when Kolibri is looking for other Kolibri devices on the network.
+    searching = _("Searching")
+    # Translators: Notification text shown to users when Kolibri is looking for other Kolibri devices on the network.
+    notification_text = _("Looking for other Kolibri devices")
+    return JobStatus(searching, notification_text)

--- a/kolibri/core/tasks/decorators.py
+++ b/kolibri/core/tasks/decorators.py
@@ -16,6 +16,7 @@ def register_task(
     track_progress=False,
     permission_classes=None,
     long_running=False,
+    status_fn=None,
 ):
     """
     Registers the decorated function as task.
@@ -34,6 +35,7 @@ def register_task(
             track_progress=track_progress,
             permission_classes=permission_classes,
             long_running=long_running,
+            status_fn=status_fn,
         )
 
     return RegisteredTask(
@@ -46,4 +48,5 @@ def register_task(
         track_progress=track_progress,
         permission_classes=permission_classes,
         long_running=long_running,
+        status_fn=status_fn,
     )

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -348,3 +348,17 @@ class Job(object):
     def status(self, lang):
         with translation.override(lang):
             return self.task.generate_status(self)
+
+
+def log_status(job, orm_job, state=None, **kwargs):
+    """
+    An example handler for task update hooks.
+    All it does is attempt to generate a status object for the job
+    and log it if it returns one.
+    """
+
+    status = job.status(translation.get_language())
+    if status:
+        logging.info(status.title)
+        if status.text:
+            logging.info(status.text)

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -105,7 +105,9 @@ def default_status_text(job):
         return _("Cancelled")
     elif job.state == State.RUNNING and job.percentage_progress:
         # Translators: Message shown to indicate the percentage completed of a background process.
-        return _("In progress - {percent}").format(percent=job.percentage_progress)
+        return _("In progress - {percent}%").format(
+            percent=round(job.percentage_progress * 100)
+        )
     # Translators: Message shown to indicate that while a background process has started, no progress can be reported yet.
     return _("Waiting")
 

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -12,6 +12,7 @@ from kolibri.core.tasks.utils import current_state_tracker
 from kolibri.core.tasks.utils import import_stringified_func
 from kolibri.core.tasks.utils import stringify_func
 from kolibri.utils import translation
+from kolibri.utils.translation import ugettext as _
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,23 @@ class Priority(object):
 
 
 JobStatus = namedtuple("Status", ("title", "text"))
+
+
+def default_status_text(job):
+    if job.state == State.COMPLETED:
+        # Translators: Message shown to indicate that a background process has finished successfully.
+        return _("Complete")
+    elif job.state == State.FAILED or job.state == State.CANCELED:
+        # Translators: Message shown to indicate that a background process has failed.
+        return _("Failed")
+    elif job.state == State.CANCELED:
+        # Translators: Message shown to indicate that a background process has been cancelled.
+        return _("Cancelled")
+    elif job.state == State.RUNNING and job.percentage_progress:
+        # Translators: Message shown to indicate the percentage completed of a background process.
+        return _("In progress - {percent}").format(percent=job.percentage_progress)
+    # Translators: Message shown to indicate that while a background process has started, no progress can be reported yet.
+    return _("Waiting")
 
 
 class Job(object):

--- a/kolibri/core/tasks/main.py
+++ b/kolibri/core/tasks/main.py
@@ -17,8 +17,6 @@ connection = SimpleLazyObject(db_connection)
 def __job_storage():
     return Storage(
         connection=connection,
-        schedule_hooks=conf.OPTIONS["Tasks"]["SCHEDULE_HOOKS"],
-        update_hooks=conf.OPTIONS["Tasks"]["UPDATE_HOOKS"],
     )
 
 

--- a/kolibri/core/tasks/test/test_decorators.py
+++ b/kolibri/core/tasks/test/test_decorators.py
@@ -7,6 +7,10 @@ from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.validation import JobValidator
 
 
+def status_fn(job):
+    pass
+
+
 class TestTaskDecorators(TestCase):
     @patch("kolibri.core.tasks.decorators.RegisteredTask")
     def test_register_decorator_calls_registered_job(self, MockRegisteredTask):
@@ -21,6 +25,7 @@ class TestTaskDecorators(TestCase):
             queue="test",
             cancellable=True,
             track_progress=True,
+            status_fn=status_fn,
         )(add)
 
         MockRegisteredTask.assert_called_once_with(
@@ -33,6 +38,7 @@ class TestTaskDecorators(TestCase):
             cancellable=True,
             track_progress=True,
             long_running=False,
+            status_fn=status_fn,
         )
 
     def test_register_decorator_registers_without_args(self):
@@ -54,6 +60,7 @@ class TestTaskDecorators(TestCase):
             queue="test",
             cancellable=True,
             track_progress=True,
+            status_fn=status_fn,
         )
         def add(x, y):
             return x + y

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -11,6 +11,10 @@ from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.validation import JobValidator
 
 
+def status_fn(job):
+    pass
+
+
 class JobTest(TestCase):
     def setUp(self):
         self.job = Job(id, track_progress=True)
@@ -64,6 +68,7 @@ class TestRegisteredTask(TestCase):
             cancellable=True,
             track_progress=True,
             long_running=True,
+            status_fn=status_fn,
         )
 
     def test_constructor_sets_required_params(self):

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -158,6 +158,7 @@
                   type: 'kolibri.plugins.user_profile.tasks.mergeuser',
                   baseurl: state.value.targetFacility.url,
                   facility: state.value.targetFacility.id,
+                  facility_name: state.value.targetFacility.name,
                   username: state.value.targetAccount.username,
                   local_user_id: state.value.userId,
                   user_id: state.value.targetAccount.id,

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -158,7 +158,6 @@
                   type: 'kolibri.plugins.user_profile.tasks.mergeuser',
                   baseurl: state.value.targetFacility.url,
                   facility: state.value.targetFacility.id,
-                  facility_name: state.value.targetFacility.name,
                   username: state.value.targetAccount.username,
                   local_user_id: state.value.userId,
                   user_id: state.value.targetAccount.id,


### PR DESCRIPTION
## Summary
* Adds capability for tasks to create their own translated notification strings
* Adds requirement for long running and high priority tasks to do so
* Uses kolibri's version of Django translation utils to allow these to be accessed even before Django has been initialized
* Adds long_running flag to all potentially long running tasks (I have deliberately omitted single user syncs - is this correct or a mistake?)
* Adds status functions for all long running and high priority tasks
* Adds them for optional display on some other user relevant tasks
* Adds a dummy update hook function, and uses it in the integration testing app script
* Tweaks how we pick up the update and schedule hooks to make sure they are always set regardless of how the Storage object is initialized

## Reviewer guidance
Does the API for registering the status functions make sense?
Is the expected input and return value of the status functions clear?

When you run `python integration_testing/scripts/run_kolibri_app_mode.py` (having built frontend assets with yarn run build) and do content import actions, do the notifications get logged to the terminal?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
