### PR TITLE
Uses before psuedo element so that navbar elements don't shift.

### DIFF
--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -152,13 +152,14 @@
   }
 
   div.dimmable.tab-title::before {
-    content: attr(title);
     display: block;
     height: 0;
-    visibility: hidden;
     overflow: hidden;
-    user-select: none;
-    pointer-events: none;
     font-weight: bold;
+    pointer-events: none;
+    visibility: hidden;
+    content: attr(title);
+    user-select: none;
   }
+
 </style>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -12,7 +12,7 @@
         <slot></slot>
       </div>
 
-      <div class="dimmable tab-title" tabindex="-1">
+      <div class="dimmable tab-title" tabindex="-1" :title="title">
         {{ title }}
       </div>
     </router-link>
@@ -151,4 +151,14 @@
     text-overflow: ellipsis;
   }
 
+  div.dimmable.tab-title::after {
+    content: attr(title);
+    display: block;
+    height: 0;
+    visibility: hidden;
+    overflow: hidden;
+    user-select: none;
+    pointer-events: none;
+    font-weight: bold;
+  }
 </style>

--- a/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
+++ b/kolibri/core/assets/src/views/Navbar/NavbarLink.vue
@@ -151,7 +151,7 @@
     text-overflow: ellipsis;
   }
 
-  div.dimmable.tab-title::after {
+  div.dimmable.tab-title::before {
     content: attr(title);
     display: block;
     height: 0;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

It uses invisible before pseudo element so that when nav element is clicked, the other elements in navbar don't shift. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10526 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please check if it works on all sizes of screen and elements don't shift when clicking various elements of navbar.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
