### PR TITLE
Adds use of remove pin translation

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -199,15 +199,13 @@
 
   import { mapActions, mapGetters, mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import { createTranslator } from 'kolibri.utils.i18n';
 
   import camelCase from 'lodash/camelCase';
   import isEqual from 'lodash/isEqual';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
-  import DeviceSettingsPage from '../../../../../device/assets/src/views/DeviceSettingsPage';
-  import PinAuthenticationModal from '../../../../../device/assets/src/views/PinAuthenticationModal';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
@@ -215,6 +213,23 @@
   import ViewPinModal from './ViewPinModal';
   import ChangePinModal from './ChangePinModal';
   import RemovePinModal from './RemovePinModal';
+
+  /**
+   * Using the crossComponentTranslator to aid concatenation
+   * of strings missed before string freeze. This only a workaround
+   */
+  const deviceSettingsPageStrings = createTranslator('DeviceSettingsPage', {
+    changeLocation: {
+      message: 'Change',
+      context: 'Label to change primary storage location',
+    },
+  });
+  const pinAuthenticationModalStrings = createTranslator('PinAuthenticationModal', {
+    pinPlaceholder: {
+      message: 'PIN',
+      context: 'Placeholder label for a PIN input',
+    },
+  });
 
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
@@ -253,8 +268,6 @@
         handleViewModal: false,
         handleChangePinModal: false,
         handleRemovePinModal: false,
-        deviceSettingsPageStrings: {},
-        pinAuthenticationModalStrings: {},
       };
     },
     computed: {
@@ -303,7 +316,7 @@
       },
       changePINLabel() {
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
-        return `${this.deviceSettingsPageStrings.$tr('changeLocation')} ${this.pinPlaceholder}`;
+        return `${deviceSettingsPageStrings.$tr('changeLocation')} ${this.pinPlaceholder}`;
         /* eslint-enable */
       },
       viewPINLabel() {
@@ -311,7 +324,7 @@
       },
       pinPlaceholder() {
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
-        return this.pinAuthenticationModalStrings.$tr('pinPlaceholder');
+        return pinAuthenticationModalStrings.$tr('pinPlaceholder');
         /* eslint-enable */
       },
     },
@@ -328,14 +341,6 @@
           this.$store.commit('facilityConfig/RESET_FACILITY_NAME_STATES');
         }
       },
-    },
-    created() {
-      /**
-       * Using the crossComponentTranslator to aid concatenation
-       * of strings missed before string freeze. This only a workaround
-       */
-      this.deviceSettingsPageStrings = crossComponentTranslator(DeviceSettingsPage);
-      this.pinAuthenticationModalStrings = crossComponentTranslator(PinAuthenticationModal);
     },
     mounted() {
       this.copySettings();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -293,7 +293,7 @@
         return [
           { label: 'View PIN', value: 'VIEW' },
           { label: 'Change PIN', value: 'CHANGE' },
-          { label: 'Remove PIN', value: 'REMOVE' },
+          { label: this.coreString('removePinPlacholder'), value: 'REMOVE' },
         ];
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -216,11 +216,6 @@
   import ChangePinModal from './ChangePinModal';
   import RemovePinModal from './RemovePinModal';
 
-  /**
-   * Use the crossComponentTranslator to aid concatenation
-   * of strings missed before string freeze. This only a workaround
-   */
-
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
     'learner_can_edit_username',
@@ -335,6 +330,10 @@
       },
     },
     created() {
+      /**
+       * Using the crossComponentTranslator to aid concatenation
+       * of strings missed before string freeze. This only a workaround
+       */
       this.deviceSettingsPageStrings = crossComponentTranslator(DeviceSettingsPage);
       this.pinAuthenticationModalStrings = crossComponentTranslator(PinAuthenticationModal);
     },

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -215,7 +215,7 @@
   import RemovePinModal from './RemovePinModal';
 
   /**
-   * Using the crossComponentTranslator to aid concatenation
+   * Using the createTranslator to aid concatenation
    * of strings missed before string freeze. This only a workaround
    */
   const deviceSettingsPageStrings = createTranslator('DeviceSettingsPage', {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -220,8 +220,6 @@
    * Use the crossComponentTranslator to aid concatenation
    * of strings missed before string freeze. This only a workaround
    */
-  const DeviceSettingsPageStrings = crossComponentTranslator(DeviceSettingsPage);
-  const PinAuthenticationModalStrings = crossComponentTranslator(PinAuthenticationModal);
 
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
@@ -260,6 +258,8 @@
         handleViewModal: false,
         handleChangePinModal: false,
         handleRemovePinModal: false,
+        deviceSettingsPageStrings: {},
+        pinAuthenticationModalStrings: {},
       };
     },
     computed: {
@@ -308,7 +308,7 @@
       },
       changePINLabel() {
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
-        return `${DeviceSettingsPageStrings.$tr('changeLocation')} ${this.pinPlaceholder}`;
+        return `${this.deviceSettingsPageStrings.$tr('changeLocation')} ${this.pinPlaceholder}`;
         /* eslint-enable */
       },
       viewPINLabel() {
@@ -316,7 +316,7 @@
       },
       pinPlaceholder() {
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
-        return PinAuthenticationModalStrings.$tr('pinPlaceholder');
+        return this.pinAuthenticationModalStrings.$tr('pinPlaceholder');
         /* eslint-enable */
       },
     },
@@ -333,6 +333,10 @@
           this.$store.commit('facilityConfig/RESET_FACILITY_NAME_STATES');
         }
       },
+    },
+    created() {
+      this.deviceSettingsPageStrings = crossComponentTranslator(DeviceSettingsPage);
+      this.pinAuthenticationModalStrings = crossComponentTranslator(PinAuthenticationModal);
     },
     mounted() {
       this.copySettings();

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -87,7 +87,7 @@
           <KButton
             v-show="isPinSet"
             hasDropdown
-            :text="$tr('optionBtn')"
+            :text="coreString('optionsLabel')"
           >
             <template #menu>
               <KDropdownMenu
@@ -471,10 +471,12 @@
         message: 'Create PIN',
         context: 'Button for the create PIN',
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
       optionBtn: {
         message: 'option',
         context: 'Options button for the create PIN page',
       },
+      /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };
 

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -199,12 +199,15 @@
 
   import { mapActions, mapGetters, mapState } from 'vuex';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
 
   import camelCase from 'lodash/camelCase';
   import isEqual from 'lodash/isEqual';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import DeviceSettingsPage from '../../../../../device/assets/src/views/DeviceSettingsPage';
+  import PinAuthenticationModal from '../../../../../device/assets/src/views/PinAuthenticationModal';
   import FacilityAppBarPage from '../FacilityAppBarPage';
   import ConfirmResetModal from './ConfirmResetModal';
   import EditFacilityNameModal from './EditFacilityNameModal';
@@ -212,6 +215,13 @@
   import ViewPinModal from './ViewPinModal';
   import ChangePinModal from './ChangePinModal';
   import RemovePinModal from './RemovePinModal';
+
+  /**
+   * Use the crossComponentTranslator to aid concatenation
+   * of strings missed before string freeze. This only a workaround
+   */
+  const DeviceSettingsPageStrings = crossComponentTranslator(DeviceSettingsPage);
+  const PinAuthenticationModalStrings = crossComponentTranslator(PinAuthenticationModal);
 
   // See FacilityDataset in core.auth.models for details
   const settingsList = [
@@ -291,10 +301,23 @@
       },
       dropdownOption() {
         return [
-          { label: 'View PIN', value: 'VIEW' },
-          { label: 'Change PIN', value: 'CHANGE' },
+          { label: this.viewPINLabel, value: 'VIEW' },
+          { label: this.changePINLabel, value: 'CHANGE' },
           { label: this.coreString('removePinPlacholder'), value: 'REMOVE' },
         ];
+      },
+      changePINLabel() {
+        /* eslint-disable kolibri/vue-no-undefined-string-uses */
+        return `${DeviceSettingsPageStrings.$tr('changeLocation')} ${this.pinPlaceholder}`;
+        /* eslint-enable */
+      },
+      viewPINLabel() {
+        return `${this.coreString('viewAction')} ${this.pinPlaceholder}`;
+      },
+      pinPlaceholder() {
+        /* eslint-disable kolibri/vue-no-undefined-string-uses */
+        return PinAuthenticationModalStrings.$tr('pinPlaceholder');
+        /* eslint-enable */
       },
     },
     watch: {

--- a/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
+++ b/kolibri/plugins/facility/assets/test/views/facility-config-page.spec.js
@@ -2,6 +2,10 @@ import { mount } from '@vue/test-utils';
 import ConfigPage from '../../src/views/FacilityConfigPage';
 import makeStore from '../makeStore';
 
+jest.mock('../../../../device/assets/src/views/DeviceSettingsPage/api.js', () => ({
+  getDeviceSettings: jest.fn(),
+}));
+
 function makeWrapper(propsData = {}) {
   const store = makeStore();
   store.commit('facilityConfig/SET_STATE', {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -71,8 +71,6 @@
   import { PageNames, KolibriStudioId } from '../../constants';
   import LibraryItem from './LibraryItem';
 
-  const PinStrings = crossComponentTranslator(LibraryItem);
-
   export default {
     name: 'ExploreLibrariesPage',
     components: {
@@ -98,6 +96,7 @@
         networkDevices: [],
         moreDevices: [],
         usersPins: [],
+        pinStrings: {},
       };
     },
     computed: {
@@ -150,6 +149,7 @@
     },
     created() {
       // Fetch user's pins
+      this.pinStrings = crossComponentTranslator(LibraryItem);
       this.fetchPinsForUser().then(resp => {
         this.usersPins = resp.map(pin => {
           const instance_id = pin.instance_id.replace(/-/g, '');
@@ -177,7 +177,7 @@
           const id = response.id;
           this.usersPins = [...this.usersPins, { instance_id, id }];
           // eslint-disable-next-line
-          this.$store.dispatch('createSnackbar', PinStrings.$tr('pinnedTo'));
+          this.$store.dispatch('createSnackbar', pinStrings.$tr('pinnedTo'));
           this.moreDevices = this.moreDevices.filter(d => d.instance_id !== instance_id);
         });
       },
@@ -193,7 +193,7 @@
             this.moreDevices.push(removedDevice);
           }
           // eslint-disable-next-line
-          this.$store.dispatch('createSnackbar', PinStrings.$tr('pinRemoved'));
+          this.$store.dispatch('createSnackbar', pinStrings.$tr('pinRemoved'));
         });
       },
       handlePinToggle(instance_id) {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -71,6 +71,8 @@
   import { PageNames, KolibriStudioId } from '../../constants';
   import LibraryItem from './LibraryItem';
 
+  const PinStrings = crossComponentTranslator(LibraryItem);
+
   export default {
     name: 'ExploreLibrariesPage',
     components: {
@@ -96,7 +98,6 @@
         networkDevices: [],
         moreDevices: [],
         usersPins: [],
-        pinStrings: {},
       };
     },
     computed: {
@@ -149,7 +150,6 @@
     },
     created() {
       // Fetch user's pins
-      this.pinStrings = crossComponentTranslator(LibraryItem);
       this.fetchPinsForUser().then(resp => {
         this.usersPins = resp.map(pin => {
           const instance_id = pin.instance_id.replace(/-/g, '');
@@ -177,7 +177,7 @@
           const id = response.id;
           this.usersPins = [...this.usersPins, { instance_id, id }];
           // eslint-disable-next-line
-          this.$store.dispatch('createSnackbar', pinStrings.$tr('pinnedTo'));
+          this.$store.dispatch('createSnackbar', PinStrings.$tr('pinnedTo'));
           this.moreDevices = this.moreDevices.filter(d => d.instance_id !== instance_id);
         });
       },
@@ -193,7 +193,7 @@
             this.moreDevices.push(removedDevice);
           }
           // eslint-disable-next-line
-          this.$store.dispatch('createSnackbar', pinStrings.$tr('pinRemoved'));
+          this.$store.dispatch('createSnackbar', PinStrings.$tr('pinRemoved'));
         });
       },
       handlePinToggle(instance_id) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr replaces the hardcoded 'Remove PIN' with its translation string

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10400

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Go to `http://localhost:8000/ar/facility/#/settings`
2. Change the app language by clicking the hamburger menu and selecting 'Change Language'. Please note that 'Change Language' options broken so you would need to use the url to change the language by replacing the language code in the url in the address bar i.e `http://localhost:8000/:language_code/facility/#/settings` where `:language_code` is any of the supported languages eg ar, en, fr, etc
3. Setup PIN by clicking on 'Create PIN' else proceed to 4.
4. Click on 'Options' button.
5. As no other language translations exist for 'Remove PIN', `CommonCoreStrings.removePinPlacholder` will be returned in the console and the default (en) used.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
