### PR TITLE
Finalize learner storage notifications

### DIFF
--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -72,10 +72,6 @@ export default function useUserSyncStatus() {
     }
   });
 
-  const userLoggedIn = computed(() => {
-    return !!store.state.core.session.user_id;
-  });
-
   return {
     queued,
     lastSynced,
@@ -84,6 +80,5 @@ export default function useUserSyncStatus() {
     deviceStatusSentiment,
     hasDownloads,
     lastDownloadRemoved,
-    userLoggedIn,
   };
 }

--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -34,9 +34,9 @@ export function fetchUserSyncStatus(params) {
 }
 
 export function pollUserSyncStatusTask() {
-  // if (!store.state.core.session.user_id) {
-  //   return Promise.resolve();
-  // }
+  if (!store.state.core.session.user_id) {
+    return Promise.resolve();
+  }
   return fetchUserSyncStatus({ user: store.state.core.session.user_id }).then(syncData => {
     if (syncData && syncData[0]) {
       queued.value = syncData[0].queued;
@@ -72,6 +72,10 @@ export default function useUserSyncStatus() {
     }
   });
 
+  const userLoggedIn = computed(() => {
+    return !!store.state.core.session.user_id;
+  });
+
   return {
     queued,
     lastSynced,
@@ -80,5 +84,6 @@ export default function useUserSyncStatus() {
     deviceStatusSentiment,
     hasDownloads,
     lastDownloadRemoved,
+    userLoggedIn,
   };
 }

--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -34,10 +34,9 @@ export function fetchUserSyncStatus(params) {
 }
 
 export function pollUserSyncStatusTask() {
-  if (!store.state.core.session.user_id) {
-    return Promise.resolve();
-  }
-
+  // if (!store.state.core.session.user_id) {
+  //   return Promise.resolve();
+  // }
   return fetchUserSyncStatus({ user: store.state.core.session.user_id }).then(syncData => {
     if (syncData && syncData[0]) {
       queued.value = syncData[0].queued;
@@ -59,6 +58,9 @@ export default function useUserSyncStatus() {
   onMounted(() => {
     usageCount.value++;
     if (usageCount.value === 1) {
+      if (store.state.core.session.user_id) {
+        pollUserSyncStatusTask();
+      }
       resume();
     }
   });

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -153,7 +153,7 @@
         }
       },
       manageChannel() {
-        redirectBrowser(urls['kolibri:kolibri.plugins.learn:learn']());
+        redirectBrowser(urls['kolibri:kolibri.plugins.device:device_management']());
       },
 
       focusChange(e) {

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -51,8 +51,9 @@
   import useUser from 'kolibri.coreVue.composables.useUser';
   import { useLocalStorage } from '@vueuse/core';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
+  import urls from 'kolibri.urls';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
-  import { PageNames } from '../../../../plugins/device/assets/src/constants';
 
   export default {
     name: 'StorageNotification',
@@ -152,7 +153,7 @@
         }
       },
       manageChannel() {
-        this.$router.push(PageNames.MANAGE_CONTENT_PAGE);
+        redirectBrowser(urls['kolibri:kolibri.plugins.learn:learn']());
       },
 
       focusChange(e) {

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div v-if="showBanner" class="banner" :style="{ background: $themeTokens.surface }">
+  <div v-if="bannerOpened" class="banner" :style="{ background: $themeTokens.surface }">
     <div class="banner-inner">
       <h1 style="display: none">
         {{ $tr('bannerHeading') }}
@@ -97,7 +97,9 @@
       };
     },
     data() {
-      return {};
+      return {
+        bannerOpened: false,
+      };
     },
     computed: {
       ...mapGetters(['isLearner', 'isAdmin', 'canManageContent']),
@@ -123,6 +125,16 @@
         );
       },
     },
+    watch: {
+      showBanner: {
+        handler(newVal, oldValue) {
+          if (newVal !== oldValue) {
+            this.bannerOpened = newVal;
+          }
+        },
+        deep: true,
+      },
+    },
     mounted() {
       document.addEventListener('focusin', this.focusChange);
     },
@@ -146,15 +158,16 @@
       closeBanner() {
         this.setLastSyncedValue(this.lastSynced);
         this.setDownloadRemovedValue(this.lastDownloadRemoved);
-        this.showBanner = false;
+        this.bannerOpened = false;
 
         if (this.previouslyFocusedElement) {
           this.previouslyFocusedElement.focus();
         }
       },
       manageChannel() {
-        if (!this.isLearner) {
-          redirectBrowser(urls['kolibri:kolibri.plugins.device:device_management']());
+        const deviceManagementUrl = urls['kolibri:kolibri.plugins.device:device_management']();
+        if (this.canManageContent && deviceManagementUrl) {
+          redirectBrowser(deviceManagementUrl);
         } else {
           this.bannerOpened = false;
         }

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -153,7 +153,11 @@
         }
       },
       manageChannel() {
-        redirectBrowser(urls['kolibri:kolibri.plugins.device:device_management']());
+        if (!this.isLearner) {
+          redirectBrowser(urls['kolibri:kolibri.plugins.device:device_management']());
+        } else {
+          this.bannerOpened = false;
+        }
       },
 
       focusChange(e) {

--- a/kolibri/core/assets/src/views/StorageNotification.vue
+++ b/kolibri/core/assets/src/views/StorageNotification.vue
@@ -52,6 +52,7 @@
   import { useLocalStorage } from '@vueuse/core';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
+  import { PageNames } from '../../../../plugins/device/assets/src/constants';
 
   export default {
     name: 'StorageNotification',
@@ -151,7 +152,7 @@
         }
       },
       manageChannel() {
-        this.$router.push('/');
+        this.$router.push(PageNames.MANAGE_CONTENT_PAGE);
       },
 
       focusChange(e) {


### PR DESCRIPTION

## Summary

- Properly handle cross-plugin routing 
- Make polling reactive to user logged in state
closes #10184
## References
#10184
## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
