### PR TITLE
server: Add systemd notify support for process management

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -43,6 +43,14 @@ ENVIRONMENT_VARIABLES = {
             cherrypy.access logs.
         """,
     },
+    "NOTIFY_SOCKET": {
+        "description": """
+            Path to a socket provided by systemd for sending it notifications
+            about daemon state, particularly for startup and shutdown. If
+            Kolibri is not running under systemd this should be unset.
+            See the sd_notify(3) man page for more details.
+        """,
+    },
 }
 
 

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -421,8 +421,13 @@ class SystemdNotifyPlugin(SimplePlugin):
 
     def __init__(self, bus):
         self.bus = bus
+
+        if not self.is_supported():
+            raise RuntimeError(
+                "Attempted to use SystemdNotifyPlugin when NOTIFY_SOCKET environment variable is not set"
+            )
+
         self.notify_socket_path = os.environ["NOTIFY_SOCKET"]
-        assert self.notify_socket_path != ""
 
         self.bus.subscribe("RUN", self.send_ready, priority=999)
         self.bus.subscribe("STOP", self.send_stopping, priority=1)


### PR DESCRIPTION
## Summary

When running Kolibri under systemd, there’s currently no way of telling when the Kolibri service has fully started up and opened all of its sockets and registered successfully on zeroconf.

This means that when running Kolibri under systemd (for example as `kolibri services --foreground`), systemd can only assume that Kolibri is ready to handle clients as soon as fork/exec has completed. That’s not true; it takes a couple of seconds to do the zeroconf registration.

Add `NOTIFY_SOCKET` support as a magicbus plugin to send state messages to systemd to tell it when Kolibri is ready after starting up, and when it’s starting to shut down.

## References

 * https://www.man7.org/linux/man-pages/man3/sd_notify.3.html
 * https://magicbus.cherrypy.dev/en/latest/

## Reviewer guidance

Start Kolibri using a simple systemd service file:
```
[Unit]
Description=Kolibri services

[Service]
ExecStart=/usr/local/bin/kolibri services --foreground
Type=notify
NotifyAccess=main

[Install]
WantedBy=multi-user.target
```

or run it manually with `NOTIFY_SOCKET=/run/systemd/notify` set in the environment.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
