### PR TITLE
Tracking merge facility users in some connection breakage situations

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -11,6 +11,7 @@ from .urls import HTTPS_PORTS
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.urls import join_url
+from kolibri.utils.server import get_urls
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,10 @@ class NetworkClient(requests.Session):
             else:
                 # if we're within a request thread, then we limit it for an overall time
                 timeout = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_SYNC_READ_TIMEOUT)
+        _, self_urls = get_urls()
         for url in get_normalized_url_variations(address):
+            if url in self_urls:
+                continue  # exclude our own URLs
             with NetworkClient(url, timeout=timeout) as client:
                 if client.connect(raise_if_unavailable=False):
                     return client

--- a/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
+++ b/kolibri/plugins/user_profile/assets/src/machines/changeFacilityMachine.js
@@ -98,6 +98,9 @@ const setTaskId = assign({
   taskId: (_, event) => event.value.task_id,
 });
 
+const resetTaskId = assign({
+  taskId: () => null,
+});
 const resetMachineContext = assign(() => {
   return generateMachineContext();
 });
@@ -381,7 +384,7 @@ const states = {
     on: {
       SETTASKID: { actions: setTaskId },
       FINISH: 'syncFinished',
-      TASKERROR: 'changeFacility',
+      TASKERROR: { target: 'changeFacility', actions: [resetTaskId] },
     },
   },
   syncFinished: {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -198,12 +198,9 @@
                           // if the request is bad, we can't do anything
                           changeFacilityService.send('TASKERROR');
                         }
-                      } else if (error.response.status == 500) {
-                        const message = error.response.data;
-                        if (message.includes('ConnectionError')) {
-                          taskError.value = true;
-                          isPolling = false;
-                        }
+                      } else if (error.response.status == 410) {
+                        taskError.value = true;
+                        isPolling = false;
                       }
                     });
                 }

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -143,42 +143,42 @@
       }
 
       function pollTask() {
-        console.log(taskId.value);
         if (taskId.value === null) {
           // first, try to see if there's already one running
-          TaskResource.fetchCollection().then(allTasks => {
-            const tasks = allTasks.filter(
-              t => t.type === 'kolibri.plugins.user_profile.tasks.mergeuser'
-            );
-            if (tasks.length > 0) {
-              updateMachineContext(tasks[0]);
-            } else {
-              // if not, start a new one or wait for the previous request to finish
-              if (!isTaskRequested) {
-                isTaskRequested = true;
-                const params = {
-                  type: 'kolibri.plugins.user_profile.tasks.mergeuser',
-                  baseurl: state.value.targetFacility.url,
-                  facility: state.value.targetFacility.id,
-                  username: state.value.targetAccount.username,
-                  local_user_id: state.value.userId,
-                  facility_name: state.value.targetFacility.name,
-                  user_id: state.value.targetAccount.id,
-                };
-                if (state.value.targetAccount.password !== '') {
-                  params['password'] = state.value.targetAccount.password;
-                }
-                if (state.value.newSuperAdminId !== '') {
-                  params['new_superuser_id'] = state.value.newSuperAdminId;
-                }
-                if (state.value.setAsSuperAdmin !== false) {
-                  params['set_as_super_user'] = true;
-                }
-                if (state.value.targetAccount.AdminUsername !== undefined) {
-                  params['using_admin'] = true;
-                  params['username'] = state.value.targetAccount.AdminUsername;
-                  params['password'] = state.value.targetAccount.AdminPassword;
-                }
+          TaskResource.fetchCollection()
+            .then(allTasks => {
+              const tasks = allTasks.filter(
+                t => t.type === 'kolibri.plugins.user_profile.tasks.mergeuser'
+              );
+              if (tasks.length > 0) {
+                updateMachineContext(tasks[0]);
+              } else {
+                // if not, start a new one or wait for the previous request to finish
+                if (!isTaskRequested) {
+                  isTaskRequested = true;
+                  const params = {
+                    type: 'kolibri.plugins.user_profile.tasks.mergeuser',
+                    baseurl: state.value.targetFacility.url,
+                    facility: state.value.targetFacility.id,
+                    username: state.value.targetAccount.username,
+                    local_user_id: state.value.userId,
+                    facility_name: state.value.targetFacility.name,
+                    user_id: state.value.targetAccount.id,
+                  };
+                  if (state.value.targetAccount.password !== '') {
+                    params['password'] = state.value.targetAccount.password;
+                  }
+                  if (state.value.newSuperAdminId !== '') {
+                    params['new_superuser_id'] = state.value.newSuperAdminId;
+                  }
+                  if (state.value.setAsSuperAdmin !== false) {
+                    params['set_as_super_user'] = true;
+                  }
+                  if (state.value.targetAccount.AdminUsername !== undefined) {
+                    params['using_admin'] = true;
+                    params['username'] = state.value.targetAccount.AdminUsername;
+                    params['password'] = state.value.targetAccount.AdminPassword;
+                  }
 
                   TaskResource.startTask(params)
                     .then(startedTask => {


### PR DESCRIPTION
## Summary

Trying to add some solutions to connection failures when merging users in different situations, according to the scenarios @pcenov reported in #10268 

> Scenario 1: The target server is stopped before pressing the Continue button. In that case there's no message displayed to the user and only a 410 Gone error in the console

I'm afraid I'm not able to reproduce it, even following strictly the video, @pcenov  please, check if the error persists on your side. It might have been solved after your tests . I always get this screen when reproducing it:
![error_merge1](https://user-images.githubusercontent.com/1008178/230621278-6fc863d0-b773-415c-8c04-1033f2e8e548.png)

> Scenario 2: The target server is stopped after pressing the Continue button. In that case I do see the Remotely preparing data: MorangoError however nothing happens after restarting the target server and clicking the RETRY button 

Reproduced and fixed here. However, I've been able to see, depending on the exact moment the remote server is closed, that sometimes the task stays forever and never reports as failure. I don't think that's something related to t his work, nor even to the syncs, but a problem in our current task system. Tasks should timeout at some point. If the task never reports a FAILED status, the local kolibri can't know there's a problem.

> Scenario 3: The target server is not being stopped but there are network interruptions before or after pressing the Continue button. In that case it's somewhat clearer to the learner what is going on however it also involves starting over the process.

Reproduced and fixed here.

## References
Closes: #10268 

## Reviewer guidance
Following the videos at #10268 try to reproduce those problems.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
