### PR TITLE
Changes data prop progress to a computed prop for reactivity

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
@@ -49,14 +49,12 @@
         default: false,
       },
     },
-    data() {
-      return {
-        title: this.quiz ? this.quiz.title : '',
-      };
-    },
     computed: {
       progress() {
         return this.quiz ? this.quiz.progress : undefined;
+      },
+      title() {
+        return this.quiz ? this.quiz.title : '';
       },
       inProgressLabel() {
         if (!this.progress) {

--- a/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/QuizCard/index.vue
@@ -51,11 +51,13 @@
     },
     data() {
       return {
-        progress: this.quiz ? this.quiz.progress : undefined,
         title: this.quiz ? this.quiz.title : '',
       };
     },
     computed: {
+      progress() {
+        return this.quiz ? this.quiz.progress : undefined;
+      },
       inProgressLabel() {
         if (!this.progress) {
           return '';


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr changes the data property `progress` within the component `QuizCard` into a computed property instead. Previously `progress` was not updating when the `quiz` object was updated because when a prop is assigned to a value in data, only the prop's value is used to initialize it, so the `progress` data prop was only updated when the page was reloaded.

Before


https://github.com/learningequality/kolibri/assets/46411498/8d921ed9-1ee1-4516-9c47-04a646ed295b



After


https://github.com/learningequality/kolibri/assets/46411498/7e6c5c20-e769-4705-8e74-8f4f16d621f1


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10589 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Assign quizzes to a learner on a learn-only device.
2. Complete a quiz as the learner.
3. Quiz score should be updated without reloading the page.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
