### PR TITLE
Update remote browsing of Studio

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1725,6 +1725,9 @@ class RemoteChannelViewSet(viewsets.ViewSet):
             if resp.status_code == 404:
                 raise requests.ConnectionError("Kolibri Studio URL is incorrect!")
             else:
-                return Response({"status": "online"})
+                data = resp.json()
+                data["available"] = True
+                data["status"] = "online"
+                return Response(data)
         except requests.ConnectionError:
-            return Response({"status": "offline"})
+            return Response({"status": "offline", "available": False})

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -121,7 +121,8 @@ class RemoteMixin(object):
     def _get_request_headers(self, request):
         return {
             "Accept": request.META.get("HTTP_ACCEPT"),
-            "Accept-Encoding": request.META.get("HTTP_ACCEPT_ENCODING"),
+            # Don't proxy client's accept headers as it may include br for brotli
+            # that we cannot rely on having decompression for available on the server.
             "Accept-Language": request.META.get("HTTP_ACCEPT_LANGUAGE"),
             "Content-Type": request.META.get("CONTENT_TYPE"),
             "If-None-Match": request.META.get("HTTP_IF_NONE_MATCH", ""),

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -154,6 +154,9 @@ class RemoteMixin(object):
             response = requests.get(
                 remote_url, params=qs, headers=self._get_request_headers(request)
             )
+            if response.status_code == 404:
+                raise Http404("Remote resource not found")
+            response.raise_for_status()
             # If Etag is set on the response we have returned here, any further Etag will not be modified
             # by the django etag decorator, so this should allow us to transparently proxy the remote etag.
             try:

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -9,7 +9,7 @@ import { setClasses, setResumableContentNodes } from '../composables/useLearnerR
 import { setContentNodeProgress } from '../composables/useContentNodeProgress';
 import { showTopicsTopic, showTopicsContent } from '../modules/topicsTree/handlers';
 import { showLibrary } from '../modules/recommended/handlers';
-import { PageNames, ClassesPageNames } from '../constants';
+import { PageNames, ClassesPageNames, KolibriStudioId } from '../constants';
 import LibraryPage from '../views/LibraryPage';
 import HomePage from '../views/HomePage';
 import TopicsPage from '../views/TopicsPage';
@@ -45,7 +45,7 @@ function hydrateHomePage() {
   });
 }
 
-const optionalDeviceIdPathSegment = '/:deviceId([a-f0-9]{32}|kolibri-studio)?';
+const optionalDeviceIdPathSegment = `/:deviceId([a-f0-9]{32}|${KolibriStudioId})?`;
 
 export default [
   {

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -205,6 +205,15 @@ export default [
     name: PageNames.EXPLORE_LIBRARIES,
     path: '/explore_libraries',
     component: ExploreLibrariesPage,
+    handler: () => {
+      if (!get(isUserLoggedIn)) {
+        router.replace({ name: PageNames.LIBRARY });
+        return;
+      }
+      if (unassignedContentGuard()) {
+        return unassignedContentGuard();
+      }
+    },
   },
   {
     path: '*',


### PR DESCRIPTION
## Summary
* Consolidates logic for checking Studio availability into the useDevices composable
* Removes special casing for Studio and defers to using the `baseurl` GET parameter to fetch channels
* Does a version check against Studio and all Kolibri devices to make sure they support remote content browsing
* Adds navigation guards for the explore libraries page
* Fixes some issues in the remote API logic that failed to properly raise errors
* Fixes issue in the remote API logic that could cause Brotli encoded responses that the server cannot decode

## References
Fixes #10280

## Reviewer guidance
Run the dev server with this environment variable set:
```
KOLIBRI_CENTRAL_CONTENT_BASE_URL=https://unstable.studio.learningequality.org
```

Complete and proper functioning is dependent on this PR being merged: https://github.com/learningequality/studio/pull/4018

This PR is now merged, and unstable should be updated automatically.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
