### PR TITLE
Updates facility sync and register workflow

### DIFF
--- a/kolibri/core/assets/src/views/sync/ConfirmationRegisterModal.vue
+++ b/kolibri/core/assets/src/views/sync/ConfirmationRegisterModal.vue
@@ -57,7 +57,7 @@
           : this.coreString('cancelAction');
       },
       registerText() {
-        return this.alreadyRegistered ? null : this.coreString('register');
+        return this.alreadyRegistered ? null : this.coreString('registerAction');
       },
     },
     methods: {

--- a/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
+++ b/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
@@ -2,11 +2,6 @@
 
   <KModal
     :title="registerFacility.$tr('registerFacility')"
-    :submitText="coreString('continueAction')"
-    :cancelText="coreString('cancelAction')"
-    :submitDisabled="submitting"
-    @submit="validateToken"
-    @cancel="closeModal"
   >
     <p>{{ $tr('enterToken') }}</p>
     <KTextbox
@@ -18,6 +13,29 @@
       :invalidText="$tr('invalidToken')"
       @input="invalid = false"
     />
+    <template #actions>
+      <KButton
+        :text="coreString('cancelAction')"
+        appearance="flat-button"
+        class="kbuttons"
+        @click="closeModal"
+      />
+      <KButton
+        v-if="displaySkipOption"
+        :text="skip.$tr('skipAction')"
+        appearance="raised-button"
+        class="kbuttons"
+        @click="skipRegister"
+      />
+      <KButton
+        :text="coreString('continueAction')"
+        appearance="raised-button"
+        primary
+        :disabled="submitting || !token"
+        @click="validateToken"
+      />
+
+    </template>
   </KModal>
 
 </template>
@@ -30,22 +48,39 @@
   import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
   import { PortalResource } from 'kolibri.resources';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import GettingStartedFormAlt from '../../../../../plugins/setup_wizard/assets/src/views/onboarding-forms/GettingStartedFormAlt.vue';
   import ConfirmationRegisterModal from './ConfirmationRegisterModal';
 
   export default {
     name: 'RegisterFacilityModal',
     mixins: [commonCoreStrings],
+    props: {
+      displaySkipOption: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
+      facility: {
+        type: Object,
+        required: false,
+        default: () => ({}),
+      },
+    },
     data() {
       return {
         submitting: false,
         token: null,
         invalid: false,
         registerFacility: crossComponentTranslator(ConfirmationRegisterModal),
+        skip: crossComponentTranslator(GettingStartedFormAlt),
       };
     },
     methods: {
       closeModal() {
         this.$emit('cancel');
+      },
+      skipRegister() {
+        this.$emit('skip', this.facility);
       },
       validateToken() {
         // TODO synchronously handle empty strings
@@ -97,5 +132,9 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
+
+  .kbuttons {
+    margin-right: 10px;
+  }
 
 </style>

--- a/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
+++ b/kolibri/core/assets/src/views/sync/SyncFacilityModalGroup.vue
@@ -49,13 +49,14 @@
     },
     data() {
       return {
-        step: this.facilityForSync.dataset.registered ? Steps.SELECT_SOURCE : Steps.SELECT_ADDRESS,
+        step: null,
         syncSubmitDisabled: false,
+        displaySkipOption: true,
       };
     },
     computed: {
       atSelectSource() {
-        return this.step === Steps.SELECT_SOURCE;
+        return !this.step;
       },
       atSelectAddress() {
         return this.step === Steps.SELECT_ADDRESS;
@@ -66,40 +67,21 @@
         if (data.source === 'PEER') {
           this.step = Steps.SELECT_ADDRESS;
         } else {
-          this.startKdpSync();
+          if (this.facilityForSync.dataset.registered) {
+            this.$emit('syncKDP', this.facilityForSync);
+          } else {
+            this.$emit('register', this.displaySkipOption, this.facilityForSync);
+          }
         }
       },
       handleAddressSubmit(data) {
         if (!data.device_name) {
           data.device_name = data.nickname;
         }
-        this.startPeerSync(data);
+        this.$emit('syncPeer', data, this.facilityForSync);
       },
       closeModal() {
         this.$emit('close');
-      },
-      startKdpSync() {
-        this.syncSubmitDisabled = true;
-        this.startKdpSyncTask(this.facilityForSync.id)
-          .then(task => {
-            this.$emit('success', task.id);
-          })
-          .catch(() => {
-            this.$emit('failure');
-          });
-      },
-      startPeerSync(peerData) {
-        this.syncSubmitDisabled = true;
-        this.startPeerSyncTask({
-          facility: this.facilityForSync.id,
-          device_id: peerData.id,
-        })
-          .then(task => {
-            this.$emit('success', task.id);
-          })
-          .catch(() => {
-            this.$emit('failure');
-          });
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/facilityTasksQueue.js
@@ -8,7 +8,7 @@ function isSyncTask(task) {
 }
 
 function taskFacilityMatch(task, facility) {
-  return task.facility === facility.id;
+  return task.facility_id === facility.id;
 }
 
 export default {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -67,7 +67,7 @@
                     <CoreMenuOption
                       :style="{ 'cursor': 'pointer', textAlign: 'left' }"
                       :label="$tr('register')"
-                      @select="handleRegister(false)"
+                      @select="handleRegister()"
                     />
                   </template>
                 </CoreMenu>
@@ -267,7 +267,7 @@
       },
       handleRegister(displaySkipOption) {
         this.closeMenu();
-        this.displaySkipOption = displaySkipOption;
+        this.displaySkipOption = Boolean(displaySkipOption);
         this.displayModal(Modals.REGISTER_FACILITY);
       },
       handleKDPSync() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pr updates the usage flow for syncing and registering facilities in Kolibri. Previously, unregistered facilities could not sync to KDP, however sometimes the facility is registered already on the KDP side, and the local device doesn’t know until it syncs. 
- Updates `RegisterFacilityModal` to include boolean property `displaySkipOption` and `facility` obj so that when skip button is pressed, the facility can still sync to KDP.
- Removes conditional statement that prevents the `Select a Source` modal from appearing if facility is not registered within `SyncFacilityModalGroup`.
- Updates `FacilitiesPage` and `SyncInterface` to handle KDP and Peer syncs instead of within `SyncFacilityModalGroup`.
- Updates `SyncInterface` to use `useKResponsiveWindow` and updates margin for more spacing within Kolibri app.


Before:

If the facility is registered, the `Register` menu option is disabled, but should not be.
<img width="1440" alt="Screenshot 2023-05-10 at 2 07 24 PM" src="https://github.com/learningequality/kolibri/assets/46411498/1d674c15-5e27-498f-a187-ab333f553b87">

`SyncInterface` buttons cut off within Kolibri app
<img width="1085" alt="Screenshot 2023-05-10 at 2 24 44 PM" src="https://github.com/learningequality/kolibri/assets/46411498/9ea67350-a829-4f24-9d5c-b48eb508dd8b">

After:
<img width="720" alt="registeredFacilityAfter" src="https://github.com/learningequality/kolibri/assets/46411498/1b33b496-01e0-47be-b3d1-b4b06feecd2c">

![syncFacilityAfter](https://github.com/learningequality/kolibri/assets/46411498/b40d6b2e-e9fc-40be-95df-e8f25720d254)


<img width="1091" alt="Screenshot 2023-05-10 at 2 26 29 PM" src="https://github.com/learningequality/kolibri/assets/46411498/918183d0-ae0a-4d10-a8e9-87867dd0b94c">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #10446 
[Relevant thread for updated workflow](https://github.com/learningequality/kolibri/issues/9090#issuecomment-1099712143)
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3630343766363338353234383366666433643764333461312f64633062313434312d306335322d343039612d623461352d363530626237616632353663](https://github.com/learningequality/kolibri/assets/46411498/d8309508-57a3-4475-9e58-c5cda00ac490)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Navigate to Facility > Data and scroll to bottom.
2. Press `sync` button, `Select a Source` modal should appear.
3. Select KDP option and press continue.
4. Confirm that `RegisterFacilityModal` is then displayed with the options to cancel, skip, or continue.
5. Press the three dots beside the sync button and  select the menu option Register.
6. Confirm that the option to skip is not displayed within `RegisterFacilityModal`.
7. Navigate to Device > Facilities and follow the same workflow.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
