### PR TITLE
Fix string references.

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
@@ -28,7 +28,7 @@
       <KButton
         id="select-address-button"
         appearance="basic-link"
-        :text="coreString('addNewAddressAction')"
+        :text="getCommonSyncString('addNewAddressAction')"
         @click="showSelectAddressModal = true"
       />
 

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -40,7 +40,7 @@
       <KGridItem>{{ $tr('doNotSeeYourFacility') }}</KGridItem>
       <KGridItem>
         <KButton
-          :text="coreString('addNewAddressAction')"
+          :text="getCommonSyncString('addNewAddressAction')"
           appearance="basic-link"
           @click="showAddAddressModal = true"
         />
@@ -80,6 +80,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import useMinimumKolibriVersion from 'kolibri.coreVue.composables.useMinimumKolibriVersion';
   import { AddDeviceForm, useDevices, useDeviceDeletion } from 'kolibri.coreVue.componentSets.sync';
+  import commonProfileStrings from '../commonProfileStrings';
 
   export default {
     name: 'SelectFacility',
@@ -90,7 +91,7 @@
     },
     components: { AddDeviceForm, BottomAppBar },
 
-    mixins: [commonCoreStrings, commonSyncElements],
+    mixins: [commonCoreStrings, commonSyncElements, commonProfileStrings],
     setup() {
       const {
         devices: _devices,

--- a/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
@@ -110,10 +110,10 @@
       </CoreTable>
       <KModal
         v-if="deviceModal"
-        :title="coreString('selectNetworkAddressTitle')"
+        :title="getCommonSyncString('selectNetworkAddressTitle')"
         size="medium"
         :submitText="coreString('continueAction')"
-        :cancelText="coreSrring('cancelAction')"
+        :cancelText="coreString('cancelAction')"
         @cancel="closeModal"
         @submit="submitModal(radioBtnValue)"
       >
@@ -185,6 +185,7 @@
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import { TaskResource, FacilityResource, NetworkLocationResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { PageNames } from '../../../../kolibri/plugins/facility/assets/src/constants';
   import AddDeviceForm from '../../../../kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue';
 
@@ -196,7 +197,7 @@
       AddDeviceForm,
     },
     extends: ImmersivePage,
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonSyncElements],
     data() {
       return {
         deviceModal: false,


### PR DESCRIPTION
## Summary
* Fixes some string references that were still to coreStrings but should have been to commonSyncStrings
* Fixes typo in coreStrings
* Adds profileStrings mixin to SelectFacility.vue that was missing it

## References
Fixes missing strings noted in https://github.com/learningequality/kolibri/pull/10247#issuecomment-1470099760

