### PR TITLE
[DO NOT MERGE] QA for KDS #438

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be",
+    "kolibri-design-system": "https://github.com/katkuskris/kolibri-design-system#8c0d02add997e6be4d9be5df6dbb6d0e70106b05",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "intl": "^1.2.4",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be",
+    "kolibri-design-system": "https://github.com/katkuskris/kolibri-design-system#8c0d02add997e6be4d9be5df6dbb6d0e70106b05",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7529,9 +7529,9 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be":
+"kolibri-design-system@https://github.com/katkuskris/kolibri-design-system#8c0d02add997e6be4d9be5df6dbb6d0e70106b05":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be"
+  resolved "https://github.com/katkuskris/kolibri-design-system#8c0d02add997e6be4d9be5df6dbb6d0e70106b05"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
https://github.com/learningequality/kolibri-design-system/pull/438 introduces a fix for alignment of an icon with a link in places that use _KRouterLink_ KDS component, for example, lessons lists (you can see before/after screenshots in https://github.com/learningequality/kolibri-design-system/pull/438)

![Screenshot from 2023-06-16 16-05-32](https://github.com/learningequality/kolibri/assets/13509191/4b48b256-4168-4e9d-b42e-c0c896b16ba3)

This PR installs the version of KDS with those changes applied for testing in Kolibri.

It would be good to preview a few places in Kolibri where we use links with icons to check for regressions before merging the KDS PR, especially in IE11.