### PR TITLE
App bar work bugs cleanup

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -84,7 +84,7 @@
         </template>
       </UiToolbar>
     </header>
-    <div v-if="!windowIsLarge" class="subpage-nav">
+    <div v-if="!windowIsLarge && !isAppContext" class="subpage-nav">
       <slot name="sub-nav"></slot>
     </div>
   </div>

--- a/kolibri/core/assets/src/views/BottomNavigationBar.vue
+++ b/kolibri/core/assets/src/views/BottomNavigationBar.vue
@@ -16,7 +16,9 @@
         >
           <KIconButton
             :icon="routeDefinition.icon"
-            :color="$themeTokens.primary"
+            :color="isActiveLink(routeDefinition.route, bottomMenuOptions[0].url)
+              ? $themeTokens.primary
+              : $themeTokens.annotation"
             :ariaLabel="routeDefinition.label"
             size="small"
           />
@@ -34,7 +36,7 @@
       <KIconButton
         icon="menu"
         :ariaLabel="coreString('menuLabel')"
-        :color="$themeTokens.primary"
+        :color="navShown ? $themeTokens.primary : $themeTokens.annotation"
         @click="$emit('toggleNav')"
       />
       <p :style="{ color: $themeTokens.primary }">{{ coreString('menuLabel') }}</p>

--- a/kolibri/core/assets/src/views/BottomNavigationBar.vue
+++ b/kolibri/core/assets/src/views/BottomNavigationBar.vue
@@ -57,6 +57,11 @@
         type: Array,
         required: true,
       },
+      navShown: {
+        type: Boolean,
+        required: true,
+        default: false,
+      },
     },
     computed: {
       bottomMenuActiveStyles() {
@@ -79,7 +84,7 @@
         return window.location.pathname === url && route == this.$router.currentRoute.path;
       },
       handleNav(route, url) {
-        if (this.isActiveLink(route, url)) {
+        if (this.isActiveLink(route, url) && this.navShown) {
           this.$emit('toggleNav');
         }
       },

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -212,7 +212,7 @@
     justify-content: flex-start;
     height: 44px;
     margin: 0 40px;
-    font-size: 12px;
+    font-size: 14px;
     text-decoration: none;
   }
 
@@ -225,13 +225,6 @@
 
   button {
     margin-top: -6px;
-  }
-
-  p {
-    margin: 0;
-    margin-top: -8px;
-    font-size: 12px;
-    text-align: center;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -189,6 +189,7 @@
     <BottomNavigationBar
       v-if="isAppContext"
       :bottomMenuOptions="bottomMenuOptions"
+      :navShown="navShown"
       @toggleNav="toggleNav()"
     />
 


### PR DESCRIPTION
## Summary
Cleans up a few small UI bugs that came out of the app bar related bug bash. Visible in App Mode ([documentation about running in app mode here](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html#running-in-app-mode)).

## References

Fixes #10406 
Fixes #10438 
Fixes #10408 

The video below shows all in action:
- Grey inactive buttons 
- no top navigations on app on non-large screens 
- tapping on bottom navigation icons when on the page (i.e. tapping on Library when currently in the Library) does not reopen the navigation menu)

It also updates the font size of the sub navigation items to 14 px following a [decision on slack](https://learningequality.slack.com/archives/C0LKG14NL/p1680905065984949)

https://user-images.githubusercontent.com/17235236/231873887-7950f860-bf50-475d-a741-419f140291fb.mp4


## Reviewer guidance



## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
