### PR TITLE
Adds has_downloads and last_download_removed fields to UserSyncStatus API response

### DIFF
--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -9,6 +9,8 @@ const queued = ref(false);
 const lastSynced = ref();
 const deviceStatus = ref(null);
 const deviceStatusSentiment = ref(null);
+const hasDownloads = ref(false);
+const lastDownloadRemoved = ref(null);
 const timeoutInterval = computed(() => {
   return get(status) === SyncStatus.QUEUED ? 1000 : 10000;
 });
@@ -43,6 +45,10 @@ export function pollUserSyncStatusTask() {
       status.value = syncData[0].status;
       deviceStatus.value = syncData[0].device_status;
       deviceStatusSentiment.value = syncData[0].device_status_sentiment;
+      hasDownloads.value = syncData[0].has_downloads;
+      lastDownloadRemoved.value = syncData[0].last_download_removed
+        ? new Date(syncData[0].last_download_removed)
+        : null;
     } else {
       status.value = SyncStatus.NOT_CONNECTED;
     }
@@ -70,5 +76,7 @@ export default function useUserSyncStatus() {
     status,
     deviceStatus,
     deviceStatusSentiment,
+    hasDownloads,
+    lastDownloadRemoved,
   };
 }

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -104,7 +104,7 @@
       },
     },
     mounted() {
-      this.validateDeviceStatus();
+      this.toggleBanner();
       document.addEventListener('focusin', this.focusChange);
     },
     beforeDestroy() {
@@ -136,7 +136,7 @@
       manageChannel() {
         this.$router.push('/');
       },
-      validateDeviceStatus() {
+      toggleBanner() {
         if (this.showBanner) {
           this.bannerOpened = false;
         } else {

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -49,7 +49,8 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { mapGetters } from 'vuex';
   import useUser from 'kolibri.coreVue.composables.useUser';
-  import { useLocalStorage, ref } from '@vue/composition-api';
+  import { useLocalStorage } from '@vueuse/core';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
 

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -101,9 +101,12 @@
       ...mapGetters(['isLearner', 'isAdmin', 'canManageContent']),
       insufficientStorageNoDownloads() {
         return (
-          (this.isLearner && this.insufficientSpace) ||
+          (this.isLearner && this.insufficientStorage) ||
           (!this.canManageContent && !this.hasDownloads)
         );
+      },
+      insufficientStorage() {
+        return this.deviceStatus === LearnerDeviceStatus.INSUFFICIENT_STORAGE;
       },
       learnOnlyRemovedResources() {
         return this.isLearner && this.lastDownloadRemoved && this.isLearnerOnlyImport;
@@ -113,8 +116,7 @@
       },
       showBanner() {
         return (
-          (this.deviceStatus === LearnerDeviceStatus.INSUFFICIENT_STORAGE &&
-            this.local_storage_last_synced < this.lastSynced) ||
+          (this.insufficientStorage && this.local_storage_last_synced < this.lastSynced) ||
           this.local_storage_lastDownloadRemoved < this.lastDownloadRemoved
         );
       },

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -138,9 +138,9 @@
       },
       toggleBanner() {
         if (this.showBanner) {
-          this.bannerOpened = false;
-        } else {
           this.bannerOpened = true;
+        } else {
+          this.bannerOpened = false;
         }
       },
       focusChange(e) {

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -49,7 +49,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { mapGetters } from 'vuex';
   import useUser from 'kolibri.coreVue.composables.useUser';
-  import { useLocalstorage, ref } from '@vue/composition-api';
+  import { useLocalStorage, ref } from '@vue/composition-api';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
 
@@ -58,8 +58,8 @@
     components: {},
     mixins: [commonCoreStrings],
     setup() {
-      const local_storage_last_synced = ref(useLocalstorage('last_synced', ''));
-      const local_storage_lastDownloadRemoved = ref(useLocalstorage('last_download_removed', ''));
+      const local_storage_last_synced = ref(useLocalStorage('last_synced', ''));
+      const local_storage_lastDownloadRemoved = ref(useLocalStorage('last_download_removed', ''));
 
       const { isLearnerOnlyImport } = useUser();
 

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div v-if="bannerOpened" class="banner" :style="{ background: $themeTokens.surface }">
+  <div v-if="showBanner" class="banner" :style="{ background: $themeTokens.surface }">
     <div class="banner-inner">
       <h1 style="display: none">
         {{ $tr('bannerHeading') }}
@@ -78,7 +78,6 @@
     data() {
       return {
         isSubsetOfUsersDevice: plugin_data.isSubsetOfUsersDevice,
-        bannerOpened: false,
       };
     },
     computed: {
@@ -104,7 +103,6 @@
       },
     },
     mounted() {
-      this.toggleBanner();
       document.addEventListener('focusin', this.focusChange);
     },
     beforeDestroy() {
@@ -127,7 +125,7 @@
       closeBanner() {
         localStorage.setItem('download_removed', this.lastDownloadRemoved);
         localStorage.setItem('last_synced', this.lastSynced);
-        this.bannerOpened = false;
+        this.showBanner = false;
 
         if (this.previouslyFocusedElement) {
           this.previouslyFocusedElement.focus();
@@ -136,13 +134,7 @@
       manageChannel() {
         this.$router.push('/');
       },
-      toggleBanner() {
-        if (this.showBanner) {
-          this.bannerOpened = true;
-        } else {
-          this.bannerOpened = false;
-        }
-      },
+
       focusChange(e) {
         // We need the element prior to the close button and more info
         if (

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -50,7 +50,6 @@
   import { mapGetters } from 'vuex';
   import useUser from 'kolibri.coreVue.composables.useUser';
   import { useLocalStorage } from '@vueuse/core';
-  import { ref } from 'kolibri.lib.vueCompositionApi';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
 
@@ -59,8 +58,8 @@
     components: {},
     mixins: [commonCoreStrings],
     setup() {
-      const local_storage_last_synced = ref(useLocalStorage('last_synced', ''));
-      const local_storage_lastDownloadRemoved = ref(useLocalStorage('last_download_removed', ''));
+      const local_storage_last_synced = useLocalStorage('last_synced', '');
+      const local_storage_lastDownloadRemoved = useLocalStorage('last_download_removed', '');
 
       const { isLearnerOnlyImport } = useUser();
 

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -457,7 +457,7 @@ class ContentRequest(models.Model):
         :return: A ContentRequest
         :rtype: ContentRequest
         """
-        return ContentRequest(
+        return cls(
             facility_id=user.facility_id,
             source_model=FacilityUser.morango_model_name,
             source_id=user.id,

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -4,7 +4,6 @@ from sys import version_info
 
 from django.conf import settings
 from django.contrib.auth import login
-from django.db.models import DateTimeField
 from django.db.models import Exists
 from django.db.models import Max
 from django.db.models import OuterRef
@@ -52,6 +51,7 @@ from kolibri.core.content.utils.channels import get_mounted_drives_with_channel_
 from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.discovery.models import DynamicNetworkLocation
+from kolibri.core.fields import DateTimeTzField
 from kolibri.core.public.constants.user_sync_options import DELAYED_SYNC
 from kolibri.core.public.constants.user_sync_statuses import INSUFFICIENT_STORAGE
 from kolibri.core.public.constants.user_sync_statuses import NOT_RECENTLY_SYNCED
@@ -352,7 +352,7 @@ class UserSyncStatusViewSet(ReadOnlyValuesViewset):
             )
             .annotate(last_removal=Max("requested_at"))
             .values("last_removal"),
-            output_field=DateTimeField(),
+            output_field=DateTimeTzField(),
         )
         queryset = queryset.annotate(
             transfer_status=Subquery(most_recent_sync_status),

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -342,6 +342,7 @@ class UserSyncStatusViewSet(ReadOnlyValuesViewset):
             ),
             has_downloads=Subquery(is_having_downloads).values("last_download"),
         )
+        pdb.set_trace()
         return queryset
 
     def annotate_queryset(self, queryset):

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import platform
 import sys
@@ -865,6 +866,7 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
 
     def test_downloads_queryset(self):
+        last_download_removed_timestamp = datetime.datetime.now()
         self.client.login(
             username=self.user1.username,
             password=DUMMY_PASSWORD,
@@ -883,5 +885,8 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
-        self.assertFalse(response.data[0]["has_downloads"], False)
-        self.assertFalse(response.data[0]["last_download_removed"], None)
+        self.assertFalse(response.data[0]["has_downloads"], True)
+        self.assertFalse(
+            response.data[0]["last_download_removed"],
+            last_download_removed_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        )

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -31,6 +31,7 @@ from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.auth.test.test_api import ClassroomFactory
 from kolibri.core.auth.test.test_api import FacilityFactory
 from kolibri.core.auth.test.test_api import FacilityUserFactory
+from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.device.models import DeviceStatus
@@ -862,7 +863,7 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
-        
+
     def test_downloads_queryset(self):
         self.client.login(
             username=self.user1.username,
@@ -872,10 +873,15 @@ class UserSyncStatusTestCase(APITestCase):
         self._create_transfer_session(
             active=False,
         )
+        content_request = ContentDownloadRequest.build_for_user(self.user1)
+        content_request.contentnode_id = uuid.uuid4().hex
         device_status = self._create_device_status("oopsie", StatusSentiment.Neutral)
         self.syncsession1.client_instance_id = device_status.instance_id
         self.syncsession1.save()
         response = self.client.get(reverse("kolibri:core:usersyncstatus-list"))
+        content_request.save()
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
+        # self.assertEqual(response.data[0]["last_download_removed"])
+        # self.assertEqual(response.data[0]["has_downloads"])

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -883,5 +883,5 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
-        # self.assertEqual(response.data[0]["last_download_removed"])
-        # self.assertEqual(response.data[0]["has_downloads"])
+        self.assertFalse(response.data[0]["has_downloads"], False)
+        self.assertFalse(response.data[0]["last_download_removed"], None)

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -862,3 +862,20 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
+        
+    def test_downloads_queryset(self):
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        self._create_transfer_session(
+            active=False,
+        )
+        device_status = self._create_device_status("oopsie", StatusSentiment.Neutral)
+        self.syncsession1.client_instance_id = device_status.instance_id
+        self.syncsession1.save()
+        response = self.client.get(reverse("kolibri:core:usersyncstatus-list"))
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["user"], self.user1.id)
+        self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import platform
 import sys
@@ -866,7 +865,6 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
 
     def test_downloads_queryset(self):
-        last_download_removed_timestamp = datetime.datetime.now()
         self.client.login(
             username=self.user1.username,
             password=DUMMY_PASSWORD,
@@ -885,8 +883,9 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]["user"], self.user1.id)
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
-        self.assertFalse(response.data[0]["has_downloads"], True)
-        self.assertFalse(
-            response.data[0]["last_download_removed"],
-            last_download_removed_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-        )
+        self.assertFalse(response.data[0]["has_downloads"])
+        self.assertIsNone(response.data[0]["last_download_removed"])
+        # self.assertEqual(
+        #     response.data[0]["last_download_removed"],
+        #     last_download_removed_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        # )

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -885,7 +885,3 @@ class UserSyncStatusTestCase(APITestCase):
         self.assertEqual(response.data[0]["status"], user_sync_statuses.RECENTLY_SYNCED)
         self.assertFalse(response.data[0]["has_downloads"])
         self.assertIsNone(response.data[0]["last_download_removed"])
-        # self.assertEqual(
-        #     response.data[0]["last_download_removed"],
-        #     last_download_removed_timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-        # )


### PR DESCRIPTION

## Summary

- Added a new response field called` has_download `and `last_download_removed.`
- Updated the useUserSyncStatus composable to extract the newly added fields` has_downloads `and `last_download_removed` from the UserSyncStatus API response.
- Refactored [StorageNotification.vue](https://github.com/AllanOXDi/kolibri/blob/develop/kolibri/core/assets/src/views/StorageNotification.vue#L67-L72) component to utilize the useUserSyncStatus composable internally, eliminating the need for the showBanner prop from AppBarPage.vue.
- Modified the usage of insufficientSpace to align with `deviceStatus === LearnerDeviceStatus.INSUFFICIENT_STORAGE.`
- Adapted the usage of availableDownloads to reflect the new `has_downloads `field in the API response.
- Adjusted the usage of `resourcesRemoved `to correspond to the new `last_download_removed `field in the API response.
- Updated the usage of `hasDevicePermission` to utilize` canManageContent` from the user session.
closes  #10378

## References
 #10378

## Reviewer guidance

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
