### PR TITLE
Handle urlparse ValueError on invalid IP addresses in python >= 3.11

### DIFF
--- a/kolibri/core/discovery/utils/network/urls.py
+++ b/kolibri/core/discovery/utils/network/urls.py
@@ -1,5 +1,6 @@
 import re
 
+from six import raise_from
 from six.moves.urllib.parse import urlparse
 
 from . import errors
@@ -117,8 +118,12 @@ def parse_address_into_components(address):  # noqa C901
     if "://" not in address:
         address = "http://" + address
 
-    # parse out the URL into its components
-    parsed = urlparse(address)
+    # parse out the URL into its components. On python >= 3.11, this
+    # will throw a ValueError on invalid IP addresses.
+    try:
+        parsed = urlparse(address)
+    except ValueError as e:
+        raise_from(errors.InvalidHostname(address), e)
     p_scheme = parsed.scheme
     p_hostname = parsed.hostname
     p_path = parsed.path.rstrip("/") + "/"


### PR DESCRIPTION
See https://github.com/python/cpython/issues/103848.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes `kolibri.core.discovery.test.test_network_utils.TestURLParsing.test_invalid_ipv6_address` on Python 3.11+.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10853

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See whether the test suite passes now.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
