### PR TITLE
kolibri-tools: Prepend to Python path rather than append

### DIFF
--- a/packages/kolibri-tools/lib/webpack_json.py
+++ b/packages/kolibri-tools/lib/webpack_json.py
@@ -169,7 +169,7 @@ def main():
     plugin_path = os.path.realpath(args.plugin_path)
 
     # Add our plugin_path to the path
-    sys.path.append(plugin_path)
+    sys.path.insert(0, plugin_path)
 
     # Put environment variable setting first to allow customized builds within buildkite through env vars
     if "BUILD_TIME_PLUGINS" in os.environ and os.environ["BUILD_TIME_PLUGINS"]:


### PR DESCRIPTION
## Summary

If the kolibri-tools are supposed to be looking in a certain directory for plugins, that directory needs to be listed first in the Python path, rather than last. Otherwise the tools could end up finding the plugin in a system directory instead — which will probably be the wrong version of it, or the wrong place to write out built files.

## References

None

## Reviewer guidance

I encountered this by:
 * Having [kolibri-explore-plugin](https://github.com/endlessm/kolibri-explore-plugin/) installed in my pyenv
 * Running `yarn build` in it, in pyenv, with my cwd as the source directory
 * Observing that the built webpack files ended up in the installed kolibri-explore-plugin package dir in my pyenv, rather than the kolibri-explore-plugin source directory

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
