### PR TITLE
Revert KFixedGridItem to KFixedGrid

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -77,7 +77,7 @@
     <slot name="underbuttons"></slot>
 
     <template #actions>
-      <KFixedGridItem
+      <KFixedGrid
         class="actions"
         numCols="4"
       >
@@ -115,7 +115,7 @@
             />
           </KButtonGroup>
         </KFixedGridItem>
-      </KFixedGridItem>
+      </KFixedGrid>
     </template>
 
     <KButton


### PR DESCRIPTION
## Summary

Fixes https://github.com/learningequality/kolibri/issues/10742

Reverts a change made in the SelectDeviceForm that changed a `KFixedGrid` parent component to a `KFixedGridItem`. Switching this back doesn't break any of the other changes in the fix, and brings back the buttons

## References
Fixes https://github.com/learningequality/kolibri/issues/10742

| Before | After |
|---|---|
| ![image](https://github.com/learningequality/kolibri/assets/17235236/68d18474-fc42-4bcc-87fd-c12fde6d3a7a) | <img width="596" alt="Screenshot 2023-05-24 at 9 51 59 AM" src="https://github.com/learningequality/kolibri/assets/17235236/80f582c9-8741-45f3-9d64-389510af482f"> |


## Reviewer guidance

- create a new kolibri home folder 
- go through the setup wizard: group learning > learn only device > import users
- buttons should be present 

The other places where the DeviceSelectionModal is present should also work: 
- setup wizard: group learning > full device > import data
- device: facility > import learning facility 


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
