### PR TITLE
remove unneeded param

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -313,8 +313,7 @@
       nextContentNodeRoute() {
         return this.genContentLinkKeepCurrentBackLink(
           this.nextContentNode.id,
-          this.nextContentNode.is_leaf,
-          true
+          this.nextContentNode.is_leaf
         );
       },
     },


### PR DESCRIPTION
## Summary
Remove legacy param that was causing a wrong device query when suggesting a new resource after one is completed.

It seems the refactoring done at https://github.com/learningequality/kolibri/pull/9910/files#diff-36e5f47e4bc1b5cbb0de9ee8e319318e7bcc61cd9e057c5227b1af1ba0f5f890 added this `true` param to the route fetch. Probably confused with some of the legacy params of the removed function

## References
Closes: #10925 

## Reviewer guidance
Follow video at #10925 to check if the behaviour is correct now.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
