### PR TITLE
Demote custom ePub viewer text alignment style

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -288,7 +288,7 @@
           color: `${this.textColor}!important`,
         };
         const alignmentStyle = {
-          'text-align': `${this.isRtl ? 'right' : 'left'}!important`,
+          'text-align': `${this.isRtl ? 'right' : 'left'}`,
         };
         const fontSizeStyle = this.fontSize ? { 'font-size': `${this.fontSize}!important` } : {};
 


### PR DESCRIPTION
## Summary

In the same line of reasoning that of the previous commit, the text-alignment CSS selector was affecting ePub files in places where it shouldn't, and making them left or right align text that is supposed to be centered. We can't simply remove the CSS selector since it would regress the small screen case.

Remove the `!important` mark from the CSS selector that affects text alignment.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
