### PR TITLE
Do not update interfaces if we're updating the broadcast of our own instance

### DIFF
--- a/kolibri/core/discovery/test/test_connections.py
+++ b/kolibri/core/discovery/test/test_connections.py
@@ -16,6 +16,7 @@ class BaseTestCase(TestCase):
     def setUp(self):
         self.mock_location = mock.MagicMock(
             spec=NetworkLocation(),
+            id="mock_location_id",
             dynamic=False,
             instance_id=None,
             connection_status=ConnectionStatus.Unknown,

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -390,13 +390,6 @@ class KolibriBroadcast(object):
         if instance is None and interfaces is None:
             return
 
-        # a new ID every time the broadcast changes
-        new_id = uuid.uuid4().hex
-        logging.debug(
-            "Updating broadcast with new ID: {}, old ID: {}".format(new_id, self.id)
-        )
-        self.id = new_id
-
         # when our instance is being updated
         if instance is not None:
             instance.zeroconf_id = self.instance.zeroconf_id
@@ -406,6 +399,13 @@ class KolibriBroadcast(object):
 
         # when interfaces is being updated, pass along to Zeroconf so it can bind to them
         if interfaces is not None:
+            # a new ID every time the broadcast interfaces change
+            new_id = uuid.uuid4().hex
+            logging.debug(
+                "Updating broadcast with new ID: {}, old ID: {}".format(new_id, self.id)
+            )
+            self.id = new_id
+
             # call the unregister listeners so that we enqueue necessary tasks to delete old
             # locations from the database
             self.events.publish(EVENT_UNREGISTER_INSTANCE, self.instance)

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -386,23 +386,33 @@ class KolibriBroadcast(object):
             logger.error("Zeroconf service is not broadcasting!")
             return
 
+        # nothing to do
+        if instance is None and interfaces is None:
+            return
+
         # a new ID every time the broadcast changes
-        self.id = uuid.uuid4().hex
+        new_id = uuid.uuid4().hex
+        logging.debug(
+            "Updating broadcast with new ID: {}, old ID: {}".format(new_id, self.id)
+        )
+        self.id = new_id
 
-        # when interfaces is being updated, pass along to Zeroconf so it can bind to them
-        if interfaces is not None:
-            self.interfaces = interfaces
-            self.zeroconf.update_interfaces(interfaces=interfaces)
-
-        # when our instance is being updated,
+        # when our instance is being updated
         if instance is not None:
             instance.zeroconf_id = self.instance.zeroconf_id
             self.instance = instance
-            self.renew()
-        else:
-            # if not provided a new instance, we still trigger this event when the broadcast is
-            # updated so the listeners can hook into that lifecycle
-            self.events.publish(EVENT_RENEW_INSTANCE, self.instance)
+            # skip broadcasting if we're also updating our interfaces
+            self.renew(do_broadcast=interfaces is None)
+
+        # when interfaces is being updated, pass along to Zeroconf so it can bind to them
+        if interfaces is not None:
+            # call the unregister listeners so that we enqueue necessary tasks to delete old
+            # locations from the database
+            self.events.publish(EVENT_UNREGISTER_INSTANCE, self.instance)
+
+            self.interfaces = interfaces
+            # `update_interfaces` will broadcast the new instance if it was updated
+            self.zeroconf.update_interfaces(interfaces=interfaces)
 
     def stop_broadcast(self):
         """Stops broadcasting our instance and shuts down Zeroconf"""
@@ -451,9 +461,11 @@ class KolibriBroadcast(object):
         self.zeroconf.register_service(service, ttl=service.ttl)
         self.instance.set_broadcasting(service, is_self=True)
 
-    def renew(self):
+    def renew(self, do_broadcast=True):
         """
         'Renews' the registration of our instance on the network
+        :param do_broadcast: Whether to broadcast the renewal or not
+        :type do_broadcast: bool
         """
         if not self.is_broadcasting:
             return
@@ -467,7 +479,20 @@ class KolibriBroadcast(object):
         service.ttl = SERVICE_TTL
         # very important to publish the event first, to avoid race conditions
         self.events.publish(EVENT_RENEW_INSTANCE, self.instance)
-        self.zeroconf.update_service(service, ttl=SERVICE_TTL)
+
+        if do_broadcast:
+            # `update_service` does 2 things:
+            # 1. updates the service info in the cache
+            # 2. sends out a new broadcast
+            self.zeroconf.update_service(service, ttl=SERVICE_TTL)
+        else:
+            # if we weren't explicitly told to broadcast, we still need to update the cache
+            # assuming something else will trigger the broadcast, like `update_interfaces` which
+            # internally calls the same broadcast method in `update_service`
+            service.ttl = SERVICE_TTL
+            self.zeroconf.services[service.name.lower()] = service
+
+        # even though may not have actually broadcast, we still set that we're broadcasting
         self.instance.set_broadcasting(service, is_self=True)
 
     def unregister(self):

--- a/kolibri/core/discovery/utils/network/connections.py
+++ b/kolibri/core/discovery/utils/network/connections.py
@@ -6,6 +6,7 @@ from . import errors
 from .client import NetworkClient
 from .urls import parse_address_into_components
 from kolibri.core.discovery.models import ConnectionStatus
+from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.ipaddress import ip_address
 
 
@@ -91,7 +92,9 @@ def capture_connection_state(network_location):
         # increment the number of faulty connection attempts
         network_location.connection_faults += 1
 
-    network_location.save()
+    # it's possible the network location was deleted while making requests during the context
+    if NetworkLocation.objects.filter(id=network_location.id).exists():
+        network_location.save()
 
 
 def update_network_location(network_location):

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -23,12 +23,11 @@ class NetworkLocationListener(KolibriInstanceListener):
         # when we start broadcasting, enqueue task to reset all connection states
         reset_connection_states.enqueue(args=(self.broadcast.id,))
 
-    def renew_instance(self, instance):
+    def unregister_instance(self, instance):
         """
         :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
         """
-        # when we update the broadcast, on a network change, we also enqueue task to reset all
-        # connection states
+        # when we stop broadcasting, enqueue task to reset all connection states
         reset_connection_states.enqueue(args=(self.broadcast.id,))
 
     def add_instance(self, instance):

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -292,6 +292,10 @@ class ZeroConfPlugin(Monitor):
 
     @property
     def addresses_changed(self):
+        # if we're bound to a specific addresses, then we don't need to do dynamic updates
+        if conf.OPTIONS["Deployment"]["LISTEN_ADDRESS"] != "0.0.0.0":
+            return False
+
         current_addresses = set(get_all_addresses())
         return (
             self.broadcast is not None

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -290,6 +290,15 @@ class ZeroConfPlugin(Monitor):
             else [conf.OPTIONS["Deployment"]["LISTEN_ADDRESS"]]
         )
 
+    @property
+    def addresses_changed(self):
+        current_addresses = set(get_all_addresses())
+        return (
+            self.broadcast is not None
+            and self.broadcast.is_broadcasting
+            and self.broadcast.addresses != current_addresses
+        )
+
     def SERVING(self, port):
         self.port = port or self.port
 
@@ -308,9 +317,10 @@ class ZeroConfPlugin(Monitor):
             self.broadcast.add_listener(NetworkLocationListener)
             self.broadcast.start_broadcast()
         else:
-            self.broadcast.update_broadcast(
-                instance=instance, interfaces=self.interfaces
-            )
+            # `interfaces` should only be passed to update when there is a change to the interfaces,
+            # like the detection in self.run()
+            interfaces = self.interfaces if self.addresses_changed else None
+            self.broadcast.update_broadcast(instance=instance, interfaces=interfaces)
 
     def UPDATE_ZEROCONF(self):
         self.RUN()
@@ -326,12 +336,7 @@ class ZeroConfPlugin(Monitor):
         # If set of addresses that were present at the last time zeroconf updated its broadcast list
         # don't match the current set of all addresses for this device, then we should reinitialize
         # zeroconf, the listener, and the broadcast kolibri service.
-        current_addresses = set(get_all_addresses())
-        if (
-            self.broadcast is not None
-            and self.broadcast.is_broadcasting
-            and self.broadcast.addresses != current_addresses
-        ):
+        if self.addresses_changed:
             logger.info(
                 "List of local addresses has changed since zeroconf was last initialized, updating now"
             )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The primary correction contained here is to avoid triggering the interfaces/addresses update flow if all we need to do is update instance's broadcast, which is the case after setup.

When interfaces change, we expect that the bound addresses changed, so we need to associate the new broadcast ID with the network locations detected by that broadcast. So we delete the old NetworkLocations, and await (re)discovery of locations after the change.

Additionally, tasks that process connection testing may block Kolibri shutdown, if they may have a pending request while the interfaces change and end up saving the location after it was deleted during that time. This double checks the location still exists before saving.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10362

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
See reproduce steps in https://github.com/learningequality/kolibri/issues/10362

Additionally, the following should also function correctly:
1) ZeroTier should be off or disconnected
2) Start a provisioned Kolibri
3) Join the ZeroTier network
4) Verify the network locations on ZeroTier are detected without restart of Kolibri
5) Disconnect from ZeroTier
6) Verify the network locations on ZeroTier are removed without restart of Kolibri

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
