### PR TITLE
Add and leverage option to ignore if a task is running and attempts to be requeued

### DIFF
--- a/kolibri/core/deviceadmin/tasks.py
+++ b/kolibri/core/deviceadmin/tasks.py
@@ -5,6 +5,7 @@ from django import db
 from django.apps import apps
 
 from kolibri.core.tasks.decorators import register_task
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.utils.lock import db_lock
 from kolibri.utils.time_utils import local_now
 
@@ -64,4 +65,7 @@ def schedule_vacuum():
         # If it is past 3AM, change the day to tomorrow.
         vacuum_time = vacuum_time + timedelta(days=1)
     # Repeat indefinitely
-    perform_vacuum.enqueue_at(vacuum_time, repeat=None, interval=24 * 60 * 60)
+    try:
+        perform_vacuum.enqueue_at(vacuum_time, repeat=None, interval=24 * 60 * 60)
+    except JobRunning:
+        pass


### PR DESCRIPTION
## Summary
* Fixes issue noted in https://github.com/learningequality/kolibri/pull/10792
* Catches JobRunning exceptions

## References
Should prevent startup errors noted in https://github.com/learningequality/kolibri/pull/10792 but without making the JobRunning exception mostly pointless as it does.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
