### PR TITLE
Add or update strings for settings flows

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1290,6 +1290,15 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Choose a 4-digit number to set as your new PIN',
     context: 'Label to allow user to choose numbers to set PIN',
   },
+  numbersOnly: {
+    message: 'Enter numbers only',
+    context:
+      'Error message indicating a user has entered characters other than numbers as their PIN',
+  },
+  noEmptyField: {
+    message: 'The field cannot be empty',
+    context: 'Error message indicating a user has not added their PIN to the form field',
+  },
 
   // preferred learning language
   preferredLanguage: {
@@ -1306,6 +1315,11 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
     message: 'Channels in the preferred language will be displayed first',
     context:
       'Explanatory text for the setting where a user can select the language that they would like to learn in',
+  },
+
+  changingStorageLocation: {
+    message: 'Changing storage location',
+    context: '',
   },
 });
 

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/RemoveStorageLocationModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/RemoveStorageLocationModal.vue
@@ -54,12 +54,12 @@
     },
     $trs: {
       removeStorageLocation: {
-        message: 'Remove storage location',
+        message: 'Removing storage location',
         context: 'Prompt for removing a storage location.',
       },
       removeStorageLocationDescription: {
         message:
-          'Removing a storage location will remove access to them on Kolibri, but will not delete the resources from your device.',
+          'When you remove a storage location, Kolibri will not be able to access it, but resources will not be deleted from your device.',
         context: 'Description for removing a storage location.',
       },
       deleteFilesDescription: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
@@ -88,7 +88,8 @@
         context: 'Reason to restart the server.',
       },
       newPrimaryLocationRestartDescription: {
-        message: 'Changing the primary storage location will restart this server.',
+        message:
+          'The server will restart. Anyone using Kolibri on this server at this time will be temporarily disconnected.',
         context: 'Reason to restart the server.',
       },
       removeLocationRestartDescription: {
@@ -97,7 +98,7 @@
       },
       serverRestartDescription: {
         message:
-          ' Anyone using Kolibri on this server right now will temporarily be unable to use it.',
+          'Anyone using Kolibri on this server right now will temporarily be unable to use it.',
         context: 'Description for restarting the server.',
       },
       /* eslint-disable kolibri/vue-no-unused-translations */
@@ -105,6 +106,11 @@
         message:
           'When you enable or disable a page, Kolibri will restart, and you must refresh the browser to see the changes. Anyone using Kolibri on this server at this time will be temporarily disconnected.',
         context: 'Changing enabled pages',
+      },
+      serverNeedsRestart: {
+        message:
+          'The server will need to restart. Do this during low server usage times to avoid disruptions.',
+        context: '',
       },
       /* eslint-enable */
       selectedPath: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -979,7 +979,8 @@
         context: 'Secondary storage paths for users to store downloaded resources',
       },
       secondaryStorageDescription: {
-        message: 'Read-only locations cannot be the primary storage location.',
+        message:
+          'Kolibri will display channels stored in these locations. Read-only locations cannot be the primary storage location.',
         context: 'Informs user of limits for read-only locations',
       },
       autoDownload: {
@@ -1043,8 +1044,7 @@
         context: 'Label for enabled pages section',
       },
       alertDisabledOptions: {
-        message:
-          'Some configuration options have been disabled due to the way Kolibri has been set up.',
+        message: 'Some configuration options are disabled due to the way Kolibri has been set up.',
         context: 'Alert text that is provided if some options are disabled',
       },
       alertDisabledPaths: {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/ChangePinModal.vue
@@ -49,7 +49,7 @@
       submit() {
         if (!this.pin) {
           this.showErrorText = true;
-          this.pinError = 'This field cannot be empty';
+          this.pinError = this.coreString('noEmptyField');
           this.focus();
         } else {
           if (this.pinPattern.test(this.pin)) {
@@ -58,7 +58,7 @@
             this.$emit('submit');
             this.showSnackbarNotification('pinUpdated');
           } else {
-            this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
+            this.pinError = this.coreString('numbersOnly');
             this.focus();
           }
         }

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/CreateManagementPinModal.vue
@@ -49,7 +49,7 @@
       submit() {
         if (!this.pin) {
           this.showErrorText = true;
-          this.pinError = 'This field cannot be empty';
+          this.pinError = this.coreString('noEmptyField');
           this.focus();
         } else {
           if (this.pinPattern.test(this.pin)) {
@@ -58,7 +58,7 @@
             this.showSnackbarNotification('pinCreated');
             this.$emit('submit');
           } else {
-            this.pinError = 'Invalid PIN format. Please enter a 4-digit number.';
+            this.pinError = this.coreString('numbersOnly');
             this.focus();
           }
         }


### PR DESCRIPTION
This PR covers the "Settings" flows page in Ditto. 

It also adds a few missing strings that had inadvertently been merged in during the 'PIN' workflow that had not been added as internationalized strings, but just as text. So, those are added to commonCore and the text has been replaced in the files.