### PR TITLE
Remove uncleaned up kwarg.

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -511,7 +511,6 @@ def diskimport(
         drive_id=drive_id,
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
-        import_updates=update,
         fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,
     )


### PR DESCRIPTION
## Summary
* A kwarg that is now being handled by switching out the resource import manager class was still being passed into the manager class __init__
* Removes the unneeded kwarg

## References
Fixes [#10934](https://github.com/learningequality/kolibri/issues/10934)

## Reviewer guidance
Import an entire channel from USB.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
