### PR TITLE
default_theme: Move favicon location to be configured by the theme

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -9,7 +9,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google" content="notranslate">
-  <link rel="shortcut icon" href="{% static 'assets/logo.ico' %}">
+  {% theme_favicon %}
   <title>{% trans "Kolibri" %}</title>
   {% if LANGUAGE_CODE == "ach-ug" %}
     <script type="text/javascript">

--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n core_tags %}
 {% load staticfiles %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 {% get_current_language as LANGUAGE_CODE %}
@@ -9,7 +9,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google" content="notranslate">
-  <link rel="shortcut icon" href="{% static 'assets/logo.ico' %}">
+  {% theme_favicon %}
   <title>{% trans "Kolibri" %}</title>
   <style>
     body {

--- a/kolibri/core/templatetags/core_tags.py
+++ b/kolibri/core/templatetags/core_tags.py
@@ -7,10 +7,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django import template
+from django.templatetags.static import static
+from django.utils.html import format_html
 
 from kolibri.core.hooks import FrontEndBaseASyncHook
 from kolibri.core.hooks import FrontEndBaseHeadHook
 from kolibri.core.hooks import FrontEndBaseSyncHook
+from kolibri.core.theme_hook import ThemeHook
 
 register = template.Library()
 
@@ -49,3 +52,22 @@ def frontend_base_head_markup():
     :return: HTML to insert into head of base.html
     """
     return FrontEndBaseHeadHook.html()
+
+
+@register.simple_tag()
+def theme_favicon():
+    """
+    Render a favicon link to put in the <head> tag of base.html, if a favicon is
+    provided by the theme. If not, a default will be returned.
+    """
+    favicon_urls = [
+        logo["src"]
+        for logo in ThemeHook.get_theme().get("logos", [])
+        if logo.get("content_type", "") == "image/vnd.microsoft.icon"
+    ]
+
+    # Choose the first available .ico file. It's unlikely there's more than
+    # one specified in the theme.
+    favicon_url = favicon_urls[0] if favicon_urls else static("assets/logo.ico")
+
+    return format_html('<link rel="shortcut icon" href="{}">', favicon_url)

--- a/kolibri/plugins/default_theme/kolibri_plugin.py
+++ b/kolibri/plugins/default_theme/kolibri_plugin.py
@@ -27,6 +27,11 @@ class DefaultThemeHook(theme_hook.ThemeHook):
             },
             "logos": [
                 {
+                    "src": static("assets/logo.ico"),
+                    "content_type": "image/vnd.microsoft.icon",
+                    "size": "32x32",
+                },
+                {
                     "src": static("kolibri-logo.svg"),
                     "content_type": "image/svg+xml",
                     # See https://web.dev/maskable-icon/ for details on what


### PR DESCRIPTION
## Summary

Previously it was hardcoded as `static/logo.ico`, which was not overrideable by individual Kolibri installations.

Add it to the base page template using a new `FrontEndBaseHeadHook` hook, since getting the theme and looking up the right icon from the logos list is not straightforward enough to do within a normal Django template variable substitution.

These changes do not affect the appearance of pages by default, as the default theme provides the same favicon as before.

## References

None

## Reviewer guidance

None

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
