### PR TITLE
Updates wrong pin message when letters are input in pin modal

### DIFF
--- a/kolibri/plugins/device/assets/src/views/PinAuthenticationModal.vue
+++ b/kolibri/plugins/device/assets/src/views/PinAuthenticationModal.vue
@@ -44,8 +44,12 @@
     methods: {
       ...mapActions('facilityConfig', ['isPinValid']),
       submit() {
-        if (!this.pin.match(/^\d+$/)) {
-          this.pinError = this.$tr('invalidPin');
+        if (!this.pin) {
+          this.pinError = this.coreString('requiredFieldError');
+          this.showErrorText = true;
+          this.focus();
+        } else if (!this.pin.match(/^\d+$/)) {
+          this.pinError = this.coreString('numbersOnly');
           this.showErrorText = true;
           this.focus();
         } else {
@@ -76,10 +80,12 @@
         message: 'Incorrect PIN, please try again',
         context: 'Error message displayed when an incorrect PIN is input',
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
       invalidPin: {
         message: 'Enter four numbers to set as your new PIN',
         context: 'Error message displayed when a PIN with less than 4 digits is input',
       },
+      /* eslint-enable kolibri/vue-no-unused-translations */
       pinPlaceholder: {
         message: 'PIN',
         context: 'Placeholder label for a PIN input',

--- a/kolibri/plugins/device/assets/src/views/__test__/PinAuthenticationModal.spec.js
+++ b/kolibri/plugins/device/assets/src/views/__test__/PinAuthenticationModal.spec.js
@@ -105,6 +105,17 @@ describe('PinAuthenticationModal', () => {
         });
     });
 
+    it('on submit, shows a validation message when PIN has letters', async () => {
+      return inputPin(wrapper, 'abcd')
+        .then(() => {
+          const elements = getElements(wrapper);
+          elements.form().trigger('submit');
+        })
+        .then(() => {
+          assertTextbox(wrapper, 'Enter numbers only', true);
+        });
+    });
+
     it('on submit, shows a validation message when PIN code is empty', async () => {
       return inputPin(wrapper, '')
         .then(() => {
@@ -112,7 +123,7 @@ describe('PinAuthenticationModal', () => {
           elements.form().trigger('submit');
         })
         .then(() => {
-          assertTextbox(wrapper, 'Enter four numbers to set as your new PIN', true);
+          assertTextbox(wrapper, 'This field is required', true);
         });
     });
   });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr update the wrong message displayed when letters are used as a pin during authentication of the Device plugin
on learn-only devices. it also adds the "This is a required field" if no input is provided.
<img width="390" alt="image" src="https://user-images.githubusercontent.com/5203639/232507212-6140cff1-b168-4e77-a845-85dcb1ee1e79.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/5203639/232507074-0fd60ab0-32a2-451e-8aba-9ea7a53a16ec.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10300

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Using a learn-only device with PIN authentication set up;

1. Navigate to the Device Plugin(`/device/#/content`). A pin authentication modal will be displayed
2. Click "Continue" with no PIN input. "This is a required field" should be displayed
3. Click "Continue" with a pin containing letters input. "Enter numbers only" should be displayed

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
