### PR TITLE
Trigger schedule_ping on first content import of channel & after SetupWizard

### DIFF
--- a/kolibri/core/analytics/tasks.py
+++ b/kolibri/core/analytics/tasks.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 from django.db import connection
 from requests.exceptions import ConnectionError
@@ -9,7 +8,7 @@ from requests.exceptions import Timeout
 from kolibri.core.analytics.utils import DEFAULT_SERVER_URL
 from kolibri.core.analytics.utils import ping_once
 from kolibri.core.tasks.decorators import register_task
-from kolibri.core.tasks.exceptions import JobRunning, JobNotRunning
+from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.main import job_storage
 from kolibri.utils import conf
 from kolibri.utils.time_utils import local_now
@@ -71,11 +70,3 @@ def schedule_ping(
             pass
     elif conf.OPTIONS["Deployment"]["DISABLE_PING"]:
         job_storage.clear(job_id=DEFAULT_PING_JOB_ID)
-
-
-def trigger_pingback():
-    try:
-        job = job_storage.get_job(job_id=DEFAULT_PING_JOB_ID)
-        job.retry_in(timedelta(seconds=1))
-    except JobNotRunning:
-        schedule_ping()

--- a/kolibri/core/analytics/tasks.py
+++ b/kolibri/core/analytics/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from django.db import connection
 from requests.exceptions import ConnectionError
@@ -8,7 +9,7 @@ from requests.exceptions import Timeout
 from kolibri.core.analytics.utils import DEFAULT_SERVER_URL
 from kolibri.core.analytics.utils import ping_once
 from kolibri.core.tasks.decorators import register_task
-from kolibri.core.tasks.exceptions import JobRunning
+from kolibri.core.tasks.exceptions import JobRunning, JobNotRunning
 from kolibri.core.tasks.main import job_storage
 from kolibri.utils import conf
 from kolibri.utils.time_utils import local_now
@@ -70,3 +71,11 @@ def schedule_ping(
             pass
     elif conf.OPTIONS["Deployment"]["DISABLE_PING"]:
         job_storage.clear(job_id=DEFAULT_PING_JOB_ID)
+
+
+def trigger_pingback():
+    try:
+        job = job_storage.get_job(job_id=DEFAULT_PING_JOB_ID)
+        job.retry_in(timedelta(seconds=1))
+    except JobNotRunning:
+        schedule_ping()

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -36,7 +36,7 @@ from .permissions import UserHasAnyDevicePermissions
 from .serializers import DevicePermissionsSerializer
 from .serializers import DeviceProvisionSerializer
 from .serializers import DeviceSettingsSerializer
-from kolibri.core.analytics.tasks import trigger_pingback
+from kolibri.core.analytics.tasks import schedule_ping
 from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
@@ -102,7 +102,7 @@ class DeviceProvisionView(viewsets.GenericViewSet):
 
             update_zeroconf_broadcast()
 
-        trigger_pingback()  # Trigger telemetry pingback after we've provisioned
+        schedule_ping()  # Trigger telemetry pingback after we've provisioned
         return Response(response_data, status=status.HTTP_201_CREATED)
 
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -36,6 +36,7 @@ from .permissions import UserHasAnyDevicePermissions
 from .serializers import DevicePermissionsSerializer
 from .serializers import DeviceProvisionSerializer
 from .serializers import DeviceSettingsSerializer
+from kolibri.core.analytics.tasks import trigger_pingback
 from kolibri.core.api import ReadOnlyValuesViewset
 from kolibri.core.auth.api import KolibriAuthPermissions
 from kolibri.core.auth.api import KolibriAuthPermissionsFilter
@@ -101,6 +102,7 @@ class DeviceProvisionView(viewsets.GenericViewSet):
 
             update_zeroconf_broadcast()
 
+        trigger_pingback()  # Trigger telemetry pingback after we've provisioned
         return Response(response_data, status=status.HTTP_201_CREATED)
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds `trigger_pingback()` to `kolbri.core.analytics.tasks` which will set the pingback job to retry in 1 second. This allows us to force the pingback job to run when we want. 

Then this is called during `run_import` in the `resource_import` module as well as within the `DeviceProvisionView#create` just before it returns. Noting that this will _not_ trigger provisioning when done via CLI or other means as this only occurs after the "Setup Wizard", as noted in the issue fixed here.


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10282 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

As noted above, I struggled to write automated tests for this so this is how I tested it:

- On a fresh KOLIBRI_HOME
- Run your Kolibri server in the foreground and watch the logs
- Provision the device through the SetupWizard
- **You should see a "Ping Succeeded" message** in your terminal output
- Next, import **select pieces of content from** a new channel for the first time ever to this device
- Once it starts up in the terminal, **you should again see the "Ping Succeeded" message**
- Now, import more content from that same channel, **you should not** see the "Ping Succeeded" message come up

Any thoughts on ways some automated tests would help here?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
