### PR TITLE
Setup wizard import task cancellation fixes

### DIFF
--- a/kolibri/core/assets/src/api-resources/task.js
+++ b/kolibri/core/assets/src/api-resources/task.js
@@ -11,7 +11,7 @@ export default new Resource({
     return this.create(tasks, multipart);
   },
 
-  cancelTask(jobId) {
+  cancel(jobId) {
     return this.postDetailEndpoint('cancel', jobId);
   },
 

--- a/kolibri/core/assets/src/utils/syncTaskUtils.js
+++ b/kolibri/core/assets/src/utils/syncTaskUtils.js
@@ -230,5 +230,7 @@ export function importLodTaskDisplayInfo(task) {
       fullname: task.extra_metadata.username,
     });
   }
+  info.canRetry = false;
+  info.canClear = false;
   return info;
 }

--- a/kolibri/core/assets/src/views/sync/FacilityTaskPanel.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityTaskPanel.vue
@@ -9,9 +9,9 @@
     :loaderType="loaderType"
     :showCircularLoader="taskInfo.isRunning"
     :buttonSet="buttonSet"
-    @cancel="$emit('click', 'cancel')"
-    @clear="$emit('click', 'clear')"
-    @retry="$emit('click', 'retry')"
+    @cancel="$emit('cancel')"
+    @clear="$emit('clear')"
+    @retry="$emit('retry')"
   />
 
 </template>

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -835,7 +835,7 @@ class PeerImportSingleSyncJobValidator(PeerSyncJobValidator):
 
 @register_task(
     validator=PeerImportSingleSyncJobValidator,
-    cancellable=True,
+    cancellable=False,
     track_progress=True,
     queue=soud_sync_queue,
     permission_classes=[IsSuperAdmin() | NotProvisioned()],

--- a/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/actions/taskActions.js
@@ -20,7 +20,7 @@ export function cancelTask(store, taskId) {
         TaskResource.clear(taskId).then(resolve);
       }
     );
-    TaskResource.cancelTask(taskId);
+    TaskResource.cancel(taskId);
   });
 }
 

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilitiesTasksPage.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/FacilitiesTasksPage.vue
@@ -27,7 +27,9 @@
           class="task-panel"
           :style="{ borderBottomColor: $themePalette.grey.v_200 }"
           :task="task"
-          @click="handlePanelClick($event, task)"
+          @cancel="cancel(task)"
+          @clear="clear(task)"
+          @retry="retry(task)"
         />
       </div>
     </KPageContainer>
@@ -38,6 +40,7 @@
 
 <script>
 
+  import { TaskResource } from 'kolibri.resources';
   import { FacilityTaskPanel } from 'kolibri.coreVue.componentSets.sync';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonTaskStrings from 'kolibri.coreVue.mixins.commonTaskStrings';
@@ -84,10 +87,14 @@
       handleClickClearAll() {
         this.clearCompletedFacilityTasks();
       },
-      handlePanelClick(action, task) {
-        this.manageFacilityTask(action, task).catch(() => {
-          // handle errors silently
-        });
+      cancel(task) {
+        return TaskResource.cancel(task.id);
+      },
+      clear(task) {
+        return TaskResource.clear(task.id);
+      },
+      retry(task) {
+        return TaskResource.restart(task.id);
       },
     },
     $trs: {

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
@@ -30,17 +30,6 @@ export default {
         }
       });
     },
-    manageFacilityTask(action, task) {
-      if (action === 'cancel') {
-        return TaskResource.cancel(task.id);
-      } else if (action === 'clear') {
-        return TaskResource.clear(task.id);
-      } else if (action === 'retry') {
-        return TaskResource.restart(task.id);
-      } else {
-        return Promise.resolve();
-      }
-    },
     clearCompletedFacilityTasks() {
       return TaskResource.clearAll('facility_task');
     },

--- a/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageTasksPage/index.vue
@@ -129,7 +129,7 @@
         });
       },
       handleClickCancel(task) {
-        TaskResource.cancelTask(task.id);
+        TaskResource.cancel(task.id);
       },
       handleClickClearAll() {
         TaskResource.clearAll();


### PR DESCRIPTION
## Summary
* Changes the `TaskResource` method for cancelling tasks to just `cancel` (which some parts of the code were already using, even though it didn't exist) - and fixes all references to the old `cancelTask`
* Rationalizes the event API of FacilityTaskPanel to emit separate events for cancel, retry, and clear
* Hides retry and clear from  LODimport tasks (this should perhaps be implemented differently in future though)
* Makes the LOD import task uncancelable, because it will almost always finish too quickly for a user to catch it, so will just complete instead

## References
Fixes #10242

## Reviewer guidance
Create a new LOD user on a remote device. Do the import, see that it no longer gives you the option to cancel, and that 'clear' is not displayed once it has finished.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
