### PR TITLE
docs: Small documentation improvements around copyright and licensing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-Kolibri is copyrighted by Learning Equality under the MIT License.
+Kolibri is copyright Learning Equality and other contributors, and is released under the MIT License.
 
 If you have contributed to Kolibri, feel free to add your name and Github account to this list:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Learning Equality
+Copyright (c) 2021 Learning Equality and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/development_workflow.rst
+++ b/docs/development_workflow.rst
@@ -96,6 +96,27 @@ First, all automated checks need to pass before merging. Then...
 * Stale reviews should be dismissed by the PR submitter when the feedback has been addressed
 
 
+Copyright and licensing
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The project as a whole is released under the MIT license, and copyright on its code is held by multiple parties including Learning Equality.
+
+Individual files, such as code copied in from other projects may be under a different license, if that license is compatible.
+
+Similarly, files from Kolibri may end up being copied into other projects.
+
+For these reasons, copyright and license data may be listed explicitly at the top of some files. For example:
+
+.. code-block:: python
+
+  # Copyright 2023 Ann Contributor
+  # SPDX-License-Identifier: MIT
+
+This format is machine readable and complies with the `REUSE specification <https://reuse.software/>`__ for software licensing.
+
+For files where the license is not explicitly stated, the `overall project license <../LICENSE>`__ applies.
+
+
 Development phases
 ------------------
 


### PR DESCRIPTION
## Summary

See the commit messages for details. This makes some minor improvements to the copyright wording in `AUTHORS.md` and `LICENSE`; and adds a section to the development workflow docs about copyright/licensing headers for files.

This is based on a Slack discussion between various parties.

I’ve verified the docs changes by running `make docs` and looking at the changes in a browser.

## References

 * https://app.slack.com/client/T0266FNKJ/C01EAFKS6KH/thread/C01EAFKS6KH-1684766197.139319?cdn_fallback=2
 * https://reuse.software/faq/ (I am not suggesting full REUSE compliance here, but the recommendations I’ve made are compliant, and their FAQ is a good guide to the reasoning behind putting copyright and license in per-file headers)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
