### PR TITLE
Fixes for peer to peer import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -1,7 +1,7 @@
 <template>
 
   <ImmersivePage
-    :appBarTitle="toolbarTitle()"
+    :appBarTitle="toolbarTitle"
     :route="backRoute"
   >
     <KPageContainer class="device-container">
@@ -265,6 +265,19 @@
             return '';
         }
       },
+      toolbarTitle() {
+        switch (this.transferType) {
+          case TransferTypes.LOCALIMPORT:
+            return this.$tr('importFromDisk', { driveName: this.selectedDrive.name });
+          case TransferTypes.PEERIMPORT:
+            return this.$tr('importFromPeer', {
+              deviceName: this.selectedPeer.device_name || this.selectedPeer.nickname,
+              address: this.selectedPeer.base_url,
+            });
+          default:
+            return this.$tr('importFromKolibriStudio');
+        }
+      },
       channelsAreLoading() {
         return this.status === 'LOADING_CHANNELS_FROM_KOLIBRI_STUDIO';
       },
@@ -299,19 +312,6 @@
       }
     },
     methods: {
-      toolbarTitle(transferType) {
-        switch (transferType) {
-          case TransferTypes.LOCALIMPORT:
-            return this.$tr('importFromDisk', { driveName: this.selectedDrive.name });
-          case TransferTypes.PEERIMPORT:
-            return this.$tr('importFromPeer', {
-              deviceName: this.selectedPeer.device_name || this.selectedPeer.nickname,
-              address: this.selectedPeer.base_url,
-            });
-          default:
-            return this.$tr('importFromKolibriStudio');
-        }
-      },
       channelIsOnDevice(channel) {
         const match = this.installedChannelsWithResources.find(({ id }) => id === channel.id);
         return Boolean(match);

--- a/kolibri/plugins/device/assets/src/views/SelectContentPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/SelectContentPage/api.js
@@ -13,7 +13,7 @@ export function startImportTask(params) {
 
   if (importSource.type === 'peer' || importSource.type === 'studio') {
     if (importSource.id) {
-      taskParams.peer_id = importSource.id;
+      taskParams.peer = importSource.id;
     }
     taskParams.type = TaskTypes.REMOTECONTENTIMPORT;
   } else if (importSource.type === 'drive') {


### PR DESCRIPTION
## Summary
* Updates frontend task parameter from `peer_id` to `peer` to match backend
* Fixes previously unreported regression where the immersive toolbar title was being improperly set

## References
Fixes #10766

Also ensures that the AvailableChannelsPage doesn't always show 'importing from Kolibri Studio':
![Screenshot from 2023-06-01 08-50-16](https://github.com/learningequality/kolibri/assets/1680573/6c36f1d8-d621-434a-a0de-128cacc6acf4)

Local testing confirms the fix:
```
[python-devserver] INFO     2023-06-01 08:30:10,304 Attempting connections to variations of the URL: http://172.27.64.38:8000/
[python-devserver] DEBUG    2023-06-01 08:30:10,306 Starting new HTTP connection (1): 127.0.0.1:8000
[python-devserver] DEBUG    2023-06-01 08:30:10,310 127.0.0.1 - - "GET /status/" 200 0 "" "python-requests/2.27.1"
[python-devserver] DEBUG    2023-06-01 08:30:10,311 http://127.0.0.1:8000/ "GET /status/ HTTP/1.1" 200 0
[python-devserver] INFO     2023-06-01 08:30:10,312 Attempting connection to: http://172.27.64.38:8000/
[python-devserver] DEBUG    2023-06-01 08:30:10,313 Starting new HTTP connection (1): 172.27.64.38:8000
[python-devserver] DEBUG    2023-06-01 08:30:10,569 http://172.27.64.38:8000/ "GET /api/public/info/?v=3 HTTP/1.1" 200 250
[python-devserver] INFO     2023-06-01 08:30:10,569 Success! We connected to: http://172.27.64.38:8000/api/public/info/?v=3
[python-devserver] DEBUG    2023-06-01 08:30:10,583 127.0.0.1 - - "POST /api/tasks/tasks/" 200 0 "http://127.0.0.1:8000/en/device/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
[python-devserver] DEBUG    2023-06-01 08:30:10,771 Starting new HTTP connection (1): 172.27.64.38:8000
[python-devserver] DEBUG    2023-06-01 08:30:11,055 http://172.27.64.38:8000/ "GET /api/public/v1/channels/lookup/27bb0abc24d44dd9896be50d47b2357e HTTP/1.1" 200 27933
[python-devserver] DEBUG    2023-06-01 08:30:11,220 Starting new HTTP connection (1): 172.27.64.38:8000
[python-devserver] DEBUG    2023-06-01 08:30:11,478 http://172.27.64.38:8000/ "HEAD /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 200 0
[python-devserver] DEBUG    2023-06-01 08:30:11,611 127.0.0.1 - - "GET /api/tasks/tasks/" 200 0 "http://127.0.0.1:8000/en/device/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
[python-devserver] DEBUG    2023-06-01 08:30:11,636 http://172.27.64.38:8000/ "GET /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:12,155 http://172.27.64.38:8000/ "GET /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:12,463 http://172.27.64.38:8000/ "GET /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:12,609 127.0.0.1 - - "GET /api/tasks/tasks/" 200 0 "http://127.0.0.1:8000/en/device/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
[python-devserver] DEBUG    2023-06-01 08:30:13,255 http://172.27.64.38:8000/ "GET /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:13,607 127.0.0.1 - - "GET /api/tasks/tasks/" 200 0 "http://127.0.0.1:8000/en/device/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
[python-devserver] DEBUG    2023-06-01 08:30:13,684 http://172.27.64.38:8000/ "GET /content/storage/5/e/5eaaf95ead10caec1e74feee049d494d.epub HTTP/1.1" 206 96907
[python-devserver] DEBUG    2023-06-01 08:30:14,015 http://172.27.64.38:8000/ "HEAD /content/storage/7/7/7757be01d4625fbc4b4931a09fbcc22c.epub HTTP/1.1" 200 0
[python-devserver] DEBUG    2023-06-01 08:30:14,169 http://172.27.64.38:8000/ "GET /content/storage/7/7/7757be01d4625fbc4b4931a09fbcc22c.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:14,599 http://172.27.64.38:8000/ "GET /content/storage/7/7/7757be01d4625fbc4b4931a09fbcc22c.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:14,607 127.0.0.1 - - "GET /api/tasks/tasks/" 200 0 "http://127.0.0.1:8000/en/device/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"
[python-devserver] DEBUG    2023-06-01 08:30:14,995 http://172.27.64.38:8000/ "GET /content/storage/7/7/7757be01d4625fbc4b4931a09fbcc22c.epub HTTP/1.1" 206 131072
[python-devserver] DEBUG    2023-06-01 08:30:15,413 http://172.27.64.38:8000/ "GET /content/storage/7/7/7757be01d4625fbc4b4931a09fbcc22c.epub HTTP/1.1" 206 53815
[python-devserver] INFO     2023-06-01 08:30:15,450 Setting availability to True of 2 LocalFile objects based on passed in checksums
[python-devserver] INFO     2023-06-01 08:30:15,456 Setting availability of non-topic ContentNode objects based on LocalFile availability in 1 batches of 3000
[python-devserver] INFO     2023-06-01 08:30:15,465 Annotating ContentNode objects with children for 1 levels
[python-devserver] INFO     2023-06-01 08:30:15,468 Annotating ContentNode objects with children for level 1
[python-devserver] DEBUG    2023-06-01 08:30:15,472 Recursive topic tree annotation took 0 seconds
```

## Reviewer guidance
Import all resources for a channel from a peer device.
Ensure that the imports are happening from the peer device, and not Kolibri Studio.
Ensure that the available channels page properly shows importing from peer device, not Studio.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
