### PR TITLE
docs: Remove mentions of fmt-backend from the getting started docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -343,19 +343,19 @@ Manual linting and formatting
 
 Linting and code auto-formatting are done by Prettier and Black.
 
-You can manually run the auto-formatters using:
+You can manually run the auto-formatters for the frontend using:
 
 .. code-block:: bash
 
   yarn run lint-frontend:format
-  yarn run fmt-backend
 
 Or to check the formatting without writing changes, run:
 
 .. code-block:: bash
 
   yarn run lint-frontend
-  yarn run fmt-backend:check
+
+The linting and formatting for the backend is handled using ``pre-commit`` below.
 
 
 Pre-commit hooks


### PR DESCRIPTION
That yarn script was removed in commit
ed25c78043e1180bb57d656f28f6d0463dc51b59. I believe pre-commit is the way to lint the backend now.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
