### PR TITLE
Fix license check

### DIFF
--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -22,7 +22,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           github_token: ${{ github.token }}
-          paths: '["requirements/*.txt", "package.json", "**/package.json", "yarn.lock", "test/conditional/test_licenses.sh"]'
+          paths: '["requirements/*.txt", "package.json", "**/package.json", "yarn.lock", "test/conditional/test_licenses.sh", ".github/workflows/check_licenses.yml"]'
   licenses:
     name: Licenses check
     needs: pre_job

--- a/.github/workflows/check_licenses.yml
+++ b/.github/workflows/check_licenses.yml
@@ -44,7 +44,14 @@ jobs:
     - uses: actions/setup-python@v4
     - name: Install dependencies
       run: |
+        # Use a Python virtual environment to ensure
+        # our license check is only for packages
+        # explicitly installed for Kolibri
+        python -m venv ./virtualenv_dir
+        source ./virtualenv_dir/bin/activate
         python -m pip install --upgrade pip
+        # Actually install all our requirements before doing a license check
+        pip install -r requirements.txt
         yarn --frozen-lockfile
         npm rebuild node-sass
     - name: Check Licenses

--- a/test/conditional/test_licenses.sh
+++ b/test/conditional/test_licenses.sh
@@ -14,20 +14,27 @@ set -e
 # Ignoring: docutils, because it's not distributed.
 # Ignoring: nose because it's something Travis installs in its Python 3.5
 #           environment without it being distributed by us.
-# Ignoring: cloud-init, because it's installed in distpackages in GHA runners.
-IGNORES="docutils;nose;cloud-init;"
+IGNORES="docutils;nose;"
 
 echo "Checking all requirements installed with pip, except $IGNORES..."
 
 for requirement in `pip freeze | grep -v '^-e' | sed 's/\(.*\)==.*/\1/'`
 do
-    echo "$requirement;"
     if echo "$IGNORES" | grep -q "$requirement;" && true
     then
         continue
     fi
 
-    details=`pip show "$requirement"`
+
+    details=`pip show "$requirement" || echo ""`
+
+    # This check is not concerned with system level packages, so ignore
+    # anything found here.
+    if echo "$details" | grep -q "dist-packages" && true
+    then
+        continue
+    fi
+
     license=`echo "$details" | grep -i "License" || echo ""`
     if echo "$license" | grep -qi " gpl" && true
     then

--- a/test/conditional/test_licenses.sh
+++ b/test/conditional/test_licenses.sh
@@ -14,12 +14,14 @@ set -e
 # Ignoring: docutils, because it's not distributed.
 # Ignoring: nose because it's something Travis installs in its Python 3.5
 #           environment without it being distributed by us.
-IGNORES="docutils;nose;"
+# Ignoring: cloud-init, because it's installed in distpackages in GHA runners.
+IGNORES="docutils;nose;cloud-init;"
 
 echo "Checking all requirements installed with pip, except $IGNORES..."
 
 for requirement in `pip freeze | grep -v '^-e' | sed 's/\(.*\)==.*/\1/'`
 do
+    echo "$requirement;"
     if echo "$IGNORES" | grep -q "$requirement;" && true
     then
         continue


### PR DESCRIPTION
## Summary
* The license check was running in the bare container, which meant that any system python packages were getting picked up
* Apparently we also weren't installing Python dependencies, so this was failing to actually check Python libraries
* Fixes both these things by adding a virtualenv for the check and then installing the dependencies into them

