### PR TITLE
Fix sync progress tracking overflow

### DIFF
--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -4,7 +4,6 @@ Utility methods for syncing.
 import getpass
 import json
 import logging
-import math
 import sys
 from contextlib import contextmanager
 from functools import wraps
@@ -659,23 +658,19 @@ class MorangoSyncCommand(AsyncCommand):
 
         def started(transfer_session):
             stats(transfer_session)
-            self.start_progress(total=100)
+            self.start_progress(total=transfer_session.records_total or 100)
 
         def handler(transfer_session):
             """
             :type transfer_session: morango.models.core.TransferSession
             """
             if transfer_session.records_total > 0:
-                progress = (
-                    100
-                    * transfer_session.records_transferred
-                    / float(transfer_session.records_total)
-                )
+                progress = transfer_session.records_transferred
             else:
                 progress = 100
 
             self.update_progress(
-                increment=math.ceil(progress - self.progresstracker.progress),
+                current_progress=progress,
                 message=stats_msg(transfer_session),
                 extra_data=dict(
                     bytes_sent=transfer_session.bytes_sent,
@@ -703,7 +698,7 @@ class MorangoSyncCommand(AsyncCommand):
         """
 
         def started(transfer_session):
-            self.start_progress(total=2)
+            self.start_progress(total=1)
             dataset_cache.clear()
             if noninteractive or self.progresstracker.progressbar is None:
                 if (

--- a/kolibri/core/auth/test/test_sync_utils.py
+++ b/kolibri/core/auth/test/test_sync_utils.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+from mock import Mock
+from morango.sync.utils import SyncSignalGroup
+
+from kolibri.core.auth.management.utils import MorangoSyncCommand
+
+
+class TestProgressTracking(TestCase):
+    def test_transfer_tracker_adapter(self):
+        # Create an instance of the class you're testing
+        instance = MorangoSyncCommand()
+
+        # Mock the relevant methods
+        instance.start_progress = Mock()
+
+        instance.progresstracker = Mock()
+        instance.progresstracker.progress = 0
+
+        signal_group = SyncSignalGroup()
+        # Mock the TransferSession
+        transfer_session_mock = Mock()
+
+        transfer_session_mock.records_transferred = 0
+        transfer_session_mock.records_total = 10
+        transfer_session_mock.bytes_sent = 0
+        transfer_session_mock.bytes_received = 0
+
+        # Connect the signal group to _transfer_tracker_adapter for testing
+        instance._transfer_tracker_adapter(signal_group, "message", "sync_state", False)
+
+        # Check if start_progress hasn't been called yet
+        instance.start_progress.assert_not_called()
+
+        # Simulate the started signal
+        signal_group.started.fire(transfer_session=transfer_session_mock)
+
+        # Check that start_progress has now been called
+        instance.start_progress.assert_called()
+
+    def test_queueing_tracker_adapter(self):
+        # Create an instance of the class you're testing
+        instance = MorangoSyncCommand()
+
+        # Mock the relevant methods
+        instance.start_progress = Mock()
+
+        instance.progresstracker = Mock()
+        instance.progresstracker.progress = 0
+
+        signal_group = SyncSignalGroup()
+        # Mock the TransferSession
+        transfer_session_mock = Mock()
+
+        transfer_session_mock.records_transferred = 0
+        transfer_session_mock.records_total = 10
+        transfer_session_mock.bytes_sent = 0
+        transfer_session_mock.bytes_received = 0
+
+        # Connect the signal group to _transfer_tracker_adapter for testing
+        instance._queueing_tracker_adapter(signal_group, "message", "sync_state", False)
+
+        # Check if start_progress hasn't been called yet
+        instance.start_progress.assert_not_called()
+
+        # Simulate the started signal
+        signal_group.started.fire(transfer_session=transfer_session_mock)
+
+        # Check that start_progress has now been called
+        instance.start_progress.assert_called()

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -196,12 +196,11 @@ class Command(AsyncCommand):
     ):
         progress_extra_data = {"channel_id": channel_id}
 
-        with filetransfer, self.start_progress(
-            total=filetransfer.transfer_size
-        ) as progress_update:
+        with filetransfer:
+            self.start_progress(total=filetransfer.transfer_size)
 
             def progress_callback(bytes):
-                progress_update(bytes, progress_extra_data)
+                self.update_progress(bytes, extra_data=progress_extra_data)
 
             filetransfer.run(progress_callback)
             # if upgrading, import the channel


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
~This made sense when I first made the changes. Then looking back through, it doesn't seem that it actually does anything differently than before. It does seem to work though~:

![Screenshot from 2023-04-25 13-02-39](https://user-images.githubusercontent.com/819838/234399208-bf49bdb4-c493-484b-ad7c-9626e4dad523.png)

@rtibbles has now updated this. This seems to make more sense, as it seemed to be an issue with `start_progress` being called outside the context of the signal handlers, so the progress total was being rapidly set to 2, then 100, then 2 - and then never being reset.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10077

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
