### PR TITLE
Do not show password edit on profile page for subset of users device.

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/index.vue
@@ -107,7 +107,7 @@
             </td>
           </tr>
 
-          <tr v-if="canEditPassword">
+          <tr v-if="!isSubsetOfUsersDevice && canEditPassword">
             <th>{{ coreString('passwordLabel') }}</th>
             <td>
               <KButton
@@ -158,7 +158,7 @@
 
 
         <ChangeUserPasswordModal
-          v-if="showPasswordModal"
+          v-if="!isSubsetOfUsersDevice && showPasswordModal"
           @cancel="showPasswordModal = false"
         />
 


### PR DESCRIPTION
## Summary
* Prevents password edit being shown as an option on the profile page when on a subset of users device

## References
Fixes https://github.com/learningequality/kolibri/issues/10314

## Reviewer guidance
Before:
![Screenshot from 2023-03-24 08-20-00](https://user-images.githubusercontent.com/1680573/227567788-96797a6e-5997-489f-94b8-18dbd0ad2242.png)

After:
![Screenshot from 2023-03-24 08-19-36](https://user-images.githubusercontent.com/1680573/227567809-49b3870c-91c0-447e-afa4-a2480c7291eb.png)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
