### PR TITLE
fixes error raised when the folder button is clicked

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -184,7 +184,8 @@
       },
       width: {
         type: [Number, String],
-        required: true,
+        required: false,
+        default: null,
       },
       topicsListDisplayed: {
         type: Boolean,

--- a/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
@@ -32,6 +32,7 @@
           </div>
 
           <KIconButton
+            v-if="closeButtonIconType"
             :icon="closeButtonIconType"
             class="close-button"
             :style="closeButtonStyle"
@@ -78,7 +79,7 @@
       /* CloseButtonIconType icon from parent component */
       closeButtonIconType: {
         type: String,
-        required: true,
+        required: false,
         default: 'close',
         validator: value => {
           return ['close', 'back'].includes(value);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -146,7 +146,6 @@
         :topicsLoading="topicMoreLoading"
         @searchTerms="newTerms => searchTerms = newTerms"
         @currentCategory="handleShowSearchModal"
-        @closeCategoryModal="closeCategoryModal"
         @loadMoreTopics="handleLoadMoreInTopic"
         @close="sidePanelIsOpen = false"
       />
@@ -182,7 +181,6 @@
         class="full-screen-side-panel"
         alignment="left"
         :closeButtonIconType="closeButtonIcon"
-        :sidePanelOverrideWidth="`${sidePanelOverlayWidth}px`"
         @closePanel="closeEventHandler()"
         @shouldFocusFirstEl="findFirstEl()"
       >
@@ -380,8 +378,6 @@
         topicMoreLoading: false,
         mobileSearchActive: false,
         currentSearchCardViewStyle: 'card',
-        closeCategoryModal: '',
-        sidePanelOverlayWidth: '',
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -380,6 +380,8 @@
         topicMoreLoading: false,
         mobileSearchActive: false,
         currentSearchCardViewStyle: 'card',
+        closeCategoryModal: '',
+        sidePanelOverlayWidth: '',
       };
     },
     computed: {


### PR DESCRIPTION

## Summary
Clean vue errors on the console when a folder is clicked
closes #10517


## References

#10517

## Reviewer guidance

-  Navigate to "Learn" -> "Library" -> "Kolibri QA Channel".
- Change the resolution to a smaller screen.
-  Open the console and click on the "Folders" 


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
