### PR TITLE
Fixes missing translation for learner

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -63,7 +63,15 @@
                 {{ username }}
               </p>
               <p :style="{ color: $themeTokens.annotation, fontSize: '12px', marginTop: 0 }">
-                {{ getUserKind }}
+                <span v-if="getUserKind === 'learner'">
+                  {{ coreString('learnerLabel') }}
+                </span>
+                <span v-if="getUserKind === 'coach'">
+                  {{ coreString('coachLabel') }}
+                </span>
+                <span v-if="getUserKind === 'super admin'">
+                  {{ coreString('superAdminLabel') }}
+                </span>
               </p>
 
 

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -63,15 +63,7 @@
                 {{ username }}
               </p>
               <p :style="{ color: $themeTokens.annotation, fontSize: '12px', marginTop: 0 }">
-                <span v-if="getUserKind === 'learner'">
-                  {{ coreString('learnerLabel') }}
-                </span>
-                <span v-if="getUserKind === 'coach'">
-                  {{ coreString('coachLabel') }}
-                </span>
-                <span v-if="getUserKind === 'super admin'">
-                  {{ coreString('superAdminLabel') }}
-                </span>
+                {{ loggedInUserKind }}
               </p>
 
 
@@ -359,6 +351,18 @@
       },
       userIsLearner() {
         return this.getUserKind == UserKinds.LEARNER;
+      },
+      loggedInUserKind() {
+        if (this.getUserKind === UserKinds.LEARNER) {
+          return this.coreString('learnerLabel');
+        }
+        if (this.getUserKind === UserKinds.ADMIN) {
+          return this.coreString('adminLabel');
+        }
+        if (this.getUserKind === UserKinds.COACH) {
+          return this.coreString('coachLabel');
+        }
+        return this.coreString('superAdminLabel');
       },
     },
     watch: {


### PR DESCRIPTION



## Summary
This PR fixes a learner missing translation on learner account
#10541

…

## References
#10541

#### Before
![image](https://user-images.githubusercontent.com/103313919/233672265-544e513d-831f-4dd6-a64a-c542abfc799e.png)

#### After 
<img width="462" alt="Screenshot 2023-04-21 at 18 03 32" src="https://user-images.githubusercontent.com/103313919/233672324-5adcb02b-18f8-4997-a90c-01e953a0a5ac.png">




## Reviewer guidance

Login as a learner  and click change language > select any other language other than English
…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
