### PR TITLE
Normalize use of BACK in setup wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -43,7 +43,7 @@ import { DeviceTypePresets, FacilityTypePresets, LodTypePresets, UsePresets } fr
  */
 
 /* eslint-disable-next-line */
-import { assign, createMachine } from 'xstate';
+import { assign, createMachine, send } from 'xstate';
 
 // NOTE: Uncomment the following function if you're using the visualizer
 // const checkCapability = capabilityToCheck => ["get_os_user"].includes(capabilityToCheck);
@@ -68,6 +68,445 @@ const initialContext = {
   importedUsers: [],
   firstImportedLodUser: null,
   facilitiesOnDeviceCount: null,
+  history: [],
+};
+
+const pushHistoryItem = assign({
+  history: (context, event) => [...context.history, event.value],
+});
+
+const removeLastHistoryItem = assign({
+  history: context => {
+    if (context.history.length) {
+      return context.history.slice(0, -1);
+    } else {
+      return [];
+    }
+  },
+});
+const setCanGetOsUser = assign({
+  canGetOsUser: (_, event) => event.value,
+});
+const setOnMyOwnOrGroup = assign({
+  onMyOwnOrGroup: (_, event) => event.value,
+});
+const setSuperuser = assign({
+  superuser: (_, event) => {
+    return event.value;
+  },
+});
+
+const setDeviceName = assign({
+  deviceName: (_, event) => event.value,
+});
+const setFullOrLOD = assign({
+  fullOrLOD: (_, event) => event.value,
+});
+const setFacilityNewOrImport = assign({
+  facilityNewOrImport: (_, event) => {
+    return event.value.importOrNew;
+  },
+  importDeviceId: (_, event) => {
+    return event.value.importDeviceId;
+  },
+});
+const setFacilityTypeAndName = assign({
+  formalOrNonformal: (_, event) => event.value.selected,
+  facilityName: (_, event) => event.value.facilityName,
+});
+const setGuestAccess = assign({
+  guestAccess: (_, event) => event.value,
+});
+const setLearnerCanCreateAccount = assign({
+  learnerCanCreateAccount: (_, event) => event.value,
+});
+const setRequirePassword = assign({
+  requirePassword: (_, event) => event.value,
+});
+const states = {
+  // This state will be the start so the machine won't progress until
+  // the setCanGetOsUser is run to set the context.canGetOsUser value
+  initializeContext: {
+    on: {
+      CONTINUE: {
+        target: 'howAreYouUsingKolibri',
+        actions: [setCanGetOsUser, send({ type: 'PUSH_HISTORY', value: 'initializeContext' })],
+      },
+    },
+  },
+  // Initial step where user selects between "On my own" or "Group learning"
+  howAreYouUsingKolibri: {
+    meta: { route: { name: 'HOW_ARE_YOU_USING_KOLIBRI', path: '/' } },
+    on: {
+      CONTINUE: {
+        target: 'onMyOwnOrGroupSetup',
+        actions: [
+          setOnMyOwnOrGroup,
+          send({ type: 'PUSH_HISTORY', value: 'howAreYouUsingKolibri' }),
+        ],
+      },
+    },
+  },
+  // A passthrough step depending on the value of context.onMyOwnOrGroup
+  onMyOwnOrGroupSetup: {
+    always: [
+      {
+        // `cond` takes a function that returns a Boolean, continuing to the
+        // `target` when it returns truthy
+        cond: 'isOnMyOwnOrGroup',
+        target: 'defaultLanguage',
+      },
+      {
+        cond: 'isGroupSetup',
+        target: 'deviceName',
+      },
+      // There is no fallback path here; if neither `cond` above is truthy, this will break
+    ],
+  },
+
+  // The On My Own path
+  defaultLanguage: {
+    meta: { route: { name: 'DEFAULT_LANGUAGE', path: 'default-language' } },
+    on: {
+      CONTINUE: {
+        target: 'createAccountOrFinalizeSetup',
+        actions: [send({ type: 'PUSH_HISTORY', value: 'defaultLanguage' })],
+      },
+    },
+  },
+  // A passthrough step depending on the value of context.canGetOsUser
+  createAccountOrFinalizeSetup: {
+    always: [
+      {
+        cond: 'canGetOsUser',
+        target: 'finalizeSetup',
+      },
+      {
+        target: 'createOnMyOwnAccount',
+      },
+    ],
+  },
+
+  createOnMyOwnAccount: {
+    meta: { route: { name: 'CREATE_SUPERUSER_AND_FACILITY', path: 'create-account' } },
+    on: {
+      CONTINUE: {
+        target: 'finalizeSetup',
+        actions: [setSuperuser, send({ type: 'PUSH_HISTORY', value: 'createOnMyOwnAccount' })],
+      },
+    },
+  },
+
+  // The Group path
+  deviceName: {
+    meta: { route: { name: 'DEVICE_NAME', path: 'device-name' } },
+    on: {
+      CONTINUE: {
+        target: 'fullOrLearnOnlyDevice',
+        actions: [setDeviceName, send({ type: 'PUSH_HISTORY', value: 'deviceName' })],
+      },
+    },
+  },
+  fullOrLearnOnlyDevice: {
+    id: 'fullOrLearnOnlyDevice',
+    meta: { route: { name: 'FULL_OR_LOD', path: 'full-or-lod' } },
+    on: {
+      CONTINUE: {
+        target: 'fullOrLodSetup',
+        actions: [setFullOrLOD, send({ type: 'PUSH_HISTORY', value: 'fullOrLearnOnlyDevice' })],
+      },
+    },
+  },
+
+  // A passthrough step depending on the value of context.fullOrLOD
+  // that either continues along with full device setup, or into the Lod setup
+  fullOrLodSetup: {
+    always: [
+      {
+        cond: 'isLodSetup',
+        target: 'importLodUsers',
+      },
+      {
+        cond: 'isFullSetup',
+        target: 'fullDeviceNewOrImportFacility',
+      },
+    ],
+  },
+
+  // Full Device Path
+  fullDeviceNewOrImportFacility: {
+    meta: { route: { name: 'FULL_NEW_OR_IMPORT_FACILITY' } },
+    on: {
+      CONTINUE: {
+        target: 'facilitySetupType',
+        actions: [
+          setFacilityNewOrImport,
+          send({ type: 'PUSH_HISTORY', value: 'fullDeviceNewOrImportFacility' }),
+        ],
+      },
+    },
+  },
+
+  // A passthrough step depending on whether the user is creating a new facility or importing
+  facilitySetupType: {
+    always: [
+      {
+        cond: 'isNewFacility',
+        target: 'setFacilityPermissions',
+      },
+      {
+        cond: 'isImportFacility',
+        target: 'importFacility',
+      },
+    ],
+  },
+
+  // Facility Creation Path
+  setFacilityPermissions: {
+    meta: { route: { name: 'FACILITY_PERMISSIONS' } },
+    on: {
+      CONTINUE: {
+        target: 'guestAccess',
+        actions: [
+          setFacilityTypeAndName,
+          send({ type: 'PUSH_HISTORY', value: 'setFacilityPermissions' }),
+        ],
+      },
+    },
+  },
+  guestAccess: {
+    meta: { route: { name: 'GUEST_ACCESS' } },
+    on: {
+      CONTINUE: {
+        target: 'createLearnerAccount',
+        actions: [setGuestAccess, send({ type: 'PUSH_HISTORY', value: 'guestAccess' })],
+      },
+    },
+  },
+  createLearnerAccount: {
+    meta: { route: { name: 'CREATE_LEARNER_ACCOUNT' } },
+    on: {
+      CONTINUE: {
+        target: 'requirePassword',
+        actions: [
+          setLearnerCanCreateAccount,
+          send({ type: 'PUSH_HISTORY', value: 'createLearnerAccount' }),
+        ],
+      },
+    },
+  },
+  requirePassword: {
+    meta: { route: { name: 'REQUIRE_PASSWORD' } },
+    on: {
+      CONTINUE: {
+        target: 'personalDataConsent',
+        actions: [setRequirePassword, send({ type: 'PUSH_HISTORY', value: 'requirePassword' })],
+      },
+    },
+  },
+  personalDataConsent: {
+    /**
+     * nextEvent here is used to provide the Vue component what command it is expected to send
+     * in this particular case
+     **/
+    meta: { route: { name: 'PERSONAL_DATA_CONSENT' }, nextEvent: 'CONTINUE' },
+    on: {
+      CONTINUE: {
+        target: 'createSuperuserAndFacility',
+        actions: [send({ type: 'PUSH_HISTORY', value: 'personalDataConsent' })],
+      },
+    },
+  },
+  // A passthrough step depending on the value of context.canGetOsUser - the finalizeSetup state
+  // will provision the device with the OS user and create the default facility
+  createSuperuserAndFacility: {
+    always: [
+      {
+        cond: 'canGetOsUser',
+        target: 'finalizeSetup',
+      },
+      {
+        target: 'createSuperuserAndFacilityForm',
+      },
+    ],
+  },
+
+  // If we're not able to get an OS user, the user creates their account
+  createSuperuserAndFacilityForm: {
+    meta: { route: { name: 'CREATE_SUPERUSER_AND_FACILITY', path: 'create-account' } },
+    on: {
+      CONTINUE: {
+        target: 'finalizeSetup',
+        actions: [
+          setSuperuser,
+          send({ type: 'PUSH_HISTORY', value: 'createSuperuserAndFacilityForm' }),
+        ],
+      },
+    },
+  },
+
+  // It's own little baby state machine
+  importFacility: {
+    initial: 'selectFacilityForm',
+    states: {
+      selectFacilityForm: {
+        meta: { route: { name: 'SELECT_FACILITY_FOR_IMPORT' } },
+        on: {
+          BACK: {
+            // #<name> points to a state w/ an `id` property; wizard is the root
+            target: '#wizard.fullDeviceNewOrImportFacility',
+            actions: ['clearSelectedSetupType', 'revertFullDeviceImport'],
+          },
+          CONTINUE: {
+            target: 'importAuthentication',
+            actions: 'setSelectedImportDeviceFacility',
+          },
+        },
+      },
+      importAuthentication: {
+        meta: { route: { name: 'IMPORT_AUTHENTICATION' } },
+        on: {
+          BACK: { target: 'selectFacilityForm' },
+          BACK_SKIP_FACILITY_FORM: {
+            target: '#wizard.fullDeviceNewOrImportFacility',
+            actions: ['clearSelectedSetupType', 'revertFullDeviceImport'],
+          },
+          // THE POINT OF NO RETURN
+          CONTINUE: { target: 'loadingTaskPage' },
+        },
+      },
+      loadingTaskPage: {
+        meta: { route: { name: 'IMPORT_LOADING' } },
+        on: {
+          CONTINUE: 'selectSuperAdminAccountForm',
+        },
+      },
+      selectSuperAdminAccountForm: {
+        meta: { route: { name: 'SELECT_ADMIN' } },
+        on: {
+          CONTINUE: {
+            target: 'personalDataConsentForm',
+            nextEvent: 'FINISH',
+            actions: 'setSuperuser',
+          },
+        },
+      },
+      personalDataConsentForm: {
+        meta: { route: { name: 'IMPORT_DATA_CONSENT' }, nextEvent: 'FINISH' },
+        on: {
+          BACK: 'selectSuperAdminAccountForm',
+        },
+      },
+    },
+    // Listener on the importFacility state; typically this would be above `states` but
+    // putting it here flows more with the above as this is the state after the final step
+    on: {
+      FINISH: 'finalizeSetup',
+    },
+  },
+
+  // LOD machine with substates to manage its own steps
+  importLodUsers: {
+    initial: 'selectLodSetupType',
+    states: {
+      selectLodSetupType: {
+        meta: { route: { name: 'LOD_SETUP_TYPE' } },
+        on: {
+          // #<name> points to a state w/ an `id` property; wizard is the root
+          BACK: { target: '#wizard.fullOrLearnOnlyDevice', actions: 'clearFullOrLOD' },
+          CONTINUE: {
+            target: 'selectLodFacility',
+            actions: 'setLodType',
+          },
+        },
+      },
+
+      selectLodFacility: {
+        meta: { route: { name: 'LOD_SELECT_FACILITY' } },
+        on: {
+          BACK: 'selectLodSetupType',
+          CONTINUE: {
+            target: 'lodProceedJoinOrNew',
+            actions: 'setSelectedImportDeviceFacility',
+          },
+        },
+      },
+
+      lodProceedJoinOrNew: {
+        always: [
+          {
+            cond: ctx => ctx.lodImportOrJoin === LodTypePresets.JOIN,
+            target: 'lodJoinFacility',
+          },
+          {
+            target: 'lodImportUserAuth',
+          },
+        ],
+      },
+
+      // IMPORT
+      lodImportUserAuth: {
+        meta: { route: { name: 'LOD_IMPORT_USER_AUTH' } },
+        on: {
+          BACK: 'selectLodSetupType',
+          CONTINUE: { target: 'lodLoading', actions: 'setLodSuperAdmin' },
+          CONTINUEADMIN: {
+            target: 'lodImportAsAdmin',
+            actions: ['setRemoteUsers', 'setLodAdmin'],
+          },
+        },
+      },
+
+      lodLoading: {
+        meta: { route: { name: 'LOD_LOADING_TASK_PAGE' } },
+        on: {
+          SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
+          IMPORT_ANOTHER: 'lodImportUserAuth',
+          // Otherwise send FINISH, which is handled at the root of this sub-machine
+        },
+      },
+
+      lodImportAsAdmin: {
+        meta: { route: { name: 'LOD_IMPORT_AS_ADMIN' } },
+        on: {
+          BACK: 'lodImportUserAuth',
+          LOADING: 'lodLoading',
+          SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
+        },
+      },
+
+      // JOIN
+      lodJoinLoading: {
+        meta: { route: { name: 'LOD_JOIN_LOADING_TASK_PAGE' } },
+        on: {
+          SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
+          IMPORT_ANOTHER: 'lodImportUserAuth',
+          // Otherwise send FINISH, which is handled at the root of this sub-machine
+        },
+      },
+
+      lodJoinFacility: {
+        meta: { route: { name: 'LOD_CREATE_USER_FORM' } },
+        on: {
+          BACK: 'selectLodSetupType',
+          CONTINUE: 'lodJoinLoading',
+        },
+      },
+    },
+    // Listener on the lod import state; typically this would be above `states` but
+    // putting it here flows more with the above as this is the state after the final step
+    on: {
+      SET_SUPERUSER: { actions: 'setSuperuser' },
+      ADD_IMPORTED_USER: { actions: 'addImportedUser' },
+      SET_FIRST_LOD: { actions: 'setFirstLodUser' },
+      FINISH: 'finalizeSetup',
+    },
+  },
+
+  // This is a dead-end where the router will send the user where they need to go
+  finalizeSetup: {
+    meta: { route: { name: 'FINALIZE_SETUP' } },
+  },
 };
 
 export const wizardMachine = createMachine(
@@ -77,355 +516,20 @@ export const wizardMachine = createMachine(
     context: initialContext,
     predictableActionArguments: true,
     on: {
+      PUSH_HISTORY: {
+        actions: [pushHistoryItem],
+      },
+      BACK: Object.keys(states).map(state => {
+        return {
+          target: state,
+          cond: context =>
+            context.history.length && context.history[context.history.length - 1] === state,
+          actions: [removeLastHistoryItem],
+        };
+      }),
       START_OVER: { target: 'howAreYouUsingKolibri', actions: 'resetContext' },
     },
-    states: {
-      // This state will be the start so the machine won't progress until
-      // the setCanGetOsUser is run to set the context.canGetOsUser value
-      initializeContext: {
-        on: {
-          CONTINUE: { target: 'howAreYouUsingKolibri', actions: 'setCanGetOsUser' },
-        },
-      },
-      // Initial step where user selects between "On my own" or "Group learning"
-      howAreYouUsingKolibri: {
-        meta: { route: { name: 'HOW_ARE_YOU_USING_KOLIBRI', path: '/' } },
-        on: {
-          CONTINUE: { target: 'onMyOwnOrGroupSetup', actions: 'setOnMyOwnOrGroup' },
-        },
-      },
-      // A passthrough step depending on the value of context.onMyOwnOrGroup
-      onMyOwnOrGroupSetup: {
-        on: { BACK: 'howAreYouUsingKolibri' },
-        always: [
-          {
-            // `cond` takes a function that returns a Boolean, continuing to the
-            // `target` when it returns truthy
-            cond: 'isOnMyOwnOrGroup',
-            target: 'defaultLanguage',
-          },
-          {
-            cond: 'isGroupSetup',
-            target: 'deviceName',
-          },
-          // There is no fallback path here; if neither `cond` above is truthy, this will break
-        ],
-      },
-
-      // The On My Own path
-      defaultLanguage: {
-        meta: { route: { name: 'DEFAULT_LANGUAGE', path: 'default-language' } },
-        on: {
-          CONTINUE: 'createAccountOrFinalizeSetup',
-          BACK: 'howAreYouUsingKolibri',
-        },
-      },
-      // A passthrough step depending on the value of context.canGetOsUser
-      createAccountOrFinalizeSetup: {
-        on: { BACK: 'defaultLanguage' },
-        always: [
-          {
-            cond: 'canGetOsUser',
-            target: 'finalizeSetup',
-          },
-          {
-            target: 'createOnMyOwnAccount',
-          },
-        ],
-      },
-
-      createOnMyOwnAccount: {
-        meta: { route: { name: 'CREATE_SUPERUSER_AND_FACILITY', path: 'create-account' } },
-        on: {
-          CONTINUE: { target: 'finalizeSetup', actions: 'setSuperuser' },
-          BACK: 'defaultLanguage',
-        },
-      },
-
-      // The Group path
-      deviceName: {
-        meta: { route: { name: 'DEVICE_NAME', path: 'device-name' } },
-        on: {
-          CONTINUE: { target: 'fullOrLearnOnlyDevice', actions: 'setDeviceName' },
-          BACK: 'howAreYouUsingKolibri',
-        },
-      },
-      fullOrLearnOnlyDevice: {
-        id: 'fullOrLearnOnlyDevice',
-        meta: { route: { name: 'FULL_OR_LOD', path: 'full-or-lod' } },
-        on: {
-          CONTINUE: { target: 'fullOrLodSetup', actions: 'setFullOrLOD' },
-          BACK: 'deviceName',
-        },
-      },
-
-      // A passthrough step depending on the value of context.fullOrLOD
-      // that either continues along with full device setup, or into the Lod setup
-      fullOrLodSetup: {
-        on: { BACK: 'fullOrLearnOnlyDevice' },
-        always: [
-          {
-            cond: 'isLodSetup',
-            target: 'importLodUsers',
-          },
-          {
-            cond: 'isFullSetup',
-            target: 'fullDeviceNewOrImportFacility',
-          },
-        ],
-      },
-
-      // Full Device Path
-      fullDeviceNewOrImportFacility: {
-        meta: { route: { name: 'FULL_NEW_OR_IMPORT_FACILITY' } },
-        on: {
-          CONTINUE: { target: 'facilitySetupType', actions: 'setFacilityNewOrImport' },
-          BACK: 'fullOrLearnOnlyDevice',
-        },
-      },
-
-      // A passthrough step depending on whether the user is creating a new facility or importing
-      facilitySetupType: {
-        on: { BACK: 'fullDeviceNewOrImportFacility' },
-        always: [
-          {
-            cond: 'isNewFacility',
-            target: 'setFacilityPermissions',
-          },
-          {
-            cond: 'isImportFacility',
-            target: 'importFacility',
-          },
-        ],
-      },
-
-      // Facility Creation Path
-      setFacilityPermissions: {
-        meta: { route: { name: 'FACILITY_PERMISSIONS' } },
-        on: {
-          CONTINUE: { target: 'guestAccess', actions: 'setFacilityTypeAndName' },
-          BACK: 'fullDeviceNewOrImportFacility',
-        },
-      },
-      guestAccess: {
-        meta: { route: { name: 'GUEST_ACCESS' } },
-        on: {
-          CONTINUE: { target: 'createLearnerAccount', actions: 'setGuestAccess' },
-          BACK: { target: 'setFacilityPermissions', actions: 'setGuestAccess' },
-        },
-      },
-      createLearnerAccount: {
-        meta: { route: { name: 'CREATE_LEARNER_ACCOUNT' } },
-        on: {
-          CONTINUE: { target: 'requirePassword', actions: 'setLearnerCanCreateAccount' },
-          BACK: { target: 'guestAccess', actions: 'setLearnerCanCreateAccount' },
-        },
-      },
-      requirePassword: {
-        meta: { route: { name: 'REQUIRE_PASSWORD' } },
-        on: {
-          CONTINUE: { target: 'personalDataConsent', actions: 'setRequirePassword' },
-          BACK: { target: 'createLearnerAccount', actions: 'setRequirePassword' },
-        },
-      },
-      personalDataConsent: {
-        /**
-         * nextEvent here is used to provide the Vue component what command it is expected to send
-         * in this particular case
-         **/
-        meta: { route: { name: 'PERSONAL_DATA_CONSENT' }, nextEvent: 'CONTINUE' },
-        on: {
-          CONTINUE: 'createSuperuserAndFacility',
-          BACK: 'requirePassword',
-        },
-      },
-      // A passthrough step depending on the value of context.canGetOsUser - the finalizeSetup state
-      // will provision the device with the OS user and create the default facility
-      createSuperuserAndFacility: {
-        on: { BACK: 'personalDataConsent' },
-        always: [
-          {
-            cond: 'canGetOsUser',
-            target: 'finalizeSetup',
-          },
-          {
-            target: 'createSuperuserAndFacilityForm',
-          },
-        ],
-      },
-
-      // If we're not able to get an OS user, the user creates their account
-      createSuperuserAndFacilityForm: {
-        meta: { route: { name: 'CREATE_SUPERUSER_AND_FACILITY', path: 'create-account' } },
-        on: {
-          CONTINUE: { target: 'finalizeSetup', actions: 'setSuperuser' },
-          BACK: 'personalDataConsent',
-        },
-      },
-
-      // It's own little baby state machine
-      importFacility: {
-        initial: 'selectFacilityForm',
-        states: {
-          selectFacilityForm: {
-            meta: { route: { name: 'SELECT_FACILITY_FOR_IMPORT' } },
-            on: {
-              BACK: {
-                // #<name> points to a state w/ an `id` property; wizard is the root
-                target: '#wizard.fullDeviceNewOrImportFacility',
-                actions: ['clearSelectedSetupType', 'revertFullDeviceImport'],
-              },
-              CONTINUE: {
-                target: 'importAuthentication',
-                actions: 'setSelectedImportDeviceFacility',
-              },
-            },
-          },
-          importAuthentication: {
-            meta: { route: { name: 'IMPORT_AUTHENTICATION' } },
-            on: {
-              BACK: { target: 'selectFacilityForm' },
-              BACK_SKIP_FACILITY_FORM: {
-                target: '#wizard.fullDeviceNewOrImportFacility',
-                actions: ['clearSelectedSetupType', 'revertFullDeviceImport'],
-              },
-              // THE POINT OF NO RETURN
-              CONTINUE: { target: 'loadingTaskPage' },
-            },
-          },
-          loadingTaskPage: {
-            meta: { route: { name: 'IMPORT_LOADING' } },
-            on: {
-              CONTINUE: 'selectSuperAdminAccountForm',
-            },
-          },
-          selectSuperAdminAccountForm: {
-            meta: { route: { name: 'SELECT_ADMIN' } },
-            on: {
-              CONTINUE: {
-                target: 'personalDataConsentForm',
-                nextEvent: 'FINISH',
-                actions: 'setSuperuser',
-              },
-            },
-          },
-          personalDataConsentForm: {
-            meta: { route: { name: 'IMPORT_DATA_CONSENT' }, nextEvent: 'FINISH' },
-            on: {
-              BACK: 'selectSuperAdminAccountForm',
-            },
-          },
-        },
-        // Listener on the importFacility state; typically this would be above `states` but
-        // putting it here flows more with the above as this is the state after the final step
-        on: {
-          FINISH: 'finalizeSetup',
-        },
-      },
-
-      // LOD machine with substates to manage its own steps
-      importLodUsers: {
-        initial: 'selectLodSetupType',
-        states: {
-          selectLodSetupType: {
-            meta: { route: { name: 'LOD_SETUP_TYPE' } },
-            on: {
-              // #<name> points to a state w/ an `id` property; wizard is the root
-              BACK: { target: '#wizard.fullOrLearnOnlyDevice', actions: 'clearFullOrLOD' },
-              CONTINUE: {
-                target: 'selectLodFacility',
-                actions: 'setLodType',
-              },
-            },
-          },
-
-          selectLodFacility: {
-            meta: { route: { name: 'LOD_SELECT_FACILITY' } },
-            on: {
-              BACK: 'selectLodSetupType',
-              CONTINUE: {
-                target: 'lodProceedJoinOrNew',
-                actions: 'setSelectedImportDeviceFacility',
-              },
-            },
-          },
-
-          lodProceedJoinOrNew: {
-            always: [
-              {
-                cond: ctx => ctx.lodImportOrJoin === LodTypePresets.JOIN,
-                target: 'lodJoinFacility',
-              },
-              {
-                target: 'lodImportUserAuth',
-              },
-            ],
-          },
-
-          // IMPORT
-          lodImportUserAuth: {
-            meta: { route: { name: 'LOD_IMPORT_USER_AUTH' } },
-            on: {
-              BACK: 'selectLodSetupType',
-              CONTINUE: { target: 'lodLoading', actions: 'setLodSuperAdmin' },
-              CONTINUEADMIN: {
-                target: 'lodImportAsAdmin',
-                actions: ['setRemoteUsers', 'setLodAdmin'],
-              },
-            },
-          },
-
-          lodLoading: {
-            meta: { route: { name: 'LOD_LOADING_TASK_PAGE' } },
-            on: {
-              SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
-              IMPORT_ANOTHER: 'lodImportUserAuth',
-              // Otherwise send FINISH, which is handled at the root of this sub-machine
-            },
-          },
-
-          lodImportAsAdmin: {
-            meta: { route: { name: 'LOD_IMPORT_AS_ADMIN' } },
-            on: {
-              BACK: 'lodImportUserAuth',
-              LOADING: 'lodLoading',
-              SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
-            },
-          },
-
-          // JOIN
-          lodJoinLoading: {
-            meta: { route: { name: 'LOD_JOIN_LOADING_TASK_PAGE' } },
-            on: {
-              SET_SUPERADMIN: { actions: 'setLodSuperAdmin' },
-              IMPORT_ANOTHER: 'lodImportUserAuth',
-              // Otherwise send FINISH, which is handled at the root of this sub-machine
-            },
-          },
-
-          lodJoinFacility: {
-            meta: { route: { name: 'LOD_CREATE_USER_FORM' } },
-            on: {
-              BACK: 'selectLodSetupType',
-              CONTINUE: 'lodJoinLoading',
-            },
-          },
-        },
-        // Listener on the lod import state; typically this would be above `states` but
-        // putting it here flows more with the above as this is the state after the final step
-        on: {
-          SET_SUPERUSER: { actions: 'setSuperuser' },
-          ADD_IMPORTED_USER: { actions: 'addImportedUser' },
-          SET_FIRST_LOD: { actions: 'setFirstLodUser' },
-          FINISH: 'finalizeSetup',
-        },
-      },
-
-      // This is a dead-end where the router will send the user where they need to go
-      finalizeSetup: {
-        meta: { route: { name: 'FINALIZE_SETUP' } },
-      },
-    },
+    states,
   },
   {
     actions: {
@@ -433,31 +537,7 @@ export const wizardMachine = createMachine(
       // `context`to functions that take two parameters `(context, event)` - where the context
       // is the current context and event refers to the event sent to the machine to initiate a
       // transition.
-      setOnMyOwnOrGroup: assign({
-        onMyOwnOrGroup: (_, event) => event.value,
-      }),
-      setDeviceName: assign({
-        deviceName: (_, event) => event.value,
-      }),
-      setFullOrLOD: assign({
-        fullOrLOD: (_, event) => event.value,
-      }),
-      setCanGetOsUser: assign({
-        canGetOsUser: (_, event) => event.value,
-      }),
-      setFacilityNewOrImport: assign({
-        facilityNewOrImport: (_, event) => {
-          return event.value.importOrNew;
-        },
-        importDeviceId: (_, event) => {
-          return event.value.importDeviceId;
-        },
-      }),
-      setSuperuser: assign({
-        superuser: (_, event) => {
-          return event.value;
-        },
-      }),
+
       setSelectedImportDeviceFacility: assign({
         selectedFacility: (_, event) => {
           return event.value.selectedFacility;
@@ -481,19 +561,7 @@ export const wizardMachine = createMachine(
         selectedFacility: () => null,
         importDeviceId: () => null,
       }),
-      setFacilityTypeAndName: assign({
-        formalOrNonformal: (_, event) => event.value.selected,
-        facilityName: (_, event) => event.value.facilityName,
-      }),
-      setGuestAccess: assign({
-        guestAccess: (_, event) => event.value,
-      }),
-      setLearnerCanCreateAccount: assign({
-        learnerCanCreateAccount: (_, event) => event.value,
-      }),
-      setRequirePassword: assign({
-        requirePassword: (_, event) => event.value,
-      }),
+
       setLodType: assign({
         lodImportOrJoin: (_, event) => event.value.importOrJoin,
         importDeviceId: (_, event) => event.value.importDeviceId,

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -455,8 +455,6 @@ const states = {
       selectLodSetupType: {
         meta: { route: { name: 'LOD_SETUP_TYPE' } },
         on: {
-          // #<name> points to a state w/ an `id` property; wizard is the root
-          BACK_LOD: { target: '#wizard.fullOrLearnOnlyDevice', actions: 'clearFullOrLOD' },
           CONTINUE: {
             target: 'selectLodFacility',
             actions: [setLodType, send({ type: 'PUSH_HISTORY', value: 'selectLodSetupType' })],

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -398,18 +398,24 @@ const states = {
       selectFacilityForm: {
         meta: { route: { name: 'SELECT_FACILITY_FOR_IMPORT' } },
         on: {
+          BACK: {
+            target: '#wizard.fullDeviceNewOrImportFacility',
+            actions: [removeLastHistoryItem],
+          },
           CONTINUE: {
             target: 'importAuthentication',
-            actions: [
-              setSelectedImportDeviceFacility,
-              send({ type: 'PUSH_HISTORY', value: 'selectFacilityForm' }),
-            ],
+            actions: [setSelectedImportDeviceFacility],
           },
         },
       },
       importAuthentication: {
         meta: { route: { name: 'IMPORT_AUTHENTICATION' } },
         on: {
+          BACK: 'selectFacilityForm',
+          BACK_SKIP_FACILITY_FORM: {
+            target: '#wizard.fullDeviceNewOrImportFacility',
+            actions: ['clearSelectedSetupType', 'revertFullDeviceImport', removeLastHistoryItem],
+          },
           // THE POINT OF NO RETURN
           CONTINUE: { target: 'loadingTaskPage' },
         },

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -597,9 +597,6 @@ export const wizardMachine = createMachine(
         importDeviceId: () => null,
       }),
 
-      setLodImportDeviceId: assign({
-        importDeviceId: (_, event) => event.value,
-      }),
       addImportedUser: assign({
         importedUsers: (ctx, event) => {
           const users = ctx.importedUsers;

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -3,7 +3,6 @@
   <OnboardingStepBase
     :title="$tr('setUpFacilityTitle')"
     :description="$tr('setUpFacilityDescription')"
-    :eventOnGoBack="backEvent"
     @continue="handleContinue"
   >
     <KRadioButton
@@ -47,11 +46,6 @@
         selected: Options.JOIN,
         showSelectAddressModal: false,
       };
-    },
-    computed: {
-      backEvent() {
-        return { type: 'BACK_LOD' };
-      },
     },
     methods: {
       handleContinueImport(address) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -3,6 +3,7 @@
   <OnboardingStepBase
     :title="$tr('setUpFacilityTitle')"
     :description="$tr('setUpFacilityDescription')"
+    :eventOnGoBack="backEvent"
     @continue="handleContinue"
   >
     <KRadioButton
@@ -46,6 +47,11 @@
         selected: Options.JOIN,
         showSelectAddressModal: false,
       };
+    },
+    computed: {
+      backEvent() {
+        return { type: 'BACK_LOD' };
+      },
     },
     methods: {
       handleContinueImport(address) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
@@ -6,6 +6,7 @@
   <OnboardingStepBase
     :title="loading ? '' : header"
     :footerMessageType="loading ? null : footerMessageType"
+    :eventOnGoBack="backEvent"
     :step="loading ? null : 1"
     :steps="loading ? null : 5"
     @continue="handleContinue"
@@ -85,6 +86,9 @@
       },
       selectedFacility() {
         return this.facilities.find(f => f.id === this.selectedFacilityId);
+      },
+      backEvent() {
+        return { type: 'BACK_SKIP_FACILITY_FORM' };
       },
     },
     beforeMount() {


### PR DESCRIPTION
## Summary
As done in the change facility state machine , `kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js` back button is managed through a history list used as a stack.
This method makes easier for the wizard to handle to which previous state the user wanted to go back when several states can drive to one same state.
It also helps to keep the consistency in our code using the same method in both machines.

There are a special cases where going back to a previous state requires the execution of some cleaning actions that have been kept as they were in the code, renaming the event to avoid conflict with the general `BACK` event.

## References
Closes: #10240 

## Reviewer guidance
Same as in #10139 paying special attention to the behaviour of the back button.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
