### PR TITLE
Add informative error message to permission denied error.

### DIFF
--- a/kolibri/core/auth/utils/sync.py
+++ b/kolibri/core/auth/utils/sync.py
@@ -97,6 +97,8 @@ def validate_and_create_sync_credentials(
         )
     except (CommandError, HTTPError) as e:
         if not username and not password:
-            raise PermissionDenied()
+            raise PermissionDenied(
+                "Username and password required to validate sync credentials, and were not supplied"
+            )
         else:
             raise AuthenticationFailed(e)


### PR DESCRIPTION
## Summary
* Adds an informative message to a PermissionDenied error that otherwise caused a bit of a head scratcher when trying to work out why we were getting a 403 when scheduling syncs