### PR TITLE
Adds safety check to superuser promotion

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -139,7 +139,7 @@ def mergeuser(command, **kwargs):
         begin_request_soud_sync(kwargs["baseurl"], remote_user.id)
 
     new_superuser_id = kwargs.get("new_superuser_id")
-    if new_superuser_id:
+    if new_superuser_id and local_user.is_superuser:
         new_superuser = FacilityUser.objects.get(id=new_superuser_id)
         # make the user a new super user for this device:
         new_superuser.facility.add_role(new_superuser, role_kinds.ADMIN)
@@ -159,7 +159,7 @@ def mergeuser(command, **kwargs):
 
     # check if current user should be set as superuser:
     set_as_super_user = kwargs.get("set_as_super_user")
-    if set_as_super_user:
+    if set_as_super_user and local_user.is_superuser:
         DevicePermissions.objects.create(
             user=remote_user, is_superuser=True, can_manage_content=True
         )


### PR DESCRIPTION
## Summary
* Prevents a user being promoted to a superuser during a user merge task if the original user was not already a superuser
* Prevents another user being promoted to a superuser during a user merge task if the original user was not already a superuser

## References
Follow up from #10461

## Reviewer guidance
I don't think this should affect anything - but it seemed safer to check that the local_user being migrated was a superuser on the backend rather than just relying on task arguments, otherwise someone could just POST to the API with the right arguments to make themselves a superuser.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
