### PR TITLE
Update dependabot to check at midnight UTC and to update github-actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+      time: "00:00"
+
+  # Maintain dependencies for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"


### PR DESCRIPTION
## Summary
* Does checks at midnight UTC to stop @rtibbles getting distracted in the middle of his workday by dependabot updates
* Does automatic upgrades of Github action versions to prevent stale versions being used