### PR TITLE
Fix topic tree redirects to not lose deviceId (or other) route parameters

### DIFF
--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -154,11 +154,7 @@ export default [
       if (toRoute.params.id === fromRoute.params.id) {
         return;
       }
-      showTopicsTopic(store, {
-        id: toRoute.params.id,
-        pageName: toRoute.name,
-        query: toRoute.query,
-      });
+      showTopicsTopic(store, toRoute);
     },
     component: TopicsPage,
     props: true,
@@ -175,12 +171,7 @@ export default [
       if (toRoute.params.id === fromRoute.params.id) {
         return;
       }
-      showTopicsTopic(store, {
-        id: toRoute.params.id,
-        pageName: toRoute.name,
-        query: toRoute.query,
-        deviceId: toRoute.params.deviceId,
-      });
+      showTopicsTopic(store, toRoute);
     },
     component: TopicsPage,
     props: true,


### PR DESCRIPTION
## Summary
* Passes entire route to topicTree handler function
* Uses this information to preserve other route parameters when a redirect happens (either to a different subpage, and/or because we are navigating down through singleton folders for skip logic).

## References
Fixes issue observed during the remote content browsing bug bash

## Reviewer guidance
Browse a remote device - navigate down to the bottom level of a topic tree with only leaf resources, and ensure that the deviceId is preserved in the URL parameters when the page redirects to the 'SEARCH' page, as opposed to 'FOLDERS' that is the default.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
