### PR TITLE
Update synchronize_content_requests to send only one parameter

### DIFF
--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -1,0 +1,62 @@
+import uuid
+
+import mock
+from django.test import TestCase
+
+from kolibri.core.content.utils.content_request import synchronize_content_requests
+
+
+_module = "kolibri.core.content.utils.content_request."
+
+
+def _facility(dataset_id=None):
+    return mock.MagicMock(id=uuid.uuid4().hex, dataset_id=dataset_id)
+
+
+@mock.patch(_module + "Facility.objects.get", new=_facility)
+class ContentRequestsTestCase(TestCase):
+    def setUp(self):
+        super(ContentRequestsTestCase, self).setUp()
+
+        self.dataset_id = uuid.uuid4().hex
+        self.transfer_session = mock.MagicMock()
+        self.transfer_session.id = uuid.uuid4().hex
+
+    @mock.patch(_module + "ContentAssignmentManager.find_all_removable_assignments")
+    @mock.patch(_module + "ContentAssignmentManager.find_all_downloadable_assignments")
+    def test_synchronize_content_requests__dataset_id_passthrough(
+        self,
+        find_all_downloadable_assignments_mock,
+        find_all_removable_assignments_mock,
+    ):
+        find_all_downloadable_assignments_mock.return_value = []
+        find_all_removable_assignments_mock.return_value = []
+
+        synchronize_content_requests(self.dataset_id, None)
+        find_all_downloadable_assignments_mock.assert_called_once_with(
+            dataset_id=self.dataset_id
+        )
+        find_all_removable_assignments_mock.assert_called_once_with(
+            dataset_id=self.dataset_id
+        )
+
+    @mock.patch(_module + "ContentAssignmentManager.find_all_removable_assignments")
+    @mock.patch(_module + "ContentAssignmentManager.find_all_downloadable_assignments")
+    def test_synchronize_content_requests__transfer_session_id_passthrough(
+        self,
+        find_all_downloadable_assignments_mock,
+        find_all_removable_assignments_mock,
+    ):
+        find_all_downloadable_assignments_mock.return_value = []
+        find_all_removable_assignments_mock.return_value = []
+
+        synchronize_content_requests(
+            self.dataset_id,
+            transfer_session=self.transfer_session,
+        )
+        find_all_downloadable_assignments_mock.assert_called_once_with(
+            transfer_session_id=self.transfer_session.id
+        )
+        find_all_removable_assignments_mock.assert_called_once_with(
+            transfer_session_id=self.transfer_session.id
+        )

--- a/kolibri/core/content/utils/assignment.py
+++ b/kolibri/core/content/utils/assignment.py
@@ -87,9 +87,10 @@ class ContentAssignmentManager(object):
         :param transfer_session_id:
         :rtype: list of ContentAssignment
         """
-
-        if dataset_id is None and transfer_session_id is None:
-            raise ValueError("Either dataset_id or transfer_session_id is required")
+        if (dataset_id is None) == (transfer_session_id is None):
+            raise ValueError(
+                "One parameter needs specified: dataset_id and transfer_session_id"
+            )
 
         for manager in CONTENT_ASSIGNMENT_MANAGER_REGISTRY.values():
             for assignment in manager.find_downloadable_assignments(
@@ -104,9 +105,10 @@ class ContentAssignmentManager(object):
         :param transfer_session_id:optional argument to filter assignments by transfer_session_id
         :rtype: list of ContentAssignment or DeletedAssignment
         """
-
-        if dataset_id is None and transfer_session_id is None:
-            raise ValueError("Either dataset_id or transfer_session_id is required")
+        if (dataset_id is None) == (transfer_session_id is None):
+            raise ValueError(
+                "One parameter needs specified: dataset_id and transfer_session_id"
+            )
 
         for manager in CONTENT_ASSIGNMENT_MANAGER_REGISTRY.values():
             for assignment in manager.find_removable_assignments(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- In writing tests for the `ContentAssignmentManager` in a prior PR from @ozer550, I made it strictly allow only one parameter (either `dataset_id` or `transfer_session_id`) to avoid having to duplicate tests to cover the case when only one parameter was defined, but I forgot to update the usage to only send one parameter
- This updates the usage in `synchronize_content_requests` to only passthrough one parameter, and adds some test coverage on that behavior

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10981

```
"traceback": "Traceback (most recent call last):
  File \"/datos/le/mio/kolibri/venv/lib/python3.10/site-packages/morango/sync/controller.py\", line 254, in _invoke_middleware
    result = middleware(prepared_context)
  File \"/datos/le/mio/kolibri/venv/lib/python3.10/site-packages/morango/registry.py\", line 228, in __call__
    result = operation(context)
  File \"/datos/le/mio/kolibri/venv/lib/python3.10/site-packages/morango/sync/operations.py\", line 942, in __call__
    result = self.handle(context)
  File \"/datos/le/mio/kolibri/kolibri/core/auth/sync_operations.py\", line 38, in handle
    result = operation(context)
  File \"/datos/le/mio/kolibri/venv/lib/python3.10/site-packages/morango/sync/operations.py\", line 942, in __call__
    result = self.handle(context)
  File \"/datos/le/mio/kolibri/kolibri/core/auth/sync_operations.py\", line 130, in handle
    result = self.handle_initial(context)
  File \"/datos/le/mio/kolibri/kolibri/core/content/kolibri_plugin.py\", line 49, in handle_initial
    synchronize_content_requests(dataset_id, context.transfer_session)
  File \"/datos/le/mio/kolibri/kolibri/core/content/utils/content_request.py\", line 76, in synchronize_content_requests
    for assignment in assignments:
  File \"/datos/le/mio/kolibri/kolibri/core/content/utils/assignment.py\", line 95, in find_all_downloadable_assignments
    for assignment in manager.find_downloadable_assignments(
  File \"/datos/le/mio/kolibri/kolibri/core/content/utils/assignment.py\", line 168, in find_downloadable_assignments
    raise ValueError(
ValueError: One parameter needs specified: dataset_id and transfer_session_id
```

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Run a sync or verify the tests cover the issue

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
