### PR TITLE
Fixes UX issues with Sync and Register buttons on Facility Data page

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <KPageContainer>
+  <KPageContainer
+    :style="windowIsSmall ? { } : { height: '300px', overflow: 'visible' }"
+  >
 
     <h1>{{ $tr('syncData') }}</h1>
     <p>
@@ -26,16 +28,12 @@
                 :goToRoute="manageSyncRoute"
               />
             </td>
-            <td class="button-col">
-              <KButtonGroup style="margin-top: 8px; overflow: visible">
+            <td
+              :style="windowIsSmall ? { padding: '8px 4px 4px' } : { maxWidth: '100px' }"
+              class="button-col"
+            >
+              <KButtonGroup style="margin-top: 12px; overflow: visible">
                 <KButton
-                  v-if="!facility.dataset.registered"
-                  appearance="raised-button"
-                  :text="$tr('register')"
-                  @click="displayModal(Modals.REGISTER_FACILITY)"
-                />
-                <KButton
-                  v-else-if="!Boolean(syncTaskId)"
                   appearance="raised-button"
                   :text="$tr('sync')"
                   @click="displayModal(Modals.SYNC_FACILITY)"
@@ -65,16 +63,10 @@
                       @select="manageSyncAction()"
                     />
                     <CoreMenuOption
-                      v-if="facility.dataset.registered"
+                      v-if="!facility.dataset.registered"
                       :style="{ 'cursor': 'pointer', textAlign: 'left' }"
                       :label="$tr('register')"
                       @select="displayModal(Modals.REGISTER_FACILITY)"
-                    />
-                    <CoreMenuOption
-                      v-else
-                      :style="{ 'cursor': 'pointer', textAlign: 'left' }"
-                      :label="$tr('sync')"
-                      @select="displayModal(Modals.SYNC_FACILITY)"
                     />
                   </template>
                 </CoreMenu>
@@ -126,6 +118,7 @@
     SyncFacilityModalGroup,
   } from 'kolibri.coreVue.componentSets.sync';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { TaskResource, FacilityResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
@@ -153,7 +146,7 @@
       CoreMenu,
       CoreMenuOption,
     },
-    mixins: [commonSyncElements, commonCoreStrings],
+    mixins: [commonSyncElements, commonCoreStrings, responsiveWindowMixin],
     data() {
       return {
         facility: null,
@@ -295,8 +288,6 @@
 
   /* derived from .core-table-button-col */
   .button-col {
-    padding: 4px;
-    padding-top: 8px;
     text-align: right;
   }
 
@@ -309,6 +300,11 @@
     top: 3px;
     display: inline-block;
     margin-right: 8px;
+  }
+
+  /deep/ .button-group-item {
+    height: max-content;
+    margin-bottom: 8px;
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -63,7 +63,6 @@
                       @select="manageSyncAction()"
                     />
                     <CoreMenuOption
-                      v-if="!facility.dataset.registered"
                       :style="{ 'cursor': 'pointer', textAlign: 'left' }"
                       :label="$tr('register')"
                       @select="displayModal(Modals.REGISTER_FACILITY)"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr updates the buttons on the Facility > Data page in the Sync facility data sections. Previously when clicking the Options icon button the options were `Manage Sync Schedule` and `Sync`. And if the facility is registered in KDP, the Register button was still displayed.
- The `Sync` button is displayed instead of `Register`.
- The option to register a facility is displayed within the Options icon button menu and does not display if a facility is registered.
- The options icon button menu is displayed beneath the buttons instead of opening beside the buttons.

Before
<img width="1065" alt="sync-facility-options-button-fix-before" src="https://user-images.githubusercontent.com/46411498/236250305-512f31a1-dffb-415c-830c-9c3d288cab27.png">

After
Unregistered Facility
<img width="1039" alt="sync-facility-options-button-fix-not-registered-after" src="https://user-images.githubusercontent.com/46411498/236250360-7fafea07-0ebc-4b25-a8d9-edbc59834bbf.png">
Registered Facility
<img width="1067" alt="sync-facility-options-button-fix-registered-after" src="https://user-images.githubusercontent.com/46411498/236509204-9b7a3dbf-f51c-461e-8dbc-064d4cffc085.png">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9090 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go to Facility > Data and scroll down to the 'Sync facility data' section
2. Confirm that the menu options beneath the Register and options icon buttons.
3. Confirm that the menu option `Register` only shows if the facility is registered.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
