### PR TITLE
Remote file cleanup and improvements

### DIFF
--- a/kolibri/core/assets/src/core-app/urls.js
+++ b/kolibri/core/assets/src/core-app/urls.js
@@ -48,13 +48,13 @@ const urls = {
     }
     return generateUrl(this.__mediaUrl, { url });
   },
-  zipContentUrl(fileId, extension, embeddedFilePath = '') {
+  zipContentUrl(fileId, extension, embeddedFilePath = '', baseurl) {
     const filename = `${fileId}.${extension}`;
     if (!this.__zipContentUrl) {
       throw new ReferenceError('Zipcontent Url is not defined');
     }
     return generateUrl(this.__zipContentUrl, {
-      url: `${filename}/${embeddedFilePath}`,
+      url: `${baseurl ? baseurl + '/' : ''}${filename}/${embeddedFilePath}`,
       origin: this.__zipContentOrigin,
       port: this.__zipContentPort,
     });

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -78,6 +78,7 @@ from kolibri.core.utils.pagination import ValuesViewsetLimitOffsetPagination
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.core.utils.urls import join_url
 from kolibri.utils.conf import OPTIONS
+from kolibri.utils.urls import validator
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,10 @@ class RemoteMixin(object):
         qs = request.GET.copy()
         del qs[self.remote_url_param]
         qs.pop("contentCacheKey", None)
+        try:
+            validator(baseurl)
+        except ValidationError:
+            raise Http404("Remote resource not found")
         remote_url = join_url(baseurl, remote_path)
         try:
             response = requests.get(

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1185,7 +1185,7 @@ class ImportContentTestCase(TestCase):
             self.assertIn("Permission denied", logger_mock.call_args_list[0][0][0])
             annotation_mock.set_content_visibility.assert_called()
 
-    @patch("kolibri.core.content.utils.resource_import.transfer.shutil.rmtree")
+    @patch("kolibri.core.content.utils.resource_import.transfer.os.remove")
     @patch(
         "kolibri.core.content.utils.resource_import.os.path.isfile",
         return_value=False,
@@ -1223,7 +1223,7 @@ class ImportContentTestCase(TestCase):
             node_ids=[self.c1_node_id],
         )
         manager.run()
-        remove_mock.assert_any_call(local_dest_path + ".chunks")
+        remove_mock.assert_any_call(local_dest_path + ".transfer")
 
     @patch(
         "kolibri.core.content.utils.resource_import.os.path.isfile",
@@ -1240,7 +1240,7 @@ class ImportContentTestCase(TestCase):
         return_value=False,
     )
     @patch(
-        "kolibri.core.content.utils.resource_import.transfer.Transfer._checksum_correct",
+        "kolibri.core.content.utils.resource_import.transfer.FileCopy._checksum_correct",
         return_value=True,
     )
     def test_local_import_source_corrupted_full_progress(

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -14,7 +14,6 @@ from cheroot import wsgi
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
-from django.core.validators import URLValidator
 from django.http import HttpResponse
 from django.http import HttpResponseNotAllowed
 from django.http import HttpResponseNotFound
@@ -31,6 +30,7 @@ from kolibri.core.content.utils.paths import get_content_storage_file_path
 from kolibri.core.content.utils.paths import get_content_storage_remote_url
 from kolibri.core.content.utils.paths import get_zip_content_base_path
 from kolibri.utils.file_transfer import RemoteFile
+from kolibri.utils.urls import validator
 
 
 logger = logging.getLogger(__name__)
@@ -182,13 +182,6 @@ def get_embedded_file(zipped_path, zipped_filename, embedded_filepath):
 path_regex = re.compile(
     r"/(?:(?P<base_url>(?![a-f0-9]{32}\.zip)[^/]+)/)?(?P<zipped_filename>[a-f0-9]{32}\.zip)/(?P<embedded_filepath>.*)"
 )
-
-validator = URLValidator(schemes=["http", "https"])
-# Need to do this as the default message is a lazily translated string
-# which then tries to invoke the Django settings, so would not work
-# outside of a Django setup context.
-validator.message = "Invalid URL"
-
 
 YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 

--- a/kolibri/core/content/zip_wsgi.py
+++ b/kolibri/core/content/zip_wsgi.py
@@ -12,7 +12,9 @@ import zipfile
 import html5lib
 from cheroot import wsgi
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
+from django.core.validators import URLValidator
 from django.http import HttpResponse
 from django.http import HttpResponseNotAllowed
 from django.http import HttpResponseNotFound
@@ -22,6 +24,7 @@ from django.http.response import StreamingHttpResponse
 from django.utils.cache import patch_response_headers
 from django.utils.encoding import force_str
 from django.utils.http import http_date
+from six.moves.urllib.parse import unquote
 
 from kolibri.core.content.errors import InvalidStorageFilenameError
 from kolibri.core.content.utils.paths import get_content_storage_file_path
@@ -167,7 +170,25 @@ def get_embedded_file(zipped_path, zipped_filename, embedded_filepath):
         return response
 
 
-path_regex = re.compile("/(?P<zipped_filename>[^/]+)/(?P<embedded_filepath>.*)")
+# Includes a prefix that is almost certain not to collide
+# with a filename embedded in a zip file. Prefix is:
+# @*._ followed by the encoded base url
+# This is used to allow the base url to be passed in the main
+# URL and allow relative paths within the loaded HTML5 zip file
+# to maintain the base URL reference. This means when loading
+# from remote URLs, the HTML5 zip can be incrementally loaded based on
+# the base URL, rather than having to load the entire zip file before
+# loading the HTML5 content.
+path_regex = re.compile(
+    r"/(?:(?P<base_url>(?![a-f0-9]{32}\.zip)[^/]+)/)?(?P<zipped_filename>[a-f0-9]{32}\.zip)/(?P<embedded_filepath>.*)"
+)
+
+validator = URLValidator(schemes=["http", "https"])
+# Need to do this as the default message is a lazily translated string
+# which then tries to invoke the Django settings, so would not work
+# outside of a Django setup context.
+validator.message = "Invalid URL"
+
 
 YEAR_IN_SECONDS = 60 * 60 * 24 * 365
 
@@ -201,7 +222,7 @@ def _zip_content_from_request(request):  # noqa: C901
     if request.method == "OPTIONS":
         return HttpResponse()
 
-    zipped_filename, embedded_filepath = match.groups()
+    remote_baseurl, zipped_filename, embedded_filepath = match.groups()
 
     try:
         # calculate the local file path to the zip file
@@ -211,7 +232,14 @@ def _zip_content_from_request(request):  # noqa: C901
             "{filename} is not a valid file name".format(filename=zipped_filename)
         )
 
-    remote_baseurl = request.GET.get("baseurl")
+    if remote_baseurl:
+        try:
+            remote_baseurl = unquote(remote_baseurl)
+            validator(remote_baseurl)
+        except ValidationError:
+            return create_error_response(
+                "{baseurl} is not a valid URL".format(baseurl=remote_baseurl)
+            )
 
     # if the zipfile does not exist on disk, return a 404
     if not os.path.exists(zipped_path):

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -165,15 +165,14 @@
       if (!this.isH5P) {
         // In the case that this is being routed via a remote URL
         // ensure we preserve that for the zip endpoint.
-        const query = this.defaultFile.storage_url.split('?')[1];
+        const url = new URL(this.defaultFile.storage_url, window.location.href);
+        const baseurl = url.searchParams.get('baseurl');
         storageUrl = urls.zipContentUrl(
           this.defaultFile.checksum,
           this.defaultFile.extension,
-          this.entry
+          this.entry,
+          baseurl ? encodeURIComponent(baseurl) : undefined
         );
-        if (query) {
-          storageUrl += '?' + query;
-        }
       }
 
       this.hashi.initialize(

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -242,12 +242,15 @@ class ChunkedFile(BufferedIOBase):
             for chunk_index in range(start_chunk, end_chunk + 1):
                 chunk_file = self._get_chunk_file_name(chunk_index)
                 with Lock(cache, chunk_file, expire=10):
-                    if not os.path.exists(chunk_file):
-                        range_start = chunk_index * self.chunk_size
-                        range_end = min(
-                            range_start + self.chunk_size - 1, self.file_size - 1
-                        )
-
+                    range_start = chunk_index * self.chunk_size
+                    range_end = min(
+                        range_start + self.chunk_size - 1, self.file_size - 1
+                    )
+                    if (
+                        not os.path.exists(chunk_file)
+                        # Add 1 to get the total file size as the range is inclusive
+                        or os.path.getsize(chunk_file) < range_end - range_start + 1
+                    ):
                         yield (
                             range_start,
                             range_end,

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -19,6 +19,7 @@ from whitenoise.responders import StaticFile
 from whitenoise.string_utils import decode_path_info
 
 from kolibri.utils.file_transfer import RemoteFile
+from kolibri.utils.urls import validator
 
 
 compressed_file_extensions = ("gz",)
@@ -169,6 +170,7 @@ class StreamingStaticFile(EndRangeStaticFile):
             return NOT_ALLOWED_RESPONSE
         if method != "HEAD":
             try:
+                validator(self.remote_url)
                 file_handle = RemoteFile(
                     self.path,
                     self.remote_url,

--- a/kolibri/utils/urls.py
+++ b/kolibri/utils/urls.py
@@ -1,0 +1,7 @@
+from django.core.validators import URLValidator
+
+validator = URLValidator(schemes=["http", "https"])
+# Need to do this as the default message is a lazily translated string
+# which then tries to invoke the Django settings, so would not work
+# outside of a Django setup context.
+validator.message = "Invalid URL"


### PR DESCRIPTION
## Summary
* Removes use of ChunkedFile object for disk to disk transfers, as it adds unnecessary complexity
* Adds edge case testing for chunks in a chunked file when the chunk is only partially written (which could happen due to the write process being interrupted) - fixes behaviour in this case
* Adds support for `seek` and `tell` for the RemoteFile wrapper class, in order to allow Python's zipfile module to do random access reads
* Changes the way the baseurl is passed to the zipcontent backend - adds it as a URLencoded URL parameter, prefixing the zipfilename and embedded zipfile - this means that the entire HTML5 app being loaded is now scoped by the baseurl, so any child files loaded by the entry point HTML file will also encode the baseurl - this allows for only the chunks of the HTML5 zip file needed have to be transferred.
* Adds validation for baseurls on the backend to prevent malicious URL insertion - uses this anywhere we are passing baseurl to the backend
* Updates the HTML5Renderer to form the new URL schema that zipcontent expects for baseurls

## References
Fixes #10583 
Fixes #10602

## Reviewer guidance
Confirm that HTML5 app browsing on a remote server now works as intended.
Confirm that file exports on Windows (as reported in #10583) no longer suffer odd errors.

One thing to flag is that the random access tests revealed an issue with the way that the lock objects and the generators interact - it appears that in some cases chunks can become prematurely locked, which leads to a ten second delay (the lock expiry) during reads. This only happens when overlapping chunks are being attempted to be downloaded, which should hopefully not happen too often, and my attempts to resolve this issue within the scope of this work did not resolve anything and just broke a bunch of other stuff. We should make a follow up issue before merging this PR, but I don't think that it should be a release blocker.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
