### PR TITLE
Add filename to the path to upgrade options

### DIFF
--- a/kolibri/core/content/management/commands/content.py
+++ b/kolibri/core/content/management/commands/content.py
@@ -137,7 +137,8 @@ class Command(BaseCommand):
         Update kolibri_settings.json in KOLIBRI_HOME so that the variable
         CONTENT_DIRECTORY points to the destination content directory.
         """
-        update_options_file("Paths", "CONTENT_DIR", dst, KOLIBRI_HOME)
+        ini_path = os.path.join(KOLIBRI_HOME, "options.ini")
+        update_options_file("Paths", "CONTENT_DIR", dst, ini_path)
 
         self.stdout.write(
             self.style.SUCCESS("\nCurrent content directory is {}".format(dst))


### PR DESCRIPTION
## Summary
Pass the actual `options.ini `filepath to the function to upgrade options after content has moved in the content command

Note: this error is happening in kolibri >= 0.15.x, so in case a new patch release of 0.15.x is done, it should be included there as well.

## References
Closes: #10112

## Reviewer guidance
Check that executing:

`kolibri manage content movedirectory wherever_path`
works properly and updates accordingly current `options.ini` file

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
