### PR TITLE
Don't update or edit facility and facility datasets for imported facilities

### DIFF
--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -215,6 +215,25 @@ class DeviceProvisionTestCase(APITestCase):
             )
             self.assertTrue(FacilityUser.objects.get().os_user)
 
+    def test_imported_facility_no_update(self):
+        facility = Facility.objects.create(name="This is a test")
+        settings = FacilityDataset.objects.get()
+        settings.learner_can_edit_username = True
+        settings.save()
+        data = self._default_provision_data()
+        data["facility_id"] = facility.id
+        del data["facility"]
+        # Client should pass an empty Dict for settings
+        data["settings"] = {
+            "learner_can_edit_username": False,
+            "on_my_own_setup": True,
+        }
+        settings.refresh_from_db()
+        facility.refresh_from_db()
+        self._post_deviceprovision(data)
+        self.assertEqual(settings.learner_can_edit_username, True)
+        self.assertEqual(facility.on_my_own_setup, False)
+
 
 class DeviceSettingsTestCase(APITestCase):
     @classmethod


### PR DESCRIPTION
## Summary
* Previously we were not using the device provisioning endpoint for import flows
* We have nicely unified that logic in recent work by @nucleogenesis 
* In doing so it introduced a bug where we were trying to set provisioning data onto the imported facility and facility datasets
* This adds conditional logic to only do this setting in the case that the facility has been created within the provisioning request

## References
Fixes https://github.com/learningequality/kolibri/issues/10273

## Reviewer guidance
Follow the steps outlined in the issue above!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
