### PR TITLE
Updated context from Crowdin, third take

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/index.vue
@@ -275,7 +275,10 @@
         context:
           'Notification that can refer to when resources are added to a lesson, for example.',
       },
-      addButtonLabel: 'Add',
+      addButtonLabel: {
+        message: 'Add',
+        context: 'Label for a button to add a resource to lessons.',
+      },
       totalQuestionsHeader: {
         message: 'Total questions',
         context: 'Refers to the total number of questions in a quiz.',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -404,8 +404,14 @@
         context: "Option on 'Facility settings' page.\n",
       },
       /* eslint-enable kolibri/vue-no-unused-translations */
-      saveFailure: 'There was a problem saving your settings',
-      saveSuccess: 'Facility settings updated',
+      saveFailure: {
+        message: 'There was a problem saving your settings',
+        context: 'Status report after the facility change operation.',
+      },
+      saveSuccess: {
+        message: 'Facility settings updated',
+        context: 'Status report after the facility change operation.',
+      },
       pageDescription: {
         message: 'Configure facility settings here.',
         context: 'Interpret as "[You can] configure facility settings here"',

--- a/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
+++ b/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
@@ -232,7 +232,10 @@
         message: 'The import succeeded',
         context: 'Success notification when import CSV works correctly.',
       },
-      changesMade: 'The following changes were made:',
+      changesMade: {
+        message: 'The following changes were made:',
+        context: 'Heading for the outcome report for the import from CSV operation.',
+      },
       summary: {
         message: 'Summary of changes if you choose to import:',
         context: "Description on the 'Import users' preview page.",
@@ -264,8 +267,16 @@
         message: 'Classes',
         context: 'Refers to the summary of changes in classes produced by a CSV import.',
       },
-      someSkipped: 'These rows were skipped:',
-      someRowErrors: 'These rows have errors and will be skipped if you continue:',
+      someSkipped: {
+        message: 'These rows were skipped:',
+        context:
+          'During the import operation of users and classes from the CSV file, some rows may be skipped because of improper formatting.',
+      },
+      someRowErrors: {
+        message: 'These rows have errors and will be skipped if you continue:',
+        context:
+          'During the import operation of users and classes from the CSV file, some rows may be skipped because of improper formatting.',
+      },
       rowNumber: {
         message: 'Row number',
         context: 'Refers to rows in the CSV file.\n',

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -221,7 +221,10 @@
         message: 'Delete class',
         context: 'Option to delete a class.',
       },
-      tableCaption: 'List of classes',
+      tableCaption: {
+        message: 'List of classes',
+        context: 'Caption for the table containing the list of classes.',
+      },
       twoCoachNames: {
         message: '{name1}, {name2}',
         context: 'DO NOT TRANSLATE\nCopy the source string.',

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -378,7 +378,10 @@
         message: 'Go to Device permissions to change this',
         context: 'Refers to admin permissions.',
       },
-      viewInDeviceTabPrompt: 'View details in Device permissions',
+      viewInDeviceTabPrompt: {
+        message: 'View details in Device permissions',
+        context: 'Reminder for the admin that they can review permissions in the Device page.',
+      },
       userUpdateNotification: {
         message: 'Changes saved',
         context: 'Notification.',

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -160,7 +160,11 @@
         context:
           "This text displays in the learner's 'Lessons' section if the coach has not added any resources to the lesson.",
       },
-      teacherNote: 'Coach note',
+      teacherNote: {
+        message: 'Coach note',
+        context:
+          'Label for the field where the coach can add notes for their learners regarding the resource.',
+      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
+++ b/kolibri/plugins/learn/assets/src/views/commonLearnStrings.js
@@ -43,7 +43,7 @@ export const learnStrings = createTranslator('CommonLearnStrings', {
   },
   multipleLearningActivitiesLabel: {
     message: 'Multiple learning activities',
-    context: '',
+    context: 'Label that indicates the user has selected learning activities of multiple types.',
   },
   exploreResources: {
     message: 'Explore resources',

--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -273,7 +273,10 @@
         message: 'Powered by Kolibri',
         context: 'Indicates that Kolibri is the technology behind this application.',
       },
-      whatsThis: "What's this?",
+      whatsThis: {
+        message: "What's this?",
+        context: 'Link with explanation of the authentication process.',
+      },
       restrictedAccess: {
         message: 'Access to Kolibri has been restricted for external devices',
         context: 'Error message description.',

--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/NewPasswordPage.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/NewPasswordPage.vue
@@ -122,7 +122,10 @@
       },
     },
     $trs: {
-      needToMakeNewPasswordLabel: 'Hi, {user}. You need to set a new password for your account.',
+      needToMakeNewPasswordLabel: {
+        message: 'Hi, {user}. You need to set a new password for your account.',
+        context: 'Instructions for the user to create a new password.',
+      },
     },
   };
 

--- a/kolibri/plugins/user_profile/assets/src/views/UserProfileSideNavEntry.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/UserProfileSideNavEntry.vue
@@ -22,7 +22,10 @@
       CoreMenuOption,
     },
     $trs: {
-      profile: 'Profile',
+      profile: {
+        message: 'Profile',
+        context: 'Option in the sidebar menu for the user to open the page with their profile.',
+      },
     },
     computed: {
       url() {


### PR DESCRIPTION
## Summary
String context values that have recently been updated on Crowdin need to be pulled into code.
…

## References
…

## Reviewer guidance

Check that PR is not changing context of any files that are more recent in the code.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
