### PR TITLE
Update Github Actions release upload

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -30,7 +30,7 @@ const file_manifest = {
   },
   "gz": {
       "extension": "gz",
-      "description": "Source Tarball",
+      "description": "TAR file",
       "content_type": "application/gzip",
   },
   "zip": {

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -70,30 +70,29 @@ jobs:
     name: Upload to Github release
     runs-on: ubuntu-latest
     needs: [whl, pex, dmg, deb, exe, zip]
+    strategy:
+      matrix:
+        filename: [
+          '${{ needs.whl.outputs.whl-file-name }}',
+          '${{ needs.whl.outputs.tar-file-name }}',
+          '${{ needs.pex.outputs.pex-file-name }}',
+          '${{ needs.dmg.outputs.dmg-file-name }}',
+          '${{ needs.deb.outputs.deb-file-name }}',
+          '${{ needs.exe.outputs.exe-file-name }}',
+          '${{ needs.zip.outputs.zip-file-name }}',
+        ]
     steps:
       - uses: actions/checkout@v3
-      - name: Download all artifacts
+      - name: Download ${{ matrix.filename }} artifact
         uses: actions/download-artifact@v3
         with:
+          name: ${{ matrix.filename }}
           path: dist
       - uses: actions/github-script@v6
         with:
           script: |
             const utils = require('./.github/githubUtils.js')
-            const filesToUpload = [
-              // When you download all artifacts, the artifact downloader action puts each one into
-              // a directory named for the artifact, for reasons, so we have to do this doubling up.
-              'dist/${{ needs.whl.outputs.whl-file-name }}/${{ needs.whl.outputs.whl-file-name }}',
-              'dist/${{ needs.whl.outputs.tar-file-name }}/${{ needs.whl.outputs.tar-file-name }}',
-              'dist/${{ needs.pex.outputs.pex-file-name }}/${{ needs.pex.outputs.pex-file-name }}',
-              'dist/${{ needs.dmg.outputs.dmg-file-name }}/${{ needs.dmg.outputs.dmg-file-name }}',
-              'dist/${{ needs.deb.outputs.deb-file-name }}/${{ needs.deb.outputs.deb-file-name }}',
-              'dist/${{ needs.exe.outputs.exe-file-name }}/${{ needs.exe.outputs.exe-file-name }}',
-              'dist/${{ needs.zip.outputs.zip-file-name }}/${{ needs.zip.outputs.zip-file-name }}',
-            ]
-            for (let filePath of filesToUpload) {
-              await utils.uploadReleaseAsset(github, context, filePath, '${{ github.event.release.id }}')
-            }
+            await utils.uploadReleaseAsset(github, context, 'dist/${{ matrix.filename }}', '${{ github.event.release.id }}')
   block_release_step:
   # This step ties to the release environment which requires manual approval
   # before it can execute. Once manual approval has been granted, the release is
@@ -124,10 +123,22 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     needs: [block_release_step, whl, pex, dmg, deb, exe, zip]
+    strategy:
+      matrix:
+        filename: [
+          '${{ needs.whl.outputs.whl-file-name }}',
+          '${{ needs.whl.outputs.tar-file-name }}',
+          '${{ needs.pex.outputs.pex-file-name }}',
+          '${{ needs.dmg.outputs.dmg-file-name }}',
+          '${{ needs.deb.outputs.deb-file-name }}',
+          '${{ needs.exe.outputs.exe-file-name }}',
+          '${{ needs.zip.outputs.zip-file-name }}',
+        ]
     steps:
-    - name: Download all artifacts
+    - name: Download ${{ matrix.filename }} artifact
       uses: actions/download-artifact@v3
       with:
+        name: ${{ matrix.filename }}
         path: dist
     - uses: 'google-github-actions/auth@v1'
       with:
@@ -137,5 +148,11 @@ jobs:
     - name: Upload files to Google Cloud Storage
       uses: 'google-github-actions/upload-cloud-storage@v1'
       with:
-        path: 'dist/'
-        destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}/'
+        path: 'dist/${{ matrix.filename }}'
+        destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}/${{ matrix.filename }}'
+    - name: Upload to BCK bucket
+      if: ${{ github.event.release.name == 'latest' }} && ${{ endsWith(matrix.filename, '.whl') }}
+      uses: 'google-github-actions/upload-cloud-storage@v1'
+      with:
+        path: 'dist/${{ matrix.filename }}'
+        destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}/${{ matrix.filename }}'

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -84,6 +84,7 @@ jobs:
               // When you download all artifacts, the artifact downloader action puts each one into
               // a directory named for the artifact, for reasons, so we have to do this doubling up.
               'dist/${{ needs.whl.outputs.whl-file-name }}/${{ needs.whl.outputs.whl-file-name }}',
+              'dist/${{ needs.whl.outputs.tar-file-name }}/${{ needs.whl.outputs.tar-file-name }}',
               'dist/${{ needs.pex.outputs.pex-file-name }}/${{ needs.pex.outputs.pex-file-name }}',
               'dist/${{ needs.dmg.outputs.dmg-file-name }}/${{ needs.dmg.outputs.dmg-file-name }}',
               'dist/${{ needs.deb.outputs.deb-file-name }}/${{ needs.deb.outputs.deb-file-name }}',


### PR DESCRIPTION
## Summary
* Adds in upload of tar file
* Runs asset upload to github asset as a matrix to avoid nested artifact downloads and allow individual rerunning of uploads
* Runs asset upload to GCS as a matrix to avoid nested artifact downloads and allow individual rerunning of uploads
* Adds upload to BCK release bucket if latest release and a whl file