### PR TITLE
Update pin_code validation on FacilityDataset model to allow null

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -246,14 +246,6 @@ class FacilityDataset(FacilityDataSyncableModel):
             setattr(self, key, value)
         self.save()
 
-    def validate_pin_code(self):
-        if self.pin_code is None:
-            raise ValidationError("Pin code cannot be null!")
-
-    def clean_fields(self, exclude=None):
-        self.validate_pin_code()
-        super().clean_fields(exclude=exclude)
-
 
 class AbstractFacilityDataModel(FacilityDataSyncableModel):
     """

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -246,6 +246,14 @@ class FacilityDataset(FacilityDataSyncableModel):
             setattr(self, key, value)
         self.save()
 
+    def validate_pin_code(self):
+        if self.pin_code is None:
+            raise ValidationError("Pin code cannot be null!")
+
+    def clean_fields(self, exclude=None):
+        self.validate_pin_code()
+        super().clean_fields(exclude=exclude)
+
 
 class AbstractFacilityDataModel(FacilityDataSyncableModel):
     """

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -89,7 +89,7 @@ extra_fields_schema = {
     "properties": {
         "facility": {"type": "object", "optional": True},
         "on_my_own_setup": {"type": "boolean", "optional": True},
-        "pin_code": {"type": "string", "optional": True},
+        "pin_code": {"type": ["string", "null"], "optional": True},
     },
 }
 

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -3,6 +3,7 @@ Tests related specifically to the FacilityDataset model.
 """
 import uuid
 
+from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
@@ -134,6 +135,11 @@ class FacilityDatasetTestCase(TestCase):
             FacilityDataset.objects.create(
                 learner_can_edit_password=True, learner_can_login_with_no_password=True
             )
+
+    def test_null_pin_code(self):
+        facility_dataset = FacilityDataset(extra_fields={"pin_code": None})
+        with self.assertRaises(ValidationError):
+            facility_dataset.clean_fields()
 
 
 class MultipleDatasetAssignmentTestCase(TestCase):

--- a/kolibri/core/auth/test/test_datasets.py
+++ b/kolibri/core/auth/test/test_datasets.py
@@ -3,7 +3,6 @@ Tests related specifically to the FacilityDataset model.
 """
 import uuid
 
-from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase
 
@@ -138,8 +137,7 @@ class FacilityDatasetTestCase(TestCase):
 
     def test_null_pin_code(self):
         facility_dataset = FacilityDataset(extra_fields={"pin_code": None})
-        with self.assertRaises(ValidationError):
-            facility_dataset.clean_fields()
+        facility_dataset.clean_fields()
 
 
 class MultipleDatasetAssignmentTestCase(TestCase):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updated `FacilityDataset.extra_fields` JSON schema to allow null for the `pin_code`
- Added regression test to ensure a null/None `pin_code` does not fail validation when `clean_fields` is called

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves #10355 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
