### PR TITLE
fix lesson visibility in coach > reports

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -73,8 +73,8 @@
                   <KSwitch
                     name="toggle-lesson-visibility"
                     label=""
-                    :checked="tableRow.active"
-                    :value="tableRow.active"
+                    :checked="tableRow.is_active"
+                    :value="tableRow.is_active"
                     @change="toggleModal(tableRow)"
                   />
                 </td>

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -266,7 +266,7 @@ def serialize_lessons(queryset):
                 "assignments",
                 "description",
                 "date_created",
-                active=F("is_active"),
+                "is_active",
             ),
         )
     )


### PR DESCRIPTION
## Summary
addresses #10483. the bug was caused by inaccurate expectations about the props supplied by `lesson` objects - we were monitoring `is_active` but that prop was `undefined` and instead we had access to `active`, which we didn't expect. this PR fixes previous buggy behavior by standardizing the class summary API to use `is_active` rather than `active`.

![fix-visibility_AdobeExpress](https://user-images.githubusercontent.com/43046460/232626927-dee6e318-40b6-4129-9085-7e8019a2d36c.gif)


## References
addresses #10483 - see here for additional context of previous buggy behavior


## Reviewer guidance
- navigate to Coach > Reports
- make different selections from the "Status" dropdown & toggle individual lesson visibility on and off, making sure the selected "Status" matches the visible/not visible status of the lessons displayed

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
