### PR TITLE
Fixes modal that adds content storage locations not resolving special…

### DIFF
--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -63,6 +63,7 @@ from kolibri.utils.android import on_android
 from kolibri.utils.conf import OPTIONS
 from kolibri.utils.filesystem import check_is_directory
 from kolibri.utils.filesystem import get_path_permission
+from kolibri.utils.filesystem import resolve_path
 from kolibri.utils.server import get_status_from_pid_file
 from kolibri.utils.server import get_urls
 from kolibri.utils.server import installation_type
@@ -434,5 +435,6 @@ class PathPermissionView(views.APIView):
             {
                 "writable": get_path_permission(pathname),
                 "directory": check_is_directory(pathname),
+                "path": resolve_path(pathname),
             }
         )

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/AddStorageLocationModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/AddStorageLocationModal.vue
@@ -67,7 +67,7 @@
           }
           this.invalidPath = !permissions.data.directory;
           if (permissions.data.directory) {
-            this.$emit('submit', this.path, writable);
+            this.$emit('submit', permissions.data.path, writable);
           } else {
             this.errorType = 'directory';
           }

--- a/kolibri/utils/filesystem.py
+++ b/kolibri/utils/filesystem.py
@@ -13,7 +13,7 @@ def get_path_permission(path):
     :return: True if the path is writable, False otherwise.
     """
     try:
-        return os.access(path, os.W_OK)
+        return os.access(resolve_path(path), os.W_OK)
     except (IOError, OSError):
         return False
 
@@ -25,6 +25,18 @@ def check_is_directory(path):
     :return: True if the path is a directory.
     """
     try:
-        return os.path.exists(path)
+        return os.path.exists(resolve_path(path))
     except (IOError, OSError):
         return False
+
+
+def resolve_path(path):
+    """
+    Expand and resolve the path.
+    :param path: Path to expand and resolve
+    :return: The resolved path.
+    """
+    try:
+        return os.path.realpath(os.path.expanduser(path))
+    except (IOError, OSError):
+        return None


### PR DESCRIPTION
… characters

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr updates the `AddStorageLocation` modal so that it resolves paths that contain special characters such as "~".
- Adds function `resolve_path` which makes use of `os.path.realpath()` and `os.path.expanduser()` for resolving and expanding ~ and ~user constructions to `filesystem.py`
- Updates `AddStorageLocationModal` to return the expanded and resolved path.

Before:

![resolvePathBefore](https://user-images.githubusercontent.com/46411498/234690097-196178cb-b994-415f-b37d-88c4ae4c17b4.gif)

After:

![resolvePathAfter](https://user-images.githubusercontent.com/46411498/234690126-f08318bf-8fa8-41b4-a691-ac6dee3bd6be.gif)



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10531 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Device Settings
2. Add a new storage location path that uses "~" 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
