### PR TITLE
Pass click event to navigate method.

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -58,7 +58,7 @@
               class="link"
               :href="href"
               :class="isActive ? subRouteActiveClass : subRouteInactiveClass"
-              @click="isActive ? toggleAndroidMenu() : navigate()"
+              @click="e => isActive ? toggleAndroidMenu() : navigate(e)"
             >
               {{ subRoute.label }}
             </a>


### PR DESCRIPTION
## Summary
Fixes unreported bug whereby the router-link component navigate method is expecting to receive the click event when invoked.

## References
Follow up to #10817

## Reviewer guidance
Prior to this fix, navigation within an SPA via the side nav would navigate but throw an error `cannot read metaKey of undefined` this stops that error from happening

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
