### PR TITLE
Follow up to remote content browsing ui polish 

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useContentLink.js
+++ b/kolibri/plugins/learn/assets/src/composables/useContentLink.js
@@ -126,11 +126,35 @@ export default function useContentLink(store) {
     return `${base}${path}${query}`;
   }
 
+  function genLibraryPageBackLink(deviceId, isExploreLibraries = false) {
+    if (!route) {
+      return null;
+    }
+
+    const oldQuery = get(route).query || {};
+    const query = {
+      prevName: get(route).name,
+    };
+    if (!isEmpty(oldQuery)) {
+      query.prevQuery = encodeURI(JSON.stringify(oldQuery));
+    }
+    const params = get(route).params;
+    if (!isEmpty(params)) {
+      query.prevParams = encodeURI(JSON.stringify(params));
+    }
+    return {
+      name: isExploreLibraries ? PageNames.EXPLORE_LIBRARIES : PageNames.LIBRARY,
+      params: pick({ deviceId: deviceId || params.deviceId }, ['deviceId']),
+      query,
+    };
+  }
+
   return {
     genContentLinkBackLinkCurrentPage,
     genContentLinkKeepCurrentBackLink,
     genExternalContentURLBackLinkCurrentPage,
     genExternalBackURL,
+    genLibraryPageBackLink,
     back,
   };
 }

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -111,7 +111,6 @@ export default [
     props: route => {
       return {
         deviceId: route.params.deviceId,
-        goBackRoute: route.params.goBackRoute,
       };
     },
   },

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -48,7 +48,7 @@
         <KRouterLink
           appearance="raised-button"
           :text="coreString('explore')"
-          :to="libraryPageRoute"
+          :to="genLibraryPageBackLink(deviceId, false)"
         />
       </KGridItem>
     </div>
@@ -80,7 +80,6 @@
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import useContentLink from '../../composables/useContentLink';
   import ChannelCard from '../ChannelCard';
-  import { PageNames } from '../../constants';
 
   export default {
     name: 'LibraryItem',
@@ -89,11 +88,12 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { genContentLinkBackLinkCurrentPage } = useContentLink();
+      const { genContentLinkBackLinkCurrentPage, genLibraryPageBackLink } = useContentLink();
       const { windowIsSmall } = useKResponsiveWindow();
 
       return {
         genContentLinkBackLinkCurrentPage,
+        genLibraryPageBackLink,
         windowIsSmall,
       };
     },
@@ -138,22 +138,6 @@
         type: Boolean,
         required: false,
         default: false,
-      },
-    },
-    computed: {
-      goBackRoute() {
-        return {
-          name: PageNames.EXPLORE_LIBRARIES,
-        };
-      },
-      libraryPageRoute() {
-        return {
-          name: PageNames.LIBRARY,
-          params: {
-            deviceId: this.deviceId,
-            goBackRoute: this.goBackRoute,
-          },
-        };
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -4,6 +4,7 @@
     :appBarTitle="learnString('exploreLibraries')"
     :route="back"
     :primary="false"
+    :loading="loading"
   >
     <div
       class="page-header"
@@ -39,8 +40,8 @@
         />
       </div>
       <LibraryItem
-        v-for="device in moreDevices"
-        :key="device['instance_id']"
+        v-for="(device, index) in moreDevices"
+        :key="index"
         :deviceId="device['instance_id']"
         :deviceName="device['device_name']"
         :deviceIcon="getDeviceIcon(device)"
@@ -64,6 +65,7 @@
 <script>
 
   import { mapGetters } from 'vuex';
+
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
@@ -101,6 +103,7 @@
     },
     data() {
       return {
+        loading: false,
         networkDevices: [],
         moreDevices: [],
         usersPins: [],
@@ -173,6 +176,7 @@
       },
     },
     created() {
+      this.loading = true;
       // Fetch user's pins
       this.fetchPinsForUser().then(resp => {
         this.usersPins = resp.map(pin => {
@@ -182,23 +186,28 @@
       });
 
       this.fetchDevices().then(devices => {
-        const fetchDevicesChannels = devices.reduce((accumulator, device) => {
+        this.loading = false;
+        for (const device of devices) {
           const baseurl = device.base_url;
-          accumulator.push(this.fetchChannels({ baseurl }));
-          return accumulator;
-        }, []);
-
-        Promise.allSettled(fetchDevicesChannels).then(devicesChannels => {
-          this.networkDevices = devices.map((device, index) => {
-            const deviceChannels = devicesChannels[index]?.value || [];
-            device['channels'] = deviceChannels.slice(0, 4);
-            device['total_count'] = deviceChannels.length;
-            return device;
-          });
-        });
+          this.fetchChannels({ baseurl })
+            .then(channels => {
+              this.addNetworkDevice(device, channels);
+            })
+            .catch(() => {
+              this.addNetworkDevice(device, []);
+            });
+        }
       });
     },
     methods: {
+      addNetworkDevice(device, channels) {
+        this.networkDevices.push(
+          Object.assign(device, {
+            channels: channels.slice(0, 4),
+            total_count: channels.length,
+          })
+        );
+      },
       createPin(instance_id) {
         return this.createPinForUser(instance_id).then(response => {
           const id = response.id;
@@ -222,13 +231,9 @@
       handlePinToggle(instance_id) {
         if (this.usersPinsDeviceIds.includes(instance_id)) {
           const pinId = this.usersPins.find(pin => pin.instance_id === instance_id);
-          this.deletePin(instance_id, pinId).catch(e => {
-            console.error(e);
-          });
+          this.deletePin(instance_id, pinId);
         } else {
-          this.createPin(instance_id).catch(e => {
-            console.error(e);
-          });
+          this.createPin(instance_id);
         }
       },
       getDeviceIcon(device) {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -2,7 +2,7 @@
 
   <ImmersivePage
     :appBarTitle="learnString('exploreLibraries')"
-    :route="backRoute"
+    :route="back"
     :primary="false"
   >
     <div
@@ -69,9 +69,10 @@
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonLearnStrings from '../commonLearnStrings';
   import useChannels from '../../composables/useChannels';
+  import useContentLink from '../../composables/useContentLink';
   import useDevices from '../../composables/useDevices';
   import usePinnedDevices from '../../composables/usePinnedDevices';
-  import { PageNames, KolibriStudioId } from '../../constants';
+  import { KolibriStudioId } from '../../constants';
   import LibraryItem from './LibraryItem';
 
   const PinStrings = crossComponentTranslator(LibraryItem);
@@ -85,6 +86,7 @@
     mixins: [commonCoreStrings, commonLearnStrings],
     setup() {
       const { fetchChannels } = useChannels();
+      const { back } = useContentLink();
       const { fetchDevices } = useDevices();
       const { createPinForUser, deletePinForUser, fetchPinsForUser } = usePinnedDevices();
 
@@ -94,6 +96,7 @@
         fetchPinsForUser,
         fetchChannels,
         fetchDevices,
+        back,
       };
     },
     data() {
@@ -107,9 +110,6 @@
       ...mapGetters(['isSuperuser']),
       areMoreDevicesAvailable() {
         return this.unpinnedDevices?.length > 0;
-      },
-      backRoute() {
-        return { name: PageNames.LIBRARY };
       },
       displayShowButton() {
         return this.moreDevices.length === 0;

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
@@ -9,7 +9,10 @@
         :layout8="{ span: 4 }"
         :layout4="{ span: 4 }"
       >
-        <UnPinnedDevices :device="device" />
+        <UnPinnedDevices
+          :device="device"
+          :routeTo="genLibraryPageBackLink(device.id, false)"
+        />
       </KGridItem>
       <KGridItem
         v-if="devices.length"
@@ -21,7 +24,7 @@
         <UnPinnedDevices
           :device="{}"
           :viewAll="true"
-          :routeTo="viewAllRoute"
+          :routeTo="genLibraryPageBackLink(null, true)"
         />
       </KGridItem>
     </KGrid>
@@ -33,7 +36,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { PageNames } from '../../constants';
+  import useContentLink from '../../composables/useContentLink';
   import UnPinnedDevices from './UnPinnedDevices';
 
   export default {
@@ -42,15 +45,16 @@
       UnPinnedDevices,
     },
     mixins: [commonCoreStrings],
+    setup() {
+      const { genLibraryPageBackLink } = useContentLink();
+      return {
+        genLibraryPageBackLink,
+      };
+    },
     props: {
       devices: {
         type: Array,
         required: true,
-      },
-    },
-    computed: {
-      viewAllRoute() {
-        return { name: PageNames.EXPLORE_LIBRARIES };
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
@@ -28,7 +28,7 @@
             :key="exploreString.toLowerCase()"
             :isMobile="windowIsSmall"
             :title="exploreString"
-            :link="libraryPageRoute(device.id)"
+            :link="genLibraryPageBackLink(device.id, false)"
             :explore="true"
           />
         </KGridItem>
@@ -45,7 +45,7 @@
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { PageNames } from '../../constants';
+  import useContentLink from '../../composables/useContentLink';
   import ChannelCard from '../ChannelCard';
   import ChannelCardGroupGrid from './../ChannelCardGroupGrid';
 
@@ -57,8 +57,10 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings],
     setup() {
+      const { genLibraryPageBackLink } = useContentLink();
       const { windowGutter } = useKResponsiveWindow();
       return {
+        genLibraryPageBackLink,
         windowGutter,
       };
     },
@@ -75,11 +77,6 @@
       exploreString() {
         return this.coreString('explore');
       },
-      goBackRoute() {
-        return {
-          name: PageNames.LIBRARY,
-        };
-      },
     },
     methods: {
       getDeviceIcon(device) {
@@ -90,12 +87,6 @@
         } else {
           return 'laptop';
         }
-      },
-      libraryPageRoute(deviceId) {
-        return this.$router.getRoute(PageNames.LIBRARY, {
-          deviceId,
-          goBackRoute: this.goBackRoute,
-        });
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -53,7 +53,6 @@
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { PageNames } from '../../constants';
 
   export default {
     name: 'UnPinnedDevices',
@@ -74,15 +73,7 @@
       },
       routeTo: {
         type: Object,
-        required: false,
-        default() {
-          return {
-            name: PageNames.LIBRARY,
-            params: {
-              deviceId: this.device.id,
-            },
-          };
-        },
+        required: true,
       },
       viewAll: {
         type: Boolean,

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -5,7 +5,7 @@
     :appearanceOverrides="{}"
     :loading="loading"
     :deviceId="deviceId"
-    :route="goBackRoute"
+    :route="back"
   >
     <main
       class="main-grid"
@@ -218,6 +218,7 @@
   import SidePanelModal from '../SidePanelModal';
   import { KolibriStudioId } from '../../constants';
   import useCardViewStyle from '../../composables/useCardViewStyle';
+  import useContentLink from '../../composables/useContentLink';
   import useDevices from '../../composables/useDevices';
   import usePinnedDevices from '../../composables/usePinnedDevices';
   import useSearch from '../../composables/useSearch';
@@ -281,6 +282,7 @@
         windowIsSmall,
       } = useKResponsiveWindow();
       const { currentCardViewStyle } = useCardViewStyle();
+      const { back } = useContentLink();
       const { baseurl, deviceName, fetchDevices } = useDevices();
       const { fetchChannels } = useChannels();
       const { fetchPinsForUser } = usePinnedDevices();
@@ -317,6 +319,7 @@
         deviceName,
         fetchChannels,
         fetchPinsForUser,
+        back,
       };
     },
     props: {
@@ -326,10 +329,6 @@
       },
       loading: {
         type: Boolean,
-        default: null,
-      },
-      goBackRoute: {
-        type: Object,
         default: null,
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes is a follow up to https://github.com/learningequality/kolibri/pull/10573 that;

- Corrects the buggy routing implementation on refresh and click back
- Delayed loading state on the Explore libraries page
- Fixes the LibraryPage skipped tests


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Follow up to https://github.com/learningequality/kolibri/pull/10573

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Explore a particular library. Clicking on the close button (X) at top left should take you back to the previous page. Also, refreshing the page and clicking the same should yield the same result
- A loading state has been added to indicate load of the resources

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
