### PR TITLE
Fixes loading states in general

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -100,7 +100,9 @@
       },
       loading: {
         type: Boolean,
-        default: null,
+        default() {
+          return this.$store.state.core.loading;
+        },
       },
     },
     data() {

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -54,6 +54,7 @@
 
   import { mapGetters } from 'vuex';
   import { get } from '@vueuse/core';
+  import _get from 'lodash/get';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
@@ -101,7 +102,7 @@
       loading: {
         type: Boolean,
         default() {
-          return this.$store.state.core.loading;
+          return _get(this, '$store.state.core.loading', false);
         },
       },
     },

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -1,9 +1,11 @@
 <script>
 
   import get from 'lodash/get';
+  import KCircularLoader from 'kolibri-design-system/lib/loaders/KCircularLoader';
 
   export default {
     name: 'CoreTable',
+    components: { KCircularLoader },
     props: {
       selectable: {
         type: Boolean,
@@ -13,6 +15,11 @@
       emptyMessage: {
         type: String,
         default: null,
+      },
+      dataLoading: {
+        type: Boolean,
+        default: false,
+        required: false,
       },
     },
     computed: {
@@ -73,9 +80,19 @@
         }
       });
 
-      // Insert an empty message as a <p> at the end if it is provided and the
-      // table has no rows.
-      const showEmptyMessage = this.emptyMessage && !tableHasRows;
+      // If we have loaded the data, but have no empty message and no rows, we log an error.
+      if (!this.dataLoading && this.emptyMessage && !tableHasRows) {
+        console.error('CoreTable: No rows in table, but no empty message provided.');
+      }
+
+      /*
+       * If data is still loading, then we show a loader. Otherwise, we show the
+       * empty message if there are no rows in the table. If we have loaded data, have
+       * an emptyMessage and have no rows.
+       */
+      var noDataEl = this.dataLoading
+        ? createElement('p', [createElement(KCircularLoader)])
+        : createElement('p', this.emptyMessage);
 
       return createElement('div', { class: 'core-table-container' }, [
         createElement('table', { class: 'core-table' }, [
@@ -83,7 +100,7 @@
           theadEl,
           tbodyCopy,
         ]),
-        showEmptyMessage && createElement('p', this.emptyMessage),
+        noDataEl,
       ]);
     },
   };

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -1,7 +1,10 @@
 <script>
 
   import get from 'lodash/get';
+  import logger from 'kolibri.lib.logging';
   import KCircularLoader from 'kolibri-design-system/lib/loaders/KCircularLoader';
+
+  const logging = logger.getLogger(__filename);
 
   export default {
     name: 'CoreTable',
@@ -82,7 +85,7 @@
 
       // If we have loaded the data, but have no empty message and no rows, we log an error.
       if (!this.dataLoading && this.emptyMessage && !tableHasRows) {
-        console.error('CoreTable: No rows in table, but no empty message provided.');
+        logging.error('CoreTable: No rows in table, but no empty message provided.');
       }
 
       /*

--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -88,11 +88,11 @@
       /*
        * If data is still loading, then we show a loader. Otherwise, we show the
        * empty message if there are no rows in the table. If we have loaded data, have
-       * an emptyMessage and have no rows.
+       * an emptyMessage and have no rows. If we have rows, then we show the table alone
        */
-      var noDataEl = this.dataLoading
+      var dataStatusEl = this.dataLoading
         ? createElement('p', [createElement(KCircularLoader)])
-        : createElement('p', this.emptyMessage);
+        : !tableHasRows && createElement('p', this.emptyMessage); // Only show message if no rows
 
       return createElement('div', { class: 'core-table-container' }, [
         createElement('table', { class: 'core-table' }, [
@@ -100,7 +100,7 @@
           theadEl,
           tbodyCopy,
         ]),
-        noDataEl,
+        dataStatusEl,
       ]);
     },
   };

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -437,13 +437,14 @@
         MasteryLogResource.fetchMostRecentDiff(this.getParams())
           .then(currentTry => {
             this.currentTry = currentTry;
+            this.loading = false;
           })
           .catch(err => {
             if (err.response && err.response.status_code === 404) {
               this.$emit('noCompleteTries');
             }
-          })
-          .finally(() => (this.loading = false));
+            this.loading = false;
+          });
       },
       loadAllTries() {
         MasteryLogResource.fetchCollection({ getParams: this.getParams(), force: true }).then(

--- a/kolibri/core/assets/src/views/UserTable/__tests__/index.spec.js
+++ b/kolibri/core/assets/src/views/UserTable/__tests__/index.spec.js
@@ -1,9 +1,13 @@
-import { shallowMount, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { UserKinds } from 'kolibri.coreVue.vuex.constants';
+import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import UserTable from '../index';
 
 function makeWrapper({ propsData } = {}) {
+  const store = coreStoreFactory({});
+  store.dispatch('notLoading');
   return mount(UserTable, {
+    store,
     propsData,
   });
 }
@@ -36,7 +40,7 @@ const TEST_USERS = [
 
 describe(`UserTable`, () => {
   it(`smoke test`, () => {
-    const wrapper = shallowMount(UserTable);
+    const wrapper = makeWrapper();
     expect(wrapper.exists()).toBeTruthy();
   });
 

--- a/kolibri/core/assets/src/views/UserTable/index.vue
+++ b/kolibri/core/assets/src/views/UserTable/index.vue
@@ -17,7 +17,7 @@
       data-test="selectAllCheckbox"
       @change="selectAll($event)"
     />
-    <CoreTable>
+    <CoreTable :emptyMessage="emptyMessage" :dataLoading="dataLoading">
       <template #headers>
         <th data-test="fullNameHeader" :style="{ minWidth: '32px' }">
           <span v-if="selectable" class="visuallyhidden">
@@ -195,13 +195,6 @@
       </template>
     </CoreTable>
 
-    <p
-      v-if="(!users || !users.length) && !$store.state.core.loading"
-      class="empty-message"
-    >
-      {{ emptyMessage }}
-    </p>
-
   </div>
 
 </template>
@@ -276,6 +269,10 @@
       selectedStyle: {
         type: String,
         default: '',
+      },
+      dataLoading: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/core/assets/src/views/UserTable/index.vue
+++ b/kolibri/core/assets/src/views/UserTable/index.vue
@@ -62,7 +62,14 @@
       </template>
 
       <template #tbody>
-        <tbody>
+        <tbody v-if="$store.state.core.loading">
+          <tr style="overflow:hidden;">
+            <td>
+              <KCircularLoader class="center-loader" />
+            </td>
+          </tr>
+        </tbody>
+        <tbody v-else>
           <tr
             v-for="user in users"
             :key="user.id"
@@ -189,7 +196,7 @@
     </CoreTable>
 
     <p
-      v-if="!users || !users.length"
+      v-if="(!users || !users.length) && !$store.state.core.loading"
       class="empty-message"
     >
       {{ emptyMessage }}
@@ -387,6 +394,21 @@
 
   td.id-col {
     max-width: 120px;
+  }
+
+  .center-loader {
+    &.ui-progress-circular {
+      position: static !important;
+      width: 100% !important;
+      overflow: hidden;
+    }
+
+    /deep/ svg {
+      top: 48px;
+      width: 32px;
+      height: 32px;
+      overflow: hidden;
+    }
   }
 
 </style>

--- a/kolibri/core/assets/src/views/UserTable/index.vue
+++ b/kolibri/core/assets/src/views/UserTable/index.vue
@@ -62,14 +62,7 @@
       </template>
 
       <template #tbody>
-        <tbody v-if="$store.state.core.loading">
-          <tr style="overflow:hidden;">
-            <td>
-              <KCircularLoader class="center-loader" />
-            </td>
-          </tr>
-        </tbody>
-        <tbody v-else>
+        <tbody>
           <tr
             v-for="user in users"
             :key="user.id"

--- a/kolibri/core/assets/src/views/UserTable/index.vue
+++ b/kolibri/core/assets/src/views/UserTable/index.vue
@@ -386,19 +386,4 @@
     max-width: 120px;
   }
 
-  .center-loader {
-    &.ui-progress-circular {
-      position: static !important;
-      width: 100% !important;
-      overflow: hidden;
-    }
-
-    /deep/ svg {
-      top: 48px;
-      width: 32px;
-      height: 32px;
-      overflow: hidden;
-    }
-  }
-
 </style>

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -21,7 +21,7 @@ const logging = logger.getLogger(__filename);
 export default {
   state() {
     return {
-      busy: false,
+      dataLoading: false,
       classList: [],
       pageName: '',
       toolbarRoute: {},
@@ -37,6 +37,9 @@ export default {
     },
     SET_TOOLBAR_TITLE(state, title) {
       state.toolbarTitle = title;
+    },
+    SET_DATA_LOADING(state, dataLoading) {
+      state.dataLoading = dataLoading;
     },
     SET_TOOLBAR_ROUTE(state, toolbarRoute) {
       state.toolbarRoute = toolbarRoute;
@@ -60,13 +63,15 @@ export default {
   },
   actions: {
     setClassList(store, facilityId) {
+      store.commit('SET_DATA_LOADING', true);
       return ClassroomResource.fetchCollection({
         getParams: { parent: facilityId || store.getters.currentFacilityId, role: 'coach' },
       })
         .then(classrooms => {
           store.commit('SET_CLASS_LIST', classrooms);
         })
-        .catch(error => store.dispatch('handleApiError', error));
+        .catch(error => store.dispatch('handleApiError', error))
+        .finally(() => store.commit('SET_DATA_LOADING', false));
     },
     /**
       * Handle coach page errors.

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -64,6 +64,7 @@ export default {
   actions: {
     setClassList(store, facilityId) {
       store.commit('SET_DATA_LOADING', true);
+      store.commit('SET_CLASS_LIST', []); // Reset the list if we're loading a new one
       return ClassroomResource.fetchCollection({
         getParams: { parent: facilityId || store.getters.currentFacilityId, role: 'coach' },
       })

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -70,9 +70,12 @@ export default {
       })
         .then(classrooms => {
           store.commit('SET_CLASS_LIST', classrooms);
+          store.commit('SET_DATA_LOADING', false);
         })
-        .catch(error => store.dispatch('handleApiError', error))
-        .finally(() => store.commit('SET_DATA_LOADING', false));
+        .catch(error => {
+          store.dispatch('handleApiError', error);
+          store.commit('SET_DATA_LOADING', false);
+        });
     },
     /**
       * Handle coach page errors.

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -17,18 +17,15 @@
       <h1>{{ coreString('classesLabel') }}</h1>
       <p>{{ $tr('classPageSubheader') }}</p>
 
-      <p v-if="classList.length === 0">
+      <p v-if="classList.length === 0 && !dataLoading">
         <KExternalLink
           v-if="isAdmin && createClassUrl"
           :text="$tr('noClassesDetailsForAdmin')"
           :href="createClassUrl"
         />
-        <span v-else>
-          {{ emptyStateDetails }}
-        </span>
       </p>
 
-      <CoreTable v-else>
+      <CoreTable v-else :dataLoading="dataLoading" :emptyMessage="emptyStateDetails">
         <template #headers>
           <th>{{ coreString('classNameLabel') }}</th>
           <th>{{ coreString('coachesLabel') }}</th>
@@ -83,7 +80,7 @@
     mixins: [commonCoach, commonCoreStrings],
     computed: {
       ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach', 'userIsMultiFacilityAdmin']),
-      ...mapState(['classList']),
+      ...mapState(['classList', 'dataLoading']),
       // Message that shows up when state.classList is empty
       emptyStateDetails() {
         if (this.isClassCoach) {

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
@@ -19,6 +19,7 @@ function fetchFacilityUsers() {
 
 export function showManagePermissionsPage(store) {
   const shouldResolve = samePageCheckGenerator(store);
+  store.commit('managePermissions/SET_LOADING_FACILITY_USERS', true);
   const promises = Promise.all([fetchFacilityUsers(store), fetchDevicePermissions()]);
   return promises
     .then(function onSuccess([users, permissions]) {
@@ -31,5 +32,8 @@ export function showManagePermissionsPage(store) {
     })
     .catch(function onFailure(error) {
       shouldResolve() ? store.dispatch('handleError', error) : null;
+    })
+    .finally(() => {
+      store.commit('managePermissions/SET_LOADING_FACILITY_USERS', false);
     });
 }

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
@@ -22,18 +22,17 @@ export function showManagePermissionsPage(store) {
   store.commit('managePermissions/SET_LOADING_FACILITY_USERS', true);
   const promises = Promise.all([fetchFacilityUsers(store), fetchDevicePermissions()]);
   return promises
-    .then(function onSuccess([users, permissions]) {
+    .then(([users, permissions]) => {
       if (shouldResolve()) {
         store.commit('managePermissions/SET_STATE', {
           facilityUsers: users,
           permissions,
         });
       }
+      return store.commit('managePermissions/SET_LOADING_FACILITY_USERS', false);
     })
-    .catch(function onFailure(error) {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
-    })
-    .finally(() => {
+    .catch(error => {
       store.commit('managePermissions/SET_LOADING_FACILITY_USERS', false);
+      return shouldResolve() ? store.dispatch('handleError', error) : null;
     });
 }

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/index.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/index.js
@@ -1,5 +1,6 @@
 function defaultState() {
   return {
+    loadingFacilityUsers: false,
     facilityUsers: [],
     permissions: {},
   };
@@ -14,6 +15,9 @@ export default {
     },
     RESET_STATE(state) {
       Object.assign(state, defaultState());
+    },
+    SET_LOADING_FACILITY_USERS(state, loadingFacilityUsers) {
+      Object.assign(state, { loadingFacilityUsers });
     },
   },
 };

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/index.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/index.js
@@ -17,7 +17,7 @@ export default {
       Object.assign(state, defaultState());
     },
     SET_LOADING_FACILITY_USERS(state, loadingFacilityUsers) {
-      Object.assign(state, { loadingFacilityUsers });
+      state.loadingFacilityUsers = loadingFacilityUsers;
     },
   },
 };

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -45,20 +45,23 @@
           @clearall="handleClickClearAll"
         />
 
-        <p v-if="!channelsAreInstalled">
+        <p v-if="!channelsAreInstalled && !channelListLoading">
           {{ $tr('emptyChannelListMessage') }}
         </p>
 
         <div class="channels-list">
-          <ChannelPanel
-            v-for="channel in sortedChannels"
-            :key="channel.id"
-            :channel="channel"
-            :disabled="channelIsBeingDeleted(channel.id)"
-            :showNewLabel="showNewLabel(channel.id)"
-            @select_delete="deleteChannelId = channel.id"
-            @select_manage="handleSelectManage(channel.id)"
-          />
+          <KCircularLoader v-if="channelListLoading" />
+          <div v-else>
+            <ChannelPanel
+              v-for="channel in sortedChannels"
+              :key="channel.id"
+              :channel="channel"
+              :disabled="channelIsBeingDeleted(channel.id)"
+              :showNewLabel="showNewLabel(channel.id)"
+              @select_delete="deleteChannelId = channel.id"
+              @select_manage="handleSelectManage(channel.id)"
+            />
+          </div>
         </div>
 
         <SelectTransferSourceModal :pageName="pageName" />
@@ -134,6 +137,7 @@
         'managedTasks',
       ]),
       ...mapState('manageContent/wizard', ['pageName']),
+      ...mapState('manageContent', ['channelListLoading']),
       pageTitle() {
         return deviceString('deviceManagementTitle');
       },

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/UserGrid.vue
@@ -2,7 +2,7 @@
 
   <div>
 
-    <CoreTable :emptyMessage="emptyMessage">
+    <CoreTable :emptyMessage="emptyMessage" :dataLoading="dataLoading">
       <template #headers>
         <th>{{ coreString('fullNameLabel') }}</th>
         <th>{{ coreString('usernameLabel') }}</th>
@@ -81,6 +81,11 @@
       userPermissions: {
         type: Function,
         default: () => null,
+      },
+      dataLoading: {
+        type: Boolean,
+        default: false,
+        required: false,
       },
     },
     computed: {

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
@@ -15,6 +15,7 @@
       </div>
 
       <PaginatedListContainer
+        :dataLoading="loadingFacilityUsers"
         :items="usersFilteredByDropdown"
         :filterPlaceholder="$tr('searchPlaceholder')"
       >
@@ -44,6 +45,7 @@
         </template>
         <template #default="{ items, filterInput }">
           <UserGrid
+            :dataLoading="loadingFacilityUsers"
             :searchFilter="searchFilterText"
             :facilityUsers="items"
             :userPermissions="userPermissions"
@@ -98,6 +100,7 @@
       ...mapState('managePermissions', {
         facilityUsers: state => state.facilityUsers,
         userPermissions: state => userid => state.permissions[userid],
+        loadingFacilityUsers: state => state.loadingFacilityUsers,
       }),
       ...mapState({
         query: state => state.query,

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -18,8 +18,11 @@ export function showClassEditPage(store, classId) {
     ClassroomResource.fetchCollection({ getParams: { parent: facilityId }, force: true }),
   ];
   const shouldResolve = samePageCheckGenerator(store);
+  store.commit('classEditManagement/SET_DATA_LOADING', true);
   Promise.all(promises).then(
     ([facilityUsers, classroom, classrooms]) => {
+      store.commit('classEditManagement/SET_DATA_LOADING', false);
+
       if (shouldResolve()) {
         store.commit('classEditManagement/SET_STATE', {
           modalShown: false,
@@ -28,7 +31,6 @@ export function showClassEditPage(store, classId) {
           classLearners: sortUsersByFullName(facilityUsers).map(_userState),
           classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
         });
-        store.commit('CORE_SET_PAGE_LOADING', false);
       }
     },
     error => {

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -17,8 +17,8 @@ export function showClassEditPage(store, classId) {
     ClassroomResource.fetchCollection({ getParams: { parent: facilityId }, force: true }),
   ];
   store.commit('classEditManagement/SET_DATA_LOADING', true);
-  Promise.all(promises).then(
-    ([facilityUsers, classroom, classrooms]) => {
+  Promise.all(promises)
+    .then(([facilityUsers, classroom, classrooms]) => {
       store.commit('classEditManagement/SET_DATA_LOADING', false);
       store.commit('classEditManagement/SET_STATE', {
         modalShown: false,
@@ -27,9 +27,6 @@ export function showClassEditPage(store, classId) {
         classLearners: sortUsersByFullName(facilityUsers).map(_userState),
         classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
       });
-    },
-    error => {
-      store.dispatch('handleError', error);
-    }
-  );
+    })
+    .catch(error => store.dispatch('handleError', error));
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -1,4 +1,3 @@
-import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { ClassroomResource, FacilityUserResource } from 'kolibri.resources';
 import { localeCompare } from 'kolibri.utils.i18n';
 import { _userState } from '../mappers';
@@ -17,24 +16,20 @@ export function showClassEditPage(store, classId) {
     ClassroomResource.fetchModel({ id: classId, force: true }),
     ClassroomResource.fetchCollection({ getParams: { parent: facilityId }, force: true }),
   ];
-  const shouldResolve = samePageCheckGenerator(store);
   store.commit('classEditManagement/SET_DATA_LOADING', true);
   Promise.all(promises).then(
     ([facilityUsers, classroom, classrooms]) => {
       store.commit('classEditManagement/SET_DATA_LOADING', false);
-
-      if (shouldResolve()) {
-        store.commit('classEditManagement/SET_STATE', {
-          modalShown: false,
-          currentClass: classroom,
-          classes: classrooms,
-          classLearners: sortUsersByFullName(facilityUsers).map(_userState),
-          classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
-        });
-      }
+      store.commit('classEditManagement/SET_STATE', {
+        modalShown: false,
+        currentClass: classroom,
+        classes: classrooms,
+        classLearners: sortUsersByFullName(facilityUsers).map(_userState),
+        classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
+      });
     },
     error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      store.dispatch('handleError', error);
     }
   );
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/index.js
@@ -1,4 +1,4 @@
-import { displayModal, SET_BUSY, SET_ERROR, SET_MODAL } from '../shared';
+import { displayModal, SET_DATA_LOADING, SET_ERROR, SET_MODAL } from '../shared';
 import { removeClassLearner, removeClassCoach, updateClass } from './actions';
 
 function defaultState() {
@@ -8,7 +8,7 @@ function defaultState() {
     classes: [],
     currentClass: null,
     error: '',
-    isBusy: false,
+    dataLoading: false,
     modalShown: false,
   };
 }
@@ -23,7 +23,7 @@ export default {
     RESET_STATE(state) {
       Object.assign(state, defaultState());
     },
-    SET_BUSY,
+    SET_DATA_LOADING,
     SET_ERROR,
     SET_MODAL,
     UPDATE_CLASS(state, { id, updatedClass }) {

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -3,23 +3,28 @@ import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 
 export function showClassesPage(store, toRoute) {
   store.dispatch('preparePage');
+  store.commit('classManagement/SET_STATE', { dataLoading: true });
   const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
   const shouldResolve = samePageCheckGenerator(store);
   return ClassroomResource.fetchCollection({
     getParams: { parent: facilityId },
     force: true,
-  }).then(
-    classrooms => {
-      if (shouldResolve()) {
-        store.commit('classManagement/SET_STATE', {
-          modalShown: false,
-          classes: [...classrooms],
-        });
-        store.commit('CORE_SET_PAGE_LOADING', false);
+  })
+    .then(
+      classrooms => {
+        if (shouldResolve()) {
+          store.commit('classManagement/SET_STATE', {
+            modalShown: false,
+            classes: [...classrooms],
+          });
+          store.commit('CORE_SET_PAGE_LOADING', false);
+        }
+      },
+      error => {
+        shouldResolve() ? store.dispatch('handleError', error) : null;
       }
-    },
-    error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
-    }
-  );
+    )
+    .finally(() => {
+      store.commit('classManagement/SET_STATE', { dataLoading: false });
+    });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -1,29 +1,23 @@
 import { ClassroomResource } from 'kolibri.resources';
-import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 
 export function showClassesPage(store, toRoute) {
   store.dispatch('preparePage');
   store.commit('classManagement/SET_STATE', { dataLoading: true });
   const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
-  const shouldResolve = samePageCheckGenerator(store);
   return ClassroomResource.fetchCollection({
     getParams: { parent: facilityId },
     force: true,
   })
-    .then(
-      classrooms => {
-        if (shouldResolve()) {
-          store.commit('classManagement/SET_STATE', {
-            modalShown: false,
-            classes: [...classrooms],
-          });
-          store.commit('CORE_SET_PAGE_LOADING', false);
-        }
-      },
-      error => {
-        shouldResolve() ? store.dispatch('handleError', error) : null;
-      }
-    )
+    .then(classrooms => {
+      store.commit('classManagement/SET_STATE', {
+        modalShown: false,
+        classes: [...classrooms],
+      });
+      store.commit('CORE_SET_PAGE_LOADING', false);
+    })
+    .catch(error => {
+      store.dispatch('handleError', error);
+    })
     .finally(() => {
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     });

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -14,11 +14,10 @@ export function showClassesPage(store, toRoute) {
         classes: [...classrooms],
       });
       store.commit('CORE_SET_PAGE_LOADING', false);
+      store.commit('classManagement/SET_STATE', { dataLoading: false });
     })
     .catch(error => {
       store.dispatch('handleError', error);
-    })
-    .finally(() => {
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/index.js
@@ -1,11 +1,11 @@
-import { displayModal, SET_BUSY, SET_ERROR, SET_MODAL } from '../shared';
+import { displayModal, SET_DATA_LOADING, SET_ERROR, SET_MODAL } from '../shared';
 import { createClass } from './actions';
 
 function defaultState() {
   return {
     classes: [],
     error: '',
-    isBusy: false,
+    dataLoading: false,
     modalShown: false,
   };
 }
@@ -20,7 +20,7 @@ export default {
     RESET_STATE(state) {
       Object.assign(state, defaultState());
     },
-    SET_BUSY,
+    SET_DATA_LOADING,
     SET_ERROR,
     SET_MODAL,
     ADD_CLASS(state, classroom) {

--- a/kolibri/plugins/facility/assets/src/modules/shared.js
+++ b/kolibri/plugins/facility/assets/src/modules/shared.js
@@ -2,8 +2,8 @@ export function SET_MODAL(state, modalName) {
   state.modalShown = modalName;
 }
 
-export function SET_BUSY(state, isBusy) {
-  state.isBusy = isBusy;
+export function SET_DATA_LOADING(state, dataLoading) {
+  state.dataLoading = dataLoading;
 }
 
 export function SET_ERROR(state, error) {
@@ -13,5 +13,5 @@ export function SET_ERROR(state, error) {
 export function displayModal(store, modalName) {
   store.commit('SET_MODAL', modalName);
   store.commit('SET_ERROR', '');
-  store.commit('SET_BUSY', false);
+  store.commit('SET_DATA_LOADING', false);
 }

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -4,6 +4,7 @@ import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { _userState } from '../mappers';
 // An action for setting up the initial state of the app by fetching data from the server
 export function showUserPage(store, toRoute, fromRoute) {
+  store.dispatch('loading');
   if (toRoute.name !== fromRoute.name) {
     store.dispatch('preparePage');
   }
@@ -26,7 +27,7 @@ export function showUserPage(store, toRoute, fromRoute) {
           totalPages: users.total_pages,
           usersCount: users.count,
         });
-        store.commit('CORE_SET_PAGE_LOADING', false);
+        store.dispatch('notLoading');
       }
     },
     error => {

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -4,7 +4,7 @@ import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import { _userState } from '../mappers';
 // An action for setting up the initial state of the app by fetching data from the server
 export function showUserPage(store, toRoute, fromRoute) {
-  store.dispatch('loading');
+  store.commit('userManagement/SET_STATE', { dataLoading: true });
   if (toRoute.name !== fromRoute.name) {
     store.dispatch('preparePage');
   }
@@ -19,19 +19,22 @@ export function showUserPage(store, toRoute, fromRoute) {
       user_type: toRoute.query.user_type,
     }),
     force: true,
-  }).then(
-    users => {
-      if (shouldResolve()) {
-        store.commit('userManagement/SET_STATE', {
-          facilityUsers: users.results.map(_userState),
-          totalPages: users.total_pages,
-          usersCount: users.count,
-        });
-        store.dispatch('notLoading');
+  })
+    .then(
+      users => {
+        if (shouldResolve()) {
+          store.commit('userManagement/SET_STATE', {
+            facilityUsers: users.results.map(_userState),
+            totalPages: users.total_pages,
+            usersCount: users.count,
+          });
+        }
+      },
+      error => {
+        shouldResolve() ? store.dispatch('handleError', error) : null;
       }
-    },
-    error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
-    }
-  );
+    )
+    .finally(() => {
+      store.commit('userManagement/SET_STATE', { dataLoading: false });
+    });
 }

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -20,21 +20,18 @@ export function showUserPage(store, toRoute, fromRoute) {
     }),
     force: true,
   })
-    .then(
-      users => {
-        if (shouldResolve()) {
-          store.commit('userManagement/SET_STATE', {
-            facilityUsers: users.results.map(_userState),
-            totalPages: users.total_pages,
-            usersCount: users.count,
-          });
-        }
-      },
-      error => {
-        shouldResolve() ? store.dispatch('handleError', error) : null;
+    .then(users => {
+      if (shouldResolve()) {
+        store.commit('userManagement/SET_STATE', {
+          facilityUsers: users.results.map(_userState),
+          totalPages: users.total_pages,
+          usersCount: users.count,
+        });
       }
-    )
-    .finally(() => {
+      store.commit('userManagement/SET_STATE', { dataLoading: false });
+    })
+    .catch(error => {
+      shouldResolve() ? store.dispatch('handleError', error) : null;
       store.commit('userManagement/SET_STATE', { dataLoading: false });
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/index.js
@@ -5,6 +5,7 @@ function defaultState() {
     facilityUsers: [],
     totalPages: 0,
     usersCount: 0,
+    dataLoading: false,
   };
 }
 

--- a/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ClassEditPage/index.vue
@@ -65,6 +65,7 @@
       <UserTable
         :users="classCoaches"
         :emptyMessage="$tr('noCoachesInClassMessge')"
+        :dataLoading="dataLoading"
         isCoach
       >
         <!-- Don't need template in Vue 2.5+ -->
@@ -100,6 +101,7 @@
 
       <UserTable
         :users="classLearners"
+        :dataLoading="dataLoading"
         :emptyMessage="$tr('noLearnersInClassMessage')"
       >
         <template #action="userRow">
@@ -153,6 +155,7 @@
         'classes',
         'currentClass',
         'modalShown',
+        'dataLoading',
       ]),
       classDetails() {
         // No errors due to race condition around currentClass being undefined

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -36,7 +36,7 @@
         </KGridItem>
       </KGrid>
 
-      <CoreTable>
+      <CoreTable :dataLoading="dataLoading" :emptyMessage="$tr('noClassesExist')">
         <caption class="visuallyhidden">
           {{ $tr('tableCaption') }}
         </caption>
@@ -93,10 +93,6 @@
         </template>
       </CoreTable>
 
-      <p v-if="noClassesExist">
-        {{ $tr('noClassesExist') }}
-      </p>
-
       <ClassDeleteModal
         v-if="Boolean(classToDelete)"
         :classToDelete="classToDelete"
@@ -152,11 +148,8 @@
       };
     },
     computed: {
-      ...mapState('classManagement', ['modalShown', 'classes']),
+      ...mapState('classManagement', ['modalShown', 'classes', 'dataLoading']),
       ...mapGetters(['userIsMultiFacilityAdmin', 'facilityPageLinks']),
-      noClassesExist() {
-        return this.classes.length === 0;
-      },
       Modals: () => Modals,
       sortedClassrooms() {
         return orderBy(this.classes, [classroom => classroom.name.toUpperCase()], ['asc']);

--- a/kolibri/plugins/facility/assets/src/views/UserPage/__test__/UserPage.spec.js
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/__test__/UserPage.spec.js
@@ -23,6 +23,7 @@ UserPage.computed.newUserLink = () => ({});
 
 function makeWrapper() {
   const store = makeStore();
+  store.dispatch('notLoading');
   const wrapper = mount(UserPage, {
     store,
     router,

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -61,6 +61,7 @@
           <UserTable
             class="move-down user-roster"
             :users="facilityUsers"
+            :dataLoading="dataLoading"
             :emptyMessage="emptyMessageForItems(facilityUsers, search)"
             :showDemographicInfo="true"
           >
@@ -151,7 +152,7 @@
         'userIsMultiFacilityAdmin',
         'facilityPageLinks',
       ]),
-      ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount']),
+      ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount', 'dataLoading']),
       Modals: () => Modals,
       userKinds() {
         return [

--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -1,9 +1,6 @@
 <template>
 
-  <LearnAppBarPage
-    :appBarTitle="learnString('learnLabel')"
-    :loading="loading"
-  >
+  <LearnAppBarPage :appBarTitle="learnString('learnLabel')">
     <div v-if="!loading" id="main" role="main">
       <MissingResourceAlert v-if="missingResources" />
       <YourClasses

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -4,7 +4,7 @@
     :is="page"
     :appBarTitle="appBarTitle"
     :appearanceOverrides="appearanceOverrides"
-    :loading="$store.state.core.loading"
+    :loading="loading"
     :primary="false"
     :route="route"
     :title="appBarTitle"
@@ -68,6 +68,10 @@
         default() {
           return {};
         },
+      },
+      loading: {
+        type: Boolean,
+        default: false,
       },
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -4,7 +4,7 @@
     :is="page"
     :appBarTitle="appBarTitle"
     :appearanceOverrides="appearanceOverrides"
-    :loading="loading"
+    :loading="$store.state.core.loading"
     :primary="false"
     :route="route"
     :title="appBarTitle"
@@ -61,10 +61,6 @@
       },
       deviceId: {
         type: String,
-        default: null,
-      },
-      loading: {
-        type: Boolean,
         default: null,
       },
       route: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -3,7 +3,6 @@
   <LearnAppBarPage
     :appBarTitle="appBarTitle"
     :appearanceOverrides="{}"
-    :loading="loading"
     :deviceId="deviceId"
     :route="back"
   >
@@ -362,10 +361,6 @@
     props: {
       deviceId: {
         type: String,
-        default: null,
-      },
-      loading: {
-        type: Boolean,
         default: null,
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -7,7 +7,7 @@
     <!-- appearanceOverrides overrides the default page styling -->
     <!-- by replacing it with an empty object -->
     <ImmersivePage
-      v-else-if="!loading"
+      v-else
       :loading="loading"
       :route="back"
       :appBarTitle="barTitle"
@@ -22,199 +22,205 @@
           color="white"
         />
       </template>
-      <!-- Header with thumbail and tagline -->
-      <TopicsHeader
-        v-if="!windowIsSmall"
-        ref="header"
-        role="complementary"
-        data-test="header-breadcrumbs"
-        :title="(topic && topic.title) || ''"
-        :description="topic && topic.description"
-        :thumbnail="topic && topic.thumbnail"
-        :breadcrumbs="breadcrumbs"
-      />
 
-      <!-- mobile tabs (different alignment and interactions) -->
-      <TopicsMobileHeader v-else :topic="topic" />
+      <KCircularLoader v-if="loading" />
 
-      <main
-        class="main-content-grid"
-        :style="gridStyle"
-      >
-        <KBreadcrumbs
-          v-if="breadcrumbs.length && windowIsSmall"
-          data-test="mobile-breadcrumbs"
-          :items="breadcrumbs"
-          :ariaLabel="learnString('channelAndFoldersLabel')"
+      <div v-else>
+        <!-- Header with thumbail and tagline -->
+        <TopicsHeader
+          v-if="!windowIsSmall"
+          ref="header"
+          role="complementary"
+          data-test="header-breadcrumbs"
+          :title="(topic && topic.title) || ''"
+          :description="topic && topic.description"
+          :thumbnail="topic && topic.thumbnail"
+          :breadcrumbs="breadcrumbs"
         />
 
-        <div class="card-grid">
-          <!-- Filter buttons - shown when not sidebar not visible -->
-          <div v-if="!windowIsLarge" data-test="tab-buttons">
-            <KButton
-              v-if="topics.length"
-              icon="topic"
-              data-test="folders-button"
-              class="overlay-toggle-button"
-              :text="coreString('folders')"
-              :primary="false"
-              @click="toggleFolderSearchSidePanel('folder')"
-            />
-            <KButton
-              icon="filter"
-              class="overlay-toggle-button"
-              data-test="filter-button"
-              :text="coreString('filter')"
-              :primary="false"
-              @click="toggleFolderSearchSidePanel('search')"
-            />
-          </div>
+        <!-- mobile tabs (different alignment and interactions) -->
+        <TopicsMobileHeader v-else :topic="topic" />
 
-          <!-- default/preview display of nested folder structure, not search -->
-          <div v-if="!displayingSearchResults" data-test="topics">
-            <!-- Rows of cards and links / show more for each Topic -->
-            <template v-for="t in topicsForDisplay">
-              <TopicSubsection
-                :key="t.id"
-                :topic="t"
-                :subTopicLoading="t.id === subTopicLoading"
+        <main
+          class="main-content-grid"
+          :style="gridStyle"
+        >
+          <KBreadcrumbs
+            v-if="breadcrumbs.length && windowIsSmall"
+            data-test="mobile-breadcrumbs"
+            :items="breadcrumbs"
+            :ariaLabel="learnString('channelAndFoldersLabel')"
+          />
+
+          <div class="card-grid">
+            <!-- Filter buttons - shown when not sidebar not visible -->
+            <div v-if="!windowIsLarge" data-test="tab-buttons">
+              <KButton
+                v-if="topics.length"
+                icon="topic"
+                data-test="folders-button"
+                class="overlay-toggle-button"
+                :text="coreString('folders')"
+                :primary="false"
+                @click="toggleFolderSearchSidePanel('folder')"
+              />
+              <KButton
+                icon="filter"
+                class="overlay-toggle-button"
+                data-test="filter-button"
+                :text="coreString('filter')"
+                :primary="false"
+                @click="toggleFolderSearchSidePanel('search')"
+              />
+            </div>
+
+            <!-- default/preview display of nested folder structure, not search -->
+            <div v-if="!displayingSearchResults" data-test="topics">
+              <!-- Rows of cards and links / show more for each Topic -->
+              <template v-for="t in topicsForDisplay">
+                <TopicSubsection
+                  :key="t.id"
+                  :topic="t"
+                  :subTopicLoading="t.id === subTopicLoading"
+                  :allowDownloads="allowDownloads"
+                  @showMore="handleShowMore"
+                  @loadMoreInSubtopic="handleLoadMoreInSubtopic"
+                  @toggleInfoPanel="toggleInfoPanel"
+                />
+              </template>
+
+              <!-- display for each nested topic/folder  -->
+              <!-- display all resources at the top level of the folder -->
+              <LibraryAndChannelBrowserMainContent
+                v-if="resources.length"
+                :gridType="2"
                 :allowDownloads="allowDownloads"
-                @showMore="handleShowMore"
-                @loadMoreInSubtopic="handleLoadMoreInSubtopic"
+                data-test="search-results"
+                :contents="resourcesDisplayed"
+                :numCols="numCols"
+                currentCardViewStyle="card"
                 @toggleInfoPanel="toggleInfoPanel"
               />
-            </template>
-
-            <!-- display for each nested topic/folder  -->
-            <!-- display all resources at the top level of the folder -->
-            <LibraryAndChannelBrowserMainContent
-              v-if="resources.length"
-              :gridType="2"
-              :allowDownloads="allowDownloads"
-              data-test="search-results"
-              :contents="resourcesDisplayed"
-              :numCols="numCols"
-              currentCardViewStyle="card"
-              @toggleInfoPanel="toggleInfoPanel"
-            />
-            <KButton
-              v-if="moreResources"
-              class="more-after-grid"
-              appearance="basic-link"
-              @click="handleShowMoreResources"
-            >
-              {{ coreString('showMoreAction') }}
-            </KButton>
-            <div v-else-if="topicMore" class="end-button-block">
               <KButton
-                v-if="!topicMoreLoading"
-                :text="coreString('viewMoreAction')"
-                appearance="raised-button"
-                :disabled="topicMoreLoading"
-                @click="handleLoadMoreInTopic"
-              />
-              <KCircularLoader v-else />
+                v-if="moreResources"
+                class="more-after-grid"
+                appearance="basic-link"
+                @click="handleShowMoreResources"
+              >
+                {{ coreString('showMoreAction') }}
+              </KButton>
+              <div v-else-if="topicMore" class="end-button-block">
+                <KButton
+                  v-if="!topicMoreLoading"
+                  :text="coreString('viewMoreAction')"
+                  appearance="raised-button"
+                  :disabled="topicMoreLoading"
+                  @click="handleLoadMoreInTopic"
+                />
+                <KCircularLoader v-else />
+              </div>
             </div>
+
+            <!-- search results -->
+            <!-- TODO: Should card preference be permitted in Topics page as well? At least for
+                search results? -->
+            <SearchResultsGrid
+              v-else
+              data-test="search-results"
+              :allowDownloads="allowDownloads"
+              :currentCardViewStyle="currentSearchCardViewStyle"
+              :hideCardViewToggle="true"
+              :results="results"
+              :removeFilterTag="removeFilterTag"
+              :clearSearch="clearSearch"
+              :moreLoading="moreLoading"
+              :searchMore="searchMore"
+              :searchTerms="searchTerms"
+              :searchLoading="searchLoading"
+              :more="more"
+              @setCardStyle="style => currentSearchCardViewStyle = style"
+              @setSidePanelMetadataContent="content => metadataSidePanelContent = content"
+            />
           </div>
+        </main>
 
-          <!-- search results -->
-          <!-- TODO: Should card preference be permitted in Topics page as well? At least for
-              search results? -->
-          <SearchResultsGrid
-            v-else
-            data-test="search-results"
-            :allowDownloads="allowDownloads"
-            :currentCardViewStyle="currentSearchCardViewStyle"
-            :hideCardViewToggle="true"
-            :results="results"
-            :removeFilterTag="removeFilterTag"
-            :clearSearch="clearSearch"
-            :moreLoading="moreLoading"
-            :searchMore="searchMore"
-            :searchTerms="searchTerms"
-            :searchLoading="searchLoading"
-            :more="more"
-            @setCardStyle="style => currentSearchCardViewStyle = style"
-            @setSidePanelMetadataContent="content => metadataSidePanelContent = content"
-          />
-        </div>
-      </main>
-
-      <!-- Side Panels for filtering and searching  -->
-      <SearchPanelModal
-        v-if="!windowIsLarge && sidePanelIsOpen"
-        v-model="searchTerms"
-        :mobileSearchActive="mobileSearchActive"
-        :topicMore="topicMore"
-        :topics="topics"
-        :topicsLoading="topicMoreLoading"
-        @searchTerms="newTerms => searchTerms = newTerms"
-        @currentCategory="handleShowSearchModal"
-        @loadMoreTopics="handleLoadMoreInTopic"
-        @close="sidePanelIsOpen = false"
-      />
-
-      <!-- Embedded Side panel is on larger views, and exists next to content -->
-      <ToggleHeaderTabs
-        v-if="!!windowIsLarge"
-        :topic="topic"
-        :topics="topics"
-        :style="tabPosition"
-      />
-      <SearchFiltersPanel
-        v-if="!!windowIsLarge"
-        ref="sidePanel"
-        v-model="searchTerms"
-        :topicsListDisplayed="!desktopSearchActive"
-        class="side-panel"
-        topicPage="True"
-        :topics="topics"
-        :topicsLoading="topicMoreLoading"
-        :more="topicMore"
-        :width="`${sidePanelWidth}px`"
-        :showChannels="false"
-        position="embedded"
-        :style="sidePanelStyleOverrides"
-        @currentCategory="handleShowSearchModal"
-        @loadMoreTopics="handleLoadMoreInTopic"
-      />
-      <!-- The full screen side panel is used on smaller screens, and toggles as an overlay -->
-      <!-- FullScreen is a container component, and then the SearchFiltersPanel sits within -->
-      <SidePanelModal
-        v-if="!windowIsLarge && sidePanelIsOpen"
-        class="full-screen-side-panel"
-        alignment="left"
-        :closeButtonIconType="closeButtonIcon"
-        @closePanel="closeEventHandler()"
-        @shouldFocusFirstEl="findFirstEl()"
-      >
-        <SearchFiltersPanel
-          v-if="!currentCategory"
-          ref="embeddedPanel"
+        <!-- Side Panels for filtering and searching  -->
+        <SearchPanelModal
+          v-if="!windowIsLarge && sidePanelIsOpen"
           v-model="searchTerms"
-          :topicsListDisplayed="!mobileSearchActive"
+          :mobileSearchActive="mobileSearchActive"
+          :topicMore="topicMore"
+          :topics="topics"
+          :topicsLoading="topicMoreLoading"
+          @searchTerms="newTerms => searchTerms = newTerms"
+          @currentCategory="handleShowSearchModal"
+          @loadMoreTopics="handleLoadMoreInTopic"
+          @close="sidePanelIsOpen = false"
+        />
+
+        <!-- Embedded Side panel is on larger views, and exists next to content -->
+        <ToggleHeaderTabs
+          v-if="!!windowIsLarge"
+          :topic="topic"
+          :topics="topics"
+          :style="tabPosition"
+        />
+        <SearchFiltersPanel
+          v-if="!!windowIsLarge"
+          ref="sidePanel"
+          v-model="searchTerms"
+          :topicsListDisplayed="!desktopSearchActive"
+          class="side-panel"
           topicPage="True"
           :topics="topics"
           :topicsLoading="topicMoreLoading"
           :more="topicMore"
+          :width="`${sidePanelWidth}px`"
           :showChannels="false"
-          position="overlay"
+          position="embedded"
+          :style="sidePanelStyleOverrides"
           @currentCategory="handleShowSearchModal"
           @loadMoreTopics="handleLoadMoreInTopic"
         />
+        <!-- The full screen side panel is used on smaller screens, and toggles as an overlay -->
+        <!-- FullScreen is a container component, and then the SearchFiltersPanel sits within -->
+        <SidePanelModal
+          v-if="!windowIsLarge && sidePanelIsOpen"
+          class="full-screen-side-panel"
+          alignment="left"
+          :closeButtonIconType="closeButtonIcon"
+          @closePanel="closeEventHandler()"
+          @shouldFocusFirstEl="findFirstEl()"
+        >
+          <SearchFiltersPanel
+            v-if="!currentCategory"
+            ref="embeddedPanel"
+            v-model="searchTerms"
+            :topicsListDisplayed="!mobileSearchActive"
+            topicPage="True"
+            :topics="topics"
+            :topicsLoading="topicMoreLoading"
+            :more="topicMore"
+            :showChannels="false"
+            position="overlay"
+            @currentCategory="handleShowSearchModal"
+            @loadMoreTopics="handleLoadMoreInTopic"
+          />
+          <CategorySearchModal
+            v-if="currentCategory && windowIsSmall"
+            :selectedCategory="currentCategory"
+            @cancel="currentCategory = null"
+            @input="handleCategory"
+          />
+        </SidePanelModal>
         <CategorySearchModal
-          v-if="currentCategory && windowIsSmall"
+          v-if="currentCategory"
           :selectedCategory="currentCategory"
           @cancel="currentCategory = null"
           @input="handleCategory"
         />
-      </SidePanelModal>
-      <CategorySearchModal
-        v-if="currentCategory"
-        :selectedCategory="currentCategory"
-        @cancel="currentCategory = null"
-        @input="handleCategory"
-      />
+
+      </div>
 
 
       <!-- Side panel for showing the information of selected content with a link to view it -->

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -3,7 +3,7 @@
   <LearnAppBarPage
     :appBarTitle="learnString('learnLabel')"
   >
-    <div id="main" role="main">
+    <div v-if="!$store.state.core.loading" id="main" role="main">
       <KBreadcrumbs :items="breadcrumbs" :ariaLabel="learnString('classesAndAssignmentsLabel')" />
       <section class="lesson-details">
         <div>
@@ -39,7 +39,6 @@
           :link="genContentLinkBackLinkCurrentPage(content.id, true)"
         />
       </section>
-      <KCircularLoader v-else-if="$store.state.core.loading" />
       <p v-else class="no-resources-message">
         {{ $tr('noResourcesInLesson') }}
       </p>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -39,6 +39,7 @@
           :link="genContentLinkBackLinkCurrentPage(content.id, true)"
         />
       </section>
+      <KCircularLoader v-else-if="$store.state.core.loading" />
       <p v-else class="no-resources-message">
         {{ $tr('noResourcesInLesson') }}
       </p>

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -39,7 +39,6 @@
           :link="genContentLinkBackLinkCurrentPage(content.id, true)"
         />
       </section>
-      <KCircularLoader v-else-if="$store.state.core.loading" />
       <p v-else class="no-resources-message">
         {{ $tr('noResourcesInLesson') }}
       </p>

--- a/kolibri/plugins/pdf_viewer/assets/tests/SideBar/Bookmarks.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/SideBar/Bookmarks.spec.js
@@ -54,6 +54,7 @@ const outline = [
 function makeWrapper(options = {}) {
   return mount(Bookmarks, {
     ...options,
+    mocks: { fetchContentNodeProgress: Promise.resolve() },
     propsData: {
       outline,
       goToDestination: jest.fn(),

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ChooseAdmin/__tests__/index.spec.js
@@ -1,9 +1,13 @@
+import { coreStoreFactory } from 'kolibri.coreVue.vuex.store';
 import { shallowMount, mount } from '@vue/test-utils';
 import ChooseAdmin from '../index.vue';
 
 const sendMachineEvent = jest.fn();
 function makeWrapper({ userId, sourceFacilityUsers } = {}) {
+  const store = coreStoreFactory();
+  store.dispatch('notLoading');
   return mount(ChooseAdmin, {
+    store,
     provide: {
       changeFacilityService: {
         send: sendMachineEvent,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

A handful of fixes to various loading states in Learn, smoothing things out a bit.

Overall, the `LearnAppBarPage` was taking a `loading` prop but it only got that prop from two components that use it. Ultimately, I think that should have never been a prop and should just be set at the highest level to reflect the value of the Core `loading` state. 

The result now is that when we load content of a page initially, we show the KLinearLoader in the AppBar -- per the [KDS loaders guidelines](https://design-system.learningequality.org/loaders/#linearloaders) -- but then use the [circular loaders](https://design-system.learningequality.org/loaders/#circularloaders) when loading new information.

I also removed and updated logic around the loaders on the BookmarkPage where now the circular loader only shows when "loading more" to the same effect.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10336 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Note that some of these things may be easier to observe with network throttling.

1) User table shows loader while fetching users

https://github.com/learningequality/kolibri/assets/6356129/ced1f702-1716-42f7-be15-8dd6c53f842a

2) Lesson playlist page does not show "no resources" message while fetching, app bar linear loader is active

https://github.com/learningequality/kolibri/assets/6356129/156fc540-d771-4e0d-8ef5-98114e8c8ac2

3) Flash in the Topics Page navigation

https://github.com/learningequality/kolibri/assets/6356129/0d592eb0-e0fb-464b-b4b5-963bb2c3cc90

---