### PR TITLE
Improve cleanup of automated LOD peer to peer syncing tasks

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -332,7 +332,11 @@ class Storage(object):
             )
 
     def check_job_canceled(self, job_id):
-        job = self.get_job(job_id)
+        try:
+            job = self.get_job(job_id)
+        except JobNotFound:
+            return True
+
         return job.state == State.CANCELED or job.state == State.CANCELING
 
     def cancel(self, job_id):


### PR DESCRIPTION
## Summary
* Adds handling for a job already being deleted when checking for cancellation and interprets it as an implicit cancel
* Allows for a job to have already been cleaned up when processing a disconnect hook
* Prevent requeuing in cases where a LOD peer to peer job stops because it has been cancelled.

## References
Fixes https://github.com/learningequality/kolibri/issues/10305

## Reviewer guidance
Join and leave ZeroTier while doing automatic syncs and ensure that cancellation of tasks gets properly handled.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
