### PR TITLE
Transpile mjs source files with babel.

### DIFF
--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -69,7 +69,7 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
 
   if (transpile) {
     rules.push({
-      test: /\.js$/,
+      test: /\.(js|mjs)$/,
       loader: 'babel-loader',
       exclude: { and: [/(node_modules\/vue|dist|core-js)/, { not: [/\.(esm\.js|mjs)$/] }] },
       options: {


### PR DESCRIPTION
## Summary
* Adds .mjs files to the rule for files transpiled by babel
* Fixes Kolibri on IE11

## References
Fixes [#10086](https://github.com/learningequality/kolibri/issues/10086)

## Reviewer guidance
Run Kolibri and load in IE11 - ensure that it is accessible.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
