### PR TITLE
Add string audit tooling.

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -411,3 +411,15 @@ It takes a comma separated list of ``intl_code`` language codes. It can also tak
 
 * ``kolibri-supported`` will include all languages listed in ``KOLIBRI_SUPPORTED_LANGUAGES``
 * ``kolibri-all`` will include all languages defined in *language_info.json*
+
+
+Auditing strings
+----------------
+
+Much of our string workflow before developer implementation happens using `Ditto <https://dittowords.com>`__. In order to do a full audit of newly added strings from Ditto, a CSV of the newly added strings can be exported from Ditto, and then our internal audit tool can be run to generate a CSV report of any strings that are potentially missing:
+
+.. code-block:: bash
+
+  yarn run yarn run auditdittostrings --ditto-file <path to Ditto CSV>
+
+This will produce an output CSV file in kolibri/locale/en/LC_MESSAGES/profiles/ditto.csv that contains an audit report on which strings from the Ditto file that are marked as FINAL were not found in the codebase (using an exact match method, so this may produce false positives if strings are not in ICU syntax on Ditto), and also any strings that have been discovered in the codebase to be an exact match - i.e. when we appear to have duplicate strings in our codebase (again, these may be false positives, as some strings may be repeated for different senses).

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -420,6 +420,6 @@ Much of our string workflow before developer implementation happens using `Ditto
 
 .. code-block:: bash
 
-  yarn run yarn run auditdittostrings --ditto-file <path to Ditto CSV>
+  yarn run auditdittostrings --ditto-file <path to Ditto CSV>
 
 This will produce an output CSV file in kolibri/locale/en/LC_MESSAGES/profiles/ditto.csv that contains an audit report on which strings from the Ditto file that are marked as FINAL were not found in the codebase (using an exact match method, so this may produce false positives if strings are not in ICU syntax on Ditto), and also any strings that have been discovered in the codebase to be an exact match - i.e. when we appear to have duplicate strings in our codebase (again, these may be false positives, as some strings may be repeated for different senses).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "yarn run hashi-build && kolibri-tools build prod --file ./build_tools/build_plugins.txt --transpile",
     "makemessages": "kolibri-tools i18n-extract-messages --pluginFile ./build_tools/build_plugins.txt --namespace kolibri-common --searchPath ./packages/kolibri-common",
     "createprofiles": "kolibri-tools i18n-profile --pluginFile ./build_tools/build_plugins.txt --output-file ./kolibri/locale/en/LC_MESSAGES/profiles/strings.csv --namespace kolibri-common --searchPath ./packages/kolibri-common",
+    "auditdittostrings": "kolibri-tools i18n-audit --pluginFile ./build_tools/build_plugins.txt --output-file ./kolibri/locale/en/LC_MESSAGES/profiles/ditto.csv --namespace kolibri-common --searchPath ./packages/kolibri-common",
     "transfercontext": "kolibri-tools i18n-transfer-context --pluginFile ./build_tools/build_plugins.txt --namespace kolibri-common --searchPath ./packages/kolibri-common",
     "watch": "kolibri-tools build dev --file ./build_tools/build_plugins.txt --cache",
     "watch-hot": "yarn run watch --hot",

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -641,6 +641,33 @@ _addPathOptions(program.command('i18n-profile'))
     profileStrings(pathInfo, options.ignore, options.outputFile, options.verbose);
   });
 
+// I18N Ditto Audit
+_addPathOptions(program.command('i18n-audit'))
+  .option(
+    '--output-file <outputFile>',
+    'File path and name to which to write out the audit to',
+    filePath
+  )
+  .option(
+    '--ditto-file <dittoFile>',
+    'File paths of the CSV files to read the ditto strings from',
+    filePath
+  )
+  .action(function(options) {
+    const pathInfo = _generatePathInfo(options);
+    if (!pathInfo) {
+      program.command('i18n-audit').help();
+    }
+    const auditStrings = require('./i18n/auditMessages');
+    auditStrings(
+      pathInfo,
+      options.ignore,
+      [options.dittoFile],
+      options.outputFile,
+      options.verbose
+    );
+  });
+
 // Check engines, then process args
 try {
   const engines = require(path.join(process.cwd(), 'package.json')).engines;

--- a/packages/kolibri-tools/lib/i18n/auditMessages.js
+++ b/packages/kolibri-tools/lib/i18n/auditMessages.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const { parse } = require('csv-parse/sync');
+const createCsvWriter = require('csv-writer').createObjectCsvWriter;
+const logging = require('../logging');
+const { getAllMessagesFromFilePath } = require('./astUtils');
+const { checkForDuplicateIds, forEachPathInfo } = require('./utils');
+
+// Instantiates the CSV data and writes to a file.
+function writeAuditToCSV(audit, outputFile) {
+  // Ensure we have a {localePath}/audit directory available.
+  mkdirp.sync(path.dirname(outputFile));
+
+  const csvWriter = createCsvWriter({
+    path: outputFile,
+    header: [
+      { id: 'message', title: 'Message' },
+      { id: 'missing', title: 'Missing?' },
+      { id: 'duplicate', title: 'Duplicated?' },
+      { id: 'messageIds', title: 'Message Ids' },
+      { id: 'namespaces', title: 'Namespaces' },
+    ],
+  });
+  csvWriter
+    .writeRecords(
+      audit.map(a => ({
+        ...a,
+        messageIds: a.messageIds.join(', '),
+        namespaces: a.namespaces.join(', '),
+      }))
+    )
+    .then(() => logging.log(`Audit CSV written to ${outputFile}`));
+}
+
+module.exports = function(pathInfo, ignore, dittoFilePaths, outputFile, verbose) {
+  // An object for storing our messages.
+  const extractedMessages = {};
+  forEachPathInfo(pathInfo, pathData => {
+    const namespace = pathData.namespace;
+    if (!extractedMessages[namespace]) {
+      const filePathMessages = getAllMessagesFromFilePath(pathData.moduleFilePath, ignore, verbose);
+      for (const otherNamespace in extractedMessages) {
+        const nameSpaceMessages = extractedMessages[otherNamespace];
+        if (checkForDuplicateIds(nameSpaceMessages, filePathMessages)) {
+          logging.error(
+            `Duplicate message ids across namespaces ${namespace} and ${otherNamespace}`
+          );
+        }
+      }
+      extractedMessages[namespace] = filePathMessages;
+    }
+  });
+
+  // All the strings we are interested in auditing, both ones from the ditto file
+  // that are missing, and strings that are duplicated within the codebase.
+  const outputStrings = [];
+
+  const messageLookup = {};
+
+  for (const namespace in extractedMessages) {
+    for (const messageId in extractedMessages[namespace]) {
+      if (!messageLookup[extractedMessages[namespace][messageId].message]) {
+        messageLookup[extractedMessages[namespace][messageId].message] = {
+          messageIds: [],
+          namespaces: [],
+          message: extractedMessages[namespace][messageId].message,
+        };
+      } else {
+        const obj = messageLookup[extractedMessages[namespace][messageId].message];
+        outputStrings.push({
+          duplicate: true,
+          missing: false,
+          messageIds: obj.messageIds,
+          namespaces: obj.namespaces,
+          message: obj.message,
+        });
+      }
+      const obj = messageLookup[extractedMessages[namespace][messageId].message];
+      obj.messageIds.push(messageId);
+      obj.namespaces.push(namespace);
+    }
+  }
+
+  const dittoStrings = [];
+
+  for (const dittoFilePath of dittoFilePaths) {
+    const dittoFile = fs.readFileSync(dittoFilePath).toString();
+    dittoStrings.push(...parse(dittoFile, { skip_empty_lines: true, columns: true }));
+  }
+
+  for (const dittoString of dittoStrings) {
+    if (dittoString.Status === 'FINAL' && !messageLookup[dittoString.Text.trim()]) {
+      outputStrings.push({
+        duplicate: false,
+        missing: true,
+        messageIds: [],
+        namespaces: [],
+        message: dittoString.Text.trim(),
+      });
+    }
+  }
+
+  writeAuditToCSV(outputStrings, outputFile);
+};

--- a/packages/kolibri-tools/lib/i18n/utils.js
+++ b/packages/kolibri-tools/lib/i18n/utils.js
@@ -1,9 +1,31 @@
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
+const intersection = require('lodash/intersection');
 const { parse } = require('csv-parse/sync');
 const { lint } = require('kolibri-tools/lib/lint');
 const { addAliases, resetAliases } = require('kolibri-tools/lib/alias_import_resolver');
+const logging = require('../logging');
+
+/*
+ * A function that compares two message objects, and ensure that they do not share any messageIds
+ * unless the text of the message is an exact match.
+ */
+function checkForDuplicateIds(obj1, obj2) {
+  const potentialDuplicates = intersection(Object.keys(obj1), Object.keys(obj2));
+  const actualDuplicates = [];
+  for (const potentialDuplicate of potentialDuplicates) {
+    const message1 = obj1[potentialDuplicate].message;
+    const message2 = obj2[potentialDuplicate].message;
+    if (message1 !== message1) {
+      logging.error(
+        `${potentialDuplicate} messageId is repeated with different strings '${message1}' and '${message2}'`
+      );
+      actualDuplicates.push(potentialDuplicate);
+    }
+  }
+  return Boolean(actualDuplicates.length);
+}
 
 function writeSourceToFile(filePath, fileSource) {
   fs.writeFileSync(filePath, fileSource, { encoding: 'utf-8' });
@@ -71,4 +93,5 @@ module.exports = {
   toLocale,
   writeSourceToFile,
   forEachPathInfo,
+  checkForDuplicateIds,
 };


### PR DESCRIPTION
## Summary
* Checks for duplicate message ids whenever we are about to merge two message objects into each other
* Adds CLI command to take a Ditto string export and check that any strings marked as FINAL are represented in the codebase
* Also checks for strings that exist in the codebase that are exact matches for each other and marks them as potential duplicates in the output CSV
* Adds section to our i18n docs describing the new command

