### PR TITLE
facility tab navigation bug

### DIFF
--- a/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
+++ b/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
@@ -1,0 +1,51 @@
+import { generateNavRoute } from '../generateNavRoutes';
+
+describe('generateNavRoutes utility', () => {
+  it('formats correctly for path with 1 required param', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id/classes',
+      {facility_id: 109000000})
+    ).toEqual('/en/facility/#/109000000/classes');
+  });
+
+  it('formats correctly for path with required param not provided', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id/classes',
+      {facility_id: undefined})
+    ).toEqual('/en/facility/');
+  });
+
+  it('formats correctly for path with 1 optional param', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id?/classes',
+      {facility_id: 109099999})
+    ).toEqual('/en/facility/#/109099999/classes');
+  });
+
+  it('formats correctly for path with optional param not provided', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id?/classes',
+      {facility_id: undefined})
+    ).toEqual('/en/facility/#/classes');
+  });
+
+  it('formats correctly for path with required param when wrong param provided', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id/classes',
+      {device_id: 900034})
+    ).toEqual('/en/facility/');
+  });
+
+  it('formats correctly for path with optional param when wrong param provided', () => {
+    expect(generateNavRoute(
+      '/en/facility/',
+      '/:facility_id?/classes',
+      {device_id: 900034})
+    ).toEqual('/en/facility/#/classes');
+  });
+})

--- a/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
+++ b/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
@@ -3,37 +3,37 @@ import { generateNavRoute } from '../generateNavRoutes';
 describe('generateNavRoutes utility', () => {
   it('formats correctly for path with 1 required param', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id/classes', {facility_id: 109000000})
+      generateNavRoute('/en/facility/', '/:facility_id/classes', { facility_id: 109000000 })
     ).toEqual('/en/facility/#/109000000/classes');
   });
 
   it('formats correctly for path with required param not provided', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id/classes', {facility_id: undefined})
+      generateNavRoute('/en/facility/', '/:facility_id/classes', { facility_id: undefined })
     ).toEqual('/en/facility/');
   });
 
   it('formats correctly for path with 1 optional param', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id?/classes', {facility_id: 109099999})
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', { facility_id: 109099999 })
     ).toEqual('/en/facility/#/109099999/classes');
   });
 
   it('formats correctly for path with optional param not provided', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id?/classes', {facility_id: undefined})
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', { facility_id: undefined })
     ).toEqual('/en/facility/#/classes');
   });
 
   it('formats correctly for path with required param when wrong param provided', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id/classes', {device_id: 900034})
+      generateNavRoute('/en/facility/', '/:facility_id/classes', { device_id: 900034 })
     ).toEqual('/en/facility/');
   });
 
   it('formats correctly for path with optional param when wrong param provided', () => {
     expect(
-      generateNavRoute('/en/facility/', '/:facility_id?/classes', {device_id: 900034})
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', { device_id: 900034 })
     ).toEqual('/en/facility/#/classes');
   });
-})
+});

--- a/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
+++ b/kolibri/core/assets/src/utils/__test__/generateNavRoutes.spec.js
@@ -2,50 +2,38 @@ import { generateNavRoute } from '../generateNavRoutes';
 
 describe('generateNavRoutes utility', () => {
   it('formats correctly for path with 1 required param', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id/classes',
-      {facility_id: 109000000})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id/classes', {facility_id: 109000000})
     ).toEqual('/en/facility/#/109000000/classes');
   });
 
   it('formats correctly for path with required param not provided', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id/classes',
-      {facility_id: undefined})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id/classes', {facility_id: undefined})
     ).toEqual('/en/facility/');
   });
 
   it('formats correctly for path with 1 optional param', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id?/classes',
-      {facility_id: 109099999})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', {facility_id: 109099999})
     ).toEqual('/en/facility/#/109099999/classes');
   });
 
   it('formats correctly for path with optional param not provided', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id?/classes',
-      {facility_id: undefined})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', {facility_id: undefined})
     ).toEqual('/en/facility/#/classes');
   });
 
   it('formats correctly for path with required param when wrong param provided', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id/classes',
-      {device_id: 900034})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id/classes', {device_id: 900034})
     ).toEqual('/en/facility/');
   });
 
   it('formats correctly for path with optional param when wrong param provided', () => {
-    expect(generateNavRoute(
-      '/en/facility/',
-      '/:facility_id?/classes',
-      {device_id: 900034})
+    expect(
+      generateNavRoute('/en/facility/', '/:facility_id?/classes', {device_id: 900034})
     ).toEqual('/en/facility/#/classes');
   });
 })

--- a/kolibri/core/assets/src/utils/generateNavRoutes.js
+++ b/kolibri/core/assets/src/utils/generateNavRoutes.js
@@ -6,28 +6,31 @@ export function generateNavRoute(rootUrl, pathReference, params = {}) {
   // when there is a direct path
   compiledRoute = `${rootUrl}#${pathReference}`;
 
-  // if the path requires params but none exist, send to root
   const pathParams = [];
   pathToRegexp(compiledRoute, pathParams);
 
-  if (pathParams.length > 0 && Object.keys(params).length < 1) {
+  const countPathParams = pathParams.length;
+  const paramName = !!countPathParams && pathParams[0].name;
+  const paramValue = paramName && params[paramName];
+
+  const onlyOptionalParams = countPathParams === 1 && pathParams[0].optional === true;
+  const missingOptionalParams = onlyOptionalParams && !paramValue;
+
+  // if path requires params but none exist (or they're the wrong params), send to root
+  if (!!countPathParams && !paramValue && !onlyOptionalParams) {
     compiledRoute = rootUrl;
   }
 
-  // if there are params, but it's the wrong params
-  if (
-    pathParams.length > 0 &&
-    pathParams[0] &&
-    pathParams[0].name &&
-    Object.keys(params)[0] !== pathParams[0].name
-  ) {
-    compiledRoute = rootUrl;
-  }
-
-  // Are there params being passes
-  if (Object.keys(params).length > 0) {
+  // if there are params with defined values being passed, include in route
+  if (Object.keys(params).length > 0 && !!Object.values(params)[0]) {
     const makeParamsRoute = pathToRegexp.compile(compiledRoute);
     compiledRoute = makeParamsRoute(params);
+  }
+
+  // if there are only optional params & they're not provided, build route without them
+  if (onlyOptionalParams && missingOptionalParams) {
+    const optionalPathReference = pathReference.slice(pathReference.indexOf('?') + 1);
+    compiledRoute = `${rootUrl}#${optionalPathReference}`
   }
 
   return compiledRoute;

--- a/kolibri/core/assets/src/utils/generateNavRoutes.js
+++ b/kolibri/core/assets/src/utils/generateNavRoutes.js
@@ -30,7 +30,7 @@ export function generateNavRoute(rootUrl, pathReference, params = {}) {
   // if there are only optional params & they're not provided, build route without them
   if (onlyOptionalParams && missingOptionalParams) {
     const optionalPathReference = pathReference.slice(pathReference.indexOf('?') + 1);
-    compiledRoute = `${rootUrl}#${optionalPathReference}`
+    compiledRoute = `${rootUrl}#${optionalPathReference}`;
   }
 
   return compiledRoute;

--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -37,6 +37,12 @@ export default {
     activeFacilityId(state, getters, rootState, rootGetters) {
       // Return either the facility_id param in the route module,
       // or the currentFacilityId value from core.session
+
+      // For multi-facility case, only use facility_id if in route because currentFacilityId
+      // fallback would always navigate to our default facility, not multi-facility landing page
+      if (getters.userIsMultiFacilityAdmin) {
+        return rootState.route.params.facility_id;
+      }
       return rootState.route.params.facility_id || rootGetters.currentFacilityId;
     },
     currentFacilityName(state, getters, rootState) {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -24,6 +24,16 @@ import {
 } from './modules/classAssignMembers/handlers';
 import { PageNames } from './constants';
 
+function facilityParamRequiredGuard(toRoute, subtopicName) {
+  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+    router.replace({
+      name: 'ALL_FACILITIES_PAGE',
+      params: { subtopicName },
+    });
+    return true;
+  }
+}
+
 export default [
   // Routes for multi-facility case
   {
@@ -43,14 +53,10 @@ export default [
     path: '/:facility_id?/classes',
     component: ManageClassPage,
     handler: toRoute => {
-      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-        return router.replace({
-          name: 'ALL_FACILITIES_PAGE',
-          params: { subtopicName: 'ManageClassPage' },
-        });
-      } else {
-        showClassesPage(store, toRoute);
+      if (facilityParamRequiredGuard(toRoute, ManageClassPage.name)) {
+        return;
       }
+      showClassesPage(store, toRoute);
     },
   },
   {
@@ -82,14 +88,10 @@ export default [
     component: UserPage,
     path: '/:facility_id?/users',
     handler: (toRoute, fromRoute) => {
-      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-        return router.replace({
-          name: 'ALL_FACILITIES_PAGE',
-          params: { subtopicName: 'UserPage' },
-        });
-      } else {
-        showUserPage(store, toRoute, fromRoute);
+      if (facilityParamRequiredGuard(toRoute, UserPage.name)) {
+        return;
       }
+      showUserPage(store, toRoute, fromRoute);
     },
   },
   {
@@ -113,14 +115,10 @@ export default [
     component: DataPage,
     path: '/:facility_id?/data',
     handler: toRoute => {
-      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-        router.replace({
-          name: 'ALL_FACILITIES_PAGE',
-          params: { subtopicName: 'DataPage' },
-        });
-      } else {
-        store.dispatch('preparePage', { isAsync: false });
+      if (facilityParamRequiredGuard(toRoute, DataPage.name)) {
+        return;
       }
+      store.dispatch('preparePage', { isAsync: false });
     },
   },
   {
@@ -136,14 +134,10 @@ export default [
     component: FacilitiesConfigPage,
     path: '/:facility_id?/settings',
     handler: toRoute => {
-      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-        router.replace({
-          name: 'ALL_FACILITIES_PAGE',
-          params: { subtopicName: 'FacilitiesConfigPage' },
-        });
-      } else {
-        showFacilityConfigPage(store, toRoute);
+      if (facilityParamRequiredGuard(toRoute, FacilitiesConfigPage.name)) {
+        return;
       }
+      showFacilityConfigPage(store, toRoute);
     },
   },
   {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -88,7 +88,7 @@ export default [
           params: { subtopicName: 'UserPage' },
         });
       } else {
-      showUserPage(store, toRoute, fromRoute);
+        showUserPage(store, toRoute, fromRoute);
       }
     },
   },
@@ -119,7 +119,8 @@ export default [
           params: { subtopicName: 'DataPage' },
         });
       } else {
-        store.dispatch('preparePage', { isAsync: false });}
+        store.dispatch('preparePage', { isAsync: false });
+      }
     },
   },
   {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -1,4 +1,5 @@
 import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
 import ManageSyncSchedule from 'kolibri-common/components/SyncSchedule/ManageSyncSchedule';
 import EditDeviceSyncSchedule from 'kolibri-common/components/SyncSchedule/EditDeviceSyncSchedule';
 import { SyncPageNames } from 'kolibri-common/components/SyncSchedule/constants';
@@ -29,6 +30,7 @@ export default [
     name: PageNames.ALL_FACILITIES_PAGE,
     path: '/facilities',
     component: AllFacilitiesPage,
+    props: true,
     handler() {
       store.dispatch('preparePage', { isAsync: false });
     },
@@ -41,7 +43,14 @@ export default [
     path: '/:facility_id?/classes',
     component: ManageClassPage,
     handler: toRoute => {
-      showClassesPage(store, toRoute);
+      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+        return router.replace({
+          name: 'ALL_FACILITIES_PAGE',
+          params: { subtopicName: 'ManageClassPage' },
+        });
+      } else {
+        showClassesPage(store, toRoute);
+      }
     },
   },
   {
@@ -73,7 +82,14 @@ export default [
     component: UserPage,
     path: '/:facility_id?/users',
     handler: (toRoute, fromRoute) => {
+      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+        return router.replace({
+          name: 'ALL_FACILITIES_PAGE',
+          params: { subtopicName: 'UserPage' },
+        });
+      } else {
       showUserPage(store, toRoute, fromRoute);
+      }
     },
   },
   {
@@ -96,8 +112,14 @@ export default [
     name: PageNames.DATA_EXPORT_PAGE,
     component: DataPage,
     path: '/:facility_id?/data',
-    handler: () => {
-      store.dispatch('preparePage', { isAsync: false });
+    handler: toRoute => {
+      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+        router.replace({
+          name: 'ALL_FACILITIES_PAGE',
+          params: { subtopicName: 'DataPage' },
+        });
+      } else {
+        store.dispatch('preparePage', { isAsync: false });}
     },
   },
   {
@@ -113,7 +135,14 @@ export default [
     component: FacilitiesConfigPage,
     path: '/:facility_id?/settings',
     handler: toRoute => {
-      showFacilityConfigPage(store, toRoute);
+      if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+        router.replace({
+          name: 'ALL_FACILITIES_PAGE',
+          params: { subtopicName: 'FacilitiesConfigPage' },
+        });
+      } else {
+        showFacilityConfigPage(store, toRoute);
+      }
     },
   },
   {

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -73,8 +73,9 @@
     },
     methods: {
       facilityLink(facility) {
-        const link = cloneDeep(this.facilityPageLinks[this.subtopicName]
-          || this.facilityPageLinks.ManageClassPage);
+        const link = cloneDeep(
+          this.facilityPageLinks[this.subtopicName] || this.facilityPageLinks.ManageClassPage
+        );
 
         link.params.facility_id = facility.id;
         return link;

--- a/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/AllFacilitiesPage.vue
@@ -51,6 +51,13 @@
       CoreTable,
     },
     mixins: [commonCoreStrings],
+    props: {
+      subtopicName: {
+        type: String,
+        required: false,
+        default: null,
+      },
+    },
     computed: {
       ...mapGetters(['facilityPageLinks', 'userIsMultiFacilityAdmin']),
       facilities() {
@@ -66,7 +73,9 @@
     },
     methods: {
       facilityLink(facility) {
-        const link = cloneDeep(this.facilityPageLinks.ManageClassPage);
+        const link = cloneDeep(this.facilityPageLinks[this.subtopicName]
+          || this.facilityPageLinks.ManageClassPage);
+
         link.params.facility_id = facility.id;
         return link;
       },

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -3,6 +3,17 @@
   <FacilityAppBarPage>
 
     <KPageContainer v-if="canUploadDownloadFiles">
+      <p>
+        <KRouterLink
+          v-if="userIsMultiFacilityAdmin"
+          :to="{
+            name: facilityPageLinks.AllFacilitiesPage.name,
+            params: { subtopicName: 'DataPage' }
+          }"
+          icon="back"
+          :text="coreString('changeLearningFacility')"
+        />
+      </p>
       <KGrid gutter="24">
 
         <KGridItem>
@@ -227,7 +238,7 @@
         'inSummaryCSVCreation',
         'firstLogDate',
       ]),
-      ...mapGetters(['activeFacilityId']),
+      ...mapGetters(['activeFacilityId', 'userIsMultiFacilityAdmin', 'facilityPageLinks']),
       ...mapState('manageCSV', ['sessionDateCreated', 'summaryDateCreated']),
       // NOTE: We disable CSV file upload/download on embedded web views like the Mac
       // and Android apps

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -289,7 +289,12 @@
         'facilityNameSaved',
         'facilityNameError',
       ]),
-      ...mapGetters(['isAppContext', 'isSuperuser', 'userIsMultiFacilityAdmin', 'facilityPageLinks']),
+      ...mapGetters([
+        'isAppContext',
+        'isSuperuser',
+        'userIsMultiFacilityAdmin',
+        'facilityPageLinks'
+      ]),
       settingsList: () => settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -5,6 +5,17 @@
       data-test="page-container"
       :style="{ marginBottom: '42px' }"
     >
+      <p>
+        <KRouterLink
+          v-if="userIsMultiFacilityAdmin"
+          :to="{
+            name: facilityPageLinks.AllFacilitiesPage.name,
+            params: { subtopicName: 'FacilitiesConfigPage' }
+          }"
+          icon="back"
+          :text="coreString('changeLearningFacility')"
+        />
+      </p>
       <div class="mb">
         <h1>{{ $tr('pageHeader') }}</h1>
         <p>
@@ -278,7 +289,7 @@
         'facilityNameSaved',
         'facilityNameError',
       ]),
-      ...mapGetters(['isAppContext', 'isSuperuser']),
+      ...mapGetters(['isAppContext', 'isSuperuser', 'userIsMultiFacilityAdmin', 'facilityPageLinks']),
       settingsList: () => settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -293,7 +293,7 @@
         'isAppContext',
         'isSuperuser',
         'userIsMultiFacilityAdmin',
-        'facilityPageLinks'
+        'facilityPageLinks',
       ]),
       settingsList: () => settingsList,
       settingsHaveChanged() {

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/index.vue
@@ -6,9 +6,12 @@
       <p>
         <KRouterLink
           v-if="userIsMultiFacilityAdmin"
-          :to="facilityPageLinks.AllFacilitiesPage"
+          :to="{
+            name: facilityPageLinks.AllFacilitiesPage.name,
+            params: { subtopicName: 'ManageClassPage' }
+          }"
           icon="back"
-          :text="coreString('allFacilitiesLabel')"
+          :text="coreString('changeLearningFacility')"
         />
       </p>
       <KGrid>

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -145,7 +145,12 @@
       };
     },
     computed: {
-      ...mapGetters(['currentUserId', 'isSuperuser', 'userIsMultiFacilityAdmin', 'facilityPageLinks'] ),
+      ...mapGetters([
+        'currentUserId',
+        'isSuperuser',
+        'userIsMultiFacilityAdmin',
+        'facilityPageLinks'
+      ]),
       ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount']),
       Modals: () => Modals,
       userKinds() {

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -2,6 +2,17 @@
 
   <FacilityAppBarPage>
     <KPageContainer>
+      <p>
+        <KRouterLink
+          v-if="userIsMultiFacilityAdmin"
+          :to="{
+            name: facilityPageLinks.AllFacilitiesPage.name,
+            params: { subtopicName: 'UserPage' }
+          }"
+          icon="back"
+          :text="coreString('changeLearningFacility')"
+        />
+      </p>
       <KGrid>
         <KGridItem
           :layout8="{ span: 4 }"
@@ -134,7 +145,7 @@
       };
     },
     computed: {
-      ...mapGetters(['currentUserId', 'isSuperuser']),
+      ...mapGetters(['currentUserId', 'isSuperuser', 'userIsMultiFacilityAdmin', 'facilityPageLinks'] ),
       ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount']),
       Modals: () => Modals,
       userKinds() {

--- a/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/index.vue
@@ -149,7 +149,7 @@
         'currentUserId',
         'isSuperuser',
         'userIsMultiFacilityAdmin',
-        'facilityPageLinks'
+        'facilityPageLinks',
       ]),
       ...mapState('userManagement', ['facilityUsers', 'totalPages', 'usersCount']),
       Modals: () => Modals,

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -27,12 +27,13 @@ const fakeDatasets = [
 
 const testCases = [
   {
-    description: 'single facility user with session.facility_id and no facility_id in toRoute params',
+    description:
+      'single facility user with session.facility_id and no facility_id in toRoute params',
     userIsMultiFacilityAdmin: false,
     toRoute: {
       params: {
         facility_id: '',
-      }
+      },
     },
     expectedResult: '1',
   },
@@ -42,7 +43,7 @@ const testCases = [
     toRoute: {
       params: {
         facility_id: '2',
-      }
+      },
     },
     expectedResult: '2',
   },
@@ -52,7 +53,7 @@ const testCases = [
     toRoute: {
       params: {
         facility_id: '3',
-      }
+      },
     },
     expectedResult: '3',
   },
@@ -84,15 +85,18 @@ describe('facility config page actions', () => {
   describe('showFacilityConfigPage action', () => {
     testCases.forEach(test => {
       beforeEach(() => {
-        const mockUserIsMultiFacilityAdmin =
-          jest.fn().mockReturnValueOnce(test.userIsMultiFacilityAdmin);
-        const mockActiveFacilityId =
-          jest.fn().mockReturnValueOnce(store.state.core.session.currentFacilityId);
+        const mockUserIsMultiFacilityAdmin = jest
+          .fn()
+          .mockReturnValueOnce(test.userIsMultiFacilityAdmin);
+
+        const mockActiveFacilityId = jest
+          .fn()
+          .mockReturnValueOnce(store.state.core.session.currentFacilityId);
 
         store.getters = {
           userIsMultiFacilityAdmin: mockUserIsMultiFacilityAdmin(),
-          activeFacilityId: mockActiveFacilityId()
-        }
+          activeFacilityId: mockActiveFacilityId(),
+        };
       });
 
       it(`should load resources successfully for ${test.description}`, () => {
@@ -120,7 +124,7 @@ describe('facility config page actions', () => {
 
         return showFacilityConfigPage(store, test.toRoute).then(() => {
           expect(FacilityDatasetResource.fetchCollection).toHaveBeenCalledWith({
-            getParams: {facility_id: test.expectedResult},
+            getParams: { facility_id: test.expectedResult },
           });
           expect(commitStub).toHaveBeenCalledWith(
             'facilityConfig/SET_STATE',

--- a/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
+++ b/kolibri/plugins/facility/assets/test/state/facilityConfig.spec.js
@@ -25,9 +25,38 @@ const fakeDatasets = [
   { id: 'dataset_3' },
 ];
 
-const toRoute = {
-  params: {},
-};
+const testCases = [
+  {
+    description: 'single facility user with session.facility_id and no facility_id in toRoute params',
+    userIsMultiFacilityAdmin: false,
+    toRoute: {
+      params: {
+        facility_id: '',
+      }
+    },
+    expectedResult: '1',
+  },
+  {
+    description: 'single facility user with facility_id in toRoute params',
+    userIsMultiFacilityAdmin: false,
+    toRoute: {
+      params: {
+        facility_id: '2',
+      }
+    },
+    expectedResult: '2',
+  },
+  {
+    description: 'multi-facility user with facility_id in toRoute params',
+    userIsMultiFacilityAdmin: true,
+    toRoute: {
+      params: {
+        facility_id: '3',
+      }
+    },
+    expectedResult: '3',
+  },
+];
 
 describe('facility config page actions', () => {
   let store;
@@ -40,7 +69,7 @@ describe('facility config page actions', () => {
     Object.assign(store.state.core, {
       pageId: '123',
       session: {
-        facility_id: 1,
+        currentFacilityId: '1',
       },
     });
   });
@@ -53,50 +82,46 @@ describe('facility config page actions', () => {
   });
 
   describe('showFacilityConfigPage action', () => {
-    it('when resources load successfully', () => {
-      FacilityResource.fetchModel.mockResolvedValue(fakeFacility);
-      FacilityResource.fetchCollection.mockResolvedValue(fakeFacilities);
-      FacilityDatasetResource.fetchCollection.mockResolvedValue(fakeDatasets);
-      const expectedState = {
-        facilityDatasetId: 'dataset_2',
-        facilityName: 'Nalanda Maths',
-        settings: expect.objectContaining({
-          learner_can_edit_name: true,
-          learner_can_edit_username: false,
-          learner_can_edit_password: true,
-          learner_can_delete_account: true,
-          learner_can_sign_up: true,
-        }),
-        settingsCopy: expect.objectContaining({
-          learner_can_edit_name: true,
-          learner_can_edit_username: false,
-          learner_can_edit_password: true,
-          learner_can_delete_account: true,
-          learner_can_sign_up: true,
-        }),
-      };
+    testCases.forEach(test => {
+      beforeEach(() => {
+        const mockUserIsMultiFacilityAdmin =
+          jest.fn().mockReturnValueOnce(test.userIsMultiFacilityAdmin);
+        const mockActiveFacilityId =
+          jest.fn().mockReturnValueOnce(store.state.core.session.currentFacilityId);
 
-      return showFacilityConfigPage(store, toRoute).then(() => {
-        expect(FacilityDatasetResource.fetchCollection).toHaveBeenCalledWith({
-          getParams: { facility_id: 1 },
-        });
-        expect(commitStub).toHaveBeenCalledWith(
-          'facilityConfig/SET_STATE',
-          expect.objectContaining(expectedState)
-        );
+        store.getters = {
+          userIsMultiFacilityAdmin: mockUserIsMultiFacilityAdmin(),
+          activeFacilityId: mockActiveFacilityId()
+        }
       });
-    });
 
-    describe('error handling', () => {
-      const expectedState = {
-        facilityName: '',
-        settings: null,
-      };
-      it('when fetching Facility fails', () => {
-        FacilityResource.fetchModel.mockRejectedValue('incomprehensible error');
+      it(`should load resources successfully for ${test.description}`, () => {
+        FacilityResource.fetchModel.mockResolvedValue(fakeFacility);
         FacilityResource.fetchCollection.mockResolvedValue(fakeFacilities);
         FacilityDatasetResource.fetchCollection.mockResolvedValue(fakeDatasets);
-        return showFacilityConfigPage(store, toRoute).then(() => {
+        const expectedState = {
+          facilityDatasetId: 'dataset_2',
+          facilityName: 'Nalanda Maths',
+          settings: expect.objectContaining({
+            learner_can_edit_name: true,
+            learner_can_edit_username: false,
+            learner_can_edit_password: true,
+            learner_can_delete_account: true,
+            learner_can_sign_up: true,
+          }),
+          settingsCopy: expect.objectContaining({
+            learner_can_edit_name: true,
+            learner_can_edit_username: false,
+            learner_can_edit_password: true,
+            learner_can_delete_account: true,
+            learner_can_sign_up: true,
+          }),
+        };
+
+        return showFacilityConfigPage(store, test.toRoute).then(() => {
+          expect(FacilityDatasetResource.fetchCollection).toHaveBeenCalledWith({
+            getParams: {facility_id: test.expectedResult},
+          });
           expect(commitStub).toHaveBeenCalledWith(
             'facilityConfig/SET_STATE',
             expect.objectContaining(expectedState)
@@ -104,15 +129,33 @@ describe('facility config page actions', () => {
         });
       });
 
-      it('when fetching FacilityDataset fails', async () => {
-        FacilityResource.fetchModel.mockResolvedValue(fakeFacility);
-        FacilityResource.fetchCollection.mockResolvedValue(fakeFacilities);
-        FacilityDatasetResource.fetchCollection.mockRejectedValue('incoprehensible error');
-        await showFacilityConfigPage(store, toRoute);
-        expect(commitStub).toHaveBeenCalledWith(
-          'facilityConfig/SET_STATE',
-          expect.objectContaining(expectedState)
-        );
+      describe(`error handling for ${test.description}`, () => {
+        const expectedState = {
+          facilityName: '',
+          settings: null,
+        };
+        it('when fetching Facility fails', () => {
+          FacilityResource.fetchModel.mockRejectedValue('incomprehensible error');
+          FacilityResource.fetchCollection.mockResolvedValue(fakeFacilities);
+          FacilityDatasetResource.fetchCollection.mockResolvedValue(fakeDatasets);
+          return showFacilityConfigPage(store, test.toRoute).then(() => {
+            expect(commitStub).toHaveBeenCalledWith(
+              'facilityConfig/SET_STATE',
+              expect.objectContaining(expectedState)
+            );
+          });
+        });
+
+        it('when fetching FacilityDataset fails', async () => {
+          FacilityResource.fetchModel.mockResolvedValue(fakeFacility);
+          FacilityResource.fetchCollection.mockResolvedValue(fakeFacilities);
+          FacilityDatasetResource.fetchCollection.mockRejectedValue('incoprehensible error');
+          await showFacilityConfigPage(store, test.toRoute);
+          expect(commitStub).toHaveBeenCalledWith(
+            'facilityConfig/SET_STATE',
+            expect.objectContaining(expectedState)
+          );
+        });
       });
     });
   });
@@ -131,51 +174,53 @@ describe('facility config page actions', () => {
       });
     });
 
-    it('when save is successful', () => {
-      const expectedRequest = {
-        learner_can_edit_name: true,
-        learner_can_edit_username: false,
-        learner_can_edit_password: true,
-        learner_can_delete_account: true,
-        learner_can_sign_up: false,
-      };
-      // IRL returns the updated Model
-      const saveStub = FacilityDatasetResource.saveModel.mockResolvedValue('ok');
-
-      return store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
-        expect(saveStub).toHaveBeenCalledWith(
-          expect.objectContaining({ id: 1000, data: expectedRequest })
-        );
-      });
-    });
-
-    it('when save fails', () => {
-      const saveStub = FacilityDatasetResource.saveModel.mockRejectedValue('heck no', true);
-      return store.dispatch('facilityConfig/saveFacilityConfig').catch(() => {
-        expect(saveStub).toHaveBeenCalled();
-        expect(store.state.facilityConfig.settings).toEqual({
+    testCases.forEach(test => {
+      it(`should successfully save for ${test.description}`, () => {
+        const expectedRequest = {
           learner_can_edit_name: true,
           learner_can_edit_username: false,
           learner_can_edit_password: true,
           learner_can_delete_account: true,
           learner_can_sign_up: false,
+        };
+        // IRL returns the updated Model
+        const saveStub = FacilityDatasetResource.saveModel.mockResolvedValue('ok');
+
+        return store.dispatch('facilityConfig/saveFacilityConfig').then(() => {
+          expect(saveStub).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 1000, data: expectedRequest })
+          );
         });
       });
-    });
 
-    it('resetFacilityConfig action dispatches resets settings and makes a save request', () => {
-      const expected = {
-        learner_can_edit_username: true,
-        learner_can_edit_name: false,
-        learner_can_edit_password: true,
-        learner_can_sign_up: false,
-        learner_can_delete_account: true,
-        learner_can_login_with_no_password: false,
-        show_download_button_in_learn: true,
-      };
-      client.mockResolvedValue({ data: expected });
-      return store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
-        expect(store.state.facilityConfig.settings).toEqual(expected);
+      it(`when save fails for ${test.description}`, () => {
+        const saveStub = FacilityDatasetResource.saveModel.mockRejectedValue('heck no', true);
+        return store.dispatch('facilityConfig/saveFacilityConfig').catch(() => {
+          expect(saveStub).toHaveBeenCalled();
+          expect(store.state.facilityConfig.settings).toEqual({
+            learner_can_edit_name: true,
+            learner_can_edit_username: false,
+            learner_can_edit_password: true,
+            learner_can_delete_account: true,
+            learner_can_sign_up: false,
+          });
+        });
+      });
+
+      it(`resetFacilityConfig action dispatches resets settings and makes a save request for ${test.description}`, () => {
+        const expected = {
+          learner_can_edit_username: true,
+          learner_can_edit_name: false,
+          learner_can_edit_password: true,
+          learner_can_sign_up: false,
+          learner_can_delete_account: true,
+          learner_can_login_with_no_password: false,
+          show_download_button_in_learn: true,
+        };
+        client.mockResolvedValue({ data: expected });
+        return store.dispatch('facilityConfig/resetFacilityConfig').then(() => {
+          expect(store.state.facilityConfig.settings).toEqual(expected);
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
During a bug bash, it was discovered that clicking any of the Facility subtopic links in the SideNav would always direct you to the Classes page regardless of the user's selection. 

This PR restores the intended behavior of SideNav links for Facility subtopics and also adds more complex functionality when a user is a multi-facility admin  - now when a user clicks on a Facility subtopic & has more than one facility, they'll be directed to the "All Facilities" page as per usual, but the links to each facility will now resolve to the subtopic initially selected (they previously always resolved to that facility's "Classes" page).

This PR also alters the string used in the backlink from a subtopic back to the "All Facilities" page, from "← All Facilities" to "← Change Learning Facility" upon team suggestion. This link has been added to each of the four main Facility subtopic pages (link was previously only on "Classes" page) & modified so that once you navigate back to "All Facilities" the routes for each facility will resolve to the same subtopic you came from (e.g. if you were on _Home Facility for A_'s "Settings" page and clicked "← Change Learning Facility" the links to each facility would resolve to their respective "Settings" pages.

This PR also adds tests for `generateNavRoutes.js` & expands tests for `facilityConfig` module functionality, making them more robust.

# `TODO`: follow-up issue addressing bug in this PR - #10649 
### _currently if you have 2+ facilities, are on the "All Facilities" page, open the SideNav, and select a different Facility subtopic, the page will not re-render and it will error in the console. The SideNav remains open & the links do not re-render to resolve to the newly-selected route. Solving this issue calls for a wider conversation about route handling with input from additional team members._
------------------------------------

### backlink text _before_:
<img width="842" alt="Screen Shot 2023-05-05 at 11 55 25 PM" src="https://user-images.githubusercontent.com/43046460/236600774-d402ae73-fb82-44cb-9b3e-b381faafcea2.png">


### backlink text _after_:
<img width="840" alt="Screen Shot 2023-05-05 at 11 46 31 PM" src="https://user-images.githubusercontent.com/43046460/236600443-6f7f2d98-c533-4b38-9e61-41b12fd903fb.png">



### single-facility use-case: links now resolving to correct subtopic (see status bar at bottom of page displaying link URLs upon hover)
![single-facility-subtopic-links_AdobeExpress](https://user-images.githubusercontent.com/43046460/236599166-b830d753-d50f-49c0-95de-9e3df2588cd0.gif)


### multi-facility use-case example user flow, showing possible navigation:
_select subtopic > "All Facilities" page > select link to specific subtopic > select different subtopic through SideNav > select "← Change learning facility" > return to "All Facilities" ~>  links resolve to subtopic user just came from_


https://user-images.githubusercontent.com/43046460/236600514-fc68f5e9-cce9-4e19-ab18-262418cce785.mov


## References
fixes #10430 


## Reviewer guidance
* Please test functionality as both a single-facility and multi-facility user. 
* Adding a facility flow: `Device > Facilities Tab > Import learning facility`
   * You can find credentials for other team members' facilities in Notion.    
* **Note:** these changes only apply to Facility plugin and have no effect on Coach plugin behavior

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
