### PR TITLE
Attempt to reduce query times and memory usage during channel deletion operations

### DIFF
--- a/kolibri/core/content/test/test_delete_content.py
+++ b/kolibri/core/content/test/test_delete_content.py
@@ -68,18 +68,15 @@ class UnavailableContentDeletion(TransactionTestCase):
 
     def delete_content(self):
         num_deleted = 0
-        freed_bytes = 0
         for deleted, file in LocalFile.objects.delete_unused_files():
             if deleted:
                 num_deleted += 1
-                freed_bytes += file.file_size
-        return num_deleted, freed_bytes
+        return num_deleted
 
     def test_delete_unavailable_stored_files(self):
         self.assertEqual(LocalFile.objects.get_unused_files().count(), 1)
-        deleted, freed_bytes = self.delete_content()
+        deleted = self.delete_content()
         self.assertEqual(deleted, 1)
-        self.assertEqual(freed_bytes, self.stored_local_file.file_size)
 
         self.assertEqual(os.path.exists(self.path), False)
         self.assertEqual(LocalFile.objects.get_unused_files().count(), 0)
@@ -99,7 +96,7 @@ class UnavailableContentDeletion(TransactionTestCase):
             id=uuid.uuid4().hex,
         )
         self.assertEqual(LocalFile.objects.get_unused_files().count(), 0)
-        deleted, freed_bytes = self.delete_content()
+        deleted = self.delete_content()
         self.assertEqual(deleted, 0)
 
     def tearDown(self):


### PR DESCRIPTION
## Summary
* Ensures final deletion progress always reaches 100%
* Simplifies unused file query considerably, hopefully making it considerably more performant
* Does a values modifier on the unused files query to avoid the cost of inflating large numbers of models, in local testing on my machine, this caused a roughly 8x speed up in iterating over the queryset for ~100 000 LocalFile objects
* For large ContentNode trees do batched deletion of ContentNodes to reduce memory usage caused by Django recording foreign key relationships to traverse and cascade delete

## References
Recent issues on BCK, and previous experience as shown in https://github.com/learningequality/kolibri/pull/8156 means that when there are a lot of channels in a database, our current deletion process can cause very long running queries, thanks to the outer joins on the file and content node tables.

## Reviewer guidance
I tweaked the tests to no longer check the deleted file bytes, as the values call removes the file size, and it is not used in production code.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
