### PR TITLE
Ensure jobs migration works properly on Postgresql

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -127,10 +127,6 @@ class Storage(object):
         scheduledjobs_table.drop(engine, checkfirst=True)
         Base.metadata.create_all(engine)
 
-    def recreate_tables(self):
-        self.Base.metadata.drop_all(self.engine)
-        self.Base.metadata.create_all(self.engine)
-
     def set_sqlite_pragmas(self):
         """
         Sets the connection PRAGMAs for the sqlalchemy engine stored in self.engine.

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -11,6 +11,7 @@ from sqlalchemy import Integer
 from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import String
+from sqlalchemy import Table
 from sqlalchemy import update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.declarative import declarative_base
@@ -114,6 +115,17 @@ class Storage(object):
                 connection.execute(select(ORMJob).where(ORMJob.id == job_id)).fetchone()
                 is not None
             )
+
+    @staticmethod
+    def recreate_default_tables(engine):
+        """
+        Recreates the default tables for the job storage backend.
+        """
+        Base.metadata.drop_all(engine)
+        scheduledjobs_base = declarative_base()
+        scheduledjobs_table = Table("scheduledjobs", scheduledjobs_base.metadata)
+        scheduledjobs_table.drop(engine, checkfirst=True)
+        Base.metadata.create_all(engine)
 
     def recreate_tables(self):
         self.Base.metadata.drop_all(self.engine)

--- a/kolibri/core/tasks/upgrade.py
+++ b/kolibri/core/tasks/upgrade.py
@@ -5,7 +5,8 @@ import logging
 
 from sqlalchemy.exc import OperationalError
 
-from kolibri.core.tasks.main import job_storage
+from kolibri.core.tasks.main import connection
+from kolibri.core.tasks.storage import Storage
 from kolibri.core.upgrade import version_upgrade
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ def drop_old_iceqube_tables():
     and let iceqube reinitialize the tables from scratch.
     """
     try:
-        job_storage.recreate_tables()
+        Storage.recreate_default_tables(connection)
     except OperationalError:
         logger.warning(
             "Could not recreate job storage table. This is probably because the database already exists and did not need to be recreated."

--- a/kolibri/utils/sanity_checks.py
+++ b/kolibri/utils/sanity_checks.py
@@ -120,12 +120,14 @@ def check_database_is_migrated():
 
 def ensure_job_tables_created():
     from kolibri.core.tasks.main import job_storage
+    from kolibri.core.tasks.main import connection
+    from kolibri.core.tasks.storage import Storage
 
     try:
         job_storage.test_table_readable()
     except (SQLAlchemyOperationalError, SQLAlchemyProgrammingError):
         logger.warning("Database table for job storage was not accessible, recreating.")
-        job_storage.recreate_tables()
+        Storage.recreate_default_tables(connection)
     except Exception as e:
         raise DatabaseInaccessible(db_exception=e)
 

--- a/kolibri/utils/tests/test_sanity_check.py
+++ b/kolibri/utils/tests/test_sanity_check.py
@@ -55,18 +55,20 @@ class SanityCheckTestCase(TestCase):
             with self.assertRaises(DatabaseNotMigrated):
                 sanity_checks.check_database_is_migrated()
 
-    def test_ensure_job_tables_created_operational_error(self):
+    @patch("kolibri.core.tasks.storage.Storage")
+    def test_ensure_job_tables_created_operational_error(self, Storage):
         with patch("kolibri.core.tasks.main.job_storage") as job_storage:
             job_storage.test_table_readable.side_effect = SQLAlchemyOperationalError(
                 "Test", "", ""
             )
             sanity_checks.ensure_job_tables_created()
-            job_storage.recreate_tables.assert_called_once()
+            Storage.recreate_default_tables.assert_called_once()
 
-    def test_ensure_job_tables_created_programming_error(self):
+    @patch("kolibri.core.tasks.storage.Storage")
+    def test_ensure_job_tables_created_programming_error(self, Storage):
         with patch("kolibri.core.tasks.main.job_storage") as job_storage:
             job_storage.test_table_readable.side_effect = SQLAlchemyProgrammingError(
                 "Test", "", ""
             )
             sanity_checks.ensure_job_tables_created()
-            job_storage.recreate_tables.assert_called_once()
+            Storage.recreate_default_tables.assert_called_once()


### PR DESCRIPTION
## Summary

With this PR:

- `Storage` is not instantiated during upgrade to avoid circular problems
- In case the old `scheduledjobs` table exists, it's dropped

## References

Closes: #10666 

## Reviewer guidance

Test if it works properly both in Postgresql, with or without the scheduledjobs table from previous kolibri versions in the database.
To help reviewing, 
[this is a old sqlite jobs db](https://github.com/learningequality/kolibri/files/11435433/job_storage.zip)  containing `scheduledjobs`


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
