### PR TITLE
fixed typo error when using corestring

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/UsernameExists.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/UsernameExists.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <h1>{{ coreString('chageLearningFacility') }}</h1>
+    <h1>{{ coreString('changeLearningFacility') }}</h1>
     <p data-test="line1">
       {{ mergeAccountInfoLine1 }}
     </p>


### PR DESCRIPTION


## Summary
This PR fixes a typo in calling the core string change learning facility
Closes #10437
…

## References

Closes #10437

### Before 
![image](https://user-images.githubusercontent.com/103313919/232112765-5900ee77-eacf-461e-82f5-70183e525a96.png)

### After
<img width="1118" alt="Screenshot 2023-04-14 at 20 16 27" src="https://user-images.githubusercontent.com/103313919/232112960-36a16a34-4ae1-48d6-9614-d49d4edbceb9.png">

…

## Reviewer guidance

Navigate to profile
change learning facility > click change and select the learning facility

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
