### PR TITLE
Include active facility id in FacilityTopNav routes

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
@@ -21,28 +21,30 @@
     mixins: [commonCoreStrings],
     computed: {
       links() {
+        const facility_id = this.$store.getters.activeFacilityId; // Ensure we stay in the current facility
+
         return [
           {
             title: this.coreString('classesLabel'),
-            link: this.$router.getRoute(PageNames.CLASS_MGMT_PAGE),
+            link: this.$router.getRoute(PageNames.CLASS_MGMT_PAGE, { facility_id }),
             icon: 'classes',
             color: this.$themeTokens.textInverted,
           },
           {
             title: this.coreString('usersLabel'),
-            link: this.$router.getRoute(PageNames.USER_MGMT_PAGE),
+            link: this.$router.getRoute(PageNames.USER_MGMT_PAGE, { facility_id }),
             icon: 'people',
             color: this.$themeTokens.textInverted,
           },
           {
             title: this.coreString('settingsLabel'),
-            link: this.$router.getRoute(PageNames.FACILITY_CONFIG_PAGE),
+            link: this.$router.getRoute(PageNames.FACILITY_CONFIG_PAGE, { facility_id }),
             icon: 'settings',
             color: this.$themeTokens.textInverted,
           },
           {
             title: this.coreString('dataLabel'),
-            link: this.$router.getRoute(PageNames.DATA_EXPORT_PAGE),
+            link: this.$router.getRoute(PageNames.DATA_EXPORT_PAGE, { facility_id }),
             icon: 'save',
             color: this.$themeTokens.textInverted,
           },

--- a/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityTopNav.vue
@@ -21,7 +21,7 @@
     mixins: [commonCoreStrings],
     computed: {
       links() {
-        const facility_id = this.$store.getters.activeFacilityId; // Ensure we stay in the current facility
+        const facility_id = this.$route.params.facility_id;
 
         return [
           {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Includes the currently selected, aka _active_, facility's ID in the params when generating the link for the Facility's top nav items.

## References

Fixes #10294 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See if the issues reported in #10294 are resolved. 

