### PR TITLE
set side nav submenus to 14px

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -104,6 +104,7 @@
                   :subRoutes="component.routes"
                   :link="component.url"
                   :icon="component.icon"
+                  style="font-size: 20px;"
                   data-test="side-nav-component"
                 />
                 <LogoutSideNavEntry v-if="showLogout" />
@@ -619,6 +620,16 @@
   .logo {
     max-width: 100%;
     height: auto;
+  }
+
+  /deep/ .link[data-v-e1ce0d72] {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    height: 44px;
+    margin: 0 40px;
+    font-size: 14px;
+    text-decoration: none;
   }
 
 </style>


### PR DESCRIPTION


## Summary
This PR standardizes the font size of side nav sub menus to 14px

…

## References
#10608
…


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
