### PR TITLE
Fix scroll bar jumping on topics pages

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -35,7 +35,7 @@
 
       <main
         class="main-content-grid"
-        :style="gridOffset"
+        :style="gridStyle"
       >
         <KBreadcrumbs
           v-if="breadcrumbs.length && windowIsSmall"
@@ -544,10 +544,30 @@
           return 346;
         }
       },
-      gridOffset() {
-        return this.isRtl
-          ? { marginRight: `${this.sidePanelWidth + 24}px` }
-          : { marginLeft: `${this.sidePanelWidth + 24}px` };
+      gridStyle() {
+        let style = {};
+        /*
+          Fixes jumping scrollbar when reaching the bottom of the page
+          for certain page heights and when side bar is present.
+          The issue is caused by the document scroll height being changed
+          by the sidebar's switching position from absolute to fixed in
+          the sticky calculation, resulting in an endless cycle
+          of the calculation being called and the sidepanel alternating between
+          fixed and absolute position over and over. Setting min height prevents
+          this by making sure that the document scroll height won't change
+          on the sidebar positioning updates.
+        */
+        if (this.windowIsLarge) {
+          style = {
+            minHeight: '900px',
+          };
+        }
+        if (this.isRtl) {
+          style.marginRight = `${this.sidePanelWidth + 24}px`;
+        } else {
+          style.marginLeft = `${this.sidePanelWidth + 24}px`;
+        }
+        return style;
       },
       numCols() {
         if (this.windowBreakpoint > 1 && this.windowBreakpoint < 2) {
@@ -740,19 +760,6 @@
   .main-content-grid {
     position: relative;
     top: $toolbar-height;
-
-    /*
-      Fixes jumping scrollbar when reaching the bottom of the page
-      for certain page heights. The issue is caused by the document
-      scroll height being changed by the sidebar's switching position
-      from absolute to fixed in the sticky calculation, resulting in
-      an endless cycle of the sticky calculation being called
-      and the sidepanel alternating between fixed and absolute position
-      over and over. Setting min width prevents this by making sure that
-      the document scroll height won't change on the sidebar positioning
-      updates.
-    */
-    min-height: 900px;
     margin: 24px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -740,6 +740,19 @@
   .main-content-grid {
     position: relative;
     top: $toolbar-height;
+
+    /*
+      Fixes jumping scrollbar when reaching the bottom of the page
+      for certain page heights. The issue is caused by the document
+      scroll height being changed by the sidebar's switching position
+      from absolute to fixed in the sticky calculation, resulting in
+      an endless cycle of the sticky calculation being called
+      and the sidepanel alternating between fixed and absolute position
+      over and over. Setting min width prevents this by making sure that
+      the document scroll height won't change on the sidebar positioning
+      updates.
+    */
+    min-height: 900px;
     margin: 24px;
   }
 


### PR DESCRIPTION
## Summary

Fixes jumping scrollbar when reaching the bottom of the page for certain page heights. The issue is caused by the document scroll height being changed by the sidebar's switching position from absolute to fixed in the sticky calculation, resulting in an endless cycle of the sticky calculation being called and the sidepanel alternating between fixed and absolute position over and over. Setting min width prevents this by making sure that the document scroll height won't change on the sidebar positioning updates.

### Before
https://drive.google.com/file/d/1RB_-w0gmQmb2UBoX20us6aNU9ch_NKpN/view?usp=share_link

### After
https://drive.google.com/file/d/1D-gE0hzv-jeJbT8__DINuFobWUOvWOCr/view?usp=share_link

## Reviewer guidance

If you can, find a place where you can reproduce the scroll bar jumping and check that this PR fixes it. Note that this issue occurs under pretty specific conditions in regard to page height. @thanksameeelian and me could commonly reproduce it when there were two rows of cards on a page, for example on _Learn --> Library --> Kolibri QA Channel --> African Story Books_ page.

## Comments

Note that in some cases, this change may add a bit extra space under the card grid.

I was experimenting with more robust solutions incorporating changes to the page layout and the sticky calculation, however, it was complicated by the complexity of the component and would result in a larger refactor that I don't have the capacity for right now. Reported in #10415.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
