### PR TITLE
Removes double focus outline on sign-in page

### DIFF
--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -430,4 +430,10 @@
     vertical-align: middle;
   }
 
+  /deep/ .ui-textbox-input {
+    &:hover {
+      outline: none;
+    }
+  }
+
 </style>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr updates the sign-in page to remove the double focus outline that occurs when running the dev server with hot reload enabled.

Before:

<img width="473" alt="usernameBefore" src="https://user-images.githubusercontent.com/46411498/231180574-9ba75498-bc3e-4fc1-b773-0490abd6b0a4.png">

<img width="488" alt="passwordbefore" src="https://user-images.githubusercontent.com/46411498/231180644-fc781c21-a7ab-4ad7-be13-5e6a2b04cdcc.png">

After:
<img width="479" alt="usernameafter" src="https://user-images.githubusercontent.com/46411498/231180690-efbe1407-2378-4bb8-9df8-123e52f6a498.png">

<img width="502" alt="passwordAfter" src="https://user-images.githubusercontent.com/46411498/231180706-ab2cb50c-632f-42b9-a3a0-2ffa7d4bcb56.png">



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10281 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Run the Kolibri dev server with hot reload enabled.
2. On the sign-in page, use TAB key to navigate to input field.
3. Confirm that there is no double focus outline for username and password input.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
