### PR TITLE
Include facility_id in dict in req.get params get_remote_users_info

### DIFF
--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -34,9 +34,11 @@ def get_remote_users_info(baseurl, facility_id, username, password):
              'users' containing the list of users of the facility if the user had rights.
     """
     user_info_url = reverse_remote(baseurl, "kolibri:core:publicuser-list")
+    params = {"facility_id": facility_id}
     try:
         response = requests.get(
             user_info_url,
+            params=params,
             auth=(
                 "username={}&{}={}".format(
                     username, FACILITY_CREDENTIAL_KEY, facility_id


### PR DESCRIPTION
## Summary

Addresses an issue noted in #10126 - this fix was on a separate branch I forgot to merge into #10293 -- need to include params w/ facility ID on get_remote_users_info

> Resolve this [comment re: params/facility_id stuff](https://github.com/learningequality/kolibri/pull/10139/files#r1125157030)