### PR TITLE
[DO NOT MERGE] Linking kds pr that updates kdaterange date formatting for testing

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.1",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.42",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#4b8f272d37446ff0e65c4048c0339e279976103b",
+    "kolibri-design-system": "LianaHarris360/kolibri-design-system#kdaterange-date-formatting",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -137,7 +137,6 @@
       :cancelText="coreString('cancelAction')"
       :title="$tr('title')"
       :description="$tr('description')"
-      :dateLocale="selectedLanguage"
       :startDateLegendText="$tr('startDateLegendText')"
       :endDateLegendText="$tr('endDateLegendText')"
       :previousMonthText="$tr('previousMonthText')"
@@ -156,7 +155,6 @@
       :cancelText="coreString('cancelAction')"
       :title="$tr('title')"
       :description="$tr('description')"
-      :dateLocale="selectedLanguage"
       :startDateLegendText="$tr('startDateLegendText')"
       :endDateLegendText="$tr('endDateLegendText')"
       :previousMonthText="$tr('previousMonthText')"
@@ -179,7 +177,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import validationConstants from 'kolibri-design-system/lib/KDateRange/validationConstants';
-  import { currentLanguage } from 'kolibri.utils.i18n';
   import { now } from 'kolibri.utils.serverClock';
   import format from 'date-fns/format';
   import KDateRange from 'kolibri-design-system/lib/KDateRange';
@@ -215,7 +212,6 @@
         summaryDateRangeModal: false,
         sessionDateRangeModal: false,
         lastAllowedDate: now(),
-        selectedLanguage: currentLanguage,
         dateRange: {},
       };
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7386,6 +7386,22 @@ kolibri-constants@0.1.42:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.42.tgz#2f62a8d8b8894e5cfbd47ee6564b31018818c93f"
   integrity sha512-2hUxYnzUEfhLFJO9egVSwYW8/PKob9wLeDYfB74mtIzgQ4zy6huRj3574WetK9gREi+W1Jcm7HGPsfZIFzFvrA==
 
+kolibri-design-system@LianaHarris360/kolibri-design-system#kdaterange-date-formatting:
+  version "1.3.0"
+  resolved "https://codeload.github.com/LianaHarris360/kolibri-design-system/tar.gz/e52983c09e8913c5c2d2e1d909ceb022dd35a5a2"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+    vue-intl "^3.1.0"
+
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#4b8f272d37446ff0e65c4048c0339e279976103b":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#4b8f272d37446ff0e65c4048c0339e279976103b"
@@ -11065,7 +11081,7 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-intl@3.1.0:
+vue-intl@3.1.0, vue-intl@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vue-intl/-/vue-intl-3.1.0.tgz#707f1f7406595c9b4afc6049254b333093be37be"
   integrity sha512-0v3S5gspuYnt6j1G+KLfPUsNnjRdbMOcYrWYoSd1gYk6rX8VuOyh7NLztPrSIJt+NLs/qzLOZXxI1LORukEiqA==


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The KDateRange component has been updated to use the vue-intl $formatDate function, which displays the months of the year within the KDateCalendar in the correct language. Previously, the JavaScript function `toLocaleString()` was used but there was no support for the following languages:
Burmese
Georgian
Khmer
Chichewa, Chewa, Nyanja
Fulfulde (Cameroon)
Hausa
Yoruba

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Change the language to one of the previously mentioned above
2. Navigate to Facility > Data
3. Select Generate Log for either session or summary logs
4. The months should be displayed in the selected language

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
