### PR TITLE
storage: Avoid raising JobRunning error when enqueuing an existing job

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -525,15 +525,23 @@ class Storage(object):
         """
         Add the job for the specified time
         """
-        return self.schedule(
-            dt,
-            job,
-            queue,
-            priority=priority,
-            interval=interval,
-            repeat=repeat,
-            retry_interval=retry_interval,
-        )
+        try:
+            return self.schedule(
+                dt,
+                job,
+                queue,
+                priority=priority,
+                interval=interval,
+                repeat=repeat,
+                retry_interval=retry_interval,
+            )
+        except JobRunning:
+            logger.debug(
+                "Attempted to enqueue a running job {job_id}, ignoring.".format(
+                    job_id=job.job_id
+                )
+            )
+            return job.job_id
 
     def enqueue_in(
         self,
@@ -551,15 +559,23 @@ class Storage(object):
         if not isinstance(delta_t, timedelta):
             raise TypeError("Time argument must be a timedelta object.")
         dt = self._now() + delta_t
-        return self.schedule(
-            dt,
-            job,
-            queue=queue,
-            priority=priority,
-            interval=interval,
-            repeat=repeat,
-            retry_interval=retry_interval,
-        )
+        try:
+            return self.schedule(
+                dt,
+                job,
+                queue=queue,
+                priority=priority,
+                interval=interval,
+                repeat=repeat,
+                retry_interval=retry_interval,
+            )
+        except JobRunning:
+            logger.debug(
+                "Attempted to enqueue a running job {job_id}, ignoring.".format(
+                    job_id=job.job_id
+                )
+            )
+            return job.job_id
 
     def schedule(
         self,


### PR DESCRIPTION
## Summary

One code path for enqueueing a job already has this protection. This commit rolls it out to the other two call sites for `self.schedule()`.

This prevents errors like the following when restarting Kolibri:
```
ERROR    2023-06-06 12:35:57,877 Error in 'START' listener <bound method ServicesPlugin.START of <kolibri.utils.server.ServicesPlugin object at 0x7f67d6546250>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/kolibri/dist/magicbus/base.py", line 273, in publish
    result = listener(*args, **kwargs)
  File "/usr/local/lib/python3.9/dist-packages/kolibri/utils/server.py", line 262, in START
    schedule_ping()
  File "/usr/local/lib/python3.9/dist-packages/kolibri/core/analytics/tasks.py", line 60, in schedule_ping
    _ping.enqueue_at(
  File "/usr/local/lib/python3.9/dist-packages/kolibri/core/tasks/registry.py", line 342, in enqueue_at
    return job_storage.enqueue_at(
  File "/usr/local/lib/python3.9/dist-packages/kolibri/core/tasks/storage.py", line 528, in enqueue_at
    return self.schedule(
  File "/usr/local/lib/python3.9/dist-packages/kolibri/core/tasks/storage.py", line 597, in schedule
    raise JobRunning()
kolibri.core.tasks.exceptions.JobRunning
```

## References

None.

## Reviewer guidance

None in particular.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
