### PR TITLE
Content request version upgrade migration

### DIFF
--- a/kolibri/core/content/test/utils/test_assignment.py
+++ b/kolibri/core/content/test/utils/test_assignment.py
@@ -1,0 +1,173 @@
+import uuid
+
+import mock
+from django.test import TestCase
+
+from kolibri.core.content.utils.assignment import ContentAssignment
+from kolibri.core.content.utils.assignment import ContentAssignmentManager
+from kolibri.core.content.utils.assignment import DeletedAssignment
+
+
+_module = "kolibri.core.content.utils.assignment."
+
+
+class ContentAssignmentManagerTestCase(TestCase):
+    def setUp(self):
+        super(ContentAssignmentManagerTestCase, self).setUp()
+
+        self.model = mock.MagicMock()
+        self.model.objects = mock.MagicMock()
+        self.model.morango_model_name = "test_model"
+        self.manager = ContentAssignmentManager()
+        self.manager.model = self.model
+        self.manager.name = self.model.morango_model_name
+
+        self.assignment = ContentAssignment(
+            contentnode_id=uuid.uuid4().hex,
+            source_model=self.manager.name,
+            source_id=uuid.uuid4().hex,
+            metadata={},
+        )
+
+    @mock.patch(_module + "ContentAssignmentManager._get_assignments")
+    def test_find_downloadable_assignments__dataset_id(self, get_assignments_mock):
+        self.manager.filters = {"test": "test"}
+        get_assignments_mock.return_value = [self.assignment]
+
+        count = 0
+        for assignment in self.manager.find_downloadable_assignments(
+            dataset_id="test_dataset"
+        ):
+            count += 1
+            self.assertEqual(assignment, self.assignment)
+
+        self.assertEqual(count, 1)
+        qs = self.model.objects.all.return_value
+        qs.filter.assert_called_once_with(dataset_id="test_dataset")
+        qs.filter.return_value.filter.assert_called_once_with(test="test")
+        get_assignments_mock.assert_called_once_with(
+            qs.filter.return_value.filter.return_value
+        )
+
+    @mock.patch(_module + "ContentAssignmentManager._get_modified_store")
+    @mock.patch(_module + "ContentAssignmentManager._get_assignments")
+    def test_find_downloadable_assignments__transfer_session_id(
+        self, get_assignments_mock, get_modified_store_mock
+    ):
+        store_qs = mock.MagicMock()
+        get_modified_store_mock.return_value = store_qs
+        store_qs.exclude.return_value = store_qs
+
+        store_ids = [uuid.uuid4().hex for _ in range(1)]
+        store_qs.values_list.return_value = store_ids
+
+        get_assignments_mock.return_value = [self.assignment]
+
+        count = 0
+        for assignment in self.manager.find_downloadable_assignments(
+            transfer_session_id="test_transfer_session"
+        ):
+            count += 1
+            self.assertEqual(assignment, self.assignment)
+
+        self.assertEqual(count, 1)
+        exclude_q = store_qs.exclude.call_args[0][0]
+        self.assertEqual(
+            str(exclude_q),
+            "(OR: ('deleted', True), ('hard_deleted', True), (NOT (AND: ('deserialization_error', ''))))",
+        )
+
+        qs = self.model.objects.all.return_value
+        get_modified_store_mock.assert_called_once_with("test_transfer_session")
+        qs.filter.assert_called_once_with(pk__in=store_ids)
+        get_assignments_mock.assert_called_once_with(qs.filter.return_value)
+
+    def test_find_downloadable_assignments__one_parameter(self):
+        with self.assertRaises(ValueError):
+            next(self.manager.find_downloadable_assignments())
+
+        with self.assertRaises(ValueError):
+            next(
+                self.manager.find_downloadable_assignments(
+                    dataset_id="test_dataset",
+                    transfer_session_id="test_transfer_session",
+                )
+            )
+
+    @mock.patch(_module + "ContentAssignmentManager._get_assignments")
+    def test_find_removable_assignments__dataset_id(self, get_assignments_mock):
+        self.manager.filters = {"test": "test"}
+        get_assignments_mock.return_value = [self.assignment]
+
+        count = 0
+        for assignment in self.manager.find_removable_assignments(
+            dataset_id="test_dataset"
+        ):
+            count += 1
+            self.assertEqual(assignment, self.assignment)
+
+        self.assertEqual(count, 1)
+        qs = self.model.objects.all.return_value
+        qs.filter.assert_called_once_with(dataset_id="test_dataset")
+        qs.filter.return_value.exclude.assert_called_once_with(test="test")
+        get_assignments_mock.assert_called_once_with(
+            qs.filter.return_value.exclude.return_value
+        )
+
+    @mock.patch(_module + "ContentAssignmentManager._get_modified_store")
+    @mock.patch(_module + "ContentAssignmentManager._get_assignments")
+    def test_find_removable_assignments__transfer_session_id(
+        self, get_assignments_mock, get_modified_store_mock
+    ):
+        store_qs = mock.MagicMock()
+        get_modified_store_mock.return_value = store_qs
+
+        modified_store_ids = [uuid.uuid4().hex for _ in range(1)]
+        store_qs.values_list.return_value = modified_store_ids
+        get_assignments_mock.return_value = [self.assignment]
+
+        deleted_store_ids = [uuid.uuid4().hex for _ in range(1)]
+        store_qs.filter.return_value.values_list.return_value = deleted_store_ids
+
+        assignments = []
+        for assignment in self.manager.find_removable_assignments(
+            transfer_session_id="test_transfer_session"
+        ):
+            assignments.append(assignment)
+
+        deleted_assignments = [
+            assignment
+            for assignment in assignments
+            if isinstance(assignment, DeletedAssignment)
+        ]
+        modified_assignments = [
+            assignment
+            for assignment in assignments
+            if isinstance(assignment, ContentAssignment)
+        ]
+        self.assertEqual(len(deleted_assignments), 1)
+        self.assertEqual(len(modified_assignments), 1)
+        self.assertEqual(deleted_assignments[0].source_id, deleted_store_ids[0])
+        self.assertEqual(modified_assignments[0], self.assignment)
+
+        filter_call = store_qs.filter.call_args[0][0]
+        self.assertEqual(
+            str(filter_call), "(OR: ('deleted', True), ('hard_deleted', True))"
+        )
+
+        qs = self.model.objects.all.return_value
+        get_modified_store_mock.assert_called_once_with("test_transfer_session")
+        qs.filter.assert_called_once_with(pk__in=modified_store_ids)
+        get_assignments_mock.assert_called_once_with(qs.filter.return_value)
+
+    def test_find_removable_assignments__one_parameter(self):
+        with self.assertRaises(ValueError):
+            next(self.manager.find_removable_assignments())
+
+        with self.assertRaises(ValueError):
+            next(
+                self.manager.find_removable_assignments(
+                    dataset_id="test_dataset",
+                    transfer_session_id="test_transfer_session",
+                )
+            )

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -79,13 +79,15 @@ class ContentAssignmentManager(object):
         CONTENT_ASSIGNMENT_MANAGER_REGISTRY.update({model.__class__.__name__: self})
 
     @classmethod
-    def find_all_downloadable_assignments(cls, dataset_id=None, transfer_session_id=None):
+    def find_all_downloadable_assignments(
+        cls, dataset_id=None, transfer_session_id=None
+    ):
         """
         :param dataset_id: optional argument to filter assignments by dataset
         :param transfer_session_id:
         :rtype: list of ContentAssignment
         """
-        
+
         if dataset_id is None and transfer_session_id is None:
             raise ValueError("Either dataset_id or transfer_session_id is required")
 
@@ -105,9 +107,11 @@ class ContentAssignmentManager(object):
 
         if dataset_id is None and transfer_session_id is None:
             raise ValueError("Either dataset_id or transfer_session_id is required")
-        
+
         for manager in CONTENT_ASSIGNMENT_MANAGER_REGISTRY.values():
-            for assignment in manager.find_removable_assignments(dataset_id, transfer_session_id):
+            for assignment in manager.find_removable_assignments(
+                dataset_id, transfer_session_id
+            ):
                 yield assignment
 
     def _get_modified_store(self, transfer_session_id):
@@ -153,7 +157,6 @@ class ContentAssignmentManager(object):
                     )
                     contentnode_ids.update([contentnode_id])
 
-
     def find_downloadable_assignments(self, dataset_id=None, transfer_session_id=None):
         """
         :param dataset_id: optional dataset_id to filter records by
@@ -168,17 +171,18 @@ class ContentAssignmentManager(object):
                 Q(deleted=True) | Q(hard_deleted=True) | ~Q(deserialization_error="")
             )
             if modified_store.exists():
-                model_qs = model_qs.filter(pk__in=modified_store.values_list("id", flat=True))
+                model_qs = model_qs.filter(
+                    pk__in=modified_store.values_list("id", flat=True)
+                )
         elif dataset_id:
             model_qs = model_qs.filter(dataset_id=dataset_id)
         if self.filters:
             model_qs = model_qs.filter(**self.filters)
-        
+
         for assignment in self._get_assignments(model_qs):
             yield assignment
-    
-    
-    def find_removable_assignments(self, dataset_id, transfer_session_id):
+
+    def find_removable_assignments(self, dataset_id=None, transfer_session_id=None):
         """
         :param dataset_id: the ID of the dataset to filter records by dataset_id
         :param transfer_session_id: the ID of the transfer session to filter records by transfer_session_id

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -79,14 +79,19 @@ class ContentAssignmentManager(object):
         CONTENT_ASSIGNMENT_MANAGER_REGISTRY.update({model.__class__.__name__: self})
 
     @classmethod
-    def find_all_downloadable_assignments(cls, transfer_session_id):
+    def find_all_downloadable_assignments(cls, dataset_id=None, transfer_session_id=None):
         """
+        :param dataset_id: optional argument to filter assignments by dataset
         :param transfer_session_id:
         :rtype: list of ContentAssignment
         """
+        
+        if dataset_id is None and transfer_session_id is None:
+            raise ValueError("Either dataset_id or transfer_session_id is required")
+
         for manager in CONTENT_ASSIGNMENT_MANAGER_REGISTRY.values():
             for assignment in manager.find_downloadable_assignments(
-                transfer_session_id
+                dataset_id, transfer_session_id
             ):
                 yield assignment
 
@@ -143,25 +148,31 @@ class ContentAssignmentManager(object):
                     )
                     contentnode_ids.update([contentnode_id])
 
-    def find_downloadable_assignments(self, transfer_session_id):
+
+    def find_downloadable_assignments(self, dataset_id=None, transfer_session_id=None):
         """
-        :param transfer_session_id:
-        :return: yields ContentAssigment tuples
+        :param dataset_id: optional dataset_id to filter records by
+        :param transfer_session_id: optional transfer_session_id to filter records by transfer_session_id
+        :return: yields ContentAssignment tuples
         :rtype: list of ContentAssignment
         """
-        modified_store = self._get_modified_store(transfer_session_id).exclude(
-            Q(deleted=True) | Q(hard_deleted=True) | ~Q(deserialization_error="")
-        )
 
-        model_qs = self.model.objects.filter(
-            pk__in=modified_store.values_list("id", flat=True)
-        )
+        model_qs = self.model.objects.all()
+        if transfer_session_id:
+            modified_store = self._get_modified_store(transfer_session_id).exclude(
+                Q(deleted=True) | Q(hard_deleted=True) | ~Q(deserialization_error="")
+            )
+            if modified_store.exists():
+                model_qs = model_qs.filter(pk__in=modified_store.values_list("id", flat=True))
+        elif dataset_id:
+            model_qs = model_qs.filter(dataset_id=dataset_id)
         if self.filters:
             model_qs = model_qs.filter(**self.filters)
-
+        
         for assignment in self._get_assignments(model_qs):
             yield assignment
-
+    
+    
     def find_removable_assignments(self, transfer_session_id):
         """
         :param transfer_session_id:

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -62,7 +62,7 @@ def synchronize_content_requests(dataset_id, transfer_session=None):
     if transfer_session is None and dataset_id is None:
         raise ValueError("Either dataset_id or transfer_session_id is required")
 
-    assignments = ContentAssignmentManager.find_all_assignments(
+    assignments = ContentAssignmentManager.find_all_downloadable_assignments(
         dataset_id=dataset_id,
         transfer_session_id=transfer_session.id if transfer_session else None,
     )


### PR DESCRIPTION
## Summary
Refactors and feature upgrades for migration according to issue #10388 
1. Refactors all the `find_*_assignments` functions to allow **_transfer_session_id_** be optional.
2. Refactors `synchronize_content_requests` function to let **_transfer_session_id_** be nullable and 
3. A new function **_synchronize_content_requests_upgrade_** with functionality as mentioned in the above reference issue.

## Reviewer guidance
Follow the steps provide in #10388 

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
