### PR TITLE
Logging configuration improvements

### DIFF
--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -318,7 +318,8 @@ def get_base_logging_config(LOG_ROOT, debug=False, debug_database=False):
     config = get_default_logging_config(
         LOG_ROOT, debug=debug, debug_database=debug_database
     )
-    config["filters"]["require_debug_true"] = {"()": get_require_debug_true(debug)}
+    filters = config.setdefault("filters", {})
+    filters["require_debug_true"] = {"()": get_require_debug_true(debug)}
 
     return config
 
@@ -333,10 +334,11 @@ def get_logging_config(LOG_ROOT, debug=False, debug_database=False):
         LOG_ROOT, debug=debug, debug_database=debug_database
     )
 
-    config["filters"]["require_debug_false"] = {
-        "()": "django.utils.log.RequireDebugFalse"
-    }
-    config["handlers"].update(
+    filters = config.setdefault("filters", {})
+    filters["require_debug_false"] = {"()": "django.utils.log.RequireDebugFalse"}
+
+    handlers = config.setdefault("handlers", {})
+    handlers.update(
         {
             "mail_admins": {
                 "level": "ERROR",
@@ -346,7 +348,9 @@ def get_logging_config(LOG_ROOT, debug=False, debug_database=False):
         }
     )
     # Add the mail_admins handler
-    config["loggers"]["kolibri"]["handlers"].append("mail_admins")
-    config["loggers"]["django"]["handlers"].append("mail_admins")
-    config["loggers"]["django.request"]["handlers"].append("mail_admins")
+    loggers = config.setdefault("loggers", {})
+    for name in ("kolibri", "django", "django.request"):
+        admin_logger = loggers.setdefault(name, {})
+        admin_logger_handlers = admin_logger.setdefault("handlers", [])
+        admin_logger_handlers.append("mail_admins")
     return config

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -261,11 +261,6 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "handlers": DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
             },
-            "kolibri": {
-                "handlers": DEFAULT_HANDLERS,
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
-            },
             "cherrypy.access": {
                 "handlers": [] if DISABLE_REQUEST_LOGGING else DEFAULT_HANDLERS,
                 "level": DEFAULT_LEVEL,
@@ -275,35 +270,14 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
             # We should introduce custom debug log levels or log
             # targets, i.e. --debug-level=high
             "kolibri.core.tasks.worker": {
-                "handlers": DEFAULT_HANDLERS,
                 "level": "INFO",
-                "propagate": False,
-            },
-            "morango": {
-                "handlers": DEFAULT_HANDLERS,
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
-            },
-            "django": {
-                "handlers": DEFAULT_HANDLERS,
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
             },
             "django.db.backends": {
-                "handlers": DEFAULT_HANDLERS,
                 "level": DATABASE_LEVEL,
-                "propagate": False,
-            },
-            "django.request": {
-                "handlers": DEFAULT_HANDLERS,
-                "level": DEFAULT_LEVEL,
-                "propagate": False,
             },
             "django.template": {
-                "handlers": DEFAULT_HANDLERS,
                 # Django template debug is very noisy, only log INFO and above.
                 "level": "INFO",
-                "propagate": False,
             },
         },
     }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

While trying to customize logging in our Kolibri application, I noticed that the way the logging configuration is constructed could be improved. There should be no functional change, but it does allow monkeypatching `kolibri.utils.logger.get_default_logging_config` more easily.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

This came from a discussion with @rtibbles about how to customize Kolibri logging. He suggested that the only way to have full control over logging would be to monkeypatch the Kolibri logging config functions. Attempting to do so worked, but the substituted default configuration needed to do more than expected to comply with how it's used in Kolibri.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To test, run the server with `kolibri start --foreground` and check that the logging output is the same as before.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
