### PR TITLE
Remove defaultLocale from availableLanguages 

### DIFF
--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -16,8 +16,6 @@ export {
 
 const logging = logger.getLogger(__filename);
 
-const languageGlobals = plugin_data['languageGlobals'] || {};
-
 let _i18nReady = false;
 
 function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
@@ -186,6 +184,8 @@ function _setUpVueIntl() {
     return $trWrapper(nameSpace, this.$options.$trs, this.$formatMessage, messageId, args);
   };
 
+  const languageGlobals = plugin_data['languageGlobals'] || {};
+
   Vue.setLocale(currentLanguage);
   if (languageGlobals.coreLanguageMessages) {
     Vue.registerMessages(currentLanguage, languageGlobals.coreLanguageMessages);
@@ -199,6 +199,8 @@ export function i18nSetup(skipPolyfill = false) {
   /**
    * Load fonts, app strings, and Intl polyfills
    **/
+
+  const languageGlobals = plugin_data['languageGlobals'] || {};
 
   // Set up exported module variable
   if (languageGlobals.languageCode) {

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -48,9 +48,7 @@ function $trWrapper(nameSpace, defaultMessages, formatter, messageId, args) {
 
 const defaultLocale = defaultLanguage.id;
 
-export const availableLanguages = {
-  [defaultLocale]: defaultLanguage,
-};
+export const availableLanguages = {};
 
 export let currentLanguage = defaultLocale;
 

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -14,6 +14,9 @@ import { i18nSetup } from 'kolibri.utils.i18n';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import KContentPlugin from 'kolibri-design-system/lib/content/KContentPlugin';
 
+import { defaultLanguage } from 'kolibri-design-system/lib/utils/i18n';
+import plugin_data from 'plugin_data';
+
 global.beforeEach(() => {
   return new Promise(resolve => {
     Aphrodite.StyleSheetTestUtils.suppressStyleInjection();
@@ -41,6 +44,13 @@ Vue.use(VueCompositionApi);
 Vue.config.silent = true;
 Vue.config.devtools = false;
 Vue.config.productionTip = false;
+
+plugin_data['languageGlobals'] = {
+  languageCode: defaultLanguage.id,
+  languages: {
+    defaultLanguage: defaultLanguage,
+  },
+};
 
 i18nSetup(true);
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The issue to resolve is displaying 'English' as an available language choice on the UI when it is not set as an available language from the backend. The cause for this issue is it sets available language object on the frontend with default entry set to English by hardcoding that. The change done here is removing that default entry to resolve the error in UI.

The UI appears as follows **before** the changes (English language appears as a choice, but give an error page when clicked): 
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/80597937/234872401-85d67101-8912-4635-ac6a-a7ec903412da.png">

The UI appears as follows **after** the change (English does not appear as a choice anymore):
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/80597937/234872058-c24762c1-1f1f-4043-9819-04fd4b83f046.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10124 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

set the KOLIBRI_LANGUAGES environment variable with few set of languages as follows: 
```
KOLIBRI_LANGUAGES=fr-fr,de yarn run devserver
```

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
