### PR TITLE
Fixes hidden search elements in search panel on scroll

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -94,7 +94,7 @@
       />
       <div
         v-if="Object.keys(availableResourcesNeeded).length"
-        class="section show-resources"
+        class="section"
       >
         <h2 class="title">
           {{ coreString('showResources') }}
@@ -356,7 +356,7 @@
     top: 60px;
     left: 0;
     height: 100%;
-    padding: 24px;
+    padding: 24px 24px 80px;
     overflow-y: scroll;
     font-size: 14px;
     box-shadow: 0 3px 3px 0 #00000040;
@@ -373,10 +373,6 @@
 
   .section {
     margin-top: 40px;
-  }
-
-  .show-resources {
-    margin-bottom: 60px;
   }
 
   .card-grid {

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/index.vue
@@ -8,7 +8,7 @@
       backgroundColor: $themeTokens.surface,
       width: width,
     }"
-    :class="position === 'embedded' ? 'side-panel' : ''"
+    :class="position === 'embedded' ? 'side-panel' : 'drawer-panel'"
   >
     <div v-if="topics && topics.length && topicsListDisplayed">
       <div
@@ -351,15 +351,28 @@
 
 <style lang="scss" scoped>
 
+  .drawer-panel {
+    padding-bottom: 60px;
+  }
+
   .side-panel {
     position: fixed;
     top: 60px;
     left: 0;
     height: 100%;
-    padding: 24px 24px 80px;
+    padding: 24px 24px 0;
     overflow-y: scroll;
     font-size: 14px;
     box-shadow: 0 3px 3px 0 #00000040;
+  }
+
+  /*
+  * Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=1417667
+  */
+  .side-panel::after {
+    display: block;
+    padding-bottom: 70px;
+    content: '';
   }
 
   .side-panel-folder-link {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes hidden search elements in the search panel on scroll.
**Before:**

https://github.com/learningequality/kolibri/assets/79847249/25f6d278-52eb-4b8b-9d27-46c23b8c1b97

**After:**
_Show resources as last filter_
<img width="645" alt="image" src="https://github.com/learningequality/kolibri/assets/5203639/ffc52e72-6e63-4361-89e2-1a7124142a79">
Accessibility as last filter
<img width="645" alt="image" src="https://github.com/learningequality/kolibri/assets/5203639/3a21130c-2b00-472c-b8be-7292386b005c">
_Activities as last filter_
<img width="645" alt="image" src="https://github.com/learningequality/kolibri/assets/5203639/bd169739-5e0b-48b1-8130-bd4f378377f9">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10775

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Import the QA channel and navigate to Learn > Library
2. Observe the the filter section of the page while resizing the browser window to allow the search panel scroll.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
