### PR TITLE
#10407 Language button is now responsive

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -31,6 +31,8 @@
         role="menuitem"
         :class="$computedClass(optionStyle)"
         tabindex="0"
+        @click="conditionalEmit"
+        @keydown.enter="conditionalEmit"
       >
         <slot>
           <KLabeledIcon>
@@ -176,6 +178,11 @@
       generateNavRoute(route) {
         const params = this.$route.params;
         return generateNavRoute(this.link, route, params);
+      },
+      conditionalEmit() {
+        if (!this.link) {
+          this.$emit('select');
+        }
       },
     },
   };


### PR DESCRIPTION
## Summary
As directed and communicating with my peers, the **Change Language** button is now responsive.
I would like any comments/reviews on the same.
Thanks

## References
[Issue Link](https://github.com/learningequality/kolibri/issues/10407)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
