### PR TITLE
Content import API fail on error support

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -15,7 +15,7 @@ env.set_env()
 
 #: This may not be the exact version as it's subject to modification with
 #: get_version() - use ``kolibri.__version__`` for the exact version string.
-VERSION = (0, 15, 11)
+VERSION = (0, 15, 12)
 
 __author__ = "Learning Equality"
 __email__ = "info@learningequality.org"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Currently the `startremotecontentimport` and `startdiskcontentimport` task APIs don't pass through the `fail_on_error` option to the `importcontent` command. This makes the APIs unreliable as errors will be ignored.

I included a commit to bump the version since I couldn't run the test suite without it. I'm happy to take that out if you have a different process to handle it, though.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#9258 and #9590 cover the `--fail-on-error` CLI option. This adds support for using the option from the task API.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

In one terminal, setup a Kolibri instance that will be a server. Import a channel from Studio, corrupt one of the channel files and then start the server.

```
export KOLIBRI_HOME=$PWD/server
kolibri manage migrate
kolibri manage importchannel f393c30f95fb4bec87f873b2013ec9e3
kolibri manage importcontent network f393c30f95fb4bec87f873b2013ec9e3
find $KOLIBRI_HOME/content/storage -type f -print -exec truncate -s 0 '{}' ';' -quit
kolibri start --foreground --port 8080
```

In another terminal, setup a Kolibri instance that will be a client. Setup a superuser, import the channel from the server instance and then start the server.

```
export KOLIBRI_HOME=$PWD/client
kolibri manage migrate
kolibri manage createsuperuser
kolibri manage importchannel f393c30f95fb4bec87f873b2013ec9e3
kolibri start --foreground --port 8081
```

In a 3rd terminal, make an API request to the client instance to import content from the first instance. Set `fail_to_error` to `true` in the request data.

```
cat > data.json << "EOF"
{
  "channel_id": "f393c30f95fb4bec87f873b2013ec9e3",
  "baseurl": "http://127.0.0.1:8080",
  "fail_on_error": true
}
EOF
curl -u "<user>:<password>" -H "Content-Type: application/json" -d @data.json \
  http://127.0.0.1:8081/api/tasks/tasks/startremotecontentimport/
```

Note the job ID in the output. Poll the job until it completes.

```
curl -u "<user>:<password>" http://127.0.0.1:8081/api/tasks/tasks/<job_id>/
```

The job will reach the `COMPLETED` state but should fail since one of the objects is corrupted. The logs of the 2nd instance will show an `ERROR` message for this.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
