### PR TITLE
pwa: Fix JS escaping of template arguments for PWA manifest

### DIFF
--- a/kolibri/plugins/pwa/templates/manifest.json
+++ b/kolibri/plugins/pwa/templates/manifest.json
@@ -5,35 +5,35 @@
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 {% get_current_language as LANGUAGE_CODE %}
 {
-  "name": "{% trans 'Kolibri' %}",
-  "short_name": "{% trans 'Kolibri' %}",
-  "dir": "{{ LANGUAGE_BIDI|yesno:'rtl,ltr' }}",
-  "lang": "{{ LANGUAGE_CODE }}",
+  "name": "{% trans 'Kolibri'|escapejs %}",
+  "short_name": "{% trans 'Kolibri'|escapejs %}",
+  "dir": "{{ LANGUAGE_BIDI|yesno:'rtl,ltr'|escapejs }}",
+  "lang": "{{ LANGUAGE_CODE|escapejs }}",
   "icons": [
 {% for icon in icons %}
     {
 {% if icon.type %}
-      "type": "{{ icon.type }}",
+      "type": "{{ icon.type|escapejs }}",
 {% endif %}
 {% if icon.sizes %}
-      "sizes": "{{ icon.sizes }}",
+      "sizes": "{{ icon.sizes|escapejs }}",
 {% endif %}
 {% if icon.label %}
-      "label": "{{ icon.label }}",
+      "label": "{{ icon.label|escapejs }}",
 {% endif %}
 {% if icon.purpose %}
-      "purpose": "{{ icon.purpose }}",
+      "purpose": "{{ icon.purpose|escapejs }}",
 {% endif %}
-      "src": "{{ icon.src }}"
+      "src": "{{ icon.src|escapejs }}"
     }{% if not forloop.last %},{% endif %}
 {% endfor %}
   ],
-  "id": "{{ id }}",
-  "start_url": "{% url 'kolibri:core:root_redirect' %}",
-  "background_color": "{{ background_color }}",
+  "id": "{{ id|escapejs }}",
+  "start_url": "{% url 'kolibri:core:root_redirect'|escapejs %}",
+  "background_color": "{{ background_color|escapejs }}",
 {% if theme_color %}
-  "theme_color": "{{ theme_color }}",
+  "theme_color": "{{ theme_color|escapejs }}",
 {% endif %}
   "display": "standalone",
-  "scope": "{{ id }}"
+  "scope": "{{ id|escapejs }}"
 }


### PR DESCRIPTION
## Summary

Minor fix for the PWA plugin to ensure that template arguments are correctly escaped in the manifest JSON.

## References

N/A

## Reviewer guidance

N/A

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
