### PR TITLE
Fix survey and practice quiz submission

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -281,8 +281,8 @@ export function setChannelInfo(store) {
 }
 
 export function fetchPoints(store) {
-  const { isUserLoggedIn, currentUserId, totalProgress } = store.getters;
-  if (isUserLoggedIn && totalProgress === null) {
+  const { isUserLoggedIn, currentUserId } = store.getters;
+  if (isUserLoggedIn && store.state.totalProgress === null) {
     UserProgressResource.fetchModel({ id: currentUserId }).then(progress => {
       store.commit('SET_TOTAL_PROGRESS', progress.progress);
     });

--- a/kolibri/core/assets/src/state/modules/core/getters.js
+++ b/kolibri/core/assets/src/state/modules/core/getters.js
@@ -18,10 +18,6 @@ export function getChannelObject(state) {
   };
 }
 
-export function totalProgress(state) {
-  return state.totalProgress;
-}
-
 export function totalPoints(state) {
   return state.totalProgress * MaxPointsPerContent;
 }

--- a/kolibri/core/assets/src/views/ContentRenderer/mixin.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/mixin.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import logger from 'kolibri.lib.logging';
 import heartbeat from 'kolibri.heartbeat';
 import { ContentErrorConstants } from 'kolibri.coreVue.vuex.constants';
 import {
@@ -9,6 +10,8 @@ import {
 } from '../../utils/i18n';
 import { getRenderableFiles, getDefaultFile } from './utils';
 import ContentRendererError from './ContentRendererError';
+
+const logging = logger.getLogger(__filename);
 
 const ContentRendererErrorComponent = Vue.extend(ContentRendererError);
 
@@ -70,7 +73,7 @@ function fileValidator(file) {
       typeof file[key] === typeof fileFieldMap[key].type() &&
       (fileFieldMap[key].validator ? fileFieldMap[key].validator(file[key]) : true);
     if (!val) {
-      console.error(`Validation failed for '${key}' in `, file); // eslint-disable-line no-console
+      logging.error(`Validation failed for '${key}' in `, file);
       result = false;
     }
   }
@@ -186,15 +189,26 @@ export default {
     contentIsRtl() {
       return this.contentDirection === languageDirections.RTL;
     },
+    availableHints() {
+      return 0;
+    },
+    totalHints() {
+      return 0;
+    },
   },
   methods: {
     /**
      * @public
      */
     checkAnswer() {
-      /* eslint-disable no-console */
-      console.warn('This content renderer has not implemented the checkAnswer method');
-      /* eslint-enable */
+      logging.warn('This content renderer has not implemented the checkAnswer method');
+      return null;
+    },
+    /**
+     * @public
+     */
+    takeHint() {
+      logging.warn('This content renderer has not implemented the takeHint method');
       return null;
     },
     _reportError(error) {

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -18,7 +18,7 @@
           :layout4="{ span: 4, alignment: 'left' }"
         >
           <div>
-            <h1 class="title">
+            <h1 v-if="userId" class="title">
               <KLabeledIcon icon="person" :label="userName" />
             </h1>
             <KLabeledIcon :icon="titleIcon" :label="title" />
@@ -203,9 +203,11 @@
         default: null,
       },
       // The user id of the user for the report
+      // Let it be null to handle anonymous users
+      // with just the title and action bar.
       userId: {
         type: String,
-        required: true,
+        default: null,
       },
       // The name of the user for the report
       userName: {
@@ -392,8 +394,10 @@
       },
     },
     created() {
-      this.loadAttempts();
-      this.loadAllTries();
+      if (this.userId) {
+        this.loadAttempts();
+        this.loadAllTries();
+      }
     },
     methods: {
       navigateToQuestion(questionNumber) {

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -905,7 +905,12 @@ class TotalContentProgressViewSet(viewsets.GenericViewSet):
                 )
             )
             .filter(Q(progress=1) | Q(mastery_progress__isnull=False))
-            .aggregate(progress__sum=Sum(Coalesce("mastery_progress", "progress")))
+            .aggregate(
+                progress__sum=Sum(
+                    Coalesce("mastery_progress", "progress"),
+                    output_field=IntegerField(),
+                )
+            )
             .get("progress__sum")
             or 0
         )

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -6,10 +6,12 @@ from random import randint
 
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.db.models import Case
 from django.db.models import IntegerField
 from django.db.models import Q
 from django.db.models import Sum
 from django.db.models import Value
+from django.db.models import When
 from django.db.models.functions import Coalesce
 from django.http import Http404
 from django_filters.rest_framework import BooleanFilter
@@ -892,9 +894,20 @@ class TotalContentProgressViewSet(viewsets.GenericViewSet):
         if request.user.is_anonymous or pk != request.user.id:
             raise PermissionDenied("Can only access progress data for self")
         progress = (
-            request.user.contentsummarylog_set.filter(progress=1)
-            .aggregate(Sum("progress"))
+            request.user.contentsummarylog_set.annotate(
+                mastery_progress=Sum(
+                    Case(
+                        When(masterylogs__complete=True, then=Value(1)),
+                        When(masterylogs__complete=False, then=Value(0)),
+                        default=Value(None),
+                        output_field=IntegerField(),
+                    )
+                )
+            )
+            .filter(Q(progress=1) | Q(mastery_progress__isnull=False))
+            .aggregate(progress__sum=Sum(Coalesce("mastery_progress", "progress")))
             .get("progress__sum")
+            or 0
         )
         return Response(
             {

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -326,11 +326,7 @@ oriented data synchronization.
         return null;
       },
       renderer() {
-        // TODO: rtibbles - update the KContentRenderer API to expose hint info
-        // and add takeHint public method
-        return (
-          this.mounted && this.$refs.contentRenderer && this.$refs.contentRenderer.$refs.contentView
-        );
+        return this.mounted && this.$refs.contentRenderer;
       },
       availableHints() {
         return (this.renderer && this.renderer.availableHints) || 0;

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -154,8 +154,9 @@
       const errored = ref(false);
       const wrappedUpdateContentSession = data => {
         if (!errored.value) {
-          updateContentSession(data);
+          return updateContentSession(data);
         }
+        return Promise.resolve();
       };
 
       return {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -349,11 +349,7 @@
     },
     watch: {
       attemptLogItemValue(newVal, oldVal) {
-        // HACK: manually dismiss the perseus renderer message when moving
-        // to a different item (fixes #3853)
-        if (newVal !== oldVal && this.$refs.contentRenderer) {
-          this.$refs.contentRenderer.$refs.contentView.dismissMessage &&
-            this.$refs.contentRenderer.$refs.contentView.dismissMessage();
+        if (newVal !== oldVal) {
           this.startTime = Date.now();
         }
       },

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/QuizReport.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/QuizReport.vue
@@ -49,7 +49,7 @@
       },
       userId: {
         type: String,
-        required: true,
+        default: null,
       },
       userName: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -331,11 +331,7 @@
     },
     watch: {
       itemId(newVal, oldVal) {
-        // HACK: manually dismiss the perseus renderer message when moving
-        // to a different item (fixes #3853)
         if (newVal !== oldVal) {
-          this.$refs.contentRenderer.$refs.contentView.dismissMessage &&
-            this.$refs.contentRenderer.$refs.contentView.dismissMessage();
           this.startTime = Date.now();
         }
       },

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -418,7 +418,7 @@
           this.itemRenderer.state.hintsVisible < this.itemRenderer.getNumHints()
         ) {
           this.itemRenderer.showHint();
-          this.$parent.$emit('hintTaken', { answerState: this.getSerializedState() });
+          this.$emit('hintTaken', { answerState: this.getSerializedState() });
         }
       },
       interactionCallback() {


### PR DESCRIPTION
## Summary
* Fixes regression for survey and practice quiz regression by ensuring a promise is always returned
* Fixes survey and practice quiz reports for anonymous users with a minimal fix to prevent errors - does not display actual reports, because userId is required to load the relevant data

## References
Fixes #10860 

## Reviewer guidance
Can surveys and reviews be submitted without errors in the console? Do they properly redirect after?

Do anonymous users submit quizzes and surveys without errors in the console? Do they see this (for surveys):
![Screenshot from 2023-06-16 11-19-54](https://github.com/learningequality/kolibri/assets/1680573/6ac4eada-d027-4d95-8465-c5fb98c56c1d)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
