### PR TITLE
do not use sqlalchemy session for tasks reads

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -439,7 +439,7 @@ class Storage(object):
                 if state is not None:
                     orm_job.state = job.state = state
                     if state == State.FAILED and orm_job.retry_interval is not None:
-                        orm_job.state = State.QUEUED
+                        orm_job.state = job.state = State.QUEUED
                         orm_job.scheduled_time = naive_utc_datetime(
                             self._now() + timedelta(seconds=orm_job.retry_interval)
                         )
@@ -450,7 +450,7 @@ class Storage(object):
                                 if orm_job.repeat is not None
                                 else None
                             )
-                            orm_job.state = State.QUEUED
+                            orm_job.state = job.state = State.QUEUED
                             orm_job.scheduled_time = naive_utc_datetime(
                                 self._now() + timedelta(seconds=orm_job.interval)
                             )

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -292,13 +292,6 @@ class Storage(object):
             q = conn.execute(select(ORMJob))
             q.first()
 
-    def count_all_jobs(self, queue=None):
-        with self.engine.connect() as conn:
-            q = select(func.count(ORMJob.id))
-            if queue:
-                q = q.where(ORMJob.queue == queue)
-            return conn.execute(q).scalar()
-
     def get_job(self, job_id):
         orm_job = self.get_orm_job(job_id)
         job = self._orm_to_job(orm_job)

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -5,8 +5,8 @@ from datetime import timedelta
 import pytest
 
 from kolibri.core.tasks.compat import Event
-from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.storage import Storage

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -316,30 +316,6 @@ class TestJobStorage(object):
 
     @mock.patch("kolibri.core.tasks.main.initialize_workers")
     @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
-    def test_count_all_jobs(
-        self,
-        mock_kolibri_broadcast,
-        initialize_workers,
-        job_storage,
-    ):
-        with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
-            # Schedule three jobs
-            from kolibri.utils.time_utils import local_now
-            from datetime import timedelta
-
-            schedule_time = local_now() + timedelta(hours=1)
-            job_storage.schedule(schedule_time, Job(id))
-            job_storage.schedule(schedule_time, Job(id))
-
-            queue = "myqueue"
-            job_storage.schedule(schedule_time, Job(id), queue)
-
-            assert job_storage.count_all_jobs() == 3
-            assert job_storage.count_all_jobs(queue=DEFAULT_QUEUE) == 2
-            assert job_storage.count_all_jobs(queue=queue) == 1
-
-    @mock.patch("kolibri.core.tasks.main.initialize_workers")
-    @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
     def test_get_running_jobs(
         self,
         mock_kolibri_broadcast,


### PR DESCRIPTION
## Summary
Replaced the direct read queries from session to connection. 

## References
- issue #10120 


## Reviewer guidance


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
