### PR TITLE
[DO NOT MERGE] temp reference to new KDS PR commit (for regression of testing KModals & KSelects)

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.1",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.42",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#a671f6f898eef07a3167dc74648ef329f8e3af44",
+    "kolibri-design-system": "https://github.com/thanksameeelian/kolibri-design-system#dd0c728bbdd442b04188e29ace1f0890c5924c2c",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.1.42",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#a671f6f898eef07a3167dc74648ef329f8e3af44",
+    "kolibri-design-system": "https://github.com/thanksameeelian/kolibri-design-system#dd0c728bbdd442b04188e29ace1f0890c5924c2c",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11006,7 +11006,7 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-intl@3.1.0, vue-intl@^3.1.0:
+vue-intl@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vue-intl/-/vue-intl-3.1.0.tgz#707f1f7406595c9b4afc6049254b333093be37be"
   integrity sha512-0v3S5gspuYnt6j1G+KLfPUsNnjRdbMOcYrWYoSd1gYk6rX8VuOyh7NLztPrSIJt+NLs/qzLOZXxI1LORukEiqA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7297,9 +7297,9 @@ kolibri-constants@0.1.42:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.1.42.tgz#2f62a8d8b8894e5cfbd47ee6564b31018818c93f"
   integrity sha512-2hUxYnzUEfhLFJO9egVSwYW8/PKob9wLeDYfB74mtIzgQ4zy6huRj3574WetK9gREi+W1Jcm7HGPsfZIFzFvrA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#a671f6f898eef07a3167dc74648ef329f8e3af44":
+"kolibri-design-system@https://github.com/thanksameeelian/kolibri-design-system#dd0c728bbdd442b04188e29ace1f0890c5924c2c":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#a671f6f898eef07a3167dc74648ef329f8e3af44"
+  resolved "https://github.com/thanksameeelian/kolibri-design-system#dd0c728bbdd442b04188e29ace1f0890c5924c2c"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
@@ -11006,7 +11006,7 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
-vue-intl@3.1.0:
+vue-intl@3.1.0, vue-intl@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/vue-intl/-/vue-intl-3.1.0.tgz#707f1f7406595c9b4afc6049254b333093be37be"
   integrity sha512-0v3S5gspuYnt6j1G+KLfPUsNnjRdbMOcYrWYoSd1gYk6rX8VuOyh7NLztPrSIJt+NLs/qzLOZXxI1LORukEiqA==


### PR DESCRIPTION
# DO NOT MERGE
## Summary

Temp reference to KDS PR: [allow KSelect to extend outside of KModal](https://github.com/learningequality/kolibri-design-system/pull/429)

The scenario addressed in that PR (and [raised in KDS issue 324](https://github.com/learningequality/kolibri-design-system/issues/324)), where a `KSelect` is inside a `KModal` and displays unexpected behavior, currently only occurs in KDP. At present, there are no `KSelect`s inside `KModal`s in Kolibri and there have been barriers to testing in KDP, but the new behavior of the combination of those two components is documented in the KDS PR. 

This Kolibri PR exists so that regression testing can occur for general `KModal` & `KSelect` behavior.


## References
- KDS PR: [429](https://github.com/learningequality/kolibri-design-system/pull/429)
- KDS PR addresses:  [issue 324](https://github.com/learningequality/kolibri-design-system/issues/324)



## Reviewer guidance
- regression testing for `KModal` and `KSelect` as there have been underlying changes



## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
