### PR TITLE
Fetch points and display points on non-small breakpoints.

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -61,6 +61,9 @@
                 icon="pointsActive"
                 :ariaLabel="$tr('pointsAriaLabel')"
               />
+              <div v-if="!windowIsSmall" class="points-description">
+                {{ $formatNumber(totalPoints) }}
+              </div>
               <div
                 v-if="pointsDisplayed"
                 class="points-popover"
@@ -109,7 +112,7 @@
 
 <script>
 
-  import { mapGetters, mapState } from 'vuex';
+  import { mapActions, mapGetters, mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
@@ -129,8 +132,8 @@
     },
     mixins: [commonCoreStrings, navComponentsMixin],
     setup() {
-      const { windowIsLarge } = useKResponsiveWindow();
-      return { themeConfig, windowIsLarge };
+      const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
+      return { themeConfig, windowIsLarge, windowIsSmall };
     },
     props: {
       title: {
@@ -155,6 +158,7 @@
       },
     },
     created() {
+      this.fetchPoints();
       window.addEventListener('click', this.handleWindowClick);
       window.addEventListener('keydown', this.handlePopoverByKeyboard, true);
     },
@@ -163,6 +167,7 @@
       window.removeEventListener('keydown', this.handlePopoverByKeyboard, true);
     },
     methods: {
+      ...mapActions(['fetchPoints']),
       handleWindowClick(event) {
         if (this.$refs.pointsButton && this.$refs.pointsButton.$el) {
           if (!this.$refs.pointsButton.$el.contains(event.target) && this.pointsDisplayed) {
@@ -316,6 +321,12 @@
     z-index: 24;
     font-size: 12px;
     border-radius: 8px;
+  }
+
+  .points-description {
+    display: inline-block;
+    margin-left: 8px;
+    font-size: 14px;
   }
 
 </style>


### PR DESCRIPTION
## Summary
* Fetches points for display in the AppBar component
* Displays points for non-small breakpoints in the AppBar component

## References
Fixes #10908

## Reviewer guidance
Mobile breakpoint:
![Screenshot from 2023-06-27 20-29-55](https://github.com/learningequality/kolibri/assets/1680573/8fe5dd34-699d-492d-a18f-ba02970be670)

Larger breakpoint:
![Screenshot from 2023-06-27 20-30-15](https://github.com/learningequality/kolibri/assets/1680573/573a5c10-75b8-4dc8-9900-0b1c45396f9c)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
