### PR TITLE
Fixes setup wizard back bug

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -331,7 +331,7 @@ export const wizardMachine = createMachine(
             meta: { route: { name: 'LOD_SETUP_TYPE' } },
             on: {
               // #<name> points to a state w/ an `id` property; wizard is the root
-              BACK: { target: '#wizard.fullOrLearnOnlyDevice', actions: 'clearFullOrLOD' },
+              BACK: { target: '#wizard.fullOrLearnOnlyDevice' },
               CONTINUE: {
                 target: 'selectLodFacility',
                 actions: 'setLodType',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
@@ -33,7 +33,7 @@
     mixins: [commonCoreStrings],
     data() {
       return {
-        value: this.wizardService.state.context.deviceName,
+        value: this.wizardService.state.context['deviceName'],
         shouldValidate: false,
       };
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -23,7 +23,6 @@
 
 <script>
 
-  import get from 'lodash/get';
   import OnboardingStepBase from '../OnboardingStepBase';
 
   const Options = Object.freeze({
@@ -38,7 +37,7 @@
     },
     inject: ['wizardService'],
     data() {
-      const selected = get(this, 'wizardService.context.setupType', Options.FULL);
+      const selected = this.wizardService.state.context['fullOrLOD'] || Options.FULL;
       return {
         Options,
         selected,

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -36,8 +36,9 @@
     mixins: [commonSyncElements],
     inject: ['wizardService'],
     data() {
+      const selected = this.wizardService.state.context['onMyOwnOrGroup'] || UsePresets.ON_MY_OWN;
       return {
-        selected: UsePresets.ON_MY_OWN,
+        selected,
       };
     },
     computed: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -41,9 +41,10 @@
     },
     inject: ['wizardService'],
     data() {
+      const selected = this.wizardService.state.context['importOrNew'] || Options.NEW;
       return {
         Options,
-        selected: Options.NEW,
+        selected,
         showSelectAddressModal: false,
       };
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -126,7 +126,7 @@
           allow_guest_access: Boolean(this.wizardContext('guestAccess')),
           is_provisioned: true,
           os_user: checkCapability('get_os_user'),
-          is_soud: this.wizardService.state.context.fullOrLOD === DeviceTypePresets.LOD,
+          is_soud: this.wizardContext('fullOrLOD') === DeviceTypePresets.LOD,
         };
 
         // Remove anything that is `null` value


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr enables setup wizard forms to fully remember previously input  fields. On click back, a user is presented with data they input previously. Please see this [slack thread](https://learningequality.slack.com/archives/CB37UM23A/p1683643033552649) for more information regarding the fix

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #https://github.com/learningequality/kolibri/issues/10528

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Set up Kolibri using the Setup Wizard.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
