### PR TITLE
Add automatic release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: What's Changed
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Adds an automatic release notes template as per: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations