### PR TITLE
final "on my own" flow updates

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -44,7 +44,7 @@
   import PinAuthenticationModal from './PinAuthenticationModal';
   import plugin_data from 'plugin_data';
 
-  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+  const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'DeviceIndex',
@@ -85,7 +85,7 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.sessionStorage.getItem(welcomeDimissalKey) !== 'true'
+          window.sessionStorage.getItem(welcomeDismissalKey) !== 'true'
         );
       },
       pageName() {
@@ -112,7 +112,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
+        window.sessionStorage.setItem(welcomeDismissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
       closePinModal() {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -4,6 +4,7 @@
     <WelcomeModal
       v-if="step === Steps.WELCOME"
       :importedFacility="importedFacility"
+      :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
     />
 
@@ -54,6 +55,12 @@
       SelectDeviceForm,
     },
     mixins: [commonSyncElements],
+    props: {
+      isOnMyOwnUser: {
+        type: Boolean,
+        required: false,
+      },
+    },
     data() {
       return {
         step: Steps.WELCOME,

--- a/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
+++ b/kolibri/plugins/device/assets/src/views/WelcomeModal.vue
@@ -34,6 +34,11 @@
         type: Object,
         default: null,
       },
+      isOnMyOwnUser: {
+        type: Boolean,
+        required: false,
+        default: false,
+      },
     },
     computed: {
       paragraphs() {
@@ -46,6 +51,9 @@
               ? this.$tr('learnOnlyDeviceWelcomeMessage2')
               : this.$tr('postSyncWelcomeMessage2', { facilityName: facility.name });
           return [this.$tr('learnOnlyDeviceWelcomeMessage1'), sndParagraph];
+        }
+        if (this.isOnMyOwnUser) {
+          return [this.coreString('nothingInLibraryLearner')];
         }
         if (this.importedFacility) {
           return [

--- a/kolibri/plugins/learn/assets/src/modules/coreLearn/mutations.js
+++ b/kolibri/plugins/learn/assets/src/modules/coreLearn/mutations.js
@@ -11,4 +11,7 @@ export default {
   SET_ROOT_NODES_LOADING(state, valToSet) {
     state.rootNodesLoading = valToSet;
   },
+  SET_WELCOME_MODAL_VISIBLE(state, visibility) {
+    state.welcomeModalVisible = visibility;
+  },
 };

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -14,6 +14,7 @@ export default {
   state() {
     return {
       pageName: '',
+      welcomeModalVisible: false,
       rootNodes: [],
       canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
       allowGuestAccess: plugin_data.allowGuestAccess,

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -52,7 +52,7 @@ export default [
     name: PageNames.ROOT,
     path: '/',
     handler: () => {
-      if (get(isUserLoggedIn)) {
+      if (get(isUserLoggedIn) && get(channels).length) {
         return router.replace({ name: PageNames.HOME });
       }
       return router.replace({ name: PageNames.LIBRARY });

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -20,13 +20,12 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
-  import { useSessionStorage } from '@vueuse/core';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import plugin_data from 'plugin_data';
   import { PageNames } from '../constants';
   import PostSetupModalGroup from '../../../../device/assets/src/views/PostSetupModalGroup.vue';
 
-  const welcomeDismissalKey = useSessionStorage('DEVICE_WELCOME_MODAL_DISMISSED', '');
+  const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'LearnIndex',
@@ -43,7 +42,10 @@
         loading: state => state.core.loading,
       }),
       welcomeModalVisible() {
-        return this.welcomeModalVisibleState && welcomeDismissalKey.value !== 'true';
+        return (
+          this.welcomeModalVisibleState &&
+          window.sessionStorage.getItem(welcomeDismissalKey) !== 'true'
+        );
       },
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
@@ -56,7 +58,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        welcomeDismissalKey.value = 'true';
+        window.sessionStorage.setItem(welcomeDismissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -20,12 +20,13 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
+  import { useSessionStorage } from '@vueuse/core';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import plugin_data from 'plugin_data';
   import { PageNames } from '../constants';
   import PostSetupModalGroup from '../../../../device/assets/src/views/PostSetupModalGroup.vue';
 
-  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+  const welcomeDismissalKey = useSessionStorage('DEVICE_WELCOME_MODAL_DISMISSED', '');
 
   export default {
     name: 'LearnIndex',
@@ -42,10 +43,7 @@
         loading: state => state.core.loading,
       }),
       welcomeModalVisible() {
-        return (
-          this.welcomeModalVisibleState &&
-          window.sessionStorage.getItem(welcomeDimissalKey) !== 'true'
-        );
+        return this.welcomeModalVisibleState && welcomeDismissalKey.value !== 'true';
       },
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
@@ -58,7 +56,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        window.sessionStorage.setItem(welcomeDimissalKey, true);
+        welcomeDismissalKey.value = 'true';
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -4,6 +4,13 @@
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
   >
+    <transition name="delay-entry">
+      <PostSetupModalGroup
+        v-if="welcomeModalVisible"
+        isOnMyOwnUser
+        @cancel="hideWelcomeModal"
+      />
+    </transition>
     <router-view :loading="loading" />
   </NotificationsRoot>
 
@@ -16,17 +23,30 @@
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import plugin_data from 'plugin_data';
   import { PageNames } from '../constants';
+  import PostSetupModalGroup from '../../../../device/assets/src/views/PostSetupModalGroup.vue';
+
+  const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'LearnIndex',
     components: {
       NotificationsRoot,
+      PostSetupModalGroup,
     },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       ...mapState({
+        welcomeModalVisibleState: 'welcomeModalVisible',
+      }),
+      ...mapState({
         loading: state => state.core.loading,
       }),
+      welcomeModalVisible() {
+        return (
+          this.welcomeModalVisibleState &&
+          window.sessionStorage.getItem(welcomeDimissalKey) !== 'true'
+        );
+      },
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
           return this.isUserLoggedIn;
@@ -34,6 +54,12 @@
         return (
           (plugin_data.allowGuestAccess && this.$store.getters.allowAccess) || this.isUserLoggedIn
         );
+      },
+    },
+    methods: {
+      hideWelcomeModal() {
+        window.sessionStorage.setItem(welcomeDimissalKey, true);
+        this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -512,7 +512,12 @@
       },
     },
     created() {
+      const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+
       this.search();
+      if (window.sessionStorage.getItem(welcomeDimissalKey) !== 'true') {
+        this.$store.commit('SET_WELCOME_MODAL_VISIBLE', true);
+      }
       if (this.isUserLoggedIn) {
         this.refreshDevices();
       }

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -512,10 +512,10 @@
       },
     },
     created() {
-      const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+      const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
       this.search();
-      if (window.sessionStorage.getItem(welcomeDimissalKey) !== 'true') {
+      if (window.sessionStorage.getItem(welcomeDismissalKey) !== 'true') {
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', true);
       }
       if (this.isUserLoggedIn) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -186,8 +186,8 @@
           data: this.deviceProvisioningData,
         })
           .then(() => {
-            const welcomeDimissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
-            window.sessionStorage.setItem(welcomeDimissalKey, false);
+            const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+            window.sessionStorage.setItem(welcomeDismissalKey, false);
 
             Lockr.rm('savedState'); // Clear out saved state machine
             redirectBrowser();


### PR DESCRIPTION
## Summary
final updates to "on my own" flow: in concert with recently-merged BE changes, this PR introduces specific behavior for "on my own" users upon exiting the setup wizard  - "on my own" users will now be redirected right to `Learn` > `Library` and greeted by a welcome message once there (just as they were previously greeted by a welcome modal when they were redirected to `Device` after completing setup). 


### Before - redirected to `Learn` > `Home` with no welcome modal 
(before very recent & related BE changes, would redirect to `Device` with welcome modal)


https://github.com/learningequality/kolibri/assets/43046460/cbd58611-2488-44f1-9e77-b7569e9d1470





### After - redirected to `Learn` > `Library` with customized message in welcome modal

https://github.com/learningequality/kolibri/assets/43046460/c4d6bac2-286e-47d6-b9f9-5cfb7b79aac4




## References
closes #10760 (in combination with https://github.com/learningequality/kolibri/pull/11019, which is already merged)


## Reviewer guidance
- start a fresh kolibri instance
- progress through the setup wizard as an "on my own" user
- once setup has finalized, expect to be redirected to `Learn` > `Library` & greeted by a dismissable welcome modal
- once dismissed, the welcome modal should not re-render upon navigating to `Device` for the first time, on subsequent re-visits to `Library`, or in any other scenarios. 

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
