### PR TITLE
adds ability to explore channel on 'Explore Libraries' page

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -55,7 +55,7 @@
           :title="channel.name"
           :tagline="channel.tagline || channel.description"
           :thumbnail="channel.thumbnail"
-          :link="{}"
+          :link="genContentLinkBackLinkCurrentPage(channel.id)"
           :version="channel.version"
         />
       </KGridItem>
@@ -69,6 +69,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
+  import useContentLink from '../../composables/useContentLink';
   import ChannelCard from '../ChannelCard';
   import { PageNames } from '../../constants';
 
@@ -79,9 +80,11 @@
     },
     mixins: [commonCoreStrings],
     setup() {
+      const { genContentLinkBackLinkCurrentPage } = useContentLink();
       const { windowIsSmall } = useKResponsiveWindow();
 
       return {
+        genContentLinkBackLinkCurrentPage,
         windowIsSmall,
       };
     },

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -55,7 +55,7 @@
           :title="channel.name"
           :tagline="channel.tagline || channel.description"
           :thumbnail="channel.thumbnail"
-          :link="genContentLinkBackLinkCurrentPage(channel.id)"
+          :link="genContentLinkBackLinkCurrentPage(channel.root)"
           :version="channel.version"
         />
       </KGridItem>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds routing links to the existing channels displayed on the new `Explore Libraries` page. Please note that the existing `LibraryPage` is reused to view a particular library. As such, the logic to explore a channel is already present thus no updates are required.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes https://github.com/learningequality/kolibri/issues/9855

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Go to `/learn/#/explore_libraries` via the address bar
- Click on any `Channel` and you should be able to explore the channel.
Please note that this works only for remote or local devices but not channels in Kolibri Studio due to https://github.com/learningequality/kolibri/pull/10227#pullrequestreview-1335522139

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
