### PR TITLE
Improve how gender and birth year is displayed when changing the facility 

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/GenderDisplayText.vue
+++ b/kolibri/core/assets/src/views/userAccounts/GenderDisplayText.vue
@@ -26,7 +26,7 @@
     },
     computed: {
       isSpecified() {
-        return this.gender !== NOT_SPECIFIED && this.birthYear !== DEFERRED;
+        return this.gender !== NOT_SPECIFIED && this.gender !== DEFERRED;
       },
       displayText() {
         if (this.gender === MALE) {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/ConfirmAccountDetails.vue
@@ -36,7 +36,7 @@
           {{ coreString('genderLabel') }}
         </th>
         <td dir="auto" data-test="gender">
-          {{ cleanValue(targetAccount.gender) }}
+          <GenderDisplayText :gender="targetAccount.gender" />
         </td>
       </tr>
       <tr>
@@ -44,7 +44,7 @@
           {{ coreString('birthYearLabel') }}
         </th>
         <td dir="auto" data-test="birthyear">
-          {{ cleanValue(targetAccount.birth_year) }}
+          <BirthYearDisplayText :birthYear="targetAccount.birth_year" />
         </td>
       </tr>
     </table>
@@ -79,6 +79,8 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { DemographicConstants } from 'kolibri.coreVue.vuex.constants';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import GenderDisplayText from 'kolibri.coreVue.components.GenderDisplayText';
+  import BirthYearDisplayText from 'kolibri.coreVue.components.BirthYearDisplayText';
   import { computed, inject } from 'kolibri.lib.vueCompositionApi';
   import get from 'lodash/get';
 
@@ -89,7 +91,7 @@
         title: this.$tr('documentTitle'),
       };
     },
-    components: { BottomAppBar },
+    components: { BottomAppBar, GenderDisplayText, BirthYearDisplayText },
 
     mixins: [commonCoreStrings],
     setup() {

--- a/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
+++ b/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/MergeAccountDialog/__tests__/ConfirmAccountDetails.spec.js
@@ -1,4 +1,5 @@
 import { mount, createLocalVue } from '@vue/test-utils';
+import { FacilityUserGender } from 'kolibri.coreVue.vuex.constants';
 import ConfirmAccountDetails from '../ConfirmAccountDetails';
 
 const localVue = createLocalVue();
@@ -43,9 +44,9 @@ describe(`ChangeFacility/MergeAccountDialog/ConfirmAccountDetails`, () => {
       targetAccount: {
         full_name: 'Test Full Name',
         username: 'remote_username',
-        gender: 'test gender',
+        gender: FacilityUserGender.FEMALE,
         id_number: 'test id',
-        birth_year: 'test birth year',
+        birth_year: '1989',
       },
       username: 'TestLocalUser',
     });
@@ -54,9 +55,9 @@ describe(`ChangeFacility/MergeAccountDialog/ConfirmAccountDetails`, () => {
     );
     expect(wrapper.find('[data-test="fullname"]').text()).toEqual('Test Full Name');
     expect(wrapper.find('[data-test="username"]').text()).toEqual('remote_username');
-    expect(wrapper.find('[data-test="gender"]').text()).toEqual('test gender');
+    expect(wrapper.find('[data-test="gender"]').text()).toEqual('Female');
     expect(wrapper.find('[data-test="idnumber"]').text()).toEqual('test id');
-    expect(wrapper.find('[data-test="birthyear"]').text()).toEqual('test birth year');
+    expect(wrapper.find('[data-test="birthyear"]').text()).toEqual('1989');
   });
 
   it(`clicking the continue button sends the continue event to the state machine`, () => {


### PR DESCRIPTION
## Summary
 
Utilize existing components for displaying gender and birth year in the _"Confirm account details"_ step when merging accounts in the change facility.

| Before | After |
| --------- | ------ |
| ![before](https://github.com/learningequality/kolibri/assets/13509191/0849720d-be8b-49f7-9917-49a5553e5692) | ![after](https://github.com/learningequality/kolibri/assets/13509191/cc50031e-d856-4c7c-9164-898c2f1931d9) |

## References

Resolves https://github.com/learningequality/kolibri/issues/10335

## Reviewer guidance

With _"On your own"_ device, go to your profile and change the facility by merging accounts (you can merge into _"test1"_ account with _"test1"_ password on _"Mr Tibbles' House of Phun"_ facility). Preview the _"Confirm account details"_ page.

![qa-steps](https://github.com/learningequality/kolibri/assets/13509191/3b0c5b9b-dbe1-412a-87b2-1a9955dc3d38)

---

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
