### PR TITLE
Prevent errors when running with a non-0.0.0.0 address binding.

### DIFF
--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -279,6 +279,10 @@ class ZeroConfPlugin(Monitor):
             # Only bother doing dynamic updates of the zeroconf service if we're bound
             # to all available IP addresses.
             Monitor.__init__(self, bus, self.run, frequency=5)
+        else:
+            # Otherwise do a dummy initialization
+            # A frequency of less than 0 will prevent the monitor from running
+            Monitor.__init__(self, bus, None, frequency=-1)
         self.bus.subscribe("SERVING", self.SERVING)
         self.bus.subscribe("UPDATE_ZEROCONF", self.UPDATE_ZEROCONF)
         self.broadcast = None


### PR DESCRIPTION
## Summary
* Still run the __init__ method for the parent class of the ZeroConfPlugin but do it in a way that prevents the polling behaviour

## References
Fixes [#10893](https://github.com/learningequality/kolibri/issues/10893)

## Reviewer guidance
Run `KOLIBRI_LISTEN_ADDRESS=127.0.0.1 kolibri start --foreground` and ensure that it does not error during startup

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
