### PR TITLE
enables sync button in sync modal

### DIFF
--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
@@ -54,7 +54,7 @@
     },
     computed: {
       isConnected() {
-        return this.$store.getters.connected;
+        return window.navigator.onLine;
       },
     },
     methods: {

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
@@ -52,14 +52,23 @@
         required: true,
       },
     },
-    computed: {
-      isConnected() {
-        return window.navigator.onLine;
-      },
+    data() {
+      return {
+        isConnected: true,
+      };
+    },
+    mounted() {
+      this.setConnectionStatus();
     },
     methods: {
       handleSubmit() {
-        this.startSyncAllTask();
+        this.setConnectionStatus();
+        if (this.isConnected) {
+          this.startSyncAllTask();
+        }
+      },
+      setConnectionStatus() {
+        this.isConnected = window.navigator.onLine;
       },
       startSyncAllTask() {
         return TaskResource.startTasks(

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
@@ -8,10 +8,9 @@
     <p>
       {{ $tr('syncExplanation') }}
     </p>
-    <p>
+    <p v-if="!isConnected">
       {{ $tr('mustBeConnectedToInternet') }}
     </p>
-
 
     <template #actions>
       <KButtonGroup>
@@ -26,23 +25,11 @@
         <span ref="syncbutton">
           <KButton
             :text="coreString('syncAction')"
-            :disabled="submitDisabled"
             primary
             type="submit"
+            :disabled="!isConnected"
           />
         </span>
-        <KTooltip
-          v-if="submitDisabled"
-          reference="syncbutton"
-          :refs="$refs"
-        >
-          <span v-if="noRegisteredFacilities">
-            {{ $tr('noFacilitiesTooltip') }}
-          </span>
-          <span v-else>
-            {{ $tr('currentlyOfflineTooltip') }}
-          </span>
-        </KTooltip>
       </KButtonGroup>
     </template>
   </KModal>
@@ -52,7 +39,6 @@
 
 <script>
 
-  import some from 'lodash/some';
   import { TaskResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
@@ -67,21 +53,13 @@
       },
     },
     computed: {
-      submitDisabled() {
-        // TODO implement a check for KDP being offline
-        return this.noRegisteredFacilities;
-      },
-      noRegisteredFacilities() {
-        return !some(this.facilities, fac => fac.dataset.registered);
+      isConnected() {
+        return this.$store.getters.connected;
       },
     },
     methods: {
       handleSubmit() {
-        // NOTE the button will not be visibly disabled, but does nothing
-        // when clicked
-        if (!this.submitDisabled) {
-          return this.startSyncAllTask();
-        }
+        this.startSyncAllTask();
       },
       startSyncAllTask() {
         return TaskResource.startTasks(
@@ -109,6 +87,7 @@
         message: 'You must be connected to the internet.',
         context: 'Modal description text',
       },
+      /* eslint-disable kolibri/vue-no-unused-translations */
       currentlyOfflineTooltip: {
         message: 'You are currently offline',
         context:
@@ -119,6 +98,7 @@
         context:
           "Floating notification message that appears over the 'Sync' button and indicates why is it not active",
       },
+      /* eslint-enable kolibri/vue-no-unused-translations */
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr enables the previously disabled `Sync` button in the facility syncing modal. It also corrects the display of the `You must be connected to the internet` message to only show when an internet connection is not available. The sync button is additionally disabled when there is no internet connection available. Finally, the tooltip has been removed.

**Before:**
![image](https://github.com/learningequality/kolibri/assets/5203639/edba4a4c-09d9-40bb-8e5d-70201353dfef)

**After:**
<img width="1331" alt="Screenshot 2023-06-01 at 12 53 22" src="https://github.com/learningequality/kolibri/assets/5203639/43107715-5106-44b9-95b1-21dc25c14752">

<img width="1800" alt="Screenshot 2023-06-01 at 12 54 10" src="https://github.com/learningequality/kolibri/assets/5203639/457d1ad0-5050-4574-9e4a-bad49cc4ff9d">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10758

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Navigate to `Device > Facilities`
- Select `Sync all`
- A syncing modal will open. Proceed to click the Sync button to start the syncing process
- `You must be connected to the internet` message is displayed when you set your connection to offline
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
