### PR TITLE
Fixes a missing string on the add device address form

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -1,7 +1,7 @@
 <template>
 
   <KModal
-    :title="coreString('newAddresTitle')"
+    :title="$tr('header')"
     :submitText="$tr('submitButtonLabel')"
     :cancelText="coreString('cancelAction')"
     size="medium"
@@ -134,6 +134,11 @@
       },
     },
     $trs: {
+      header: {
+        message: 'New address',
+        context:
+          'The title of the section that an admin accesses when they select the "Add new address" link in the Device > Facilities section.\n\nThey use this screen to add a new network address.',
+      },
       addressDesc: {
         message:
           "The network address can be an IP and port like '192.168.0.100:8080' or a URL like 'example.com':",

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -66,7 +66,7 @@
     components: {
       UiAlert,
     },
-    mixins: [commonCoreStrings,commonSyncElements],
+    mixins: [commonCoreStrings, commonSyncElements],
     data() {
       return {
         address: '',

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -1,7 +1,7 @@
 <template>
 
   <KModal
-    :title="$tr('header')"
+    :title="$tr('newAddressTitle')"
     :submitText="$tr('submitButtonLabel')"
     :cancelText="coreString('cancelAction')"
     size="medium"
@@ -134,10 +134,10 @@
       },
     },
     $trs: {
-      header: {
-        message: 'New address',
-        context:
-          'The title of the section that an admin accesses when they select the "Add new address" link in the Device > Facilities section.\n\nThey use this screen to add a new network address.',
+      newAddressTitle: {
+    message: 'New device',
+    context:
+      'Title of the menu where the user manually adds a new device device from where to import a facility',
       },
       addressDesc: {
         message:

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -1,7 +1,7 @@
 <template>
 
   <KModal
-    :title="$tr('newAddressTitle')"
+    :title="getCommonSyncString('newAddressTitle')"
     :submitText="$tr('submitButtonLabel')"
     :cancelText="coreString('cancelAction')"
     size="medium"
@@ -52,6 +52,7 @@
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { createDevice } from './api';
 
@@ -65,7 +66,7 @@
     components: {
       UiAlert,
     },
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings,commonSyncElements],
     data() {
       return {
         address: '',
@@ -134,11 +135,6 @@
       },
     },
     $trs: {
-      newAddressTitle: {
-    message: 'New device',
-    context:
-      'Title of the menu where the user manually adds a new device device from where to import a facility',
-      },
       addressDesc: {
         message:
           "The network address can be an IP and port like '192.168.0.100:8080' or a URL like 'example.com':",


### PR DESCRIPTION


## Summary
This PR fixes a missing string on the add address device form
###  Before
![image](https://user-images.githubusercontent.com/103313919/228576707-85866343-6d77-4c1a-b773-694f3dfa304e.png)

### After
<img width="616" alt="Screenshot 2023-03-29 at 17 39 29" src="https://user-images.githubusercontent.com/103313919/228577018-5219a6f3-d206-4f22-8b8c-d677cf7f9a0a.png">

Closes #10330

## References

#10330

## Reviewer guidance

Navigate to Device plugin> facilities > sync > select device > add new device 


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
