### PR TITLE
Update provisioning logic to work with app flows. Simplify redirect.

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -44,7 +44,6 @@ from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.channels import get_mounted_drives_with_channel_info
 from kolibri.core.device.permissions import IsSuperuser
-from kolibri.core.device.utils import APP_KEY_COOKIE_NAME
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.models import DynamicNetworkLocation
 from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
@@ -93,9 +92,6 @@ class DeviceProvisionView(viewsets.GenericViewSet):
             login(request, data["superuser"])
         output_serializer = self.get_serializer(data)
         response_data = output_serializer.data
-        if APP_KEY_COOKIE_NAME in request.COOKIES:
-            app_key = request.COOKIES[APP_KEY_COOKIE_NAME]
-            response_data["app_key"] = app_key
 
         # Restart zeroconf before moving along when we're a SoUD
         if response_data["is_soud"]:

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -25,6 +25,7 @@ LANDING_PAGE_SIGN_IN = "sign-in"
 LANDING_PAGE_LEARN = "learn"
 
 APP_KEY_COOKIE_NAME = "app_key_cookie"
+APP_AUTH_TOKEN_COOKIE_NAME = "app_auth_token_cookie"
 
 
 class DeviceNotProvisioned(Exception):
@@ -128,10 +129,13 @@ def valid_app_key_on_request(request):
     )
 
 
-def set_app_key_on_response(response):
+def set_app_key_on_response(response, auth_token):
     from .models import DeviceAppKey
 
     response.set_cookie(APP_KEY_COOKIE_NAME, DeviceAppKey.get_app_key())
+
+    if auth_token:
+        response.set_cookie(APP_AUTH_TOKEN_COOKIE_NAME, auth_token, httponly=True)
 
 
 def _check_setting(name, available, msg):

--- a/kolibri/plugins/app/api.py
+++ b/kolibri/plugins/app/api.py
@@ -78,5 +78,5 @@ class InitializeAppView(APIView):
             ):
                 redirect_url = "/"
         response = HttpResponseRedirect(redirect_url)
-        set_app_key_on_response(response)
+        set_app_key_on_response(response, auth_token)
         return response

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -17,11 +17,11 @@
 
 <script>
 
-  import { v4 } from 'uuid';
   import omitBy from 'lodash/omitBy';
   import get from 'lodash/get';
   import { currentLanguage } from 'kolibri.utils.i18n';
   import { checkCapability } from 'kolibri.utils.appCapabilities';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import KolibriLoadingSnippet from 'kolibri.coreVue.components.KolibriLoadingSnippet';
   import urls from 'kolibri.urls';
   import client from 'kolibri.client';
@@ -127,7 +127,6 @@
           is_provisioned: true,
           os_user: checkCapability('get_os_user'),
           is_soud: this.wizardService.state.context.fullOrLOD === DeviceTypePresets.LOD,
-          auth_token: v4(),
         };
 
         // Remove anything that is `null` value
@@ -153,18 +152,12 @@
           method: 'POST',
           data: this.deviceProvisioningData,
         })
-          .then(response => {
-            const appKey = response.data.app_key;
-
-            const path = appKey
-              ? urls['kolibri:kolibri.plugins.app:initialize'](appKey) + '?auth_token=' + v4()
-              : urls['kolibri:kolibri.plugins.user_auth:user_auth']();
-
+          .then(() => {
             const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
             window.sessionStorage.setItem(welcomeDimissalKey, false);
 
             Lockr.set('savedState', null); // Clear out saved state machine
-            window.location.href = path;
+            redirectBrowser();
           })
           .catch(e => console.error(e));
       },


### PR DESCRIPTION
## Summary
* Removes random generation of auth_token/removes references to it on the client side completely
* Simplifies redirect to use default redirect mechanisms rather than hardcoding plugin references

## References
Needed to support https://github.com/learningequality/kolibri-installer-android/issues/133

## Reviewer guidance
Verify that adding an auth_token to the initialize URL when first loaded properly creates a user during provisioning

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
