### PR TITLE
Download speed remediation

### DIFF
--- a/kolibri/core/content/management/commands/exportchannel.py
+++ b/kolibri/core/content/management/commands/exportchannel.py
@@ -32,9 +32,7 @@ class Command(AsyncCommand):
 
             with self.start_progress(total=copy.transfer_size) as progress_update:
                 try:
-                    for block in copy:
-                        progress_update(len(block))
-
+                    copy.run(progress_update=progress_update)
                 except transfer.TransferCanceled:
                     pass
 

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -138,12 +138,14 @@ class Command(AsyncCommand):
         with copy, self.start_progress(
             total=copy.transfer_size
         ) as file_cp_progress_update:
+
+            def progress_update(length):
+                self.exported_size = self.exported_size + length
+                overall_progress_update(length)
+                file_cp_progress_update(length)
+
             try:
-                for chunk in copy:
-                    length = len(chunk)
-                    self.exported_size = self.exported_size + length
-                    overall_progress_update(length)
-                    file_cp_progress_update(length)
+                copy.run(progress_update=progress_update)
             except transfer.TransferCanceled:
                 job = get_current_job()
                 if job:

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -198,8 +198,11 @@ class Command(AsyncCommand):
         with filetransfer, self.start_progress(
             total=filetransfer.transfer_size
         ) as progress_update:
-            for chunk in filetransfer:
-                progress_update(len(chunk), progress_extra_data)
+
+            def progress_callback(bytes):
+                progress_update(bytes, progress_extra_data)
+
+            filetransfer.run(progress_callback)
             # if upgrading, import the channel
             if not no_upgrade:
                 try:

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -484,6 +484,7 @@ def diskimport(
     update=False,
     node_ids=None,
     exclude_node_ids=None,
+    fail_on_error=False,
     all_thumbnails=False,
 ):
     drive = get_mounted_drive_by_id(drive_id)
@@ -511,6 +512,7 @@ def diskimport(
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
         import_updates=update,
+        fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,
     )
     manager.run()

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -13,7 +13,6 @@ from django.utils import six
 from le_utils.constants import content_kinds
 from mock import call
 from mock import MagicMock
-from mock import mock_open
 from mock import patch
 from requests import Session
 from requests.exceptions import ChunkedEncodingError
@@ -565,13 +564,16 @@ class ImportChannelTestCase(TestCase):
                     "decryption failed or bad record mac",
                 ]
             )
-        with patch("kolibri.utils.file_transfer.Transfer.next", side_effect=SSLERROR):
+        with patch(
+            "kolibri.utils.file_transfer.FileDownload._run_download",
+            side_effect=SSLERROR,
+        ):
             call_command("importchannel", "network", "197934f144305350b5820c7c4dd8e194")
             cancel_mock.assert_called_with()
             import_channel_mock.assert_not_called()
 
     @patch(
-        "kolibri.utils.file_transfer.Transfer.next",
+        "kolibri.utils.file_transfer.FileDownload._run_download",
         side_effect=ReadTimeout("Read timed out."),
     )
     @patch(
@@ -908,7 +910,7 @@ class ImportContentTestCase(TestCase):
         annotation_mock.set_content_visibility.assert_called()
 
     @patch(
-        "kolibri.utils.file_transfer.Transfer.next",
+        "kolibri.utils.file_transfer.FileDownload._run_download",
         side_effect=ConnectionError("connection error"),
     )
     @patch(
@@ -922,7 +924,7 @@ class ImportContentTestCase(TestCase):
         self,
         is_cancelled_mock,
         cancel_mock,
-        next_mock,
+        run_mock,
         annotation_mock,
         get_import_export_mock,
         channel_list_status_mock,
@@ -1006,41 +1008,6 @@ class ImportContentTestCase(TestCase):
             exclude_node_ids=None,
             public=False,
         )
-
-    @patch("kolibri.core.content.utils.resource_import.transfer.Transfer.next")
-    @patch("kolibri.core.content.utils.resource_import.transfer.sleep")
-    @patch("kolibri.core.content.utils.resource_import.transfer.requests.Session.get")
-    @patch(
-        "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path",
-        return_value="test/test",
-    )
-    def test_remote_import_httperror_502(
-        self,
-        content_storage_file_path_mock,
-        requests_get_mock,
-        sleep_mock,
-        transfer_next_mock,
-        annotation_mock,
-        get_import_export_mock,
-        channel_list_status_mock,
-    ):
-        response_mock = MagicMock()
-        response_mock.status_code = 502
-        exception_502 = HTTPError("Bad Gateway", response=response_mock)
-        transfer_next_mock.side_effect = [exception_502, ""]
-        LocalFile.objects.filter(
-            files__contentnode__channel_id=self.the_channel_id
-        ).update(file_size=1)
-        get_import_export_mock.return_value = (
-            1,
-            [LocalFile.objects.values("id", "file_size", "extension").first()],
-            10,
-        )
-        manager = RemoteChannelResourceImportManager(self.the_channel_id)
-        manager.run()
-
-        sleep_mock.assert_called()
-        annotation_mock.set_content_visibility.assert_called()
 
     @patch("kolibri.utils.file_transfer.requests.Session.get")
     @patch(
@@ -1185,7 +1152,7 @@ class ImportContentTestCase(TestCase):
 
     @patch("kolibri.utils.file_transfer.sleep")
     @patch(
-        "kolibri.utils.file_transfer.Transfer.next",
+        "kolibri.utils.file_transfer.FileDownload._run_download",
         side_effect=ChunkedEncodingError("Chunked Encoding Error"),
     )
     @patch(
@@ -1955,62 +1922,6 @@ class ImportContentTestCase(TestCase):
             all_thumbnails=False,
             peer_id=None,
         )
-
-    @patch("kolibri.core.content.utils.resource_import.transfer.sleep")
-    @patch("kolibri.core.content.utils.resource_import.transfer.requests.Session.get")
-    @patch("kolibri.core.content.utils.resource_import.transfer.Transfer.next")
-    @patch(
-        "kolibri.core.content.utils.resource_import.paths.get_content_storage_file_path",
-        return_value="test/test",
-    )
-    @patch(
-        "kolibri.core.content.utils.resource_import.JobProgressMixin.is_cancelled",
-        return_value=False,
-    )
-    def test_remote_import_file_compressed_on_gcs(
-        self,
-        is_cancelled_mock,
-        content_storage_file_path_mock,
-        transfer_next_mock,
-        requests_get_mock,
-        sleep_mock,
-        annotation_mock,
-        get_import_export_mock,
-        channel_list_status_mock,
-    ):
-        response_mock = MagicMock()
-        response_mock.status_code = 503
-        exception_503 = HTTPError("Service Unavailable", response=response_mock)
-        transfer_next_mock.side_effect = [exception_503, ""]
-        requests_get_mock.return_value.headers = {"X-Goog-Stored-Content-Length": "1"}
-        LocalFile.objects.filter(
-            files__contentnode__channel_id=self.the_channel_id
-        ).update(file_size=1)
-        get_import_export_mock.return_value = (
-            1,
-            [LocalFile.objects.values("id", "file_size", "extension").first()],
-            10,
-        )
-
-        m = mock_open()
-        with patch("kolibri.utils.file_transfer.open", m):
-            try:
-                manager = RemoteChannelResourceImportManager(self.the_channel_id)
-                manager.run()
-            except Exception:
-                pass
-            sleep_mock.assert_called()
-            annotation_mock.set_content_visibility.assert_called_with(
-                self.the_channel_id,
-                [
-                    LocalFile.objects.values("id", "file_size", "extension").first()[
-                        "id"
-                    ]
-                ],
-                node_ids=None,
-                exclude_node_ids=None,
-                public=False,
-            )
 
     @patch("kolibri.core.content.utils.resource_import.logger.warning")
     @patch(

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -488,7 +488,7 @@ class ImportChannelTestCase(TestCase):
         os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
-        FileDownloadMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileDownloadMock.return_value.run.side_effect = TransferCanceled()
         call_command("importchannel", "network", self.the_channel_id)
         # Check that is_cancelled was called
         is_cancelled_mock.assert_called_with()
@@ -527,7 +527,7 @@ class ImportChannelTestCase(TestCase):
         os.close(fd1)
         os.close(fd2)
         local_path_mock.side_effect = [local_dest_path, local_src_path]
-        FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileCopyMock.return_value.run.side_effect = TransferCanceled()
         call_command("importchannel", "disk", self.the_channel_id, tempfile.mkdtemp())
         # Check that is_cancelled was called
         is_cancelled_mock.assert_called_with()
@@ -640,7 +640,6 @@ class ImportChannelTestCase(TestCase):
         os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
-        FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
         import_channel_mock.return_value = True
         call_command("importchannel", "network", self.the_channel_id)
         self.assertTrue(channel_stats_clear_mock.called)
@@ -686,8 +685,6 @@ class ImportContentTestCase(TestCase):
         get_import_export_mock,
         channel_list_status_mock,
     ):
-        # Check behaviour if cancellation is called before any file download starts
-        FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
         get_import_export_mock.return_value = (
             1,
             [LocalFile.objects.all().values("id", "file_size", "extension").first()],
@@ -734,8 +731,7 @@ class ImportContentTestCase(TestCase):
         os.close(fd)
         local_path_mock.return_value = local_path
         remote_path_mock.return_value = "notest"
-        # Mock this __iter__ so that the filetransfer can be looped over
-        FileDownloadMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileDownloadMock.return_value.run.side_effect = TransferCanceled()
         get_import_export_mock.return_value = (
             1,
             [LocalFile.objects.all().values("id", "file_size", "extension").first()],
@@ -803,8 +799,6 @@ class ImportContentTestCase(TestCase):
             f.write("a")
         local_path_mock.side_effect = [local_path_1, local_path_2]
         remote_path_mock.return_value = "notest"
-        # Mock this __iter__ so that the filetransfer can be looped over
-        FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
         FileDownloadMock.return_value.transfer_size = 1
         FileDownloadMock.return_value.dest = local_path_1
         LocalFile.objects.update(file_size=1)
@@ -841,7 +835,6 @@ class ImportContentTestCase(TestCase):
         channel_list_status_mock,
     ):
         # Local version of test above
-        FileCopyMock.return_value.__iter__.return_value = ["one", "two", "three"]
         get_import_export_mock.return_value = (
             1,
             list(LocalFile.objects.all().values("id", "file_size", "extension")),
@@ -886,7 +879,7 @@ class ImportContentTestCase(TestCase):
         os.close(fd1)
         os.close(fd2)
         local_path_mock.side_effect = [local_dest_path, local_src_path] * 10
-        FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileCopyMock.return_value.run.side_effect = TransferCanceled()
         get_import_export_mock.return_value = (
             1,
             [LocalFile.objects.all().values("id", "file_size", "extension").first()],
@@ -2106,7 +2099,6 @@ class ImportContentTestCase(TestCase):
         LocalFile.objects.update(file_size=1)
         local_path_mock.side_effect = [local_path]
         remote_path_mock.return_value = "notest"
-        FileDownloadMock.return_value.__iter__.return_value = ["one", "two", "three"]
         FileDownloadMock.return_value.transfer_size = 1
         FileDownloadMock.return_value.dest = local_path
         get_import_export_mock.return_value = (
@@ -2165,7 +2157,7 @@ class ExportChannelTestCase(TestCase):
         os.close(fd1)
         os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
-        FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileCopyMock.return_value.run.side_effect = TransferCanceled()
         call_command("exportchannel", self.the_channel_id, local_dest_path)
         FileCopyMock.assert_called_with(
             local_src_path, local_dest_path, cancel_check=is_cancelled_mock
@@ -2204,7 +2196,7 @@ class ExportContentTestCase(TestCase):
         get_import_export_nodes_mock,
     ):
         # If cancel comes in before we do anything, make sure nothing happens!
-        FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileCopyMock.return_value.run.side_effect = TransferCanceled()
         get_content_nodes_data_mock.return_value = (
             1,
             [LocalFile.objects.values("id", "file_size", "extension").first()],
@@ -2246,7 +2238,7 @@ class ExportContentTestCase(TestCase):
         os.close(fd1)
         os.close(fd2)
         local_path_mock.side_effect = [local_src_path, local_dest_path]
-        FileCopyMock.return_value.__iter__.side_effect = TransferCanceled()
+        FileCopyMock.return_value.run.side_effect = TransferCanceled()
         get_content_nodes_data_mock.return_value = (
             1,
             [LocalFile.objects.values("id", "file_size", "extension").first()],

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -95,22 +95,23 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
             channel_id, node_ids=node_ids, exclude_node_ids=exclude_node_ids, **kwargs
         )
 
-    def _start_file_transfer(self, f, filetransfer):
+    def _start_file_transfer(self, f):
         """
         Start to transfer the file from network/disk to the destination.
-
-        Returns a tuple containing an error that occurred and the amount
-        of data transferred. The error value will be None if no error
-        occurred.
         """
+        filename = get_content_file_name(f)
+        dest = paths.get_content_storage_file_path(
+            filename, contentfolder=self.content_dir
+        )
 
-        with filetransfer:
-            try:
+        # if the file already exists add its size to our overall progress, and skip
+        if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
+            return
+
+        filetransfer = self.create_file_transfer(f, filename, dest)
+        if filetransfer:
+            with filetransfer:
                 filetransfer.run()
-            except transfer.TransferFailed as e:
-                return e, 0
-
-        return None, f["file_size"] or 0
 
     @abstractmethod
     def get_import_data(self):
@@ -129,42 +130,20 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         """
         pass
 
-    def _attempt_file_transfer(self, f):
-        filename = get_content_file_name(f)
-        try:
-            dest = paths.get_content_storage_file_path(
-                filename, contentfolder=self.content_dir
-            )
-        except InvalidStorageFilenameError:
-            # If the destination file name is malformed, just stop now.
-            self.update_progress(f["file_size"])
-            return
-
-        # if the file already exists add its size to our overall progress, and skip
-        if os.path.isfile(dest) and os.path.getsize(dest) == f["file_size"]:
-            self.update_progress(f["file_size"])
-            self.file_checksums_to_annotate.append(f["id"])
-            self.transferred_file_size += f["file_size"]
-            return
-
-        filetransfer = self.create_file_transfer(f, filename, dest)
-        if filetransfer:
-            future = self.executor.submit(self._start_file_transfer, f, filetransfer)
-            self.future_file_transfers[future] = f
-
     def _handle_future(self, future, f):
         try:
-            error, data_transferred = future.result()
+            # Handle updating all tracking of downloaded file sizes
+            # before we check for errors
+            data_transferred = f["file_size"] or 0
             self.update_progress(data_transferred)
-            if error:
-                if self.fail_on_error:
-                    raise error
-                self.number_of_skipped_files += 1
-            else:
-                self.file_checksums_to_annotate.append(f["id"])
-                self.transferred_file_size += f["file_size"] or 0
-            self.remaining_bytes_to_transfer -= f["file_size"] or 0
+            self.transferred_file_size += data_transferred
+            self.remaining_bytes_to_transfer -= data_transferred
             remaining_free_space = get_free_space(self.content_dir)
+            # Check for errors from the download
+            future.result()
+            # If not errors, mark this file to be annotated
+            self.file_checksums_to_annotate.append(f["id"])
+            # Finally check if we have enough space to continue
             if remaining_free_space <= self.remaining_bytes_to_transfer:
                 raise InsufficientStorageSpaceError(
                     "Kolibri ran out of storage space while importing content"
@@ -173,16 +152,16 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
             pass
         except Exception as e:
             logger.error("An error occurred during content import: {}".format(e))
-
             if not self.fail_on_error and (
                 (
                     isinstance(e, requests.exceptions.HTTPError)
                     and e.response.status_code == 404
                 )
                 or (isinstance(e, OSError) and e.errno == 2)
+                or isinstance(e, InvalidStorageFilenameError)
             ):
-                # Continue file import when the current file is not found from the source and is skipped.
-                self.update_progress(f["file_size"])
+                # Continue file import when the current file is not found from the source and is skipped,
+                # or an invalid destination or source file name is provided.
                 self.number_of_skipped_files += 1
             else:
                 self.exception = e
@@ -301,7 +280,8 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
                     for f in file_batch:
                         if self.is_cancelled() or self.exception:
                             break
-                        self._attempt_file_transfer(f)
+                        future = self.executor.submit(self._start_file_transfer, f)
+                        self.future_file_transfers[future] = f
 
                     self._wait_for_futures()
                     i += batch_size
@@ -472,14 +452,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
         return cls(channel_id, path=path, drive_id=drive_id, **kwargs)
 
     def create_file_transfer(self, f, filename, dest):
-        try:
-            srcpath = paths.get_content_storage_file_path(
-                filename, datafolder=self.path
-            )
-        except InvalidStorageFilenameError:
-            # If the source file name is malformed, just stop now.
-            self.update_progress(f["file_size"])
-            return
+        srcpath = paths.get_content_storage_file_path(filename, datafolder=self.path)
         return transfer.FileCopy(
             srcpath,
             dest,

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -39,7 +39,9 @@ class CustomDjangoCache(DjangoCache):
 
         """
         try:
-            return super(CustomDjangoCache, self).has_key(key, version=version)
+            return super(CustomDjangoCache, self).has_key(  # noqa: W601
+                key, version=version
+            )
         except sqlite3.OperationalError:
             return False
 

--- a/kolibri/deployment/default/custom_django_cache.py
+++ b/kolibri/deployment/default/custom_django_cache.py
@@ -30,6 +30,19 @@ class CustomDjangoCache(DjangoCache):
         except sqlite3.OperationalError:
             return False
 
+    def has_key(self, key, version=None):
+        """Returns True if the key is in the cache and has not expired.
+
+        :param key: key for item
+        :param int version: key version number (default None, cache parameter)
+        :return: True if key is found
+
+        """
+        try:
+            return super(CustomDjangoCache, self).has_key(key, version=version)
+        except sqlite3.OperationalError:
+            return False
+
     def get(
         self,
         key,

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -406,7 +406,7 @@
         if (this.inLocalImportMode) {
           baseParams.drive_id = this.selectedDrive.id;
         } else if (this.inPeerImportMode) {
-          baseParams.peer_id = this.selectedPeer.id;
+          baseParams.peer = this.selectedPeer.id;
         }
         const taskParams = this.selectedChannels.map(x => ({
           ...baseParams,

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -125,7 +125,7 @@
       return {
         title: this.learnString('documentTitle', {
           contentTitle: this.content.title,
-          channelTitle: this.content.ancestors[0].title,
+          channelTitle: this.content.ancestors[0] ? this.content.ancestors[0].title : '',
         }),
       };
     },

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -85,6 +85,18 @@ def retry_import(e):
     return False
 
 
+def replace(file_path, new_file_path):
+    """
+    Do a replace type operation.
+    This is not the same as an atomic replacement, as it could result
+    in the target file being removed before the rename happens.
+    This can be removed once Python 2.7 support is dropped
+    """
+    if os.path.exists(new_file_path):
+        os.remove(new_file_path)
+    os.rename(file_path, new_file_path)
+
+
 class ChunkedFile(BufferedIOBase):
     # Set chunk size to 128KB
     chunk_size = 128 * 1024
@@ -279,7 +291,7 @@ class ChunkedFile(BufferedIOBase):
                 chunk_file = self._get_chunk_file_name(chunk_index)
                 with open(chunk_file, "rb") as input_file:
                     shutil.copyfileobj(input_file, output_file)
-        os.rename(tmp_filepath, self.filepath)
+        replace(tmp_filepath, self.filepath)
 
     def _get_expected_chunk_size(self, chunk_index):
         return (
@@ -749,7 +761,7 @@ class FileCopy(Transfer):
         self.hasher = hashlib.md5()
 
     def _move_tmp_to_dest(self):
-        os.rename(self.dest_tmp, self.dest)
+        replace(self.dest_tmp, self.dest)
 
     def delete(self):
         try:

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -368,6 +368,11 @@ class Transfer(with_metaclass(ABCMeta)):
     def _get_content_iterator(self):
         pass
 
+    def run(self, progress_update=None):
+        for chunk in self:
+            if callable(progress_update):
+                progress_update(len(chunk))
+
     def _next(self):
         try:
             # Get the next chunk from the content iterator
@@ -534,7 +539,7 @@ class FileDownload(Transfer):
         return (
             self._finalize_download
             and (self.range_start is None or self.range_start == 0)
-            and (self.range_end is None or self.range_end == self.file_size - 1)
+            and (self.range_end is None or self.range_end == self.total_size - 1)
         )
 
     def finalize(self):

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -510,6 +510,10 @@ class FileDownload(Transfer):
 
         self.dest_file_obj = ChunkedFile(self.dest)
 
+        self.completed = self.dest_file_obj.is_complete(
+            start=self.range_start, end=self.range_end
+        )
+
     def set_range(self, range_start, range_end):
         if range_start is not None and not isinstance(range_start, int):
             raise TypeError("range_start must be an integer")
@@ -587,7 +591,8 @@ class FileDownload(Transfer):
 
     @_catch_exception_and_retry
     def run(self, progress_update=None):
-        self._run_download(progress_update=progress_update)
+        if not self.completed:
+            self._run_download(progress_update=progress_update)
         self.complete_close_and_finalize()
 
     @property
@@ -628,8 +633,9 @@ class FileDownload(Transfer):
 
     @_catch_exception_and_retry
     def start(self):
-        # initiate the download, check for status errors, and calculate download size
-        self._set_headers()
+        if not self.completed:
+            # initiate the download, check for status errors, and calculate download size
+            self._set_headers()
         self.started = True
 
     def _run_byte_range_download(self, progress_update):

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -131,8 +131,6 @@ class EndRangeStaticFile(StaticFile):
         if start >= end:
             return self.get_range_not_satisfiable_response(file_handle, size)
         if file_handle is not None:
-            if isinstance(file_handle, RemoteFile):
-                file_handle.set_range(start, end)
             file_handle = SlicedFile(file_handle, start, end)
         headers.append(("Content-Range", "bytes {}-{}/{}".format(start, end, size)))
         headers.append(("Content-Length", str(end - start + 1)))

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -265,3 +265,16 @@ class TestChunkedFile(unittest.TestCase):
         self.assertEqual(combined_md5, self.chunked_file.md5_checksum())
 
         os.remove(self.file_path)
+
+    def test_file_removed_by_parallel_process_after_opening(self):
+        shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
+        self.chunked_file._file_size = None
+        with self.assertRaises(ValueError):
+            self.chunked_file.file_size
+
+    def test_file_finalized_by_parallel_process_after_opening(self):
+        self.chunked_file.finalize_file()
+        self.chunked_file.delete()
+        self.chunked_file._file_size = None
+        with self.assertRaises(ValueError):
+            self.chunked_file.file_size

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import unittest
 
-from kolibri.utils.file_transfer import BLOCK_SIZE
 from kolibri.utils.file_transfer import ChunkedFile
 
 
@@ -12,7 +11,7 @@ class TestChunkedFile(unittest.TestCase):
     def setUp(self):
         self.file_path = "test_file"
 
-        self.chunk_size = BLOCK_SIZE
+        self.chunk_size = ChunkedFile.chunk_size
         self.file_size = (1024 * 1024) + 731
 
         self.chunked_file = ChunkedFile(self.file_path)
@@ -52,17 +51,17 @@ class TestChunkedFile(unittest.TestCase):
         self.assertEqual(data, self.data[512 * 1024 : (512 * 1024) + 512])
 
     def test_write(self):
-        new_data = os.urandom(BLOCK_SIZE)
+        new_data = os.urandom(self.chunk_size)
         os.remove(
             os.path.join(
                 self.chunked_file.chunk_dir, ".chunk_{}".format(self.chunks_count - 2)
             )
         )
-        self.chunked_file.seek((self.chunks_count - 2) * BLOCK_SIZE)
+        self.chunked_file.seek((self.chunks_count - 2) * self.chunk_size)
         self.chunked_file.write(new_data)
 
-        self.chunked_file.seek((self.chunks_count - 2) * BLOCK_SIZE)
-        data = self.chunked_file.read(BLOCK_SIZE)
+        self.chunked_file.seek((self.chunks_count - 2) * self.chunk_size)
+        data = self.chunked_file.read(self.chunk_size)
         self.assertEqual(data, new_data)
 
     def test_write_whole_file(self):
@@ -100,13 +99,13 @@ class TestChunkedFile(unittest.TestCase):
         self.chunked_file.seek(0)
         self.chunked_file.write(new_data)
 
-        self.chunked_file.seek(BLOCK_SIZE * (self.chunks_count - 2))
-        data = self.chunked_file.read(BLOCK_SIZE)
+        self.chunked_file.seek(self.chunk_size * (self.chunks_count - 2))
+        data = self.chunked_file.read(self.chunk_size)
         self.assertEqual(
             data,
             new_data[
-                BLOCK_SIZE
-                * (self.chunks_count - 2) : BLOCK_SIZE
+                self.chunk_size
+                * (self.chunks_count - 2) : self.chunk_size
                 * (self.chunks_count - 1)
             ],
         )

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -135,12 +135,12 @@ class TestChunkedFile(unittest.TestCase):
         start = self.chunk_size
         end = self.chunk_size * 4 - 1
         missing_ranges = [
-            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+            mr for mr in self.chunked_file.missing_chunks_generator(start, end)
         ]
 
         expected_ranges = [
-            (self.chunk_size * 1, self.chunk_size * 2 - 1),
-            (self.chunk_size * 3, self.chunk_size * 4 - 1),
+            (1, self.chunk_size * 1, self.chunk_size * 2 - 1),
+            (3, self.chunk_size * 3, self.chunk_size * 4 - 1),
         ]
         self.assertEqual(missing_ranges, expected_ranges)
 
@@ -152,11 +152,11 @@ class TestChunkedFile(unittest.TestCase):
         start = self.chunk_size
         end = self.chunk_size * 3 - 1
         missing_ranges = [
-            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+            mr for mr in self.chunked_file.missing_chunks_generator(start, end)
         ]
 
         expected_ranges = [
-            (self.chunk_size * 1, self.chunk_size * 2 - 1),
+            (1, self.chunk_size * 1, self.chunk_size * 2 - 1),
         ]
         self.assertEqual(missing_ranges, expected_ranges)
 
@@ -167,11 +167,11 @@ class TestChunkedFile(unittest.TestCase):
         start = self.chunk_size
         end = self.chunk_size * 2 - 1
         missing_ranges = [
-            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+            mr for mr in self.chunked_file.missing_chunks_generator(start, end)
         ]
 
         expected_ranges = [
-            (self.chunk_size, self.chunk_size * 2 - 1),
+            (1, self.chunk_size, self.chunk_size * 2 - 1),
         ]
         self.assertEqual(missing_ranges, expected_ranges)
 
@@ -182,13 +182,13 @@ class TestChunkedFile(unittest.TestCase):
         start = self.chunk_size // 3
         end = self.chunk_size * 2 + self.chunk_size // 3
         missing_ranges = [
-            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
+            mr for mr in self.chunked_file.missing_chunks_generator(start, end)
         ]
 
         expected_ranges = [
-            (0, self.chunk_size - 1),
-            (self.chunk_size, self.chunk_size * 2 - 1),
-            (self.chunk_size * 2, self.chunk_size * 3 - 1),
+            (0, 0, self.chunk_size - 1),
+            (1, self.chunk_size, self.chunk_size * 2 - 1),
+            (2, self.chunk_size * 2, self.chunk_size * 3 - 1),
         ]
         self.assertEqual(missing_ranges, expected_ranges)
 
@@ -197,132 +197,13 @@ class TestChunkedFile(unittest.TestCase):
         os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
         os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_3"))
 
-        missing_ranges = [
-            mr[:2] for mr in self.chunked_file.next_missing_chunk_and_read()
-        ]
+        missing_ranges = [mr for mr in self.chunked_file.missing_chunks_generator()]
 
         expected_ranges = [
-            (self.chunk_size * 1, self.chunk_size * 2 - 1),
-            (self.chunk_size * 3, self.chunk_size * 4 - 1),
+            (1, self.chunk_size * 1, self.chunk_size * 2 - 1),
+            (3, self.chunk_size * 3, self.chunk_size * 4 - 1),
         ]
         self.assertEqual(missing_ranges, expected_ranges)
-
-    def test_get_missing_chunk_ranges_reading(self):
-        # Remove some chunks
-        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_1"))
-        os.remove(os.path.join(self.chunked_file.chunk_dir, ".chunk_3"))
-
-        start = self.chunk_size
-        end = self.chunk_size * 4 - 1
-        generator = self.chunked_file.next_missing_chunk_and_read(start, end)
-
-        missing_range_1 = next(generator)
-
-        # Make sure we don't read the first chunk as its before the start of the range
-        self.assertEqual(b"".join(missing_range_1[2]), b"")
-
-        # Seek past the first missing chunk to make sure we don't try to read it.
-        # In normal operation, the missing chunk would be filled in with a write before
-        # the next read, which would cause the read to skip past.
-        self.chunked_file.seek(self.chunk_size * 2)
-
-        missing_range_2 = next(generator)
-
-        self.assertEqual(
-            b"".join(missing_range_2[2]),
-            self.data[self.chunk_size * 2 : self.chunk_size * 3],
-        )
-
-        expected_ranges = [
-            (self.chunk_size * 1, self.chunk_size * 2 - 1),
-            (self.chunk_size * 3, self.chunk_size * 4 - 1),
-        ]
-        self.assertEqual([missing_range_1[:2], missing_range_2[:2]], expected_ranges)
-
-    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading(
-        self,
-    ):
-        # Remove some chunks
-        shutil.rmtree(self.chunked_file.chunk_dir)
-
-        start = self.chunk_size + self.chunk_size // 3
-        end = self.chunk_size * 2 + self.chunk_size // 3
-        missing = [
-            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
-        ]
-
-        missing_ranges = [mr[:2] for mr in missing]
-
-        expected_ranges = [
-            (self.chunk_size, self.chunk_size * 2 - 1),
-            (self.chunk_size * 2, self.chunk_size * 3 - 1),
-        ]
-        self.assertEqual(missing_ranges, expected_ranges)
-
-        output = b""
-
-        for mr in missing:
-            output += b"".join(mr[2])
-            self.chunked_file.seek(mr[1] + 1)
-
-        self.assertEqual(output, b"")
-
-    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading_include_first_chunk(
-        self,
-    ):
-        # Remove some chunks
-        shutil.rmtree(self.chunked_file.chunk_dir)
-
-        start = self.chunk_size // 3
-        end = self.chunk_size * 2 + self.chunk_size // 3
-        missing = [
-            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
-        ]
-
-        missing_ranges = [mr[:2] for mr in missing]
-
-        expected_ranges = [
-            (0, self.chunk_size - 1),
-            (self.chunk_size, self.chunk_size * 2 - 1),
-            (self.chunk_size * 2, self.chunk_size * 3 - 1),
-        ]
-        self.assertEqual(missing_ranges, expected_ranges)
-
-        output = b""
-
-        for mr in missing:
-            output += b"".join(mr[2])
-            self.chunked_file.seek(mr[1] + 1)
-
-        self.assertEqual(output, b"")
-
-    def test_get_missing_chunk_ranges_slice_no_download_not_chunk_size_ranges_reading_include_last_chunk(
-        self,
-    ):
-        # Remove some chunks
-        shutil.rmtree(self.chunked_file.chunk_dir)
-
-        start = self.chunk_size + self.chunk_size // 3
-        end = self.file_size - 7
-        missing = [
-            mr for mr in self.chunked_file.next_missing_chunk_and_read(start, end)
-        ]
-
-        missing_ranges = [mr[:2] for mr in missing]
-
-        expected_ranges = [
-            (self.chunk_size * i, min(self.file_size, self.chunk_size * (i + 1)) - 1)
-            for i in range(1, self.chunks_count)
-        ]
-        self.assertEqual(missing_ranges, expected_ranges)
-
-        output = b""
-
-        for mr in missing:
-            output += b"".join(mr[2])
-            self.chunked_file.seek(mr[1] + 1)
-
-        self.assertEqual(output, b"")
 
     def test_finalize_file(self):
         self.chunked_file.finalize_file()

--- a/kolibri/utils/tests/test_file_transfer.py
+++ b/kolibri/utils/tests/test_file_transfer.py
@@ -362,6 +362,37 @@ class TestTransferDownloadByteRangeSupport(BaseTestTransfer):
         )
         self._assert_request_calls()
 
+    def test_remote_file_iterator_repeated(self):
+        output = b""
+        with patch(
+            "kolibri.utils.file_transfer.requests.Session",
+            return_value=self.mock_session,
+        ):
+            rf = RemoteFile(self.dest, self.source)
+            chunk = rf.read(BLOCK_SIZE)
+            while chunk:
+                output += chunk
+                chunk = rf.read(BLOCK_SIZE)
+        self.assertEqual(output, self.content, "Content does not match")
+        self.assertEqual(
+            self.mock_session.get.call_count,
+            self.chunks_count if self.byte_range_support else 1,
+        )
+        self._assert_request_calls()
+
+        output = b""
+        with patch(
+            "kolibri.utils.file_transfer.requests.Session",
+            return_value=self.mock_session,
+        ):
+            rf = RemoteFile(self.dest, self.source)
+            chunk = rf.read(BLOCK_SIZE)
+            while chunk:
+                output += chunk
+                chunk = rf.read(BLOCK_SIZE)
+
+        self.mock_session.head.assert_called_once()
+
     def test_partial_remote_file_iterator(self):
         self.set_test_data(partial=True)
 


### PR DESCRIPTION
## Summary
* Removes iteration API for Transfer objects
* Uses the disckcache for storing file size data and header information to allow efficient repeated requests to the same host
* Restore full file range requests to allow non-parallelized downloads to not make chunked requests with small byte ranges to prevent download speed regression
* Prevent unnecessary downloads when chunked files are complete but not finalized
* Separate the chunked file chunk size and transfer block size to allow them to be independently tweaked.
* Add locking of chunked file chunks for all downloads to help reduce parallel redundant data transfer
* Check whether chunks still need to be downloaded after a lock has been acquired when we are able to do byte range downloads

## References
Fixes [#10848](https://github.com/learningequality/kolibri/issues/10848)
Fixes #10836
Fixes [#10862](https://github.com/learningequality/kolibri/issues/10862)
I believe this also fixes #10905 - although noting that one underyling cause there is a fundamental bug in MacOS Catalina, which we are not able to fix.

## Reviewer guidance
Ensure that channel import and resource import function as intended.

Ensure that all files can be remotely browsed from other Kolibris.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
