### PR TITLE
Correcting two strings that have already been amended on Crowdin

### DIFF
--- a/kolibri/core/assets/src/mixins/taskStrings.js
+++ b/kolibri/core/assets/src/mixins/taskStrings.js
@@ -31,7 +31,7 @@ const taskStrings = createTranslator('TaskStrings', {
     context: 'Displays the user that started a task',
   },
   taskLODFinishedByLabel: {
-    message: "Account '{fullname} from '{facilityname}' successfully loaded to this device",
+    message: "Account '{fullname}' from '{facilityname}' successfully loaded to this device",
     context: 'Displays the full name of the user that has been synced in a task',
   },
   clearCompletedTasksAction: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -67,7 +67,7 @@
     },
     $trs: {
       channels: {
-        message: '{count, plural, one {channel} other {channels}',
+        message: '{count, number, integer} {count, plural, one {channel} other {channels}}',
         context: 'Indicates the number of channels',
       },
     },


### PR DESCRIPTION
## Summary

Two source strings that need correction:
* ``TaskStrings.taskLODFinishedByLabel`` was missing a single quote
* ``UnPinnedDevices.channels`` had an incorrect ICU syntax

Both strings have **already been corrected on Crowdin** (to match exactly what is in this PR), **together with all the translations** (took some translation reusing and wrangling, but we should be OK)

## References
…

## Reviewer guidance
Can't think of a possible issue, a part from linter complains, as I was not able to run `pre-commit` (need to update Python to 3.10)
…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
