### PR TITLE
Handle network problems when merging users

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -62,6 +62,7 @@
         if (this.role === 'learner') return '';
         return this.$tr('changeFacilityInfoLine2', {
           role: this.role,
+          facility: this.targetFacility.name,
         });
       },
       thirdLine() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -182,7 +182,6 @@
                     isTaskRequested = false;
                   })
                   .catch(error => {
-                    console.log('-- error starting task', error);
                     if (error.response.status === 400) {
                       const message = get(error.response, 'data[0].metadata.message', '');
                       if (
@@ -194,6 +193,11 @@
                       } else {
                         // if the request is bad, we can't do anything
                         changeFacilityService.send('TASKERROR');
+                      }
+                    } else if (error.response.status == 500) {
+                      const message = error.response.data;
+                      if (message.includes('ConnectionError')) {
+                        taskError.value = true;
                       }
                     }
                   });
@@ -269,7 +273,7 @@
           const targetUsername = get(state, 'value.targetAccount.username', '');
           const currentUsername = get(state, 'value.username', '');
           let errorString = 'failedTaskError';
-          if (get(task, 'value.status', '') !== TaskStatuses.FAILED) {
+          if (task.value !== null && get(task, 'value.status', '') !== TaskStatuses.FAILED) {
             errorString = targetUsername !== currentUsername ? 'userExistsError' : 'userAdminError';
           }
           return this.$tr(errorString, {

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -1,5 +1,6 @@
 import requests
 from django.core.management import call_command
+from morango.errors import MorangoError
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.status import HTTP_201_CREATED
@@ -10,6 +11,7 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.tasks import PeerImportSingleSyncJobValidator
 from kolibri.core.auth.utils.migrate import merge_users
 from kolibri.core.device.models import DevicePermissions
+from kolibri.core.device.utils import set_device_settings
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.job import JobStatus
 from kolibri.core.tasks.job import Priority
@@ -106,16 +108,33 @@ def mergeuser(command, **kwargs):
 
     local_user_id = kwargs.pop("local_user_id")
     local_user = FacilityUser.objects.get(id=local_user_id)
+    job = get_current_job()
+
     # Sync with the server to get the remote user:
     kwargs["no_push"] = True
-    call_command(command, **kwargs)
+    try:
+        call_command(command, **kwargs)
+    except MorangoError:
+        # error syncing with the server, probably a networking issue
+        job.storage.mark_job_as_failed(job.job_id, MorangoError, "")
+        raise
 
     remote_user = FacilityUser.objects.get(id=kwargs["user"])
     merge_users(local_user, remote_user)
+    set_device_settings(subset_of_users_device=True)
 
     # Resync with the server to update the merged records
     del kwargs["no_push"]
-    call_command("sync", **kwargs)
+
+    try:
+        call_command(command, **kwargs)
+    except MorangoError:
+        # error syncing with the server, probably a networking issue
+        # syncing will happen later in scheduled syncs
+        from kolibri.core.auth.tasks import begin_request_soud_sync
+
+        begin_request_soud_sync(kwargs["baseurl"], remote_user.id)
+
     new_superuser_id = kwargs.get("new_superuser_id")
     if new_superuser_id:
         new_superuser = FacilityUser.objects.get(id=new_superuser_id)
@@ -125,7 +144,6 @@ def mergeuser(command, **kwargs):
             user=new_superuser, is_superuser=True, can_manage_content=True
         )
 
-    job = get_current_job()
     # create token to validate user in the new facility
     # after it's deleted in the current facility:
     remote_user_pk = job.kwargs["user"]

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -116,7 +116,6 @@ def mergeuser(command, **kwargs):
         call_command(command, **kwargs)
     except MorangoError:
         # error syncing with the server, probably a networking issue
-        job.storage.mark_job_as_failed(job.job_id, MorangoError, "")
         raise
 
     remote_user = FacilityUser.objects.get(id=kwargs["user"])


### PR DESCRIPTION
## Summary

When trying to move one user to another facility device network errors could happen:
1. before the merge has actually happened
2. after the merge has happened

For case 1, this PR just stop the process and show an error message to the user
For case 2, this PR schedules a new sync and inform the user the merge has happened

![error_merge](https://user-images.githubusercontent.com/1008178/225126019-6ac74050-00a9-462c-a900-7d3703fc7e02.png)


## References
Closes: #9792 @pcenov 

## Reviewer guidance
Prepare an scenario with two kolibri devices running and start the merge project.
Stop it after the process has begun and check things happen as this PR summary states

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
