### PR TITLE
Prevent and consolidate duplicated attempt logs for coach assigned and practice quizzes

### DIFF
--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -675,6 +675,36 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
             **interaction
         )
 
+    def _get_attemptlog(self, session_id, masterylog_id, user, interaction):
+        if "id" in interaction:
+            try:
+                return AttemptLog.objects.get(
+                    id=interaction["id"],
+                    masterylog_id=masterylog_id,
+                    user=user,
+                )
+            except AttemptLog.DoesNotExist:
+                raise ValidationError("Invalid attemptlog id specified")
+        elif interaction.get("replace", False):
+            try:
+                if user:
+                    return AttemptLog.objects.get(
+                        masterylog_id=masterylog_id,
+                        user=user,
+                        item=interaction["item"],
+                    )
+                else:
+                    # If this is an anonymous user, then the best we can do is
+                    # try to update any previous attempt from this session.
+                    return AttemptLog.objects.get(
+                        masterylog_id=masterylog_id,
+                        sessionlog_id=session_id,
+                        user=user,
+                        item=interaction["item"],
+                    )
+            except AttemptLog.DoesNotExist:
+                pass
+
     def _update_or_create_attempts(
         self, session_id, masterylog_id, user, interactions, end_timestamp, context
     ):
@@ -691,16 +721,11 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 "_morango_dirty_bit",
             }
             item_interactions = list(item_interactions)
-            if "id" in item_interactions[0]:
-                try:
-                    attemptlog = AttemptLog.objects.get(
-                        id=item_interactions[0]["id"],
-                        masterylog_id=masterylog_id,
-                        user=user,
-                    )
-                except AttemptLog.DoesNotExist:
-                    raise ValidationError("Invalid attemptlog id specified")
-            else:
+            attemptlog = self._get_attemptlog(
+                session_id, masterylog_id, user, item_interactions[0]
+            )
+
+            if attemptlog is None:
                 attemptlog = self._create_attempt(
                     session_id,
                     masterylog_id,

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -696,10 +696,11 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 else:
                     # If this is an anonymous user, then the best we can do is
                     # try to update any previous attempt from this session.
+                    # In this case, both the user and masterylog_id will be null.
                     return AttemptLog.objects.get(
-                        masterylog_id=masterylog_id,
+                        masterylog_id__isnull=True,
                         sessionlog_id=session_id,
-                        user=user,
+                        user__isnull=True,
                         item=interaction["item"],
                     )
             except AttemptLog.DoesNotExist:

--- a/kolibri/core/logger/kolibri_plugin.py
+++ b/kolibri/core/logger/kolibri_plugin.py
@@ -53,7 +53,7 @@ class AttemptLogsConsolidationOperation(KolibriVersionedSyncOperation):
             AttemptLog
         )
         logger.info(
-            "Consolidating duplicates in {} AttemptLogs records".format(
+            "Consolidating duplicates in {} AttemptLog records".format(
                 len(attempt_logs_ids)
             )
         )

--- a/kolibri/core/logger/kolibri_plugin.py
+++ b/kolibri/core/logger/kolibri_plugin.py
@@ -2,8 +2,12 @@ import logging
 
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.sync_operations import KolibriVersionedSyncOperation
+from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import ExamLog
+from kolibri.core.logger.utils.attempt_log_consolidation import (
+    consolidate_quiz_attempt_logs,
+)
 from kolibri.core.logger.utils.exam_log_migration import migrate_from_exam_logs
 from kolibri.plugins.hooks import register_hook
 
@@ -35,3 +39,24 @@ class ExamLogsCompatibilityOperation(KolibriVersionedSyncOperation):
 @register_hook
 class LoggerSyncHook(FacilityDataSyncHook):
     cleanup_operations = [ExamLogsCompatibilityOperation()]
+
+
+class AttemptLogsConsolidationOperation(KolibriVersionedSyncOperation):
+    version = "0.16.0"
+
+    def upgrade(self, context):
+        """
+        Consolidates duplicate attempt logs synced from older Kolibri versions
+        :type context: morango.sync.context.LocalSessionContext
+        """
+        attempt_logs_ids = context.transfer_session.get_touched_record_ids_for_model(
+            AttemptLog
+        )
+        logger.info(
+            "Consolidating duplicates in {} AttemptLogs records".format(
+                len(attempt_logs_ids)
+            )
+        )
+        consolidate_quiz_attempt_logs(
+            AttemptLog.objects.filter(id__in=attempt_logs_ids)
+        )

--- a/kolibri/core/logger/test/test_attempt_log_consolidation.py
+++ b/kolibri/core/logger/test/test_attempt_log_consolidation.py
@@ -1,0 +1,162 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import uuid
+from random import choice
+from random import uniform
+
+from django.core.exceptions import MultipleObjectsReturned
+from django.test import TestCase
+from le_utils.constants import exercises
+
+from kolibri.core.auth.test.test_api import FacilityFactory
+from kolibri.core.logger.models import AttemptLog
+from kolibri.core.logger.models import ContentSessionLog
+from kolibri.core.logger.models import ContentSummaryLog
+from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.test.factory_logger import FacilityUserFactory
+from kolibri.core.logger.utils.attempt_log_consolidation import (
+    consolidate_quiz_attempt_logs,
+)
+from kolibri.utils.time_utils import local_now
+
+
+class ConsolidateBase(TestCase):
+    MASTERY_LEVEL = -1
+    MASTERY_CRITERION = {"type": exercises.QUIZ, "coach_assigned": True}
+
+    def setUp(self):
+        self.facility = FacilityFactory.create()
+        self.user = FacilityUserFactory.create(facility=self.facility)
+
+        self.content_id = uuid.uuid4().hex
+        self.node_id = uuid.uuid4().hex
+
+        self.session_log = ContentSessionLog.objects.create(
+            user=self.user,
+            content_id=self.content_id,
+            start_timestamp=local_now(),
+            end_timestamp=local_now(),
+            kind="exercise",
+            extra_fields={
+                "context": {
+                    "quiz_id": self.content_id,
+                    "mastery_level": self.MASTERY_LEVEL,
+                }
+            },
+        )
+        self.summary_log = ContentSummaryLog.objects.create(
+            user=self.user,
+            content_id=self.content_id,
+            start_timestamp=local_now(),
+            end_timestamp=local_now(),
+            kind="exercise",
+        )
+
+        self.mastery_log = MasteryLog.objects.create(
+            mastery_criterion=self.MASTERY_CRITERION,
+            summarylog=self.summary_log,
+            start_timestamp=self.summary_log.start_timestamp,
+            user=self.user,
+            mastery_level=self.MASTERY_LEVEL,
+        )
+        for i in range(3):
+            AttemptLog.objects.create(
+                item="item_{i}".format(i=i),
+                start_timestamp=local_now(),
+                end_timestamp=local_now(),
+                time_spent=uniform(1.0, 10.0),
+                correct=choice([0, 1]),
+                user=self.user,
+                masterylog=self.mastery_log,
+                sessionlog=self.session_log,
+            )
+
+        # Create duplicated AttemptLog instances
+        self.duplicated_item = "duplicate"
+        five_minutes = datetime.timedelta(minutes=5)
+        for i in range(5):
+            AttemptLog.objects.create(
+                item=self.duplicated_item,
+                start_timestamp=local_now() - five_minutes * (i + 2),
+                end_timestamp=local_now() - five_minutes * (-1) ** i * (i + 1),
+                time_spent=uniform(1.0, 10.0),
+                correct=choice([0, 1]),
+                user=self.user,
+                masterylog=self.mastery_log,
+                sessionlog=self.session_log,
+            )
+
+
+class ConsolidateAttemptLogsCoachQuizTestCase(ConsolidateBase, TestCase):
+    MASTERY_LEVEL = -1
+    MASTERY_CRITERION = {"type": exercises.QUIZ, "coach_assigned": True}
+
+    def test_consolidation(self):
+        end_timestamp = (
+            AttemptLog.objects.filter(item=self.duplicated_item)
+            .order_by("-end_timestamp")[0]
+            .end_timestamp
+        )
+        start_timestamp = (
+            AttemptLog.objects.filter(item=self.duplicated_item)
+            .order_by("start_timestamp")[0]
+            .start_timestamp
+        )
+        duplicated_logs = AttemptLog.objects.filter(item=self.duplicated_item).order_by(
+            "-end_timestamp"
+        )
+        time_spent = 0
+        interaction_history = []
+        for log in duplicated_logs:
+            time_spent += log.time_spent
+            interaction_history += log.interaction_history
+
+        kept_id = duplicated_logs[0].id
+        consolidate_quiz_attempt_logs(AttemptLog.objects.all())
+        try:
+            attemptlog = AttemptLog.objects.get(
+                item=self.duplicated_item, user=self.user, masterylog=self.mastery_log
+            )
+        except AttemptLog.DoesNotExist:
+            self.fail("AttemptLog was deleted not consolidated")
+        except MultipleObjectsReturned:
+            self.fail("Multiple AttemptLogs were not consolidated")
+
+        self.assertEqual(attemptlog.start_timestamp, start_timestamp)
+        self.assertEqual(attemptlog.end_timestamp, end_timestamp)
+        self.assertEqual(attemptlog.time_spent, time_spent)
+        self.assertEqual(attemptlog.interaction_history, interaction_history)
+        self.assertEqual(attemptlog.id, kept_id)
+        for i in range(3):
+            try:
+                AttemptLog.objects.get(
+                    item="item_{i}".format(i=i),
+                    user=self.user,
+                    masterylog=self.mastery_log,
+                )
+            except AttemptLog.DoesNotExist:
+                self.fail("AttemptLog was deleted when it was already unique")
+
+
+class ConsolidateAttemptLogsPracticeQuizTestCase(
+    ConsolidateAttemptLogsCoachQuizTestCase
+):
+    MASTERY_CRITERION = {"type": exercises.QUIZ}
+
+
+class ConsolidateAttemptLogsExerciseTestCase(ConsolidateBase, TestCase):
+    """
+    This case is purely to ensure against any consolidation happening for exercises
+    """
+
+    MASTERY_LEVEL = 1
+    MASTERY_CRITERION = {"type": exercises.M_OF_N, "m": 8, "n": 10}
+
+    def test_no_consolidation(self):
+        consolidate_quiz_attempt_logs(AttemptLog.objects.all())
+        self.assertEqual(
+            AttemptLog.objects.filter(item=self.duplicated_item).count(), 5
+        )

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -5,6 +5,7 @@ Also tests whether the users with permissions can create logs.
 """
 import uuid
 
+from django.core.exceptions import MultipleObjectsReturned
 from django.http.cookie import SimpleCookie
 from django.urls import reverse
 from le_utils.constants import content_kinds
@@ -2526,9 +2527,13 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
         self.assertIsNotNone(attempt_id)
         self.assertEqual(attemptlog.id, attempt_id)
         try:
-            attempt = AttemptLog.objects.get(id=attempt_id)
+            attempt = AttemptLog.objects.get(
+                item=self.item, user=self.user, masterylog=self.mastery_log
+            )
         except AttemptLog.DoesNotExist:
-            self.fail("Nonexistent attempt_id returned")
+            self.fail("AttemptLog does not exist")
+        except MultipleObjectsReturned:
+            self.fail("Multiple AttemptLogs created")
         self.assertEqual(attempt.correct, 0)
         self.assertEqual(attempt.answer, {"response": "hinty mchintyson2"})
         self.assertEqual(attempt.time_spent, 10)
@@ -2771,9 +2776,13 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentPracticeQuizTestCase
         self.assertIsNotNone(attempt_id)
         self.assertEqual(attemptlog.id, attempt_id)
         try:
-            attempt = AttemptLog.objects.get(id=attempt_id)
+            attempt = AttemptLog.objects.get(
+                item=self.item, user=self.user, masterylog=self.mastery_log
+            )
         except AttemptLog.DoesNotExist:
-            self.fail("Nonexistent attempt_id returned")
+            self.fail("AttemptLog does not exist")
+        except MultipleObjectsReturned:
+            self.fail("Multiple AttemptLogs created")
         self.assertEqual(attempt.correct, 0)
         self.assertEqual(attempt.answer, {"response": "hinty mchintyson2"})
         self.assertEqual(attempt.time_spent, 10)

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -2486,6 +2486,61 @@ class ProgressTrackingViewSetLoggedInUpdateSessionCoachQuizTestCase(
 
         self.assertEqual(response.status_code, 403)
 
+    def test_update_assessment_session_update_attempt_no_id_updates_not_creates(self):
+        """
+        Quizzes should be unique for attempts/masterylogs, so we should not create a new attempt
+        for the same masterylog/item combination, even if the id is not provided.
+        """
+        timestamp = local_now()
+        hinteraction = {
+            "type": interaction_types.HINT,
+            "answer": {"response": "hinty mchintyson"},
+        }
+        attemptlog = AttemptLog.objects.create(
+            masterylog=self.mastery_log,
+            sessionlog=self.session_log,
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            correct=0,
+            item=self.item,
+            user=self.user,
+            interaction_history=[hinteraction],
+        )
+        response = self._make_request(
+            {
+                "interactions": [
+                    {
+                        "item": self.item,
+                        "answer": {"response": "hinty mchintyson2"},
+                        "hinted": True,
+                        "correct": 0,
+                        "time_spent": 10,
+                        "replace": True,
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        attempt_id = response.json().get("attempts", [{}])[0].get("id")
+        self.assertIsNotNone(attempt_id)
+        self.assertEqual(attemptlog.id, attempt_id)
+        try:
+            attempt = AttemptLog.objects.get(id=attempt_id)
+        except AttemptLog.DoesNotExist:
+            self.fail("Nonexistent attempt_id returned")
+        self.assertEqual(attempt.correct, 0)
+        self.assertEqual(attempt.answer, {"response": "hinty mchintyson2"})
+        self.assertEqual(attempt.time_spent, 10)
+        self.assertEqual(attempt.interaction_history[0], hinteraction)
+        self.assertEqual(
+            attempt.interaction_history[1],
+            {
+                "type": interaction_types.HINT,
+                "answer": {"response": "hinty mchintyson2"},
+            },
+        )
+
     def tearDown(self):
         self.client.logout()
 
@@ -2673,6 +2728,149 @@ class ProgressTrackingViewSetLoggedInUpdateSessionAssessmentPracticeQuizTestCase
                 "type": interaction_types.ANSWER,
                 "answer": {"response": "test"},
                 "correct": 1.0,
+            },
+        )
+
+    def test_update_assessment_session_update_attempt_no_id_updates_not_creates(self):
+        """
+        Quizzes should be unique for attempts/masterylogs, so we should not create a new attempt
+        for the same masterylog/item combination, even if the id is not provided.
+        """
+        timestamp = local_now()
+        hinteraction = {
+            "type": interaction_types.HINT,
+            "answer": {"response": "hinty mchintyson"},
+        }
+        attemptlog = AttemptLog.objects.create(
+            masterylog=self.mastery_log,
+            sessionlog=self.session_log,
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            correct=0,
+            item=self.item,
+            user=self.user,
+            interaction_history=[hinteraction],
+        )
+        response = self._make_request(
+            {
+                "interactions": [
+                    {
+                        "item": self.item,
+                        "answer": {"response": "hinty mchintyson2"},
+                        "hinted": True,
+                        "correct": 0,
+                        "time_spent": 10,
+                        "replace": True,
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        attempt_id = response.json().get("attempts", [{}])[0].get("id")
+        self.assertIsNotNone(attempt_id)
+        self.assertEqual(attemptlog.id, attempt_id)
+        try:
+            attempt = AttemptLog.objects.get(id=attempt_id)
+        except AttemptLog.DoesNotExist:
+            self.fail("Nonexistent attempt_id returned")
+        self.assertEqual(attempt.correct, 0)
+        self.assertEqual(attempt.answer, {"response": "hinty mchintyson2"})
+        self.assertEqual(attempt.time_spent, 10)
+        self.assertEqual(attempt.interaction_history[0], hinteraction)
+        self.assertEqual(
+            attempt.interaction_history[1],
+            {
+                "type": interaction_types.HINT,
+                "answer": {"response": "hinty mchintyson2"},
+            },
+        )
+
+    def test_update_assessment_session_update_attempt_no_id_updates_not_creates_anonymous(
+        self,
+    ):
+        """
+        Quizzes should be unique for attempts/masterylogs, so we should not create a new attempt
+        for the same masterylog/item combination, even if the id is not provided.
+        """
+        self.client.logout()
+        timestamp = local_now()
+        # Create a distractor session log and attempt log to ensure that the correct one is updated.
+        session_log = ContentSessionLog.objects.create(
+            user=None,
+            content_id=self.content_id,
+            channel_id=self.channel_id,
+            start_timestamp=local_now(),
+            end_timestamp=local_now(),
+            kind="exercise",
+            extra_fields={"context": {"node_id": self.node.id, "mastery_level": -1}},
+        )
+        AttemptLog.objects.create(
+            masterylog=None,
+            sessionlog=session_log,
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            correct=0,
+            item=self.item,
+            user=None,
+            interaction_history=[],
+        )
+        # Update self.session_log to ensure _make_request works as expected.
+        self.session_log = ContentSessionLog.objects.create(
+            user=None,
+            content_id=self.content_id,
+            channel_id=self.channel_id,
+            start_timestamp=local_now(),
+            end_timestamp=local_now(),
+            kind="exercise",
+            extra_fields={"context": {"node_id": self.node.id, "mastery_level": -1}},
+        )
+        hinteraction = {
+            "type": interaction_types.HINT,
+            "answer": {"response": "hinty mchintyson"},
+        }
+        attemptlog = AttemptLog.objects.create(
+            masterylog=None,
+            sessionlog=self.session_log,
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            correct=0,
+            item=self.item,
+            user=None,
+            interaction_history=[hinteraction],
+        )
+        response = self._make_request(
+            {
+                "interactions": [
+                    {
+                        "item": self.item,
+                        "answer": {"response": "hinty mchintyson2"},
+                        "hinted": True,
+                        "correct": 0,
+                        "time_spent": 10,
+                        "replace": True,
+                    }
+                ],
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        attempt_id = response.json().get("attempts", [{}])[0].get("id")
+        self.assertIsNotNone(attempt_id)
+        self.assertEqual(attemptlog.id, attempt_id)
+        try:
+            attempt = AttemptLog.objects.get(id=attempt_id)
+        except AttemptLog.DoesNotExist:
+            self.fail("Nonexistent attempt_id returned")
+        self.assertEqual(attempt.correct, 0)
+        self.assertEqual(attempt.answer, {"response": "hinty mchintyson2"})
+        self.assertEqual(attempt.time_spent, 10)
+        self.assertEqual(attempt.interaction_history[0], hinteraction)
+        self.assertEqual(
+            attempt.interaction_history[1],
+            {
+                "type": interaction_types.HINT,
+                "answer": {"response": "hinty mchintyson2"},
             },
         )
 

--- a/kolibri/core/logger/upgrade.py
+++ b/kolibri/core/logger/upgrade.py
@@ -1,8 +1,12 @@
 """
 A file to contain specific logic to handle version upgrades in Kolibri.
 """
+from kolibri.core.logger.models import AttemptLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import ExamLog
+from kolibri.core.logger.utils.attempt_log_consolidation import (
+    consolidate_quiz_attempt_logs,
+)
 from kolibri.core.logger.utils.exam_log_migration import migrate_from_exam_logs
 from kolibri.core.notifications.api import parse_summarylog
 from kolibri.core.notifications.api import quiz_completed_notification
@@ -44,3 +48,12 @@ def fix_asymptotic_progress():
         if not quiz:
             # If this isn't a quiz generate the appropriate completion notification for the resource.
             parse_summarylog(summarylog)
+
+
+@version_upgrade(old_version="<0.16.0")
+def fix_duplicated_attempt_logs():
+    """
+    Migrate any AttemptLogs for Quizzes and PracticeQuizzes that have been duplicated - i.e. have the same
+    item and non-null masterylog_id.
+    """
+    consolidate_quiz_attempt_logs(AttemptLog.objects.all())

--- a/kolibri/core/logger/utils/attempt_log_consolidation.py
+++ b/kolibri/core/logger/utils/attempt_log_consolidation.py
@@ -1,0 +1,42 @@
+from django.db import transaction
+from django.db.models import Count
+
+from kolibri.core.logger.models import AttemptLog
+
+
+def consolidate_quiz_attempt_logs(source_logs):
+    """
+    This function checks the attempt logs in the queryset passed in as the sole argument
+    and ensures that they if they are associated with a masterylog and a quiz, that they are not duplicates
+    with other attemptlogs for the same masterylog and the same item value.
+    """
+    source_logs = source_logs.filter(masterylog__mastery_level__lt=0)
+
+    duplicates = (
+        source_logs.values("user", "item", "masterylog")
+        .annotate(count=Count("id"))
+        .filter(count__gt=1)
+    )
+
+    for duplicate in duplicates:
+        with transaction.atomic():
+            duplicate_objects = AttemptLog.objects.filter(
+                user=duplicate["user"],
+                item=duplicate["item"],
+                masterylog=duplicate["masterylog"],
+                # For simplicity, we will keep the most recent attemptlog and consolidate the others into it
+            ).order_by("-end_timestamp")
+            attemptlog_to_keep = duplicate_objects[0]
+            for attemptlog in duplicate_objects[1:]:
+                if attemptlog_to_keep.start_timestamp > attemptlog.start_timestamp:
+                    attemptlog_to_keep.start_timestamp = attemptlog.start_timestamp
+                # Always prepend the interaction history to the attemptlog to keep
+                # as we are keeping the answers for the most recent attempt, and want
+                # to preserve the sequence of attempts leading up to that attempt.
+                attemptlog_to_keep.interaction_history = (
+                    attemptlog.interaction_history
+                    + attemptlog_to_keep.interaction_history
+                )
+                attemptlog_to_keep.time_spent += attemptlog.time_spent
+                attemptlog.delete()
+            attemptlog_to_keep.save()

--- a/kolibri/core/logger/utils/exam_log_migration.py
+++ b/kolibri/core/logger/utils/exam_log_migration.py
@@ -14,6 +14,9 @@ from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import ContentSummaryLog
 from kolibri.core.logger.models import ExamAttemptLog
 from kolibri.core.logger.models import MasteryLog
+from kolibri.core.logger.utils.attempt_log_consolidation import (
+    consolidate_quiz_attempt_logs,
+)
 from kolibri.utils.time_utils import local_now
 
 
@@ -244,6 +247,9 @@ def _handle_unprocessed_attemptlog_ids(unprocessed_attempt_log_ids):
             lambda x: x.masterylog_id,
         ):
             _update_attempt_logs(masterylog_id, logs)
+            consolidate_quiz_attempt_logs(
+                AttemptLog.objects.filter(masterylog_id=masterylog_id)
+            )
 
 
 def migrate_from_exam_logs(source_logs, source_attempt_log_ids=None):  # noqa C901


### PR DESCRIPTION
## Summary
* Fixes potential source of a bug where the resolve/reject stack might cross its wires with subsequent invocations when called frequently
* Updates integrated logging API to enforce updating any existing attempt, when `replace` is set to `True` (as it is for coach assigned and practice quizzes) even when the attempt id is not specified
* Adds tests for the above
* Adds logic to consolidate previously duplicated attempt logs for coach assigned and practice quizzes to remedy previously duplicated data - defers to the attempt with the most recent end_timestamp
* Adds tests for the above
* Adds a syncing hook to check for duplicated attempts after a sync from versions prior to 0.16.0
* Adds an upgrade step to remove duplicated attempts when upgrading from a version prior to 0.16.0
* Adds the consolidation logic into the examlog/examattemptlog migration utilities to remove any historic duplication

## References
Fixes https://github.com/learningequality/kolibri/issues/10804

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
