### PR TITLE
Updates LearnerDeviceStatus status saving method to remove NotImpleme…

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -464,15 +464,11 @@ class LearnerDeviceStatus(AbstractFacilityDataModel):
         :param status: A status tuple of which to save, see `DeviceStatus`
         :type status: tuple(string, int)
         """
-        if not get_device_setting(
+        if get_device_setting(
             "subset_of_users_device", default=not device_provisioned()
         ):
-            raise NotImplementedError(
-                "Saving all learner statuses is not supported on full-facility devices"
-            )
-
-        for user_id in FacilityUser.objects.all().values_list("id", flat=True):
-            cls.save_learner_status(user_id, status)
+            for user_id in FacilityUser.objects.all().values_list("id", flat=True):
+                cls.save_learner_status(user_id, status)
 
     @classmethod
     def save_learner_status(cls, learner_user_id, status):
@@ -507,15 +503,11 @@ class LearnerDeviceStatus(AbstractFacilityDataModel):
         provisioned as a `subset_of_users_device`
         :return:
         """
-        if not get_device_setting(
+        if get_device_setting(
             "subset_of_users_device", default=not device_provisioned()
         ):
-            raise NotImplementedError(
-                "Saving all learner statuses is not supported on full-facility devices"
-            )
-
-        for user_id in FacilityUser.objects.all().values_list("id", flat=True):
-            cls.clear_learner_status(user_id)
+            for user_id in FacilityUser.objects.all().values_list("id", flat=True):
+                cls.clear_learner_status(user_id)
 
     @classmethod
     def clear_learner_status(cls, learner_user_id):

--- a/kolibri/core/device/test/test_models.py
+++ b/kolibri/core/device/test/test_models.py
@@ -139,8 +139,8 @@ class LearnerDeviceStatusTestCase(TestCase):
 
     @mock.patch("kolibri.core.device.models.device_provisioned", return_value=True)
     def test_save_statuses__not_subset_of_users_device(self, _):
-        with self.assertRaises(NotImplementedError):
-            LearnerDeviceStatus.save_statuses(DeviceStatus.InsufficientStorage)
+        LearnerDeviceStatus.save_statuses(DeviceStatus.InsufficientStorage)
+        self.assertEqual(LearnerDeviceStatus.objects.count(), 0)
 
     @mock.patch("kolibri.core.device.models.get_device_setting", return_value=True)
     def test_save_statuses(self, mock_device_setting):


### PR DESCRIPTION
…ntedError

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR updates the `save_statuses` class method for the model `LearnerDeviceStatus` to only save learner statuses on learner-only devices and removes the `NotImplementedError` raised when on a full-facility device. Test case `test_save_statuses__not_subset_of_users_device` has also been updated.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #10733 


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
