### PR TITLE
Replaced "Deferred" with "-" in change facility flow

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -94,3 +94,5 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Akila Induranga | akila-i |
 | Sahajpreet Singh | photon0205 |
 | Nishant Shrivastva | shrinishant  |
+| Estela Bobadilla-Cruz | estelacruz |
+

--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -163,7 +163,7 @@ export const ERROR_CONSTANTS = {
 
 export const DemographicConstants = {
   NOT_SPECIFIED: 'NOT_SPECIFIED',
-  DEFERRED: 'DEFERRED',
+  DEFERRED: '-',
 };
 
 // See FacilityUser model


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
 * Description of the change: Replaced ‘DEFERRED’ with a ‘–’ in the constants.js file, updating the DemographicConstants imported in the confirmAccountDeatils file for the merge accounts preview
 * Screenshots: <img width="581" alt="Screen Shot 2023-04-30 at 1 48 00 AM" src="https://user-images.githubusercontent.com/79770461/235337820-bbb6442f-9da8-4523-9c45-21e0cc0f6da7.png">
 
 *  Manual verification steps performed:

-  Opened constants.js file (Path: kolibri/core/assets/src/constants.js) since it is imported in ConfirmAccountDetails.vue (path: Kolibri/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue)
- updated the key value of "DEFERRED" to "-"

<!--
 * description of the change
 *
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ x] Contributor has fully tested the PR manually
- [x ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests



## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
