### PR TITLE
Updates Change facility page container with standard max container width

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/index.vue
@@ -4,6 +4,7 @@
     <ImmersivePage
       :appBarTitle="coreString('changeLearningFacility')"
       :route="$router.getRoute('PROFILE')"
+      :appearanceOverrides="wrapperStyles"
     >
       <KPageContainer>
         <router-view />
@@ -60,6 +61,14 @@
 
     computed: {
       ...mapGetters(['session', 'getUserKind']),
+      wrapperStyles() {
+        return {
+          maxWidth: '1064px',
+          margin: '0px auto auto',
+          padding: '96px 32px 72px',
+          backgroundColor: this.$themePalette.grey.v_100,
+        };
+      },
     },
 
     beforeRouteUpdate(to, from, next) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR updates the page container of the Change Facility pages to be the standard max container width.
- Included the `ImmersivePage` property `appearanceOverrides` on the `Change Facility` view

Before
<img width="721" alt="Before1" src="https://user-images.githubusercontent.com/46411498/228573245-753a3cb0-21f1-433f-bbfd-f15368d29be6.png">

<img width="1440" alt="Before2" src="https://user-images.githubusercontent.com/46411498/228573249-5ed2ba80-6355-4575-85ac-2cb8f48a8fdd.png">

<img width="722" alt="Before3" src="https://user-images.githubusercontent.com/46411498/228573266-3160962c-c1e8-4f19-96a0-d2b1726da30a.png">


After

<img width="721" alt="After1" src="https://user-images.githubusercontent.com/46411498/228573307-25471176-1c89-4139-aa8f-a13d8ffcfcaf.png">

<img width="722" alt="After2" src="https://user-images.githubusercontent.com/46411498/228573327-270e9e0a-f208-4fc4-90c5-baf2f37aabd3.png">

<img width="720" alt="After3" src="https://user-images.githubusercontent.com/46411498/228573339-e2b1e9bf-b9ab-4994-beb7-0646a6ca7202.png">


## References
Closes #10331 

## Reviewer guidance
1. Navigate to profile page of a user device that has an `On My Own` setup
2. Select the button to change the learning facility at bottom of page
3. Confirm that the page container width is the standard max container width
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
