### PR TITLE
Misc SetupWizard fixes

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportAuthentication.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportAuthentication.vue
@@ -60,9 +60,6 @@
         return this.wizardService.state.context.importDevice;
       },
     },
-    mounted() {
-      console.log('ImportAuthentication', this.wizardService.state);
-    },
     methods: {
       callSubmitCredentials() {
         const $credentialsForm = this.$refs.credentialsForm;

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -42,7 +42,15 @@
       :noPadding="true"
     >
 
-      <div class="content">
+      <div v-if="coreError" style="padding: 2em;">
+        <h2>{{ coreError }}</h2>
+        <KButton
+          :text="coreString('startOverAction')"
+          :primary="true"
+          @click="startOver"
+        />
+      </div>
+      <div v-else class="content">
         <!-- Optional back arrow to show at the top for longer content views -->
         <KIconButton
           v-if="showBackArrow"
@@ -208,8 +216,15 @@
       selectedLanguage() {
         return availableLanguages[currentLanguage];
       },
+      coreError() {
+        return this.$store.state.core.error;
+      },
     },
     methods: {
+      startOver() {
+        this.wizardService.send('START_OVER');
+        this.$store.dispatch('clearError');
+      },
       /* If the user is focused on a form element and hits enter, continue */
       handleEnterKey(e) {
         e.preventDefault();

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -217,7 +217,11 @@
         return availableLanguages[currentLanguage];
       },
       coreError() {
-        return this.$store.state.core.error;
+        if (this.$store) {
+          return this.$store.state.core.error;
+        } else {
+          return null;
+        }
       },
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
@@ -38,7 +38,7 @@
     </template>
 
     <p v-if="importedUserIsSelected">
-      {{ $tr('enterPasswordPrompt', { username: selected.label }) }}
+      {{ $tr('enterPasswordPrompt', { username: selected.label, facility_name: facility.name }) }}
     </p>
   </UserCredentialsForm>
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -116,8 +116,6 @@
       this.service.start(savedState);
 
       this.service.onTransition(state => {
-        console.log('ontransition', state);
-        console.log(this.service);
         synchronizeRouteAndMachine(state);
         Lockr.set('savedState', this.service._state);
       });

--- a/kolibri/plugins/setup_wizard/assets/src/views/__test__/LoadingTaskPage.spec.js
+++ b/kolibri/plugins/setup_wizard/assets/src/views/__test__/LoadingTaskPage.spec.js
@@ -49,7 +49,6 @@ describe('LoadingTaskPage', () => {
     const { wrapper } = makeWrapper();
     await global.flushPromises();
     const taskPanel = wrapper.findComponent({ name: 'FacilityTaskPanel' });
-    console.log(taskPanel);
     expect(taskPanel.exists()).toBe(true);
     expect(wrapper.vm.isPolling).toBe(true);
     expect(wrapper.find('h1').text()).toEqual('Import learning facility');

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
@@ -5,6 +5,7 @@
     :footerMessageType="footerMessageType"
     :step="step"
     :steps="step"
+    :noBackAction="true"
     :description="$tr('description')"
     @continue="handleContinue"
   >


### PR DESCRIPTION
## Summary

Misc fixes and clean-up:
- Remove console logs
- Fixed error on super admin form w/ string missing a parameter
- Removed "go back" from personal data consent
- When we have a core error in vuex, onboarding step base will present the error along with a "start over" button

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10126 

This will close that issue and anything not fixed here in that issue will be made into individual issues (namely the "fix the number of characters allowed on name/device name").

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I need help here -- I thought I could use the `AppError` component here but that's pretty specifically setup for a non setup-wizard context. It _does_ have some messaging that I'd like to hijack so I was considering one of the two following:
- Update the `AppError` component to take some props and configure it to show only some of the more relevant-to-this-context messages (ie, "Something went wrong") -- and then could even update the buttons to say "Start Over" instead
- `crossComponentTranslator` :vomiting_face: 

Any additional thoughts would be appreciated.

NOTE also that there is not a robust use of `handleApiError` action throughout Setup Wizard.
