### PR TITLE
Add the perseus plugin to the list of internal plugins.

### DIFF
--- a/kolibri/__init__.py
+++ b/kolibri/__init__.py
@@ -36,6 +36,7 @@ INTERNAL_PLUGINS = [
     "kolibri.plugins.learn",
     "kolibri.plugins.media_player",
     "kolibri.plugins.pdf_viewer",
+    "kolibri.plugins.perseus_viewer",
     "kolibri.plugins.setup_wizard",
     "kolibri.plugins.slideshow_viewer",
     "kolibri.plugins.user_auth",


### PR DESCRIPTION
## Summary
Fixes a weird oversight in the listing of Kolibri's available plugins