### PR TITLE
Drop the version string from the webpack plugin filenames

### DIFF
--- a/packages/kolibri-tools/lib/webpack.config.plugin.js
+++ b/packages/kolibri-tools/lib/webpack.config.plugin.js
@@ -107,10 +107,10 @@ module.exports = (
     mode,
     output: {
       path: path.resolve(path.join(data.static_dir, data.name)),
-      filename: '[name]-' + data.version + '.js',
+      filename: '[name].js',
       // Need to define this in order for chunks to be named
       // Without this chunks from different bundles will likely have colliding names
-      chunkFilename: data.name + '-[name]-' + data.version + '.js',
+      chunkFilename: data.name + '-[name].js',
       // c.f. https://webpack.js.org/configuration/output/#outputchunkloadingglobal
       // Without this namespacing, there is a possibility that chunks from different
       // plugins could conflict in the global chunk namespace.
@@ -137,8 +137,8 @@ module.exports = (
     },
     plugins: [
       new MiniCssExtractPlugin({
-        filename: '[name]' + data.version + '.css',
-        chunkFilename: '[name]' + data.version + '[id].css',
+        filename: '[name].css',
+        chunkFilename: '[name][id].css',
       }),
       new WebpackRTLPlugin({
         minify: false,


### PR DESCRIPTION
## Summary
Some scan tools cannot open the file whose full path name is too long. So, drop the version string from the plugin filenames.

## Reference

The Endless Key app for Windows bundles Kolibri within an `MSIX/APPX` package. When we updated the app to the 0.16-alpha12 release of Kolibri, we had issues where Microsoft's validation tool (Windows App Certification Kit) would fail with the following error, which blocked publishing the app in the Microsoft store:

```
Error Found: The blocked executables test has detected the following errors: 
...
◦System.IO.PathTooLongException: The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
 at System.IO.PathHelper.GetFullPathName()
 at System.IO.Path.LegacyNormalizePath(String path, Boolean fullCheck, Int32 maxPathLength, Boolean expandShortPaths)
 at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
 at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
 at Microsoft.Windows.SoftwareLogo.Shared.TextByteReader.<EnumerateTextStrings>d__68.MoveNext()
 at Microsoft.Windows.SoftwareLogo.Shared.PackageFileAnalyzer.AnalyzeFile(FileInfo file)
 at Microsoft.Windows.SoftwareLogo.Shared.PackageFileAnalyzer.AnalyzePackage()
 at Microsoft.Windows.SoftwareLogo.Tests.DetectBlockedExes.DetectBlockedExes.CheckForBlockedExeReferences()
 at Microsoft.Windows.SoftwareLogo.Tests.DetectBlockedExes.DetectBlockedExes.ExecuteSharedTests()
 at Microsoft.Windows.SoftwareLogo.TestBase.TestBase.ExecuteTest()
```

It appears that the tool is crashing due to paths in the package exceeding the `MAX_PATH` limit of **260** characters. See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry for more details on this limitation.

Examining the contents of the package, the longest paths are the following:
```
C:\Program Files\WindowsApps\EndlessOSFoundation.EndlessKey_1.0.45.0_x64__bt8q3zn5k2ahy\resources\app\src\Kolibri\kolibri\plugins\user_profile\static\kolibri.plugins.user_profile.user_profile_side_nav\kolibri.plugins.user_profile.user_profile_side_nav-0.16.0a12.js
C:\Program Files\WindowsApps\EndlessOSFoundation.EndlessKey_1.0.45.0_x64__bt8q3zn5k2ahy\resources\app\src\Kolibri\kolibri\plugins\user_profile\static\kolibri.plugins.user_profile.user_profile_side_nav\kolibri.plugins.user_profile.user_profile_side_nav-0.16.0a12.js.gz
C:\Program Files\WindowsApps\EndlessOSFoundation.EndlessKey_1.0.45.0_x64__bt8q3zn5k2ahy\resources\app\src\Kolibri\kolibri\plugins\user_profile\static\kolibri.plugins.user_profile.user_profile_side_nav\kolibri.plugins.user_profile.user_profile_side_nav-0.16.0a12.js.map
C:\Program Files\WindowsApps\EndlessOSFoundation.EndlessKey_1.0.45.0_x64__bt8q3zn5k2ahy\resources\app\src\Kolibri\kolibri\plugins\user_profile\static\kolibri.plugins.user_profile.user_profile_side_nav\kolibri.plugins.user_profile.user_profile_side_nav-0.16.0a12.js.map.gz
```

Removing the version number from these names takes them under the 260-character limit.
It is safe to remove the version number from the filenames because they are controlled by `webpack.config.plugin.js`.

## Reviewer guidance

Check the built webpack plugins' filenames that do not contain the version string.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
