### PR TITLE
Adds missing translatable "no results" string

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -77,7 +77,7 @@
           {{ $tr('noLessons') }}
         </p>
         <p v-else-if="!hasVisibleLessons">
-          {{ $tr('noVisibleLessons') }}
+          {{ coreString('noResultsLabel') }}
         </p>
         <KModal
           v-if="showLessonIsVisibleModal && !userHasDismissedModal"
@@ -342,7 +342,6 @@
         context:
           "Text displayed in the 'Lessons' tab of the 'Plan' section if there are no lessons created",
       },
-      noVisibleLessons: 'No visible lessons',
       dontShowAgain: {
         message: "Don't show this message again",
         context: 'Option for a check box to not be prompted again with an informational modal',


### PR DESCRIPTION

## Summary

This PR fixes the missing translatable string on the lessons page
Closes #10540

…

## References
#1054
#### Before 
![image](https://user-images.githubusercontent.com/103313919/234077009-16cdd9d9-982c-45bb-9707-7677622a5918.png)



### After 
<img width="834" alt="Screenshot 2023-04-24 at 20 53 56" src="https://user-images.githubusercontent.com/103313919/234077199-8789db0e-79be-4bd4-b377-98a4476b9f1f.png">



…

## Reviewer guidance

Navigate to Coach > Plan > Lesson > change the status of the lesson to `Visible`

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
