### PR TITLE
[Setup Wizard] Validate nonunique usernames

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
@@ -8,9 +8,9 @@
     :step="1"
     :steps="2"
     :doNotContinue="true"
-    :uniqueUsernameValidator="() => true"
     :adminUserLabels="false"
     :noBackAction="false"
+    :errors.sync="caughtErrors"
     @submit="handleClickNext"
   />
 
@@ -39,8 +39,7 @@
       return {
         loading: false,
         footerMessageType,
-        shouldValidate: false,
-        usernameIsUniqueFn: () => true,
+        caughtErrors: [],
       };
     },
     computed: {
@@ -50,7 +49,6 @@
     },
     methods: {
       handleClickNext() {
-        this.shouldValidate = true;
         const { baseurl, id } = this.wizardService.state.context.importDevice;
 
         const user = {
@@ -83,7 +81,7 @@
           } else {
             const errorData = JSON.parse(data);
             if (errorData.find(error => error.id === ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS)) {
-              this.usernameIsUniqueFn = () => false;
+              this.caughtErrors = [ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS];
             }
             this.loading = false;
           }

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
@@ -38,7 +38,7 @@
     </template>
 
     <p v-if="importedUserIsSelected">
-      {{ $tr('enterPasswordPrompt', { username: selected.label }) }}
+      {{ $tr('enterPasswordPrompt', { username: selected.label, facility_name: facility.name }) }}
     </p>
   </UserCredentialsForm>
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -39,6 +39,7 @@
         :isValid.sync="usernameValid"
         :disabled="disabled"
         :shouldValidate="formSubmitted"
+        :errors.sync="caughtErrors"
         :isUniqueValidator="!selectedUser ? uniqueUsernameValidator : () => true"
       />
 
@@ -144,6 +145,12 @@
         required: false,
         default: null,
       },
+      // Pass in errors with .sync modifier
+      errors: {
+        type: Array,
+        required: false,
+        default: () => [],
+      },
     },
     data() {
       let user;
@@ -160,6 +167,8 @@
         password: '',
         passwordValid: false,
         formSubmitted: false,
+        // Property to wrap props.errors and avoid warnings about mutating props
+        caughtErrors: [],
       };
     },
     computed: {
@@ -200,6 +209,15 @@
           this.syncOnboardingData();
           this.focusOnInvalidField();
         });
+      },
+      errors() {
+        if (this.errors && this.errors.length) {
+          this.focusOnInvalidField();
+        }
+        this.caughtErrors = this.errors;
+      },
+      caughtErrors() {
+        this.$emit('update:errors', this.caughtErrors);
       },
     },
     mounted() {


### PR DESCRIPTION
## Summary

Show an error on `UserCredentialsForm` when the user to trying to create a user with an existing username when creating a new account on LOD.

https://user-images.githubusercontent.com/51239030/226908097-2bcc94c0-69d4-41d7-a7b7-c29019fbff75.mov

## References

Closes #10239

## Reviewer guidance

On setup wizard try to create an account with duplicate username for an existing facility.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
