### PR TITLE
Remote content browsing followup

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
@@ -10,7 +10,7 @@
         <UnPinnedDevices
           :deviceName="device.device_name"
           :channels="device.channels.length"
-          :allDevices="device"
+          :device="device"
           :operatingSystem="device.operatingSystem"
         />
       </KGridItem>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -14,7 +14,7 @@
       >
         <div class="unpinned-device-card">
           <div class="col device-icon">
-            <KIcon :icon="getDeviceIcon(device)" class="icon" />
+            <KIcon :icon="getDeviceIcon" class="icon" />
           </div>
           <div class="col device-detail">
             <TextTruncator
@@ -50,7 +50,6 @@
         windowGutter,
       };
     },
-
     props: {
       deviceName: {
         type: String,
@@ -78,12 +77,10 @@
           textAlign: 'center',
         };
       },
-    },
-    methods: {
-      getDeviceIcon(device) {
-        if (device['operating_system'] === 'Android') {
+      getDeviceIcon() {
+        if (this.device['operating_system'] === 'Android') {
           return 'device';
-        } else if (!device['subset_of_users_device']) {
+        } else if (!this.device['subset_of_users_device']) {
           return 'cloud';
         } else {
           return 'laptop';

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -7,14 +7,14 @@
     >
 
       <KRouterLink
-        v-if="allDevices !== null"
-        :text="allDevices.nickname.length ? allDevices.nickname : allDevices.device_name"
-        :to="{ name: 'LIBRARY', params: { deviceId: allDevices.id } }"
+        v-if="device !== null"
+        :text="device.nickname.length ? device.nickname : device.device_name"
+        :to="{ name: 'LIBRARY', params: { deviceId: device.id } }"
         style="text-decoration:none;width:100%;"
       >
         <div class="unpinned-device-card">
           <div class="col device-icon">
-            <KIcon :icon="getDeviceIcon(allDevices)" class="icon" />
+            <KIcon :icon="getDeviceIcon(device)" class="icon" />
           </div>
           <div class="col device-detail">
             <TextTruncator
@@ -62,7 +62,7 @@
         required: false,
         default: 0,
       },
-      allDevices: {
+      device: {
         type: Object,
         required: true,
       },


### PR DESCRIPTION

## Summary
This PR is  following up a review comments  on #10420

…

## References
#10420



## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
