### PR TITLE
Fix remote browsing language label display in search chips

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useLanguages.js
+++ b/kolibri/plugins/learn/assets/src/composables/useLanguages.js
@@ -10,9 +10,13 @@ import plugin_data from 'plugin_data';
 const langArray = plugin_data.languages ? plugin_data.languages : [];
 const langMap = {};
 
-for (const lang of langArray) {
-  langMap[lang.id] = lang;
+export function setLanguages(langs) {
+  for (const lang of langs) {
+    langMap[lang.id] = lang;
+  }
 }
+
+setLanguages(langArray);
 
 // The refs are defined in the outer scope so they can be used as a shared store
 const languagesMap = ref(langMap);


### PR DESCRIPTION
## Summary
* Stores fetched language filters from remotes in the global languages map
* Tracks the loading state of global label fetching
* Includes this loading state in the overall 'searchLoading' state to prevent premature display of search results before the search has finished loading

## References
Fixes [#10989](https://github.com/learningequality/kolibri/issues/10989)

## Reviewer guidance
Browse Kolibri Studio
Filter by a language that is not available on your local device
Observe properly rendered search chips
Filter by Uncategorized - see similarly.

![Screenshot from 2023-07-18 12-49-00](https://github.com/learningequality/kolibri/assets/1680573/f981f46a-9372-4f31-b1b2-175986e54c24)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
