### PR TITLE
Allow including all thumbnails in import

### DIFF
--- a/kolibri/core/content/fixtures/content_test.json
+++ b/kolibri/core/content/fixtures/content_test.json
@@ -344,6 +344,71 @@
   },
   {
     "fields": {
+      "contentnode": "2e8bac07947855369fe2d77642dfc870",
+      "lang": null,
+      "local_file": "2318e5a9d6a24ae8f96e9110006e0c53",
+      "preset": "topic_thumbnail",
+      "priority": null,
+      "supplementary": false,
+      "thumbnail": true
+    },
+    "model": "content.file",
+    "pk": "2318e5a9d6a24ae8f96e9110006e0c53"
+  },
+  {
+    "fields": {
+      "contentnode": "42a941fb77c2576e8f6b294cde4c3b0c",
+      "lang": null,
+      "local_file": "37c5c250fbc66e597ae7d604846e9df2",
+      "preset": "video_thumbnail",
+      "priority": null,
+      "supplementary": false,
+      "thumbnail": true
+    },
+    "model": "content.file",
+    "pk": "37c5c250fbc66e597ae7d604846e9df2"
+  },
+  {
+    "fields": {
+      "contentnode": "2b6926ed22025518a8b9da91745b51d3",
+      "lang": null,
+      "local_file": "2cea0feba5f930c81661c5c759943964",
+      "preset": "exercise_thumbnail",
+      "priority": null,
+      "supplementary": false,
+      "thumbnail": true
+    },
+    "model": "content.file",
+    "pk": "2cea0feba5f930c81661c5c759943964"
+  },
+  {
+    "fields": {
+      "contentnode": "32a941fb77c2576e8f6b294cde4c3b0c",
+      "lang": null,
+      "local_file": "5437c68903de934521128d7656a3b572",
+      "preset": "video_thumbnail",
+      "priority": null,
+      "supplementary": false,
+      "thumbnail": true
+    },
+    "model": "content.file",
+    "pk": "5437c68903de934521128d7656a3b572"
+  },
+  {
+    "fields": {
+      "contentnode": "4d0c890de9b65d6880ccfa527800e0f4",
+      "lang": null,
+      "local_file": "c6f26814b067da30e1cb6239512dc1da",
+      "preset": "document_thumbnail",
+      "priority": null,
+      "supplementary": false,
+      "thumbnail": true
+    },
+    "model": "content.file",
+    "pk": "c6f26814b067da30e1cb6239512dc1da"
+  },
+  {
+    "fields": {
       "file_size": null,
       "available": true,
       "extension": "mp4"
@@ -386,6 +451,51 @@
     },
     "pk": "8ad3fffedf144cba9492e16daec1e39a",
     "model": "content.localfile"
+  },
+  {
+    "fields": {
+      "available": true,
+      "extension": "png",
+      "file_size": 1
+    },
+    "model": "content.localfile",
+    "pk": "2318e5a9d6a24ae8f96e9110006e0c53"
+  },
+  {
+    "fields": {
+      "available": true,
+      "extension": "png",
+      "file_size": 1
+    },
+    "model": "content.localfile",
+    "pk": "37c5c250fbc66e597ae7d604846e9df2"
+  },
+  {
+    "fields": {
+      "available": true,
+      "extension": "jpeg",
+      "file_size": 1
+    },
+    "model": "content.localfile",
+    "pk": "2cea0feba5f930c81661c5c759943964"
+  },
+  {
+    "fields": {
+      "available": true,
+      "extension": "jpeg",
+      "file_size": 1
+    },
+    "model": "content.localfile",
+    "pk": "5437c68903de934521128d7656a3b572"
+  },
+  {
+    "fields": {
+      "available": true,
+      "extension": "png",
+      "file_size": 1
+    },
+    "model": "content.localfile",
+    "pk": "c6f26814b067da30e1cb6239512dc1da"
   },
   {
     "fields": {

--- a/kolibri/core/content/management/commands/importcontent.py
+++ b/kolibri/core/content/management/commands/importcontent.py
@@ -91,6 +91,14 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
+            "--all-thumbnails",
+            action="store_true",
+            default=False,
+            dest="all_thumbnails",
+            help="Import thumbnails for all content nodes regardless of included or excluded node IDs",
+        )
+
+        parser.add_argument(
             "--import_updates",
             action="store_true",
             default=False,
@@ -177,6 +185,7 @@ class Command(BaseCommand):
         baseurl=None,
         peer_id=None,
         renderable_only=True,
+        all_thumbnails=False,
         import_updates=False,
         fail_on_error=False,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
@@ -199,6 +208,7 @@ class Command(BaseCommand):
                 baseurl=baseurl,
                 peer_id=peer_id,
                 renderable_only=renderable_only,
+                all_thumbnails=all_thumbnails,
                 fail_on_error=fail_on_error,
                 timeout=timeout,
                 content_dir=content_dir,
@@ -210,6 +220,7 @@ class Command(BaseCommand):
             baseurl=baseurl,
             peer_id=peer_id,
             renderable_only=renderable_only,
+            all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             timeout=timeout,
             content_dir=content_dir,
@@ -225,6 +236,7 @@ class Command(BaseCommand):
         node_ids=None,
         exclude_node_ids=None,
         renderable_only=True,
+        all_thumbnails=False,
         import_updates=False,
         fail_on_error=False,
         content_dir=None,
@@ -242,6 +254,7 @@ class Command(BaseCommand):
                     path=path,
                     drive_id=drive_id,
                     renderable_only=renderable_only,
+                    all_thumbnails=all_thumbnails,
                     fail_on_error=fail_on_error,
                     content_dir=content_dir,
                 )
@@ -251,6 +264,7 @@ class Command(BaseCommand):
                     path=path,
                     drive_id=drive_id,
                     renderable_only=renderable_only,
+                    all_thumbnails=all_thumbnails,
                     fail_on_error=fail_on_error,
                     content_dir=content_dir,
                 )
@@ -261,6 +275,7 @@ class Command(BaseCommand):
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             renderable_only=renderable_only,
+            all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
         )
@@ -293,6 +308,7 @@ class Command(BaseCommand):
                 baseurl=options["baseurl"],
                 peer_id=options["peer_id"],
                 renderable_only=options["renderable_only"],
+                all_thumbnails=options["all_thumbnails"],
                 import_updates=options["import_updates"],
                 fail_on_error=options["fail_on_error"],
                 timeout=options["timeout"],
@@ -313,6 +329,7 @@ class Command(BaseCommand):
                 node_ids=options["node_ids"],
                 exclude_node_ids=options["exclude_node_ids"],
                 renderable_only=options["renderable_only"],
+                all_thumbnails=options["all_thumbnails"],
                 import_updates=options["import_updates"],
                 fail_on_error=options["fail_on_error"],
                 content_dir=options["content_dir"],

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -92,6 +92,7 @@ class ChannelResourcesImportValidator(ChannelResourcesValidator):
     update = serializers.BooleanField(default=False)
     fail_on_error = serializers.BooleanField(default=False)
     new_version = serializers.IntegerField(required=False)
+    all_thumbnails = serializers.BooleanField(default=False)
 
     def validate(self, data):
         job_data = super(ChannelResourcesImportValidator, self).validate(data)
@@ -99,6 +100,7 @@ class ChannelResourcesImportValidator(ChannelResourcesValidator):
             {
                 "update": data.get("update"),
                 "fail_on_error": data.get("fail_on_error"),
+                "all_thumbnails": data.get("all_thumbnails"),
             }
         )
         if data.get("new_version"):
@@ -147,6 +149,7 @@ def diskcontentimport(
     node_ids=None,
     exclude_node_ids=None,
     fail_on_error=False,
+    all_thumbnails=False,
 ):
     manager_class = (
         DiskChannelUpdateManager if update else DiskChannelResourceImportManager
@@ -159,6 +162,7 @@ def diskcontentimport(
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
         fail_on_error=fail_on_error,
+        all_thumbnails=all_thumbnails,
     )
     manager.run()
 
@@ -233,6 +237,7 @@ def remotecontentimport(
     exclude_node_ids=None,
     update=False,
     fail_on_error=False,
+    all_thumbnails=False,
 ):
     manager_class = (
         RemoteChannelUpdateManager if update else RemoteChannelResourceImportManager
@@ -244,6 +249,7 @@ def remotecontentimport(
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
         fail_on_error=fail_on_error,
+        all_thumbnails=all_thumbnails,
     )
     manager.run()
 
@@ -434,6 +440,7 @@ def remoteimport(
     exclude_node_ids=None,
     update=False,
     fail_on_error=False,
+    all_thumbnails=False,
 ):
     call_command(
         "importchannel",
@@ -457,6 +464,7 @@ def remoteimport(
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
         fail_on_error=fail_on_error,
+        all_thumbnails=all_thumbnails,
     )
     manager.run()
 
@@ -471,7 +479,12 @@ def remoteimport(
     status_fn=get_status,
 )
 def diskimport(
-    channel_id, drive_id, update=False, node_ids=None, exclude_node_ids=None
+    channel_id,
+    drive_id,
+    update=False,
+    node_ids=None,
+    exclude_node_ids=None,
+    all_thumbnails=False,
 ):
     drive = get_mounted_drive_by_id(drive_id)
     directory = drive.datafolder
@@ -498,6 +511,7 @@ def diskimport(
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
         import_updates=update,
+        all_thumbnails=all_thumbnails,
     )
     manager.run()
 

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -823,12 +823,12 @@ class LocalFileByDisk(TransactionTestCase):
 
     @patch(
         "kolibri.core.content.utils.annotation.get_content_storage_file_path",
-        side_effect=[mock_content_file[1]] * 2 + [""] * 3,
+        side_effect=[mock_content_file[1]] * 2 + [""] * 8,
     )
     def test_set_all_files_two_exist(self, path_mock):
         set_local_file_availability_from_disk()
         self.assertEqual(LocalFile.objects.filter(available=True).count(), 2)
-        self.assertEqual(LocalFile.objects.exclude(available=True).count(), 3)
+        self.assertEqual(LocalFile.objects.exclude(available=True).count(), 8)
 
     def test_set_bad_filenames(self):
         local_files = list(LocalFile.objects.all())

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1221,7 +1221,7 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
 
     def test_file_list(self):
         response = self.client.get(reverse("kolibri:core:file-list"))
-        self.assertEqual(len(response.data), 5)
+        self.assertEqual(len(response.data), 10)
 
     def test_file_retrieve(self):
         response = self.client.get(

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1571,6 +1571,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id=None,
         )
 
@@ -1607,6 +1608,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id=None,
         )
 
@@ -1726,6 +1728,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id=None,
         )
 
@@ -1773,6 +1776,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id=None,
         )
 
@@ -1791,6 +1795,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id="",
         )
 
@@ -1851,6 +1856,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id=None,
         )
 
@@ -1899,6 +1905,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             drive_id="",
         )
 
@@ -1945,6 +1952,7 @@ class ImportContentTestCase(TestCase):
             None,
             False,
             renderable_only=True,
+            all_thumbnails=False,
             peer_id=None,
         )
 

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -319,6 +319,21 @@ class GetContentNodesDataTestCase(TestCase):
                 "file_size": None,
                 "extension": "mp4",
             },
+            {
+                "id": "2cea0feba5f930c81661c5c759943964",
+                "file_size": 1,
+                "extension": "jpeg",
+            },
+            {
+                "id": "5437c68903de934521128d7656a3b572",
+                "file_size": 1,
+                "extension": "jpeg",
+            },
+            {
+                "id": "2318e5a9d6a24ae8f96e9110006e0c53",
+                "file_size": 1,
+                "extension": "png",
+            },
         ]
 
         selected_content_nodes = ContentNode.objects.filter(
@@ -331,7 +346,7 @@ class GetContentNodesDataTestCase(TestCase):
 
         self.assertEqual(total_resource_count, 2)
         self.assertCountEqual(files, expected_files_list)
-        self.assertEqual(total_bytes_to_transfer, 0)
+        self.assertEqual(total_bytes_to_transfer, 3)
 
 
 @patch(
@@ -857,13 +872,16 @@ class ImportContentTestCase(TestCase):
         fd1, local_dest_path_1 = tempfile.mkstemp()
         fd2, local_dest_path_2 = tempfile.mkstemp()
         fd3, local_dest_path_3 = tempfile.mkstemp()
+        fd4, local_dest_path_4 = tempfile.mkstemp()
         os.close(fd1)
         os.close(fd2)
         os.close(fd3)
+        os.close(fd4)
         path_mock.side_effect = [
             local_dest_path_1,
             local_dest_path_2,
             local_dest_path_3,
+            local_dest_path_4,
         ]
         ContentNode.objects.filter(pk=self.c2c1_node_id).update(available=False)
         LocalFile.objects.filter(files__contentnode__pk=self.c2c1_node_id).update(
@@ -885,7 +903,7 @@ class ImportContentTestCase(TestCase):
         )
         manager.run()
         logger_mock.assert_called_once()
-        self.assertIn("3 files are skipped", logger_mock.call_args_list[0][0][0])
+        self.assertIn("4 files are skipped", logger_mock.call_args_list[0][0][0])
         annotation_mock.set_content_visibility.assert_called_with(
             self.the_channel_id,
             [],
@@ -1940,13 +1958,16 @@ class ImportContentTestCase(TestCase):
         fd1, local_dest_path_1 = tempfile.mkstemp()
         fd2, local_dest_path_2 = tempfile.mkstemp()
         fd3, local_dest_path_3 = tempfile.mkstemp()
+        fd4, local_dest_path_4 = tempfile.mkstemp()
         os.close(fd1)
         os.close(fd2)
         os.close(fd3)
+        os.close(fd4)
         path_mock.side_effect = [
             local_dest_path_1,
             local_dest_path_2,
             local_dest_path_3,
+            local_dest_path_4,
         ]
         ContentNode.objects.filter(pk=self.c2c1_node_id).update(available=False)
         LocalFile.objects.filter(files__contentnode__pk=self.c2c1_node_id).update(
@@ -2328,7 +2349,10 @@ class TestFilesToTransfer(TestCase):
         _, files_to_transfer, _ = get_import_export_data(
             self.the_channel_id, None, None, False, renderable_only=False, drive_id="1"
         )
-        self.assertEqual(len(files_to_transfer), obj.files.count())
+        self.assertEqual(
+            len(files_to_transfer),
+            obj.files.count() + obj.parent.files.filter(thumbnail=True).count(),
+        )
 
     @patch(
         "kolibri.core.content.utils.import_export_content.get_channel_stats_from_disk"
@@ -2348,7 +2372,10 @@ class TestFilesToTransfer(TestCase):
             renderable_only=False,
             drive_id="1",
         )
-        self.assertEqual(len(files_to_transfer), obj.files.count())
+        self.assertEqual(
+            len(files_to_transfer),
+            parent.files.filter(thumbnail=True).count() + obj.files.count(),
+        )
 
     @patch(
         "kolibri.core.content.utils.import_export_content.get_channel_stats_from_disk"
@@ -2392,7 +2419,10 @@ class TestFilesToTransfer(TestCase):
         _, files_to_transfer, _ = get_import_export_data(
             self.the_channel_id, None, None, False, renderable_only=False, peer_id="1"
         )
-        self.assertEqual(len(files_to_transfer), obj.files.count())
+        self.assertEqual(
+            len(files_to_transfer),
+            obj.files.count() + obj.parent.files.filter(thumbnail=True).count(),
+        )
 
     @patch(
         "kolibri.core.content.utils.import_export_content.get_channel_stats_from_peer"

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -57,6 +57,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         node_ids=None,
         exclude_node_ids=None,
         renderable_only=True,
+        all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
     ):
@@ -71,6 +72,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         self.node_ids = node_ids
         self.exclude_node_ids = exclude_node_ids
         self.renderable_only = renderable_only
+        self.all_thumbnails = all_thumbnails
         self.fail_on_error = fail_on_error
         self.content_dir = content_dir or conf.OPTIONS["Paths"]["CONTENT_DIR"]
         super(ResourceImportManagerBase, self).__init__()
@@ -350,6 +352,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
         node_ids=None,
         exclude_node_ids=None,
         renderable_only=True,
+        all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
@@ -359,6 +362,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             renderable_only=renderable_only,
+            all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
         )
@@ -406,6 +410,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
         node_ids=None,
         exclude_node_ids=None,
         renderable_only=True,
+        all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
     ):
@@ -420,6 +425,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
             node_ids=node_ids,
             exclude_node_ids=exclude_node_ids,
             renderable_only=renderable_only,
+            all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
         )
@@ -486,6 +492,7 @@ class RemoteChannelResourceImportManager(RemoteResourceImportManagerBase):
             self.exclude_node_ids,
             False,
             renderable_only=self.renderable_only,
+            all_thumbnails=self.all_thumbnails,
             peer_id=self.peer_id,
         )
 
@@ -507,6 +514,7 @@ class DiskChannelResourceImportManager(DiskResourceImportManagerBase):
             self.exclude_node_ids,
             False,
             renderable_only=self.renderable_only,
+            all_thumbnails=self.all_thumbnails,
             drive_id=self.drive_id,
         )
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Add an option to include all thumbnails in import/export data and wire it up to be used when importing via the API or CLI. The idea is that you have a subset of a channel's nodes that you actually want to import but you want all the thumbnails so that you can display the nodes that aren't available in a visually appealing way.

Note that I only wired up the import side, but I don't think there's any reason it can't be wired up on the export side.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10770

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

This can be tested with the CLI. Here's an example using the "How to get started with Kolibri" channel:

```
kolibri manage importchannel network 624e09bb5eeb4d20aa8de62e7b4778a0
kolibri manage importcontent --node_ids 8593e4eec90a4cc3a4f2967c0c7dfd03 --include-unrenderable-content --all-thumbnails --fail-on-error network 624e09bb5eeb4d20aa8de62e7b4778a0
```

After that you should find that all thumbnails in the channel. You can do something like this from the shell:

```
from kolibri.core.content.models import File
assert File.objects.filter(contentnode__channel_id="624e09bb5eeb4d20aa8de62e7b4778a0", thumbnail=True, local_file__available=False).count() == 0
```

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
