### PR TITLE
Channel order persists across upgrades

### DIFF
--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -4,9 +4,9 @@ import logging
 import time
 from itertools import islice
 
+from django.apps import apps
 from django.db.models import Case
 from django.db.models import When
-from django.apps import apps
 from django.db.models.fields.related import ForeignKey
 from six import string_types
 from sqlalchemy import and_
@@ -450,7 +450,6 @@ class ChannelImport(object):
         return "INSERT OR REPLACE"
 
     def raw_attached_sqlite_table_import(self, model, table_mapper):
-
         self.check_cancelled()
 
         source_table = self.source.get_table(model)
@@ -597,7 +596,6 @@ class ChannelImport(object):
                 yield value if value is not None else default
 
         if not merge:
-
             separator = "\t"
             data_string_iterator = StringIteratorIO(
                 (
@@ -802,7 +800,6 @@ class ChannelImport(object):
             self.destination.execute(query)
 
     def delete_old_channel_tree_data(self, old_tree_id):
-
         # we want to delete all content models, but not "merge models" (ones that might also be used by other channels), and ContentNode last
         models_to_delete = [
             model
@@ -909,10 +906,9 @@ class ChannelImport(object):
                 )
 
     def import_channel_data(self):
-
         logger.debug("Beginning channel metadata import")
         channel_order = ChannelMetadata.objects.all().values()
-        id_order = [channel['id'] for channel in channel_order]
+        id_order = [channel["id"] for channel in channel_order]
         start = time.time()
         import_ran = False
 
@@ -955,13 +951,19 @@ class ChannelImport(object):
         )
         # Create ChannelMetadata object deleted during import
         if import_ran:
-            ids = list(ChannelMetadata.objects.filter(root__available=True).all().values_list('id', flat=True))
+            ids = list(
+                ChannelMetadata.objects.filter(root__available=True)
+                .all()
+                .values_list("id", flat=True)
+            )
             if len(ids) != len(id_order):
                 deleted_channel_id = [id for id in id_order if id not in ids][0]
                 deleted_channel = channel_order.filter(id=deleted_channel_id)[0]
                 ChannelMetadata.objects.update_or_create(**deleted_channel)
                 ChannelMetadata.objects.update(
-                    order=Case(*(When(id=uuid, then=i + 1) for i, uuid in enumerate(id_order)))
+                    order=Case(
+                        *(When(id=uuid, then=i + 1) for i, uuid in enumerate(id_order))
+                    )
                 )
 
         return import_ran

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -956,7 +956,7 @@ class ChannelImport(object):
         # Create ChannelMetadata object deleted during import
         if import_ran:
             ids = list(ChannelMetadata.objects.filter(root__available=True).all().values_list('id', flat=True))
-            if len(ids)!=len(id_order):
+            if len(ids) != len(id_order):
                 deleted_channel_id = [id for id in id_order if id not in ids][0]
                 deleted_channel = channel_order.filter(id=deleted_channel_id)[0]
                 ChannelMetadata.objects.update_or_create(**deleted_channel)

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -950,7 +950,9 @@ class ChannelImport(object):
 
     def run_and_annotate(self):
         try:
-            old_order = ChannelMetadata.objects.values("order").get(id=self.channel_id)["order"]
+            old_order = ChannelMetadata.objects.values("order").get(id=self.channel_id)[
+                "order"
+            ]
         except ChannelMetadata.DoesNotExist:
             old_order = None
 


### PR DESCRIPTION
## Summary
* On upgrading a channel, the order of the channels persists.
* This has been verified manually by upgrading a channel and noting that the ordering of the channels does not change.
## References
* fixes #10309 

## Reviewer guidance

* Changes can be tested by having an old version of a channel and then upgrading it and noting that the order of the channels does not change. 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] Critical and brittle code paths are covered by unit tests 

^ It has been mentioned in #10309 that a test must be created to check if the change is preserved but this PR does not contain that. I will try to create another PR in a few days with the tests included.

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
