### PR TITLE
Fix error for user merge data

### DIFF
--- a/kolibri/core/auth/utils/migrate.py
+++ b/kolibri/core/auth/utils/migrate.py
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 
 
 def _merge_user_models(source_user, target_user):
-    for f in ["gender", "birth_year", "id_number"]:
+    for f in ["gender", "birth_year", "id_number", "full_name"]:
         source_value = getattr(source_user, f, None)
         target_value = getattr(target_user, f, None)
-        if not target_value and source_value:
+        if not target_value and source_value is not None:
             setattr(target_user, f, source_value)
     target_user.save()
 

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -111,7 +111,7 @@ def mergeuser(command, **kwargs):
     merge_users(local_user, remote_user)
 
     # Resync with the server to update the merged records
-    # kwargs["no_pull"] = True
+    kwargs["no_pull"] = True
     del kwargs["no_push"]
     call_command("sync", **kwargs)
     new_superuser_id = kwargs.get("new_superuser_id")

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -111,7 +111,6 @@ def mergeuser(command, **kwargs):
     merge_users(local_user, remote_user)
 
     # Resync with the server to update the merged records
-    kwargs["no_pull"] = True
     del kwargs["no_push"]
     call_command("sync", **kwargs)
     new_superuser_id = kwargs.get("new_superuser_id")


### PR DESCRIPTION
## Summary
When merging the user to a different facility, if the remote facility didn't have any gender, birthdate or full name assigned, the result of the merge set them in blank for the final user. 

## References
Related: #10206

## Reviewer guidance
When merging an user as described in #9791 if the local user has set Gender, Birth year, identifier or fullname, they should stay after the merge when seing the profile in the local device.

NOTE: Checked that the remote facility does not get this info because users are usually in a morango partition that's read only. It's a known issue that has no solution by now according to @bjester 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
