### PR TITLE
Prevent unnecessary polling of the network location endpoint when browsing Studio

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -21,11 +21,11 @@
 
 <script>
 
-  import { get, set } from '@vueuse/core';
+  import { set, onBeforeUnmount, useTimeoutPoll } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { useDevices } from 'kolibri.coreVue.componentSets.sync';
   import { RemoteChannelResource } from 'kolibri.resources';
-  import { ref, watch } from 'kolibri.lib.vueCompositionApi';
+  import { ref } from 'kolibri.lib.vueCompositionApi';
   import { KolibriStudioId } from '../constants';
   import commonLearnStrings from './commonLearnStrings';
 
@@ -33,38 +33,44 @@
     name: 'DeviceConnectionStatus',
     mixins: [commonCoreStrings, commonLearnStrings],
     setup(props) {
-      const { isFetching, devices } = useDevices({
-        id: props.deviceId,
-      });
-      const isFetched = ref(false);
-      const allDevices = ref([]);
-
-      const getStudio = async () => {
-        let studio = [];
-        if (props.deviceId === KolibriStudioId) {
+      // Because the network location endpoint doesn't currently report status
+      // about special static locations like Kolibri Studio and KDP, we need to
+      // do a separate check for those.
+      // Once that functionality has been enabled, this can be cleaned up!
+      if (props.deviceId === KolibriStudioId) {
+        const isFetched = ref(false);
+        const allDevices = ref([]);
+        const getStudio = async () => {
           const response = await RemoteChannelResource.getKolibriStudioStatus();
-          const studioData = {
-            ...response.data,
-            id: KolibriStudioId,
-            instance_id: KolibriStudioId,
-          };
-          studio = [studioData];
-        }
-        return studio;
-      };
-
-      watch(isFetching, async currentValue => {
-        if (!get(currentValue)) {
-          const studio = await getStudio();
-          set(allDevices, [...get(devices), ...studio]);
+          set(allDevices, [
+            {
+              ...response.data,
+              id: KolibriStudioId,
+              instance_id: KolibriStudioId,
+            },
+          ]);
           set(isFetched, props.deviceId !== null);
-        }
-      });
+        };
+        // Start polling
+        const fetch = useTimeoutPoll(getStudio, 5000, { immediate: true });
 
-      return {
-        allDevices,
-        isFetched,
-      };
+        // Stop polling
+        onBeforeUnmount(() => {
+          fetch.pause();
+        });
+        return {
+          allDevices,
+          isFetched,
+        };
+      } else {
+        const { hasFetched, devices } = useDevices({
+          id: props.deviceId,
+        });
+        return {
+          allDevices: devices,
+          isFetched: hasFetched,
+        };
+      }
     },
     props: {
       // eslint-disable-next-line kolibri/vue-no-unused-properties

--- a/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
+++ b/kolibri/plugins/learn/assets/src/views/DeviceConnectionStatus.vue
@@ -21,11 +21,11 @@
 
 <script>
 
-  import { set, onBeforeUnmount, useTimeoutPoll } from '@vueuse/core';
+  import { set, useTimeoutPoll } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { useDevices } from 'kolibri.coreVue.componentSets.sync';
   import { RemoteChannelResource } from 'kolibri.resources';
-  import { ref } from 'kolibri.lib.vueCompositionApi';
+  import { ref, onBeforeUnmount } from 'kolibri.lib.vueCompositionApi';
   import { KolibriStudioId } from '../constants';
   import commonLearnStrings from './commonLearnStrings';
 


### PR DESCRIPTION
## Summary
* Further conditionalizes the device connection info setup method to only check for either Studio status or network device status

## References
Fixes unreported issue where the network location endpoint was still being polled even when browsing Studio

## Reviewer guidance
My only concern here was that the setup method would not get reactively re-entered - I think it works OK though because the component gets torn down between the deviceId changing. I tested this by first browsing Studio and checking the fix, then browsing another peer on the network and seeing that the polling did indeed switch to the network location endpoint.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
