### PR TITLE
Tweak asset upload for github releases.

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 
 
 const file_manifest = {
@@ -128,8 +129,9 @@ async function findComment(github, context, issue_number) {
   }
 }
 
-async function uploadReleaseAsset(github, context, name, release_id) {
-  const extension = name.split('.').pop()
+async function uploadReleaseAsset(github, context, filePath, release_id) {
+  const name = path.basename(filePath);
+  const extension = path.extname(name)
   const label = (file_manifest[extension] || {}).description || name
   await github.rest.repos.uploadReleaseAsset({
     owner: context.repo.owner,
@@ -137,7 +139,7 @@ async function uploadReleaseAsset(github, context, name, release_id) {
     release_id,
     name,
     label,
-    data: fs.readFileSync(name),
+    data: fs.readFileSync(filePath),
   });
 }
 

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -65,19 +65,23 @@ jobs:
     needs: [whl, pex, dmg, deb, exe]
     steps:
       - uses: actions/checkout@v3
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
       - uses: actions/github-script@v6
         with:
           script: |
             const utils = require('./.github/githubUtils.js')
             const filesToUpload = [
-              '${{ needs.whl.outputs.whl-file-name }}',
-              '${{ needs.pex.outputs.pex-file-name }}',
-              '${{ needs.dmg.outputs.dmg-file-name }}',
-              '${{ needs.deb.outputs.deb-file-name }}',
-              '${{ needs.exe.outputs.exe-file-name }}',
+              'dist/${{ needs.whl.outputs.whl-file-name }}',
+              'dist/${{ needs.pex.outputs.pex-file-name }}',
+              'dist/${{ needs.dmg.outputs.dmg-file-name }}',
+              'dist/${{ needs.deb.outputs.deb-file-name }}',
+              'dist/${{ needs.exe.outputs.exe-file-name }}',
             ]
-            for (let filename of filesToUpload) {
-              await utils.uploadReleaseAsset(github, context, filename, '${{ github.event.release.release_id }}')
+            for (let filePath of filesToUpload) {
+              await utils.uploadReleaseAsset(github, context, filePath, '${{ github.event.release.release_id }}')
             }
   block_release_step:
   # This step ties to the release environment which requires manual approval


### PR DESCRIPTION
## Summary
* Downloads assets before upload
* Gives filepaths for upload rather than filenames
* Uses nodejs path to appropriately massage the filepaths for use