### PR TITLE
Fix typo to remove unicode character that was breaking Py2.7

### DIFF
--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -12,7 +12,7 @@ from kolibri.core.utils.urls import reverse_remote
 
 class OnMyOwnSetupViewset(APIView):
     """
-    Viewset to determine if the facility has been setup as an "On my own setup" facoñotu.
+    Viewset to determine if the facility has been setup as an "On my own setup" facility.
     """
 
     def get(self, request, format=None):


### PR DESCRIPTION
## Summary
Fixes typo to remove `ñ` that was breaking Py2.7 because of no declared encoding

## References
Fixes https://github.com/learningequality/kolibri/issues/10269

## Reviewer guidance
I was tempted to add appropriate encoding to every single Python file in our codebase, but that seemed excessive, and unwarranted given our deprecation notices for Py2.7 in this upcoming release.

To test, run Kolibri in py2.7 and see the error in the issue does not appear.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
