### PR TITLE
Skip pre-initialization updates

### DIFF
--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -279,7 +279,8 @@ def initialize(  # noqa C901
 
     updated = version_updated(kolibri.__version__, version)
 
-    _upgrades_before_django_setup(updated, version)
+    if not skip_update:
+        _upgrades_before_django_setup(updated, version)
 
     _setup_django()
 


### PR DESCRIPTION
## Summary
* Fixes a bug with the skip_update flag where some update routines were still being run
* Doesn't run pre-kolibri and django initialization upgrade routines when skip_update is True.

## Reviewer guidance
This appears to have been an oversight in implementation - a slight surprise that errors have not appeared before now.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
