### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/build_pex.yml
+++ b/.github/workflows/build_pex.yml
@@ -18,12 +18,12 @@ jobs:
     outputs:
       pex-file-name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 2.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 2.7
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
@@ -39,7 +39,7 @@ jobs:
       run: make pex
     - name: Get PEX filename
       id: get-pex-filename
-      run: echo "::set-output name=pex-file-name::$(ls dist | grep .pex | cat)"
+      run: echo "pex-file-name=$(ls dist | grep .pex | cat)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ steps.get-pex-filename.outputs.pex-file-name }}

--- a/.github/workflows/build_pex.yml
+++ b/.github/workflows/build_pex.yml
@@ -31,7 +31,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install Python build dependencies
       run: pip install -r requirements/build.txt
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.whl-file-name }}
         path: dist
@@ -40,7 +40,7 @@ jobs:
     - name: Get PEX filename
       id: get-pex-filename
       run: echo "pex-file-name=$(ls dist | grep .pex | cat)" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.get-pex-filename.outputs.pex-file-name }}
         path: dist/${{ steps.get-pex-filename.outputs.pex-file-name }}

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -69,14 +69,14 @@ jobs:
     - name: Get WHL filename
       id: get-whl-filename
       run: echo "whl-file-name=$(ls dist | grep .whl | cat)" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
         path: dist/${{ steps.get-whl-filename.outputs.whl-file-name }}
     - name: Get TAR filename
       id: get-tar-filename
       run: echo "tar-file-name=$(ls dist | grep .tar | cat)" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
         path: dist/${{ steps.get-tar-filename.outputs.tar-file-name }}

--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -18,7 +18,7 @@ jobs:
       whl-file-name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
       tar-file-name: ${{ steps.get-tar-filename.outputs.tar-file-name }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         lfs: true
@@ -27,16 +27,16 @@ jobs:
         sudo apt-get -y -qq update
         sudo apt-get install -y gettext
     - name: Set up Python 2.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 2.7
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Cache Node.js modules
       uses: actions/cache@v3
       with:
@@ -49,14 +49,14 @@ jobs:
         yarn --frozen-lockfile
         npm rebuild node-sass
     - name: Cache Python dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Cache C extensions
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: cext_cache
         key: ${{ runner.os }}-cext-${{ hashFiles('requirements/cext*.txt') }}
@@ -68,14 +68,14 @@ jobs:
       run: make dist
     - name: Get WHL filename
       id: get-whl-filename
-      run: echo "::set-output name=whl-file-name::$(ls dist | grep .whl | cat)"
+      run: echo "whl-file-name=$(ls dist | grep .whl | cat)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ steps.get-whl-filename.outputs.whl-file-name }}
         path: dist/${{ steps.get-whl-filename.outputs.whl-file-name }}
     - name: Get TAR filename
       id: get-tar-filename
-      run: echo "::set-output name=tar-file-name::$(ls dist | grep .tar | cat)"
+      run: echo "tar-file-name=$(ls dist | grep .tar | cat)" >> $GITHUB_OUTPUT
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ steps.get-tar-filename.outputs.tar-file-name }}

--- a/.github/workflows/c_extensions.yml
+++ b/.github/workflows/c_extensions.yml
@@ -29,12 +29,12 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 2.7
     - name: pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-ext-${{ hashFiles('requirements/*.txt') }}
@@ -67,12 +67,12 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 2.7
     - name: pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-no-ext-${{ hashFiles('requirements/*.txt') }}

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -29,13 +29,13 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-docs-${{ hashFiles('requirements/docs.txt') }}

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -29,19 +29,19 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
     - name: Cache Node.js modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: '**/node_modules'
         key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.OS }}-node-
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/no_zombies.yml
+++ b/.github/workflows/no_zombies.yml
@@ -29,12 +29,12 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
     - name: pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-base-${{ hashFiles('requirements/base.txt') }}

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -32,9 +32,9 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9 for Postgres
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install tox
@@ -42,7 +42,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install tox
     - name: tox env cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/.tox/py3.9
         key: ${{ runner.os }}-tox-py3.9-${{ hashFiles('requirements/*.txt') }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,17 +29,17 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Cache Node.js modules
       uses: actions/cache@v3
       with:

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -36,11 +36,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.whl-file-name }}
         path: dist
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.tar-file-name }}
         path: dist

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -27,9 +27,9 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 2.7
     - name: Install dependencies

--- a/.github/workflows/python2lint.yml
+++ b/.github/workflows/python2lint.yml
@@ -29,9 +29,9 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 2.7
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 2.7
     - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -33,10 +33,10 @@ jobs:
         python-version: [2.7, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
@@ -46,7 +46,7 @@ jobs:
         pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
@@ -77,10 +77,10 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9 for Postgres
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install tox
@@ -90,7 +90,7 @@ jobs:
         pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/.tox/py3.9
         key: ${{ runner.os }}-tox-py3.9-${{ hashFiles('requirements/*.txt') }}
@@ -107,10 +107,10 @@ jobs:
         python-version: [3.6]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox
@@ -120,7 +120,7 @@ jobs:
         pip install "tox<4"
     - name: tox env cache
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('requirements/*.txt') }}
@@ -137,10 +137,10 @@ jobs:
         python-version: [3.6]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tox

--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -29,14 +29,14 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: '16.x'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
     - name: Cache Node.js modules
       uses: actions/cache@v3
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,7 @@ repos:
     entry: We do not allow _auto_ in migration names. Please give the migration a telling name.
     language: fail
     files: .*/migrations/.*_auto_.*\.py$
-    exclude: ^
-      (?x)^(
+    exclude: (?x)^(
         kolibri/core/auth/migrations/0002_auto_20170608_2125\.py|
         kolibri/core/auth/migrations/0003_auto_20170621_0958\.py|
         kolibri/core/auth/migrations/0004_auto_20170816_1607\.py|


### PR DESCRIPTION
## Summary
* Removes leading `^` in pre-commit auto migrations excludes regex to allow parsing in Python 3.11
* Updates all github actions to latest versions to handle the deprecation of those versions by Github
* Updates how we set output from job steps following the deprecation of `set-output`: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Reviewer guidance
Run `pre-commit run --all-files` confirm nothing breaks.
Temporarily delete the `exclude` regex from `.pre_commit_config.yml` and run again - confirm that it does now flag the pre-existing automigrations we are trying to exclude.

Verify that all actions properly complete, especially the build actions.

Note: some deprecation warnings may persist, as these deprecation updates have not been made in all of the installer repos yet.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
