### PR TITLE
Fix truncated titles on mobile view

### DIFF
--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -141,7 +141,7 @@
 
   /deep/ .ui-toolbar__left {
     margin-left: 5px;
-    overflow-x: clip;
+    overflow: hidden;
   }
 
   /deep/ .ui-toolbar__nav-icon {

--- a/kolibri/core/assets/src/views/ImmersiveToolbar.vue
+++ b/kolibri/core/assets/src/views/ImmersiveToolbar.vue
@@ -139,4 +139,17 @@
     outline-offset: -4px;
   }
 
+  /deep/ .ui-toolbar__left {
+    margin-left: 5px;
+    overflow-x: clip;
+  }
+
+  /deep/ .ui-toolbar__nav-icon {
+    margin-left: 0;
+  }
+
+  /deep/ .ui-toolbar__title {
+    text-overflow: ellipsis;
+  }
+
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -503,6 +503,7 @@
   }
 
   /deep/ .ui-toolbar__left {
+    margin-left: 10px;
     overflow-x: hidden;
   }
 
@@ -511,7 +512,7 @@
   }
 
   /deep/ .ui-toolbar__nav-icon {
-    margin-left: -0.7rem; // prevents icon cutoff
+    margin-left: 0; // prevents icon cutoff
   }
 
   /deep/ .ui-toolbar__body {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -502,6 +502,18 @@
     min-width: 0;
   }
 
+  /deep/ .ui-toolbar__left {
+    overflow-x: hidden;
+  }
+
+  /deep/ .ui-toolbar__right {
+    display: flex;
+  }
+
+  /deep/ .ui-toolbar__nav-icon {
+    margin-left: -0.7rem; // prevents icon cutoff
+  }
+
   /deep/ .ui-toolbar__body {
     flex-grow: 0; // make sure that the completion icon is right next to the title
     align-items: center;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -503,8 +503,8 @@
   }
 
   /deep/ .ui-toolbar__left {
-    margin-left: 10px;
-    overflow-x: hidden;
+    margin-left: 5px;
+    overflow-x: clip;
   }
 
   /deep/ .ui-toolbar__right {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -504,7 +504,7 @@
 
   /deep/ .ui-toolbar__left {
     margin-left: 5px;
-    overflow-x: clip;
+    overflow: hidden;
   }
 
   /deep/ .ui-toolbar__right {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR fixes the resource titles not being truncated on mobile views and adjusts the button placement on smaller screen sizes.


Correctly truncated title on mobile view
<img width="611" alt="Screenshot 2023-03-14 at 4 36 43 PM" src="https://user-images.githubusercontent.com/46411498/225446697-1393cd28-c2d0-448e-9a32-467a9f37b0f0.png">
--------------
<img width="571" alt="Screenshot 2023-03-14 at 4 36 51 PM" src="https://user-images.githubusercontent.com/46411498/225446718-e4688c6e-7a80-4e57-b36b-a7d196356309.png">



Before: `next steps` and `more options` button placement
<img width="652" alt="Screenshot 2023-03-14 at 4 20 36 PM" src="https://user-images.githubusercontent.com/46411498/225446859-9711cfba-6648-4dea-b5b1-224b728cf253.png">
-------------
<img width="589" alt="Screenshot 2023-03-14 at 4 21 09 PM" src="https://user-images.githubusercontent.com/46411498/225446966-23d644cc-95f3-4f23-a292-ae04c52b155e.png">

After: `next steps` and `more options` button placement
<img width="626" alt="Screenshot 2023-03-14 at 4 20 48 PM" src="https://user-images.githubusercontent.com/46411498/225446999-899537ca-811b-4471-80e4-1c10fa5c0d49.png">
------------
<img width="595" alt="Screenshot 2023-03-14 at 4 21 18 PM" src="https://user-images.githubusercontent.com/46411498/225447022-1aea577d-5a79-4c8a-845a-20422809bd7e.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9624 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Go to the Library and select a channel resource with a long title.
2. Using Chrome's dev tools emulator, select a mobile dimension.
3. Ensure that the title cuts off with an ellipsis (...).
4. Select responsive dimension and confirm correct button placement.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
