### PR TITLE
pwa: Allow specifying related apps in the PWA manifest

### DIFF
--- a/kolibri/plugins/pwa/kolibri_plugin.py
+++ b/kolibri/plugins/pwa/kolibri_plugin.py
@@ -34,6 +34,7 @@ class PwaPlugin(KolibriPluginBase):
     You must also provide a themed logo in scalable, 192px and 512px versions.
     """
 
+    kolibri_options = "options"
     translated_view_urls = "urls"
     root_view_urls = "root_urls"
 

--- a/kolibri/plugins/pwa/options.py
+++ b/kolibri/plugins/pwa/options.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2023 Endless OS Foundation, LLC
+# SPDX-License-Identifier: MIT
+
+option_spec = {
+    "Pwa": {
+        # Ideally this would be an array of dicts defining *all* the related
+        # apps, not just a couple of platform-specific ones. However, the type
+        # system for `option_spec` doesn’t support that at the moment.
+        "ANDROID_APPLICATION_ID": {
+            "type": "string",
+            "default": "",
+            "description": "ID of the related Android app for this PWA (for example: `com.example.app1`)",
+        },
+        "WINDOWS_APPLICATION_ID": {
+            "type": "string",
+            "default": "",
+            # See https://web.dev/get-installed-related-apps/#tell-your-website-about-your-windows-app
+            "description": "ID of the related Windows app for this PWA (for example: `9WZDNCRFJBH4`, "
+            "the <Application> Id value in your Package.appxmanifest file)",
+        },
+        "PREFER_RELATED_APPLICATIONS": {
+            "type": "boolean",
+            "default": False,
+            "description": "Whether the browser should recommend installing the relevant related application for the platform rather than using the PWA",
+        },
+    },
+}

--- a/kolibri/plugins/pwa/templates/pwa/manifest.json
+++ b/kolibri/plugins/pwa/templates/pwa/manifest.json
@@ -28,6 +28,18 @@
     }{% if not forloop.last %},{% endif %}
 {% endfor %}
   ],
+  "related_applications": [
+{% for app in related_applications %}
+    {
+      "platform": "{{ app.platform|escapejs }}",
+      "id": "{{ app.id|escapejs }}",
+      "url": "{{ app.url|escapejs }}"
+    }{% if not forloop.last %},{% endif %}
+{% endfor %}
+  ],
+{% if prefer_related_applications %}
+  "prefer_related_applications": true,
+{% endif %}
   "id": "{{ id|escapejs }}",
   "start_url": "{% url 'kolibri:core:root_redirect'|escapejs %}",
   "background_color": "{{ background_color|escapejs }}",


### PR DESCRIPTION
## Summary

This is useful on Android devices, where a native Android app may be more comfortable to use than a PWA (just like a PWA is more comfortable to use than a normal website). If the organisation running the Kolibri instance have an Android app, they can configure it and Chrome on Android will prompt to install that instead of the PWA, if the user tries to install the PWA.

It adds a few new configuration options to the `pwa` plugin. Their default values leave the current behaviour of the plugin unchanged.

## References

 * https://www.w3.org/TR/appmanifest/#related_applications-member
 * https://developer.mozilla.org/en-US/docs/Web/Manifest/related_applications

## Reviewer guidance

N/A

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
