### PR TITLE
Cleans up remote content browsing cards

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -4,9 +4,7 @@
     <KGridItem
       v-for="content in contents"
       :key="content.id"
-      :layout12="{ span: 3 }"
-      :layout8="{ span: 4 }"
-      :layout4="{ span: 4 }"
+      :layout="{ span: layoutSpan }"
     >
       <ChannelCard
         :isMobile="windowIsSmall"
@@ -27,7 +25,7 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import useContentLink from '../composables/useContentLink';
   import ChannelCard from './ChannelCard';
 
@@ -36,10 +34,14 @@
     components: {
       ChannelCard,
     },
-    mixins: [responsiveWindowMixin],
     setup() {
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
-      return { genContentLinkBackLinkCurrentPage };
+      const { windowBreakpoint, windowIsSmall } = useKResponsiveWindow();
+      return {
+        genContentLinkBackLinkCurrentPage,
+        windowBreakpoint,
+        windowIsSmall,
+      };
     },
     props: {
       contents: {
@@ -54,6 +56,17 @@
       isRemote: {
         type: Boolean,
         default: false,
+      },
+    },
+    computed: {
+      layoutSpan() {
+        let span = 3;
+        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
+          span = 4;
+        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
+          span = 6;
+        }
+        return span;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -36,13 +36,13 @@
     },
     setup() {
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
-      const { windowBreakpoint, windowIsSmall } = useKResponsiveWindow();
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         genContentLinkBackLinkCurrentPage,
-        windowBreakpoint,
         windowIsSmall,
       };
     },
+    inject: ['$layoutSpan'],
     props: {
       contents: {
         type: Array,
@@ -60,13 +60,7 @@
     },
     computed: {
       layoutSpan() {
-        let span = 3;
-        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
-          span = 4;
-        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
-          span = 6;
-        }
-        return span;
+        return this.$layoutSpan();
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -56,9 +56,7 @@
       <KGridItem
         v-for="channel in channels"
         :key="channel.id"
-        :layout12="{ span: 3 }"
-        :layout8="{ span: 4 }"
-        :layout4="{ span: 4 }"
+        :layout="{ span: layoutSpan }"
       >
         <ChannelCard
           :title="channel.name"
@@ -89,11 +87,12 @@
     mixins: [commonCoreStrings],
     setup() {
       const { genContentLinkBackLinkCurrentPage, genLibraryPageBackLink } = useContentLink();
-      const { windowIsSmall } = useKResponsiveWindow();
+      const { windowIsSmall, windowBreakpoint } = useKResponsiveWindow();
 
       return {
         genContentLinkBackLinkCurrentPage,
         genLibraryPageBackLink,
+        windowBreakpoint,
         windowIsSmall,
       };
     },
@@ -138,6 +137,17 @@
         type: Boolean,
         required: false,
         default: false,
+      },
+    },
+    computed: {
+      layoutSpan() {
+        let span = 3;
+        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
+          span = 4;
+        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
+          span = 6;
+        }
+        return span;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -141,6 +141,21 @@
     },
     computed: {
       layoutSpan() {
+        /**
+         * The breakpoints below represent the window widths
+         * 0: < 480px  | Small screen  | 4 columns
+         * 1: < 600px  | Small screen  | 4 columns
+         * 2: < 840px  | Medium screen | 8 columns
+         * 3: < 960px  | Large screen  | 12 columns
+         * 4: < 1280px | Large screen  | 12 columns
+         * 5: < 1440px | Large screen  | 12 columns
+         * 6: < 1600px | Large screen  | 12 columns
+         *
+         * On resize, display X cards per row where:
+         * X = total columns in grid / column span for each card.
+         * For example, if the total number of columns is 12, and
+         * column span for each cards is 4, then X is 3.
+         */
         let span = 3;
         if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
           span = 4;

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -228,6 +228,7 @@
     display: flex;
     width: 100%;
     padding: $margin;
+    margin-bottom: $margin-thin;
   }
 
   .progress-bar {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
@@ -5,9 +5,7 @@
       <KGridItem
         v-for="device in devices"
         :key="device.id"
-        :layout12="{ span: 3 }"
-        :layout8="{ span: 4 }"
-        :layout4="{ span: 4 }"
+        :layout="{ span: layoutSpan }"
       >
         <UnPinnedDevices
           :device="device"
@@ -17,9 +15,7 @@
       <KGridItem
         v-if="devices.length"
         key="view-all"
-        :layout12="{ span: 3 }"
-        :layout8="{ span: 4 }"
-        :layout4="{ span: 4 }"
+        :layout="{ span: layoutSpan }"
       >
         <UnPinnedDevices
           :device="{}"
@@ -36,6 +32,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import useContentLink from '../../composables/useContentLink';
   import UnPinnedDevices from './UnPinnedDevices';
 
@@ -47,14 +44,27 @@
     mixins: [commonCoreStrings],
     setup() {
       const { genLibraryPageBackLink } = useContentLink();
+      const { windowBreakpoint } = useKResponsiveWindow();
       return {
         genLibraryPageBackLink,
+        windowBreakpoint,
       };
     },
     props: {
       devices: {
         type: Array,
         required: true,
+      },
+    },
+    computed: {
+      layoutSpan() {
+        let span = 3;
+        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
+          span = 4;
+        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
+          span = 6;
+        }
+        return span;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/MoreNetworkDevices.vue
@@ -32,7 +32,6 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import useContentLink from '../../composables/useContentLink';
   import UnPinnedDevices from './UnPinnedDevices';
 
@@ -44,12 +43,11 @@
     mixins: [commonCoreStrings],
     setup() {
       const { genLibraryPageBackLink } = useContentLink();
-      const { windowBreakpoint } = useKResponsiveWindow();
       return {
         genLibraryPageBackLink,
-        windowBreakpoint,
       };
     },
+    inject: ['$layoutSpan'],
     props: {
       devices: {
         type: Array,
@@ -58,13 +56,7 @@
     },
     computed: {
       layoutSpan() {
-        let span = 3;
-        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
-          span = 4;
-        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
-          span = 6;
-        }
-        return span;
+        return this.$layoutSpan();
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
@@ -53,11 +53,9 @@
     mixins: [commonCoreStrings],
     setup() {
       const { genLibraryPageBackLink } = useContentLink();
-      const { windowBreakpoint, windowGutter, windowIsSmall } = useKResponsiveWindow();
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         genLibraryPageBackLink,
-        windowBreakpoint,
-        windowGutter,
         windowIsSmall,
       };
     },
@@ -71,19 +69,14 @@
       },
     },
     computed: {
+      layoutSpan() {
+        return this.$layoutSpan();
+      },
       exploreString() {
         return this.coreString('explore');
       },
-      layoutSpan() {
-        let span = 3;
-        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
-          span = 4;
-        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
-          span = 6;
-        }
-        return span;
-      },
     },
+    inject: ['$layoutSpan'],
     methods: {
       getDeviceIcon(device) {
         if (device['operating_system'] === 'Android') {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/PinnedNetworkResources.vue
@@ -19,11 +19,7 @@
         :contents="device.channels"
         :isRemote="true"
       >
-        <KGridItem
-          :layout12="{ span: 3 }"
-          :layout8="{ span: 4 }"
-          :layout4="{ span: 4 }"
-        >
+        <KGridItem :layout="{ span: layoutSpan }">
           <ChannelCard
             :key="exploreString.toLowerCase()"
             :isMobile="windowIsSmall"
@@ -43,7 +39,6 @@
 <script>
 
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useContentLink from '../../composables/useContentLink';
   import ChannelCard from '../ChannelCard';
@@ -55,13 +50,15 @@
       ChannelCard,
       ChannelCardGroupGrid,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
     setup() {
       const { genLibraryPageBackLink } = useContentLink();
-      const { windowGutter } = useKResponsiveWindow();
+      const { windowBreakpoint, windowGutter, windowIsSmall } = useKResponsiveWindow();
       return {
         genLibraryPageBackLink,
+        windowBreakpoint,
         windowGutter,
+        windowIsSmall,
       };
     },
     props: {
@@ -76,6 +73,15 @@
     computed: {
       exploreString() {
         return this.coreString('explore');
+      },
+      layoutSpan() {
+        let span = 3;
+        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
+          span = 4;
+        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
+          span = 6;
+        }
+        return span;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -129,6 +129,7 @@
 
     position: relative;
     width: 100%;
+    padding: 16px;
     margin-bottom: 24px;
     text-decoration: none;
     vertical-align: top;

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -464,9 +464,6 @@
         }
         document.documentElement.style.position = '';
       },
-      windowBreakpoint(xx) {
-        console.log(xx);
-      },
     },
     created() {
       this.search();

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -379,6 +379,30 @@
           ? { marginRight: `${this.sidePanelWidth + 24}px` }
           : { marginLeft: `${this.sidePanelWidth + 24}px` };
       },
+      layoutSpan() {
+        /**
+         * The breakpoints below represent the window widths
+         * 0: < 480px  | Small screen  | 4 columns
+         * 1: < 600px  | Small screen  | 4 columns
+         * 2: < 840px  | Medium screen | 8 columns
+         * 3: < 960px  | Large screen  | 12 columns
+         * 4: < 1280px | Large screen  | 12 columns
+         * 5: < 1440px | Large screen  | 12 columns
+         * 6: < 1600px | Large screen  | 12 columns
+         *
+         * On resize, display X cards per row where:
+         * X = total columns in grid / column span for each card.
+         * For example, if the total number of columns is 12, and
+         * column span for each cards is 4, then X is 3.
+         */
+        let span = 3;
+        if ([0, 1, 2, 6].includes(this.windowBreakpoint)) {
+          span = 4;
+        } else if ([3, 4, 5].includes(this.windowBreakpoint)) {
+          span = 6;
+        }
+        return span;
+      },
       pinnedDevices() {
         return this.devicesWithChannels.filter(device => {
           return (
@@ -424,6 +448,11 @@
         return this.usersPins.map(pin => pin.instance_id);
       },
     },
+    provide() {
+      return {
+        $layoutSpan: () => this.layoutSpan,
+      };
+    },
     watch: {
       searchTerms() {
         this.mobileSidePanelIsOpen = false;
@@ -434,6 +463,9 @@
           return;
         }
         document.documentElement.style.position = '';
+      },
+      windowBreakpoint(xx) {
+        console.log(xx);
       },
     },
     created() {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -85,7 +85,7 @@
                     />
                   </span>
                   &nbsp;&nbsp;
-                  {{ $tr('showingAllLibraries') }}
+                  <span>{{ $tr('showingAllLibraries').slice(0, -1) }}</span>
                   &nbsp;&nbsp;
                   <KButton
                     :text="coreString('refresh')"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -85,7 +85,7 @@
                     />
                   </span>
                   &nbsp;&nbsp;
-                  <span>{{ $tr('showingAllLibraries').slice(0, -1) }}</span>
+                  <span>{{ showingAllLibrariesLabel }}</span>
                   &nbsp;&nbsp;
                   <KButton
                     :text="coreString('refresh')"
@@ -398,6 +398,13 @@
         } else {
           return 346;
         }
+      },
+      showingAllLibrariesLabel() {
+        let label = this.$tr('showingAllLibraries');
+        if (label.slice(-1) === '.') {
+          label = label.slice(0, -1);
+        }
+        return label;
       },
       studioId() {
         return KolibriStudioId;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr does clean up on cards within the remote content browsing feature.
**Before 1**
![image](https://user-images.githubusercontent.com/5203639/236002047-d7022a61-e7ac-4df9-9e36-21fa69c1524e.png)
**After 1**
Device cards are now resized based on available space
<img width="834" alt="Screenshot 2023-05-03 at 20 34 03" src="https://user-images.githubusercontent.com/5203639/236002120-e3573526-6757-4dc9-96f4-ee70ac2736d0.png">

**Before 2**
![image](https://user-images.githubusercontent.com/5203639/236002423-f31bed5e-a4cc-416e-be52-8e2ba2c783e2.png)
**After 2**
<img width="1143" alt="Screenshot 2023-05-03 at 20 33 08" src="https://user-images.githubusercontent.com/5203639/236002565-e120e56f-6c59-4be0-a39d-d375876e6337.png">

**Before 3**
![image](https://user-images.githubusercontent.com/5203639/236002680-510a1072-855c-448a-a36d-2f68ff0f1f40.png)
**After 3**
Content cards are now resized based on available space
<img width="808" alt="Screenshot 2023-05-03 at 20 32 24" src="https://user-images.githubusercontent.com/5203639/236002883-ed696c2d-c95a-44c4-abf9-86d33ff6d24f.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10604

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Navigate to the areas in the attached in the screenshots  and try to resize the browser window.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
