### PR TITLE
learner names  and close button

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -18,6 +18,7 @@
         }"
       >
 
+
         <FocusTrap
           @shouldFocusFirstEl="$emit('shouldFocusFirstEl')"
           @shouldFocusLastEl="focusLastEl"
@@ -38,7 +39,15 @@
               :style="themeConfig.sideNav.topLogo.style"
             >
 
-            <div v-if="userIsLearner" class="user-information">
+
+            <div v-if="userIsLearner || isAppContext" class="user-information">
+              <div v-if="isAppContext" class="">
+                <KIconButton
+                  ref="closeButton"
+                  icon="close"
+                  @click="toggleNav"
+                />
+              </div>
               <!-- display user details -->
               <TotalPoints class="points" />
               <b>{{ fullName }}</b>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -41,10 +41,11 @@
 
 
             <div v-if="userIsLearner || isAppContext" class="user-information">
-              <div v-if="isAppContext" class="">
+              <div v-if="isAppContext" style="margin-bottom:10px;margin-left:-15px">
                 <KIconButton
                   ref="closeButton"
                   icon="close"
+                  class="side-nav-header-icon"
                   @click="toggleNav"
                 />
               </div>


### PR DESCRIPTION

## Summary
This PR fixes  top part of the menu where the account information  is missing on the app version of the side menu.
Closes  #10429

## References
 #10429

#### Before 
![image](https://user-images.githubusercontent.com/103313919/232075130-da3c67a4-2c12-4c43-a907-0646289525b0.png)

#### After 
<img width="555" alt="Screenshot 2023-04-14 at 17 23 48" src="https://user-images.githubusercontent.com/103313919/232075253-2eb791c8-3807-4275-b49b-bfad1ea5ddaa.png">

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
