### PR TITLE
When creating a new remote user send all the local user information

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -53,6 +53,9 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
             "password": data["password"],
             "facility": facility,
         }
+        for f in ["gender", "birth_year", "id_number", "full_name"]:
+            if getattr(data["local_user_id"], f, None):
+                user_data[f] = getattr(data["local_user_id"], f, None)
         public_signup_url = reverse_remote(baseurl, "kolibri:core:publicsignup-list")
         response = requests.post(public_signup_url, data=user_data)
         if response.status_code != HTTP_201_CREATED:
@@ -111,7 +114,7 @@ def mergeuser(command, **kwargs):
     merge_users(local_user, remote_user)
 
     # Resync with the server to update the merged records
-    # kwargs["no_pull"] = True
+    kwargs["no_pull"] = True
     del kwargs["no_push"]
     call_command("sync", **kwargs)
     new_superuser_id = kwargs.get("new_superuser_id")

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -54,7 +54,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
             "facility": facility,
         }
         for f in ["gender", "birth_year", "id_number", "full_name"]:
-            if getattr(data["local_user_id"], f, None):
+            if getattr(data["local_user_id"], f, "NOT_SPECIFIED") != "NOT_SPECIFIED":
                 user_data[f] = getattr(data["local_user_id"], f, None)
         public_signup_url = reverse_remote(baseurl, "kolibri:core:publicsignup-list")
         response = requests.post(public_signup_url, data=user_data)


### PR DESCRIPTION
## Summary
In the merge facility process, when a new user needs to be created in the remote facility, send all the user information, not just the username and password.
Pushing the sync info won't work because the Morango partition is read only, so we need to ensure the creation includes all the existing information


## References
Closes: #10223
Depends:  #10222

## Reviewer guidance
Same process as in #10222 
This PR must not be merged until #10222 has been merged

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [s] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
