### PR TITLE
Static network device form error handling updates

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -12,6 +12,7 @@
     <p>{{ $tr('addressDesc') }}</p>
     <div>
       <KTextbox
+        ref="address"
         v-model="address"
         :label="$tr('addressLabel')"
         :placeholder="$tr('addressPlaceholder')"
@@ -123,8 +124,10 @@
             ]);
             if (errorsCaught.includes(ERROR_CONSTANTS.NETWORK_LOCATION_NOT_FOUND)) {
               this.status = Statuses.COULD_NOT_CONNECT;
+              this.$refs.address.focus();
             } else if (errorsCaught.includes(ERROR_CONSTANTS.INVALID_NETWORK_LOCATION_FORMAT)) {
               this.status = Statuses.INVALID_ADDRESS;
+              this.$refs.address.focus();
             } else {
               this.$store.dispatch('handleApiError', err);
             }

--- a/kolibri/core/discovery/serializers.py
+++ b/kolibri/core/discovery/serializers.py
@@ -55,7 +55,7 @@ class NetworkLocationSerializer(serializers.ModelSerializer):
     def validate(self, data):
         try:
             client = NetworkClient.build_for_address(data["base_url"])
-        except errors.NetworkClientError as e:
+        except (errors.NetworkClientError, errors.URLParseError) as e:
             raise ValidationError(
                 "Error with address {} ({})".format(
                     data["base_url"], e.__class__.__name__


### PR DESCRIPTION
## Summary
Fixes https://github.com/learningequality/kolibri/issues/10267

This adds additional error handling for address input that is a string with a space in it. It also adjusts the frontend so that if there is an error message for the address, the focus is automatically shifted back to that form field, so the user sees it by default. Previously, the way the KModal was managing the errors didn't update until the user clicked back into the form field, which is not the best user experience and could cause confusion about if there is an error

BEFORE 

https://user-images.githubusercontent.com/17235236/233707932-42c69d39-d1f6-40f1-accd-608c6c064c8c.mp4

AFTER

https://user-images.githubusercontent.com/17235236/233707979-700394a2-71bd-4b4c-a541-161f842aade6.mp4



## Reviewer guidance
Enter a non-address string (i.e. either one or multiple words) into the form field

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
