### PR TITLE
[WIP] handling browser "back" button, round 2

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -37,6 +37,7 @@ export default {
       },
       loading: false,
       error: false,
+      wizardNavigated: false,
     };
   },
   actions: {
@@ -66,6 +67,9 @@ export default {
       store.commit('SET_ERROR', true);
       store.dispatch('handleApiError', errorMsg);
     },
+    setWizardNavigated(store, wizardNavFlag) {
+      store.commit('SET_WIZARD_NAVIGATION', wizardNavFlag);
+    }
   },
   mutations: {
     CLEAR_PASSWORD(state) {
@@ -73,6 +77,9 @@ export default {
     },
     SET_LANGUAGE(state, language_id) {
       state.onboardingData.language_id = language_id;
+    },
+    SET_WIZARD_NAVIGATION(state, wizardNavFlag) {
+      state.wizardNavigated = wizardNavFlag;
     },
     SET_USER_CREDENTIALS(state, payload) {
       state.onboardingData.user = {

--- a/kolibri/plugins/setup_wizard/assets/src/routes.js
+++ b/kolibri/plugins/setup_wizard/assets/src/routes.js
@@ -30,53 +30,94 @@ export default [
     path: '/default-language',
     name: 'DEFAULT_LANGUAGE',
     component: DefaultLanguageForm,
+    // // beforeRouteLeave not set up on route yet
+    // meta: {
+    //   previousNavigationAllowed: ['HOW_ARE_YOU_USING_KOLIBRI'],
+    // }
   },
   {
     path: '/create-account',
     name: 'CREATE_SUPERUSER_AND_FACILITY',
     component: UserCredentialsForm,
+    // // beforeRouteLeave not set up on route yet
+    // meta: {
+    //   previousNavigationAllowed: ['DEFAULT_LANGUAGE'],
+    // }
   },
   {
     path: '/device-name',
     name: 'DEVICE_NAME',
     component: DeviceNameForm,
+    meta: {
+      previousNavigationAllowed: ['HOW_ARE_YOU_USING_KOLIBRI'],
+      // // didn't end up working and it doesn't seem so bad to have
+      // // forward browser button disabled (state is retained when you return)
+      // nextNavigationAllowed: ['FULL_OR_LOD'],
+    }
   },
   {
     path: '/full-or-lod',
     name: 'FULL_OR_LOD',
     component: FullOrLearnOnlyDeviceForm,
+    meta: {
+      previousNavigationAllowed: ['DEVICE_NAME'],
+      // nextNavigationAllowed: ['FULL_NEW_OR_IMPORT_FACILITY', 'LOD_SETUP_TYPE']
+    }
   },
   {
     path: '/facility-new-or-import',
     name: 'FULL_NEW_OR_IMPORT_FACILITY',
     component: SetUpLearningFacilityForm,
+    meta: {
+      previousNavigationAllowed: ['FULL_OR_LOD'],
+      // nextNavigationAllowed: ['FACILITY_PERMISSIONS', 'SELECT_FACILITY_FOR_IMPORT']
+    }
   },
   // create a facility
   {
     name: 'FACILITY_PERMISSIONS',
     path: '/create_facility/1',
     component: FacilityPermissionsForm,
+    meta: {
+      previousNavigationAllowed: ['FULL_NEW_OR_IMPORT_FACILITY'],
+      // nextNavigationAllowed: ['GUEST_ACCESS']
+    }
   },
   {
     name: 'GUEST_ACCESS',
     path: '/create-facility/2',
     component: GuestAccessForm,
+    meta: {
+      previousNavigationAllowed: ['FACILITY_PERMISSIONS'],
+      // nextNavigationAllowed: ['CREATE_LEARNER_ACCOUNT']
+    }
   },
   {
     name: 'CREATE_LEARNER_ACCOUNT',
     path: '/create-facility/3',
     component: CreateLearnerAccountForm,
+    meta: {
+      previousNavigationAllowed: ['GUEST_ACCESS'],
+      // nextNavigationAllowed: ['REQUIRE_PASSWORD']
+    }
   },
   {
     name: 'REQUIRE_PASSWORD',
     path: '/create-facility/4',
     component: RequirePasswordForLearnersForm,
+    meta: {
+      previousNavigationAllowed: ['CREATE_LEARNER_ACCOUNT'],
+      // nextNavigationAllowed: ['PERSONAL_DATA_CONSENT']
+    }
   },
   {
     name: 'PERSONAL_DATA_CONSENT',
     path: '/create-facility/5',
     component: PersonalDataConsentForm,
     props: { footerMessageType: FooterMessageTypes.NEW_FACILITY },
+    meta: {
+      previousNavigationAllowed: [''],
+    }
   },
   // Import a facility
   {
@@ -99,12 +140,22 @@ export default [
     name: 'SELECT_ADMIN',
     path: '/import-facility/select-admin',
     component: SelectSuperAdminAccountForm,
+    meta: {
+      previousNavigationAllowed: [''],
+      // backActionAllowed: 'never',
+      // nextNavigationAllowed: ['IMPORT_DATA_CONSENT'],
+    }
   },
   {
     name: 'IMPORT_DATA_CONSENT',
     path: '/import-facility/consent',
     component: PersonalDataConsentForm,
     props: { footerMessageType: FooterMessageTypes.IMPORT_FACILITY },
+    meta: {
+      previousNavigationAllowed: [''],
+      // backActionAllowed: 'never',
+      // nextNavigationAllowed: ['FINALIZE_SETUP'],
+    }
   },
 
   // Learn only device
@@ -122,6 +173,12 @@ export default [
     name: 'LOD_IMPORT_USER_AUTH',
     path: '/learn-only/import/sign-in',
     component: ImportIndividualUserForm,
+    meta: {
+      // // how to accomplish this?
+      backActionAllowed: 'checkImportedUsers', // if there are imported users, you can't go back
+      previousNavigationAllowed: [''],
+      // nextNavigationAllowed: ['LOD_LOADING_TASK_PAGE', 'LOD_IMPORT_AS_ADMIN'],
+    }
   },
   {
     name: 'LOD_LOADING_TASK_PAGE',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
@@ -63,6 +63,14 @@
         return { type: 'BACK', value: Boolean(this.setting) };
       },
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.backEvent;
+          // return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinue() {
         this.wizardService.send({ type: 'CONTINUE', value: this.setting });

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/DeviceNameForm.vue
@@ -49,6 +49,13 @@
         return '';
       },
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinue() {
         this.shouldValidate = true;

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -66,6 +66,13 @@
         Presets,
       };
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     mounted() {
       this.focusOnTextbox();
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -43,6 +43,14 @@
         selected,
       };
     },
+
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinue() {
         this.wizardService.send({ type: 'CONTINUE', value: this.selected });

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
@@ -59,6 +59,14 @@
         return { type: 'BACK', value: Boolean(this.setting) };
       },
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.backEvent;
+          // return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinue() {
         this.wizardService.send({ type: 'CONTINUE', value: this.setting });

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
@@ -66,6 +66,22 @@
         return null;
       },
     },
+    // // same as beforeRouteLeave in other routes
+    // beforeRouteLeave(to, from, next) {
+    //   if (!this.$store.state.wizardNavigated) {
+    //     if (from.meta.previousNavigationAllowed.includes(to.name)) {
+    //       return this.wizardService.send({ type: 'BACK' });
+    //     }
+    //   }
+    //   else {
+    //     return next();
+    //   }
+    // },
+    beforeRouteLeave(to, from, next) {
+      if (this.$store.state.wizardNavigated) {
+        return next();
+      }
+    },
     mounted() {
       this.focusOnModalButton();
     },
@@ -78,7 +94,9 @@
         // form. The state machine can define the expected event name for it's particular context.
         // See the comments around this in wizardMachine
         const lastStatePath = Object.keys(this.wizardService._state.meta)[0];
-        const { nextEvent = null } = this.wizardService.state.meta[lastStatePath];
+        // const backFromCreateSuperuser = lastStatePath === 'wizard.createSuperuserAndFacilityForm' && 'CONTINUE';
+        const { nextEvent = null } = this.wizardService.state.meta[lastStatePath]
+          // || backFromCreateSuperuser;
         console.log('OK NEXT:', nextEvent);
         if (!nextEvent) {
           console.error(

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
@@ -62,6 +62,14 @@
         return { type: 'BACK', value: Boolean(this.setting) };
       },
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.backEvent;
+          // return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinue() {
         this.wizardService.send({ type: 'CONTINUE', value: this.setting });

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -48,6 +48,13 @@
         showSelectAddressModal: false,
       };
     },
+    beforeRouteLeave(to, from, next) {
+      if (!this.$store.state.wizardNavigated) {
+        if (from.meta.previousNavigationAllowed.includes(to.name)) {
+          return this.wizardService.send({ type: 'BACK' });
+        }
+      } else { return next(); }
+    },
     methods: {
       handleContinueImport(address) {
         this.wizardService.send({

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -155,8 +155,7 @@
           .then(() => {
             const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
             window.sessionStorage.setItem(welcomeDimissalKey, false);
-
-            Lockr.set('savedState', null); // Clear out saved state machine
+            Lockr.rm('savedState'); // Clear out saved state machine
             redirectBrowser();
           })
           .catch(e => console.error(e));


### PR DESCRIPTION
# WIP, proof of concept for alternative approach to #10730 

somewhat-working proof of concept for different approach to #9027 (& duplicate #10240) than previously attempted.

this is NOT a sophisticated approach - one could fairly call it spectacularly dumb, even - but considering we were previously unable to get anything working in our recent attempts, i thought it could provide a good potential jumping off point for additional refinement or at least discussion (or even just used as a touchstone for what we **_don't_** want to do)

## things to address:
- not DRY, of course!
    - currently the behavior is only implemented in certain files along the happy path
        - happy path = `Group` setup > `Full device` > `New device` > first radio button selection for all facility permissions > Personal Data Consent is last currently-handled route
        - need to add lists of acceptable `BACK` routes to all remaining routes or come up with a different way to receive and persist this information
    - could be defined as a `beforeRouteLeave` handler within `routes.js` and applied to each route there instead of within the components — we just need to be able to feed in custom “BACK” behavior for some, so need to be sure that’s passed along to handler if it’s outside of individual route components
        - we **do not** want to define it on `handler` in the routes (which we've tacked on for other purposes), we want to just attach it as a guard for each because applying it in `handler` would lead to code intended for `beforeRouteLeave` getting called `beforeEnter` or `beforeEach`, breaking its current functionality
    - seems easiest for routes with no wizard `BACK` behavior to just not have `previousNavigationAllowed` OR for the sake of a more universal function, to have the field there but for it to be empty (rather than attaching additional `backAllowed` route `meta` data)
- `onTransition` listens for changes in `state`. the behavior introduced in this draft means that browser "back" clicks that are missed by `onTransition` are caught in `updated()` using specific conditions and `updated()` initiates the relevant route update that `onTransition` was missing, cool.
    - BUT that change in `state` then finally triggers `onTransition`, so things get called more than necessary
    - because of this, assessment & assignment of `wizardNavigated` bool in `app.js` `state` is not completely representative of reality (...yet?)
- sometimes strange behavior on browser back after going back and forth for a while mixing UI & browser navigation:
    - may have to do many clicks to get back but can see the URL changing
    - retains info from future steps if you’ve done browser back but doesn’t allow any browser forward behavior…honestly i think that’s a good thing or at least fine
- in preliminary testing, sometimes setting up facility steps 2, 3 & 4 are missing radio buttons if you navigated back and forth with a mix of UI & browser buttons:
    - i believe i've addressed/corrected this by sending these components' custom `backEvent`s in their respective in-component `beforeRouteLeave` navigation guards, which can be extrapolated from in order to inform a reusable `beforeRouteLeave` guard that can be applied to all more DRYly.



<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks


## Summary
…

## References

…

## Reviewer guidance
…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
-->