### PR TITLE
Fix string to be Learn more rather than just learn

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -82,6 +82,7 @@
   import UsernameTextbox from 'kolibri.coreVue.components.UsernameTextbox';
   import PasswordTextbox from 'kolibri.coreVue.components.PasswordTextbox';
   import PrivacyLinkAndModal from 'kolibri.coreVue.components.PrivacyLinkAndModal';
+  import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import OnboardingStepBase from '../OnboardingStepBase';
 
   export default {
@@ -93,7 +94,7 @@
       PasswordTextbox,
       PrivacyLinkAndModal,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonSyncElements],
     inject: ['wizardService'],
     props: {
       disabled: {
@@ -169,7 +170,7 @@
       },
       description() {
         return this.adminUserLabels
-          ? this.getCommonSyncString('superAdminPermissionsDecription')
+          ? this.getCommonSyncString('superAdminPermissionsDescription')
           : this.$tr('learnerAccountCreationDescription', { facility: this.selectedFacilityName });
       },
       selectedFacilityName() {

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -149,7 +149,7 @@
             <span>{{ $tr('changeLearningFacilityDescription') }}</span>
             <span><KButton
               appearance="basic-link"
-              :text="$tr('learn')"
+              :text="$tr('learnMore')"
               class="learn"
               @click="showLearnModal = true"
             /></span>
@@ -301,8 +301,8 @@
         message: 'Move your account and progress data to another learning facility.',
         context: 'Explanation of what change a learning facility means',
       },
-      learn: {
-        message: 'Learn',
+      learnMore: {
+        message: 'Learn more',
         context:
           'Link to open a modal window explaining what changing to another learning facility represents.',
       },


### PR DESCRIPTION
and cleanup a string mis-match in setup wizard along the way



## References
Fixes #10237 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
