### PR TITLE
Policies plugin initialization fixes

### DIFF
--- a/kolibri/plugins/policies/assets/src/app.js
+++ b/kolibri/plugins/policies/assets/src/app.js
@@ -1,4 +1,3 @@
-import router from 'kolibri.coreVue.router';
 import PageRoot from 'kolibri.coreVue.components.PageRoot';
 import routes from './routes';
 import pluginModule from './modules/pluginModule';
@@ -6,7 +5,6 @@ import KolibriApp from 'kolibri_app';
 
 class PoliciesModule extends KolibriApp {
   get routes() {
-    console.log('policies routes', routes);
     return routes;
   }
   get RootVue() {
@@ -16,9 +14,6 @@ class PoliciesModule extends KolibriApp {
     return pluginModule;
   }
   ready() {
-    router.afterEach((toRoute, fromRoute) => {
-      this.store.dispatch('resetModuleState', { toRoute, fromRoute });
-    });
     super.ready();
   }
 }

--- a/kolibri/plugins/policies/assets/src/views/CookiePolicy.vue
+++ b/kolibri/plugins/policies/assets/src/views/CookiePolicy.vue
@@ -6,7 +6,7 @@
     :appBarTitle="coreString('cookiePolicy')"
     :route="cookiePolicyRoute"
   >
-    <KPageContainer :topMargin="100">
+    <KPageContainer>
       <h1>{{ coreString('cookiePolicy') }}</h1>
 
       <section>
@@ -21,7 +21,7 @@
 
         <table>
           <tr>
-            <th>{{ coreString('name') }}</th>
+            <th>{{ coreString('nameLabel') }}</th>
             <th>{{ $tr('cookiePurposeTableHeader') }}</th>
             <th>{{ $tr('cookieExpiryTableHeader') }}</th>
           </tr>
@@ -49,7 +49,7 @@
         <p>{{ $tr('statisticsCookiesP1') }}</p>
         <table>
           <tr>
-            <th>{{ coreString('name') }}</th>
+            <th>{{ coreString('nameLabel') }}</th>
             <th>{{ $tr('cookiePurposeTableHeader') }}</th>
             <th>{{ $tr('cookieExpiryTableHeader') }}</th>
           </tr>
@@ -62,7 +62,7 @@
       </section>
       <section>
         <h2>{{ $tr('yourChoicesHeader') }}</h2>
-        <p>{{ $tr('choicesP1') }}</p>
+        <p>{{ $tr('choicesP1', { choice: "AYE" }) }}</p>
       </section>
       <KButton
         :text="coreString('closeAction')"
@@ -79,11 +79,19 @@
 
 <script>
 
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'CookiePolicy',
+    components: { ImmersivePage },
     mixins: [commonCoreStrings],
+    computed: {
+      cookiePolicyRoute() {
+        // FIXME This will just go back to the root
+        return { path: window.location.origin };
+      },
+    },
     $trs: {
       cookieP1: {
         message:
@@ -146,8 +154,7 @@
         message: 'Your choices',
       },
       choicesP1: {
-        message:
-          'You {choice, string} to receive statistics cookies. You can change this preference here:',
+        message: 'You {choice} to receive statistics cookies. You can change this preference here:',
       },
     },
   };

--- a/kolibri/plugins/policies/assets/src/views/UsageAndPrivacy.vue
+++ b/kolibri/plugins/policies/assets/src/views/UsageAndPrivacy.vue
@@ -63,11 +63,13 @@
 
 <script>
 
+  import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import plugin_data from 'plugin_data';
 
   export default {
     name: 'UsageAndPrivacy',
+    components: { ImmersivePage },
     mixins: [commonCoreStrings],
     props: {
       hideUsersSection: {

--- a/kolibri/plugins/policies/kolibri_plugin.py
+++ b/kolibri/plugins/policies/kolibri_plugin.py
@@ -10,6 +10,8 @@ from kolibri.utils.translation import ugettext as _
 
 
 class Policies(KolibriPluginBase):
+    translated_view_urls = "urls"
+
     @property
     def url_slug(self):
         return "policies"
@@ -21,5 +23,4 @@ class Policies(KolibriPluginBase):
 
 @register_hook
 class PoliciesAsset(webpack_hooks.WebpackBundleHook):
-    print("policies app")
     bundle_id = "app"

--- a/kolibri/plugins/policies/urls.py
+++ b/kolibri/plugins/policies/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [url(r"^$", views.PoliciesView.as_view(), name="policies")]


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The Policies plugin was not loading as it was missing the urls configuration in the plugin setup.

Additionally the CookiePolicy component was not loading due to a string missing its parameters (which took far too long to identify thanks to Chrome devtools' useless traces...) and both components needed to import ImmersivePage.

This plugin sets up for follow-up work on the front-end, namely:

- Figuring out how to get the CookiesBanner hooked into wherever we want it
- Handling the `route` prop of `ImmersivePage` so that we can send the user back to where they were reliably.
- Some styling issues

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10148 - won't put a closing keyword as there is follow-up to do

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Anything that should be included here rather than in a follow-up?

