### PR TITLE
Use Kolibri hooks for storage hooks.

### DIFF
--- a/kolibri/core/tasks/hooks.py
+++ b/kolibri/core/tasks/hooks.py
@@ -15,5 +15,5 @@ class StorageHook(KolibriHook):
         pass
 
     @abstractmethod
-    def clear(self, job_id):
+    def clear(self, job, orm_job):
         pass

--- a/kolibri/core/tasks/hooks.py
+++ b/kolibri/core/tasks/hooks.py
@@ -1,0 +1,19 @@
+from abc import abstractmethod
+
+from kolibri.plugins.hooks import define_hook
+from kolibri.plugins.hooks import KolibriHook
+
+
+@define_hook
+class StorageHook(KolibriHook):
+    @abstractmethod
+    def schedule(self, job, orm_job):
+        pass
+
+    @abstractmethod
+    def update(self, job, orm_job, state=None, **kwargs):
+        pass
+
+    @abstractmethod
+    def clear(self, job_id):
+        pass

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -381,8 +381,9 @@ class Storage(object):
                 )
             if self._hooks:
                 for orm_job in q:
+                    job = self._orm_to_job(orm_job)
                     for hook in self._hooks:
-                        hook.clear(orm_job.id)
+                        hook.clear(job, orm_job)
             q.delete(synchronize_session=False)
 
     def update_job_progress(self, job_id, progress, total_progress):

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -19,10 +19,10 @@ from sqlalchemy.orm import sessionmaker
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
+from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
-from kolibri.utils import conf
 from kolibri.utils.time_utils import local_now
 from kolibri.utils.time_utils import naive_utc_datetime
 
@@ -72,14 +72,6 @@ class ORMJob(Base):
     __table_args__ = (Index("queue__scheduled_time", "queue", "scheduled_time"),)
 
 
-def _validate_hooks(hooks):
-    if hooks is None:
-        return []
-    if not isinstance(hooks, list) or any(not callable(h) for h in hooks):
-        raise RuntimeError("hooks must be a list of callables")
-    return hooks
-
-
 class Storage(object):
     def __init__(self, connection, Base=Base):
         self.engine = connection
@@ -88,10 +80,7 @@ class Storage(object):
         self.Base = Base
         self.Base.metadata.create_all(self.engine)
         self.sessionmaker = sessionmaker(bind=self.engine)
-        schedule_hooks = conf.OPTIONS["Tasks"]["SCHEDULE_HOOKS"]
-        update_hooks = conf.OPTIONS["Tasks"]["UPDATE_HOOKS"]
-        self.schedule_hooks = _validate_hooks(schedule_hooks)
-        self.update_hooks = _validate_hooks(update_hooks)
+        self._hooks = list(StorageHook.registered_hooks)
 
     @contextmanager
     def session_scope(self):
@@ -390,7 +379,10 @@ class Storage(object):
                         ORMJob.state == State.CANCELED,
                     )
                 )
-
+            if self._hooks:
+                for orm_job in q:
+                    for hook in self._hooks:
+                        hook.clear(orm_job.id)
             q.delete(synchronize_session=False)
 
     def update_job_progress(self, job_id, progress, total_progress):
@@ -462,8 +454,8 @@ class Storage(object):
                     setattr(job, kwarg, kwargs[kwarg])
                 orm_job.saved_job = job.to_json()
                 session.add(orm_job)
-                for update_hook in self.update_hooks:
-                    update_hook(job, orm_job, state=state, **kwargs)
+                for hook in self._hooks:
+                    hook.update(job, orm_job, state=state, **kwargs)
                 return job, orm_job
             except JobNotFound:
                 if state:
@@ -601,15 +593,9 @@ class Storage(object):
             return job.job_id
 
     def _run_scheduled_hooks(self, orm_job):
-        for schedule_hook in self.schedule_hooks:
-            schedule_hook(
-                id=orm_job.id,
-                priority=orm_job.priority,
-                interval=orm_job.interval,
-                repeat=orm_job.repeat,
-                retry_interval=orm_job.retry_interval,
-                scheduled_time=orm_job.scheduled_time,
-            )
+        job = self._orm_to_job(orm_job)
+        for hook in self._hooks:
+            hook.schedule(job, orm_job)
 
     def _now(self):
         return local_now()

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -684,22 +684,6 @@ base_option_spec = {
                 The file to use for the job storage database. This is only used in the case that the database backend being used is SQLite.
             """,
         },
-        "SCHEDULE_HOOKS": {
-            "type": "lazy_import_callback_list",
-            "description": """
-                A list of module paths for function callbacks that will be called when a job is scheduled in the storage class.
-                This is intended to allow an external task runner to be used to execute Kolibri tasks. The default is empty,
-                as the internal handling is sufficient for Kolibri's task running.
-            """,
-        },
-        "UPDATE_HOOKS": {
-            "type": "lazy_import_callback_list",
-            "description": """
-                A list of module paths for function callbacks that will be called when a job is updated in the storage class.
-                This is intended to allow an external task runner to do additional actions when the status of a kolibri Job is updated.
-                The default is empty, as the internal handling is sufficient for Kolibri's task running.
-            """,
-        },
     },
 }
 


### PR DESCRIPTION
## Summary
* Final update for hooking into the Job storage class
* Adds the ability to hook into jobs being cleared
* Also cleans up the way that hooks are registered to use a proper Kolibri hook rather than creating parallel mechanisms

## References
In support of https://github.com/learningequality/kolibri-installer-android/pull/119

## Reviewer guidance
Create a mock hook derived from the StorageHook and register it somewhere, for example:
```
@register_hook
class StorageHookExample(StorageHook):
    def schedule(self, job, orm_job):
        print("Job {} scheduled".format(job.job_id))
    
    def update(self, job, orm_job, state=None, **kwargs):
        print("Job {} updated".format(job.job_id))
    
    def clear(self, job, orm_job):
        print("Job {} cleared".format(orm_job.id))

```

Then run Kolibri and see that the hook properly does these print statements.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
