### PR TITLE
Remote browsing filter fixes

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -11,7 +11,7 @@
       class="main-grid"
       :style="gridOffset"
     >
-      <div v-if="!windowIsLarge && !isLocalLibraryEmpty && !deviceId">
+      <div v-if="!windowIsLarge && (!isLocalLibraryEmpty || deviceId)">
         <KButton
           icon="filter"
           data-test="filter-button"
@@ -190,7 +190,7 @@
 
     <!-- Side Panels for filtering and searching  -->
     <SidePanel
-      v-if="!isLocalLibraryEmpty && !deviceId"
+      v-if="!isLocalLibraryEmpty || deviceId"
       ref="sidePanel"
       data-test="side-panel"
       :searchTerms="searchTerms"
@@ -454,8 +454,7 @@
         if (
           this.windowIsSmall ||
           this.windowIsMedium ||
-          this.isLocalLibraryEmpty ||
-          this.deviceId
+          (this.isLocalLibraryEmpty && !this.deviceId)
         ) {
           return 0;
         } else if (this.windowBreakpoint < 4) {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
@@ -79,7 +79,9 @@
         if (this.topic) {
           return {
             name: PageNames.TOPICS_TOPIC,
-            id: this.topic.id,
+            params: {
+              ...this.$route.params,
+            },
           };
         }
         return {};
@@ -91,7 +93,9 @@
           delete query.dropdown;
           return {
             name: PageNames.TOPICS_TOPIC_SEARCH,
-            id: this.topic.id,
+            params: {
+              ...this.$route.params,
+            },
             query: query,
           };
         }

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -424,19 +424,6 @@
           { text: this.topic.ancestors.length ? this.topic.title : this.channelTitle },
         ];
       },
-      searchTabLink() {
-        // navigates the main page to the search view
-        if (this.topic) {
-          const query = { ...this.$route.query };
-          delete query.dropdown;
-          return {
-            name: PageNames.TOPICS_TOPIC_SEARCH,
-            id: this.topic.id,
-            query: query,
-          };
-        }
-        return {};
-      },
       desktopSearchActive() {
         return this.$route.name === PageNames.TOPICS_TOPIC_SEARCH;
       },
@@ -609,9 +596,6 @@
           return;
         }
         if (!isEqual(newVal, oldVal)) {
-          if (!isEqual(this.searchTabLink, this.$route)) {
-            this.$router.push({ ...this.searchTabLink }).catch(() => {});
-          }
           this.sidePanelIsOpen = false;
         }
       },

--- a/kolibri/utils/kolibri_whitenoise.py
+++ b/kolibri/utils/kolibri_whitenoise.py
@@ -141,7 +141,7 @@ class StreamingStaticFile(EndRangeStaticFile):
     def __init__(self, path, headers, remote_url, encodings=None, stat_cache=None):
         self.path = path
         self.remote_url = remote_url
-        super().__init__(path, headers, encodings, stat_cache)
+        super(StreamingStaticFile, self).__init__(path, headers, encodings, stat_cache)
 
     @staticmethod
     def get_file_stats(path, encodings, stat_cache):


### PR DESCRIPTION
## Summary
* Fixes uncaught Python 2.7 compatibility issue with remote file browsing
* Displays the search side panel for remote libraries on the channels page consistent with spec
* Ensures that the device id parameter is preserved in the Folder and Search header tabs
* Removes a residual guard that was no longer needed and causing an incorrect navigation to a page without the device id parameter

## References
Fixes #10926
Fixes missing search panel referenced in #10931

Spec:
![Screenshot from 2023-07-12 15-27-30](https://github.com/learningequality/kolibri/assets/1680573/6896ae92-255c-4f9a-b454-d494c1be48c1)


## Reviewer guidance
[Screencast from 07-12-2023 08:00:01 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/68ffb8b3-34c1-4b8f-a04e-2aa3b58671ed)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
