### PR TITLE
Initial implementation of download chunking to allow more robust, interruptable file downloading and streaming

### DIFF
--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -55,6 +55,7 @@ from kolibri.core.tasks.validation import JobValidator
 from kolibri.core.utils.urls import reverse_remote
 from kolibri.utils.conf import KOLIBRI_HOME
 from kolibri.utils.conf import OPTIONS
+from kolibri.utils.filesystem import mkdirp
 from kolibri.utils.translation import ugettext as _
 
 
@@ -144,7 +145,7 @@ class ImportUsersFromCSVValidator(JobValidator):
         else:
             raise serializers.ValidationError("Facility must be specified")
         temp_dir = os.path.join(KOLIBRI_HOME, "temp")
-        os.makedirs(temp_dir, exist_ok=True)
+        mkdirp(temp_dir, exist_ok=True)
         if "csvfile" in data:
             tmpfile = data["csvfile"].temporary_file_path()
             filename = ntpath.basename(tmpfile)

--- a/kolibri/core/content/management/commands/exportchannel.py
+++ b/kolibri/core/content/management/commands/exportchannel.py
@@ -30,7 +30,7 @@ class Command(AsyncCommand):
 
         with transfer.FileCopy(src, dest, cancel_check=self.is_cancelled) as copy:
 
-            with self.start_progress(total=copy.total_size) as progress_update:
+            with self.start_progress(total=copy.transfer_size) as progress_update:
                 try:
                     for block in copy:
                         progress_update(len(block))

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -136,7 +136,7 @@ class Command(AsyncCommand):
             return
         copy = transfer.FileCopy(srcpath, dest, cancel_check=self.is_cancelled)
         with copy, self.start_progress(
-            total=copy.total_size
+            total=copy.transfer_size
         ) as file_cp_progress_update:
             try:
                 for chunk in copy:

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -196,7 +196,7 @@ class Command(AsyncCommand):
         progress_extra_data = {"channel_id": channel_id}
 
         with filetransfer, self.start_progress(
-            total=filetransfer.total_size
+            total=filetransfer.transfer_size
         ) as progress_update:
             for chunk in filetransfer:
                 progress_update(len(chunk), progress_extra_data)

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -113,7 +113,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
             # the difference so that the overall progress is never incorrect.
             # This could happen, for example for a local transfer if a file
             # has been replaced or corrupted (which we catch below)
-            data_transferred += f["file_size"] - filetransfer.total_size
+            data_transferred += f["file_size"] - filetransfer.transfer_size
 
         return None, data_transferred
 

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -196,12 +196,13 @@ class ChunkedFile(BufferedIOBase):
                     amount_to_write -= diff
                     remaining -= diff
                 f.seek(chunk_position)
-                bytes_written = f.write(
-                    data[
-                        len(data) - remaining : len(data) - remaining + amount_to_write
-                    ]
-                )
-
+                to_write = data[
+                    len(data) - remaining : len(data) - remaining + amount_to_write
+                ]
+                # For some reason in Python 2.7 this is failing to return the number of bytes written.
+                # as we know exactly how much we are writing, we can just use that value.
+                f.write(to_write)
+                bytes_written = len(to_write)
                 self.position += bytes_written
                 remaining -= bytes_written
 

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -18,6 +18,8 @@ from requests.exceptions import HTTPError
 from requests.exceptions import Timeout
 from six import with_metaclass
 
+from kolibri.utils.filesystem import mkdirp
+
 
 try:
     import OpenSSL
@@ -98,7 +100,7 @@ class ChunkedFile(BufferedIOBase):
     def __init__(self, filepath):
         self.filepath = filepath
         self.chunk_dir = filepath + ".chunks"
-        os.makedirs(self.chunk_dir, exist_ok=True)
+        mkdirp(self.chunk_dir, exist_ok=True)
         self.chunk_size = BLOCK_SIZE
         self.position = 0
         self._file_size = None
@@ -353,7 +355,7 @@ class Transfer(with_metaclass(ABCMeta)):
             )
 
         # ensure the directories in the destination path exist
-        os.makedirs(os.path.dirname(self.dest), exist_ok=True)
+        mkdirp(os.path.dirname(self.dest), exist_ok=True)
 
         self.chunked_file_obj = ChunkedFile(self.dest)
 

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -251,6 +251,7 @@ class Transfer(object):
         remove_existing_temp_file=True,
         timeout=DEFAULT_TIMEOUT,
         cancel_check=None,
+        retry_wait=30,
     ):
         self.source = source
         self.dest = dest
@@ -258,6 +259,7 @@ class Transfer(object):
         self.checksum = checksum
         self.block_size = BLOCK_SIZE
         self.timeout = timeout
+        self.retry_wait = retry_wait
         self.started = False
         self.completed = False
         self.finalized = False
@@ -491,8 +493,12 @@ class FileDownload(Transfer):
         super(FileDownload, self).close()
 
     def resume(self):
-        logger.info("Waiting 30s before retrying import: {}".format(self.source))
-        for i in range(30):
+        logger.info(
+            "Waiting {}s before retrying import: {}".format(
+                self.retry_wait, self.source
+            )
+        )
+        for i in range(self.retry_wait):
             if self.cancel_check():
                 logger.info("Canceling import: {}".format(self.source))
                 return

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -155,7 +155,6 @@ class Transfer(object):
             self._content_iterator = self._get_content_iterator()
 
     def __next__(self):  # proxy this method to fully support Python 3
-        self._set_iterator()
         return self.next()
 
     def __iter__(self):
@@ -168,6 +167,7 @@ class Transfer(object):
         )
 
     def next(self):
+        self._set_iterator()
         try:
             chunk = next(self._content_iterator)
         except StopIteration:

--- a/kolibri/utils/filesystem.py
+++ b/kolibri/utils/filesystem.py
@@ -40,3 +40,15 @@ def resolve_path(path):
         return os.path.realpath(os.path.expanduser(path))
     except (IOError, OSError):
         return None
+
+
+def mkdirp(path, exist_ok=False):
+    """
+    Make a directory and any missing parent directories.
+    Do this to add the exist_ok parameter to Python 2's os.makedirs.
+    """
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != 17 or not exist_ok:
+            raise e

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -183,6 +183,10 @@ class StreamingStaticFile(EndRangeStaticFile):
         return Response(HTTPStatus.OK, self.headers.items(), file_handle)
 
 
+def add_headers_function(headers, path, url):
+    headers["Accept-Ranges"] = "bytes"
+
+
 class DynamicWhiteNoise(WhiteNoise):
     index_file = "index.html"
 
@@ -203,6 +207,7 @@ class DynamicWhiteNoise(WhiteNoise):
             # these files will be cached indefinitely
             "immutable_file_test": r"((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)|[a-f0-9]{32})",
             "autorefresh": os.environ.get("KOLIBRI_DEVELOPER_MODE", False),
+            "add_headers_function": add_headers_function,
         }
         kwargs.update(whitenoise_settings)
         super(DynamicWhiteNoise, self).__init__(application, **kwargs)

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -130,6 +130,8 @@ class EndRangeStaticFile(StaticFile):
         if start >= end:
             return self.get_range_not_satisfiable_response(file_handle, size)
         if file_handle is not None:
+            if isinstance(file_handle, RemoteFile):
+                file_handle.set_range(start, end)
             file_handle = SlicedFile(file_handle, start, end)
         headers.append(("Content-Range", "bytes {}-{}/{}".format(start, end, size)))
         headers.append(("Content-Length", str(end - start + 1)))
@@ -137,34 +139,41 @@ class EndRangeStaticFile(StaticFile):
 
 
 class StreamingStaticFile(EndRangeStaticFile):
-    def __init__(self, path, headers, remote_url):
+    def __init__(self, path, headers, remote_url, encodings=None, stat_cache=None):
         self.path = path
         self.remote_url = remote_url
-        self.headers = headers
+        super().__init__(path, headers, encodings, stat_cache)
 
-    def complete_transfer(self):
-        super(StreamingStaticFile, self).__init__(self.path, self.headers.items())
+    @staticmethod
+    def get_file_stats(path, encodings, stat_cache):
+        # Override this method to avoid statting the file
+        return {}
+
+    def get_headers(self, headers_list, files):
+        headers = Headers(headers_list)
+        self.headers = headers
+        # Override this method to avoid statting the file
+        return headers
+
+    @staticmethod
+    def get_alternatives(base_headers, files):
+        # Override this method to avoid statting the file
+        return []
 
     def get_response(self, method, request_headers):
         """
         Returns a streaming response for a request.
         Vendored and modified from Whitenoise.
         """
-        if os.path.exists(self.path):
-            return super(StreamingStaticFile, self).get_response(
-                method, request_headers
-            )
         if method not in ("GET", "HEAD"):
             return NOT_ALLOWED_RESPONSE
         if method != "HEAD":
             try:
                 file_handle = RemoteFile(
-                    self.path, self.remote_url, callback=self.complete_transfer
+                    self.path,
+                    self.remote_url,
                 )
-                if file_handle.transfer.total_size:
-                    self.headers["Content-Length"] = str(
-                        file_handle.transfer.total_size
-                    )
+                self.headers["Content-Length"] = str(file_handle.get_file_size())
             except Exception:
                 return NOT_FOUND.get_response(method, request_headers)
         else:
@@ -323,7 +332,7 @@ class DynamicWhiteNoise(WhiteNoise):
     def get_streaming_static_file(self, url, remote_baseurl):
         """
         Vendor this function from source to substitute in our
-        own StaticFile class that can properly handle ranges.
+        own StaticFile class that can handle remote files.
         """
         headers = Headers([])
         prefix, local_dir = next(
@@ -341,6 +350,6 @@ class DynamicWhiteNoise(WhiteNoise):
         headers["Content-Encoding"] = ""
         return StreamingStaticFile(
             os.path.join(local_dir, path),
-            headers,
+            headers.items(),
             urljoin(remote_baseurl, url.lstrip("/")),
         )

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -38,7 +38,7 @@ class TestChunkedFile(unittest.TestCase):
         self.chunked_file.file_size = self.file_size
 
     def tearDown(self):
-        shutil.rmtree(self.chunked_file.chunk_dir)
+        shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
 
     def test_read(self):
         # Read from the beginning
@@ -144,6 +144,54 @@ class TestChunkedFile(unittest.TestCase):
         ]
         self.assertEqual(missing_ranges, expected_ranges)
 
+    def test_get_missing_chunk_ranges_slice(self):
+        # Remove some chunks
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_3"))
+
+        start = self.chunk_size
+        end = self.chunk_size * 3 - 1
+        missing_ranges = [
+            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        expected_ranges = [
+            (self.chunk_size * 1, self.chunk_size * 2 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+    def test_get_missing_chunk_ranges_slice_no_download(self):
+        # Remove some chunks
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+        start = self.chunk_size
+        end = self.chunk_size * 2 - 1
+        missing_ranges = [
+            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        expected_ranges = [
+            (self.chunk_size, self.chunk_size * 2 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges(self):
+        # Remove some chunks
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+        start = self.chunk_size // 3
+        end = self.chunk_size * 2 + self.chunk_size // 3
+        missing_ranges = [
+            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        expected_ranges = [
+            (0, self.chunk_size - 1),
+            (self.chunk_size, self.chunk_size * 2 - 1),
+            (self.chunk_size * 2, self.chunk_size * 3 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
     def test_get_missing_chunk_ranges_whole_file(self):
         # Remove some chunks
         os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
@@ -170,7 +218,8 @@ class TestChunkedFile(unittest.TestCase):
 
         missing_range_1 = next(generator)
 
-        self.assertEqual(b"".join(missing_range_1[2]), self.data[0 : self.chunk_size])
+        # Make sure we don't read the first chunk as its before the start of the range
+        self.assertEqual(b"".join(missing_range_1[2]), b"")
 
         # Seek past the first missing chunk to make sure we don't try to read it.
         # In normal operation, the missing chunk would be filled in with a write before
@@ -189,6 +238,91 @@ class TestChunkedFile(unittest.TestCase):
             (self.chunk_size * 3, self.chunk_size * 4 - 1),
         ]
         self.assertEqual([missing_range_1[:2], missing_range_2[:2]], expected_ranges)
+
+    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading(
+        self,
+    ):
+        # Remove some chunks
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+        start = self.chunk_size + self.chunk_size // 3
+        end = self.chunk_size * 2 + self.chunk_size // 3
+        missing = [
+            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        missing_ranges = [mr[:2] for mr in missing]
+
+        expected_ranges = [
+            (self.chunk_size, self.chunk_size * 2 - 1),
+            (self.chunk_size * 2, self.chunk_size * 3 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+        output = b""
+
+        for mr in missing:
+            output += b"".join(mr[2])
+            self.chunked_file.seek(mr[1] + 1)
+
+        self.assertEqual(output, b"")
+
+    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading_include_first_chunk(
+        self,
+    ):
+        # Remove some chunks
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+        start = self.chunk_size // 3
+        end = self.chunk_size * 2 + self.chunk_size // 3
+        missing = [
+            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        missing_ranges = [mr[:2] for mr in missing]
+
+        expected_ranges = [
+            (0, self.chunk_size - 1),
+            (self.chunk_size, self.chunk_size * 2 - 1),
+            (self.chunk_size * 2, self.chunk_size * 3 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+        output = b""
+
+        for mr in missing:
+            output += b"".join(mr[2])
+            self.chunked_file.seek(mr[1] + 1)
+
+        self.assertEqual(output, b"")
+
+    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading_include_last_chunk(
+        self,
+    ):
+        # Remove some chunks
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+        start = self.chunk_size + self.chunk_size // 3
+        end = self.file_size - 7
+        missing = [
+            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+        ]
+
+        missing_ranges = [mr[:2] for mr in missing]
+
+        expected_ranges = [
+            (self.chunk_size * i, min(self.file_size, self.chunk_size * (i + 1)) - 1)
+            for i in range(1, self.chunks_count)
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+        output = b""
+
+        for mr in missing:
+            output += b"".join(mr[2])
+            self.chunked_file.seek(mr[1] + 1)
+
+        self.assertEqual(output, b"")
 
     def test_finalize_file(self):
         self.chunked_file.finalize_file()

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -1,0 +1,194 @@
+import hashlib
+import math
+import os
+import shutil
+import unittest
+
+from kolibri.utils.file_transfer import BLOCK_SIZE
+from kolibri.utils.file_transfer import ChunkedFile
+
+
+class TestChunkedFile(unittest.TestCase):
+    def setUp(self):
+        self.file_path = "test_file"
+
+        self.chunk_size = BLOCK_SIZE
+        self.file_size = 1024 * 1024  # 1 MB
+
+        self.chunked_file = ChunkedFile(self.file_path)
+
+        # Create dummy chunks
+        self.chunks_count = int(
+            math.ceil(float(self.file_size) / float(self.chunk_size))
+        )
+        self.data = b""
+        for i in range(self.chunks_count):
+            with open(
+                os.path.join(self.chunked_file.chunk_dir, ".chunk_{}".format(i)), "wb"
+            ) as f:
+                to_write = os.urandom(self.chunk_size)
+                f.write(to_write)
+                self.data += to_write
+
+        self.chunked_file.file_size = self.file_size
+
+    def tearDown(self):
+        shutil.rmtree(self.chunked_file.chunk_dir)
+
+    def test_read(self):
+        # Read from the beginning
+        data = self.chunked_file.read(512)
+        self.assertEqual(len(data), 512)
+
+        # Read from the middle
+        self.chunked_file.seek(512 * 1024)
+        data = self.chunked_file.read(512)
+        self.assertEqual(len(data), 512)
+
+    def test_write(self):
+        new_data = os.urandom(BLOCK_SIZE)
+        os.remove(
+            os.path.join(
+                self.chunked_file.chunk_dir, ".chunk_{}".format(self.chunks_count - 1)
+            )
+        )
+        self.chunked_file.seek(self.file_size - BLOCK_SIZE)
+        self.chunked_file.write(new_data)
+
+        self.chunked_file.seek(self.file_size - BLOCK_SIZE)
+        data = self.chunked_file.read(BLOCK_SIZE)
+        self.assertEqual(data, new_data)
+
+    def test_write_whole_file(self):
+        new_data = os.urandom(self.file_size)
+        for i in range(self.chunks_count):
+            os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_{}".format(i)))
+        self.chunked_file.seek(0)
+        self.chunked_file.write(new_data)
+
+        self.chunked_file.seek(0)
+        data = self.chunked_file.read()
+        self.assertEqual(data, new_data)
+
+    def test_write_fails_longer_than_file_size(self):
+        new_data = os.urandom(256)
+        self.chunked_file.seek(self.file_size)
+        with self.assertRaises(EOFError):
+            self.chunked_file.write(new_data)
+
+    def test_write_ignores_overwrite(self):
+        data = self.chunked_file.read(256)
+        new_data = os.urandom(256)
+        self.chunked_file.seek(0)
+        self.chunked_file.write(new_data)
+        self.chunked_file.seek(0)
+        self.assertEqual(self.chunked_file.read(256), data)
+
+    def test_write_whole_file_ignores_overwrite_writes_remainder(self):
+        new_data = os.urandom(self.file_size)
+        os.remove(
+            os.path.join(
+                self.chunked_file.chunk_dir, ".chunk_{}".format(self.chunks_count - 1)
+            )
+        )
+        self.chunked_file.seek(0)
+        self.chunked_file.write(new_data)
+
+        self.chunked_file.seek(BLOCK_SIZE * (self.chunks_count - 1))
+        data = self.chunked_file.read()
+        self.assertEqual(data, new_data[-BLOCK_SIZE:])
+
+    def test_seek_set(self):
+        # SEEK_SET
+        self.chunked_file.seek(512 * 1024)
+        self.assertEqual(self.chunked_file.position, 512 * 1024)
+
+    def test_seek_cur(self):
+        # SEEK_CUR
+        self.chunked_file.seek(512 * 1024)
+        self.chunked_file.seek(256, os.SEEK_CUR)
+        self.assertEqual(self.chunked_file.position, 512 * 1024 + 256)
+
+    def test_seek_end(self):
+        # SEEK_END
+        self.chunked_file.seek(-256, os.SEEK_END)
+        self.assertEqual(self.chunked_file.position, self.file_size - 256)
+
+    def test_get_missing_chunk_ranges(self):
+        # Remove some chunks
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_3"))
+
+        start = self.chunk_size
+        end = self.chunk_size * 4 - 1
+        missing_ranges = list(
+            self.chunked_file.next_missing_chunk_for_range_generator(start, end)
+        )
+
+        expected_ranges = [
+            (self.chunk_size * 1, self.chunk_size * 2 - 1),
+            (self.chunk_size * 3, self.chunk_size * 4 - 1),
+        ]
+        self.assertEqual(missing_ranges, expected_ranges)
+
+    def test_finalize_file(self):
+        self.chunked_file.finalize_file()
+
+        with open(self.file_path, "rb") as f:
+            data = f.read()
+
+        self.assertEqual(data, self.data)
+        os.remove(self.file_path)
+
+    def test_finalize_file_chunk_missing(self):
+        # Remove a chunk
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
+        with self.assertRaises(ValueError):
+            self.chunked_file.finalize_file()
+
+    def test_is_complete_chunk_missing(self):
+        # Remove a chunk
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
+        self.assertFalse(self.chunked_file.is_complete())
+
+    def test_is_complete_chunk_size_incorrect(self):
+        # Create a chunk with incorrect size
+        with open(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"), "wb") as f:
+            f.write(os.urandom(self.chunk_size // 2))
+        self.assertFalse(self.chunked_file.is_complete())
+
+    def test_is_complete_chunk_size_correct(self):
+        self.assertTrue(self.chunked_file.is_complete())
+
+    def test_md5_checksum(self):
+        expected_md5 = hashlib.md5()
+        for i in range(self.chunks_count):
+            with open(
+                os.path.join(self.chunked_file.chunk_dir, ".chunk_{}".format(i)), "rb"
+            ) as f:
+                while True:
+                    data = f.read(8192)
+                    if not data:
+                        break
+                    expected_md5.update(data)
+
+        self.assertEqual(expected_md5.hexdigest(), self.chunked_file.md5_checksum())
+
+    def test_md5_checksum_chunk_missing(self):
+        # Remove a chunk
+        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
+        with self.assertRaises(ValueError):
+            self.chunked_file.md5_checksum()
+
+    def test_finalize_file_md5(self):
+        self.chunked_file.finalize_file()
+
+        with open(self.file_path, "rb") as f:
+            data = f.read()
+
+        self.assertEqual(data, self.data)
+
+        combined_md5 = hashlib.md5(data).hexdigest()
+        self.assertEqual(combined_md5, self.chunked_file.md5_checksum())
+
+        os.remove(self.file_path)

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -23,6 +23,7 @@ from kolibri.utils.file_transfer import retry_import
 from kolibri.utils.file_transfer import RETRY_STATUS_CODE
 from kolibri.utils.file_transfer import SSLERROR
 from kolibri.utils.file_transfer import TransferFailed
+from kolibri.utils.filesystem import mkdirp
 
 
 class BaseTestTransfer(unittest.TestCase):
@@ -33,7 +34,7 @@ class BaseTestTransfer(unittest.TestCase):
         # Create dummy chunks
         self.chunks_count = int(math.ceil(float(self.file_size) / float(BLOCK_SIZE)))
 
-        os.makedirs(self.dest + ".chunks", exist_ok=True)
+        mkdirp(self.dest + ".chunks", exist_ok=True)
 
         hash = hashlib.md5()
 

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -1,0 +1,193 @@
+import hashlib
+import os
+import tempfile
+import unittest
+
+from mock import call
+from mock import MagicMock
+from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ConnectionError
+from requests.exceptions import HTTPError
+from requests.exceptions import RequestException
+from requests.exceptions import Timeout
+
+from kolibri.utils.file_transfer import FileCopy
+from kolibri.utils.file_transfer import FileDownload
+from kolibri.utils.file_transfer import retry_import
+from kolibri.utils.file_transfer import RETRY_STATUS_CODE
+from kolibri.utils.file_transfer import SSLERROR
+from kolibri.utils.file_transfer import TransferFailed
+
+
+class TestTransfer(unittest.TestCase):
+    def setUp(self):
+        self.source = "http://example.com/testfile"
+        self.destdir = tempfile.mkdtemp()
+        self.dest = self.destdir + "/test_file"
+        self.content = b"test"
+        hash = hashlib.md5()
+        hash.update(self.content)
+        self.checksum = hash.hexdigest()
+
+    def tearDown(self):
+        if os.path.exists(self.dest):
+            os.remove(self.dest)
+
+    def test_download_iterator(self):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = iter([self.content])
+        mock_response.headers = {"content-length": str(len(self.content))}
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        # Test FileDownload iterator
+        with FileDownload(
+            self.source, self.dest, self.checksum, session=mock_session
+        ) as fd:
+            for chunk in fd:
+                self.assertEqual(chunk, self.content)
+
+    def test_copy_iterator(self):
+        self.copy_source = tempfile.NamedTemporaryFile(delete=False).name
+        # Test FileCopy iterator
+        with open(self.copy_source, "wb") as testfile:
+            testfile.write(self.content)
+
+        with FileCopy(self.copy_source, self.dest + "_copy", self.checksum) as fc:
+            for chunk in fc:
+                self.assertEqual(chunk, self.content)
+
+        if os.path.exists(self.copy_source + "_copy"):
+            os.remove(self.copy_source + "_copy")
+
+    def test_download_checksum_validation(self):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = iter([self.content])
+        mock_response.headers = {"content-length": str(len(self.content))}
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+
+        # Test FileDownload checksum validation
+        with FileDownload(
+            self.source, self.dest, self.checksum, session=mock_session
+        ) as fd:
+            for chunk in fd:
+                pass
+        self.assertTrue(os.path.isfile(self.dest))
+
+    def test_copy_checksum_validation(self):
+        self.copy_source = tempfile.NamedTemporaryFile(delete=False).name
+        # Test FileCopy checksum validation
+        with open(self.copy_source, "wb") as testfile:
+            testfile.write(self.content)
+
+        dest_copy = self.copy_source + "_copy"
+        with FileCopy(self.copy_source, dest_copy, self.checksum) as fc:
+            for chunk in fc:
+                pass
+        self.assertTrue(os.path.isfile(dest_copy))
+
+        os.remove(dest_copy)
+
+    def test_file_download_retry_resume(self):
+        mock_response_1 = MagicMock()
+        mock_response_1.raise_for_status.side_effect = ConnectionError
+        mock_response_1.request.headers = {}
+        mock_response_2 = MagicMock()
+        mock_response_2.iter_content.return_value = iter([self.content])
+        mock_response_2.headers = {"content-length": str(len(self.content))}
+        mock_session = MagicMock()
+        mock_session.get.side_effect = [
+            mock_response_1,  # First call to requests.get
+            mock_response_2,  # Second call to requests.get
+        ]
+
+        # Test retry and resume functionality in the FileDownload class
+        with FileDownload(
+            self.source, self.dest, self.checksum, session=mock_session, retry_wait=0
+        ) as fd:
+            for chunk in fd:
+                pass
+
+        self.assertTrue(os.path.isfile(self.dest))
+        self.assertEqual(mock_session.get.call_count, 2)
+        mock_session.get.assert_has_calls(
+            [
+                call(self.source, stream=True, timeout=60),
+                call(
+                    self.source, headers={"Range": "bytes=0-"}, stream=True, timeout=60
+                ),
+            ]
+        )
+
+        with open(self.dest, "rb") as f:
+            downloaded_content = f.read()
+        self.assertEqual(downloaded_content, self.content)
+
+    def test_file_download_request_exception(self):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = iter([self.content])
+        mock_response.headers = {"content-length": str(len(self.content))}
+        mock_session = MagicMock()
+        mock_session.get.side_effect = RequestException
+
+        # Test various exceptions during file downloads
+        with self.assertRaises(RequestException):
+            with FileDownload(
+                self.source, self.dest, self.checksum, session=mock_session
+            ) as fd:
+                for chunk in fd:
+                    pass
+        self.assertFalse(os.path.isfile(self.dest))
+
+    def test_file_download_checksum_exception(self):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = iter([self.content])
+        mock_response.headers = {"content-length": str(len(self.content))}
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_response
+        with self.assertRaises(TransferFailed):
+            with FileDownload(
+                self.source, self.dest, "invalid_checksum", session=mock_session
+            ) as fd:
+                for chunk in fd:
+                    pass
+        self.assertFalse(os.path.isfile(self.dest))
+
+
+class TestRetryImport(unittest.TestCase):
+    def _retry_import_helper(self, exception_class, *args, **kwargs):
+        e = exception_class(*args, **kwargs)
+        self.assertTrue(
+            retry_import(e), "Expected retry for {}".format(exception_class.__name__)
+        )
+
+    def test_retry_import_connection_error(self):
+        self._retry_import_helper(ConnectionError)
+
+    def test_retry_import_timeout(self):
+        self._retry_import_helper(Timeout)
+
+    def test_retry_import_chunked_encoding_error(self):
+        self._retry_import_helper(ChunkedEncodingError)
+
+    def test_retry_import_http_error(self):
+        for status_code in RETRY_STATUS_CODE:
+            self._retry_import_helper(
+                HTTPError, response=MagicMock(status_code=status_code)
+            )
+
+    def test_retry_import_ssl_error(self):
+        self._retry_import_helper(SSLERROR, "decryption failed or bad record mac")
+
+    def test_retry_import_non_retry_exceptions(self):
+        non_retry_exceptions = [
+            (RequestException, {}),
+            (HTTPError, {"response": MagicMock(status_code=400)}),
+        ]
+        for exception_class, kwargs in non_retry_exceptions:
+            e = exception_class(**kwargs)
+            self.assertFalse(
+                retry_import(e),
+                "Expected no retry for {}".format(exception_class.__name__),
+            )


### PR DESCRIPTION
## Summary
* Fixes a bug in Python 2.7 by moving a method invocation into the `next` method which is called in Python 2 and 3, rather than the `__next__` method which is only called in Python 3
* Creates a ChunkedFile class to allow reading and writing to a temporary directory of files with fixed chunk sizes, that can eventually be concatenated to create the entire file
* The ChunkedFile class also exposes a file like interface to allow reading and writing from the ChunkedFile
* Adds test coverage for this file class
* Adds tests for the file transfer utilities which were currently only tangentially tested in content import/export
* Updates the file transfer utilities to use the ChunkedFile object as the backend, and distinguishes between the 'transfer_size' and 'total_size' on disk of the file being downloaded
* Updates the RemoteFile class that is used as a wrapper for FileDownloads when streaming files from remote
* Adds tests for the RemoteFile class
* Adds `Accept-Ranges` headers to our whitenoise implementation, as it was previously missing, so older versions of Kolibri were not properly reporting that they accepted range requests
* Because of the above, updates the file transfer logic to do a try/except for range requests, relying on the first request to see if it fulfills the range request, and otherwise carrying on
* Updates our whitenoise modifications to handle the fact that with the ChunkedFile downloads we are now streaming data in the response before the file is available locally, so cuts out any part of whitenoise that would be getting file stats from disk (for streamed files only)
* Does an initial lock implementation for downloads to prevent thundering herds.

## References
Fixes elements of https://github.com/learningequality/kolibri/issues/10393
Also lays some groundwork that will be useful for [#9389](https://github.com/learningequality/kolibri/issues/9389)

## Reviewer guidance
I tested this by running my devserver locally with this code `yarn run python-devserver` and then running siege against it:
```
siege http://127.0.0.1:8000/content/storage/3/7/37a2786aa33fb4e6943da9879ed08ba6.zip?baseurl=http://172.27.234.9:8080/
```

This accesses a file on the Mr Tibbles' Classroom Server via the backend.

Unfortunately, the initial thundering herd handling prevent parallelized downloads of the files, so this would have to be handled as a later optimization.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
