### PR TITLE
fix missing "back" links in coach 

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -460,12 +460,13 @@ export default {
       return ClassSummaryResource.fetchModel({ id: classId, force: true })
         .then(summary => {
           store.commit('SET_STATE', summary);
+          return summary;
         })
-        .then(() => {
+        .then(summary => {
           return Promise.all([
             store.dispatch('fetchLessonsSizes', classId),
             store.dispatch('fetchQuizzesSizes', classId),
-          ]);
+          ]).then(() => summary);
         });
     },
     fetchLessonsSizes(store, classId) {

--- a/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
@@ -13,7 +13,7 @@ export function showExamsPage(store, classId) {
       force: true,
     }),
     // state.classList needs to be set for Copy Exam modal to work
-    store.dispatch('setClassList'),
+    store.dispatch('setClassList', store.state.classSummary.facility_id),
   ];
 
   const shouldResolve = samePageCheckGenerator(store);

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -16,7 +16,7 @@ export function setLessonSummaryState(store, params) {
     store.dispatch('lessonSummary/updateCurrentLesson', lessonId),
     LearnerGroupResource.fetchCollection({ getParams: { parent: classId } }),
     // Need state.classList to be set for copying to work
-    store.dispatch('setClassList'),
+    store.dispatch('setClassList', store.state.classSummary.facility_id),
   ];
 
   return Promise.all(loadRequirements)

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -63,13 +63,16 @@ export default {
   },
   actions: {
     setClassList(store, facilityId) {
-      if (!facilityId) {
+      const activeFacilityId =
+        store.state.core.facilities.length === 1 ? store.getters.currentFacilityId : facilityId;
+
+      if (!activeFacilityId) {
         throw new Error("Missing required 'facilityId' argument");
       }
       store.commit('SET_DATA_LOADING', true);
       store.commit('SET_CLASS_LIST', []); // Reset the list if we're loading a new one
       return ClassroomResource.fetchCollection({
-        getParams: { parent: facilityId, role: 'coach' },
+        getParams: { parent: activeFacilityId, role: 'coach' },
       })
         .then(classrooms => {
           store.commit('SET_CLASS_LIST', classrooms);

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -63,10 +63,13 @@ export default {
   },
   actions: {
     setClassList(store, facilityId) {
+      if (!facilityId) {
+        throw new Error("Missing required 'facilityId' argument");
+      }
       store.commit('SET_DATA_LOADING', true);
       store.commit('SET_CLASS_LIST', []); // Reset the list if we're loading a new one
       return ClassroomResource.fetchCollection({
-        getParams: { parent: facilityId || store.getters.currentFacilityId, role: 'coach' },
+        getParams: { parent: facilityId, role: 'coach' },
       })
         .then(classrooms => {
           store.commit('SET_CLASS_LIST', classrooms);
@@ -115,8 +118,9 @@ export default {
         return Promise.all([
           // Make sure we load any class list data, so that we know
           // whether this user has access to multiple classes or not.
-          store.dispatch('setClassList'),
-          store.dispatch('classSummary/loadClassSummary', classId),
+          store
+            .dispatch('classSummary/loadClassSummary', classId)
+            .then(summary => store.dispatch('setClassList', summary.facility_id)),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
         ]).catch(error => {
           store.dispatch('handleError', error);

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -10,7 +10,7 @@
         <KRouterLink
           v-if="userIsMultiFacilityAdmin"
           :to="{ name: 'AllFacilitiesPage' }"
-          :text="coreString('allFacilitiesLabel')"
+          :text="coreString('changeLearningFacility')"
           icon="back"
         />
       </p>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -7,6 +7,11 @@
         :to="classListLink"
         :text="$tr('allClassesLabel')"
       />
+      <BackLink
+        v-else-if="userIsMultiFacilityAdmin && !classListPageEnabled"
+        :to="{ name: 'AllFacilitiesPage' }"
+        :text="coreString('changeLearningFacility')"
+      />
     </p>
 
     <h1>
@@ -53,15 +58,16 @@
 
   import { mapGetters } from 'vuex';
   import pickBy from 'lodash/pickBy';
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { ClassesPageNames } from '../../../../../../learn/assets/src/constants';
   import commonCoach from '../../common';
   import { LastPages } from '../../../constants/lastPagesConstants';
 
   export default {
     name: 'OverviewBlock',
-    mixins: [commonCoach],
+    mixins: [commonCoach, commonCoreStrings],
     computed: {
-      ...mapGetters(['classListPageEnabled']),
+      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
       coachNames() {
         return this.coaches.map(coach => coach.name);
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -3,7 +3,7 @@
   <div>
     <p>
       <BackLink
-        v-if="classListPageEnabled"
+        v-if="classListPageEnabled || userIsMultiFacilityAdmin"
         :to="$router.getRoute('HomePage')"
         :text="coreString('classHome')"
       />
@@ -58,7 +58,7 @@
       };
     },
     computed: {
-      ...mapGetters(['classListPageEnabled']),
+      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
       LessonsPageNames() {
         return LessonsPageNames;
       },

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -3,7 +3,7 @@
   <div>
     <p>
       <BackLink
-        v-if="classListPageEnabled"
+        v-if="classListPageEnabled || userIsMultiFacilityAdmin"
         :to="$router.getRoute('HomePage')"
         :text="coreString('classHome')"
       />
@@ -62,7 +62,7 @@
       };
     },
     computed: {
-      ...mapGetters(['classListPageEnabled']),
+      ...mapGetters(['classListPageEnabled', 'userIsMultiFacilityAdmin']),
       reportTitle() {
         return this.title || this.coachString('reportsLabel');
       },

--- a/kolibri/plugins/coach/assets/test/showPageActions.spec.js
+++ b/kolibri/plugins/coach/assets/test/showPageActions.spec.js
@@ -4,6 +4,10 @@ import makeStore from './makeStore';
 
 jest.mock('kolibri.resources');
 
+const fakeClassSummaryState = {
+  facility_id: 'djefrijgeriojfioegsd',
+};
+
 // fakes for data, since they have similar shape
 const fakeItems = [
   {
@@ -328,6 +332,7 @@ describe('showPage actions for coach exams section', () => {
 
   beforeEach(() => {
     store = makeStore();
+    store.state.classSummary = fakeClassSummaryState;
     ClassroomResource.fetchCollection.mockReset();
     ExamResource.fetchCollection.mockReset();
   });


### PR DESCRIPTION
## Summary
as reported in #10673, the back link "← All classes" was not displaying as expected when a multi-facility admin was exploring classes within an imported facility **_if_** their default facility had only 1 class. 

though this was an edge case, it uncovered a pervasive issue with the `setClassList` action, which is used throughout the `Coach` app to determine the list of classes to display & decide which back links to render in which cases. when `setClassList` was called without a `facilityId` argument, it used the value of `currentFacilityId` to inform its behavior, and that value always corresponds to a multi-facility user's default facility. though it only became evident in these specific conditions, we were in fact generally assessing the wrong facility much of the time we invoked `setClassList` in an imported facility.

this PR introduces changes to `setClassList` and how it is used - now, it requires a `facilityId` argument and throws an error if one is not provided. in each place the action is called, it is now supplied with a `facilityId` that has been accessed through `store.state.classSummary`, which is also now guaranteed to be set wherever `setClassList` is invoked.


## References
fixes #10673


## Reviewer guidance
**Note:** this bug appeared only in the special edge case that the user was a multi-facility admin, with 1 class in their default facility & multiple classes in an imported facility. please replicate that scenario to test these changes, but also keep in mind the full list of expectations outlined in #10673 & investigate as much as is reasonable:
- if user 1 is a multi-facility admin of Facility A & Facility B, and Facility A has only one class:
    - selecting Facility A will lead the user directly to the sole class's `Class home` page. when there, the back link is "← Change learning facility"
    - if user navigates to `Plan` or `Report` subtopics, the back link "← Class home" will be displayed [_NEW & open to debate - added for ease of navigation back to `All facilities` page in this specific multi-facility, single-class scenario_]
- when user 1 selects Facility B, which has multiple classes:
    - they are redirected to the `All Classes` page which has a back link to "← Change learning facility"
    - selecting a class from `All Classes` will take the user that class's specific `Class home` page, which contains a back link to "← All classes"
    - once within a specific class, if user navigates to `Plan` or `Report` subtopics, the back link "← Class home" will be displayed
- if user 2 has access to only Facility A, which has one class (or user has other limitations only allowing access to one class):
    - selecting `Class home` within `Coach` in the top- or sidenav leads directly to that class's page
    - there are no back links displayed
- if user 3 has access to only Facility B, which has multiple classes:
    - selecting `Class home` within `Coach` in the top- or sidenav redirects them to the `All Classes` page and there is no back link displayed.
    - selecting a class will take user to its specific class page with a back link to "← All classes"
    - once within a specific class, if user navigates to `Plan` or `Report` subtopics, the back link "← Class home" will be displayed

changes introduced in this PR impacted the code wherever `setClassList` was invoked, so while exploring the scenarios outlined above, it would also be helpful to visit the two additional places where this occurs, which are encountered when digging into the details of a specific class:
- `LessonSummaryPage`, found at `/:classId/plan/lessons/:lessonId` for a specific lesson
- `CoachExamsPage`, found at `/:classId/plan/quizzes`

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
