### PR TITLE
Fix missing network locations after zeroconf restart

### DIFF
--- a/kolibri/core/discovery/test/test_network_broadcast.py
+++ b/kolibri/core/discovery/test/test_network_broadcast.py
@@ -235,6 +235,10 @@ class KolibriBroadcastTestCase(SimpleTestCase):
         self.zeroconf = mock.MagicMock(spec_set=Zeroconf)()
         self.broadcast = KolibriBroadcast(self.instance)
         self.listener = self.broadcast.add_listener(KolibriTestInstanceListener)
+        self.other_instance = KolibriInstance("abc")
+        self.broadcast.other_instances = {
+            "abc": self.other_instance,
+        }
 
     def test_is_broadcasting(self):
         self.assertFalse(self.broadcast.is_broadcasting)
@@ -277,6 +281,7 @@ class KolibriBroadcastTestCase(SimpleTestCase):
         self.assertEqual(updated_instance, self.broadcast.instance)
         self.assertEqual("abc-1", self.broadcast.instance.zeroconf_id)
         mock_renew.assert_called_once()
+        self.listener.mock.update_instance.assert_called_once_with(self.other_instance)
 
     @pytest.mark.skipIf(ZEROCONF_NEEDS_UPDATE, "Needs updated Zeroconf")
     def test_update_broadcast__interfaces(self):
@@ -288,6 +293,7 @@ class KolibriBroadcastTestCase(SimpleTestCase):
         self.zeroconf.update_interfaces.assert_called_once_with(
             interfaces=new_interfaces
         )
+        self.listener.mock.update_instance.assert_called_once_with(self.other_instance)
 
     @mock.patch(BROADCAST_MODULE + "logger.error")
     def test_update_broadcast__not_broadcasting(self, mock_logger):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
When a Zeroconf broadcast update occurs, we need to associate the new broadcast ID with the network locations detected by that broadcast. So we delete the old `NetworkLocation`s, but unless we updated the interfaces, the TTL of the mDNS records may delay the ADD/UPDATE event that will refill the existing locations into the database with the new broadcast ID. This forces that by using the local Zeroconf cache of `other_instances`

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10362

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
See reproduce steps in https://github.com/learningequality/kolibri/issues/10362

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
