### PR TITLE
Polishing loading states in Device & Facility

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -33,3 +33,7 @@ export function pageSessionId(state) {
 export function allowAccess(state, getters, rootState, rootGetters) {
   return state.allowRemoteAccess || rootGetters.isAppContext;
 }
+
+export function isPageLoading(state) {
+  return state.loading;
+}

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -16,7 +16,7 @@
         </template>
       </AppBar>
       <KLinearLoader
-        v-if="loading"
+        v-if="isLoading"
         type="indeterminate"
         :delay="false"
       />
@@ -54,7 +54,6 @@
 
   import { mapGetters } from 'vuex';
   import { get } from '@vueuse/core';
-  import _get from 'lodash/get';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
@@ -102,7 +101,7 @@
       loading: {
         type: Boolean,
         default() {
-          return _get(this, '$store.state.core.loading', false);
+          return false;
         },
       },
     },
@@ -114,7 +113,10 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext']),
+      ...mapGetters(['isAppContext', 'isPageLoading']),
+      isLoading() {
+        return this.isPageLoading || this.loading;
+      },
       wrapperStyles() {
         return this.appearanceOverrides
           ? this.appearanceOverrides

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
@@ -7,11 +7,15 @@ export default {
   state: {
     deviceInfo: {},
     deviceName: null,
+    dataLoading: false,
   },
   mutations: {
     SET_STATE(state, payload) {
       state.deviceInfo = payload.deviceInfo;
       state.deviceName = payload.deviceInfo.device_name;
+    },
+    SET_DATA_LOADING(state, payload) {
+      state.dataLoading = payload;
     },
     SET_DEVICE_NAME(state, name) {
       state.deviceName = name;
@@ -24,6 +28,9 @@ export default {
   getters: {
     getDeviceOS(state) {
       return state.deviceInfo.os;
+    },
+    getDataLoading(state) {
+      return state.dataLoading;
     },
     canRestart() {
       return plugin_data.canRestart;

--- a/kolibri/plugins/device/assets/src/modules/manageContent/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/handlers.js
@@ -5,7 +5,8 @@ export function showManageContentPage(store) {
     return Promise.all([
       store.dispatch('manageContent/refreshTaskList'),
       store.dispatch('manageContent/refreshChannelList'),
-    ]);
+    ]).then(() => store.dispatch('notLoading'));
   }
+  store.dispatch('notLoading');
   return Promise.resolve();
 }

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
@@ -20,6 +20,7 @@ function fetchFacilityUsers() {
 export function showManagePermissionsPage(store) {
   const shouldResolve = samePageCheckGenerator(store);
   store.commit('managePermissions/SET_LOADING_FACILITY_USERS', true);
+  store.dispatch('notLoading'); // We're loading data now, not the page
   const promises = Promise.all([fetchFacilityUsers(store), fetchDevicePermissions()]);
   return promises
     .then(([users, permissions]) => {

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -41,7 +41,7 @@ function fetchUserPermissions(userId) {
  */
 export function showUserPermissionsPage(store, userId) {
   const setUserPermissionsState = state => store.commit('userPermissions/SET_STATE', state);
-  const stopLoading = () => store.commit('CORE_SET_PAGE_LOADING', false);
+  const stopLoading = () => store.dispatch('notLoading');
 
   // Don't request any data if not an Admin
   if (!store.getters.isSuperuser) {
@@ -56,8 +56,8 @@ export function showUserPermissionsPage(store, userId) {
     .then(([data]) => {
       if (samePage()) {
         setUserPermissionsState({ user: data.user, permissions: data.permissions });
-        stopLoading();
       }
+      stopLoading();
     })
     .catch(error => {
       if (samePage()) {

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -21,7 +21,7 @@ import { PageNames } from '../constants';
 import wizardTransitionRoutes from './wizardTransitionRoutes';
 
 function hideLoadingScreen() {
-  store.commit('CORE_SET_PAGE_LOADING', false);
+  store.dispatch('notLoading');
 }
 
 function defaultHandler(toRoute) {

--- a/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceInfoPage.vue
@@ -2,8 +2,8 @@
 
   <DeviceAppBarPage :title="pageTitle">
 
-    <KPageContainer class="device-container">
-      <div v-if="!$store.state.core.loading">
+    <KPageContainer v-if="!isPageLoading" class="device-container">
+      <div>
         <h1>{{ $tr('header') }}</h1>
         <table :class="windowIsSmall ? 'mobile-table' : ''">
           <tr>
@@ -78,7 +78,7 @@
 
 <script>
 
-  import { mapState } from 'vuex';
+  import { mapGetters, mapState } from 'vuex';
   import TechnicalTextBlock from 'kolibri-common/components/AppError/TechnicalTextBlock';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
@@ -106,6 +106,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isPageLoading']),
       ...mapState('deviceInfo', ['deviceInfo', 'deviceName']),
       buttonText() {
         return this.advancedShown ? this.$tr('hide') : this.coreString('showAction');

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -2,7 +2,11 @@
 
   <DeviceAppBarPage :title="pageTitle">
 
-    <KPageContainer class="device-container">
+    <template #subNav>
+      <DeviceTopNav />
+    </template>
+
+    <KPageContainer v-if="!isPageLoading" class="device-container">
       <UiAlert
         v-if="showDisabledAlert && alertDismissed"
         type="warning"
@@ -453,7 +457,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext']),
+      ...mapGetters(['isAppContext', 'isPageLoading']),
       ...mapGetters('deviceInfo', ['getDeviceOS', 'canRestart', 'isRemoteContent']),
       pageTitle() {
         return this.deviceString('deviceManagementTitle');
@@ -559,46 +563,48 @@
       this.setFreeSpace();
     },
     beforeMount() {
-      this.getDeviceSettings().then(settings => {
-        const {
-          languageId = null,
-          landingPage = '',
-          allowGuestAccess = false,
-          allowLearnerUnassignedResourceAccess = false,
-          allowPeerUnlistedChannelImport = null,
-          allowOtherBrowsersToConnect = null,
-          primaryStorageLocation = null,
-          secondaryStorageLocations = [],
-          extraSettings = {},
-        } = settings;
-        const match = find(this.languageOptions, { value: languageId });
-        if (match) {
-          this.language = { ...match };
-        } else {
-          this.language = this.browserDefaultOption;
-        }
+      this.getDeviceSettings()
+        .then(settings => {
+          const {
+            languageId = null,
+            landingPage = '',
+            allowGuestAccess = false,
+            allowLearnerUnassignedResourceAccess = false,
+            allowPeerUnlistedChannelImport = null,
+            allowOtherBrowsersToConnect = null,
+            primaryStorageLocation = null,
+            secondaryStorageLocations = [],
+            extraSettings = {},
+          } = settings;
+          const match = find(this.languageOptions, { value: languageId });
+          if (match) {
+            this.language = { ...match };
+          } else {
+            this.language = this.browserDefaultOption;
+          }
 
-        if (settings.landingPage === LandingPageChoices.SIGN_IN) {
-          this.setSignInPageOption(settings);
-        }
+          if (settings.landingPage === LandingPageChoices.SIGN_IN) {
+            this.setSignInPageOption(settings);
+          }
 
-        this.setExtraSettings(extraSettings);
+          this.setExtraSettings(extraSettings);
 
-        Object.assign(this, {
-          landingPage,
-          allowGuestAccess,
-          allowLearnerUnassignedResourceAccess,
-          allowPeerUnlistedChannelImport,
-          allowOtherBrowsersToConnect,
-          primaryStorageLocation,
-          secondaryStorageLocations,
-          extraSettings,
-        });
-        this.storageLocations = getPathsPermissions([
-          ...this.secondaryStorageLocations,
-          this.primaryStorageLocation,
-        ]);
-      });
+          Object.assign(this, {
+            landingPage,
+            allowGuestAccess,
+            allowLearnerUnassignedResourceAccess,
+            allowPeerUnlistedChannelImport,
+            allowOtherBrowsersToConnect,
+            primaryStorageLocation,
+            secondaryStorageLocations,
+            extraSettings,
+          });
+          this.storageLocations = getPathsPermissions([
+            ...this.secondaryStorageLocations,
+            this.primaryStorageLocation,
+          ]);
+        })
+        .then(() => this.$store.dispatch('notLoading'));
     },
     methods: {
       setSignInPageOption(settings) {

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -30,7 +30,7 @@
         @clearall="handleClickClearAll"
       />
 
-      <CoreTable>
+      <CoreTable :dataLoading="loadingFacilities">
         <template #headers>
           <th>{{ coreString('facilityLabel') }}</th>
         </template>
@@ -241,6 +241,7 @@
         facilityForRegister: null,
         kdpProject: null, // { name, token }
         taskIdsToWatch: [],
+        loadingFacilities: true, // We're fetching in beforeMount so should make it true
       };
     },
     computed: {
@@ -279,7 +280,9 @@
       },
     },
     beforeMount() {
-      this.fetchFacilites();
+      this.fetchFacilites()
+        .then(() => (this.loadingFacilities = false))
+        .catch(() => (this.loadingFacilities = false));
     },
     methods: {
       facilityOptions() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/DeleteExportChannelsPage.vue
@@ -3,8 +3,9 @@
   <ImmersivePage
     :appBarTitle="appBarTitle"
     :route="backRoute"
+    :loading="loading"
   >
-    <KPageContainer class="device-container">
+    <KPageContainer v-if="!loading" class="device-container">
       <FilteredChannelListContainer
         :channels="allChannels"
         :selectedChannels.sync="selectedChannels"

--- a/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/UserPermissionsPage/index.vue
@@ -1,11 +1,11 @@
 <template>
 
   <ImmersivePage
-    v-if="!$store.state.core.loading"
     :appBarTitle="$tr('permissionsTitle')"
     :route="backRoute"
+    :loading="isPageLoading"
   >
-    <KPageContainer class="device-container">
+    <KPageContainer v-if="!isPageLoading" class="device-container">
       <h1 v-if="user === null">
         {{ $tr('userDoesNotExist') }}
       </h1>
@@ -141,7 +141,7 @@
       };
     },
     computed: {
-      ...mapGetters(['facilities', 'currentUserId']),
+      ...mapGetters(['isPageLoading', 'facilities', 'currentUserId']),
       ...mapState('userPermissions', ['user', 'permissions']),
       backRoute() {
         return { name: PageNames.MANAGE_PERMISSIONS_PAGE };

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -46,7 +46,7 @@ export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
 export function showCoachClassAssignmentPage(store, toRoute, fromRoute) {
   const { id, facility_id } = toRoute.params;
   if (toRoute.name !== fromRoute.name) {
-    store.commit('CORE_SET_PAGE_LOADING', true);
+    store.dispatch('loading');
   }
   const facilityId = facility_id || store.getters.activeFacilityId;
   // all users in facility eligible to be a coach that is not already a coach
@@ -76,10 +76,11 @@ export function showCoachClassAssignmentPage(store, toRoute, fromRoute) {
           class: classroom,
           modalShown: false,
         });
-        store.commit('CORE_SET_PAGE_LOADING', false);
       }
+      store.dispatch('notLoading');
     },
     error => {
+      store.dispatch('notLoading');
       shouldResolve() ? store.dispatch('handleError', error) : null;
     }
   );

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -27,10 +27,10 @@ export function showClassEditPage(store, classId) {
         classLearners: sortUsersByFullName(facilityUsers).map(_userState),
         classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
       });
-      store.dispatch("notLoading");
+      store.dispatch('notLoading');
     })
     .catch(error => {
-      store.dispatch("notLoading");
+      store.dispatch('notLoading');
       store.dispatch('handleError', error);
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -27,6 +27,10 @@ export function showClassEditPage(store, classId) {
         classLearners: sortUsersByFullName(facilityUsers).map(_userState),
         classCoaches: sortUsersByFullName(classroom.coaches).map(_userState),
       });
+      store.dispatch("notLoading");
     })
-    .catch(error => store.dispatch('handleError', error));
+    .catch(error => {
+      store.dispatch("notLoading");
+      store.dispatch('handleError', error);
+    });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -13,10 +13,11 @@ export function showClassesPage(store, toRoute) {
         modalShown: false,
         classes: [...classrooms],
       });
-      store.commit('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('notLoading');
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     })
     .catch(error => {
+      store.dispatch('notLoading');
       store.dispatch('handleError', error);
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     });

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -10,7 +10,7 @@ export function showFacilityConfigPage(store, toRoute) {
   ];
 
   return Promise.all(resourceRequests)
-    .then(function onSuccess([facility, facilityDatasets, facilities]) {
+    .then(([facility, facilityDatasets, facilities]) => {
       const dataset = facilityDatasets[0]; // assumes for now is only one facility being managed
       store.commit('facilityConfig/SET_STATE', {
         facilityDatasetId: dataset.id,
@@ -22,14 +22,13 @@ export function showFacilityConfigPage(store, toRoute) {
         settingsCopy: { ...dataset },
         facilities: facilities,
       });
-
-      store.commit('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('notLoading').then(() => console.log('NOT LOADING!'));
     })
-    .catch(function onFailure() {
+    .catch(() => {
       store.commit('facilityConfig/SET_STATE', {
         facilityName: '',
         settings: null,
       });
-      store.commit('CORE_SET_PAGE_LOADING', false);
+      store.dispatch('notLoading');
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/handlers.js
@@ -3,6 +3,7 @@ import { FacilityResource, FacilityDatasetResource } from 'kolibri.resources';
 export function showFacilityConfigPage(store, toRoute) {
   const facilityId = toRoute.params.facility_id || store.getters.activeFacilityId;
   store.dispatch('preparePage');
+  store.commit('facilityConfig/SET_FACILITY_DATA_LOADING', true);
   const resourceRequests = [
     FacilityResource.fetchModel({ id: facilityId }),
     FacilityDatasetResource.fetchCollection({ getParams: { facility_id: facilityId } }),
@@ -22,13 +23,15 @@ export function showFacilityConfigPage(store, toRoute) {
         settingsCopy: { ...dataset },
         facilities: facilities,
       });
-      store.dispatch('notLoading').then(() => console.log('NOT LOADING!'));
+      store.dispatch('notLoading'); // preparePage sets loading to true
+      store.commit('facilityConfig/SET_FACILITY_DATA_LOADING', false);
     })
     .catch(() => {
       store.commit('facilityConfig/SET_STATE', {
         facilityName: '',
         settings: null,
       });
-      store.dispatch('notLoading');
+      store.dispatch('notLoading'); // preparePage sets loading to true
+      store.commit('facilityConfig/SET_FACILITY_DATA_LOADING', false);
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
+++ b/kolibri/plugins/facility/assets/src/modules/facilityConfig/index.js
@@ -18,12 +18,18 @@ function defaultState() {
     facilityNameError: false,
     facilities: [],
     isFacilityPinValid: false,
+    facilityDataLoading: false,
   };
 }
 
 export default {
   namespaced: true,
   state: defaultState(),
+  getters: {
+    getFacilityDataLoading(state) {
+      return state.facilityDataLoading;
+    },
+  },
   mutations: {
     SET_STATE(state, payload) {
       Object.assign(state, payload);
@@ -56,6 +62,9 @@ export default {
     RESET_FACILITY_NAME_STATES(state) {
       state.facilityNameError = false;
       state.facilityNameSaved = false;
+    },
+    SET_FACILITY_DATA_LOADING(state, value) {
+      state.facilityDataLoading = value;
     },
     UPDATE_FACILITIES(state, payload) {
       state.facilities.find(f => {

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -29,9 +29,11 @@ export function showUserPage(store, toRoute, fromRoute) {
         });
       }
       store.commit('userManagement/SET_STATE', { dataLoading: false });
+      store.dispatch('notLoading');
     })
     .catch(error => {
       shouldResolve() ? store.dispatch('handleError', error) : null;
       store.commit('userManagement/SET_STATE', { dataLoading: false });
+      store.dispatch('notLoading');
     });
 }

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -47,7 +47,7 @@
       };
     },
     computed: {
-      ...mapGetters(["isPageLoading"]),
+      ...mapGetters(['isPageLoading']),
       ...mapState('classAssignMembers', [
         'class',
         'facilityUsers',

--- a/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/CoachClassAssignmentPage.vue
@@ -3,8 +3,9 @@
   <ImmersivePage
     :appBarTitle="className"
     :route="$store.getters.facilityPageLinks.ClassEditPage($route.params.id)"
+    :loading="isPageLoading"
   >
-    <KPageContainer>
+    <KPageContainer v-if="!isPageLoading">
       <h1>{{ $tr('pageHeader', { className }) }}</h1>
       <p>{{ $tr('pageSubheader') }}</p>
       <ClassEnrollForm
@@ -23,7 +24,7 @@
 
 <script>
 
-  import { mapState, mapActions } from 'vuex';
+  import { mapState, mapActions, mapGetters } from 'vuex';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ClassEnrollForm from './ClassEnrollForm';
@@ -46,6 +47,7 @@
       };
     },
     computed: {
+      ...mapGetters(["isPageLoading"]),
       ...mapState('classAssignMembers', [
         'class',
         'facilityUsers',

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -32,13 +32,17 @@
         <div class="mb">
           <h2>{{ coreString('facilityLabel') }}</h2>
           <p class="current-facility-name">
-            {{ coreString('facilityNameWithId', { facilityName: facilityName, id: lastPartId }) }}
-            <KButton
-              appearance="basic-link"
-              :text="coreString('editAction')"
-              name="edit-facilityname"
-              @click="showEditFacilityModal = true"
-            />
+            <KCircularLoader v-if="getFacilityDataLoading" class="facility-loader" />
+            <span v-else>
+              {{ coreString('facilityNameWithId', { facilityName: facilityName, id: lastPartId }) }}
+              <KButton
+                appearance="basic-link"
+                :text="coreString('editAction')"
+                :disabled="getFacilityDataLoading"
+                name="edit-facilityname"
+                @click="showEditFacilityModal = true"
+              />
+            </span>
 
           </p>
         </div>
@@ -295,6 +299,7 @@
         'userIsMultiFacilityAdmin',
         'facilityPageLinks',
       ]),
+      ...mapGetters('facilityConfig', ['getFacilityDataLoading']),
       settingsList: () => settingsList,
       settingsHaveChanged() {
         return !isEqual(this.settings, this.settingsCopy);
@@ -522,6 +527,11 @@
 
   .mobile-button {
     margin-top: 16px;
+  }
+
+  .facility-loader {
+    display: inline-block;
+    margin-bottom: -0.5em; // To align with the text
   }
 
 </style>

--- a/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/LearnerClassEnrollmentPage.vue
@@ -3,8 +3,9 @@
   <ImmersivePage
     :appBarTitle="className"
     :route="$store.getters.facilityPageLinks.ClassEditPage($route.params.id)"
+    :loading="isPageLoading"
   >
-    <KPageContainer>
+    <KPageContainer v-if="!isPageLoading">
       <h1>{{ $tr('pageHeader', { className }) }}</h1>
       <p>{{ $tr('pageSubheader') }}</p>
       <ClassEnrollForm
@@ -23,7 +24,7 @@
 
 <script>
 
-  import { mapState, mapActions } from 'vuex';
+  import { mapState, mapActions, mapGetters } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import ClassEnrollForm from './ClassEnrollForm';
@@ -46,6 +47,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isPageLoading']),
       ...mapState('classAssignMembers', [
         'class',
         'facilityUsers',

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -3,6 +3,7 @@
   <ImmersivePage
     :route="this.$store.getters.facilityPageLinks.UserPage"
     :appBarTitle="coreString('usersLabel')"
+    :loading="loading"
   >
     <KPageContainer v-if="!loading" class="narrow-container">
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Cleans up and puts some polish on the code and UX of loading states in the Facility & Device plugins.

Generally, this involved identifying that many routes in both plugins call a `preparePage` action along w/ a payload to determine whether the `CORE_SET_PAGE_LOADING` value is set to true or not.

This results in, generally, many page route handlers are entered into with the `CORE_SET_PAGE_LOADING` state already set to `true` -- but many of them never unset that value. 

---

As a separate note, I removed calls to `commit` wherever I made changes to favor `dispatch` mostly because it's more concise:

```javascript
store.commit("CORE_SET_PAGE_LOADING", true) --> store.dispatch('loading')
store.commit("CORE_SET_PAGE_LOADING", false) --> store.dispatch('notLoading')
```

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10731 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

You'll want to get your data speed throttled in dev tools.

Go through each page in Facility and Device navigating to each page.

Generally, identify that the following happens:

- When the page is initially loading, the KLinearLoader just under the AppBar should be active until the content is loaded
- When the page has loaded but content within the page is loading, the KLinearLoader should NOT be active, but, wherever the currently loading data will go should show a KCircularLoader

The following should never happen:

- You should never see a big blank white screen while navigating _within_ a plugin (ie, going from Device Info to Device Settings, etc) -- when you go _between_ plugins (ie, from Facility to Device) you should still see a brief white screen and the flying kolibri logo.
- A page successfully loaded (ie, showing a KPageContainer) that is empty (no loaders at all) which then suddenly shows data. There should always bee a KCircularLoader in this instance.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
