### PR TITLE
Defers all active link calculation to vue router.

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -49,20 +49,25 @@
     <div v-if="visibleSubMenu">
       <div v-for="subRoute in subRoutes" :key="subRoute.label">
         <div class="link-container">
-          <KRouterLink
-            v-if="isActive"
-            :class="$computedClass(subpathStyles(generateNavRoute(subRoute.route)))"
-            :text="subRoute.label"
-            class="link"
-            :to="$router.getRoute(subRoute.name,$route.params,$router.query)"
-            appearance="basic-link"
-          />
+          <router-link
+            v-if="linkActive"
+            v-slot="{ href, navigate, isActive }"
+            :to="{ name: subRoute.name, params: $route.params, query: $router.query }"
+          >
+            <a
+              class="link"
+              :href="href"
+              :class="isActive ? subRouteActiveClass : subRouteInactiveClass"
+              @click="isActive ? toggleAndroidMenu() : navigate()"
+            >
+              {{ subRoute.label }}
+            </a>
+          </router-link>
           <a
             v-else
             :href="generateNavRoute(subRoute.route)"
             class="link"
-            :class="$computedClass(subpathStyles(subRoute.route))"
-            @click="handleNav(subRoute.route)"
+            :class="subRouteInactiveClass"
           >
             {{ subRoute.label }}
           </a>
@@ -119,7 +124,7 @@
       };
     },
     computed: {
-      isActive() {
+      linkActive() {
         return window.location.pathname == this.link;
       },
       optionStyle() {
@@ -129,7 +134,7 @@
             margin: '8px',
           };
         }
-        if (this.isActive) {
+        if (this.linkActive) {
           return {
             color: this.$themeTokens.primaryDark,
             fontWeight: 'bold',
@@ -161,15 +166,29 @@
       iconAfter() {
         return this.visibleSubMenu ? 'chevronUp' : 'chevronDown';
       },
+      subRouteActiveClass() {
+        return this.$computedClass({
+          color: this.$themeTokens.primaryDark,
+          fontWeight: 'bold',
+          textDecoration: 'none',
+        });
+      },
+      subRouteInactiveClass() {
+        return this.$computedClass({
+          color: this.$themeTokens.text,
+          textDecoration: 'none',
+          ':hover': {
+            color: this.$themeTokens.primaryDark,
+            fontWeight: 'bold',
+          },
+          ':focus': this.$coreOutline,
+        });
+      },
     },
     mounted() {
       this.submenuShouldBeOpen();
     },
     methods: {
-      isActiveLink(route) {
-        const fullPath = !route.includes('#') ? `${this.link}#${route}` : route;
-        return `${window.location.pathname}${window.location.hash}`.includes(fullPath);
-      },
       submenuShouldBeOpen() {
         if (this.subRoutes && this.subRoutes.length > 0) {
           window.location.pathname === this.link
@@ -178,32 +197,11 @@
         }
         return false;
       },
-      subpathStyles(route) {
-        if (this.isActiveLink(route)) {
-          return {
-            color: this.$themeTokens.primaryDark,
-            fontWeight: 'bold',
-            textDecoration: 'none',
-          };
-        }
-        return {
-          color: this.$themeTokens.text,
-          textDecoration: 'none',
-          ':hover': {
-            color: this.$themeTokens.primaryDark,
-            fontWeight: 'bold',
-          },
-          ':focus': this.$coreOutline,
-        };
-      },
       toggleAndroidMenu() {
         if (this.disabled) {
           return;
         }
         this.$emit('toggleAndroidMenu');
-      },
-      handleNav(route) {
-        this.isActiveLink(route) ? this.toggleAndroidMenu() : null;
       },
       generateNavRoute(route) {
         const params = this.$route.params;
@@ -253,6 +251,7 @@
     margin: 0 40px;
     font-size: 14px;
     text-decoration: none;
+    cursor: pointer;
 
     /deep/ .link-text {
       text-decoration: none !important;

--- a/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
@@ -20,6 +20,7 @@ const sideNavConfig = {
       routes.push({
         label: coreStrings.$tr('channelsLabel'),
         route: baseRoutes.content.path,
+        name: baseRoutes.content.name,
       });
     }
     if (get(isSuperuser)) {


### PR DESCRIPTION
## Summary
* Small follow up to previous work on side nav routing
* Uses the vue router slot API to defer to the vue router `isActive` property
* Updates all active/inactive styling to use that property

## Reviewer guidance
Check the side nav behaviours, styling etc.

[Screencast from 06-08-2023 01:32:13 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/f1c53792-1bb0-47a7-be7b-173b8d0009ab)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
