### PR TITLE
Allows superusers and those with can_manage_content permision to access '/ispinvalid' API resource

### DIFF
--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -6,6 +6,7 @@ from .api import FacilityDatasetViewSet
 from .api import FacilityUsernameViewSet
 from .api import FacilityUserViewSet
 from .api import FacilityViewSet
+from .api import IsPINValidView
 from .api import LearnerGroupViewSet
 from .api import MembershipViewSet
 from .api import RoleViewSet
@@ -48,6 +49,11 @@ urlpatterns = (
             r"^usernameavailable$",
             UsernameAvailableView.as_view(),
             name="usernameavailable",
+        ),
+        url(
+            r"^ispinvalid/(?P<pk>[a-f0-9]{32})$",
+            IsPINValidView.as_view(),
+            name="ispinvalid",
         ),
     ]
 )

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1273,15 +1273,6 @@ class FacilityDatasetAPITestCase(APITestCase):
             payload,
         )
 
-    def is_pin_valid(self, payload):
-        return self.client.post(
-            reverse(
-                "kolibri:core:facilitydataset-is-pin-valid",
-                kwargs={"pk": self.facility.dataset_id},
-            ),
-            payload,
-        )
-
     def test_return_all_datasets_for_an_admin(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.get(reverse("kolibri:core:facilitydataset-list"))
@@ -1477,6 +1468,35 @@ class FacilityDatasetAPITestCase(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["extra_fields"]["pin_code"], None)
+
+
+class IsPINValidAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.admin = FacilityUserFactory.create(facility=cls.facility)
+        cls.user = FacilityUserFactory.create(facility=cls.facility)
+        cls.facility.add_admin(cls.admin)
+
+    def update_pin(self, payload):
+        return self.client.post(
+            reverse(
+                "kolibri:core:facilitydataset-update-pin",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            payload,
+        )
+
+    def is_pin_valid(self, payload):
+        return self.client.post(
+            reverse(
+                "kolibri:core:ispinvalid",
+                kwargs={"pk": self.facility.dataset_id},
+            ),
+            payload,
+        )
 
     def test_facility_admin_can_check_is_pin_valid_correct_pin(self):
         self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -27,7 +27,7 @@ class DeviceManagementModule extends KolibriApp {
     const isSuperuser = store.getters.isSuperuser;
     const isFacilityAdmin = store.getters.isFacilityAdmin;
     const userCanManageContent = store.getters.canManageContent;
-    if (!isLearnOnlyDevice && isFacilityAdmin && (isSuperuser || userCanManageContent)) {
+    if (isLearnOnlyDevice && !isFacilityAdmin && (isSuperuser || userCanManageContent)) {
       //While browsing within the device plugin, prevent expiry.
       //On page refresh within plugin, show pin prompt if cookie has expired.
       viewPlugin = viewPlugin ? viewPlugin : this.isPinAuthenticated;

--- a/kolibri/plugins/device/assets/src/app.js
+++ b/kolibri/plugins/device/assets/src/app.js
@@ -7,6 +7,8 @@ import pluginModule from './modules/pluginModule';
 import KolibriApp from 'kolibri_app';
 import plugin_data from 'plugin_data';
 
+let viewPlugin = false;
+
 class DeviceManagementModule extends KolibriApp {
   get routes() {
     return routes;
@@ -17,20 +19,25 @@ class DeviceManagementModule extends KolibriApp {
   get pluginModule() {
     return pluginModule;
   }
-  checkIfPinAuthenticationIsRequired(store, next) {
+  get isPinAuthenticated() {
+    return Cookies.get(IsPinAuthenticated) === 'true';
+  }
+  checkIfPinAuthenticationIsRequired(store, grantPluginAccess) {
     const isLearnOnlyDevice = plugin_data.isSubsetOfUsersDevice;
     const isSuperuser = store.getters.isSuperuser;
     const isFacilityAdmin = store.getters.isFacilityAdmin;
     const userCanManageContent = store.getters.canManageContent;
-    if (isLearnOnlyDevice && !isFacilityAdmin && (isSuperuser || userCanManageContent)) {
-      const authenticated = Cookies.get(IsPinAuthenticated) === 'true';
-      if (authenticated) {
-        next(true);
+    if (!isLearnOnlyDevice && isFacilityAdmin && (isSuperuser || userCanManageContent)) {
+      //While browsing within the device plugin, prevent expiry.
+      //On page refresh within plugin, show pin prompt if cookie has expired.
+      viewPlugin = viewPlugin ? viewPlugin : this.isPinAuthenticated;
+      if (viewPlugin) {
+        grantPluginAccess();
       } else {
-        store.dispatch('displayPinModal', next);
+        store.dispatch('displayPinModal', grantPluginAccess);
       }
     } else {
-      next(true);
+      grantPluginAccess();
     }
   }
   ready() {
@@ -45,7 +52,10 @@ class DeviceManagementModule extends KolibriApp {
       this.store.dispatch('resetModuleState', { toRoute, fromRoute });
     });
     router.beforeResolve((to, from, next) => {
-      this.checkIfPinAuthenticationIsRequired(this.store, next);
+      this.checkIfPinAuthenticationIsRequired(this.store, function() {
+        viewPlugin = true;
+        next();
+      });
     });
     super.ready();
   }

--- a/kolibri/plugins/device/assets/src/views/PinAuthenticationModal.vue
+++ b/kolibri/plugins/device/assets/src/views/PinAuthenticationModal.vue
@@ -11,6 +11,7 @@
       ref="pinFocus"
       v-model="pin"
       input="number"
+      type="password"
       :label="$tr('pinPlaceholder')"
       :maxlength="4"
       :invalid="showErrorText"

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/actions.js
@@ -81,7 +81,7 @@ export function unsetPin(store) {
 export function isPinValid(store, payload) {
   const { facilityDatasetId } = store.state;
   return client({
-    url: urls['kolibri:core:facilitydataset-is-pin-valid'](facilityDatasetId),
+    url: urls['kolibri:core:ispinvalid'](facilityDatasetId),
     method: 'POST',
     data: payload,
   }).then(({ data }) => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes issues raised [here](https://github.com/learningequality/kolibri/issues/10238) related to the device management pin feature picked up during manual QA. The `/ispinvalid`(previously `/is-pin-valid` before this fix) resource has been updated to allow access to both superusers and users with the `can_manage_content` permission.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10238 https://github.com/learningequality/kolibri/issues/10275

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Please see https://github.com/learningequality/kolibri/pull/10135

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
