### PR TITLE
 Fixes a case where sidenav  is not working in special cases.

### DIFF
--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -2,7 +2,6 @@ import VueRouter from 'vue-router';
 import logger from 'kolibri.lib.logging';
 
 const logging = logger.getLogger(__filename);
-// const { isNavigationFailure, NavigationFailureType } = VueRouter
 
 /** Wrapper around Vue Router.
  *  Implements URL mapping to Vuex actions in addition to Vue components.
@@ -84,23 +83,11 @@ class Router {
   /* vue-router proxy methods */
   /****************************/
 
-  // _silenceNavigationError(error){
-  //   if (!isNavigationFailure(error, NavigationFailureType.duplicated)) {
-  //     throw Error(error)
-  //   }
-  // }
-
   replace(location, onComplete, onAbort) {
     return this._vueRouter.replace(location, onComplete, onAbort);
-    // .catch(error=>{
-    //   this._silenceNavigationError(error);
-    // });
   }
   push(location, onComplete, onAbort) {
     return this._vueRouter.push(location, onComplete, onAbort);
-    // .catch(error=>{
-    //   this._silenceNavigationError(error);
-    // });
   }
 
   go(location, onComplete, onAbort) {

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -86,6 +86,7 @@ class Router {
   replace(location, onComplete, onAbort) {
     return this._vueRouter.replace(location, onComplete, onAbort);
   }
+
   push(location, onComplete, onAbort) {
     return this._vueRouter.push(location, onComplete, onAbort);
   }

--- a/kolibri/core/assets/src/router.js
+++ b/kolibri/core/assets/src/router.js
@@ -2,6 +2,7 @@ import VueRouter from 'vue-router';
 import logger from 'kolibri.lib.logging';
 
 const logging = logger.getLogger(__filename);
+// const { isNavigationFailure, NavigationFailureType } = VueRouter
 
 /** Wrapper around Vue Router.
  *  Implements URL mapping to Vuex actions in addition to Vue components.
@@ -83,12 +84,23 @@ class Router {
   /* vue-router proxy methods */
   /****************************/
 
+  // _silenceNavigationError(error){
+  //   if (!isNavigationFailure(error, NavigationFailureType.duplicated)) {
+  //     throw Error(error)
+  //   }
+  // }
+
   replace(location, onComplete, onAbort) {
     return this._vueRouter.replace(location, onComplete, onAbort);
+    // .catch(error=>{
+    //   this._silenceNavigationError(error);
+    // });
   }
-
   push(location, onComplete, onAbort) {
     return this._vueRouter.push(location, onComplete, onAbort);
+    // .catch(error=>{
+    //   this._silenceNavigationError(error);
+    // });
   }
 
   go(location, onComplete, onAbort) {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -24,13 +24,23 @@ import {
 } from './modules/classAssignMembers/handlers';
 import { PageNames } from './constants';
 
-function facilityParamRequiredGuard(toRoute, subtopicName) {
-  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-    router.replace({
-      name: 'ALL_FACILITIES_PAGE',
-      params: { subtopicName },
-    });
-    return true;
+function facilityParamRequiredGuard(toRoute, fromRoute, subtopicName) {
+  if (
+    store.getters.userIsMultiFacilityAdmin &&
+    !toRoute.params.facility_id &&
+    fromRoute.query.subtopicName !== subtopicName
+  ) {
+    const currentSubtopicName = toRoute.query.subtopicName;
+
+    if (currentSubtopicName !== subtopicName) {
+      router.replace({
+        name: 'ALL_FACILITIES_PAGE',
+        query: { subtopicName },
+        params: { subtopicName },
+      });
+      return true;
+    }
+    return false;
   }
 }
 
@@ -38,7 +48,7 @@ export default [
   // Routes for multi-facility case
   {
     name: PageNames.ALL_FACILITIES_PAGE,
-    path: '/facilities',
+    path: '/:subtopicName?/facilities',
     component: AllFacilitiesPage,
     props: true,
     handler() {
@@ -52,8 +62,8 @@ export default [
     name: PageNames.CLASS_MGMT_PAGE,
     path: '/:facility_id?/classes',
     component: ManageClassPage,
-    handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, ManageClassPage.name)) {
+    handler: (toRoute, fromRoute) => {
+      if (facilityParamRequiredGuard(toRoute, fromRoute, ManageClassPage.name)) {
         return;
       }
       showClassesPage(store, toRoute);
@@ -88,7 +98,7 @@ export default [
     component: UserPage,
     path: '/:facility_id?/users',
     handler: (toRoute, fromRoute) => {
-      if (facilityParamRequiredGuard(toRoute, UserPage.name)) {
+      if (facilityParamRequiredGuard(toRoute, fromRoute, UserPage.name)) {
         return;
       }
       showUserPage(store, toRoute, fromRoute);
@@ -114,8 +124,8 @@ export default [
     name: PageNames.DATA_EXPORT_PAGE,
     component: DataPage,
     path: '/:facility_id?/data',
-    handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, DataPage.name)) {
+    handler: (toRoute, fromRoute) => {
+      if (facilityParamRequiredGuard(toRoute, fromRoute, DataPage.name)) {
         return;
       }
       store.dispatch('preparePage', { isAsync: false });
@@ -133,8 +143,8 @@ export default [
     name: PageNames.FACILITY_CONFIG_PAGE,
     component: FacilitiesConfigPage,
     path: '/:facility_id?/settings',
-    handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, FacilitiesConfigPage.name)) {
+    handler: (toRoute, fromRoute) => {
+      if (facilityParamRequiredGuard(toRoute, fromRoute, FacilitiesConfigPage.name)) {
         return;
       }
       showFacilityConfigPage(store, toRoute);

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -28,7 +28,6 @@ import { PageNames } from './constants';
 function facilityParamRequiredGuard(toRoute, subtopicName) {
   const { isNavigationFailure, NavigationFailureType } = VueRouter;
   if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
-    console.log(toRoute);
     router
       .replace({
         name: 'ALL_FACILITIES_PAGE',
@@ -41,8 +40,8 @@ function facilityParamRequiredGuard(toRoute, subtopicName) {
           throw Error(e);
         }
       });
+    return true;
   }
-  return true;
 }
 
 export default [

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -28,10 +28,12 @@ import { PageNames } from './constants';
 function facilityParamRequiredGuard(toRoute, subtopicName) {
   const { isNavigationFailure, NavigationFailureType } = VueRouter;
   if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.facility_id) {
+    console.log(toRoute);
     router
       .replace({
         name: 'ALL_FACILITIES_PAGE',
         query: { subtopicName },
+        params: { subtopicName },
       })
       .catch(e => {
         if (!isNavigationFailure(e, NavigationFailureType.duplicated)) {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -32,7 +32,6 @@ function facilityParamRequiredGuard(toRoute, subtopicName) {
       .replace({
         name: 'ALL_FACILITIES_PAGE',
         query: { subtopicName },
-        params: { subtopicName },
       })
       .catch(e => {
         if (!isNavigationFailure(e, NavigationFailureType.duplicated)) {

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -31,16 +31,30 @@ function facilityParamRequiredGuard(toRoute, fromRoute, subtopicName) {
     fromRoute.query.subtopicName !== subtopicName
   ) {
     const currentSubtopicName = toRoute.query.subtopicName;
-
     if (currentSubtopicName !== subtopicName) {
       router.replace({
-        name: 'ALL_FACILITIES_PAGE',
+        name: PageNames.ALL_FACILITIES_PAGE,
         query: { subtopicName },
         params: { subtopicName },
       });
       return true;
     }
     return false;
+  } else {
+    if (!toRoute.params.facility_id) {
+      router
+        .replace({
+          name: PageNames.ALL_FACILITIES_PAGE,
+          query: { subtopicName },
+          params: { subtopicName },
+        })
+        .catch(error => {
+          return error;
+        });
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -47,7 +47,7 @@ export default [
   // Routes for multi-facility case
   {
     name: PageNames.ALL_FACILITIES_PAGE,
-    path: '/facilities',
+    path: '/:subtopicName?/facilities',
     component: AllFacilitiesPage,
     props: true,
     handler() {


### PR DESCRIPTION

## Summary

This PR fixes redundant navigation waring issue   specifically triggered by facility plugin routing updates on the sidenav
### After
https://github.com/learningequality/kolibri/assets/103313919/d3fe70a7-b8a4-4e26-bf63-eb7cad6e5af9
## References
fixes [#10649](https://github.com/learningequality/kolibri/issues/10649)
## Reviewer guidance
- Navigate to facility and the click the side nave menus while your developer console is open


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
