### PR TITLE
Fix Update2 #8532 Remove text truncator

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -27,6 +27,17 @@
           :showTooltip="true"
         />
       </h3>
+    <h3
+      class="title"
+      dir="auto"
+      :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
+    >
+      <TextTruncatorCss
+        :text="title"
+        :maxLines="2"
+        :showTooltip="true"
+      />
+    </h3>
 
       <KFixedGrid
         numCols="4"
@@ -84,7 +95,7 @@
   import { validateLinkObject } from 'kolibri.utils.validators';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import ChannelThumbnail from './ChannelThumbnail';
 
   export default {
@@ -92,7 +103,7 @@
     components: {
       ChannelThumbnail,
       CoachContentLabel,
-      TextTruncator,
+      TextTruncatorCss,
     },
     mixins: [responsiveWindowMixin],
     props: {
@@ -152,12 +163,6 @@
           marginBottom: `${this.windowGutter}px`,
           minHeight: `${this.overallHeight}px`,
         };
-      },
-      titleHeight() {
-        return 60;
-      },
-      taglineHeight() {
-        return 155;
       },
       versionStyle() {
         return {

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -21,23 +21,12 @@
         dir="auto"
         :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
       >
-        <TextTruncator
+        <TextTruncatorCss
           :text="title"
-          :maxHeight="titleHeight"
+          :maxLines="2"
           :showTooltip="true"
         />
       </h3>
-    <h3
-      class="title"
-      dir="auto"
-      :style="{ borderBottom: `1px solid ${$themeTokens.fineLine}` }"
-    >
-      <TextTruncatorCss
-        :text="title"
-        :maxLines="2"
-        :showTooltip="true"
-      />
-    </h3>
 
       <KFixedGrid
         numCols="4"
@@ -54,9 +43,9 @@
           span="3"
           alignment="auto"
         >
-          <TextTruncator
+          <TextTruncatorCss
             :text="tagline"
-            :maxHeight="taglineHeight"
+            :maxLines="4"
             :showTooltip="false"
           />
         </KFixedGridItem>


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary

From the issue #8532 
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I have updated the TextTruncator `with `TexTruncatorCss  inside the `ChannelCard.vue`
`
## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
I have taken the reference from the previous issue and commits #8532 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

A reviewer can test those changes by decreasing the width of the window he/she would expect that the `title` should be up to 2 lines and the `description of the resource will be under 4 lines` if it exceeds it will truncate with `...`



- [X]  After making the changes we can see 
![Screenshot from 2023-05-02 13-03-04](https://user-images.githubusercontent.com/81693090/235668478-a1eb3946-6656-485b-83ab-06eb90436efb.png)


----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
