### PR TITLE
 Changes to be committed:

### DIFF
--- a/kolibri/core/lessons/serializers.py
+++ b/kolibri/core/lessons/serializers.py
@@ -86,6 +86,20 @@ class LessonSerializer(ModelSerializer):
                 "The fields title, collection must make a unique set.",
                 code=error_constants.UNIQUE,
             )
+            
+    def validate_description(self, description):
+        if len(description) > 500:
+            raise ValidationError("Description must not exceed 500 characters.")
+        return description
+
+    def validate_resources(self, resources):
+        for resource in resources:
+            if not resource["content_id"]:
+                raise ValidationError("Content ID is required.")
+            if not resource["channel_id"]:
+                raise ValidationError("Channel ID is required.")
+        return resources
+
 
     def to_internal_value(self, data):
         data = OrderedDict(data)


### PR DESCRIPTION
	modified:   kolibri/core/lessons/serializers.py


## Summary
Add additional validation for fields like the lesson description and resources. Check if the description length is within an acceptable range, and validate the resources' content IDs and channel IDs. 

## References


## Reviewer guidance


## Testing checklist

- [x ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
