### PR TITLE
Removes facility after last user changes facility and sets migrated u…

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/ConfirmChangeFacility.vue
@@ -32,6 +32,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { FacilityUserResource } from 'kolibri.resources';
   import commonProfileStrings from '../commonProfileStrings';
 
   export default {
@@ -46,6 +47,11 @@
     mixins: [commonCoreStrings, commonProfileStrings],
 
     inject: ['changeFacilityService', 'state'],
+    data() {
+      return {
+        lastUserOnDevice: false,
+      };
+    },
     computed: {
       targetFacility() {
         return this.state.value.targetFacility;
@@ -59,7 +65,7 @@
         });
       },
       secondLine() {
-        if (this.role === 'learner') return '';
+        if (this.role === 'learner' || this.lastUserOnDevice) return '';
         return this.$tr('changeFacilityInfoLine2', {
           role: this.role,
           facility: this.targetFacility.name,
@@ -71,7 +77,18 @@
         });
       },
     },
-
+    created() {
+      FacilityUserResource.fetchCollection({
+        force: true,
+        getParams: {
+          member_of: this.state.value.sourceFacility,
+        },
+      }).then(users => {
+        if (Object.keys(users).length === 1) {
+          this.lastUserOnDevice = true;
+        }
+      });
+    },
     methods: {
       to_continue() {
         this.changeFacilityService.send({

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeFacility.vue
@@ -170,6 +170,9 @@
                 if (state.value.newSuperAdminId !== '') {
                   params['new_superuser_id'] = state.value.newSuperAdminId;
                 }
+                if (state.value.setAsSuperAdmin !== false) {
+                  params['set_as_super_user'] = true;
+                }
                 if (state.value.targetAccount.AdminUsername !== undefined) {
                   params['using_admin'] = true;
                   params['username'] = state.value.targetAccount.AdminUsername;

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -9,6 +9,7 @@ from .utils import TokenGenerator
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.tasks import PeerImportSingleSyncJobValidator
+from kolibri.core.auth.utils.delete import delete_facility
 from kolibri.core.auth.utils.migrate import merge_users
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import set_device_settings
@@ -32,6 +33,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
         queryset=FacilityUser.objects.all(), required=False
     )
     facility_name = serializers.CharField(default="")
+    set_as_super_user = serializers.BooleanField(required=False)
 
     def validate(self, data):
         try:
@@ -44,6 +46,8 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
         job_data["extra_metadata"].update(user_fullname=data["local_user_id"].full_name)
         if data.get("new_superuser_id"):
             job_data["kwargs"]["new_superuser_id"] = data["new_superuser_id"].id
+        if data.get("set_as_super_user"):
+            job_data["kwargs"]["set_as_super_user"] = data["set_as_super_user"]
 
         return job_data
 
@@ -152,4 +156,16 @@ def mergeuser(command, **kwargs):
     job.extra_metadata["remote_user_pk"] = remote_user_pk
     job.save_meta()
     job.update_progress(1.0, 1.0)
-    local_user.delete()
+
+    # check if current user should be promoted to superuser:
+    set_as_super_user = kwargs.get("set_as_super_user")
+    if set_as_super_user:
+        # set current user as the new superuser of this device:
+        remote_user.facility.add_role(remote_user, role_kinds.ADMIN)
+        DevicePermissions.objects.create(
+            user=remote_user, is_superuser=True, can_manage_content=True
+        )
+        delete_facility(local_user.facility)
+        set_device_settings(default_facility=remote_user.facility)
+    else:
+        local_user.delete()


### PR DESCRIPTION
…ser as superadmin

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr updates the change facility workflow for the last user in a facility with the removal of the user's source facility from the device and sets the migrated user as the `superadmin` on the device.
- The `ChangeFacilityMachine` has been updated to include a `setAsSuperAdmin` property that is false unless the current user is the last user in the source facility.
- The `mergeuser` task receives a `set_as_super_user` argument that is true if the user is the last user in their source facility. If this argument exists, the user is set as a superuser on the device and the source facility is removed.
- The user no longer sees this string if they will be set as the superadmin after the facility change:
     - `Your user account type will change from '{role}' to 'learner' and you will no longer be able to manage resources on this device. You will need someone with admin permissions in '{facility}' to change your account type back to '{role}'.`


If the user is the last user in the facility they are migrating from, they are met with this screen after selecting a facility to migrate to:
<img width="861" alt="Screenshot 2023-04-11 at 8 17 19 AM" src="https://user-images.githubusercontent.com/46411498/231535465-0304ea19-66c1-4a87-833e-018a24bc5d63.png">


https://user-images.githubusercontent.com/46411498/231536484-a04b15d6-0eb9-4d5a-8158-900e79d024e5.mp4



Note: When the source facility is being removed, the terminal displays the warning: `Deleted {count} database records but expected to delete {total_to_delete} records for facility {facility.name}`. Despite this warning, the workflow still works as intended. The cause for this warning is being investigated.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #10333 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. On a learning facility, change the facility of the last user.
2. After the facility change, the user should be a superuser on the device and only the target facility should be on the device.
3. Test that the `chooseAdmin` page still displays if there are other users in the source facility.
4. Test the workflow when creating a new account or merging accounts with an existing user in the remote facility.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
