### PR TITLE
Don't user username for admin

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/index.vue
@@ -104,7 +104,13 @@
       });
 
       watch(changeFacilityService, currentValue => {
-        usingAdminPasswordState.value = currentValue.state.value === 'useAdminPassword';
+        if (currentValue.state.value === 'useAdminPassword') {
+          usingAdminPasswordState.value = true;
+          formData.value['username'] = '';
+        } else {
+          usingAdminPasswordState.value = false;
+          formData.value['username'] = get(state, 'value.username', '');
+        }
       });
 
       const mergeAccountUserInfo = computed({


### PR DESCRIPTION
## Summary
Ensures the username is reset when the user selects to use admin credentials

## References
Closes: #9793

## Reviewer guidance
Report in #9793 explains how to reproduce it.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
