### PR TITLE
fix title string on "Select learning facility" page

### DIFF
--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue
@@ -86,7 +86,7 @@
     name: 'SelectFacility',
     metaInfo() {
       return {
-        title: this.profileString('documentTitle'),
+        title: this.getCommonSyncString('selectFacilityTitle'),
       };
     },
     components: { AddDeviceForm, BottomAppBar },


### PR DESCRIPTION
## Summary

The string for the title of the "Select learning facility" page was removed from `SelectFacility.vue` during refactoring and the replacement string wasn't quite configured correctly, leading to broken page title. Before refactoring, the document title was `"Select learning facility"`. This same string is currently located in `commonSyncElements`, so is now accessed through there as of this PR.

**before**
<img width="697" alt="Screen Shot 2023-05-10 at 5 20 41 PM" src="https://github.com/learningequality/kolibri/assets/43046460/037a1eb0-3179-4c18-ac72-c980d0fbce36">

**after**
<img width="670" alt="Screen Shot 2023-05-10 at 5 22 16 PM" src="https://github.com/learningequality/kolibri/assets/43046460/a579f46d-947d-4d2e-b3e0-92ee28f72271">


## References
Addresses #10568

## Reviewer guidance
- user with an "on my own" kolibri setup
- `Profile` > `Change learning facility` > `Change` brings you to "Select learning facility" step
- the page title visible in the browser tab should be "Select learning facility"

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
