### PR TITLE
Update strings across develop after final string review session

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1252,6 +1252,10 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Remove PIN',
     context: 'Placholder text for the remove PIN textbox',
   },
+  setPin: {
+    message: 'Choose a 4-digit number to set as your new PIN',
+    context: 'Label to allow user to choose numbers to set PIN',
+  },
 
   // preferred learning language
   preferredLanguage: {

--- a/kolibri/core/assets/src/views/SyncStatusDescription.vue
+++ b/kolibri/core/assets/src/views/SyncStatusDescription.vue
@@ -34,24 +34,24 @@
     },
     $trs: {
       syncedDescription: {
-        message: 'Device has recently successfully synced to class server',
+        message: 'The device has been recently synced with the class server.',
         context: 'Description of the device syncing status.',
       },
       syncingDescription: {
-        message: 'Device is in the process of syncing information',
+        message: 'The device is currently syncing.',
         context: 'Description of the device syncing status.',
       },
       queuedDescription: {
-        message: 'Device is in queue to sync',
+        message: 'The device is waiting to sync.',
         context: 'Description of the device syncing status.',
       },
       unableOrNoSyncDescription: {
         message:
-          'The problem can be that the device is connected to server but hasn’t recently synced. Or syncing was attempted but failed for some reason.',
+          'The problem could be that the device is connected to the server but hasn’t recently synced. Or syncing was attempted but failed for some reason.',
         context: 'Description of the device syncing status.',
       },
       notConnectedDescription: {
-        message: 'Device isn’t connected to a server it can sync with',
+        message: 'The device isn’t connected to a server it can be synced with.',
         context: 'Description of the device syncing status.',
       },
       insufficientStorageDescription: {

--- a/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/DeviceConnectingModal.vue
+++ b/kolibri/core/assets/src/views/sync/SelectAddressModalGroup/DeviceConnectingModal.vue
@@ -113,13 +113,13 @@
       },
       deviceIsNotKolibri: {
         message:
-          "Another program is running at the network address on '{name}'. Please close that program, ensure Kolibri is running on the device, and try again.",
+          "Another program is running at the same network address as '{name}'. Please close the program, ensure Kolibri is running on that device, and try again.",
         context:
           "Error message when testing the connection to the network device specified by 'name' fails for this reason",
       },
       connectionTimedOut: {
         message:
-          "The connection with '{name}' is taking too long to respond. Please check the connection and try again.",
+          "The device '{name}' is taking too long to respond. Please check the connection and try again.",
         context:
           "Error message when testing the connection to the network device specified by 'name' fails for this reason",
       },

--- a/kolibri/plugins/coach/assets/src/views/StorageNotificationBanner.vue
+++ b/kolibri/plugins/coach/assets/src/views/StorageNotificationBanner.vue
@@ -74,7 +74,7 @@
     $trs: {
       warningMessage: {
         message:
-          'Some devices do not have enough storage for updates. Change the visibility of any active lessons and quizzes you aren’t using right now to free up space. ',
+          'Some devices do not have enough storage for updates. Change the visibility of lessons and quizzes you aren’t using right now to free up space.',
         context: 'Message displayed when a learner device does not have enough storage to sync.',
       },
       alertLink: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
@@ -101,9 +101,16 @@
       },
       newPluginsState: {
         message:
-          'When you enable or disable a page, Kolibri will restart, and you must refresh the browser to see the changes.',
+          'When you uncheck a page, it will make it invisible to users even if they have permission to access it.',
         context: 'Description for restarting the server.',
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      enableOrDisableRequiresRefresh: {
+        message:
+          'When you enable or disable a page, Kolibri will restart, and you must refresh the browser to see the changes. Anyone using Kolibri on this server at this time will be temporarily disconnected.',
+        context: 'Changing enabled pages',
+      },
+      /* eslint-enable */
       selectedPath: {
         message: 'Selected: {path}',
         context: 'Label for the selected path.',

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
@@ -29,10 +29,11 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonDeviceStrings from '../commonDeviceStrings';
 
   export default {
     name: 'ServerRestartModal',
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonDeviceStrings],
     props: {
       changedSetting: {
         type: String, // primary, remove, add, plugins
@@ -63,7 +64,7 @@
             message = this.$tr('newLocationRestartDescription');
             break;
           case 'plugin':
-            message = this.$tr('newPluginsState');
+            message = this.deviceString('newEnabledPluginsState');
             break;
         }
         // message is a separate sentence, concatenating them is not problematic
@@ -97,11 +98,6 @@
       serverRestartDescription: {
         message:
           ' Anyone using Kolibri on this server right now will temporarily be unable to use it.',
-        context: 'Description for restarting the server.',
-      },
-      newPluginsState: {
-        message:
-          'When you uncheck a page, it will make it invisible to users even if they have permission to access it.',
         context: 'Description for restarting the server.',
       },
       /* eslint-disable kolibri/vue-no-unused-translations */

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -1043,7 +1043,8 @@
         context: 'Label for enabled pages section',
       },
       enabledPagesDescription: {
-        message: 'Unselect a page to hide it even if the user has permission to access it.',
+        message:
+          'When you uncheck a page, it will make it invisible to users even if they have permission to access it.',
         context: "Description for the 'Enabled pages' section.",
       },
       alertDisabledOptions: {
@@ -1057,7 +1058,7 @@
       },
       alertDisabledPlugins: {
         message:
-          'This Kolibri is not able to initiate a restart from the user interface - any plugin management will have to happen from the command line, and Kolibri will have to be restarted manually.',
+          'This Kolibri is not able to initiate a restart from the user interface - management of the enabled pages will have to happen from the command line, and Kolibri will have to be restarted manually.',
         context: 'Alert text that is provided if some plugins are disabled',
       },
     },

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -253,7 +253,7 @@
             {{ $tr('enabledPages') }}
           </h2>
           <p class="info-description">
-            {{ $tr('enabledPagesDescription') }}
+            {{ deviceString('newEnabledPluginsState') }}
           </p>
 
           <KCheckbox
@@ -354,9 +354,9 @@
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { deviceString } from '../commonDeviceStrings';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
   import DeviceTopNav from '../DeviceTopNav';
-  import { deviceString } from '../commonDeviceStrings';
   import { getFreeSpaceOnServer } from '../AvailableChannelsPage/api';
   import useDeviceRestart from '../../composables/useDeviceRestart';
   import usePlugins from '../../composables/usePlugins';
@@ -1041,11 +1041,6 @@
       enabledPages: {
         message: 'Enabled pages',
         context: 'Label for enabled pages section',
-      },
-      enabledPagesDescription: {
-        message:
-          'When you uncheck a page, it will make it invisible to users even if they have permission to access it.',
-        context: "Description for the 'Enabled pages' section.",
       },
       alertDisabledOptions: {
         message:

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -354,7 +354,7 @@
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
-  import { deviceString } from '../commonDeviceStrings';
+  import commonDeviceStrings from '../commonDeviceStrings';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
   import DeviceTopNav from '../DeviceTopNav';
   import { getFreeSpaceOnServer } from '../AvailableChannelsPage/api';
@@ -389,7 +389,7 @@
       ServerRestartModal,
       UiAlert,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonDeviceStrings],
     setup() {
       const { restart } = useDeviceRestart();
       const { plugins, fetchPlugins, togglePlugin } = usePlugins();
@@ -461,7 +461,7 @@
       ...mapGetters(['isAppContext']),
       ...mapGetters('deviceInfo', ['getDeviceOS', 'canRestart', 'isRemoteContent']),
       pageTitle() {
-        return deviceString('deviceManagementTitle');
+        return this.deviceString('deviceManagementTitle');
       },
       facilities() {
         return this.$store.getters.facilities;

--- a/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
+++ b/kolibri/plugins/device/assets/src/views/commonDeviceStrings.js
@@ -18,6 +18,11 @@ const deviceStrings = createTranslator('CommonDeviceStrings', {
     message: 'New',
     context: 'Refers to CHANNEL; indicates that it was recently updated, imported, and unlocked',
   },
+  newEnabledPluginsState: {
+    message:
+      'When you uncheck a page, it will become invisible to users even if they have permission to access it.',
+    context: 'Description for restarting the server.',
+  },
   unlistedChannelLabel: {
     message: 'Unlisted channel',
     context:

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -399,19 +399,19 @@
         context: 'Description of modal',
       },
       startDateLegendText: {
-        message: 'Start Date',
+        message: 'Start date',
         context: 'Start date input label for calendar modal',
       },
       endDateLegendText: {
-        message: 'End Date',
+        message: 'End date',
         context: 'End date input label for calendar modal',
       },
       previousMonthText: {
-        message: 'Previous Month',
+        message: 'Previous month',
         context: 'label for previous month button',
       },
       nextMonthText: {
-        message: 'Next Month',
+        message: 'Next month',
         context: 'label for next month button',
       },
       invalidateDateError: {
@@ -423,7 +423,7 @@
         context: 'Error message displayed when the start date is after the end date',
       },
       futureDateError: {
-        message: 'Cannot select a future date',
+        message: 'You cannot select a future date',
         context: 'Error message displayed when an unavailable future date is entered',
       },
       beforeFirstAllowedDateError: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -9,7 +9,7 @@
   >
     <div>
       <p>{{ $tr('needToSync') }}</p>
-      <p>{{ $tr('setPin') }}</p>
+      <p>{{ coreString('setPin') }}</p>
 
       <KTextbox
         ref="pinFocus"
@@ -76,10 +76,6 @@
         message:
           'You will need to sync this device with other devices that share this facility in order to use this PIN.',
         context: 'Reminder to sync devices',
-      },
-      setPin: {
-        message: 'Choose a 4-digit number to set as your new PIN',
-        context: 'Label to allow user to choose numbers to set PIN',
       },
     },
   };

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -78,7 +78,7 @@
         context: 'Reminder to sync devices',
       },
       setPin: {
-        message: 'Choose four numbers to set as your new PIN.',
+        message: 'Choose a 4-digit number to set as your new PIN',
         context: 'Label to allow user to choose numbers to set PIN',
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfirmResetModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ConfirmResetModal.vue
@@ -31,7 +31,7 @@
       },
       reconfirmation: {
         message:
-          'Your device management PIN will not be affected, but any other custom changes will be lost.',
+          'Your device management PIN will not be affected, but any other changes made to the facility settings will be lost.',
         context:
           "Description on the 'Reset to defaults' window accessed via the Facility > Settings page.",
       },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -78,7 +78,7 @@
         context: 'Reminder to sync devices',
       },
       enterPin: {
-        message: 'Enter four numbers to set as your new PIN',
+        message: 'Choose a 4-digit number to set as your new PIN',
         context: 'Label to allow user to enter PIN',
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -9,7 +9,7 @@
   >
     <div>
       <p>{{ $tr('newToSync') }}</p>
-      <p>{{ $tr('enterPin') }}</p>
+      <p>{{ coreString('setPin') }}</p>
 
       <KTextbox
         ref="pinFocus"
@@ -76,10 +76,6 @@
         message:
           'You will need to sync this device with other devices with the same facility in order to use this PIN.',
         context: 'Reminder to sync devices',
-      },
-      enterPin: {
-        message: 'Choose a 4-digit number to set as your new PIN',
-        context: 'Label to allow user to enter PIN',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -190,7 +190,7 @@
         context: 'An action to filter only downloaded resources',
       },
       useDownloadedResourcesFilter: {
-        message: 'Use this filter to see only resources you have downloaded from this library.',
+        message: 'Use this filter to only see resources you have downloaded from this library.',
         context: 'A dialog message displayed when filtering only downloaded resources',
       },
       /* eslint-enable kolibri/vue-no-unused-translations */

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportLODUsersSetup.vue
@@ -140,6 +140,13 @@
         message: 'Import individual user accounts - {step, number} of {total, number}',
         context: 'Title that goes on top of the screen to indicate the current step.',
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      firstUserWarning: {
+        message:
+          'Please note: The first user you choose to import will be given super admin permissions on this device, and be able to manage all channels and device settings.',
+        context: 'Notice about impleications of importing the first user on a learn-only device',
+      },
+      /* eslint-enable */
     },
   };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/importLODUsers/ImportIndividualUserForm.vue
@@ -267,6 +267,12 @@
         context:
           "Appears on 'Device limitations' window which informs that only learner features will be available on the device.",
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
+      deviceLimitationsAdminsMessage: {
+        message:
+          '’{full_name} ({username})’ is an admin on ‘{device}’. This device is limited to features for learners only. Features for coaches and admins will not be available.',
+      },
+      /* eslint-enable */
       headerAdmin: {
         message: 'Use an admin account',
         context: 'Modal form to introduce admin account credentials.',


### PR DESCRIPTION
This should be cross-referenced with the Notion page and/or Ditto to ensure alignment after final string review took place.