### PR TITLE
hooks: Fix a minor typo in a documentation comment

### DIFF
--- a/kolibri/plugins/hooks.py
+++ b/kolibri/plugins/hooks.py
@@ -100,7 +100,7 @@ against any abstract KolibriHook descendants that it inherits from. In this case
 being registered inherits from NavigationHook, so any hook registered will be available on
 the ``NavigationHook.registered_hooks`` property.
 
-Here is the definition of the abstract NavigatonHook in kolibri.core.hooks:
+Here is the definition of the abstract NavigationHook in kolibri.core.hooks:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary

Fixes a minor typo.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
