### PR TITLE
Strings==: for when multiple devices are not responding

### DIFF
--- a/kolibri/core/assets/src/mixins/commonSyncElements.js
+++ b/kolibri/core/assets/src/mixins/commonSyncElements.js
@@ -72,6 +72,11 @@ const syncStrings = createTranslator('CommonSyncStrings', {
       'This super admin account allows you to manage all facilities, resources, and users on this device.',
     context: 'Explanation of what the super admin account is used for on device.',
   },
+  devicesUnreachable: {
+    message: 'Some devices are not responding. Please check the connection and try again.',
+    context:
+      "Error message that displays when some devices aren't reachable and their selection is disabled",
+  },
 });
 
 export default {

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/DeviceConnectingModal.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/DeviceConnectingModal.vue
@@ -134,11 +134,6 @@
           "Error message when testing the connection to a network device fails because Kolibri isn't connected to the internet and the device address is on the internet",
       },
       /* eslint-disable kolibri/vue-no-unused-translations */
-      devicesNotResponding: {
-        message: 'Some devices are not responding. Please check the connection and try again.',
-        context:
-          'Error message when testing the connection to a network device fails for this reason',
-      },
       connectionFailureKolibriVersion: {
         message:
           "Unable to connect to '{name}'. Please update both devices to Kolibri version {version_number} or higher.",


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
I missed a string in https://github.com/learningequality/kolibri/pull/10141 that I realized was missing while rebasing https://github.com/learningequality/kolibri/pull/10133

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/pull/10133

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
This only adds a UI string that is unused

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
