### PR TITLE
fix device limitations modal

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
@@ -182,7 +182,7 @@
             !importedUserIsAdmin &&
             this.coreString('coachLabel').toLocaleLowerCase(currentLanguage),
           device: this.device.name,
-        }
+        };
 
         if (importedUserIsAdmin) {
           return this.$tr('deviceLimitationsAdminsMessage', messageArgs);


### PR DESCRIPTION
## Summary
This PR updates the "device limitations" modal, which can appear during individual user import when you're attempting to import an admin or coach from an existing facility on to a fresh device. Previously, the modal only had one button, `Cancel`, which ended up initiating the import process despite its intended functionality & user-facing label. Attempting to import a coach would result in an error because of a variable being referenced in the message string was missing, and an admin-specific message was available but not displayed to the user. 

This PR adds an `Import` option to the "Device limitations" modal, adjusts the BE to accept user imports outside of learners at this endpoint, adds the variable needed for the "coach" message to be rendered, and adds conditionality to allow for the rendering of the "admin"-specific message when appropriate

`TODO`: address subsequent issue of users being imported despite "cancel" being selected -- likely related to the process in which we initially get a certificate corresponding to the selected user from the remote server and store it locally, but this certificate is not locally removed upon "cancel": #10675  

**before**
<img width="613" alt="QA screenshot from issue" src="https://github.com/learningequality/kolibri/assets/43046460/b29fe844-d3c7-46b0-9781-eca2331dee6b">


**after**

_coach_
<img width="778" alt="coach device limitations modal message" src="https://github.com/learningequality/kolibri/assets/43046460/6e82872b-ffb5-48e4-984e-50a41a1743cf">


_admin_
<img width="756" alt="admin device limitations modal message" src="https://github.com/learningequality/kolibri/assets/43046460/700e975d-9249-4305-a64e-c8634d13e2d9">


## References
fixes #9495 

## Reviewer guidance
_additional details may be found in #9495_
- create a user on a remote facility with "coach" or "admin" permissions
- on a fresh learn-only device, choose to import an individual account and enter the user's credentials
- upon selecting "continue," you should remain on the same page and the "device limitations" modal should render, correctly displaying the details of your user's username and role. 
- "Import" should bring you to the next step of the setup wizard, where you can choose to finish the process and will be logged in as the user you selected
- "Cancel" should dismiss the modal and keep you on the import individual user page
----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
