### PR TITLE
Composable translators

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -92,9 +92,35 @@ A pattern we use in order to avoid having to define the same string across multi
 
 In order to avoid bloating the common modules, we typically will not add a string we are duplicating to a common module unless it is being used across three or more files.
 
-Common strings modules should typically have the following components:
+Common strings modules should typically have a translator created using the ``createTranslator`` function in which strings are defined - these can then be used in the setup function of a component to expose specific strings as functions:
 
-- A translator created using the ``createTranslator`` function in which strings are defined.
+.. code-block:: javascript
+
+  import commonStringsModule from '../common/commonStringsModule';
+
+
+  export default {
+    name: 'someComponent',
+    setup() {
+      const { myCoolString$, stringWithArgument$ } = commonStringsModule();
+      return {
+        myCoolString$, stringWithArgument$
+      };
+    },
+  };
+
+.. code-block:: html
+
+  <template>
+    <div>
+      <p>{{ myCoolString$() }}</p>
+      <p>{{ stringWithArgument$({ count: 4 }) }}</p>
+    </div>
+  </template>
+
+
+Previously, this has been handled via mixins, which has required this additional complexity in the modules. You may see modules that include the translator object and the following:
+
 - An exported function that accepts a ``string`` and an ``object`` - which it then passes to the ``$tr()`` function to get a string from the translator in the module.
 - An exported Vue mixin that exposes the exported function as a ``method``. This allows Vue components to use the mixin and have the exported function to get a translated string readily at hand easily.
 

--- a/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
+++ b/kolibri/core/assets/src/mixins/__test__/notificationStrings.spec.js
@@ -25,7 +25,7 @@ describe('Coach Notification Strings', () => {
   // Test that the rest of the messages don't need paramaters
   it('The other notification strings do not require params', () => {
     const paramMsgs = pluralTestCases.map(([key]) => key);
-    Object.keys(NotificationStrings.defaultMessages).forEach(key => {
+    Object.keys(NotificationStrings._defaultMessages).forEach(key => {
       if (paramMsgs.includes(key)) {
         expect(() => {
           NotificationStrings.$tr(key);

--- a/kolibri/core/assets/src/utils/i18n.js
+++ b/kolibri/core/assets/src/utils/i18n.js
@@ -132,13 +132,16 @@ class Translator {
    * @param {object} defaultMessages - an object mapping message ids to default messages.
    */
   constructor(nameSpace, defaultMessages) {
-    this.nameSpace = nameSpace;
-    this.defaultMessages = defaultMessages;
+    this._nameSpace = nameSpace;
+    this._defaultMessages = defaultMessages;
+    for (const key in defaultMessages) {
+      this[`${key}$`] = this.$tr.bind(this, key);
+    }
   }
   $tr(messageId, args) {
     return $trWrapper(
-      this.nameSpace,
-      this.defaultMessages,
+      this._nameSpace,
+      this._defaultMessages,
       Vue.prototype.$formatMessage,
       messageId,
       args

--- a/kolibri/plugins/learn/assets/src/composables/useDevices.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDevices.js
@@ -13,12 +13,14 @@ import { learnStrings } from '../views/commonLearnStrings';
 // The refs are defined in the outer scope so they can be used as a shared store
 const currentDevice = ref(null);
 
+const { kolibriLibrary$ } = learnStrings;
+
 const KolibriStudioDeviceData = {
   id: KolibriStudioId,
   instance_id: KolibriStudioId,
   base_url: plugin_data.studio_baseurl,
   get device_name() {
-    return learnStrings.$tr('kolibriLibrary');
+    return kolibriLibrary$();
   },
 };
 


### PR DESCRIPTION
## Summary
* Adds a destructurable interface to Translator objects so that they expose each message within themselves as an invocable function, keyed as `<message_id>$`
* Adds an example of use

