### PR TITLE
setup wizard "back" button handling

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -190,6 +190,14 @@
               this.pollTask();
             }, 2000);
           }
+        }).catch(error => {
+          if (error.status == 500) {
+            if (this.isPolling) {
+              setTimeout(() => {
+                this.pollTask();
+              }, 2000);
+            }
+          }
         });
       },
       retryImport() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -162,43 +162,45 @@
          - Save tasks returned to this.loadingTasks
          - Clear completed
          **/
-        TaskResource.list({ queue: this.queue }).then(tasks => {
-          if (!tasks.length) {
-            // If we have no tasks (ie, they've been cleared and the page loaded here)
-            // we can just move along to the next step
-            this.handleClickContinue();
-          }
-          if (this.loadingTask) {
-            // We cache the last task so when all are complete we can show its status
-            this.lastLoadingTask = this.loadingTask;
-          }
-          this.allTasks = tasks;
-          this.pushCompletedToWizardMachine(); // Update state machine
+        TaskResource.list({ queue: this.queue })
+          .then(tasks => {
+            if (!tasks.length) {
+              // If we have no tasks (ie, they've been cleared and the page loaded here)
+              // we can just move along to the next step
+              this.handleClickContinue();
+            }
+            if (this.loadingTask) {
+              // We cache the last task so when all are complete we can show its status
+              this.lastLoadingTask = this.loadingTask;
+            }
+            this.allTasks = tasks;
+            this.pushCompletedToWizardMachine(); // Update state machine
 
-          // No more tasks are yet to be completed
-          if (this.runningTasks.length === 0) {
-            // In case we got here and every task was already done, set the lastLoadingTask
-            // to the last COMPLETED task -- or the first of all of the tasks
-            this.lastLoadingTask = this.completedTasks.length
-              ? this.completedTasks[this.completedTasks.length - 1]
-              : this.allTasks[0];
-            this.isPolling = false;
-          }
-          // New timeout to poll again if we should
-          if (this.isPolling) {
-            setTimeout(() => {
-              this.pollTask();
-            }, 2000);
-          }
-        }).catch(error => {
-          if (error.status == 500) {
+            // No more tasks are yet to be completed
+            if (this.runningTasks.length === 0) {
+              // In case we got here and every task was already done, set the lastLoadingTask
+              // to the last COMPLETED task -- or the first of all of the tasks
+              this.lastLoadingTask = this.completedTasks.length
+                ? this.completedTasks[this.completedTasks.length - 1]
+                : this.allTasks[0];
+              this.isPolling = false;
+            }
+            // New timeout to poll again if we should
             if (this.isPolling) {
               setTimeout(() => {
                 this.pollTask();
               }, 2000);
             }
-          }
-        });
+          })
+          .catch(error => {
+            if (error.status == 500) {
+              if (this.isPolling) {
+                setTimeout(() => {
+                  this.pollTask();
+                }, 2000);
+              }
+            }
+          });
       },
       retryImport() {
         TaskResource.restart(this.loadingTask.id).catch(error => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -85,7 +85,7 @@
 
         // Dump out of here if there is nothing to resume from
         if (!Object.keys(meta).length) {
-          this.$router.push('/');
+          this.$router.replace('/');
           return;
         }
 
@@ -93,10 +93,10 @@
         if (route) {
           // Avoid redundant navigation
           if (this.$route.name !== route.name) {
-            this.$router.push(route);
+            this.$router.replace(route);
           }
         } else {
-          this.$router.push('/');
+          this.$router.replace('/');
         }
       };
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -157,7 +157,7 @@
       if (this.selectedUser) {
         user = this.selectedUser;
       } else {
-        user = this.$store.state.onboardingData;
+        user = this.$store.state.onboardingData.user;
       }
       return {
         fullName: user.full_name,


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

as reported in #10240 & #9027, navigation behavior using the browser "back" & "forward" buttons in the setup wizard has not been consistent with the navigation behavior using the `Go back` & `Continue` buttons provided by the wizard UI. this led to odd and unexpected behavior, including the ability to navigate away from wizard steps that were designed to be "points of no return." in one extreme example, if you got to the second-to-last step of the wizard, used the browser "back" button to get all the way to the beginning of the wizard ("How are you using Kolibri?") and pressed the `Continue` UI button once from that page, you'd be catapulted all the way forward to the finalizing step of the wizard, the "Setting up Kolibri" view. 

with the update presented in this PR, "back" navigation using the browser buttons is disallowed within the wizard. this has been accomplished by changing instances of `$router.push` in `synchronizeRouteAndMachine` to `$router.replace`.

with these changes, now if the user engages the browser "back" button, they will be sent to wherever they were before they entered the wizard. if they go forward in the browser from that page, they will be returned to the step in the wizard where they left off. out of many attempted approaches to solve the problem, this appeared to be the cleanest solution that introduced the least unexpected behavior and general bugginess. 

### TODO: 
potentially introduce an alert before browser "back" navigation occurs, so the user can be informed that they will be exiting the wizard and they can accept this choice or reject it to remain on their present page in the wizard. currently, there are not translated strings available to convey this message to all users, so the alert has not been implemented. 


## References
fixes #10240
fixes #9027


## Reviewer guidance
- remove/rename your `.kolibri` folder or `rm -rf $KOLIBRI_HOME` so you have a fresh device
- start up kolibri in your terminal & enter the setup wizard
   - if you find yourself on an unexpected step of the wizard upon first entering it & you're using a fresh device, delete `savedState` from your browser local storage 
- navigate through the wizard using a mix of the UI buttons and browser buttons:
   - UI buttons `Go back` & `Continue` should continue to work as established & as expected
   - browser "back" should take you to the page you were on before entering the wizard
   - browser "forward" should take you to the wizard page you were on before engaging browser "back" 
      - once you are back in the wizard, browser "forward" should no longer be available
      
**Note:** if you use the browser buttons to navigate away from a page you have entered information into, that data may not be retained when you return using the browser buttons. in chrome, it may be the case that your previously-entered information is visible until you focus an element on the page. while ephemeral information may not be retained, no submitted information should ever be lost using any browser. 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
