### PR TITLE
remove need for two clicks on "Continue" to progress through Setup Wizard

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -156,7 +156,7 @@
             const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
             window.sessionStorage.setItem(welcomeDimissalKey, false);
 
-            Lockr.set('savedState', null); // Clear out saved state machine
+            Lockr.rm('savedState');
             redirectBrowser();
           })
           .catch(e => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -156,7 +156,7 @@
             const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
             window.sessionStorage.setItem(welcomeDimissalKey, false);
 
-            Lockr.rm('savedState');
+            Lockr.rm('savedState'); // Clear out saved state machine
             redirectBrowser();
           })
           .catch(e => {


### PR DESCRIPTION
## Summary
Addresses an edge case currently experienced by developers: if a user(/developer) progresses through all the steps of the Kolibri Setup Wizard and finalizes their setup, then deletes their `.kolibri` folder and attempts to go through the setup wizard a second time, the user will have to click `Continue` twice in order to move on from the initial "_How are you using Kolibri?_" page and navigate to the second step of the wizard. they also may see a `NavigationDuplicated` error in the browser console upon first re-entering the wizard. (if the user also deletes all Kolibri Setup Wizard local storage when they delete their `.kolibri` folder, they will not encounter the navigation error or the need to double-click.)

this PR changes the behavior of Lockr in `SettingUpKolibri.vue`, replacing the previous behavior of setting `savedState` to `null` with a slightly altered approach that removes `savedState` altogether.

## References
fixes #10597 

## Reviewer guidance
- start with a fresh device (e.g. having deleted `.kolibri` folder, which should be found in same location as `kolibri` project, but display may be hidden)
- run through the Setup Wizard fully - your selections shouldn't matter, but please complete all Setup Wizard steps and finalize -- after syncing, you should be redirected to your new Kolibri instance.
- delete `.kolibri` folder again
- begin Setup Wizard again and ensure that:
       a) upon initial load, there are no navigation errors in the browser console
       b) upon selecting "on my own" or "group learning," clicking `Continue` **_once_** should allow you to progress to the next step of the wizard
       
**Note:** There is a pre-existing `SET_FACILITY_PRESETS` error that may arise in the console after selecting `On my own`, but it is unrelated to the change introduced in this PR

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~


## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
