### PR TITLE
Fix some remote loading states

### DIFF
--- a/kolibri/core/assets/src/validators.js
+++ b/kolibri/core/assets/src/validators.js
@@ -22,6 +22,9 @@ export function validateContentNodeKind(value, others = []) {
 }
 
 export function validateLearningActivity(arr) {
+  if (!arr.length) {
+    return true;
+  }
   const isValidLearningActivity = v => Object.values(LearningActivities).includes(v);
-  return arr.length > 0 && arr.every(isValidLearningActivity);
+  return arr.every(isValidLearningActivity);
 }

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/getters.js
@@ -31,3 +31,7 @@ export function canAccessUnassignedContent(state, getters) {
 export function allowGuestAccess(state) {
   return state.allowGuestAccess;
 }
+
+export function getRootNodesLoading(state) {
+  return state.rootNodesLoading;
+}

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/mutations.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/mutations.js
@@ -8,4 +8,7 @@ export default {
   SET_SHOW_COMPLETE_CONTENT_MODAL(state, valToSet) {
     state.showCompleteContentModal = valToSet;
   },
+  SET_ROOT_NODES_LOADING(state, valToSet) {
+    state.rootNodesLoading = valToSet;
+  },
 };

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -23,6 +23,7 @@ export default {
        * or not at any time. It should be set as `false` whenever the content page is loaded.
        **/
       showCompleteContentModal: false,
+      rootNodesLoading: false,
     };
   },
   actions,

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -47,15 +47,21 @@ function _showChannels(store, query, channels, baseurl) {
         store.commit('CORE_SET_PAGE_LOADING', false);
         store.commit('CORE_SET_ERROR', null);
         store.commit('SET_PAGE_NAME', PageNames.LIBRARY);
+        store.commit('SET_ROOT_NODES_LOADING', false);
       }
     },
     error => {
       shouldResolve() ? store.dispatch('handleError', error) : null;
+      store.commit('SET_ROOT_NODES_LOADING', false);
     }
   );
 }
 
 function _showLibrary(store, query, channels, baseurl) {
+  // Don't set the 'page loading' boolean, to prevent flash and loss of keyboard focus.
+  if (store.state.pageName !== PageNames.LIBRARY) {
+    store.commit('CORE_SET_PAGE_LOADING', true);
+  }
   if (!channels.length && !store.getters.isUserLoggedIn) {
     return;
   }
@@ -71,6 +77,7 @@ function _showLibrary(store, query, channels, baseurl) {
     store.commit('CORE_SET_PAGE_LOADING', false);
     store.commit('CORE_SET_ERROR', null);
     store.commit('SET_PAGE_NAME', PageNames.LIBRARY);
+    store.commit('SET_ROOT_NODES_LOADING', false);
     return Promise.resolve();
   }
   return _showChannels(store, query, channels, baseurl);
@@ -78,9 +85,11 @@ function _showLibrary(store, query, channels, baseurl) {
 
 export function showLibrary(store, query, deviceId = null) {
   if (deviceId) {
+    store.commit('SET_ROOT_NODES_LOADING', true);
     return setCurrentDevice(deviceId).then(device => {
       const baseurl = device.base_url;
       return fetchChannels({ baseurl }).then(channels => {
+        // _showLibrary should unset the rootNodesLoading
         return _showLibrary(store, query, channels, baseurl);
       });
     });

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -74,7 +74,6 @@
         @finished="onFinished"
       />
     </template>
-    <KCircularLoader v-else />
 
     <CompletionModal
       v-if="showCompletionModal"

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityIcon.vue
@@ -36,6 +36,9 @@
         type: [String, Array],
         required: true,
         validator(value) {
+          if (!value.length) {
+            return true;
+          }
           const isValidLearningActivity = v => Object.values(LearningActivities).includes(v);
 
           if (Array.isArray(value) && value.length > 0) {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -2,6 +2,7 @@
 
   <LearnAppBarPage
     :appBarTitle="appBarTitle"
+    :loading="getRootNodesLoading"
     :appearanceOverrides="{}"
     :deviceId="deviceId"
     :route="back"
@@ -33,7 +34,7 @@
         :delay="false"
       />
       <div
-        v-else-if="!displayingSearchResults"
+        v-else-if="!displayingSearchResults && !getRootNodesLoading"
         data-test="channels"
       >
         <h1 class="channels-label">
@@ -376,7 +377,7 @@
     },
     computed: {
       ...mapState(['rootNodes']),
-      ...mapGetters(['isSuperuser', 'isUserLoggedIn']),
+      ...mapGetters(['isSuperuser', 'isUserLoggedIn', 'getRootNodesLoading']),
       appBarTitle() {
         return this.learnString(this.deviceId ? 'exploreLibraries' : 'learnLabel');
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -1,27 +1,27 @@
 <template>
 
   <div
-    v-if="!loading && content"
     ref="mainWrapper"
     class="main-wrapper"
   >
 
     <div v-if="blockDoubleClicks" class="click-mask"></div>
+
     <SkipNavigationLink />
     <LearningActivityBar
       ref="activityBar"
       :resourceTitle="resourceTitle"
-      :learningActivities="content.learning_activities"
+      :learningActivities="contentLearningActivities"
       :isLessonContext="lessonContext"
       :isQuiz="practiceQuiz"
       :showingReportState="contentProgress >= 1"
-      :duration="content.duration"
+      :duration="contentDuration"
       :timeSpent="timeSpent"
       :isBookmarked="bookmark ? true : bookmark"
       :isCoachContent="isCoachContent"
       :contentProgress="contentProgress"
       :allowMarkComplete="allowMarkComplete"
-      :contentKind="content.kind"
+      :contentKind="contentKind"
       :showBookmark="allowBookmark"
       :showDownloadButton="allowRemoteDownload"
       :isDownloading="isDownloading"
@@ -40,6 +40,7 @@
       type="indeterminate"
       :delay="false"
     />
+
     <KPageContainer v-if="notAuthorized">
       <AuthMessage
         :authorizedRole="authorizedRole"
@@ -52,7 +53,7 @@
     </KPageContainer>
 
     <div
-      v-else
+      v-else-if="!loading && content"
       id="main"
       role="main"
       tabindex="-1"
@@ -234,11 +235,6 @@
       };
     },
     props: {
-      loading: {
-        type: Boolean,
-        required: false,
-        default: true,
-      },
       // AUTHORIZATION SPECIFIC
       authorized: {
         type: Boolean,
@@ -277,11 +273,23 @@
       ...mapState('topicsTree', {
         isCoachContent: state => (state.content && state.content.coach_content ? 1 : 0),
       }),
+      contentProgress() {
+        return this.content ? this.contentNodeProgressMap[this.content.content_id] : null;
+      },
+      contentKind() {
+        return this.content ? this.content.kind : null;
+      },
+      contentDuration() {
+        return this.content ? this.content.duration : null;
+      },
+      contentLearningActivities() {
+        return this.content ? this.content.learning_activities : [];
+      },
+      loading() {
+        return this.$store.state.core.loading;
+      },
       practiceQuiz() {
         return get(this, ['content', 'options', 'modality']) === Modalities.QUIZ;
-      },
-      contentProgress() {
-        return this.contentNodeProgressMap[this.content && this.content.content_id];
       },
       notAuthorized() {
         // catch "not authorized" error, display AuthMessage
@@ -330,6 +338,7 @@
         return this.isDownloadingByLearner(this.content);
       },
       isDownloaded() {
+        if (!this.content) return false;
         return this.content.admin_imported || this.isDownloadedByLearner(this.content);
       },
       allowRemoteDownload() {

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -43,6 +43,7 @@ function makeWrapper({
       admin_imported: isContentAdminImported,
     },
   };
+  store.state.core = { loading: false };
   store.getters = {
     isUserLoggedIn,
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Resolves two issues:
- Stale state showing when going between remote sources' channels lists
- White blank screen between TopicsContentPage and the ContentPage

Implements a state `rootNodesLoading` in `coreLearn` to indicate specifically if there nodes are being loaded for the page, resulting in a proper KLinearLoader (page is loading indicator) until the channels are ready to load.

Additionally tweaks the TopicsContentPage to safely pass things to the LearnActivityBar before stuff is loaded so that it and the KLinearLoader can show while the initial content loads.

---

Something to note is that #10747 blocks one additional bit of polish that we can apply here which is to remove the `ContentRendererLoading` which puts another unneeded KCircularLoader on the content page -- but that can be reviewed and resolved when both of these are merged.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10786 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

With your connection throttled test these:

- Stale state showing when going between remote sources' channels lists
- White blank screen between TopicsContentPage and the ContentPage

