### PR TITLE
Fix clear button not visible in Channel select due to text overflow for long labels

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/SelectGroup.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/SelectGroup.vue
@@ -216,6 +216,17 @@
 
 <style lang="scss" scoped>
 
+  // Do not let text oveflow in select menu
+  /deep/ .ui-select-content {
+    width: 100%;
+
+    // remove position absolute to prevent text from getting under button
+    .overlay-close-button {
+      position: unset;
+      flex-shrink: 0;
+    }
+  }
+
   /deep/ .ui-select-label-text.is-inline {
     position: absolute;
     bottom: 45px;


### PR DESCRIPTION
Resolves  #10370

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixed the text overlapping from the Library > Resources > select channel 
## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Before 
![Screenshot from 2023-04-02 01-42-49](https://user-images.githubusercontent.com/81693090/230477270-91a9d474-9fda-4584-b385-a25ff4e5964e.png)

- [X] After 
![image](https://user-images.githubusercontent.com/81693090/230476942-5225d65e-44d8-4d70-bf3c-c7ba39a2eb43.png)


References : 
https://kolibri-dev.readthedocs.io/en/develop/getting_started.html?highlight=linting#manual-linting-and-formatting
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->




----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
