### PR TITLE
sets side nav submenus to remain active onclick

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -158,9 +158,10 @@
     },
     methods: {
       isActiveLink(route) {
+        const hash = window.location.hash;
         return (
-          this.standarizeSubPathRoutes('#' + route) === `${window.location.hash}` ||
-          window.location.hash.includes(this.checkClassIdInString(route))
+          this.standarizeSubPathRoutes('#' + route) === `${hash}` ||
+          hash.includes(this.checkClassIdInString(route))
         );
       },
       submenuShouldBeOpen() {

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -158,7 +158,11 @@
     },
     methods: {
       isActiveLink(route) {
-        return `${this.link}#${route}` === `${window.location.pathname}${window.location.hash}`;
+        // return `${this.link}#${route}` === `${window.location.pathname}${window.location.hash}`;
+        return (
+          this.standarizeSubPathRoutes('#' + route) === `${window.location.hash}` ||
+          window.location.hash.includes(this.checkClassIdInString(route))
+        );
       },
       submenuShouldBeOpen() {
         if (this.subRoutes && this.subRoutes.length > 0) {
@@ -204,6 +208,22 @@
           return;
         }
         this.$emit('select');
+      },
+      standarizeSubPathRoutes(link) {
+        var subRoutePath = link.replace(/\/:[^/]*\??/, '');
+        return subRoutePath;
+      },
+
+      // for special cases, like the classId in the coach, where the id is required
+      //which bring thr change in the url, this function will handle the change in the url
+      // to match it with the actual url route in the browser
+      checkClassIdInString(str) {
+        const classId = 'classId';
+        const regex = new RegExp(`\\b${classId}\\b`, 'i');
+        if (regex.test(str)) {
+          console.log(str.replace('/:classId', ''));
+          return str.replace('/:classId', '');
+        }
       },
     },
   };

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -158,7 +158,6 @@
     },
     methods: {
       isActiveLink(route) {
-        // return `${this.link}#${route}` === `${window.location.pathname}${window.location.hash}`;
         return (
           this.standarizeSubPathRoutes('#' + route) === `${window.location.hash}` ||
           window.location.hash.includes(this.checkClassIdInString(route))
@@ -214,14 +213,12 @@
         return subRoutePath;
       },
 
-      // for special cases, like the classId in the coach, where the id is required
-      //which bring thr change in the url, this function will handle the change in the url
-      // to match it with the actual url route in the browser
+      // changes urls that contain IDs
+      // to match with the actual url route in the browser
       checkClassIdInString(str) {
         const classId = 'classId';
         const regex = new RegExp(`\\b${classId}\\b`, 'i');
         if (regex.test(str)) {
-          console.log(str.replace('/:classId', ''));
           return str.replace('/:classId', '');
         }
       },

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -51,9 +51,10 @@
         <div class="link-container">
           <KRouterLink
             v-if="isActive"
-            :class="$computedClass(subpathStyles(subRoute.route))"
+            :class="$computedClass(subpathStyles(generateNavRoute(subRoute.route)))"
             :text="subRoute.label"
-            :to="generateTo(subRoute.name,$route.params)"
+            class="link"
+            :to="$router.getRoute(subRoute.name,$route.params,$router.query)"
             appearance="basic-link"
           />
           <a
@@ -166,7 +167,8 @@
     },
     methods: {
       isActiveLink(route) {
-        return `${this.link}#${route}` === `${window.location.pathname}${window.location.hash}`;
+        const full_path = !route.includes('#') ? `${this.link}#${route}` : route;
+        return `${window.location.pathname}${window.location.hash}`.includes(full_path);
       },
       submenuShouldBeOpen() {
         if (this.subRoutes && this.subRoutes.length > 0) {
@@ -213,9 +215,6 @@
         }
         this.$emit('select');
       },
-      generateTo(name, params) {
-        return this.$router.getRoute(name, params);
-      },
     },
   };
 
@@ -254,6 +253,10 @@
     margin: 0 40px;
     font-size: 14px;
     text-decoration: none;
+
+    /deep/ .link-text {
+      text-decoration: none !important;
+    }
   }
 
   .nav-menu-item {

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -52,8 +52,8 @@
           <KRouterLink
             v-if="isActive"
             :class="$computedClass(subpathStyles(subRoute.route))"
-            :text="coreString('subRoute.label')"
-            :to=" $router.generateTo(subRoute.label,$route.params )"
+            :text="subRoute.label"
+            :to="generateTo(subRoute.name,$route.params)"
             appearance="basic-link"
           />
           <a
@@ -68,6 +68,7 @@
         </div>
       </div>
     </div>
+
   </div>
 
 </template>
@@ -117,19 +118,6 @@
       };
     },
     computed: {
-      // // activeClass() {
-      //   return {
-      //     color: black,
-      //     fontWeight: 'bold',
-      //     margin: '8px',
-      //     textDecoration: 'none',
-      //     backgroundColor: this.$themeBrand.primary.v_50,
-      //     ':hover': {
-      //       backgroundColor: this.$themeBrand.primary.v_100,
-      //     },
-      //     ':focus': this.$coreOutline,
-      //   };
-      // },
       isActive() {
         return window.location.pathname == this.link;
       },
@@ -178,11 +166,7 @@
     },
     methods: {
       isActiveLink(route) {
-        const hash = window.location.hash;
-        return (
-          this.standarizeSubPathRoutes('#' + route) === hash ||
-          hash.includes(this.checkClassIdInString(route))
-        );
+        return `${this.link}#${route}` === `${window.location.pathname}${window.location.hash}`;
       },
       submenuShouldBeOpen() {
         if (this.subRoutes && this.subRoutes.length > 0) {
@@ -194,14 +178,11 @@
       },
       subpathStyles(route) {
         if (this.isActiveLink(route)) {
-          // console.log(this.$router.currentRoute.path);
-          if (route === this.$router.currentRoute.path) {
-            return {
-              color: this.$themeTokens.primaryDark,
-              fontWeight: 'bold',
-              textDecoration: 'none',
-            };
-          }
+          return {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+            textDecoration: 'none',
+          };
         }
         return {
           color: this.$themeTokens.text,
@@ -232,36 +213,8 @@
         }
         this.$emit('select');
       },
-      standarizeSubPathRoutes(link) {
-        var subRoutePath = link.replace(/\/:[^/]*\??/, '');
-        return subRoutePath;
-      },
-      // getRoute(name, params) {
-      // this.isActiveLink(name);
-      // console.log(name);
-      // console.log(route);
-      // if(route.includes("classId")){
-      //   const navigationLink = this.standarizeSubPathRoutes(route).toLowerCase();
-      //   return {path: navigationLink, params: {classId: this.$route.params.classId}};
-      // }else{
-      //   return {path: name};
-      // }
-      // return { path: name, params: params };
-      // },
-      // routeStyle(route) {
-      //   if (this.isActiveLink(route)) {
-      //     return this.activeClass;
-      //   }
-      // },
-
-      // changes urls that contain IDs
-      // to match with the actual url route in the browser
-      checkClassIdInString(str) {
-        const classId = 'classId';
-        const regex = new RegExp(`\\b${classId}\\b`, 'i');
-        if (regex.test(str)) {
-          return str.replace('/:classId', '');
-        }
+      generateTo(name, params) {
+        return this.$router.getRoute(name, params);
       },
     },
   };
@@ -279,6 +232,7 @@
     margin: 4px 8px;
     font-size: 16px;
     text-decoration: none;
+    cursor: pointer;
     border-radius: $radius;
     outline-offset: -1px; // override global styles
     transition: background-color $core-time ease;

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -49,7 +49,15 @@
     <div v-if="visibleSubMenu">
       <div v-for="subRoute in subRoutes" :key="subRoute.label">
         <div class="link-container">
+          <KRouterLink
+            v-if="isActive"
+            :class="$computedClass(subpathStyles(subRoute.route))"
+            :text="coreString('subRoute.label')"
+            :to=" $router.generateTo(subRoute.label,$route.params )"
+            appearance="basic-link"
+          />
           <a
+            v-else
             :href="generateNavRoute(subRoute.route)"
             class="link"
             :class="$computedClass(subpathStyles(subRoute.route))"
@@ -60,7 +68,6 @@
         </div>
       </div>
     </div>
-
   </div>
 
 </template>
@@ -110,6 +117,19 @@
       };
     },
     computed: {
+      // // activeClass() {
+      //   return {
+      //     color: black,
+      //     fontWeight: 'bold',
+      //     margin: '8px',
+      //     textDecoration: 'none',
+      //     backgroundColor: this.$themeBrand.primary.v_50,
+      //     ':hover': {
+      //       backgroundColor: this.$themeBrand.primary.v_100,
+      //     },
+      //     ':focus': this.$coreOutline,
+      //   };
+      // },
       isActive() {
         return window.location.pathname == this.link;
       },
@@ -174,11 +194,14 @@
       },
       subpathStyles(route) {
         if (this.isActiveLink(route)) {
-          return {
-            color: this.$themeTokens.primaryDark,
-            fontWeight: 'bold',
-            textDecoration: 'none',
-          };
+          // console.log(this.$router.currentRoute.path);
+          if (route === this.$router.currentRoute.path) {
+            return {
+              color: this.$themeTokens.primaryDark,
+              fontWeight: 'bold',
+              textDecoration: 'none',
+            };
+          }
         }
         return {
           color: this.$themeTokens.text,
@@ -213,6 +236,23 @@
         var subRoutePath = link.replace(/\/:[^/]*\??/, '');
         return subRoutePath;
       },
+      // getRoute(name, params) {
+      // this.isActiveLink(name);
+      // console.log(name);
+      // console.log(route);
+      // if(route.includes("classId")){
+      //   const navigationLink = this.standarizeSubPathRoutes(route).toLowerCase();
+      //   return {path: navigationLink, params: {classId: this.$route.params.classId}};
+      // }else{
+      //   return {path: name};
+      // }
+      // return { path: name, params: params };
+      // },
+      // routeStyle(route) {
+      //   if (this.isActiveLink(route)) {
+      //     return this.activeClass;
+      //   }
+      // },
 
       // changes urls that contain IDs
       // to match with the actual url route in the browser

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -160,7 +160,7 @@
       isActiveLink(route) {
         const hash = window.location.hash;
         return (
-          this.standarizeSubPathRoutes('#' + route) === `${hash}` ||
+          this.standarizeSubPathRoutes('#' + route) === hash ||
           hash.includes(this.checkClassIdInString(route))
         );
       },

--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -167,8 +167,8 @@
     },
     methods: {
       isActiveLink(route) {
-        const full_path = !route.includes('#') ? `${this.link}#${route}` : route;
-        return `${window.location.pathname}${window.location.hash}`.includes(full_path);
+        const fullPath = !route.includes('#') ? `${this.link}#${route}` : route;
+        return `${window.location.pathname}${window.location.hash}`.includes(fullPath);
       },
       submenuShouldBeOpen() {
         if (this.subRoutes && this.subRoutes.length > 0) {

--- a/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.js
+++ b/kolibri/plugins/coach/assets/src/views/CoachSideNavEntry.js
@@ -15,14 +15,17 @@ const sideNavConfig = {
       {
         label: coreStrings.$tr('classHome'),
         route: baseRoutes.classHome.path,
+        name: baseRoutes.classHome.name,
       },
       {
         label: coachStrings.$tr('reportsLabel'),
         route: baseRoutes.reports.path,
+        name: baseRoutes.reports.name,
       },
       {
         label: coachStrings.$tr('planLabel'),
         route: baseRoutes.plan.path,
+        name: baseRoutes.plan.name,
       },
     ];
   },

--- a/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
@@ -27,18 +27,22 @@ const sideNavConfig = {
         {
           label: deviceString('permissionsLabel'),
           route: baseRoutes.permissions.path,
+          name: baseRoutes.permissions.name,
         },
         {
           label: coreStrings.$tr('facilitiesLabel'),
           route: baseRoutes.facilities.path,
+          name: baseRoutes.facilities.name,
         },
         {
           label: coreStrings.$tr('infoLabel'),
           route: baseRoutes.info.path,
+          name: baseRoutes.info.name,
         },
         {
           label: coreStrings.$tr('settingsLabel'),
           route: baseRoutes.settings.path,
+          name: baseRoutes.settings.name,
         }
       );
     }

--- a/kolibri/plugins/facility/assets/src/views/FacilityManagementSideNavEntry.js
+++ b/kolibri/plugins/facility/assets/src/views/FacilityManagementSideNavEntry.js
@@ -14,18 +14,22 @@ const sideNavConfig = {
       {
         label: coreStrings.$tr('classesLabel'),
         route: baseRoutes.classes.path,
+        name: baseRoutes.classes.name,
       },
       {
         label: coreStrings.$tr('usersLabel'),
         route: baseRoutes.users.path,
+        name: baseRoutes.users.name,
       },
       {
         label: coreStrings.$tr('settingsLabel'),
         route: baseRoutes.settings.path,
+        name: baseRoutes.settings.name,
       },
       {
         label: coreStrings.$tr('dataLabel'),
         route: baseRoutes.data.path,
+        name: baseRoutes.data.name,
       },
     ];
   },

--- a/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.js
+++ b/kolibri/plugins/learn/assets/src/views/LearnSideNavEntry.js
@@ -15,16 +15,19 @@ const sideNavConfig = {
         label: coreStrings.$tr('homeLabel'),
         icon: 'dashboard',
         route: baseRoutes.home.path,
+        name: baseRoutes.home.name,
       },
       {
         label: coreStrings.$tr('libraryLabel'),
         icon: 'library',
         route: baseRoutes.library.path,
+        name: baseRoutes.library.name,
       },
       {
         label: coreStrings.$tr('bookmarksLabel'),
         icon: 'bookmark',
         route: baseRoutes.bookmarks.path,
+        name: baseRoutes.bookmarks.name,
       },
     ];
   },


### PR DESCRIPTION


## Summary
This PR sets the submenus to remain active on click

Closes #10674

# References
#10674
[screen-capture (4).webm](https://github.com/learningequality/kolibri/assets/103313919/576e9f87-195b-47a9-8708-2fd3ace1d07c)


## Reviewer guidance
1. Open the SideNav and select a page from either the Facility or the Coach plugin.
2. Observe that the link to the selected page is displayed in bold.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
