### PR TITLE
[DO NOT MERGE] Remote download on a content page

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -41,6 +41,8 @@ export function showTopicsContent(store, id, deviceId = null) {
   if (deviceId) {
     return setCurrentDevice(deviceId).then(device => {
       const baseurl = device.base_url;
+      const { fetchUserDownloadRequests } = useDownloadRequests(store);
+      fetchUserDownloadRequests();
       return fetchChannels({ baseurl }).then(() => {
         return _loadTopicsContent(store, id, baseurl);
       });

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -167,6 +167,7 @@
      * - `markComplete` on 'Mark resource as finished' click. Only when
      *                  a resource can be marked as complete.
      * - `viewInfo` on 'View information' click
+     * - `download` on 'Download' click
      */
     props: {
       resourceTitle: {
@@ -274,6 +275,14 @@
         required: false,
         default: true,
       },
+      /**
+      Should the download button be displayed?
+      */
+      showDownload: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
     },
     data() {
       return {
@@ -308,6 +317,15 @@
             event: 'toggleBookmark',
             disabled: this.isBookmarked === null,
             dataTest: this.isBookmarked ? 'removeBookmarkButton' : 'addBookmarkButton',
+          });
+        }
+        if (this.showDownload) {
+          actions.push({
+            id: 'download',
+            icon: 'download',
+            label: this.coreString('downloadAction'),
+            event: 'download',
+            dataTest: 'downloadButton',
           });
         }
         if (this.showMarkComplete) {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -27,6 +27,7 @@
       data-test="learningActivityBar"
       @navigateBack="navigateBack"
       @toggleBookmark="toggleBookmark"
+      @download="handleRemoteDownloadRequest"
       @viewResourceList="toggleResourceList"
       @viewInfo="openSidePanel"
       @completionModal="openCompletionModal"
@@ -208,7 +209,7 @@
       const { fetchLesson } = useLearnerResources();
       const { back } = useContentLink();
       const { baseurl } = useDevices();
-      const { downloadRequestMap } = useDownloadRequests();
+      const { addDownloadRequest, downloadRequestMap } = useDownloadRequests();
       return {
         baseurl,
         canDownload,
@@ -217,6 +218,7 @@
         fetchContentNodeTreeProgress,
         fetchLesson,
         back,
+        addDownloadRequest,
         downloadRequestMap,
       };
     },
@@ -508,6 +510,9 @@
         if (this.$refs.contentPage) {
           this.$refs.contentPage.displayCompletionModal();
         }
+      },
+      handleRemoteDownloadRequest() {
+        this.addDownloadRequest(this.content);
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -252,5 +252,33 @@ describe('LearningActivityBar', () => {
         expect(wrapper.emitted().viewInfo.length).toBe(1);
       });
     });
+
+    describe(`download`, () => {
+      it(`doesn't show the download button by default`, () => {
+        const wrapper = makeWrapper();
+        expect(wrapper.find("[data-test='bar_downloadButton']").exists()).toBeFalsy();
+      });
+
+      describe(`when the download option should be displayed`, () => {
+        let wrapper;
+
+        beforeEach(() => {
+          wrapper = makeWrapper({
+            propsData: {
+              showDownload: true,
+            },
+          });
+        });
+
+        it(`shows the download button`, () => {
+          expect(wrapper.find("[data-test='bar_downloadButton']").exists()).toBeTruthy();
+        });
+
+        it(`clicking the download button emits the 'download' event`, () => {
+          wrapper.find("[data-test='bar_downloadButton']").trigger('click');
+          expect(wrapper.emitted().download.length).toBe(1);
+        });
+      });
+    });
   });
 });

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -76,4 +76,35 @@ describe('TopicsContentPage', () => {
   it('shows the Content Page', () => {
     expect(wrapper.find('[data-test="contentPage"]').exists()).toBeTruthy();
   });
+
+  describe(`bookmark`, () => {
+    describe(`when a user is not logged in`, () => {
+      it(`the bookmark button is not displayed`, () => {});
+    });
+
+    describe(`when a user is logged in`, () => {
+      it(`the bookmark button is displayed when content is not remote`, () => {});
+      it(
+        `the bookmark button is displayed for remote content that has been downloaded by a learner`
+      );
+      it(`the bookmark button is displayed for remote content that has been imported by an admin`);
+      it(`the bookmark button is not displayed for remote content that hasn't been downloaded by a learner or imported by an admin yet`, () => {});
+    });
+  });
+
+  describe(`remote download`, () => {
+    describe(`when a user is not logged in`, () => {
+      it(`the download button is not displayed`, () => {});
+    });
+
+    describe(`when a user is logged in`, () => {
+      it(`the download button is not displayed when content is not remote`, () => {});
+      it(`the download button is not displayed for remote content that has been downloaded by a learner`, () => {});
+      it(`the download button is not displayed for remote content that has been imported by an admin`, () => {});
+      it(`the download button is displayed for remote content that hasn't been downloaded by a learner or imported by an admin yet`, () => {});
+      describe('clicking the download button', () => {
+        // TODO
+      });
+    });
+  });
 });


### PR DESCRIPTION
WIP

Adds the ability to download remote content from the learning bar on a remote content page

![Peek 2023-03-21 18-09](https://user-images.githubusercontent.com/13509191/226688407-dd41759f-03fc-4ece-bce6-9c1f739a3d61.gif)

**TODO**

- [ ] Rebase on top of the latest `develop` branch after https://github.com/learningequality/kolibri/pull/10137 is merged (some smaller tweaks may be needed as `useDownloadRequests` interface has been updated
