### PR TITLE
Move where we mark a job as running inside job execution to make it runner independent.

### DIFF
--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -24,6 +24,8 @@ def execute_job(job_id):
 
     job = storage.get_job(job_id)
 
+    storage.mark_job_as_running(job_id)
+
     job.execute()
 
     connection.dispose()
@@ -162,8 +164,6 @@ class Worker(object):
 
         :return future:
         """
-        self.storage.mark_job_as_running(job.job_id)
-
         future = self.workers.submit(
             execute_job,
             job_id=job.job_id,


### PR DESCRIPTION
## Summary
Move our setting of the Running state inside the task execution function, so that when we run on a different task runner (e.g. Android's WorkManager) the task still gets set as running.

## References
Supports https://github.com/learningequality/kolibri-installer-android/issues/105 and https://github.com/learningequality/kolibri-installer-android/issues/104

## Reviewer guidance
If tests all pass, this should be good to go.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
