### PR TITLE
Add remote content browsing error strings to commonLearn

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -156,6 +156,20 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
     message: 'What you will need',
     context: '',
   },
+  //
+  loadingLibraries: {
+    message: 'Loading Kolibri libraries around you',
+    context: '',
+  },
+  cannotConnectToLibrary: {
+    message:
+      'Kolibri cannot connect to the library on {deviceName}. Your network connection may be unstable, or {deviceName} is no longer available.',
+    context: '',
+  },
+  backToAllLibraries: {
+    message: 'Go back to all libraries',
+    context: '',
+  },
 });
 
 export function learnString(key, args) {


### PR DESCRIPTION
## Summary
Adds additional strings that may help support loading and error states for remote content browsing. 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
