### PR TITLE
Restart zeroconf before provisioning

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from sys import version_info
 
@@ -74,6 +75,9 @@ from kolibri.utils.server import STATUS_RUNNING
 from kolibri.utils.system import get_free_space
 from kolibri.utils.time_utils import local_now
 
+logger = logging.getLogger(__name__)
+logger.info("Updating our Kolibri instance on the Zeroconf network now")
+
 
 class DevicePermissionsViewSet(viewsets.ModelViewSet):
     queryset = DevicePermissions.objects.all()
@@ -98,13 +102,12 @@ class DeviceProvisionView(viewsets.GenericViewSet):
             app_key = request.COOKIES[APP_KEY_COOKIE_NAME]
             response_data["app_key"] = app_key
 
-        # Restart zeroconf before moving along
-        import logging
-        from kolibri.utils.server import update_zeroconf_broadcast
+        # Restart zeroconf before moving along when we're a SoUD
+        if data["is_soud"]:
+            from kolibri.utils.server import update_zeroconf_broadcast
 
-        logger = logging.getLogger(__name__)
-        logger.info("Updating our Kolibri instance on the Zeroconf network now")
-        update_zeroconf_broadcast()
+            update_zeroconf_broadcast()
+
         return Response(response_data, status=status.HTTP_201_CREATED)
 
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -76,7 +76,6 @@ from kolibri.utils.system import get_free_space
 from kolibri.utils.time_utils import local_now
 
 logger = logging.getLogger(__name__)
-logger.info("Updating our Kolibri instance on the Zeroconf network now")
 
 
 class DevicePermissionsViewSet(viewsets.ModelViewSet):
@@ -103,7 +102,8 @@ class DeviceProvisionView(viewsets.GenericViewSet):
             response_data["app_key"] = app_key
 
         # Restart zeroconf before moving along when we're a SoUD
-        if data["is_soud"]:
+        if response_data["is_soud"]:
+            logger.info("Updating our Kolibri instance on the Zeroconf network now")
             from kolibri.utils.server import update_zeroconf_broadcast
 
             update_zeroconf_broadcast()

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -97,6 +97,14 @@ class DeviceProvisionView(viewsets.GenericViewSet):
         if APP_KEY_COOKIE_NAME in request.COOKIES:
             app_key = request.COOKIES[APP_KEY_COOKIE_NAME]
             response_data["app_key"] = app_key
+
+        # Restart zeroconf before moving along
+        import logging
+        from kolibri.utils.server import update_zeroconf_broadcast
+
+        logger = logging.getLogger(__name__)
+        logger.info("Updating our Kolibri instance on the Zeroconf network now")
+        update_zeroconf_broadcast()
         return Response(response_data, status=status.HTTP_201_CREATED)
 
 

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -163,22 +163,3 @@ class FacilityImportViewSet(ViewSet):
             raise PermissionDenied()
         students = [u for u in facility_info["users"] if not u["roles"]]
         return Response({"students": students, "admin": facility_info["user"]})
-
-
-class SetupWizardRestartZeroconf(ViewSet):
-    """
-    An utility endpoint to restart zeroconf after setup is finished
-    in case this is a SoUD
-    """
-
-    permission_classes = [HasPermissionDuringSetup | HasPermissionDuringLODSetup]
-
-    @decorators.action(methods=["post"], detail=False)
-    def restart(self, request):
-        import logging
-        from kolibri.utils.server import update_zeroconf_broadcast
-
-        logger = logging.getLogger(__name__)
-        logger.info("Updating our Kolibri instance on the Zeroconf network now")
-        update_zeroconf_broadcast()
-        return Response({})

--- a/kolibri/plugins/setup_wizard/api_urls.py
+++ b/kolibri/plugins/setup_wizard/api_urls.py
@@ -2,14 +2,10 @@ from rest_framework import routers
 
 from .api import FacilityImportViewSet
 from .api import SetupWizardResource
-from .api import SetupWizardRestartZeroconf
 
 router = routers.SimpleRouter()
 
 router.register(r"facilityimport", FacilityImportViewSet, basename="facilityimport")
 router.register(r"setupwizard", SetupWizardResource, basename="setupwizard")
-router.register(
-    r"restartzeroconf", SetupWizardRestartZeroconf, basename="restartzeroconf"
-)
 
 urlpatterns = router.urls

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -1,6 +1,4 @@
 import { Resource } from 'kolibri.lib.apiResource';
-import urls from 'kolibri.urls';
-import redirectBrowser from 'kolibri.utils.redirectBrowser';
 
 /**
  * The <Module>Resource classes here map directly to the <Module>ViewSet of the same
@@ -52,12 +50,4 @@ export const FacilityImportResource = new Resource({
 export const FinishSoUDSyncingResource = new Resource({
   name: 'restartzeroconf',
   namespace: 'kolibri.plugins.setup_wizard',
-  finish() {
-    const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
-    const device_url = urls['kolibri:kolibri.plugins.device:device_management'];
-    window.sessionStorage.setItem(welcomeDimissalKey, false);
-    this.postListEndpoint('restart');
-    redirectBrowser(device_url ? device_url() : null);
-    return '';
-  },
 });

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -46,8 +46,3 @@ export const FacilityImportResource = new Resource({
     });
   },
 });
-
-export const FinishSoUDSyncingResource = new Resource({
-  name: 'restartzeroconf',
-  namespace: 'kolibri.plugins.setup_wizard',
-});

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -65,7 +65,6 @@
   import urls from 'kolibri.urls';
   import client from 'kolibri.client';
   import Lockr from 'lockr';
-  import { FinishSoUDSyncingResource } from '../../api';
   import { DeviceTypePresets, UsePresets } from '../../constants';
 
   export default {
@@ -195,9 +194,6 @@
         return this.wizardService.state.context[key];
       },
       provisionDevice() {
-        // Restart ZeroConf (needs to be done before provisioning)
-        FinishSoUDSyncingResource.postListEndpoint('restart');
-
         client({
           url: urls['kolibri:core:deviceprovision'](),
           method: 'POST',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -65,6 +65,7 @@
   import urls from 'kolibri.urls';
   import client from 'kolibri.client';
   import Lockr from 'lockr';
+  import { FinishSoUDSyncingResource } from '../../api';
   import { DeviceTypePresets, UsePresets } from '../../constants';
 
   export default {
@@ -194,6 +195,9 @@
         return this.wizardService.state.context[key];
       },
       provisionDevice() {
+        // Restart ZeroConf (needs to be done before provisioning)
+        FinishSoUDSyncingResource.postListEndpoint('restart');
+
         client({
           url: urls['kolibri:core:deviceprovision'](),
           method: 'POST',
@@ -205,6 +209,9 @@
             const path = appKey
               ? urls['kolibri:kolibri.plugins.app:initialize'](appKey) + '?auth_token=' + v4()
               : urls['kolibri:kolibri.plugins.user_auth:user_auth']();
+
+            const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+            window.sessionStorage.setItem(welcomeDimissalKey, false);
 
             Lockr.set('savedState', null); // Clear out saved state machine
             window.location.href = path;


### PR DESCRIPTION
## Summary
The code that restarted ZeroConf was left unused in the new provisioning call. This ensures that we call to restart ZeroConf just before we provision.

I moved the logic from the JS API Resource method directly into the `SettingUpKolibri` device provisioning.

## References

Tracked in #10126 

## Reviewer guidance
Provision Kolibri a couple times using a couple different flows - keep an eye on the Devtools -> Network tab to see that the `/restart` call comes back `200`.

Is there anything I'm missing here?