### PR TITLE
Uses isUserLoggedIn to show LogoutSideNavEntry

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -107,7 +107,7 @@
                   style="cursor: pointer;"
                   data-test="side-nav-component"
                 />
-                <LogoutSideNavEntry v-if="showLogout" />
+                <LogoutSideNavEntry v-if="isUserLoggedIn" />
                 <CoreMenuOption
                   :label="coreString('changeLanguageOption')"
                   icon="language"
@@ -312,7 +312,14 @@
       };
     },
     computed: {
-      ...mapGetters(['isSuperuser', 'isAdmin', 'isCoach', 'getUserKind', 'isAppContext']),
+      ...mapGetters([
+        'isSuperuser',
+        'isAdmin',
+        'isCoach',
+        'getUserKind',
+        'isAppContext',
+        'isUserLoggedIn',
+      ]),
       ...mapState({
         username: state => state.core.session.username,
         fullName: state => state.core.session.full_name,
@@ -341,9 +348,6 @@
         return [...accountComponents]
           .filter(this.filterByRole)
           .filter(this.filterByFullFacilityOnly);
-      },
-      showLogout() {
-        return this.getUserKind !== UserKinds.ANONYMOUS;
       },
       bottomMenuOptions() {
         return navComponents.filter(component => component.bottomBar == true);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
To support logging out within Kolibri Data Portal, this PR updates the side navigation to use `isUserLoggedIn` for displaying `LogoutSideNavEntry`.

Before

<img width="1439" alt="kdp_before" src="https://github.com/learningequality/kolibri/assets/46411498/6dd0f84c-74c6-4950-a409-5806617adb3f">

After
<img width="481" alt="kdp_after" src="https://github.com/learningequality/kolibri/assets/46411498/70fc9eef-1e20-4d7f-be53-a00b500febfe">

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10744 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Logout display should work the same as before.

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
