### PR TITLE
Reduces test noise by setting loglevel to silent.

### DIFF
--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -10,6 +10,7 @@ import VueMeta from 'vue-meta';
 import VueRouter from 'vue-router';
 import VueCompositionApi from '@vue/composition-api';
 import Vuex from 'vuex';
+import logging from 'kolibri.lib.logging';
 import { i18nSetup } from 'kolibri.utils.i18n';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 import KContentPlugin from 'kolibri-design-system/lib/content/KContentPlugin';
@@ -29,6 +30,9 @@ global.afterEach(() => {
     return process.nextTick(resolve);
   });
 });
+
+// Disable all core logging during tests.
+logging.setLevel('silent');
 
 // Register Vue plugins and components
 Vue.use(Vuex);


### PR DESCRIPTION
## Summary
* Sets the level for our logging library to silent during tests to suppress all log statements using the library