### PR TITLE
Fixed Update #8532 Replace TextTruncator with TextTruncatorCss 

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -38,7 +38,7 @@
       <TextTruncatorCss
         v-if="!windowIsSmall"
         :text="description"
-        :maxHeight="80"
+        :maxLines="3"
         class="description"
       />
       <div>
@@ -60,7 +60,7 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
-  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss'; //update
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CardThumbnail from './CardThumbnail';
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -35,7 +35,7 @@
       <div v-if="message" class="message" :style="{ color: $themeTokens.text }">
         {{ message }}
       </div>
-      <TextTruncator
+      <TextTruncatorCss
         v-if="!windowIsSmall"
         :text="description"
         :maxHeight="80"
@@ -60,7 +60,7 @@
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import { validateLinkObject, validateContentNodeKind } from 'kolibri.utils.validators';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss'; //update
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CardThumbnail from './CardThumbnail';
 
@@ -69,7 +69,7 @@
     components: {
       CardThumbnail,
       ContentIcon,
-      TextTruncator,
+      TextTruncatorCss,
       CoachContentLabel,
     },
     mixins: [responsiveWindowMixin],

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -35,7 +35,7 @@
             <TextTruncatorCss
               class="content-title"
               :text="content.title"
-              :maxHeight="72"
+              :maxLines="2"
             />
             <TimeDuration
               v-if="content.duration"
@@ -93,7 +93,7 @@
 <script>
 
   import isBoolean from 'lodash/isBoolean';
-  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss'; //update
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -32,7 +32,7 @@
 
         <div class="content-meta">
           <div class="text-and-time">
-            <TextTruncator
+            <TextTruncatorCss
               class="content-title"
               :text="content.title"
               :maxHeight="72"
@@ -93,7 +93,7 @@
 <script>
 
   import isBoolean from 'lodash/isBoolean';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss'; //update
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
@@ -107,7 +107,7 @@
     components: {
       LearningActivityIcon,
       ProgressBar,
-      TextTruncator,
+      TextTruncatorCss,
       TimeDuration,
       MissingResourceAlert,
     },


### PR DESCRIPTION


<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

From the Issue #8532  I have changed the `TextTruncator` with `TextTruncatorCss` in two files only ie `index.vue ` and `AlsoInThis.vue` 



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

From the Issue discussion, i got the little clue to do this #8532 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I have been asked to do changes in [step by step](https://github.com/learningequality/kolibri/issues/8532#issuecomment-1508085573) so that it would be easy to be evaluated and make corrections

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
