### PR TITLE
Frontend remote browsing tweaks

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -274,7 +274,7 @@
         },
       },
       epubURL() {
-        return this.defaultFile.storage_url;
+        return new URL(this.defaultFile.storage_url, window.location).href;
       },
       backgroundColor() {
         return this.theme.backgroundColor;

--- a/kolibri/plugins/learn/assets/src/composables/useContentLink.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentLink.js
@@ -11,11 +11,11 @@ export default function useContentLink(store) {
   store = store || getCurrentInstance().proxy.$store;
   const route = computed(() => store.state.route);
 
-  function _makeLink(id, isResource, query) {
+  function _makeLink(id, isResource, query, deviceId) {
     const params = get(route).params;
     return {
       name: isResource ? PageNames.TOPICS_CONTENT : PageNames.TOPICS_TOPIC,
-      params: pick({ id, deviceId: params.deviceId }, ['id', 'deviceId']),
+      params: pick({ id, deviceId: deviceId || params.deviceId }, ['id', 'deviceId']),
       query,
     };
   }
@@ -29,7 +29,7 @@ export default function useContentLink(store) {
    * @param {boolean} isResource - whether this is a resource or not
    * @return {Object} VueRouter link object
    */
-  function genContentLinkBackLinkCurrentPage(id, isResource = false) {
+  function genContentLinkBackLinkCurrentPage(id, isResource = false, deviceId) {
     if (!route) {
       return null;
     }
@@ -44,7 +44,7 @@ export default function useContentLink(store) {
     if (!isEmpty(params)) {
       query.prevParams = encodeURI(JSON.stringify(params));
     }
-    return _makeLink(id, isResource, query);
+    return _makeLink(id, isResource, query, deviceId);
   }
 
   function genExternalContentURLBackLinkCurrentPage(id) {
@@ -82,14 +82,14 @@ export default function useContentLink(store) {
    * @param {boolean} isResource - whether this is a resource or not
    * @return {Object} VueRouter link object
    */
-  function genContentLinkKeepCurrentBackLink(id, isResource = false) {
+  function genContentLinkKeepCurrentBackLink(id, isResource = false, deviceId) {
     if (!route) {
       return null;
     }
     const oldQuery = get(route).query || {};
     const query = pick(oldQuery, ['prevName', 'prevQuery', 'prevParams']);
 
-    return _makeLink(id, isResource, query);
+    return _makeLink(id, isResource, query, deviceId);
   }
 
   const back = computed(() => {

--- a/kolibri/plugins/learn/assets/src/composables/useSearch.js
+++ b/kolibri/plugins/learn/assets/src/composables/useSearch.js
@@ -225,9 +225,11 @@ export default function useSearch(descendant, store, router) {
   }
 
   function search() {
+    const currentBaseUrl = get(baseurl);
     const getParams = {
       include_coach_content:
         store.getters.isAdmin || store.getters.isCoach || store.getters.isSuperuser,
+      baseurl: currentBaseUrl,
     };
     const descValue = descendant ? get(descendant) : null;
     if (descValue) {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -60,7 +60,7 @@
           :title="channel.name"
           :tagline="channel.tagline || channel.description"
           :thumbnail="channel.thumbnail"
-          :link="genContentLinkBackLinkCurrentPage(channel.root)"
+          :link="genContentLinkBackLinkCurrentPage(channel.root, false, deviceId)"
           :version="channel.version"
         />
       </KGridItem>


### PR DESCRIPTION
## Summary
* Updates the channel links on the Explore Libraries page to include the reference to the device Id
* Updates the URL generation for EPUBJS to allow it to parse the URL including the baseurl GET parameter
* Adds baseurl to GET params for one place in the useSearch composable where it was missing

## References
These all seem to be unreported, so thought they could be fixed without toe stepping. @akolson if you've fixed any of these independently, let me know.

## Reviewer guidance
Navigate to a channel from the explore libraries page.
Open an EPUB in remote browsing.
Search within a channel in remote browsing.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
