### PR TITLE
Removed debugger from the setup wizard #10458

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -26,7 +26,6 @@
         overflow: auto;
       "
     >
-      <h2>Setup Wizard Debugger 3000</h2>
       <h3>Device Provisioning Data</h3>
       <pre>{{ JSON.stringify(deviceProvisioningData, null, 2) }}</pre>
       <KButtonGroup


### PR DESCRIPTION
Reviewer guidance
On a learning facility, change the facility of the last user.
After the facility change, the user should be a superuser on the device and only the target facility should be on the device.
Test that the chooseAdmin page still displays if there are other users in the source facility.
Test the workflow when creating a new account or merging accounts with an existing user in the remote facility.
Testing checklist
 Contributor has fully tested the PR manually
 If there are any front-end changes, before/after screenshots are included
 Critical user journeys are covered by Gherkin stories
 Critical and brittle code paths are covered by unit test

## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
