### PR TITLE
enabled a user with no channels on the device to access the remote content browsing feature

### DIFF
--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -98,11 +98,6 @@ export default [
     name: PageNames.LIBRARY,
     path: '/library' + optionalDeviceIdPathSegment,
     handler: to => {
-      if ((!get(channels) || !get(channels).length) && !get(isUserLoggedIn)) {
-        router.replace({ name: PageNames.CONTENT_UNAVAILABLE });
-        return;
-      }
-
       if (unassignedContentGuard()) {
         return unassignedContentGuard();
       }

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -37,23 +37,24 @@
         v-else-if="!displayingSearchResults"
         data-test="channels"
       >
-        <h1 class="channels-label">
-          {{ channelsLabel }}
-        </h1>
-        <p
-          v-if="isLocalLibraryEmpty"
-          data-test="nothing-in-lib-label"
-          class="nothing-in-lib-label"
-        >
-          {{ coreString('nothingInLibraryLearner') }}
-        </p>
-        <ChannelCardGroupGrid
-          v-if="!isLocalLibraryEmpty"
-          data-test="channel-cards"
-          class="grid"
-          :contents="rootNodes"
-          :deviceId="deviceId"
-        />
+        <div v-if="!isLocalLibraryEmpty">
+          <h1 class="channels-label">
+            {{ channelsLabel }}
+          </h1>
+          <p
+            v-if="isLocalLibraryEmpty"
+            data-test="nothing-in-lib-label"
+            class="nothing-in-lib-label"
+          >
+            {{ coreString('nothingInLibraryLearner') }}
+          </p>
+          <ChannelCardGroupGrid
+            data-test="channel-cards"
+            class="grid"
+            :contents="rootNodes"
+            :deviceId="deviceId"
+          />
+        </div>
         <!-- ResumableContentGrid mostly handles whether it renders or not internally !-->
         <!-- but we conditionalize it based on whether we are on another device's library page !-->
         <ResumableContentGrid

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -37,24 +37,23 @@
         v-else-if="!displayingSearchResults"
         data-test="channels"
       >
-        <div v-if="!isLocalLibraryEmpty">
-          <h1 class="channels-label">
-            {{ channelsLabel }}
-          </h1>
-          <p
-            v-if="isLocalLibraryEmpty"
-            data-test="nothing-in-lib-label"
-            class="nothing-in-lib-label"
-          >
-            {{ coreString('nothingInLibraryLearner') }}
-          </p>
-          <ChannelCardGroupGrid
-            data-test="channel-cards"
-            class="grid"
-            :contents="rootNodes"
-            :deviceId="deviceId"
-          />
-        </div>
+        <h1 class="channels-label">
+          {{ channelsLabel }}
+        </h1>
+        <p
+          v-if="isLocalLibraryEmpty"
+          data-test="nothing-in-lib-label"
+          class="nothing-in-lib-label"
+        >
+          {{ coreString('nothingInLibraryLearner') }}
+        </p>
+        <ChannelCardGroupGrid
+          v-if="!isLocalLibraryEmpty"
+          data-test="channel-cards"
+          class="grid"
+          :contents="rootNodes"
+          :deviceId="deviceId"
+        />
         <!-- ResumableContentGrid mostly handles whether it renders or not internally !-->
         <!-- but we conditionalize it based on whether we are on another device's library page !-->
         <ResumableContentGrid


### PR DESCRIPTION

## Summary
This PR  allows a user without any content on their device to browse network devices

## References
#10599
…

## Reviewer guidance

1. Delete the channels on your device 
2. Navigate to Learn >  Library 

Fixes  #10599
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
