### PR TITLE
Fix resource import counts

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -109,6 +109,7 @@ class GetImportExportNodesTestCase(TestCase):
             ContentNode.objects.filter(channel_id=self.the_channel_id)
             .filter(renderable_contentnodes_q_filter)
             .exclude(kind=content_kinds.TOPIC)
+            .distinct()
         )
 
         matched_nodes_queries_list = get_import_export_nodes(self.the_channel_id)

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -195,7 +195,7 @@ def get_import_export_nodes(  # noqa: C901
         # Only bother with this query if there were any resources returned above.
 
         if nodes_query.count() > 0:
-            nodes_queries_list.append(nodes_query)
+            nodes_queries_list.append(nodes_query.distinct())
 
     return nodes_queries_list
 

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -232,7 +232,6 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         self.resources_before_transfer = (
             ContentNode.objects.filter(channel_id=self.channel_id, available=True)
             .exclude(kind=content_kinds.TOPIC)
-            .values("content_id")
             .count()
         )
 
@@ -318,7 +317,6 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         self.resources_after_transfer = (
             ContentNode.objects.filter(channel_id=self.channel_id, available=True)
             .exclude(kind=content_kinds.TOPIC)
-            .values("content_id")
             .count()
         )
 

--- a/kolibri/plugins/device/test/test_api.py
+++ b/kolibri/plugins/device/test/test_api.py
@@ -263,7 +263,7 @@ class CalculateImportExportSizeViewTestCase(APITestCase):
             data={"channel_id": self.the_channel_id},
             format="json",
         )
-        self.assertEqual(response.data["resource_count"], 3)
+        self.assertEqual(response.data["resource_count"], 2)
         self.assertEqual(
             response.data["file_size"],
             sum(
@@ -310,7 +310,7 @@ class CalculateImportExportSizeViewTestCase(APITestCase):
             data={"channel_id": self.the_channel_id, "export": True},
             format="json",
         )
-        self.assertEqual(response.data["resource_count"], 3)
+        self.assertEqual(response.data["resource_count"], 2)
         self.assertEqual(
             response.data["file_size"],
             sum(


### PR DESCRIPTION
## Summary
* Fixes the import counts for resources

## References
Fixes https://github.com/learningequality/kolibri/issues/10287

## Reviewer guidance
Import the entire Kolibri QA channel. Ensure that it shows that all resources are imported if it is successful.

![Screenshot from 2023-03-24 08-07-12](https://user-images.githubusercontent.com/1680573/227565562-ad4ad3df-e363-4ffb-be1d-d4adb8b1e54e.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
