### PR TITLE
10440 fix

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -133,6 +133,30 @@ export default function useLearningActivities(contentNode) {
   });
 
   /**
+   * @returns {String} Returns the translated exercise type(Practice Quiz or other)
+   */
+  const exerciseDescription = computed(() => {
+    const isPracticeQuiz = lodashGet(contentNode, ['options', 'modality'], false) === 'QUIZ';
+    const mastery_model = lodashGet(
+      contentNode,
+      ['options', 'completion_criteria', 'threshold', 'mastery_model'],
+      false
+    );
+
+    if (mastery_model) {
+      if (mastery_model == "do_all" && isPracticeQuiz) {
+        return coreStrings.$tr('practiceQuizLabel');
+      } else if (mastery_model.match(/num_correct_in_a_row_\d+/)) {
+        const count = mastery_model.match(/\d+/)[0];
+        return coreStrings.$tr('shortExerciseGoalDescription', { count : count });
+      } else if (mastery_model == "m_of_n" || mastery_model == "do_all") {
+        const m = contentNode.assessmentmetadata.mastery_model.m;
+        return coreStrings.$tr('shortExerciseGoalDescription', { count : m });
+      }
+    }
+  });
+
+  /**
    * @param {String} learningActivity A learning activity constant
    * @returns {String} A translated label for the learning activity
    */
@@ -158,6 +182,7 @@ export default function useLearningActivities(contentNode) {
     displayEstimatedDuration,
     durationInSeconds,
     durationEstimation,
+    exerciseDescription,
     getLearningActivityLabel,
     getLearningActivityIcon,
   };

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -137,20 +137,28 @@ export default function useLearningActivities(contentNode) {
    */
   const exerciseDescription = computed(() => {
     const isPracticeQuiz = lodashGet(contentNode, ['options', 'modality'], false) === 'QUIZ';
-    const mastery_model = lodashGet(
+    const options_mastery_model = lodashGet(
       contentNode,
       ['options', 'completion_criteria', 'threshold', 'mastery_model'],
       false
     );
+    const assessmentmetadata_mastery_model = lodashGet(
+      contentNode,
+      ['assessmentmetadata', 'mastery_model'],
+      false
+    );
 
-    if (mastery_model) {
-      if (mastery_model == "do_all" && isPracticeQuiz) {
+    if (options_mastery_model) {
+      if (options_mastery_model == "do_all" && isPracticeQuiz) {
         return coreStrings.$tr('practiceQuizLabel');
-      } else if (mastery_model.match(/num_correct_in_a_row_\d+/)) {
-        const count = mastery_model.match(/\d+/)[0];
-        return coreStrings.$tr('shortExerciseGoalDescription', { count : count });
-      } else if (mastery_model == "m_of_n" || mastery_model == "do_all") {
-        const m = contentNode.assessmentmetadata.mastery_model.m;
+      }
+    } 
+    if (assessmentmetadata_mastery_model) {
+      if (assessmentmetadata_mastery_model.type.match(/num_correct_in_a_row_\d+/)) {
+          const count = assessmentmetadata_mastery_model.type.match(/\d+/)[0];
+          return coreStrings.$tr('shortExerciseGoalDescription', { count : count });
+      } else {
+        const m = assessmentmetadata_mastery_model.m;
         return coreStrings.$tr('shortExerciseGoalDescription', { count : m });
       }
     }

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -149,17 +149,17 @@ export default function useLearningActivities(contentNode) {
     );
 
     if (options_mastery_model) {
-      if (options_mastery_model == "do_all" && isPracticeQuiz) {
+      if (options_mastery_model == 'do_all' && isPracticeQuiz) {
         return coreStrings.$tr('practiceQuizLabel');
       }
-    } 
+    }
     if (assessmentmetadata_mastery_model) {
       if (assessmentmetadata_mastery_model.type.match(/num_correct_in_a_row_\d+/)) {
-          const count = assessmentmetadata_mastery_model.type.match(/\d+/)[0];
-          return coreStrings.$tr('shortExerciseGoalDescription', { count : count });
+        const count = assessmentmetadata_mastery_model.type.match(/\d+/)[0];
+        return coreStrings.$tr('shortExerciseGoalDescription', { count: count });
       } else {
         const m = assessmentmetadata_mastery_model.m;
-        return coreStrings.$tr('shortExerciseGoalDescription', { count : m });
+        return coreStrings.$tr('shortExerciseGoalDescription', { count: m });
       }
     }
   });

--- a/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLearningActivities.js
@@ -137,24 +137,16 @@ export default function useLearningActivities(contentNode) {
    */
   const exerciseDescription = computed(() => {
     const isPracticeQuiz = lodashGet(contentNode, ['options', 'modality'], false) === 'QUIZ';
-    const options_mastery_model = lodashGet(
-      contentNode,
-      ['options', 'completion_criteria', 'threshold', 'mastery_model'],
-      false
-    );
     const assessmentmetadata_mastery_model = lodashGet(
       contentNode,
       ['assessmentmetadata', 'mastery_model'],
       false
     );
 
-    if (options_mastery_model) {
-      if (options_mastery_model == 'do_all' && isPracticeQuiz) {
-        return coreStrings.$tr('practiceQuizLabel');
-      }
-    }
     if (assessmentmetadata_mastery_model) {
-      if (assessmentmetadata_mastery_model.type.match(/num_correct_in_a_row_\d+/)) {
+      if (assessmentmetadata_mastery_model.type == 'do_all' && isPracticeQuiz) {
+        return coreStrings.$tr('practiceQuizLabel');
+      } else if (assessmentmetadata_mastery_model.type.match(/num_correct_in_a_row_\d+/)) {
         const count = assessmentmetadata_mastery_model.type.match(/\d+/)[0];
         return coreStrings.$tr('shortExerciseGoalDescription', { count: count });
       } else {

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -5,7 +5,7 @@
   >
     <template #labels>
       <LearningActivityDuration
-        v-if="displayDurationChip"
+        v-if="checkIfExercise || displayDurationChip"
         :contentNode="contentNode"
         appearance="chip"
         class="duration"
@@ -54,6 +54,12 @@
         }
         return true;
       },
+      checkIfExercise(){
+        if (this.contentNode.kind === "exercise") {
+          return true;
+        }
+        return false;
+      }
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -54,12 +54,12 @@
         }
         return true;
       },
-      checkIfExercise(){
-        if (this.contentNode.kind === "exercise") {
+      checkIfExercise() {
+        if (this.contentNode.kind === 'exercise') {
           return true;
         }
         return false;
-      }
+      },
     },
   };
 

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <span
-    v-if="isReference || displayPreciseDuration || displayEstimatedDuration"
+    v-if="isReference || displayPreciseDuration || displayEstimatedDuration || exerciseDescription"
     :class="[ appearance === 'chip' ? 'chip' : '']"
     :style="[ appearance === 'chip' ? { color: $themeTokens.textInverted } : {}]"
   >
@@ -14,6 +14,9 @@
     />
     <template v-else-if="displayEstimatedDuration">
       {{ durationEstimation }}
+    </template>
+    <template v-else-if="exerciseDescription">
+      {{ exerciseDescription }}
     </template>
   </span>
 
@@ -48,6 +51,7 @@
         displayEstimatedDuration,
         durationInSeconds,
         durationEstimation,
+        exerciseDescription,
       } = useLearningActivities(props.contentNode);
 
       return {
@@ -57,6 +61,7 @@
         displayEstimatedDuration,
         durationInSeconds,
         durationEstimation,
+        exerciseDescription
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityDuration/index.vue
@@ -61,7 +61,7 @@
         displayEstimatedDuration,
         durationInSeconds,
         durationEstimation,
-        exerciseDescription
+        exerciseDescription,
       };
     },
     props: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes #10440 by altering LearningActivityDuration. This uses assessmentmetadata to compare if it is practice quiz. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10440 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

The editing is mainly done in `LearningActivityDuration` component. These changes are shown where `CardThumbnail` component exist, i.e. 
1. Learn->Library->Recent (If you have recently done a quiz)
2. Wherever quiz exists inside a channel.
3. Learn->Bookmarks (If you have bookmarked a quiz)
Kindly check whether the labels work as intended in above locations and are responsive. 


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
