### PR TITLE
docs: Document sd-notify support for production servers

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -253,6 +253,13 @@ In production, content is served through `Whitenoise <http://whitenoise.evans.io
 
 Now you should be able to access the server at ``http://127.0.0.1:8080/``.
 
+Kolibri has support for being run as a ``Type=notify`` service under
+`systemd <https://www.freedesktop.org/software/systemd/>`__. When doing so, it
+is recommended to run ``kolibri start`` with the ``--skip-update`` option, and
+to run ``kolibri configure setup`` separately beforehand to handle database
+migrations and other one-time setup steps. This avoids the ``kolibri start``
+command timing out under systemd if migrations are happening.
+
 
 Separate servers
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

This follows on from
https://github.com/learningequality/kolibri/pull/10791#issuecomment-1581023181, adding a bit of documentation about the new sd-notify support in Kolibri, with some advice about how best to use it on production servers.

## References

 * https://github.com/learningequality/kolibri/pull/10791

## Reviewer guidance

None

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
