### PR TITLE
Fixed several follow up issues

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -150,7 +150,7 @@ export function showTopicsTopic(store, route) {
       return setCurrentDevice(route.params.deviceId).then(device => {
         const baseurl = device.base_url;
         const { fetchUserDownloadRequests } = useDownloadRequests(store);
-        fetchUserDownloadRequests();
+        fetchUserDownloadRequests({ page: 1, pageSize: 100 });
         return fetchChannels({ baseurl }).then(() => {
           return _loadTopicsTopic(store, { route, baseurl });
         });

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <span v-if="!devices.some(device => device.id === deviceId && device.available)">
+  <span v-if="isFetched && (!devices.some(device => device.id === deviceId && device.available))">
     <span class="inner" style="font-size: 14px;">
       {{ coreString('disconnected') }}
     </span>
@@ -20,21 +20,29 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+  import { ref, watch } from 'kolibri.lib.vueCompositionApi';
 
   export default {
     name: 'DeviceConnectionStatus',
     mixins: [commonCoreStrings],
-    setup() {
-      const { devices } = useDevicesWithFacility();
+    setup(props) {
+      const { isFetching, devices } = useDevicesWithFacility();
+      const isFetched = ref(false);
+      watch(isFetching, currentValue => {
+        if (!currentValue.value) {
+          isFetched.value = props.deviceId !== null;
+        }
+      });
       return {
         devices,
+        isFetched,
       };
     },
     props: {
       // eslint-disable-next-line kolibri/vue-no-unused-properties
       deviceId: {
         type: String,
-        required: true,
+        default: null,
       },
       color: {
         type: String,

--- a/kolibri/plugins/learn/assets/test/views/device-connection-status.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/device-connection-status.spec.js
@@ -38,13 +38,16 @@ describe('DeviceConnectionStatus', () => {
     expect(wrapper.find('[data-test="disconnected-icon"]').exists()).toBeFalsy();
   });
 
-  it('shows the disconnected icon', () => {
-    useDevicesWithFacility.mockReturnValue({ devices: [] });
+  it('shows the disconnected icon', async () => {
+    useDevicesWithFacility.mockReturnValue({ devices: [], isFetching: true });
     const wrapper = makeWrapper({
       propsData: {
         deviceId: '1',
       },
     });
-    expect(wrapper.find('[data-test="disconnected-icon"]').exists()).toBeTruthy();
+    useDevicesWithFacility.mockReturnValue({ isFetching: false });
+    wrapper.vm.$nextTick(() => {
+      expect(wrapper.find('[data-test="disconnected-icon"]').exists()).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Solves several problems detected by @pcenov after #10347 was merged:

> 1. Why is the 'Disconnected' status icon being displayed for channels and resources which are on my own device?

It was a clear bug. It seems making a prop required was not enough. It's fixed now.

> 2. The following error is displayed in the console: TypeError: Cannot read properties of undefined (reading 'page')

I've seen this is a regression introduced in #10137. It's fixed here

> 3. When I refresh the 'Explore libraries' page for a moment I see the 'Disconnected' status icon.

It happened because in the moment the page is loaded, the list of devices is not fetched yet, so it showed disconnected. I've added a guard to avoid showing disconnected until the devices are fetched for the first time.

@pcenov I hope everything is clean now, thanks for the detailed and reproducible report, as usual!




## References
Follows up #10347 
## Reviewer guidance
Just follow the comments @pcenov left at https://github.com/learningequality/kolibri/pull/10347#issuecomment-1494101761

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
