### PR TITLE
Temporarily disable raspberry pi image generation for releases

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -46,13 +46,6 @@ jobs:
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}
-  zip:
-    name: Build Raspberry Pi Image
-    needs: deb
-    uses: learningequality/pi-gen/.github/workflows/build_zip.yml@master
-    with:
-      deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: master
   test_pypi_upload:
     name: Upload to TestPyPi
     needs: whl
@@ -69,7 +62,7 @@ jobs:
   github_upload:
     name: Upload to Github release
     runs-on: ubuntu-latest
-    needs: [whl, pex, dmg, deb, exe, zip]
+    needs: [whl, pex, dmg, deb, exe]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/github-script@v6
@@ -82,7 +75,6 @@ jobs:
               '${{ needs.dmg.outputs.dmg-file-name }}',
               '${{ needs.deb.outputs.deb-file-name }}',
               '${{ needs.exe.outputs.exe-file-name }}',
-              '${{ needs.zip.outputs.zip-file-name }}',
             ]
             for (let filename of filesToUpload) {
               await utils.uploadReleaseAsset(github, context, filename, '${{ github.event.release.release_id }}')
@@ -116,7 +108,7 @@ jobs:
     name: Upload to Google Cloud Storage
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    needs: [block_release_step, whl, pex, dmg, deb, exe, zip]
+    needs: [block_release_step, whl, pex, dmg, deb, exe]
     steps:
     - name: Download all artifacts
       uses: actions/download-artifact@v3


### PR DESCRIPTION
## Summary
* Currently the debian build on GHA does not produce deb files with back compatible compression, which breaks the Pi image build