### PR TITLE
Logging cleanup

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -3,39 +3,8 @@ import os
 import platform
 import sys
 
-try:
-    # Do this to allow this to be accessed
-    # during build, when dependencies are not
-    # installed.
-    # TODO: Move version tools to build tools, so we don't have to do this
-    from colorlog import TTYColoredFormatter
-    from colorlog import getLogger
-except ImportError:
-    getLogger = None
-    TTYColoredFormatter = None
-
-from .logger import LOG_COLORS
-from .logger import EncodingStreamHandler as StreamHandler
 from kolibri.utils.compat import monkey_patch_collections
 from kolibri.utils.compat import monkey_patch_translation
-
-
-logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
-logging.StreamHandler(sys.stdout)
-
-if StreamHandler and getLogger and TTYColoredFormatter:
-    handler = StreamHandler(stream=sys.stdout)
-    handler.setFormatter(
-        TTYColoredFormatter(
-            fmt="%(log_color)s%(levelname)-8s %(message)s", log_colors=LOG_COLORS
-        )
-    )
-    handler.setLevel(logging.INFO)
-    logger = getLogger("env")
-    logger.addHandler(handler)
-    logger.propagate = False
-else:
-    logger = logging.getLogger("env")
 
 
 def settings_module():
@@ -105,6 +74,9 @@ def prepend_cext_path(dist_path):
         # add it + the matching noarch (OpenSSL) modules to sys.path
         sys.path = [str(dirname), str(noarch_dir)] + sys.path
     else:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
+        logging.StreamHandler(sys.stdout)
+        logger = logging.getLogger("env")
         logger.debug("No C extensions are available for this platform")
 
 

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -2,6 +2,9 @@ import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
 
+from colorlog import ColoredFormatter
+from colorlog import TTYColoredFormatter as BaseTTYColoredFormatter
+
 
 GET_FILES_TO_DELETE = "getFilesToDelete"
 DO_ROLLOVER = "doRollover"
@@ -165,6 +168,24 @@ class NoExceptionsFilter(logging.Filter):
         return record.levelno < logging.ERROR
 
 
+class TTYColoredFormatter(BaseTTYColoredFormatter):
+    """
+    A logging formatter that can be used to colorize output to a TTY.
+    Subclassed from the base TTY formatter to allow slightly more more permissive
+    color formatting when we are running using the NPM concurrently package,
+    which does not register as a TTY context.
+    """
+
+    def color(self, log_colors, level_name):
+        """
+        Only returns colors if STDOUT is a TTY, or if we are running in a
+        NPM concurrently context.
+        """
+        if not self.stream.isatty() and "FORCE_COLOR" not in os.environ:
+            log_colors = {}
+        return ColoredFormatter.color(self, log_colors, level_name)
+
+
 def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     """
     A minimal logging config for just kolibri without any Django
@@ -197,7 +218,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             },
             "simple_date": {"format": "%(levelname)s %(asctime)s %(name)s %(message)s"},
             "color": {
-                "()": "colorlog.TTYColoredFormatter",
+                "()": "kolibri.utils.logger.TTYColoredFormatter",
                 "format": "%(log_color)s%(levelname)-8s %(asctime)s %(message)s",
                 "log_colors": LOG_COLORS,
             },

--- a/kolibri/utils/main.py
+++ b/kolibri/utils/main.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import logging
+import logging.config
 import os
 import shutil
 import sys

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -5,7 +5,7 @@ The settings can be changed through environment variables or sections and keys
 in the options.ini file.
 """
 import ast
-import logging.config
+import logging
 import os
 import sys
 from functools import update_wrapper
@@ -38,6 +38,9 @@ from kolibri.deployment.default.sqlite_db_names import (
     ADDITIONAL_SQLITE_DATABASES,
 )
 from kolibri.utils.system import get_fd_limit
+
+
+logger = logging.getLogger(__name__)
 
 
 CACHE_SHARDS = 8
@@ -704,21 +707,6 @@ def _get_validator():
     )
 
 
-def _get_logger():
-    """
-    We define a minimal default logger config here, since we can't yet
-    load up Django settings.
-
-    NB! Since logging can be defined by options, the logging from some
-    of the functions in this module do not use fully customized logging.
-    """
-    from kolibri.utils.conf import LOG_ROOT
-    from kolibri.utils.logger import get_default_logging_config
-
-    logging.config.dictConfig(get_default_logging_config(LOG_ROOT))
-    return logging.getLogger(__name__)
-
-
 def _get_option_spec():
     """
     Combine the default option spec with any options that are defined in plugins
@@ -789,7 +777,6 @@ def _set_from_envvars(conf):
     """
     Set the configuration from environment variables.
     """
-    logger = _get_logger()
     # keep track of which options were overridden using environment variables, to support error reporting
     using_env_vars = {}
 
@@ -836,7 +823,6 @@ def _set_from_deprecated_aliases(conf):
     """
     Set the configuration from deprecated aliases.
     """
-    logger = _get_logger()
     # keep track of which options were overridden using environment variables, to support error reporting
     using_deprecated_alias = {}
 
@@ -864,8 +850,6 @@ def _set_from_deprecated_aliases(conf):
 def read_options_file(ini_filename="options.ini"):
 
     from kolibri.utils.conf import KOLIBRI_HOME
-
-    logger = _get_logger()
 
     ini_path = os.path.join(KOLIBRI_HOME, ini_filename)
 
@@ -962,8 +946,6 @@ def update_options_file(section, key, value, ini_filename="options.ini"):
     in-memory conf.OPTIONS as it can contain temporary in-memory values
     that are not intended to be stored.
     """
-
-    logger = _get_logger()
 
     # load the current conf from disk into memory
     conf = read_options_file(ini_filename=ini_filename)


### PR DESCRIPTION
## Summary
* Cleans up logging configuration in options.py which was preventing logging of debug messages during initialization.
* Removes unnecessary logging configuration from env and only configures it when needed for single logger message
* Subclasses TTYColoredFormatter so that we can check either for a TTY or the FORCE_COLOR env var that the npm `concurrently` library injects - this reinstates color logging when running `yarn run devserver` etc.


## Reviewer guidance
Run the devserver check that all expected messages are logged

----

## Testing checklist

- [X] Contributor has fully tested the PR manually

## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
