### PR TITLE
Fix: formatting of installing pyenv in windows

### DIFF
--- a/docs/howtos/installing_pyenv.md
+++ b/docs/howtos/installing_pyenv.md
@@ -94,11 +94,15 @@ The output of the command tells you to add certain lines to your startup files f
 1. Run PowerShell terminal as Administrator
 2. Run the following installation command in the PowerShell terminal :
 
-`Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1" `
+```sh
+Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" -OutFile "./install-pyenv-win.ps1"; &"./install-pyenv-win.ps1"
+```
 
 If you are getting any **UnauthorizedAccess** error, run:
 
-`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine`
+```sh
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine
+```
 
 press Y not A, to execute Policy Change for this power shell only.
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,5 +8,6 @@ sphinx-autobuild==0.7.1
 m2r==0.2.1
 mistune<2.0.0
 sphinx-notfound-page==0.6
+kolibri==0.15.11
 # Do this to prevent undefined imports in newer versions of Jinja2
 Jinja2<3.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,6 +8,5 @@ sphinx-autobuild==0.7.1
 m2r==0.2.1
 mistune<2.0.0
 sphinx-notfound-page==0.6
-kolibri==0.15.11
 # Do this to prevent undefined imports in newer versions of Jinja2
 Jinja2<3.1


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
Fixes #10198 
- Just added three backticks to make the formatting uniform
- Added kolibri package to the docs as the build was failing in read the docs because module `kolibri` was missing 

## Testing checklist

- [x] Contributor has fully tested the PR manually


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
