### PR TITLE
Adds correct string to register facility modal

### DIFF
--- a/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
+++ b/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
@@ -1,7 +1,7 @@
 <template>
 
   <KModal
-    :title="coreString('registerFacility')"
+    :title="registerFacility.$tr('registerFacility')"
     :submitText="coreString('continueAction')"
     :cancelText="coreString('cancelAction')"
     :submitDisabled="submitting"
@@ -29,6 +29,8 @@
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import { PortalResource } from 'kolibri.resources';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import ConfirmationRegisterModal from './ConfirmationRegisterModal';
 
   export default {
     name: 'RegisterFacilityModal',
@@ -38,6 +40,7 @@
         submitting: false,
         token: null,
         invalid: false,
+        registerFacility: crossComponentTranslator(ConfirmationRegisterModal),
       };
     },
     methods: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pr updates the `registerFacility` modal with the correct string.
- Uses the import `crossComponentTranslator` to access `registerFacility` string in `ConfirmationRegisterModal` file

Before
<img width="1439" alt="Before" src="https://user-images.githubusercontent.com/46411498/232102167-2740e9e1-8c1f-4b6a-aaf6-3a96506be4e4.png">

After

<img width="1439" alt="After" src="https://user-images.githubusercontent.com/46411498/232102180-7253d671-c684-4fb6-ac2a-22248a4d392b.png">

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #10428 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to facility sync tab.
2. Select `options`
3. Select the menu option to register facility.
4. Confirm that the correct string "Register Facility" is displayed.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
