### PR TITLE
Do release artifact uploads individually to allow assets to be uploaded in spite of failures.

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -8,12 +8,24 @@ jobs:
   whl:
     name: Build WHL file
     uses: ./.github/workflows/build_whl.yml
+  upload_whl:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: whl
+    with:
+      filename: ${{ needs.whl.outputs.whl-file-name }}
+      release_id: ${{ github.event.release.id }}
   pex:
     name: Build PEX file
     needs: whl
     uses: ./.github/workflows/build_pex.yml
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
+  upload_pex:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: pex
+    with:
+      filename: ${{ needs.pex.outputs.pex-file-name }}
+      release_id: ${{ github.event.release.id }}
   dmg:
     name: Build DMG file
     needs: whl
@@ -28,6 +40,12 @@ jobs:
       KOLIBRI_MAC_APP_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_MAC_APP_CERTIFICATE_PASSWORD }}
       KOLIBRI_MAC_APP_USERNAME: ${{ secrets.KOLIBRI_MAC_APP_USERNAME }}
       KOLIBRI_MAC_APP_PASSWORD: ${{ secrets.KOLIBRI_MAC_APP_PASSWORD }}
+  upload_dmg:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: dmg
+    with:
+      filename: ${{ needs.dmg.outputs.dmg-file-name }}
+      release_id: ${{ github.event.release.id }}
   deb:
     name: Build DEB file
     needs: whl
@@ -35,6 +53,12 @@ jobs:
     with:
       tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
       ref: master
+  upload_deb:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: deb
+    with:
+      filename: ${{ needs.deb.outputs.deb-file-name }}
+      release_id: ${{ github.event.release.id }}
   exe:
     name: Build EXE file
     needs: whl
@@ -46,6 +70,12 @@ jobs:
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}
+  upload_exe:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: exe
+    with:
+      filename: ${{ needs.exe.outputs.exe-file-name }}
+      release_id: ${{ github.event.release.id }}
   zip:
     name: Build Raspberry Pi Image
     needs: deb
@@ -53,6 +83,12 @@ jobs:
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
       ref: master
+  upload_zip:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: zip
+    with:
+      filename: ${{ needs.zip.outputs.zip-file-name }}
+      release_id: ${{ github.event.release.id }}
   test_pypi_upload:
     name: Upload to TestPyPi
     needs: whl
@@ -66,33 +102,6 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  github_upload:
-    name: Upload to Github release
-    runs-on: ubuntu-latest
-    needs: [whl, pex, dmg, deb, exe, zip]
-    strategy:
-      matrix:
-        filename: [
-          '${{ needs.whl.outputs.whl-file-name }}',
-          '${{ needs.whl.outputs.tar-file-name }}',
-          '${{ needs.pex.outputs.pex-file-name }}',
-          '${{ needs.dmg.outputs.dmg-file-name }}',
-          '${{ needs.deb.outputs.deb-file-name }}',
-          '${{ needs.exe.outputs.exe-file-name }}',
-          '${{ needs.zip.outputs.zip-file-name }}',
-        ]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Download ${{ matrix.filename }} artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.filename }}
-          path: dist
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            const utils = require('./.github/githubUtils.js')
-            await utils.uploadReleaseAsset(github, context, 'dist/${{ matrix.filename }}', '${{ github.event.release.id }}')
   block_release_step:
   # This step ties to the release environment which requires manual approval
   # before it can execute. Once manual approval has been granted, the release is

--- a/.github/workflows/upload_github_release_asset.yml
+++ b/.github/workflows/upload_github_release_asset.yml
@@ -1,0 +1,28 @@
+name: Upload Release Asset to GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      filename:
+        required: true
+        type: string
+      release_id:
+        required: true
+        type: string
+
+jobs:
+  github_upload:
+    name: Upload to Github release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download ${{ inputs.filename }} artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.filename }}
+          path: dist
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const utils = require('./.github/githubUtils.js')
+            await utils.uploadReleaseAsset(github, context, 'dist/${{ inputs.filename }}', '${{ inputs.release_id }}')


### PR DESCRIPTION
## Summary
* Splits out release asset upload to the Github release into a reusable workflow
* Reuses it in a separate job for each built asset to allow assets to be uploaded to the release as they are created, rather than waiting for all asset jobs to complete