### PR TITLE
"Sync All" button visible only if a facility is registered with KDP 

### DIFF
--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -12,8 +12,8 @@
           <!-- Margins to and bottom adds space when buttons are vertically stacked -->
           <KButtonGroup>
             <KButton
-              :text="$tr('syncAllAction')"
               v-if="isAnyFacilityRegistered"
+              :text="$tr('syncAllAction')"
               style="margin-top: 16px; margin-bottom: -16px;"
               @click="showSyncAllModal = true"
             />
@@ -198,6 +198,7 @@
     SyncFacilityModalGroup,
   } from 'kolibri.coreVue.componentSets.sync';
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
+  import some from 'lodash/some';
   import { PageNames } from '../../constants';
   import { deviceString } from '../commonDeviceStrings';
   import TasksBar from '../ManageContentPage/TasksBar';
@@ -207,7 +208,6 @@
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';
   import facilityTaskQueue from './facilityTasksQueue';
-  import some from 'lodash/some';
 
   const Options = Object.freeze({
     REGISTER: 'REGISTER',

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -13,6 +13,7 @@
           <KButtonGroup>
             <KButton
               :text="$tr('syncAllAction')"
+              v-if="isAnyFacilityRegistered"
               style="margin-top: 16px; margin-bottom: -16px;"
               @click="showSyncAllModal = true"
             />
@@ -206,6 +207,7 @@
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';
   import facilityTaskQueue from './facilityTasksQueue';
+  import some from 'lodash/some';
 
   const Options = Object.freeze({
     REGISTER: 'REGISTER',
@@ -250,6 +252,9 @@
     computed: {
       pageTitle() {
         return deviceString('deviceManagementTitle');
+      },
+      isAnyFacilityRegistered() {
+        return some(this.facilities, facility => facility.dataset.registered);
       },
     },
     watch: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- fixes #10755 
- Sync all button disappears when no registered facilities are present.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

- References to issues: fixes #10755 and #10758 might be relevant

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- changes can be tested by having one or more unregistered facilities and then going to the `devices` > `facilities`
- no risky areas 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
