### PR TITLE
add flex properties to LessonContentCard title and message

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -10,33 +10,36 @@
     />
 
     <div :class="windowIsSmall ? 'mobile-text' : 'text'" :style="{ color: $themeTokens.text }">
-      <div :class="{ 'title-message-wrapper': Boolean(!windowIsSmall) }" :style="{ color: $themeTokens.text }">
-      <h3
-        v-if="!windowIsSmall"
-        class="title"
-        :class="{ 'has-message': Boolean(message) }"
-        dir="auto"
+      <div 
+        :class="{ 'title-message-wrapper': Boolean(!windowIsSmall) }" 
+        :style="{ color: $themeTokens.text }"
       >
-        <KLabeledIcon :label="title">
-          <template #icon>
-            <ContentIcon :kind="kind" />
-          </template>
-        </KLabeledIcon>
-      </h3>
-      <h3
-        v-if="windowIsSmall"
-        dir="auto"
-      >
-        <KLabeledIcon :label="title">
-          <template #icon>
-            <ContentIcon :kind="kind" />
-          </template>
-        </KLabeledIcon>
-      </h3>
-      <div v-if="message" class="message" :style="{ color: $themeTokens.text }">
-        {{ message }}
+        <h3
+          v-if="!windowIsSmall"
+          class="title"
+          :class="{ 'has-message': Boolean(message) }"
+          dir="auto"
+        >
+          <KLabeledIcon :label="title">
+            <template #icon>
+              <ContentIcon :kind="kind" />
+            </template>
+          </KLabeledIcon>
+        </h3>
+        <h3
+          v-if="windowIsSmall"
+          dir="auto"
+        >
+          <KLabeledIcon :label="title">
+            <template #icon>
+              <ContentIcon :kind="kind" />
+            </template>
+          </KLabeledIcon>
+        </h3>
+        <div v-if="message" class="message" :style="{ color: $themeTokens.text }">
+          {{ message }}
+        </div>
       </div>
-    </div>
       <TextTruncatorCss
         v-if="!windowIsSmall"
         :text="description"
@@ -156,8 +159,8 @@
   }
 
   .text {
-    margin-left: $thumb-width + 8;
     flex-direction: column;
+    margin-left: $thumb-width + 8;
   }
 
   .mobile-text {
@@ -170,7 +173,8 @@
     justify-content: space-between;
   }
 
-  .title, .message {
+  .title,
+  .message {
     margin-top: 0;
     overflow: hidden;
   }

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -10,6 +10,7 @@
     />
 
     <div :class="windowIsSmall ? 'mobile-text' : 'text'" :style="{ color: $themeTokens.text }">
+      <div :class="{ 'title-message-wrapper': Boolean(!windowIsSmall) }" :style="{ color: $themeTokens.text }">
       <h3
         v-if="!windowIsSmall"
         class="title"
@@ -35,6 +36,7 @@
       <div v-if="message" class="message" :style="{ color: $themeTokens.text }">
         {{ message }}
       </div>
+    </div>
       <TextTruncatorCss
         v-if="!windowIsSmall"
         :text="description"
@@ -155,32 +157,27 @@
 
   .text {
     margin-left: $thumb-width + 8;
+    display: flex;
+    flex-direction: column;
   }
 
   .mobile-text {
     margin-left: $mobile-thumb-width + 8;
   }
 
-  .title,
-  .message {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  .title-message-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
   }
 
-  .title.has-message,
-  .message {
-    max-width: 45%;
-  }
-
-  .title {
+  .title, .message {
     margin-top: 0;
+    overflow: hidden;
   }
 
   .message {
-    position: absolute;
-    top: 16px;
-    right: 16px;
+    text-align: right;
   }
 
   .coach-content-label {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -157,7 +157,6 @@
 
   .text {
     margin-left: $thumb-width + 8;
-    display: flex;
     flex-direction: column;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -10,14 +10,13 @@
     />
 
     <div :class="windowIsSmall ? 'mobile-text' : 'text'" :style="{ color: $themeTokens.text }">
-      <div 
-        :class="{ 'title-message-wrapper': Boolean(!windowIsSmall) }" 
+      <div
+        :class="{ 'title-message-wrapper': Boolean(!windowIsSmall) }"
         :style="{ color: $themeTokens.text }"
       >
         <h3
           v-if="!windowIsSmall"
           class="title"
-          :class="{ 'has-message': Boolean(message) }"
           dir="auto"
         >
           <KLabeledIcon :label="title">


### PR DESCRIPTION
## Summary
Added a `title-message-wrapper` with flex properties to avoid having the text of `title` and `message` elements overlap with each other in lesson content cards. Adjusted some properties of `title` and `message` so they would play nice.

## Before/after Screenshots
# Lesson Content Card Default -- No Overlap But Title is Trimmed
![Lesson Content Card Default -- No Overlap But Title is Trimmed](https://github.com/learningequality/kolibri/assets/81499114/0011ba32-e692-4c78-9165-63e1f1f89b61)
# Lesson Content Card After -- No Overlap
![Lesson Content Card After -- No Overlap](https://github.com/learningequality/kolibri/assets/81499114/7724d002-ebd5-4128-8cd8-0872c8b6e219)
# Lesson Content Card Default -- Overlap
![Lesson Content Card Default -- Overlap](https://github.com/learningequality/kolibri/assets/81499114/ca033b30-74f0-4a65-8792-1760ca7811f8)
# Lesson Content Card After -- Overlap Averted
![Lesson Content Card After -- Overlap Averted](https://github.com/learningequality/kolibri/assets/81499114/bc221df0-d19f-4d2c-b4bd-1f0ec35e8862)
# Lesson Content Card Default -- Mobile Format
![Lesson Content Card Default -- Mobile Format](https://github.com/learningequality/kolibri/assets/81499114/6c6a38cc-dd10-49a8-b119-9a2cb5060f42)
# Lesson Content Card After -- Mobile Format
![Lesson Content Card After -- Mobile Format](https://github.com/learningequality/kolibri/assets/81499114/9e4d267b-832e-4ac0-8155-afa800a9c09b)

## Steps to Test
1. In Kolibri, as a Coach, go to a course dashboard for which you are a coach. Click the Plan tab, then select a lesson by clicking on its title. (Or, in the Plan tab, create a new lesson and click on its title. The goal is to get to the lesson's management page. 
2. From the lesson page, click the manage resources button. If no resources are already selected, navigate the content cards to add content, then, from the lesson page, click the manage resources button again. At this point at least one of your resource cards should also contain a message in the top-right corner that reads something like "10 of 100 resources selected"
3.  Change the width of the page/window to see how the card Title and Message either overlap with each other (default behavior) or flex to maintain visibility of content (new behavior). With the default behavior, the Title can be cut off even when the card is wide enough to avoid overlap in the first place.
4. You can repeat this test using a ltr language such as Arabic (you can change the /en/ in the url to /ar/ for a quick change. Note that a documented bug causes rtl formatting to be inaccurate when running devserver-hot
(optional) Implementation notes

## At a high level, how did you implement this?
Added a title-message-wrapper element with `display: flex` property to wrap title and message, and `justify-content: space-between` to push them to opposite sides.  

Note that because `title` element inherits some of its attributes (weight, size) from being an `h3`, the `title` and `message` classes are actually defined the same. However, because `message` is derived from a distinct prop and has unique purpose and display logic (only displayed if a message prop is sent to the content card), I did not combine them into a single class.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md


