### PR TITLE
conditionalizes display of device connection status and prevents unec…

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -153,7 +153,7 @@ export function useDevicesWithChannel(channelId = '') {
  *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
  * }}
  */
-export function useDevicesWithFacility({ deviceId, facilityId = '', soud = false } = {}) {
+export function useDevicesWithFacility({ facilityId = '', soud = false } = {}) {
   // If facilityId is not provided, then we are at the initial Facility Import workflow
   // disable any devices unless it is unavailable/offline
   const filterDevices =
@@ -161,7 +161,7 @@ export function useDevicesWithFacility({ deviceId, facilityId = '', soud = false
       ? () => Promise.resolve(true)
       : facilityIsAvailableAtDevice.bind({}, facilityId);
 
-  return useDevicesWithFilter({ id: deviceId, subset_of_users_device: soud }, filterDevices);
+  return useDevicesWithFilter({ subset_of_users_device: soud }, filterDevices);
 }
 
 /**

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -153,7 +153,7 @@ export function useDevicesWithChannel(channelId = '') {
  *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
  * }}
  */
-export function useDevicesWithFacility({ facilityId = '', soud = false } = {}) {
+export function useDevicesWithFacility({ deviceId, facilityId = '', soud = false } = {}) {
   // If facilityId is not provided, then we are at the initial Facility Import workflow
   // disable any devices unless it is unavailable/offline
   const filterDevices =
@@ -161,7 +161,7 @@ export function useDevicesWithFacility({ facilityId = '', soud = false } = {}) {
       ? () => Promise.resolve(true)
       : facilityIsAvailableAtDevice.bind({}, facilityId);
 
-  return useDevicesWithFilter({ subset_of_users_device: soud }, filterDevices);
+  return useDevicesWithFilter({ id: deviceId, subset_of_users_device: soud }, filterDevices);
 }
 
 /**

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -29,6 +29,7 @@ class NetworkLocationViewSet(viewsets.ModelViewSet):
     queryset = NetworkLocation.objects.all()
     filter_backends = [DjangoFilterBackend]
     filter_fields = [
+        "id",
         "subset_of_users_device",
     ]
 

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -48,7 +48,7 @@
 
       const getStudio = async () => {
         let studio = [];
-        if (props.deviceId) {
+        if (props.deviceId === KolibriStudioId) {
           const response = await RemoteChannelResource.getKolibriStudioStatus();
           const studioData = {
             ...response.data,

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -23,7 +23,7 @@
 
   import { get, set } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+  import { useDevices } from 'kolibri.coreVue.componentSets.sync';
   import { RemoteChannelResource } from 'kolibri.resources';
   import { ref, watch } from 'kolibri.lib.vueCompositionApi';
   import { KolibriStudioId } from '../constants';
@@ -33,15 +33,8 @@
     name: 'DeviceConnectionStatus',
     mixins: [commonCoreStrings, commonLearnStrings],
     setup(props) {
-      /**
-       * soud(subset_of_user_device) is a query param for filtering.
-       * false to return non learn-only devices and true otherwise.
-       * null has been specified to return both type of devices which
-       * is necesary for device connection statuses
-       */
-      const { isFetching, devices } = useDevicesWithFacility({
-        deviceId: props.deviceId,
-        soud: null,
+      const { isFetching, devices } = useDevices({
+        id: props.deviceId,
       });
       const isFetched = ref(false);
       const allDevices = ref([]);

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -39,7 +39,10 @@
        * null has been specified to return both type of devices which
        * is necesary for device connection statuses
        */
-      const { isFetching, devices } = useDevicesWithFacility({ soud: null });
+      const { isFetching, devices } = useDevicesWithFacility({
+        deviceId: props.deviceId,
+        soud: null,
+      });
       const isFetched = ref(false);
       const allDevices = ref([]);
 

--- a/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnAppBarPage.vue
@@ -10,7 +10,11 @@
     :title="appBarTitle"
   >
     <template #actions>
-      <DeviceConnectionStatus :deviceId="deviceId" color="white" />
+      <DeviceConnectionStatus
+        v-if="deviceId"
+        :deviceId="deviceId"
+        color="white"
+      />
     </template>
 
     <template

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -313,9 +313,9 @@
         default: null,
       },
       /**
-            A Boolean check whether we should show the Bookmark Icon
-            what should not happen if the user is not logged in
-            */
+      A Boolean check whether we should show the Bookmark Icon
+      what should not happen if the user is not logged in
+      */
       showBookmark: {
         type: Boolean,
         required: false,

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -1,7 +1,11 @@
 <template>
 
   <nav :aria-label="$tr('optionsLabel')">
-    <UiToolbar style="z-index: 8;" :style="contentSpecificStyles" class="toolbar">
+    <UiToolbar
+      style="z-index: 8;"
+      :style="contentSpecificStyles"
+      class="toolbar"
+    >
       <CoachContentLabel
         :value="isCoachContent"
         style="margin-top: 8px; width: auto;"
@@ -19,7 +23,10 @@
           :maxLines="1"
         />
       </KLabeledIcon>
-      <ProgressIcon :progress="contentProgress" class="progress-icon" />
+      <ProgressIcon
+        :progress="contentProgress"
+        class="progress-icon"
+      />
 
       <template #icon>
         <KIconButton
@@ -85,11 +92,17 @@
               <div v-if="duration">
                 <strong>{{ learnString('suggestedTime') }}</strong>
               </div>
-              <SuggestedTime v-if="duration" :seconds="duration" />
+              <SuggestedTime
+                v-if="duration"
+                :seconds="duration"
+              />
             </div>
           </template>
         </CoreMenu>
-        <DeviceConnectionStatus :deviceId="deviceId" />
+        <DeviceConnectionStatus
+          v-if="deviceId"
+          :deviceId="deviceId"
+        />
 
         <TransitionGroup name="bar-actions">
           <KIconButton
@@ -242,67 +255,67 @@
         default: false,
       },
       /**
-      The progress of the currently viewed content to determine
-      if and which progress icon should be shown (none/started/complete)
-      */
+        The progress of the currently viewed content to determine
+        if and which progress icon should be shown (none/started/complete)
+        */
       contentProgress: {
         type: Number,
         required: false,
         default: 0,
       },
       /**
-      A 1/0 Boolean check whether we should show the Coach Content icon
-      to be passed to the CoachContentLabel component
-      */
+        A 1/0 Boolean check whether we should show the Coach Content icon
+        to be passed to the CoachContentLabel component
+        */
       isCoachContent: {
         type: Number,
         required: false,
         default: 0,
       },
       /**
-      The ContentNodeKinds kind of the content being viewed
-      */
+        The ContentNodeKinds kind of the content being viewed
+        */
       contentKind: {
         type: String,
         required: false,
         default: null,
       },
       /**
-      Is this a practice quiz?
-      */
+        Is this a practice quiz?
+        */
       isQuiz: {
         type: Boolean,
         required: false,
         default: false,
       },
       /**
-      Is the post-quiz report what is currently displayed?
-      */
+        Is the post-quiz report what is currently displayed?
+        */
       showingReportState: {
         type: Boolean,
         required: false,
         default: false,
       },
       /**
-      Suggested time in seconds
-      */
+        Suggested time in seconds
+        */
       duration: {
         type: Number,
         required: false,
         default: null,
       },
       /**
-      Actual time spent in seconds
-      */
+        Actual time spent in seconds
+        */
       timeSpent: {
         type: Number,
         required: false,
         default: null,
       },
       /**
-      A Boolean check whether we should show the Bookmark Icon
-      what should not happen if the user is not logged in
-      */
+        A Boolean check whether we should show the Bookmark Icon
+        what should not happen if the user is not logged in
+        */
       showBookmark: {
         type: Boolean,
         required: false,
@@ -565,14 +578,14 @@
   }
 
   /*
-    Make truncation via text ellipsis work well in UIToolbar's body flex item:
-    By default, `min-width` is `auto`  for a flex item which means it
-    cannot be smaller than the size of its content which causes the whole
-    title being visible even in cases when it should be already truncated.
-    Overriding it to `0` allows the title to be shrinked and then truncated
-    properly. Labeled icon wrapper needs to have this set too for its parent
-    flex item to shrink.
-  */
+      Make truncation via text ellipsis work well in UIToolbar's body flex item:
+      By default, `min-width` is `auto`  for a flex item which means it
+      cannot be smaller than the size of its content which causes the whole
+      title being visible even in cases when it should be already truncated.
+      Overriding it to `0` allows the title to be shrinked and then truncated
+      properly. Labeled icon wrapper needs to have this set too for its parent
+      flex item to shrink.
+    */
   /deep/ .ui-toolbar__body,
   /deep/ .labeled-icon-wrapper {
     min-width: 0;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -255,67 +255,67 @@
         default: false,
       },
       /**
-        The progress of the currently viewed content to determine
-        if and which progress icon should be shown (none/started/complete)
-        */
+      The progress of the currently viewed content to determine
+      if and which progress icon should be shown (none/started/complete)
+      */
       contentProgress: {
         type: Number,
         required: false,
         default: 0,
       },
       /**
-        A 1/0 Boolean check whether we should show the Coach Content icon
-        to be passed to the CoachContentLabel component
-        */
+      A 1/0 Boolean check whether we should show the Coach Content icon
+      to be passed to the CoachContentLabel component
+      */
       isCoachContent: {
         type: Number,
         required: false,
         default: 0,
       },
       /**
-        The ContentNodeKinds kind of the content being viewed
-        */
+      The ContentNodeKinds kind of the content being viewed
+      */
       contentKind: {
         type: String,
         required: false,
         default: null,
       },
       /**
-        Is this a practice quiz?
-        */
+      Is this a practice quiz?
+      */
       isQuiz: {
         type: Boolean,
         required: false,
         default: false,
       },
       /**
-        Is the post-quiz report what is currently displayed?
-        */
+      Is the post-quiz report what is currently displayed?
+      */
       showingReportState: {
         type: Boolean,
         required: false,
         default: false,
       },
       /**
-        Suggested time in seconds
-        */
+      Suggested time in seconds
+      */
       duration: {
         type: Number,
         required: false,
         default: null,
       },
       /**
-        Actual time spent in seconds
-        */
+      Actual time spent in seconds
+      */
       timeSpent: {
         type: Number,
         required: false,
         default: null,
       },
       /**
-        A Boolean check whether we should show the Bookmark Icon
-        what should not happen if the user is not logged in
-        */
+            A Boolean check whether we should show the Bookmark Icon
+            what should not happen if the user is not logged in
+            */
       showBookmark: {
         type: Boolean,
         required: false,
@@ -578,14 +578,14 @@
   }
 
   /*
-      Make truncation via text ellipsis work well in UIToolbar's body flex item:
-      By default, `min-width` is `auto`  for a flex item which means it
-      cannot be smaller than the size of its content which causes the whole
-      title being visible even in cases when it should be already truncated.
-      Overriding it to `0` allows the title to be shrinked and then truncated
-      properly. Labeled icon wrapper needs to have this set too for its parent
-      flex item to shrink.
-    */
+    Make truncation via text ellipsis work well in UIToolbar's body flex item:
+    By default, `min-width` is `auto`  for a flex item which means it
+    cannot be smaller than the size of its content which causes the whole
+    title being visible even in cases when it should be already truncated.
+    Overriding it to `0` allows the title to be shrinked and then truncated
+    properly. Labeled icon wrapper needs to have this set too for its parent
+    flex item to shrink.
+  */
   /deep/ .ui-toolbar__body,
   /deep/ .labeled-icon-wrapper {
     min-width: 0;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -1,11 +1,7 @@
 <template>
 
   <nav :aria-label="$tr('optionsLabel')">
-    <UiToolbar
-      style="z-index: 8;"
-      :style="contentSpecificStyles"
-      class="toolbar"
-    >
+    <UiToolbar style="z-index: 8;" :style="contentSpecificStyles" class="toolbar">
       <CoachContentLabel
         :value="isCoachContent"
         style="margin-top: 8px; width: auto;"
@@ -23,10 +19,7 @@
           :maxLines="1"
         />
       </KLabeledIcon>
-      <ProgressIcon
-        :progress="contentProgress"
-        class="progress-icon"
-      />
+      <ProgressIcon :progress="contentProgress" class="progress-icon" />
 
       <template #icon>
         <KIconButton
@@ -92,10 +85,7 @@
               <div v-if="duration">
                 <strong>{{ learnString('suggestedTime') }}</strong>
               </div>
-              <SuggestedTime
-                v-if="duration"
-                :seconds="duration"
-              />
+              <SuggestedTime v-if="duration" :seconds="duration" />
             </div>
           </template>
         </CoreMenu>

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -16,7 +16,11 @@
       class="page"
     >
       <template #actions>
-        <DeviceConnectionStatus :deviceId="deviceId" color="white" />
+        <DeviceConnectionStatus
+          v-if="deviceId"
+          :deviceId="deviceId"
+          color="white"
+        />
       </template>
       <!-- Header with thumbail and tagline -->
       <TopicsHeader
@@ -31,7 +35,10 @@
       />
 
       <!-- mobile tabs (different alignment and interactions) -->
-      <TopicsMobileHeader v-else :topic="topic" />
+      <TopicsMobileHeader
+        v-else
+        :topic="topic"
+      />
 
       <main
         class="main-content-grid"
@@ -46,7 +53,10 @@
 
         <div class="card-grid">
           <!-- Filter buttons - shown when not sidebar not visible -->
-          <div v-if="!windowIsLarge" data-test="tab-buttons">
+          <div
+            v-if="!windowIsLarge"
+            data-test="tab-buttons"
+          >
             <KButton
               v-if="topics.length"
               icon="topic"
@@ -67,7 +77,10 @@
           </div>
 
           <!-- default/preview display of nested folder structure, not search -->
-          <div v-if="!displayingSearchResults" data-test="topics">
+          <div
+            v-if="!displayingSearchResults"
+            data-test="topics"
+          >
             <!-- Rows of cards and links / show more for each Topic -->
             <template v-for="t in topicsForDisplay">
               <TopicSubsection
@@ -101,7 +114,10 @@
             >
               {{ coreString('showMoreAction') }}
             </KButton>
-            <div v-else-if="topicMore" class="end-button-block">
+            <div
+              v-else-if="topicMore"
+              class="end-button-block"
+            >
               <KButton
                 v-if="!topicMoreLoading"
                 :text="coreString('viewMoreAction')"
@@ -211,7 +227,6 @@
         @cancel="currentCategory = null"
         @input="handleCategory"
       />
-
 
       <!-- Side panel for showing the information of selected content with a link to view it -->
       <SidePanelModal
@@ -545,16 +560,16 @@
       gridStyle() {
         let style = {};
         /*
-          Fixes jumping scrollbar when reaching the bottom of the page
-          for certain page heights and when side bar is present.
-          The issue is caused by the document scroll height being changed
-          by the sidebar's switching position from absolute to fixed in
-          the sticky calculation, resulting in an endless cycle
-          of the calculation being called and the sidepanel alternating between
-          fixed and absolute position over and over. Setting min height prevents
-          this by making sure that the document scroll height won't change
-          on the sidebar positioning updates.
-        */
+            Fixes jumping scrollbar when reaching the bottom of the page
+            for certain page heights and when side bar is present.
+            The issue is caused by the document scroll height being changed
+            by the sidebar's switching position from absolute to fixed in
+            the sticky calculation, resulting in an endless cycle
+            of the calculation being called and the sidepanel alternating between
+            fixed and absolute position over and over. Setting min height prevents
+            this by making sure that the document scroll height won't change
+            on the sidebar positioning updates.
+          */
         if (this.windowIsLarge) {
           style = {
             minHeight: '900px',

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -35,10 +35,7 @@
       />
 
       <!-- mobile tabs (different alignment and interactions) -->
-      <TopicsMobileHeader
-        v-else
-        :topic="topic"
-      />
+      <TopicsMobileHeader v-else :topic="topic" />
 
       <main
         class="main-content-grid"
@@ -53,10 +50,7 @@
 
         <div class="card-grid">
           <!-- Filter buttons - shown when not sidebar not visible -->
-          <div
-            v-if="!windowIsLarge"
-            data-test="tab-buttons"
-          >
+          <div v-if="!windowIsLarge" data-test="tab-buttons">
             <KButton
               v-if="topics.length"
               icon="topic"
@@ -77,10 +71,7 @@
           </div>
 
           <!-- default/preview display of nested folder structure, not search -->
-          <div
-            v-if="!displayingSearchResults"
-            data-test="topics"
-          >
+          <div v-if="!displayingSearchResults" data-test="topics">
             <!-- Rows of cards and links / show more for each Topic -->
             <template v-for="t in topicsForDisplay">
               <TopicSubsection
@@ -114,10 +105,7 @@
             >
               {{ coreString('showMoreAction') }}
             </KButton>
-            <div
-              v-else-if="topicMore"
-              class="end-button-block"
-            >
+            <div v-else-if="topicMore" class="end-button-block">
               <KButton
                 v-if="!topicMoreLoading"
                 :text="coreString('viewMoreAction')"

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -560,16 +560,16 @@
       gridStyle() {
         let style = {};
         /*
-            Fixes jumping scrollbar when reaching the bottom of the page
-            for certain page heights and when side bar is present.
-            The issue is caused by the document scroll height being changed
-            by the sidebar's switching position from absolute to fixed in
-            the sticky calculation, resulting in an endless cycle
-            of the calculation being called and the sidepanel alternating between
-            fixed and absolute position over and over. Setting min height prevents
-            this by making sure that the document scroll height won't change
-            on the sidebar positioning updates.
-          */
+          Fixes jumping scrollbar when reaching the bottom of the page
+          for certain page heights and when side bar is present.
+          The issue is caused by the document scroll height being changed
+          by the sidebar's switching position from absolute to fixed in
+          the sticky calculation, resulting in an endless cycle
+          of the calculation being called and the sidepanel alternating between
+          fixed and absolute position over and over. Setting min height prevents
+          this by making sure that the document scroll height won't change
+          on the sidebar positioning updates.
+        */
         if (this.windowIsLarge) {
           style = {
             minHeight: '900px',

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -216,6 +216,7 @@
         @input="handleCategory"
       />
 
+
       <!-- Side panel for showing the information of selected content with a link to view it -->
       <SidePanelModal
         v-if="metadataSidePanelContent"

--- a/kolibri/plugins/learn/assets/test/views/device-connection-status.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/device-connection-status.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount, mount } from '@vue/test-utils';
-import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+import { useDevices } from 'kolibri.coreVue.componentSets.sync';
 import DeviceConnectionStatus from '../../src/views/DeviceConnectionStatus';
 
 jest.mock('kolibri.coreVue.componentSets.sync');
@@ -10,7 +10,7 @@ function makeWrapper({ propsData } = {}) {
 
 describe('DeviceConnectionStatus', () => {
   beforeEach(() => {
-    useDevicesWithFacility.mockReturnValue({
+    useDevices.mockReturnValue({
       devices: [
         {
           id: '1',
@@ -21,9 +21,7 @@ describe('DeviceConnectionStatus', () => {
   });
   it('smoke test', () => {
     const wrapper = shallowMount(DeviceConnectionStatus, {
-      propsData: {
-        deviceId: '1',
-      },
+      propsData: {},
     });
     expect(wrapper.exists()).toBe(true);
   });
@@ -39,13 +37,13 @@ describe('DeviceConnectionStatus', () => {
   });
 
   it('shows the disconnected icon', async () => {
-    useDevicesWithFacility.mockReturnValue({ devices: [], isFetching: true });
+    useDevices.mockReturnValue({ devices: [], isFetching: true });
     const wrapper = makeWrapper({
       propsData: {
         deviceId: '1',
       },
     });
-    useDevicesWithFacility.mockReturnValue({ isFetching: false });
+    useDevices.mockReturnValue({ isFetching: false });
     wrapper.vm.$nextTick(() => {
       expect(wrapper.find('[data-test="disconnected-icon"]').exists()).toBeTruthy();
     });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr conditionalizes display of device connection status and prevents unnecessary device polling. It also adds the ability to filter by deviceId

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10735

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Browse any page in the `Learn` plugin
- Inspect the page taking note of any polling on the pages in the network tab.
   - Polling should occur when exploring remote content browsing devices only
   - Look out for `/discovery/networklocation` as one of the requests polled

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
