### PR TITLE
Upgrade morango, cryptography and dependency versions.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.2.2
 jsonfield==2.0.2
 requests-toolbelt==0.9.1
-morango==0.6.19
+morango==0.7.1
 tzlocal==2.1
 pytz==2022.1
 python-dateutil==2.8.2

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -3,7 +3,7 @@
 # This does not depend on runtime stuff so we do not
 # include base.txt
 pex<1.6
-pip>=20.1
+pip>=20.3.4
 setuptools>=20.3,<41,!=34.*,!=35.*  # https://github.com/pantsbuild/pex/blob/master/pex/version.py#L6 # pyup: ignore
 beautifulsoup4==4.8.2
 requests==2.21.0

--- a/requirements/cext.txt
+++ b/requirements/cext.txt
@@ -1,8 +1,8 @@
 # If libraries in here have dependencies
 # they must be explicitly listed in here if
 # they have architecture requirements, or
-# in other files toe ensure they are properly
+# in other files to ensure they are properly
 # installed - as these dependencies are installed
 # without their dependencies.
-cryptography==2.3
 cffi==1.14.4
+cryptography==3.3.2

--- a/requirements/cext_noarch.txt
+++ b/requirements/cext_noarch.txt
@@ -3,3 +3,4 @@
 # arch/OS/pyVesion
 pyOpenSSL==18.0.0
 asn1crypto==1.4.0
+pycparser==2.21


### PR DESCRIPTION
## Summary
* Upgrades morango to version that is tested against newer version of cryptography library and that drops support for Python 3.4 and 3.5
* Upgrades cryptography and its dependencies to the latest version supported by Python 2.7
* Updates C extension bundling to ensure that we properly bundle for all supported Python 3 versions
* Updates C extension bundling to ensure that we bundle for Python 3.8 on Windows
* Updates tox tests to run on Python 3.8 on Windows

## Reviewer guidance
Hopefully ameliorates https://github.com/learningequality/kolibri/issues/9908

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
