### PR TITLE
Fixes disconnected status on kolibri library

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -77,19 +77,29 @@
     <slot name="underbuttons"></slot>
 
     <template #actions>
-      <KFixedGrid class="actions" numCols="4">
+      <KFixedGridItem
+        class="actions"
+        numCols="4"
+      >
         <KFixedGridItem span="1">
           <transition name="spinner-fade">
             <div v-if="isFetching || isChecking">
               <KLabeledIcon>
                 <template #icon>
-                  <KCircularLoader :size="16" :stroke="6" class="loader" />
+                  <KCircularLoader
+                    :size="16"
+                    :stroke="6"
+                    class="loader"
+                  />
                 </template>
               </KLabeledIcon>
             </div>
           </transition>
         </KFixedGridItem>
-        <KFixedGridItem span="3" alignment="right">
+        <KFixedGridItem
+          span="3"
+          alignment="right"
+        >
           <KButtonGroup style="margin-top: 8px;">
             <KButton
               :text="coreString('cancelAction')"
@@ -105,7 +115,7 @@
             />
           </KButtonGroup>
         </KFixedGridItem>
-      </KFixedGrid>
+      </KFixedGridItem>
     </template>
 
     <KButton
@@ -159,7 +169,7 @@
         useDevicesResult = useDevicesWithChannel(props.filterByChannelId);
       } else if (props.filterByFacilityId !== null) {
         // This is inherently filtered to full-facility devices
-        useDevicesResult = useDevicesWithFacility(props.filterByFacilityId);
+        useDevicesResult = useDevicesWithFacility({ facilityId: props.filterByFacilityId });
       } else if (props.filterLODAvailable) {
         useDevicesResult = useDevicesForLearnOnlyDevice();
       } else {

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import SelectDeviceForm from '../SelectDeviceForm';
 import { fetchDevices, updateConnectionStatus } from '../api';
 
@@ -39,7 +39,7 @@ const staticDevices = devices.map(a => ({ ...a, dynamic: false }));
 const dynamicDevices = devices.map(a => ({ ...a, dynamic: true }));
 
 function makeWrapper() {
-  const wrapper = mount(SelectDeviceForm);
+  const wrapper = shallowMount(SelectDeviceForm);
   // prettier-ignore
   const els = {
     KModal: () => wrapper.findComponent({ name: 'KModal' }),

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -153,7 +153,7 @@ export function useDevicesWithChannel(channelId = '') {
  *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
  * }}
  */
-export function useDevicesWithFacility(facilityId = '') {
+export function useDevicesWithFacility({ facilityId = '', soud = false } = {}) {
   // If facilityId is not provided, then we are at the initial Facility Import workflow
   // disable any devices unless it is unavailable/offline
   const filterDevices =
@@ -161,7 +161,7 @@ export function useDevicesWithFacility(facilityId = '') {
       ? () => Promise.resolve(true)
       : facilityIsAvailableAtDevice.bind({}, facilityId);
 
-  return useDevicesWithFilter({ subset_of_users_device: false }, filterDevices);
+  return useDevicesWithFilter({ subset_of_users_device: soud }, filterDevices);
 }
 
 /**

--- a/kolibri/plugins/learn/assets/src/composables/__mocks__/usePinnedDevices.js
+++ b/kolibri/plugins/learn/assets/src/composables/__mocks__/usePinnedDevices.js
@@ -32,9 +32,9 @@
  */
 
 const MOCK_DEFAULTS = {
-  createPinForUser: jest.fn(() => ''),
-  deletePinForUser: jest.fn(() => ''),
-  fetchPinsForUser: jest.fn(() => []),
+  createPinForUser: jest.fn(() => Promise.resolve({})),
+  deletePinForUser: jest.fn(() => Promise.resolve({})),
+  fetchPinsForUser: jest.fn(() => Promise.resolve([])),
 };
 
 export function usePinnedDevicesMock(overrides = {}) {

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -1,7 +1,10 @@
 <template>
 
-  <span v-if="isFetched && (!devices.some(device => device.id === deviceId && device.available))">
-    <span class="inner" style="font-size: 14px;">
+  <span v-if="isFetched && (!isDeviceAvailable)">
+    <span
+      class="inner"
+      style="font-size: 14px;"
+    >
       {{ coreString('disconnected') }}
     </span>
     <KIconButton
@@ -18,23 +21,52 @@
 
 <script>
 
+  import { get, set } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+  import { RemoteChannelResource } from 'kolibri.resources';
   import { ref, watch } from 'kolibri.lib.vueCompositionApi';
+  import { KolibriStudioId } from '../constants';
+  import commonLearnStrings from './commonLearnStrings';
 
   export default {
     name: 'DeviceConnectionStatus',
-    mixins: [commonCoreStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup(props) {
-      const { isFetching, devices } = useDevicesWithFacility();
+      /**
+       * soud(subset_of_user_device) is a query param for filtering.
+       * false to return non learn-only devices and true otherwise.
+       * null has been specified to return both type of devices which
+       * is necesary for device connection statuses
+       */
+      const { isFetching, devices } = useDevicesWithFacility({ soud: null });
       const isFetched = ref(false);
-      watch(isFetching, currentValue => {
-        if (!currentValue.value) {
-          isFetched.value = props.deviceId !== null;
+      const allDevices = ref([]);
+
+      const getStudio = async () => {
+        let studio = [];
+        if (props.deviceId) {
+          const response = await RemoteChannelResource.getKolibriStudioStatus();
+          const studioData = {
+            ...response.data,
+            id: KolibriStudioId,
+            instance_id: KolibriStudioId,
+          };
+          studio = [studioData];
+        }
+        return studio;
+      };
+
+      watch(isFetching, async currentValue => {
+        if (!get(currentValue)) {
+          const studio = await getStudio();
+          set(allDevices, [...get(devices), ...studio]);
+          set(isFetched, props.deviceId !== null);
         }
       });
+
       return {
-        devices,
+        allDevices,
         isFetched,
       };
     },
@@ -48,6 +80,11 @@
         type: String,
         // 'primary' by default, but could add more later
         default: 'primary',
+      },
+    },
+    computed: {
+      isDeviceAvailable() {
+        return this.allDevices.some(device => device.id === this.deviceId && device.available);
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -8,6 +8,7 @@
   >
     <div
       class="page-header"
+      data-test="page-header"
       :style="pageHeaderStyle"
     >
       <h1>
@@ -30,10 +31,14 @@
       @togglePin="handlePinToggle"
     />
     <div v-if="areMoreDevicesAvailable">
-      <div v-if="pinnedDevicesExist">
+      <div
+        v-if="pinnedDevicesExist"
+        data-test="more-libraries"
+      >
         <h2>{{ learnString('moreLibraries') }}</h2>
         <KButton
           v-if="displayShowButton"
+          data-test="show-button"
           :text="coreString('showAction')"
           :primary="false"
           @click="loadMoreDevices"
@@ -52,6 +57,7 @@
       />
       <KButton
         v-if="displayShowMoreButton"
+        data-test="show-more-button"
         :text="coreString('showMoreAction')"
         :primary="false"
         @click="loadMoreDevices"

--- a/kolibri/plugins/learn/assets/test/views/explore-libraries-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/explore-libraries-page.spec.js
@@ -1,0 +1,92 @@
+import { createLocalVue, mount, shallowMount } from '@vue/test-utils';
+import Vuex from 'vuex';
+import VueRouter from 'vue-router';
+import ExploreLibrariesPage from '../../src/views/ExploreLibrariesPage';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(VueRouter);
+
+jest.mock('../../src/composables/useChannels');
+jest.mock('../../src/composables/useDevices');
+jest.mock('../../src/composables/useContentLink');
+jest.mock('../../src/composables/usePinnedDevices');
+
+function makeWrapper({ getters, options, fullMount = false } = {}) {
+  const store = new Vuex.Store({
+    state: { core: { loading: false } },
+    getters: {
+      isSuperuser: jest.fn(),
+      ...getters,
+    },
+  });
+  if (fullMount) {
+    return mount(ExploreLibrariesPage, { store, localVue, ...options });
+  } else {
+    return shallowMount(ExploreLibrariesPage, { store, localVue, ...options });
+  }
+}
+
+describe('ExploreLibrariesPage', () => {
+  let wrapper;
+
+  const translations = {
+    allLibraries: 'All Libraries',
+    showingLibraries: 'Showing',
+  };
+  const options = {
+    computed: {
+      areMoreDevicesAvailable: jest.fn(() => true),
+      displayShowMoreButton: jest.fn(() => true),
+      pageHeaderStyle: jest.fn(),
+    },
+    methods: {
+      refreshDevices: jest.fn(),
+    },
+    $trs: translations,
+  };
+  beforeEach(() => {
+    wrapper = makeWrapper({
+      options,
+    });
+  });
+
+  it('renders without errors', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the page header correctly', () => {
+    const pageHeader = wrapper.find('[data-test="page-header"]');
+    expect(pageHeader.exists()).toBe(true);
+    expect(pageHeader.text()).toContain(translations.allLibraries);
+    expect(pageHeader.text()).toContain(translations.showingLibraries);
+  });
+
+  it('show more libraries section if pinned devices exist', () => {
+    wrapper = makeWrapper({
+      options: {
+        ...options,
+        computed: {
+          ...options.computed,
+          pinnedDevicesExist: jest.fn(() => true),
+          displayShowButton: jest.fn(() => true),
+        },
+      },
+    });
+    const moreLibraries = wrapper.find('[data-test="more-libraries"]');
+    expect(moreLibraries.element).toBeTruthy();
+    expect(moreLibraries.text()).toContain('More');
+    const showButton = wrapper.find('[data-test="show-button"]');
+    expect(showButton.element).toBeTruthy();
+  });
+
+  it('loads more devices when show more button is clicked', async () => {
+    const showMoreButton = wrapper.find('[data-test="show-more-button"]');
+    showMoreButton.trigger('click');
+    await wrapper.vm.$nextTick();
+    const libraryItems = wrapper.findAllComponents({ name: 'LibraryItem' });
+    expect(libraryItems.length).toEqual(0);
+  });
+
+  // Add more tests as needed for other functionality in the component
+});


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the device connection status bug when exploring the Kolibri Library. It also write tests for the `ExploreLibrariesPage`.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10721

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Remember to run Zerotier. This should already be set up from earlier sessions, but you may need to reopen the application. Incase you need a refresher on setup, please visit [ZeroTier](https://www.notion.so/ZeroTier-3e508bf09b7e4c72a1713b8374a43cac)
- To view the Kolibri Library when exploring libraries, set the environment variable below before you run the app file
   - `KOLIBRI_CENTRAL_CONTENT_BASE_URL=https://unstable.studio.learningequality.org`
- Go to `/learn/#/library`
- Click on the `Explore` card under the Kolibri library section
- Also, browse any devices available and observe the behavior of the device connection status

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
