### PR TITLE
Always update content cache key after channel import

### DIFF
--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -9,6 +9,7 @@ from ...utils import paths
 from ...utils.annotation import update_content_metadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
+from kolibri.core.device.models import ContentCacheKey
 from kolibri.core.errors import KolibriUpgradeError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.utils import conf
@@ -214,10 +215,14 @@ class Command(AsyncCommand):
                     import_ran = import_channel_by_id(
                         channel_id, self.is_cancelled, contentfolder
                     )
-                    if node_ids and import_ran:
-                        # annotate default channel db based on previously annotated leaf nodes
-                        update_content_metadata(channel_id, node_ids=node_ids)
                     if import_ran:
+                        if node_ids:
+                            # annotate default channel db based on previously annotated leaf nodes
+                            update_content_metadata(channel_id, node_ids=node_ids)
+                        else:
+                            # ensure the channel is available to the frontend
+                            ContentCacheKey.update_cache_key()
+
                         # Clear any previously set channel availability stats for this channel
                         clear_channel_stats(channel_id)
                 except channel_import.ImportCancelError:


### PR DESCRIPTION
When a channel is imported, the content cache key needs to be updated so clients won't receive stale content from `ChannelMetadataViewSet`. Currently that only happens if the channel has content nodes, but that would preclude a client from discovering a new channel and offering it as available to download resources for. Clients can still query the `ChannelMetadataViewSet` endpoint with the `available` parameter if they prefer to only see channels that already have resources.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

See above commit message.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://github.com/endlessm/kolibri-explore-plugin/pull/654

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Start a kolibri server, request `/api/content/channel/` with `curl -I`. Note the `ETag` response header. Run `kolibri manage importchannel <newchannel>` to import a new channel. Make the request again with `curl` and note the `ETag` never changes.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
