### PR TITLE
Fix bug where lesson active state was not properly conditionalized

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -198,7 +198,7 @@
         const hideModalConfirmation = Lockr.get(LESSON_VISIBILITY_MODAL_DISMISSED);
         this.activeLesson = lesson;
         if (!hideModalConfirmation) {
-          if (lesson.active) {
+          if (lesson.active || lesson.is_active) {
             this.showLessonIsVisibleModal = false;
             this.showLessonIsNotVisibleModal = true;
           } else {

--- a/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/LessonStatus.vue
@@ -198,7 +198,7 @@
         const hideModalConfirmation = Lockr.get(LESSON_VISIBILITY_MODAL_DISMISSED);
         this.activeLesson = lesson;
         if (!hideModalConfirmation) {
-          if (lesson.active || lesson.is_active) {
+          if (lesson.is_active) {
             this.showLessonIsVisibleModal = false;
             this.showLessonIsNotVisibleModal = true;
           } else {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -32,7 +32,7 @@
             {{ coachString('statusLabel') }}
           </template>
           <!--           <template #value>
-            <LessonActive :active="lesson.active" />
+            <LessonActive :active="lesson.is_active" />
           </template> -->
         </HeaderTableRow>
         <HeaderTableRow v-show="!$isPrint">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -185,9 +185,9 @@
           if (this.filter.value === 'allLessons') {
             return true;
           } else if (this.filter.value === 'visibleLessons') {
-            return lesson.active;
+            return lesson.is_active;
           } else if (this.filter.value === 'lessonsNotVisible') {
-            return !lesson.active;
+            return !lesson.is_active;
           }
         });
         const sorted = this._.orderBy(filtered, ['date_created'], ['desc']);
@@ -209,7 +209,7 @@
           let sum = 0;
           this.table.forEach(lesson => {
             // only include visible lessons
-            if (lesson.active) {
+            if (lesson.is_active) {
               sum += this.lessonsSizes[0][lesson.id];
             }
           });
@@ -224,7 +224,7 @@
     },
     methods: {
       handleToggleVisibility(lesson) {
-        const newActiveState = !lesson.active;
+        const newActiveState = !lesson.is_active;
         const snackbarMessage = newActiveState
           ? this.coachString('lessonVisibleToLearnersLabel')
           : this.coachString('lessonNotVisibleToLearnersLabel');
@@ -259,7 +259,7 @@
         const hideModalConfirmation = Lockr.get(LESSON_VISIBILITY_MODAL_DISMISSED);
         this.activeLesson = lesson;
         if (!hideModalConfirmation) {
-          if (lesson.active) {
+          if (lesson.is_active) {
             this.showLessonIsVisibleModal = false;
             this.showLessonIsNotVisibleModal = true;
           } else {


### PR DESCRIPTION
## Summary

Not actually a string regression, rather an uncaught bug, but... a quick fix! 

## References
Fixes #10236 

Now, a currently visible lesson under the "plan" tab displays the "make lesson not visible" state 

![Screenshot 2023-03-14 at 2 12 46 PM](https://user-images.githubusercontent.com/17235236/225099128-7237c183-4c9b-432a-853e-b7f37cc93733.png)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
