### PR TITLE
Bypass browser cache for forced resource fetches

### DIFF
--- a/kolibri/core/assets/src/api-resource.js
+++ b/kolibri/core/assets/src/api-resource.js
@@ -68,7 +68,15 @@ export class Model {
           } else {
             this.synced = false;
             // Do a fetch on the URL.
-            this.resource.client({ url: this.url, params: this.getParams }).then(
+            const options = {
+              url: this.url,
+              params: this.getParams,
+            };
+            if (force) {
+              // Ensure the request reaches the backend.
+              options.headers = { 'Cache-Control': 'max-age=0' };
+            }
+            this.resource.client(options).then(
               response => {
                 // Set the retrieved Object onto the Model instance.
                 this.set(response.data);
@@ -298,7 +306,15 @@ export class Collection {
             resolve(this.data);
           } else {
             this.synced = false;
-            this.resource.client({ url: this.url, params: this.getParams }).then(
+            const options = {
+              url: this.url,
+              params: this.getParams,
+            };
+            if (force) {
+              // Ensure the request reaches the backend.
+              options.headers = { 'Cache-Control': 'max-age=0' };
+            }
+            this.resource.client(options).then(
               response => {
                 // Set response object - an Array - on the Collection to record the data.
                 // First check that the response *is* an Array

--- a/kolibri/core/assets/test/api-resource.spec.js
+++ b/kolibri/core/assets/test/api-resource.spec.js
@@ -268,6 +268,16 @@ describe('Collection', function() {
               done();
             });
           });
+          it('should call the client without caching disabled', function(done) {
+            collection.synced = false;
+            collection.fetch().then(() => {
+              expect(client).toHaveBeenCalledWith({
+                url: 'test',
+                params: {},
+              });
+              done();
+            });
+          });
           it('should call clearCache once', function(done) {
             collection.synced = false;
             collection.fetch().then(() => {
@@ -331,6 +341,16 @@ describe('Collection', function() {
             collection.synced = false;
             collection.fetch().then(() => {
               expect(client).toHaveBeenCalledTimes(1);
+              done();
+            });
+          });
+          it('should call the client without caching disabled', function(done) {
+            collection.synced = false;
+            collection.fetch().then(() => {
+              expect(client).toHaveBeenCalledWith({
+                url: 'test',
+                params: {},
+              });
               done();
             });
           });
@@ -445,13 +465,26 @@ describe('Collection', function() {
       });
     });
     describe('if called with force true and synced is true', function() {
-      it('should call the client once', function(done) {
+      beforeEach(function() {
         response = { data: [{ testing: 'testing' }] };
         client = jest.fn().mockResolvedValue(response);
         resource.client = client;
+      });
+      it('should call the client once', function(done) {
         collection.synced = true;
         collection.fetch({}, true).then(() => {
           expect(client).toHaveBeenCalledTimes(1);
+          done();
+        });
+      });
+      it('should call the client with caching disabled', function(done) {
+        collection.synced = true;
+        collection.fetch({}, true).then(() => {
+          expect(client).toHaveBeenCalledWith({
+            url: 'test',
+            params: {},
+            headers: { 'Cache-Control': 'max-age=0' },
+          });
           done();
         });
       });
@@ -887,6 +920,16 @@ describe('Model', function() {
           await model.fetch();
           expect(client).toHaveBeenCalledTimes(1);
         });
+        it('should call the client without caching disabled', function(done) {
+          model.synced = false;
+          model.fetch().then(() => {
+            expect(client).toHaveBeenCalledWith({
+              url: 'modelUrl',
+              params: {},
+            });
+            done();
+          });
+        });
         it('should call set once', function(done) {
           model.synced = false;
           model.fetch().then(() => {
@@ -954,14 +997,27 @@ describe('Model', function() {
       });
     });
     describe('if called with force true and synced is true', function() {
-      it('should call the client once', function(done) {
+      beforeEach(function() {
         response = { data: [{ testing: 'testing' }] };
         client = jest.fn();
         client.mockResolvedValue(response);
         resource.client = client;
+      });
+      it('should call the client once', function(done) {
         model.synced = true;
         model.fetch({}, true).then(() => {
           expect(client).toHaveBeenCalledTimes(1);
+          done();
+        });
+      });
+      it('should call the client with caching disabled', function(done) {
+        model.synced = true;
+        model.fetch({}, true).then(() => {
+          expect(client).toHaveBeenCalledWith({
+            url: 'modelUrl',
+            params: {},
+            headers: { 'Cache-Control': 'max-age=0' },
+          });
           done();
         });
       });


### PR DESCRIPTION
If the app makes a forced resource fetch, ensure the request reaches the backend without using the browser cache by setting the `Cache-Control` header to `max-age=0`. that `max-age=0` is preferred to `no-cache` since the browser will still add an `If-No-Match` header that allows the backend to return a 304 with no content and avoid the data transfer.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Frontend resource fetches can be returned from the browser cache even when using `force: true`. This is particularly with content resources that have 1 year TTLs on their responses. Currently this is avoided by using the `contentCacheKey` query parameter, but that requires the backend to update it and the frontend to reload since it's provided to JS via static HTML.

By setting `Cache-Control: max-age=0` on forced fetches, the request is guaranteed to bypass the browser cache and reach the backend. Since the browser will still add an `If-None-Match` header with the previously received `ETag`, the backend can still respond with a 304 to indicate no update and let the browser use its cached value if the `ETag` hasn't changed. However, if the cache key has changed, the backend will perform the view function as desired by the frontend.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/endlessm/kolibri-explore-plugin/pull/654

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Start a kolibri server with some content and open a browser with devtools. In the console, repeatedly run `await fetch('http://127.0.0.1:8080/api/content/channel/') and note in the network window that it's being served from the browser cache. Meanwhile, import a new content node with `kolibri manage importcontent`. Note that the `fetch` requests in the console will continue to use the browser cache response. Now run `await fetch('http://127.0.0.1:8080/api/content/channel', { headers: { "Cache-Control": "max-age=0" }})` and note that the request is not served from the browser cache.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
