### PR TITLE
options: Clarify that zipcontent should be served from a different origin

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -573,6 +573,8 @@ base_option_spec = {
                 When zipcontent is being served from a completely separate domain, you can set an
                 absolute origin (full protocol plus domain, e.g. 'https://myzipcontent.com/')
                 to be used for all zipcontent origin requests.
+                It is strongly recommended that zipcontent is served from a different origin from the main Kolibri app,
+                either by port or domain, to allow for proper sandboxing.
             """,
         },
         "ZIP_CONTENT_PORT": {
@@ -583,6 +585,8 @@ base_option_spec = {
                 is used to serve all content for the zipcontent endpoint, so as to provide safe IFrame sandboxing
                 but avoiding issues with null origins.
                 This is the alternate origin server equivalent of HTTP_PORT.
+                It is strongly recommended that zipcontent is served from a different origin from the main Kolibri app,
+                either by port or domain, to allow for proper sandboxing.
             """,
         },
         "ZIP_CONTENT_URL_PATH_PREFIX": {


### PR DESCRIPTION
## Summary

Zipcontent is not necessarily fully trusted, but it is shown in an iframe within the main Kolibri app. If it comes from the same origin as the Kolibri app, it will have permissions within the browser to access the parent frame and its resources. That’s undesirable.

Clarify that zipcontent should therefore be served from a different origin. For a Kolibri instance which is running locally, this is handled by serving zipcontent from a different port. For a Kolibri instance which is running online, it should be handled by serving zipcontent from a different domain or subdomain.

## References

None

## Reviewer guidance

None

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
