### PR TITLE
Validate NoneType client sock connection

### DIFF
--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -115,6 +115,9 @@ class NetworkClient(requests.Session):
             with super(NetworkClient, self).request(
                 method, url, stream=True, **kwargs
             ) as response:
+                if response.raw._connection.sock is None:
+                    raise requests.exceptions.ConnectionError("No socket available")
+
                 # capture the remote IP address, which requires `stream=True` and before consumed
                 self.remote_ip = response.raw._connection.sock.getpeername()[0]
                 # now consume content, see how `Session.send` does this when `stream=False`


### PR DESCRIPTION
## Summary

This PR validates a None on the client request method

## References

Closes #10356

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
