### PR TITLE
adds error handling to diskcache.DjangoCache

### DIFF
--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -24,7 +24,7 @@ default_cache = {
 # to be shared across processes - most frequently, things that might be needed
 # inside asynchronous tasks.
 process_cache = {
-    "BACKEND": "diskcache.DjangoCache",
+    "BACKEND": "kolibri.deployment.default.custom_django_cache.CustomDjangoCache",
     "LOCATION": diskcache_location,
     "TIMEOUT": cache_options["CACHE_TIMEOUT"],
     "SHARDS": CACHE_SHARDS,

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -24,9 +24,7 @@ class CustomDjangoCache(DjangoCache):
         retry=True,
     ):
         try:
-            return super(CustomDjangoCache, self).add(
-                key, value, timeout, version, read, tag, retry
-            )
+            return DjangoCache.add(self, key, value, timeout, version, read, tag, retry)
         except sqlite3.OperationalError:
             return False
 
@@ -41,8 +39,8 @@ class CustomDjangoCache(DjangoCache):
         retry=False,
     ):
         try:
-            return super(CustomDjangoCache, self).get(
-                key, default, version, read, expire_time, tag, retry
+            return DjangoCache.get(
+                self, key, default, version, read, expire_time, tag, retry
             )
         except sqlite3.OperationalError:
             return None
@@ -58,15 +56,13 @@ class CustomDjangoCache(DjangoCache):
         retry=True,
     ):
         try:
-            return super(CustomDjangoCache, self).set(
-                key, value, timeout, version, read, tag, retry
-            )
+            return DjangoCache.set(self, key, value, timeout, version, read, tag, retry)
         except sqlite3.OperationalError:
             return False
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, retry=True):
         try:
-            return super(CustomDjangoCache, self).touch(key, timeout, version, retry)
+            return DjangoCache.touch(self, key, timeout, version, retry)
         except sqlite3.OperationalError:
             return False
 
@@ -74,78 +70,72 @@ class CustomDjangoCache(DjangoCache):
         self, key, default=None, version=None, expire_time=False, tag=False, retry=True
     ):
         try:
-            return super(CustomDjangoCache, self).pop(
-                key, default, version, expire_time, tag, retry
-            )
+            return DjangoCache.pop(self, key, default, version, expire_time, tag, retry)
         except sqlite3.OperationalError:
             return None
 
     def delete(self, key, version=None, retry=True):
         try:
-            super(CustomDjangoCache, self).delete(key, version, retry)
+            DjangoCache.delete(self, key, version, retry)
         except sqlite3.OperationalError:
             pass
 
     def incr(self, key, delta=1, version=None, default=None, retry=True):
         try:
-            return super(CustomDjangoCache, self).incr(
-                key, delta, version, default, retry
-            )
+            return DjangoCache.incr(self, key, delta, version, default, retry)
         except sqlite3.OperationalError:
             return None
 
     def decr(self, key, delta=1, version=None, default=None, retry=True):
         try:
-            return super(CustomDjangoCache, self).decr(
-                key, delta, version, default, retry
-            )
+            return DjangoCache.decr(self, key, delta, version, default, retry)
         except sqlite3.OperationalError:
             return None
 
     def expire(self, retry=False):
         try:
-            return super(CustomDjangoCache, self).expire(retry)
+            return DjangoCache.expire(self, retry)
         except sqlite3.OperationalError:
             return 0
 
     def stats(self, enable=True, reset=False):
         try:
-            return super(CustomDjangoCache, self).stats(enable, reset)
+            return DjangoCache.stats(self, enable, reset)
         except sqlite3.OperationalError:
             return 0, 0
 
     def create_tag_index(self):
         try:
-            super(CustomDjangoCache, self).create_tag_index()
+            DjangoCache.create_tag_index(self)
         except sqlite3.OperationalError:
             pass
 
     def drop_tag_index(self):
         try:
-            super(CustomDjangoCache, self).drop_tag_index()
+            DjangoCache.drop_tag_index(self)
         except sqlite3.OperationalError:
             pass
 
     def evict(self, tag):
         try:
-            return super(CustomDjangoCache, self).evict(tag)
+            return DjangoCache.evict(self, tag)
         except sqlite3.OperationalError:
             return 0
 
     def cull(self):
         try:
-            return super(CustomDjangoCache, self).cull()
+            return DjangoCache.cull(self)
         except sqlite3.OperationalError:
             return 0
 
     def clear(self):
         try:
-            return super(CustomDjangoCache, self).clear()
+            return DjangoCache.clear(self)
         except sqlite3.OperationalError:
             return 0
 
     def close(self, **kwargs):
         try:
-            super(CustomDjangoCache, self).close(**kwargs)
+            DjangoCache.close(self, **kwargs)
         except sqlite3.OperationalError:
             pass

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -1,0 +1,141 @@
+import sqlite3
+
+from diskcache import DjangoCache
+from django.core.cache.backends.base import DEFAULT_TIMEOUT
+
+
+class CustomDjangoCache(DjangoCache):
+    """
+    Inherits from the DjangoCache to better manage the error handling of
+    the diskcache package by try-catching methods that perform database operations
+    under the hood by compairing against the version of diskcache used in kolibri:
+
+    https://github.com/grantjenks/python-diskcache/blob/v4.1.0/diskcache/djangocache.py
+    """
+
+    def add(
+        self,
+        key,
+        value,
+        timeout=DEFAULT_TIMEOUT,
+        version=None,
+        read=False,
+        tag=None,
+        retry=True,
+    ):
+        try:
+            return DjangoCache.add(self, key, value, timeout, version, read, tag, retry)
+        except sqlite3.OperationalError:
+            return False
+
+    def get(
+        self,
+        key,
+        default=None,
+        version=None,
+        read=False,
+        expire_time=False,
+        tag=False,
+        retry=False,
+    ):
+        try:
+            return DjangoCache.get(
+                self, key, default, version, read, expire_time, tag, retry
+            )
+        except sqlite3.OperationalError:
+            return None
+
+    def set(
+        self,
+        key,
+        value,
+        timeout=DEFAULT_TIMEOUT,
+        version=None,
+        read=False,
+        tag=None,
+        retry=True,
+    ):
+        try:
+            return DjangoCache.set(self, key, value, timeout, version, read, tag, retry)
+        except sqlite3.OperationalError:
+            return False
+
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, retry=True):
+        try:
+            return DjangoCache.touch(self, key, timeout, version, retry)
+        except sqlite3.OperationalError:
+            return False
+
+    def pop(
+        self, key, default=None, version=None, expire_time=False, tag=False, retry=True
+    ):
+        try:
+            return DjangoCache.pop(self, key, default, version, expire_time, tag, retry)
+        except sqlite3.OperationalError:
+            return None
+
+    def delete(self, key, version=None, retry=True):
+        try:
+            DjangoCache.delete(self, key, version, retry)
+        except sqlite3.OperationalError:
+            pass
+
+    def incr(self, key, delta=1, version=None, default=None, retry=True):
+        try:
+            return DjangoCache.incr(self, key, delta, version, default, retry)
+        except sqlite3.OperationalError:
+            return None
+
+    def decr(self, key, delta=1, version=None, default=None, retry=True):
+        try:
+            return DjangoCache.decr(self, key, delta, version, default, retry)
+        except sqlite3.OperationalError:
+            return None
+
+    def expire(self, retry=False):
+        try:
+            return DjangoCache.expire(self, retry)
+        except sqlite3.OperationalError:
+            return 0
+
+    def stats(self, enable=True, reset=False):
+        try:
+            return DjangoCache.stats(self, enable, reset)
+        except sqlite3.OperationalError:
+            return 0, 0
+
+    def create_tag_index(self):
+        try:
+            DjangoCache.create_tag_index(self)
+        except sqlite3.OperationalError:
+            pass
+
+    def drop_tag_index(self):
+        try:
+            DjangoCache.drop_tag_index(self)
+        except sqlite3.OperationalError:
+            pass
+
+    def evict(self, tag):
+        try:
+            return DjangoCache.evict(self, tag)
+        except sqlite3.OperationalError:
+            return 0
+
+    def cull(self):
+        try:
+            return DjangoCache.cull(self)
+        except sqlite3.OperationalError:
+            return 0
+
+    def clear(self):
+        try:
+            return DjangoCache.clear(self)
+        except sqlite3.OperationalError:
+            return 0
+
+    def close(self, **kwargs):
+        try:
+            DjangoCache.close(self, **kwargs)
+        except sqlite3.OperationalError:
+            pass

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -24,7 +24,9 @@ class CustomDjangoCache(DjangoCache):
         retry=True,
     ):
         try:
-            return DjangoCache.add(self, key, value, timeout, version, read, tag, retry)
+            return super(CustomDjangoCache, self).add(
+                key, value, timeout, version, read, tag, retry
+            )
         except sqlite3.OperationalError:
             return False
 
@@ -39,8 +41,8 @@ class CustomDjangoCache(DjangoCache):
         retry=False,
     ):
         try:
-            return DjangoCache.get(
-                self, key, default, version, read, expire_time, tag, retry
+            return super(CustomDjangoCache, self).get(
+                key, default, version, read, expire_time, tag, retry
             )
         except sqlite3.OperationalError:
             return None
@@ -56,13 +58,15 @@ class CustomDjangoCache(DjangoCache):
         retry=True,
     ):
         try:
-            return DjangoCache.set(self, key, value, timeout, version, read, tag, retry)
+            return super(CustomDjangoCache, self).set(
+                key, value, timeout, version, read, tag, retry
+            )
         except sqlite3.OperationalError:
             return False
 
     def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, retry=True):
         try:
-            return DjangoCache.touch(self, key, timeout, version, retry)
+            return super(CustomDjangoCache, self).touch(key, timeout, version, retry)
         except sqlite3.OperationalError:
             return False
 
@@ -70,72 +74,78 @@ class CustomDjangoCache(DjangoCache):
         self, key, default=None, version=None, expire_time=False, tag=False, retry=True
     ):
         try:
-            return DjangoCache.pop(self, key, default, version, expire_time, tag, retry)
+            return super(CustomDjangoCache, self).pop(
+                key, default, version, expire_time, tag, retry
+            )
         except sqlite3.OperationalError:
             return None
 
     def delete(self, key, version=None, retry=True):
         try:
-            DjangoCache.delete(self, key, version, retry)
+            super(CustomDjangoCache, self).delete(key, version, retry)
         except sqlite3.OperationalError:
             pass
 
     def incr(self, key, delta=1, version=None, default=None, retry=True):
         try:
-            return DjangoCache.incr(self, key, delta, version, default, retry)
+            return super(CustomDjangoCache, self).incr(
+                key, delta, version, default, retry
+            )
         except sqlite3.OperationalError:
             return None
 
     def decr(self, key, delta=1, version=None, default=None, retry=True):
         try:
-            return DjangoCache.decr(self, key, delta, version, default, retry)
+            return super(CustomDjangoCache, self).decr(
+                key, delta, version, default, retry
+            )
         except sqlite3.OperationalError:
             return None
 
     def expire(self, retry=False):
         try:
-            return DjangoCache.expire(self, retry)
+            return super(CustomDjangoCache, self).expire(retry)
         except sqlite3.OperationalError:
             return 0
 
     def stats(self, enable=True, reset=False):
         try:
-            return DjangoCache.stats(self, enable, reset)
+            return super(CustomDjangoCache, self).stats(enable, reset)
         except sqlite3.OperationalError:
             return 0, 0
 
     def create_tag_index(self):
         try:
-            DjangoCache.create_tag_index(self)
+            super(CustomDjangoCache, self).create_tag_index()
         except sqlite3.OperationalError:
             pass
 
     def drop_tag_index(self):
         try:
-            DjangoCache.drop_tag_index(self)
+            super(CustomDjangoCache, self).drop_tag_index()
         except sqlite3.OperationalError:
             pass
 
     def evict(self, tag):
         try:
-            return DjangoCache.evict(self, tag)
+            return super(CustomDjangoCache, self).evict(tag)
         except sqlite3.OperationalError:
             return 0
 
     def cull(self):
         try:
-            return DjangoCache.cull(self)
+            return super(CustomDjangoCache, self).cull()
         except sqlite3.OperationalError:
             return 0
 
     def clear(self):
         try:
-            return DjangoCache.clear(self)
+            return super(CustomDjangoCache, self).clear()
         except sqlite3.OperationalError:
             return 0
 
     def close(self, **kwargs):
         try:
-            DjangoCache.close(self, **kwargs)
+            super(CustomDjangoCache, self).close(**kwargs)
         except sqlite3.OperationalError:
             pass

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -6,8 +6,8 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 class CustomDjangoCache(DjangoCache):
     """
-    Inherits from the DjangoCache to better manage the error handling of
-    the diskcache package by try-catching methods that perform database operations
+    Inherits from the DjangoCache to better manage the error handling of the
+    diskcache package by try-catching methods that perform database operations
     under the hood by compairing against the version of diskcache used in kolibri:
 
     https://github.com/grantjenks/python-diskcache/blob/v4.1.0/diskcache/djangocache.py


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds error handling around DjangoCache methods that perform database operations under the hood. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/9418 and https://github.com/learningequality/kolibri/issues/9417

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Start kolibri
- Monitor for any 500s in the logs as you perform general testing. Also, see https://github.com/learningequality/kolibri/issues/9418 and https://github.com/learningequality/kolibri/issues/9417 for hints on possible locations where this could be replicated

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
