### PR TITLE
fix blank screen for coach with no classes

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -63,15 +63,13 @@ export default {
   },
   actions: {
     setClassList(store, facilityId) {
-      const activeFacilityId =
-        store.state.core.facilities.length === 1 ? store.getters.userFacilityId : facilityId;
-      if (!activeFacilityId) {
+      if (facilityId) {
         throw new Error("Missing required 'facilityId' argument");
       }
       store.commit('SET_DATA_LOADING', true);
       store.commit('SET_CLASS_LIST', []); // Reset the list if we're loading a new one
       return ClassroomResource.fetchCollection({
-        getParams: { parent: activeFacilityId, role: 'coach' },
+        getParams: { parent: facilityId, role: 'coach' },
       })
         .then(classrooms => {
           store.commit('SET_CLASS_LIST', classrooms);

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -63,7 +63,7 @@ export default {
   },
   actions: {
     setClassList(store, facilityId) {
-      if (facilityId) {
+      if (!facilityId) {
         throw new Error("Missing required 'facilityId' argument");
       }
       store.commit('SET_DATA_LOADING', true);

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -27,7 +27,10 @@ export default [
     component: CoachClassListPage,
     handler(toRoute) {
       store.dispatch('loading');
-      store.dispatch('setClassList', toRoute.query.facility_id).then(
+      // if user only has access to one facility, facility_id will not be accessible from URL,
+      // but always defaulting to userFacilityId would cause problems for multi-facility admins
+      const facilityId = toRoute.query.facility_id || store.getters.userFacilityId;
+      store.dispatch('setClassList', facilityId).then(
         () => {
           if (!store.getters.classListPageEnabled) {
             // If no class list page, redirect to


### PR DESCRIPTION
## Summary
recent changes were made to behavior in coach to fix problems with missing or misdirecting back links. however, these did not take into account handling the case of coaches, leading to errors when coaches logged in.

this pr introduces changes to `setClassList()` & the handler for `CoachClassListPage`, altering the way we check for and assign the value of `facilityId`, which is fed into `setClassList()`.

this newest change has been manually tested for superadmins, assignable coaches, coaches, and even learners for good measure. 


## References
fixes #10811 (& should also fix #10835)

new issue created, #10816, in order to improve behavior observed while addressing this issue (not related to or impacted by the issue at hand).

## Reviewer guidance
- as a superadmin, create a coach user, without assigning them any classes
- log out & log in as your new coach user
- you will arrive on the `Classes` page, which will be empty aside from "View learner performance and behavior" text
- you will not be able to access the other subtopics in the `Coach` plugin (this is identical to the behavior on `develop`, see screen recordings below) but will be able to access facility content in `Learn`

behavior with this branch's changes:

https://github.com/learningequality/kolibri/assets/43046460/16e55f57-8475-4b11-b00a-d5cfe5627c88


while this is not ideal UX, it is fully in line with the current behavior and an issue for improving this behavior has been created (#10816), to be addressed at a later date.

for reference, the behavior on develop:


https://github.com/learningequality/kolibri/assets/43046460/cecdf979-474d-4299-a1fa-52d47a89d196





----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
