### PR TITLE
standardize percent calculation in ExamReport display

### DIFF
--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -332,13 +332,15 @@
       },
       pastTriesOptions() {
         return this.pastTries.map((quizTry, index) => {
-          const score = Math.floor((quizTry.correct / this.questions.length) * 100);
+          const rawScore = quizTry.correct / this.questions.length;
+          const score = this.$formatNumber(rawScore, { style: 'percent' });
           const time = this.$formatRelative(quizTry.completion_timestamp || quizTry.end_timestamp, {
             now: this.now,
           });
+
           return {
             value: index,
-            label: this.isSurvey ? time : `(${score}%) ${time}`,
+            label: this.isSurvey ? time : `(${score}) ${time}`,
           };
         });
       },


### PR DESCRIPTION
## Summary
Addresses #10443 by standardizing the percent calculation, introducing `$formatNumber` into the "Attempts" dropdown display, as that's how the value calculated for  "Best Score"


## References
_before - note disparity between a "Best score"/"Score" and the same attempt as it is displayed in the "Attempt" dropdown: `67%` vs. `66%`, though they are referencing the same value._
![before number mismatch](https://user-images.githubusercontent.com/43046460/231272153-2571f544-7de9-42fe-a206-6aa8dbd3d25f.png)

_after_
![image](https://user-images.githubusercontent.com/43046460/231272360-25671ab2-5142-4292-8ea5-ce973b536bbd.png)


## Reviewer guidance
recreate this scenario by creating a practice quiz (through creating a Lesson or other means) for a class, logging in as a learner in that class, and making at least 2 attempts to complete the quiz. compare the values seen in "Best Score"/"Score" to the value selected in the "Attempt" dropdown



----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
