### PR TITLE
SetupWizard - Set Selected Facility properly + improved error handling

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
@@ -110,8 +110,6 @@
   import commonProfileStrings from '../../../../user_profile/assets/src/views/commonProfileStrings';
   import OnboardingStepBase from './OnboardingStepBase';
 
-  commonProfileStrings;
-
   export default {
     name: 'ImportIndividualUserForm',
     components: {
@@ -201,6 +199,9 @@
         }
       });
     },
+    mounted() {
+      this.selectedFacilityId = this.wizardService.state.context.selectedFacility.id;
+    },
     methods: {
       fetchNetworkLocation(deviceId) {
         this.loadingNewAddress = true;
@@ -212,7 +213,6 @@
               id: data.device_id,
               baseurl: data.device_address,
             };
-            this.selectedFacilityId = this.facilities[0].id;
             this.loadingNewAddress = false;
           })
           .catch(error => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
@@ -77,7 +77,9 @@
 
             TaskResource.startTask(params)
               .then(() => this.wizardService.send('CONTINUE'))
-              .catch(err => console.error(err));
+              .catch(err => {
+                this.$store.dispatch('handleApiError', err);
+              });
           } else {
             const errorData = JSON.parse(data);
             if (errorData.find(error => error.id === ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS)) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -42,13 +42,17 @@
       :noPadding="true"
     >
 
-      <div v-if="coreError" style="padding: 2em;">
-        <h2>{{ coreError }}</h2>
-        <KButton
-          :text="coreString('startOverAction')"
-          :primary="true"
-          @click="startOver"
-        />
+      <div v-if="coreError" style="padding: 16px;">
+        <AppError :hideParagraphs="true">
+          <h2>{{ coreError }}</h2>
+          <template #buttons>
+            <KButton
+              :text="coreString('startOverAction')"
+              :primary="true"
+              @click="startOver"
+            />
+          </template>
+        </AppError>
       </div>
       <div v-else class="content">
         <!-- Optional back arrow to show at the top for longer content views -->
@@ -71,6 +75,7 @@
 
       <!-- Border hidden on mobile by making it the same as the background -->
       <div
+        v-if="!coreError"
         class="footer"
         :style="{
           borderTop: `1px solid ${windowIsSmall ? $themeTokens.surface : $themeTokens.fineLine}`
@@ -138,13 +143,14 @@
   import CoreLogo from 'kolibri.coreVue.components.CoreLogo';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import AppError from 'kolibri-common/components/AppError';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import { FooterMessageTypes } from '../constants';
 
   export default {
     name: 'OnboardingStepBase',
-    components: { CoreLogo, LanguageSwitcherModal },
+    components: { AppError, CoreLogo, LanguageSwitcherModal },
     inject: ['wizardService'],
     mixins: [commonCoreStrings, responsiveWindowMixin],
     props: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
@@ -79,13 +79,12 @@
         // See the comments around this in wizardMachine
         const lastStatePath = Object.keys(this.wizardService._state.meta)[0];
         const { nextEvent = null } = this.wizardService.state.meta[lastStatePath];
-        console.log('OK NEXT:', nextEvent);
+
         if (!nextEvent) {
-          console.error(
-            'Please provide the event you expect where you are using this Component in',
-            "the state machine in the meta field's `nextEvent` property."
-          );
-          return;
+          const err =
+            'Please provide the event you expect where you are using this Component in' +
+            " the state machine in the meta field's `nextEvent` property.";
+          return this.$store.dispatch('handleApiError', err);
         }
         // TODO Add an Error State with a "Start over" button? Something better than
         // "this silently fails" if something goes wrong for the user

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -159,7 +159,9 @@
             Lockr.set('savedState', null); // Clear out saved state machine
             redirectBrowser();
           })
-          .catch(e => console.error(e));
+          .catch(e => {
+            this.$store.dispatch('handleApiError', e);
+          });
       },
     },
     $trs: {

--- a/packages/kolibri-common/components/AppError/index.vue
+++ b/packages/kolibri-common/components/AppError/index.vue
@@ -8,12 +8,15 @@
       {{ headerText }}
     </h1>
 
-    <p v-for="(paragraph, idx) in paragraphTexts" :key="idx">
-      {{ paragraph }}
-    </p>
+    <template v-if="!hideParagraphs">
+      <p v-for="(paragraph, idx) in paragraphTexts" :key="idx">
+        {{ paragraph }}
+      </p>
+    </template>
 
     <p>
-      <KButtonGroup>
+      <slot name="buttons"></slot>
+      <KButtonGroup v-if="!$slots.buttons">
         <KButton
           v-if="!isPageNotFound"
           :text="coreString('refresh')"
@@ -62,6 +65,13 @@
       ReportErrorModal,
     },
     mixins: [commonCoreStrings],
+    props: {
+      /* Generalize the component to just show the title */
+      hideParagraphs: {
+        type: Boolean,
+        default: false,
+      },
+    },
     data() {
       return {
         showDetailsModal: false,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Uses an updated AppError to provide a "Sorry" message with a "Start Over" button when something goes wrong in the Setup Wizard
- Ensures the user's selected facility is maintained throughout
- Hopefully mitigates the 500 error noted in #10459 -- I only replicated it once and after I fixed the "selected facility" bug that @radinamatic mentioned there I never saw it again so hopefully it isn't still lurking. In any case, failure should now throw 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #10459 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

@pcenov - go through the import and creation learn only device flows and see if you can break anything. Ensure the facility you've chosen from a multi-facility device is the one maintained through the rest of the process.

@marcellamaki one note from the expected behavior noted in the issue:
> If the username exists, there should be a way to sign in as that user and exit the setup wizard.

As it is, the user can go back and then select to "import" a user as that must happen before signing in. Is that sufficient here? It got me thinking that maybe we should make a follow-up issue for the copy around this or, perhaps, provide a link to go to the "Import" page instead if they're using existing credentials in a future release when we can add messaging for it. Thoughts?