### PR TITLE
First user made is superuser

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -197,7 +197,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
                 if DevicePermissions.objects.count() == 0:
                     DevicePermissions.objects.create(
                         user=superuser,
-                        is_superuser=not is_soud,
+                        is_superuser=True,
                         can_manage_content=True,
                     )
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes #10769 by no longer conditionalizing whether the first made user during provisioning becomes a `superuser` on whether we're on an SoUD. The first user will always be a `superuser`.

Note that this should be handled in the case of importing multiple users as I took this approach initially during development on the Setup Wizard but changed it to depend on SoUD based on feedback so the first imported user is set as the "superuser" whenever the provisioning occurs.


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Provision via Learn Only flow and when you sign in as the first imported user, you should see the Device plugin available in the side panel.

