### PR TITLE
Fixes Missing Strings on quiz and lesson reports

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -164,10 +164,10 @@
           return this.coachString('lessonListEmptyState');
         }
         if (this.filter.value === 'visibleLessons') {
-          return this.coreString('noResults');
+          return this.coreString('noResultsLabel');
         }
         if (this.filter.value === 'lessonsNotVisible') {
-          return this.coreString('noResults');
+          return this.coreString('noResultsLabel');
         }
         return '';
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -180,10 +180,10 @@
           return this.coachString('quizListEmptyState');
         }
         if (this.filter.value === 'startedQuizzes') {
-          return this.coreString('noResults');
+          return this.coreString('noResultsLabel');
         }
         if (this.filter.value === 'quizzesNotStarted') {
-          return this.coreString('noResults');
+          return this.coreString('noResultsLabel');
         }
         if (this.filter.value === 'endedQuizzes') {
           return this.$tr('noEndedExams');


### PR DESCRIPTION

## Summary
This PR fixes missing string no result on both quiz and lesson list pages.

Closes #10473
…

## References

### Before

![image](https://user-images.githubusercontent.com/103313919/232099650-47a205a7-2edc-4075-af21-2b158ebac7fe.png)
![image](https://user-images.githubusercontent.com/103313919/232099719-867494dc-7f80-4bb2-b769-1a24852eb005.png)

### After 
<img width="1270" alt="Screenshot 2023-04-14 at 19 02 14" src="https://user-images.githubusercontent.com/103313919/232099782-17a31105-2740-4a94-b834-f51642fa261c.png">

…

## Reviewer guidance
Navigate to Coach > Reports 

- Change the status of the lesson to visible 

 Switch to Quiz tab 

- Change the status of the quiz to Not started


…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
