### PR TITLE
Fix buttons running together on the post setup modal

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -77,8 +77,6 @@
       </template>
     </template>
 
-    <slot name="underbuttons"></slot>
-
     <template #actions>
       <KFixedGrid
         class="actions"
@@ -121,14 +119,16 @@
       </KFixedGrid>
     </template>
 
-    <KButton
-      v-show="!newDeviceButtonDisabled && !formDisabled"
-      class="new-device-button"
-      :text="getCommonSyncString('addNewAddressAction')"
-      appearance="basic-link"
-      @click="$emit('click_add_address')"
-    />
-
+    <KButtonGroup class="under-buttons">
+      <slot name="underbuttons"></slot>
+      <KButton
+        v-show="!newDeviceButtonDisabled && !formDisabled"
+        class="new-device-button"
+        :text="getCommonSyncString('addNewAddressAction')"
+        appearance="basic-link"
+        @click="$emit('click_add_address')"
+      />
+    </KButtonGroup>
   </KModal>
 
 </template>
@@ -462,6 +462,11 @@
   .loader {
     position: relative;
     top: 12px;
+  }
+
+  .under-buttons {
+    /* align button group with the form content */
+    margin-left: -8px;
   }
 
 </style>


### PR DESCRIPTION
## Summary

| Before | After |
| --------- | ------ |
| ![before](https://github.com/learningequality/kolibri/assets/13509191/7fe2f1fe-5de0-423d-9c63-9d3dcf55f87f) | ![after](https://github.com/learningequality/kolibri/assets/13509191/b3c9c8d1-e5e5-4b48-8874-e374fc54498d) |

## References

Fixes https://github.com/learningequality/kolibri/issues/10886

## Reviewer guidance

I wasn't able to test it in a regular way due to https://github.com/learningequality/kolibri/issues/10959, so you may run into the same problem too. I needed to temporarily tweak several places in the code responsible for displaying the modal to be able to preview it and make these fixes.

It's possible https://github.com/learningequality/kolibri/issues/10959 is only happening under certain circumstances so you can give it a try by

1. Start a first facility
2. Start a fresh instance of a second facility. In the setup wizard, follow _Group learning_ > _Full device_ > _Import all data from an existing learning facility_ and import data from the first facility.
3. After you're redirected to the _Device Channels_ page, click _Continue_ on the _Welcome_ modal
4. Preview the _Select a source_ modal

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
