### PR TITLE
Allow update and delete of scheduled tasks

### DIFF
--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -1,7 +1,6 @@
 import datetime
 from uuid import uuid4
 
-import pytz
 from django.core.management.base import CommandError
 from django.test import TestCase
 from django.urls import reverse
@@ -56,7 +55,7 @@ def fake_job(**kwargs):
 
 
 class dummy_orm_job_data(object):
-    scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
+    scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=None)
     repeat = 5
     interval = 8600
     retry_interval = 5

--- a/kolibri/core/content/test/test_tasks.py
+++ b/kolibri/core/content/test/test_tasks.py
@@ -98,6 +98,7 @@ class ValidateContentTaskTestCase(TestCase):
             validator.validated_data,
             {
                 "args": [self.channel_id],
+                "enqueue_args": {},
                 "kwargs": {
                     "exclude_node_ids": [exclude_id],
                     "node_ids": [include_id],
@@ -154,6 +155,7 @@ class ValidateRemoteImportTaskTestCase(TestCase):
             validator.validated_data,
             {
                 "args": [channel_id],
+                "enqueue_args": {},
                 "extra_metadata": {
                     "channel_id": channel_id,
                     "channel_name": "test",
@@ -187,6 +189,7 @@ class ValidateRemoteImportTaskTestCase(TestCase):
             validator.validated_data,
             {
                 "args": [channel_id],
+                "enqueue_args": {},
                 "extra_metadata": {
                     "channel_id": channel_id,
                     "channel_name": "test",
@@ -246,6 +249,7 @@ class ValidateLocalImportTaskTestCase(TestCase):
             validator.validated_data,
             {
                 "args": [channel_id, drive_id],
+                "enqueue_args": {},
                 "extra_metadata": {
                     "channel_id": channel_id,
                     "channel_name": "test",

--- a/kolibri/core/discovery/test/test_tasks.py
+++ b/kolibri/core/discovery/test/test_tasks.py
@@ -393,33 +393,29 @@ class TaskUtilitiesTestCase(TestCase):
             generate_job_id("test", "a" * 32), "42440939765e6e06237a90ec42c80b4b"
         )
 
-    @mock.patch(
-        "kolibri.core.discovery.tasks.perform_network_location_update.enqueue_in"
-    )
+    @mock.patch("kolibri.core.discovery.tasks.get_current_job")
     def test_enqueue_network_location_update_with_backoff__zero_faults(
-        self, mock_enqueue
+        self, mock_get_current_job
     ):
+        current_job_mock = mock.MagicMock()
+        mock_get_current_job.return_value = current_job_mock
         next_attempt = datetime.timedelta(minutes=1)
         _enqueue_network_location_update_with_backoff(self.network_location)
-        mock_enqueue.assert_called_once_with(
+        current_job_mock.retry_in.assert_called_once_with(
             next_attempt,
-            job_id="88452dfa2ec2726589d4c63732cc51e4",
-            args=(self.network_location.id,),
             priority=Priority.LOW,
         )
 
-    @mock.patch(
-        "kolibri.core.discovery.tasks.perform_network_location_update.enqueue_in"
-    )
+    @mock.patch("kolibri.core.discovery.tasks.get_current_job")
     def test_enqueue_network_location_update_with_backoff__non_zero_faults(
-        self, mock_enqueue
+        self, mock_get_current_job
     ):
+        current_job_mock = mock.MagicMock()
+        mock_get_current_job.return_value = current_job_mock
         self.network_location.connection_faults = 3
         next_attempt = datetime.timedelta(minutes=8)
         _enqueue_network_location_update_with_backoff(self.network_location)
-        mock_enqueue.assert_called_once_with(
+        current_job_mock.retry_in.assert_called_once_with(
             next_attempt,
-            job_id="88452dfa2ec2726589d4c63732cc51e4",
-            args=(self.network_location.id,),
             priority=Priority.LOW,
         )

--- a/kolibri/core/logger/test/test_tasks.py
+++ b/kolibri/core/logger/test/test_tasks.py
@@ -31,6 +31,7 @@ class StartExportLogCSVTestCase(TestCase):
             validator.validated_data,
             {
                 "facility_id": self.facility.id,
+                "enqueue_args": {},
                 "kwargs": {
                     "facility": self.facility.id,
                     "start_date": self.start_date,

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1,6 +1,8 @@
 import logging
 
 from django.http.response import Http404
+from django.utils.timezone import make_aware
+from pytz import utc
 from rest_framework import decorators
 from rest_framework import serializers
 from rest_framework import status
@@ -88,7 +90,8 @@ class TasksViewSet(viewsets.GenericViewSet):
             "clearable": job.state in [State.FAILED, State.CANCELED, State.COMPLETED],
             "facility_id": job.facility_id,
             "extra_metadata": job.extra_metadata,
-            "scheduled_datetime": str(orm_job.scheduled_time),  # Output is UTC naive.
+            # Output is UTC naive, coerce to UTC aware.
+            "scheduled_datetime": make_aware(orm_job.scheduled_time, utc).isoformat(),
             "repeat": orm_job.repeat,
             "repeat_interval": orm_job.interval,
             "retry_interval": orm_job.retry_interval,

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -249,6 +249,21 @@ class TasksViewSet(viewsets.GenericViewSet):
 
         return self.retrieve(request, pk=pk)
 
+    def delete(self, request, pk=None):
+        """
+        Delete a task.
+        """
+        job_to_clear = self._get_job_for_pk(request, pk)
+
+        if job_to_clear.state == State.RUNNING:
+            raise serializers.ValidationError(
+                "Cannot delete job with state: {}".format(job_to_clear.state)
+            )
+
+        job_storage.clear(job_id=job_to_clear.job_id, force=True)
+
+        return Response({})
+
     def partial_update(self, request, *args, **kwargs):
         kwargs["partial"] = True
         return self.update(request, *args, **kwargs)

--- a/kolibri/core/tasks/exceptions.py
+++ b/kolibri/core/tasks/exceptions.py
@@ -15,3 +15,7 @@ class JobNotFound(Exception):
 
 class JobNotRestartable(Exception):
     pass
+
+
+class JobRunning(Exception):
+    pass

--- a/kolibri/core/tasks/exceptions.py
+++ b/kolibri/core/tasks/exceptions.py
@@ -19,3 +19,11 @@ class JobNotRestartable(Exception):
 
 class JobRunning(Exception):
     pass
+
+
+class JobNotRunning(Exception):
+    pass
+
+
+class JobAlreadyRetrying(Exception):
+    pass

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -281,6 +281,9 @@ class Job(object):
         self.cancellable = cancellable
         self.storage.save_job_as_cancellable(self.job_id, cancellable=cancellable)
 
+    def retry_in(self, dt, **kwargs):
+        self.storage.retry_job_in(self.job_id, dt, **kwargs)
+
     def execute(self):
         self._check_storage_attached()
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -18,8 +18,10 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.exceptions import JobAlreadyRetrying
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
+from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Job
@@ -163,15 +165,23 @@ class Storage(object):
         Note: Does not actually run the job.
         """
         dt = self._now()
-        return self.schedule(
-            dt,
-            job,
-            queue,
-            priority=priority,
-            interval=0,
-            repeat=0,
-            retry_interval=retry_interval,
-        )
+        try:
+            return self.schedule(
+                dt,
+                job,
+                queue,
+                priority=priority,
+                interval=0,
+                repeat=0,
+                retry_interval=retry_interval,
+            )
+        except JobRunning:
+            logger.debug(
+                "Attempted to enqueue a running job {job_id}, ignoring.".format(
+                    job_id=job.job_id
+                )
+            )
+            return job.job_id
 
     def mark_job_as_canceled(self, job_id):
         """
@@ -438,28 +448,42 @@ class Storage(object):
     def save_job_as_cancellable(self, job_id, cancellable=True):
         self._update_job(job_id, cancellable=cancellable)
 
-    def _update_job(self, job_id, state=None, **kwargs):
+    def retry_job_in(self, job_id, delta_t, **kwargs):
+        if not isinstance(delta_t, timedelta):
+            raise TypeError("Time argument must be a timedelta object.")
+        orm_job = self.get_orm_job(job_id)
+        if orm_job.state != State.RUNNING:
+            raise JobNotRunning("Job is not running, cannot retry.")
+        if orm_job.retry_interval is not None or orm_job.repeat != 0:
+            raise JobAlreadyRetrying("Job is already retrying.")
+        # Update the job to repeat once after delta_t seconds.
+        self._update_job(job_id, interval=delta_t.total_seconds(), repeat=1, **kwargs)
+
+    def _handle_state_update(self, orm_job, job, state):
+        if state is not None:
+            orm_job.state = job.state = state
+            if state == State.FAILED and orm_job.retry_interval is not None:
+                orm_job.state = job.state = State.QUEUED
+                orm_job.scheduled_time = naive_utc_datetime(
+                    self._now() + timedelta(seconds=orm_job.retry_interval)
+                )
+            elif state in {State.COMPLETED, State.FAILED, State.CANCELED}:
+                if orm_job.repeat is None or orm_job.repeat > 0:
+                    orm_job.repeat = (
+                        orm_job.repeat - 1 if orm_job.repeat is not None else None
+                    )
+                    orm_job.state = job.state = State.QUEUED
+                    orm_job.scheduled_time = naive_utc_datetime(
+                        self._now() + timedelta(seconds=orm_job.interval)
+                    )
+
+    def _update_job(self, job_id, state=None, priority=None, **kwargs):
         with self.session_scope() as session:
             try:
                 job, orm_job = self._get_job_and_orm_job(job_id, session)
-                if state is not None:
-                    orm_job.state = job.state = state
-                    if state == State.FAILED and orm_job.retry_interval is not None:
-                        orm_job.state = job.state = State.QUEUED
-                        orm_job.scheduled_time = naive_utc_datetime(
-                            self._now() + timedelta(seconds=orm_job.retry_interval)
-                        )
-                    elif state in {State.COMPLETED, State.FAILED, State.CANCELED}:
-                        if orm_job.repeat is None or orm_job.repeat > 0:
-                            orm_job.repeat = (
-                                orm_job.repeat - 1
-                                if orm_job.repeat is not None
-                                else None
-                            )
-                            orm_job.state = job.state = State.QUEUED
-                            orm_job.scheduled_time = naive_utc_datetime(
-                                self._now() + timedelta(seconds=orm_job.interval)
-                            )
+                self._handle_state_update(orm_job, job, state)
+                if priority is not None:
+                    orm_job.priority = priority
                 for kwarg in kwargs:
                     setattr(job, kwarg, kwargs[kwarg])
                 orm_job.saved_job = job.to_json()
@@ -525,7 +549,7 @@ class Storage(object):
         Add the job in the specified time delta
         """
         if not isinstance(delta_t, timedelta):
-            raise ValueError("Time argument must be a timedelta object.")
+            raise TypeError("Time argument must be a timedelta object.")
         dt = self._now() + delta_t
         return self.schedule(
             dt,

--- a/kolibri/core/tasks/test/taskrunner/test_scheduler.py
+++ b/kolibri/core/tasks/test/taskrunner/test_scheduler.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.test.base import connection
@@ -20,114 +21,123 @@ def job_storage():
 
 @pytest.mark.django_db
 class TestScheduler(object):
-    def test_enqueue_at_a_function(self, job_storage):
-        job_id = job_storage.enqueue_at(local_now(), Job(id))
+    @pytest.fixture
+    def job(self):
+        return Job(id)
+
+    def test_enqueue_at_a_function(self, job_storage, job):
+        job_id = job_storage.enqueue_at(local_now(), job)
 
         # is the job recorded in the chosen backend?
         assert job_storage.get_job(job_id).job_id == job_id
 
-    def test_enqueue_at_a_function_sets_time(self, job_storage):
+    def test_enqueue_at_a_function_sets_time(self, job_storage, job):
         now = local_now()
-        job_id = job_storage.enqueue_at(now, Job(id))
+        job_id = job_storage.enqueue_at(now, job)
 
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
         assert scheduled_time == naive_utc_datetime(now)
 
-    def test_enqueue_at_preserves_extra_metadata(self, job_storage):
+    def test_enqueue_at_preserves_extra_metadata(self, job_storage, job):
         metadata = {"saved": True}
-        job_id = job_storage.enqueue_at(local_now(), Job(id, extra_metadata=metadata))
+        job.extra_metadata = metadata
+        job_id = job_storage.enqueue_at(local_now(), job)
 
         # Do we get back the metadata we save?
         assert job_storage.get_job(job_id).extra_metadata == metadata
 
-    def test_enqueue_in_a_function(self, job_storage):
-        job_id = job_storage.enqueue_in(datetime.timedelta(seconds=1000), Job(id))
+    def test_enqueue_in_a_function(self, job_storage, job):
+        job_id = job_storage.enqueue_in(datetime.timedelta(seconds=1000), job)
 
         # is the job recorded in the chosen backend?
         assert job_storage.get_job(job_id).job_id == job_id
 
-    def test_enqueue_in_a_function_sets_time(self, job_storage):
+    def test_enqueue_in_a_function_sets_time(self, job_storage, job):
         diff = datetime.timedelta(seconds=1000)
         now = local_now()
         job_storage._now = lambda: now
-        job_id = job_storage.enqueue_in(diff, Job(id))
+        job_id = job_storage.enqueue_in(diff, job)
 
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
         assert scheduled_time == naive_utc_datetime(now) + diff
 
-    def test_schedule_a_function_sets_time(self, job_storage):
+    def test_schedule_a_function_sets_time(self, job_storage, job):
         now = local_now()
-        job_id = job_storage.schedule(now, Job(id))
+        job_id = job_storage.schedule(now, job)
 
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
         assert scheduled_time == naive_utc_datetime(now)
 
-    def test_schedule_a_function_gives_value_error_without_datetime(self, job_storage):
+    def test_schedule_a_function_gives_value_error_without_datetime(
+        self, job_storage, job
+    ):
         now = "test"
         with pytest.raises(ValueError) as error:
-            job_storage.schedule(now, Job(id))
+            job_storage.schedule(now, job)
             assert "must be a datetime object" in str(error.value)
 
     def test_schedule_a_function_gives_value_error_repeat_zero_interval(
-        self, job_storage
+        self, job_storage, job
     ):
         now = local_now()
         with pytest.raises(ValueError) as error:
-            job_storage.schedule(now, Job(id), interval=0, repeat=None)
+            job_storage.schedule(now, job, interval=0, repeat=None)
             assert "specify an interval" in str(error.value)
 
     def test_schedule_a_function_gives_value_error_not_timezone_aware_datetime(
-        self, job_storage
+        self, job_storage, job
     ):
         now = datetime.datetime.utcnow()
         with pytest.raises(ValueError) as error:
-            job_storage.schedule(now, Job(id))
+            job_storage.schedule(now, job)
             assert "timezone aware datetime object" in str(error.value)
 
-    def test_scheduled_repeating_function_updates_old_job(self, job_storage):
+    def test_scheduled_repeating_function_updates_old_job(self, job_storage, job):
         now = local_now()
-        old_id = job_storage.schedule(now, Job(id), interval=1000, repeat=None)
+        old_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(old_id)
         new_id = job_storage.get_all_jobs()[0].job_id
         assert old_id == new_id
 
     def test_scheduled_repeating_function_sets_endless_repeat_new_job(
-        self, job_storage
+        self, job_storage, job
     ):
         now = local_now()
-        job_id = job_storage.schedule(now, Job(id), interval=1000, repeat=None)
+        job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
         assert repeat is None
 
-    def test_scheduled_repeating_function_enqueues_job(self, job_storage):
+    def test_scheduled_repeating_function_enqueues_job(self, job_storage, job):
         now = local_now()
-        job_id = job_storage.schedule(now, Job(id), interval=1000, repeat=None)
+        job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
         assert job_storage.get_job(job_id).job_id == job_id
 
     def test_scheduled_repeating_function_sets_new_job_with_one_fewer_repeats(
-        self, job_storage
+        self, job_storage, job
     ):
         now = local_now()
-        job_id = job_storage.schedule(now, Job(id), interval=1000, repeat=1)
+        job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage.complete_job(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
         assert repeat == 0
 
-    def test_scheduled_repeating_function_sets_new_job_at_interval(self, job_storage):
+    def test_scheduled_repeating_function_sets_new_job_at_interval(
+        self, job_storage, job
+    ):
         now = local_now()
-        job_id = job_storage.schedule(now, Job(id), interval=1000, repeat=1)
+        job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage._now = lambda: now
         job_storage.complete_job(job_id)
         with job_storage.session_scope() as session:
@@ -138,11 +148,11 @@ class TestScheduler(object):
         )
 
     def test_scheduled_repeating_function_failure_sets_new_job_at_retry_interval(
-        self, job_storage
+        self, job_storage, job
     ):
         now = local_now()
         job_id = job_storage.schedule(
-            now, Job(id), interval=1000, repeat=1, retry_interval=5
+            now, job, interval=1000, repeat=1, retry_interval=5
         )
         job_storage._now = lambda: now
         job_storage.mark_job_as_failed(job_id, "Exception", "Traceback")
@@ -150,3 +160,17 @@ class TestScheduler(object):
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
         assert scheduled_time == naive_utc_datetime(now) + datetime.timedelta(seconds=5)
+
+
+class TestReschedule(TestScheduler):
+    @pytest.fixture
+    def job(self, job_storage):
+        now = local_now()
+        job_id = job_storage.schedule(now, Job(id), interval=1, repeat=123)
+        return job_storage.get_job(job_id)
+
+    def test_reschedule_a_function_gives_job_running_error(self, job_storage, job):
+        now = local_now()
+        job_storage.mark_job_as_running(job.job_id)
+        with pytest.raises(JobRunning):
+            job_storage.schedule(now, job)

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -15,6 +15,7 @@ from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobNotFound
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.permissions import CanManageContent
@@ -708,9 +709,7 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
         # Did API call go through successfully?
         self.assertEqual(response.status_code, 200)
         # Did we schedule the job at specified enqueue_at?
-        self.assertEqual(
-            mock_job_storage.enqueue_at.call_args[1]["dt"], self.datetime_obj
-        )
+        self.assertEqual(mock_job_storage.enqueue_at.call_args[0][0], self.datetime_obj)
 
     def test_enqueue_in(self, mock_job_storage):
         enqueue_args = {
@@ -738,7 +737,7 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
         # Make sure the task is scheduled after one day and one hour
         self.assertEqual(
-            mock_job_storage.enqueue_in.call_args[1]["delta_t"], self.timedelta_obj
+            mock_job_storage.enqueue_in.call_args[0][0], self.timedelta_obj
         )
 
     def test_enqueue_job_with_retry_interval(self, mock_job_storage):
@@ -813,6 +812,269 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
         # Did we set `retry_interval` correctly?
         self.assertEqual(mock_job_storage.enqueue_in.call_args[1]["retry_interval"], 60)
+
+
+@patch("kolibri.core.tasks.api.job_storage")
+class EnqueueArgsUpdateAPITestCase(BaseAPITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super(EnqueueArgsUpdateAPITestCase, cls).setUpTestData()
+
+        cls.datetime_obj = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
+        cls.timedelta_obj = datetime.timedelta(days=1, hours=1)
+
+        cls.enqueue_at_datetime = str(cls.datetime_obj)
+        cls.enqueue_in_timedelta = str(cls.timedelta_obj)
+
+    def setUp(self):
+        @register_task(job_id="test-id")
+        def life():
+            return 42
+
+        TaskRegistry["kolibri.core.tasks.test.test_api.life"] = life
+        self.registered_task = TaskRegistry["kolibri.core.tasks.test.test_api.life"]
+        self.fake_job = fake_job(
+            state=State.QUEUED,
+            job_id="test-id",
+            func="kolibri.core.tasks.test.test_api.life",
+        )
+        self.client.login(username=self.superuser.username, password=DUMMY_PASSWORD)
+
+    def tearDown(self):
+        TaskRegistry.clear()
+
+    def test_erroneous_request(self, mock_job_storage):
+        mock_job_storage.get_job.return_value = self.fake_job
+        erroneous_enqueue_args = [
+            {"enqueue_at": self.enqueue_in_timedelta},  # Wrong format.
+            {  # Both `enqueue_at` and `enqueue_in` specified.
+                "enqueue_at": self.enqueue_at_datetime,
+                "enqueue_in": self.enqueue_in_timedelta,
+            },
+            {"repeat": 1},  # `repeat` without enqueue_in, enqueue_at.
+            {"repeat_interval": 1},  # `repeat_interval` without enqueue_in, enqueue_at.
+            {  # `repeat` and `repeat_interval` 0 not allowed.
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": 0,
+                "repeat_interval": 0,
+            },
+            {  # `repeat` not specified.
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat_interval": 1,
+            },
+            {  # `repeat_interval` not specified.
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": 1,
+            },
+            {  # Task infinite repeat but no `repeat_interval`.
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": None,
+            },
+            {"retry_interval": None},  # `retry_interval` None not allowed.
+        ]
+
+        for err_enq_arg in erroneous_enqueue_args:
+            response = self.client.patch(
+                reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+                {
+                    "enqueue_args": err_enq_arg,
+                },
+                format="json",
+            )
+            # Did API raise `ValidationError`` on erroneous input?
+            self.assertEqual(response.status_code, 400)
+
+    def test_acceptable_request(self, mock_job_storage):
+        acceptable_enqueue_args = [
+            {},
+            {
+                "enqueue_at": self.enqueue_at_datetime,
+            },
+            {
+                "enqueue_in": self.enqueue_in_timedelta,
+            },
+            {
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": 1,
+                "repeat_interval": 1,
+            },
+            {
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": None,
+                "repeat_interval": 86400,
+            },
+            {
+                "enqueue_in": self.enqueue_in_timedelta,
+                "repeat": None,
+                "repeat_interval": 360,
+            },
+            {
+                "enqueue_at": self.enqueue_at_datetime,
+                "repeat": None,
+                "repeat_interval": 7200,
+                "retry_interval": 60,
+            },
+            {
+                "retry_interval": 0,
+            },
+            {
+                "retry_interval": 900,
+            },
+        ]
+
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        for enq_arg in acceptable_enqueue_args:
+
+            response = self.client.patch(
+                reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+                {
+                    "enqueue_args": enq_arg,
+                },
+                format="json",
+            )
+
+            # Did API call go through successfully?
+            self.assertEqual(response.status_code, 200)
+
+    def test_enqueue_at(self, mock_job_storage):
+        enqueue_args = {
+            "enqueue_at": self.enqueue_at_datetime,
+            "repeat": None,
+            "repeat_interval": 60,
+        }
+
+        job, validated_enq_args = self.registered_task.validate_job_data(
+            user=self.superuser, data={"enqueue_args": enqueue_args}
+        )
+
+        mock_job_storage.enqueue_at.return_value = "test-id"
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": enqueue_args,
+            },
+            format="json",
+        )
+
+        # Did API call go through successfully?
+        self.assertEqual(response.status_code, 200)
+        # Did we schedule the job at specified enqueue_at?
+        self.assertEqual(mock_job_storage.enqueue_at.call_args[0][0], self.datetime_obj)
+
+    def test_enqueue_in(self, mock_job_storage):
+        enqueue_args = {
+            "enqueue_in": self.enqueue_in_timedelta,
+            "repeat": None,
+            "repeat_interval": 60,
+        }
+
+        mock_job_storage.enqueue_in.return_value = "test-id"
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": enqueue_args,
+            },
+            format="json",
+        )
+
+        # Did API call go through successfully?
+        self.assertEqual(response.status_code, 200)
+        # Make sure the task is scheduled after one day and one hour
+        self.assertEqual(
+            mock_job_storage.enqueue_in.call_args[0][0], self.timedelta_obj
+        )
+
+    def test_enqueue_job_with_retry_interval(self, mock_job_storage):
+        mock_job_storage.enqueue_job.return_value = "test-id"
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": {"retry_interval": 60},
+            },
+            format="json",
+        )
+
+        # Did API call go through successfully?
+        self.assertEqual(response.status_code, 200)
+        # Did we set `retry_interval` correctly?
+        self.assertEqual(
+            mock_job_storage.enqueue_job.call_args[1]["retry_interval"], 60
+        )
+
+    def test_enqueue_at_with_retry_interval(self, mock_job_storage):
+        mock_job_storage.enqueue_at.return_value = "test-id"
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": {
+                    "enqueue_at": self.enqueue_at_datetime,
+                    "repeat": 10,
+                    "repeat_interval": 86400,
+                    "retry_interval": 60,
+                },
+            },
+            format="json",
+        )
+
+        # Did API call go through successfully?
+        self.assertEqual(response.status_code, 200)
+        # Did we set `retry_interval` correctly?
+        self.assertEqual(mock_job_storage.enqueue_at.call_args[1]["retry_interval"], 60)
+
+    def test_enqueue_in_with_retry_interval(self, mock_job_storage):
+        mock_job_storage.enqueue_in.return_value = "test-id"
+        mock_job_storage.get_job.return_value = self.fake_job
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": {
+                    "enqueue_in": self.enqueue_in_timedelta,
+                    "retry_interval": 60,
+                },
+            },
+            format="json",
+        )
+
+        # Did API call go through successfully?
+        self.assertEqual(response.status_code, 200)
+        # Did we set `retry_interval` correctly?
+        self.assertEqual(mock_job_storage.enqueue_in.call_args[1]["retry_interval"], 60)
+
+    def test_update_while_running(self, mock_job_storage):
+        mock_job_storage.enqueue_in.side_effect = JobRunning
+        mock_job_storage.get_job.return_value = self.fake_job
+        self.fake_job.state = State.RUNNING
+        mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
+
+        response = self.client.patch(
+            reverse("kolibri:core:task-detail", kwargs={"pk": "test-id"}),
+            {
+                "enqueue_args": {
+                    "enqueue_in": self.enqueue_in_timedelta,
+                    "retry_interval": 60,
+                },
+            },
+            format="json",
+        )
+
+        # Did API call return correct error code?
+        self.assertEqual(response.status_code, 409)
 
 
 @patch("kolibri.core.tasks.api.job_storage")

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -2,9 +2,11 @@ import datetime
 
 import pytz
 from django.urls import reverse
+from django.utils.timezone import make_aware
 from mock import call
 from mock import Mock
 from mock import patch
+from pytz import utc
 from rest_framework import serializers
 from rest_framework.test import APITestCase
 
@@ -47,7 +49,7 @@ def fake_job(**kwargs):
 
 
 class dummy_orm_job_data(object):
-    scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
+    scheduled_time = datetime.datetime(year=2023, month=1, day=1, tzinfo=None)
     repeat = 5
     interval = 8600
     retry_interval = 5
@@ -271,7 +273,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
             "clearable": False,
             "extra_metadata": {},
             "facility_id": None,
-            "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+            "scheduled_datetime": make_aware(
+                dummy_orm_job_data.scheduled_time, utc
+            ).isoformat(),
             "repeat": dummy_orm_job_data.repeat,
             "repeat_interval": dummy_orm_job_data.interval,
             "retry_interval": dummy_orm_job_data.retry_interval,
@@ -328,7 +332,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "clearable": False,
                 "extra_metadata": {},
                 "facility_id": None,
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -344,7 +350,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "clearable": False,
                 "extra_metadata": {},
                 "facility_id": None,
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -423,7 +431,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
             "extra_metadata": {
                 "facility": "kolibri HQ",
             },
-            "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+            "scheduled_datetime": make_aware(
+                dummy_orm_job_data.scheduled_time, utc
+            ).isoformat(),
             "repeat": dummy_orm_job_data.repeat,
             "repeat_interval": dummy_orm_job_data.interval,
             "retry_interval": dummy_orm_job_data.retry_interval,
@@ -510,7 +520,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "extra_metadata": {
                     "facility": "kolibri HQ",
                 },
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -528,7 +540,9 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "extra_metadata": {
                     "facility": "kolibri HQ",
                 },
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -569,7 +583,7 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
         cls.datetime_obj = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
         cls.timedelta_obj = datetime.timedelta(days=1, hours=1)
 
-        cls.enqueue_at_datetime = str(cls.datetime_obj)
+        cls.enqueue_at_datetime = cls.datetime_obj.isoformat()
         cls.enqueue_in_timedelta = str(cls.timedelta_obj)
 
     def setUp(self):
@@ -610,7 +624,6 @@ class EnqueueArgsCreateAPITestCase(BaseAPITestCase):
                 "enqueue_at": self.enqueue_at_datetime,
                 "repeat": None,
             },
-            {"retry_interval": None},  # `retry_interval` None not allowed.
         ]
 
         for err_enq_arg in erroneous_enqueue_args:
@@ -823,7 +836,7 @@ class EnqueueArgsUpdateAPITestCase(BaseAPITestCase):
         cls.datetime_obj = datetime.datetime(year=2023, month=1, day=1, tzinfo=pytz.utc)
         cls.timedelta_obj = datetime.timedelta(days=1, hours=1)
 
-        cls.enqueue_at_datetime = str(cls.datetime_obj)
+        cls.enqueue_at_datetime = cls.datetime_obj.isoformat()
         cls.enqueue_in_timedelta = str(cls.timedelta_obj)
 
     def setUp(self):
@@ -870,7 +883,6 @@ class EnqueueArgsUpdateAPITestCase(BaseAPITestCase):
                 "enqueue_at": self.enqueue_at_datetime,
                 "repeat": None,
             },
-            {"retry_interval": None},  # `retry_interval` None not allowed.
         ]
 
         for err_enq_arg in erroneous_enqueue_args:
@@ -1180,7 +1192,9 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "clearable": False,
                 "facility_id": self.superuser.facility_id,
                 "extra_metadata": {},
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -1196,7 +1210,9 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "clearable": False,
                 "facility_id": self.superuser.facility_id,
                 "extra_metadata": {},
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,
@@ -1212,7 +1228,9 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "clearable": False,
                 "facility_id": self.facility2user.facility_id,
                 "extra_metadata": {},
-                "scheduled_datetime": str(dummy_orm_job_data.scheduled_time),
+                "scheduled_datetime": make_aware(
+                    dummy_orm_job_data.scheduled_time, utc
+                ).isoformat(),
                 "repeat": dummy_orm_job_data.repeat,
                 "repeat_interval": dummy_orm_job_data.interval,
                 "retry_interval": dummy_orm_job_data.retry_interval,

--- a/kolibri/core/tasks/validation.py
+++ b/kolibri/core/tasks/validation.py
@@ -2,19 +2,19 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from kolibri.core.serializers import DateTimeTzField
-
 
 class EnqueueArgsSerializer(serializers.Serializer):
     """
     A serializer for `enqueue_args` object of incoming user request data.
     """
 
-    enqueue_at = DateTimeTzField(required=False)
+    enqueue_at = serializers.DateTimeField(required=False)
     enqueue_in = serializers.DurationField(required=False)
     repeat = serializers.IntegerField(required=False, allow_null=True, min_value=1)
     repeat_interval = serializers.IntegerField(required=False, min_value=1)
-    retry_interval = serializers.IntegerField(required=False, min_value=0)
+    retry_interval = serializers.IntegerField(
+        required=False, allow_null=True, min_value=0
+    )
 
     def validate(self, data):
         if data.get("enqueue_at") and data.get("enqueue_in"):

--- a/kolibri/core/tasks/validation.py
+++ b/kolibri/core/tasks/validation.py
@@ -1,4 +1,6 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from kolibri.core.serializers import DateTimeTzField
 
@@ -51,17 +53,48 @@ class JobValidator(serializers.Serializer):
     enqueue_args = EnqueueArgsSerializer(required=False)
 
     def validate(self, data):
-        kwargs = data.copy()
-        kwargs.pop("type")
-        kwargs.pop("enqueue_args", None)
         return {
             "args": (),
-            "kwargs": kwargs,
+            "kwargs": data,
             "extra_metadata": {},
         }
 
+    def _verify_args(self, value):
+        args = value.get("args")
+        if args is None:
+            value["args"] = ()
+        elif not isinstance(args, (list, tuple)):
+            raise TypeError("'args' must be a list or tuple.")
+
+    def _verify_kwargs(self, value):
+        kwargs = value.get("kwargs")
+        if kwargs is None:
+            value["kwargs"] = {}
+        elif not isinstance(kwargs, dict):
+            raise TypeError("'kwargs' must be a dict.")
+
     def run_validation(self, data):
-        value = super(JobValidator, self).run_validation(data)
+        """
+        Vendored and modified from rest_framework/serializers.py to allow removing
+        the type argument and enqueue_args before passing to the validate method.
+        This means that the validate method will only be concerned with additional
+        validation of the data set by the subclasses.
+        """
+        (is_empty_value, data) = self.validate_empty_values(data)
+        if is_empty_value:
+            return data
+
+        value = self.to_internal_value(data)
+        try:
+            self.run_validators(value)
+            value.pop("type")
+            enqueue_args = value.pop("enqueue_args", {})
+            value = self.validate(value)
+            value["enqueue_args"] = enqueue_args
+            assert value is not None, ".validate() should return the validated data"
+        except (ValidationError, DjangoValidationError) as exc:
+            raise ValidationError(detail=serializers.as_serializer_error(exc))
+
         if not isinstance(value, dict):
             raise TypeError("Validator must return a dict.")
         extra_metadata = value.get("extra_metadata", {})
@@ -76,4 +109,9 @@ class JobValidator(serializers.Serializer):
                 }
             )
         value["extra_metadata"] = extra_metadata
+
+        self._verify_args(value)
+
+        self._verify_kwargs(value)
+
         return value


### PR DESCRIPTION
## Summary
* This is a backend only update to the general tasks API and the tasks API endpoint to allow for updating of the enqueue args of tasks, and to allow non-running tasks to be deleted (the clear action is only for tasks that have finished).
* Does a small amount of cleanup of arg validation to make it less brittle
* Updates the job storage class to allow tasks to update their enqueue args
* Updates the API endpoint to allow an update of enqueue args
* Adds a `retry_in` method for the job object to allow running jobs to schedule themselves for retry for dynamic retrying rather than using the static retry_interval
* Updates the single user sync tasks and network location discovery tasks to use this new method
* Adds handling of the delete method to the tasks API endpoint for deleting scheduled tasks

## References
Prerequisite for resolving #10490 

## Reviewer guidance
Do the changes make sense?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
