### PR TITLE
Fixes missing language filter

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -94,7 +94,7 @@
       />
       <div
         v-if="Object.keys(availableResourcesNeeded).length"
-        class="section"
+        class="section show-resources"
       >
         <h2 class="title">
           {{ coreString('showResources') }}
@@ -373,6 +373,9 @@
 
   .section {
     margin-top: 40px;
+  }
+
+  .show-resources {
     margin-bottom: 60px;
   }
 

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -11,7 +11,10 @@
     :class="position === 'embedded' ? 'side-panel' : ''"
   >
     <div v-if="topics && topics.length && topicsListDisplayed">
-      <div v-for="t in topics" :key="t.id">
+      <div
+        v-for="t in topics"
+        :key="t.id"
+      >
         <KRouterLink
           ref="folders"
           :text="t.title"
@@ -98,7 +101,6 @@
         </h2>
         <div
           v-for="(val, activity) in availableResourcesNeeded"
-
           :key="activity"
           span="4"
           alignment="center"
@@ -371,6 +373,7 @@
 
   .section {
     margin-top: 40px;
+    margin-bottom: 60px;
   }
 
   .card-grid {

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -60,7 +60,6 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
     def plugin_data(self):
         from kolibri.core.content.utils.search import get_all_contentnode_label_metadata
         from kolibri.core.content.api import ChannelMetadataViewSet
-        from kolibri.core.content.models import Language
 
         channel_viewset = ChannelMetadataViewSet()
 
@@ -68,11 +67,6 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             channel_viewset.get_queryset().filter(root__available=True)
         )
         label_metadata = get_all_contentnode_label_metadata()
-        languages = list(
-            Language.objects.filter(id__in=label_metadata["languages"]).values(
-                "id", "lang_name"
-            )
-        )
         return {
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerUnassignedResourceAccess": allow_learner_unassigned_resource_access(),
@@ -81,7 +75,7 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
             ],
             "categories": label_metadata["categories"],
             "learningActivities": label_metadata["learning_activities"],
-            "languages": languages,
+            "languages": label_metadata["languages"],
             "channels": channels,
             "gradeLevels": label_metadata["grade_levels"],
             "accessibilityLabels": label_metadata["accessibility_labels"],


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes UI regressions with the"Language" filter and "Show resources". Both are now showing as before.
**Before:**
![image](https://github.com/learningequality/kolibri/assets/5203639/226990f7-c878-4f8c-8735-7150e0cc4a76)

**After:**
<img width="1331" alt="Screenshot 2023-06-01 at 08 50 22" src="https://github.com/learningequality/kolibri/assets/5203639/1c204fde-256f-4049-a2f7-05788275c682">

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10235

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Go to `/learn/#/library`
- The language filter and options under "Show resources" should be displayed as before

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
