### PR TITLE
Provide task arguments in API response

### DIFF
--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -43,6 +43,8 @@ fake_job_defaults = dict(
     traceback="",
     percentage_progress=0,
     cancellable=False,
+    args=(),
+    kwargs={},
     extra_metadata={},
     func="",
 )

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -89,6 +89,8 @@ class TasksViewSet(viewsets.GenericViewSet):
             "cancellable": job.cancellable,
             "clearable": job.state in [State.FAILED, State.CANCELED, State.COMPLETED],
             "facility_id": job.facility_id,
+            "args": job.args,
+            "kwargs": job.kwargs,
             "extra_metadata": job.extra_metadata,
             # Output is UTC naive, coerce to UTC aware.
             "scheduled_datetime": make_aware(orm_job.scheduled_time, utc).isoformat(),

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -39,6 +39,8 @@ fake_job_defaults = dict(
     cancellable=False,
     extra_metadata={},
     func="",
+    args=(),
+    kwargs={},
 )
 
 
@@ -271,6 +273,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
             "type": "",
             "cancellable": False,
             "clearable": False,
+            "args": (),
+            "kwargs": {},
             "extra_metadata": {},
             "facility_id": None,
             "scheduled_datetime": make_aware(
@@ -330,6 +334,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "type": "",
                 "cancellable": False,
                 "clearable": False,
+                "args": (),
+                "kwargs": {},
                 "extra_metadata": {},
                 "facility_id": None,
                 "scheduled_datetime": make_aware(
@@ -348,6 +354,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "type": "",
                 "cancellable": False,
                 "clearable": False,
+                "args": (),
+                "kwargs": {},
                 "extra_metadata": {},
                 "facility_id": None,
                 "scheduled_datetime": make_aware(
@@ -408,7 +416,10 @@ class CreateTaskAPITestCase(BaseAPITestCase):
 
         mock_job_storage.enqueue_job.return_value = "test"
         mock_job_storage.get_job.return_value = fake_job(
-            state=State.QUEUED, job_id="test", extra_metadata={"facility": "kolibri HQ"}
+            state=State.QUEUED,
+            job_id="test",
+            kwargs={"x": 0, "y": 42},
+            extra_metadata={"facility": "kolibri HQ"},
         )
         mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
 
@@ -428,6 +439,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
             "cancellable": False,
             "clearable": False,
             "facility_id": None,
+            "args": (),
+            "kwargs": {"x": 0, "y": 42},
             "extra_metadata": {
                 "facility": "kolibri HQ",
             },
@@ -489,7 +502,10 @@ class CreateTaskAPITestCase(BaseAPITestCase):
 
         mock_job_storage.enqueue_job.return_value = "test"
         mock_job_storage.get_job.return_value = fake_job(
-            state=State.QUEUED, job_id="test", extra_metadata={"facility": "kolibri HQ"}
+            state=State.QUEUED,
+            job_id="test",
+            kwargs={"x": 0, "y": 42},
+            extra_metadata={"facility": "kolibri HQ"},
         )
         mock_job_storage.get_orm_job.return_value = dummy_orm_job_data
 
@@ -517,6 +533,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "cancellable": False,
                 "clearable": False,
                 "facility_id": None,
+                "args": (),
+                "kwargs": {"x": 0, "y": 42},
                 "extra_metadata": {
                     "facility": "kolibri HQ",
                 },
@@ -537,6 +555,8 @@ class CreateTaskAPITestCase(BaseAPITestCase):
                 "cancellable": False,
                 "clearable": False,
                 "facility_id": None,
+                "args": (),
+                "kwargs": {"x": 0, "y": 42},
                 "extra_metadata": {
                     "facility": "kolibri HQ",
                 },
@@ -1191,6 +1211,8 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "cancellable": False,
                 "clearable": False,
                 "facility_id": self.superuser.facility_id,
+                "args": (),
+                "kwargs": {},
                 "extra_metadata": {},
                 "scheduled_datetime": make_aware(
                     dummy_orm_job_data.scheduled_time, utc
@@ -1209,6 +1231,8 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "cancellable": False,
                 "clearable": False,
                 "facility_id": self.superuser.facility_id,
+                "args": (),
+                "kwargs": {},
                 "extra_metadata": {},
                 "scheduled_datetime": make_aware(
                     dummy_orm_job_data.scheduled_time, utc
@@ -1227,6 +1251,8 @@ class TaskManagementAPITestCase(BaseAPITestCase):
                 "cancellable": False,
                 "clearable": False,
                 "facility_id": self.facility2user.facility_id,
+                "args": (),
+                "kwargs": {},
                 "extra_metadata": {},
                 "scheduled_datetime": make_aware(
                     dummy_orm_job_data.scheduled_time, utc


### PR DESCRIPTION
It's not possible to identify a task's purpose using only its type and extra metadata. Expose the task's `args` and `kwargs` through the API responses so that frontend code can match jobs to specific resources.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The tasks API only exposes the type and extra metadata in job responses. In many cases this is not enough to identify the actual purpose of the job. For example, a `kolibri.core.content.tasks.remotecontentimport` will only have the channel ID in extra metadata. This doesn't tell you about the `node_ids`, `exclude_node_ids` or `all_thumbnails` keyword arguments, so you don't really know what the task was used for.

Alternatively, I have a branch that adds the above properties to the extra metadata in `ChannelResourcesValidator` and `ChannelResourcesImportValidator`. Simply sending the `args` and `kwargs` seemed more general, though.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

None, but I can open an issue describing the above situation.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Start a download task, go to the device content page and use the browser's devtools to inspect a job response. It should contain `args` and `kwargs`.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
