### PR TITLE
Relax discovery permissions in SOuD devices

### DIFF
--- a/kolibri/core/discovery/permissions.py
+++ b/kolibri/core/discovery/permissions.py
@@ -1,36 +1,13 @@
 from rest_framework.permissions import BasePermission
 
-from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
-from kolibri.core.device.utils import get_device_setting
-
 
 class NetworkLocationPermissions(BasePermission):
     """
-    A user can access NetworkLocation objects if:
-    1. User can manage content (to get import/export peers)
-    2. User is a facility admin (to be able to sync facility with peer)
-    In not Learner Only Devices, for users to be able to change to another facility,
-    any facility user must be able to discover other facilities
+    A user can access NetworkLocation objects if is a facility user:
     """
 
     def has_permission(self, request, view):
-        subset_of_users_device = get_device_setting(
-            "subset_of_users_device", default=False
-        )
-        if subset_of_users_device:
-            return request.user.can_manage_content or _user_is_admin_for_own_facility(
-                request.user
-            )
-        else:
-            return request.user.is_facility_user
+        return request.user.is_facility_user
 
     def has_object_permission(self, request, view, obj):
-        subset_of_users_device = get_device_setting(
-            "subset_of_users_device", default=False
-        )
-        if subset_of_users_device:
-            return request.user.can_manage_content or _user_is_admin_for_own_facility(
-                request.user
-            )
-        else:
-            return request.user.is_facility_user
+        return request.user.is_facility_user


### PR DESCRIPTION
## Summary
Unrestrict some of the Subset of Users Device permissions to discover network devices. 
After one device has one or more users merged to another facility, this is considered a SoUD. Any remaining FacilityUser must have the ability to explore the network to move to another facility.

## References
Closes: #10661

## Reviewer guidance
Any concern with this less restricted conditions to be able to explore the network in SoUD devices?
Check the issue described in #10661 is fixed now.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
