### PR TITLE
py27 ie11 deprecation warnings

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -1,0 +1,73 @@
+<template>
+
+  <div class="alert" :style="{ backgroundColor: $themePalette.red.v_50, display: displayBanner }">
+    <h1 style="display: none">
+      {{ "was insufiicientstorage header" }}
+    </h1>
+    <div style="display:flex">
+      <div>
+        <KIcon
+          icon="warn"
+          class="icon"
+        />
+      </div>
+
+      <div class="error-message">
+        {{ "warning" }}
+        <router-link :to="url">
+          <KButton appearance="basic-link">
+            {{ "link ? button?" }}
+          </KButton>
+        </router-link>
+      </div>
+
+      <div>
+        <!-- TODO update aria-labels -->
+        <KIconButton
+          size="small"
+          icon="incorrect"
+          :ariaLabel="'arialabel'"
+          :tooltip="'tooltip'"
+          @click="closeAlert"
+        />
+      </div>
+
+    </div>
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'DeprecationWarningBanner',
+    mixins: [commonCoreStrings],
+    data: function() {
+      return {
+        displayBanner: 'auto',
+      };
+    },
+  };
+
+</script>
+
+
+<style scoped>
+.alert {
+  padding: 10px;
+  margin-bottom: 15px;
+}
+.icon {
+  height: 24px;
+  width: 24px;
+  margin-top: 3px;
+}
+.error-message {
+  font-size:14px;
+  margin: 7px 7px 0px 10px;
+}
+</style>

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -1,39 +1,27 @@
 <template>
 
-  <div class="alert" :style="{ backgroundColor: $themePalette.red.v_50, display: displayBanner }">
-    <h1 style="display: none">
-      {{ "was insufiicientstorage header" }}
-    </h1>
+  <div
+    v-show="showBanner"
+    class="alert"
+    :style="{ backgroundColor: $themePalette.red.v_50 }"
+  >
     <div style="display:flex">
       <div>
         <KIcon
-          icon="warn"
+          icon="warning"
           class="icon"
         />
       </div>
 
       <div class="error-message">
-        {{ "warning" }}
-        <router-link :to="url">
-          <KButton appearance="basic-link">
-            {{ "link ? button?" }}
-          </KButton>
-        </router-link>
+        <p v-if="py27Deprecated">
+          {{ coreString('pythonSupportWillBeDropped') }}
+        </p>
+        <p v-if="ie11Deprecated">
+          {{ coreString('browserSupportWillBeDroppedIE11') }}
+        </p>
       </div>
-
-      <div>
-        <!-- TODO update aria-labels -->
-        <KIconButton
-          size="small"
-          icon="incorrect"
-          :ariaLabel="'arialabel'"
-          :tooltip="'tooltip'"
-          @click="closeAlert"
-        />
-      </div>
-
     </div>
-
   </div>
 
 </template>
@@ -42,14 +30,21 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import plugin_data from 'plugin_data';
 
   export default {
     name: 'DeprecationWarningBanner',
     mixins: [commonCoreStrings],
-    data: function() {
-      return {
-        displayBanner: 'auto',
-      };
+    computed: {
+      showBanner() {
+        return this.ie11Deprecated || this.py27Deprecated;
+      },
+      ie11Deprecated() {
+        return plugin_data.deprecationWarnings.ie11;
+      },
+      py27Deprecated() {
+        return plugin_data.deprecationWarnings.py27;
+      },
     },
   };
 
@@ -58,16 +53,21 @@
 
 <style scoped>
 .alert {
-  padding: 10px;
-  margin-bottom: 15px;
+  position: relative;
+  padding: 1em 1em 1em 2em;
+  margin-top: 1em;
+  max-width: 1000px;
+  width: 100%;
 }
 .icon {
   height: 24px;
   width: 24px;
-  margin-top: 3px;
+  top: 2em;
+  left: 1em;
+  position: absolute;
 }
 .error-message {
   font-size:14px;
-  margin: 7px 7px 0px 10px;
+  margin: 0em 1em 0 2em;
 }
 </style>

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -18,7 +18,13 @@
         <p v-if="py27Deprecated">
           {{ coreString('pythonSupportWillBeDropped') }}
         </p>
-        <p v-if="ie11Deprecated">
+        <p v-if="currentUserOnIE11">
+          {{ coreString('currentDeviceUsingIE11') }}
+        </p>
+        <p v-if="userDevicesUsingIE11">
+          {{ coreString('userDevicesUsingIE11') }}
+        </p>
+        <p v-if="currentUserOnIE11 || userDevicesUsingIE11">
           {{ coreString('browserSupportWillBeDroppedIE11') }}
         </p>
       </div>
@@ -31,6 +37,7 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { browser } from 'kolibri.utils.browserInfo';
   import plugin_data from 'plugin_data';
 
   export default {
@@ -38,13 +45,16 @@
     mixins: [commonCoreStrings],
     computed: {
       showBanner() {
-        return this.ie11Deprecated || this.py27Deprecated;
+        return this.currentUserOnIE11 || this.userDevicesUsingIE11 || this.py27Deprecated;
       },
-      ie11Deprecated() {
+      userDevicesUsingIE11() {
         return plugin_data.deprecationWarnings.ie11;
       },
       py27Deprecated() {
         return plugin_data.deprecationWarnings.py27;
+      },
+      currentUserOnIE11() {
+        return browser.name === 'IE';
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -3,13 +3,14 @@
   <div
     v-show="showBanner"
     class="alert"
-    :style="{ backgroundColor: $themePalette.red.v_50 }"
+    :style="{ backgroundColor: $themePalette.yellow.v_100 }"
   >
     <div style="display:flex">
       <div>
         <KIcon
           icon="warning"
           class="icon"
+          :color="$themePalette.amber.v_a400"
         />
       </div>
 
@@ -54,15 +55,15 @@
 <style scoped>
 .alert {
   position: relative;
-  padding: 1em 1em 1em 2em;
-  margin-top: 1em;
+  padding-left: 2em;
+  margin: 1em auto 0;
   max-width: 1000px;
   width: 100%;
 }
 .icon {
   height: 24px;
   width: 24px;
-  top: 2em;
+  top: 1em;
   left: 1em;
   position: absolute;
 }

--- a/kolibri/plugins/device/assets/src/views/DeviceAppBarPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceAppBarPage.vue
@@ -6,9 +6,9 @@
       <DeviceTopNav />
     </template>
 
-    <DeprecationWarningBanner />
+    <DeprecationWarningBanner style="margin-bottom: 1em" />
 
-    <div style="margin-top: 1em">
+    <div>
       <slot></slot>
     </div>
 

--- a/kolibri/plugins/device/assets/src/views/DeviceAppBarPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceAppBarPage.vue
@@ -1,0 +1,37 @@
+<template>
+
+  <AppBarPage :title="title">
+
+    <template #subNav>
+      <DeviceTopNav />
+    </template>
+
+    <DeprecationWarningBanner />
+
+    <div style="margin-top: 1em">
+      <slot></slot>
+    </div>
+
+  </AppBarPage>
+
+</template>
+
+
+<script>
+
+  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
+  import DeviceTopNav from './DeviceTopNav';
+  import DeprecationWarningBanner from './DeprecationWarningBanner';
+
+  export default {
+    name: 'DeviceAppBarPage',
+    components: { AppBarPage, DeprecationWarningBanner, DeviceTopNav },
+    props: {
+      title: {
+        type: String,
+        required: true,
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -1,10 +1,6 @@
 <template>
 
-  <AppBarPage :title="pageTitle">
-
-    <template #subNav>
-      <DeviceTopNav />
-    </template>
+  <DeviceAppBarPage :title="pageTitle">
 
     <KPageContainer class="device-container">
       <div v-if="!$store.state.core.loading">
@@ -75,7 +71,7 @@
         />
       </div>
     </KPageContainer>
-  </AppBarPage>
+  </DeviceAppBarPage>
 
 </template>
 
@@ -86,9 +82,8 @@
   import TechnicalTextBlock from 'kolibri-common/components/AppError/TechnicalTextBlock';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
+  import DeviceAppBarPage from './DeviceAppBarPage';
   import { deviceString } from './commonDeviceStrings';
-  import DeviceTopNav from './DeviceTopNav';
   import DeviceNameModal from './DeviceNameModal';
 
   export default {
@@ -99,9 +94,8 @@
       };
     },
     components: {
-      AppBarPage,
+      DeviceAppBarPage,
       DeviceNameModal,
-      DeviceTopNav,
       TechnicalTextBlock,
     },
     mixins: [commonCoreStrings, responsiveWindowMixin],

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
@@ -13,6 +13,15 @@ import { getFreeSpaceOnServer } from '../../AvailableChannelsPage/api';
 jest.mock('../../../composables/usePlugins');
 jest.mock('kolibri.urls');
 
+jest.mock('plugin_data', () => {
+  return {
+    __esModule: true,
+    default: {
+      deprecationWarnings: {},
+    },
+  };
+});
+
 jest.mock('../api.js', () => ({
   getPathPermissions: jest.fn(),
   getPathsPermissions: jest.fn(),

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -1,10 +1,7 @@
 <template>
 
-  <AppBarPage :title="pageTitle">
+  <DeviceAppBarPage :title="pageTitle">
 
-    <template #subNav>
-      <DeviceTopNav />
-    </template>
     <KPageContainer class="device-container">
       <UiAlert
         v-if="showDisabledAlert && alertDismissed"
@@ -336,7 +333,7 @@
       />
 
     </KPageContainer>
-  </AppBarPage>
+  </DeviceAppBarPage>
 
 </template>
 
@@ -351,12 +348,11 @@
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import commonDeviceStrings from '../commonDeviceStrings';
+  import DeviceAppBarPage from '../DeviceAppBarPage';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
-  import DeviceTopNav from '../DeviceTopNav';
   import { getFreeSpaceOnServer } from '../AvailableChannelsPage/api';
   import useDeviceRestart from '../../composables/useDeviceRestart';
   import usePlugins from '../../composables/usePlugins';
@@ -380,9 +376,8 @@
       };
     },
     components: {
-      AppBarPage,
+      DeviceAppBarPage,
       BottomAppBar,
-      DeviceTopNav,
       PrimaryStorageLocationModal,
       AddStorageLocationModal,
       RemoveStorageLocationModal,

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -1,10 +1,6 @@
 <template>
 
-  <AppBarPage :title="pageTitle">
-
-    <template #subNav>
-      <DeviceTopNav />
-    </template>
+  <DeviceAppBarPage :title="pageTitle">
 
     <KPageContainer class="device-container">
       <HeaderWithOptions :headerText="coreString('facilitiesLabel')">
@@ -178,7 +174,7 @@
         @syncPeer="handlePeerSync"
       />
     </KPageContainer>
-  </AppBarPage>
+  </DeviceAppBarPage>
 
 </template>
 
@@ -188,7 +184,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import CoreTable from 'kolibri.coreVue.components.CoreTable';
   import { FacilityResource } from 'kolibri.resources';
   import {
@@ -199,10 +194,10 @@
   } from 'kolibri.coreVue.componentSets.sync';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import some from 'lodash/some';
+  import DeviceAppBarPage from '../DeviceAppBarPage';
   import { PageNames } from '../../constants';
   import { deviceString } from '../commonDeviceStrings';
   import TasksBar from '../ManageContentPage/TasksBar';
-  import DeviceTopNav from '../DeviceTopNav';
   import HeaderWithOptions from '../HeaderWithOptions';
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
@@ -223,10 +218,9 @@
       };
     },
     components: {
-      AppBarPage,
+      DeviceAppBarPage,
       ConfirmationRegisterModal,
       CoreTable,
-      DeviceTopNav,
       HeaderWithOptions,
       FacilityNameAndSyncStatus,
       ImportFacilityModalGroup,

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -1,10 +1,6 @@
 <template>
 
-  <AppBarPage :title="pageTitle">
-
-    <template #subNav>
-      <DeviceTopNav />
-    </template>
+  <DeviceAppBarPage :title="pageTitle">
 
     <KPageContainer class="device-container">
 
@@ -77,7 +73,7 @@
 
     </KPageContainer>
 
-  </AppBarPage>
+  </DeviceAppBarPage>
 
 </template>
 
@@ -90,14 +86,13 @@
   import sortBy from 'lodash/sortBy';
   import { mapState, mapGetters, mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { TaskResource } from 'kolibri.resources';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import DeviceAppBarPage from '../DeviceAppBarPage';
   import taskNotificationMixin from '../taskNotificationMixin';
   import useContentTasks from '../../composables/useContentTasks';
   import { PageNames } from '../../constants';
   import HeaderWithOptions from '../HeaderWithOptions';
-  import DeviceTopNav from '../DeviceTopNav';
   import { deviceString } from '../commonDeviceStrings';
   import SelectTransferSourceModal from './SelectTransferSourceModal';
   import ChannelPanel from './ChannelPanel/WithSizeAndOptions';
@@ -112,10 +107,9 @@
       };
     },
     components: {
-      AppBarPage,
+      DeviceAppBarPage,
       ChannelPanel,
       DeleteChannelModal,
-      DeviceTopNav,
       HeaderWithOptions,
       SelectTransferSourceModal,
       TasksBar,

--- a/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManagePermissionsPage/index.vue
@@ -1,10 +1,6 @@
 <template>
 
-  <AppBarPage :title="pageTitle">
-
-    <template #subNav>
-      <DeviceTopNav />
-    </template>
+  <DeviceAppBarPage :title="pageTitle">
 
     <KPageContainer class="device-container">
       <div class="description">
@@ -55,7 +51,7 @@
       </PaginatedListContainer>
 
     </KPageContainer>
-  </AppBarPage>
+  </DeviceAppBarPage>
 
 </template>
 
@@ -67,8 +63,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import PaginatedListContainer from 'kolibri.coreVue.components.PaginatedListContainer';
   import { PermissionTypes, UserKinds } from 'kolibri.coreVue.vuex.constants';
-  import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
-  import DeviceTopNav from '../DeviceTopNav';
+  import DeviceAppBarPage from '../DeviceAppBarPage';
   import { deviceString } from '../commonDeviceStrings';
   import UserGrid from './UserGrid';
 
@@ -82,8 +77,7 @@
       };
     },
     components: {
-      AppBarPage,
-      DeviceTopNav,
+      DeviceAppBarPage,
       PaginatedListContainer,
       UserGrid,
     },

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
+
 from kolibri.core.auth.constants.user_kinds import SUPERUSER
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
@@ -16,18 +18,29 @@ class DeviceManagementPlugin(KolibriPluginBase):
     translated_view_urls = "urls"
 
 
+def any_ie11_users():
+    from kolibri.core.logger.models import UserSessionLog
+
+    return UserSessionLog.objects.filter(device_info__contains="IE,11").count() > 0
+
+
+def using_py27():
+    return sys.version_info.major == 2
+
+
 @register_hook
 class DeviceManagementAsset(WebpackBundleHook):
     bundle_id = "app"
 
     @property
     def plugin_data(self):
+
         return {
             "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"],
             "canRestart": bool(OPTIONS["Deployment"]["RESTART_HOOKS"]),
             "deprecationWarnings": {
-                "py27": False,
-                "ie11": False,
+                "py27": using_py27(),
+                "ie11": any_ie11_users(),
             },
         }
 

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -24,10 +24,6 @@ def any_ie11_users():
     return UserSessionLog.objects.filter(device_info__contains="IE,11").count() > 0
 
 
-def using_py27():
-    return sys.version_info.major == 2
-
-
 @register_hook
 class DeviceManagementAsset(WebpackBundleHook):
     bundle_id = "app"
@@ -39,7 +35,7 @@ class DeviceManagementAsset(WebpackBundleHook):
             "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"],
             "canRestart": bool(OPTIONS["Deployment"]["RESTART_HOOKS"]),
             "deprecationWarnings": {
-                "py27": using_py27(),
+                "py27": sys.version_info.major == 2,
                 "ie11": any_ie11_users(),
             },
         }

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -25,6 +25,10 @@ class DeviceManagementAsset(WebpackBundleHook):
         return {
             "isRemoteContent": OPTIONS["Deployment"]["REMOTE_CONTENT"],
             "canRestart": bool(OPTIONS["Deployment"]["RESTART_HOOKS"]),
+            "deprecationWarnings": {
+                "py27": False,
+                "ie11": False,
+            },
         }
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Implements banner for deprecation warnings in Device for py2.7 and IE11.

### Follow-up Tasks

- [x] Probably can remove py27...() function and call to sys directly. I'd moved them out of the `plugin_data` method's scope trying to debug why the Device plugin was failing to enable - I'm wrapping for the day so I'll update this tomorrow
~- [ ] Looking to write front-end tests for the banner to put a bow on this ~
- [x] Not super sure right now on how to test the `plugin_data` from the backend side and it's fairly low-risk code so I'll probably skip

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #10482 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Use IE11 on your server and view content as a sign-in user (if you've used IE11 on this database before, skip this step)
- Go to Device as super admin and see the warning re: IE11

- Run the pex using Python 2.7
- Go to Device as super admin and see the warning re: Python 2.7

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
