### PR TITLE
Compatibility fixes for PDFJS and in general

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
@@ -64,5 +64,6 @@
     margin: 8px;
     text-align: left;
     width: calc(100% - 16px);
+    background: white;
   }
 </style>

--- a/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/ContentRendererError.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div class="container">
     <UiAlert :dismissible="false" class="alert" type="error">
       <span>{{ $tr('rendererNotAvailable') }}</span><br>
       <KButton
@@ -8,6 +8,10 @@
         appearance="basic-link"
         :text="appErrorTranslator.$tr('defaultErrorReportPrompt')"
         @click="showDetailsModal = true"
+      />
+      <DownloadButton
+        class="download-button"
+        :files="files"
       />
     </UiAlert>
     <ReportErrorModal
@@ -26,10 +30,12 @@
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import AppError from 'kolibri-common/components/AppError';
   import ReportErrorModal from 'kolibri-common/components/AppError/ReportErrorModal';
+  import DownloadButton from './DownloadButton';
 
   export default {
     name: 'ContentRendererError',
     components: {
+      DownloadButton,
       ReportErrorModal,
       UiAlert,
     },
@@ -37,6 +43,10 @@
       error: {
         type: Object,
         default: null,
+      },
+      files: {
+        type: Array,
+        default: () => [],
       },
     },
     data() {
@@ -60,6 +70,16 @@
 
 
 <style scoped>
+  .container {
+    background: rgba(0, 0, 0, 0.7);
+    height: 100%;
+    width: 100%;
+  }
+
+  .download-button {
+    float: right;
+  }
+
   .alert {
     margin: 8px;
     text-align: left;

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -21,7 +21,6 @@
 <script>
 
   import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
-  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { getFilePresetString } from './filePresetStrings';
   import { getRenderableFiles } from './utils';
 
@@ -32,10 +31,6 @@
         type: Array,
         default: () => [],
       },
-      contentKind: {
-        type: String,
-        default: '',
-      },
       nodeTitle: {
         type: String,
         default: '',
@@ -43,14 +38,10 @@
     },
     computed: {
       downloadableFiles() {
-        return getRenderableFiles(this.files);
+        return getRenderableFiles(this.files).filter(file => file.preset !== 'exercise');
       },
       canDownload() {
-        return (
-          this.downloadableFiles.length &&
-          this.contentKind !== ContentNodeKinds.EXERCISE &&
-          !isEmbeddedWebView
-        );
+        return !isEmbeddedWebView && this.downloadableFiles.length;
       },
       fileOptions() {
         const options = this.files.map(file => {
@@ -59,7 +50,7 @@
             label,
             url: file.storage_url,
             fileName: this.$tr('downloadFilename', {
-              resourceTitle: this.nodeTitle,
+              resourceTitle: this.nodeTitle.length ? this.nodeTitle : file.checksum,
               fileExtension: file.extension,
               fileId: file.checksum.slice(0, 6),
             }),

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -1,6 +1,7 @@
 <template>
 
   <KButton
+    v-if="canDownload"
     ref="button"
     hasDropdown
     :primary="$attrs.primary"
@@ -19,7 +20,10 @@
 
 <script>
 
+  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
+  import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { getFilePresetString } from './filePresetStrings';
+  import { getRenderableFiles } from './utils';
 
   export default {
     name: 'DownloadButton',
@@ -28,12 +32,26 @@
         type: Array,
         default: () => [],
       },
+      contentKind: {
+        type: String,
+        default: '',
+      },
       nodeTitle: {
         type: String,
         default: '',
       },
     },
     computed: {
+      downloadableFiles() {
+        return getRenderableFiles(this.files);
+      },
+      canDownload() {
+        return (
+          this.downloadableFiles.length &&
+          this.contentKind !== ContentNodeKinds.EXERCISE &&
+          !isEmbeddedWebView
+        );
+      },
       fileOptions() {
         const options = this.files.map(file => {
           const label = getFilePresetString(file);

--- a/kolibri/core/assets/src/views/ContentRenderer/mixin.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/mixin.js
@@ -219,7 +219,7 @@ export default {
         this._errorComponent = new ContentRendererErrorComponent({
           el: domNode,
           parent: this,
-          propsData: { error: this._resourceError },
+          propsData: { error: this._resourceError, files: this.files },
         });
       }
     },

--- a/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearDisplayText.vue
@@ -2,7 +2,7 @@
 
   <KOptionalText
     :text="
-      (isSpecified && birthYear) ? $formatDate(birthYear, { year: 'numeric' }) : ''"
+      birthYearDate ? $formatDate(birthYearDate, { year: 'numeric' }) : ''"
   />
 
 </template>
@@ -27,6 +27,14 @@
     computed: {
       isSpecified() {
         return this.birthYear !== NOT_SPECIFIED && this.birthYear !== DEFERRED;
+      },
+      birthYearDate() {
+        if (!this.isSpecified || !this.birthYear) {
+          return null;
+        }
+        const date = new Date();
+        date.setFullYear(this.birthYear);
+        return date;
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -160,6 +160,7 @@
       };
 
       return {
+        errored,
         progress,
         time_spent,
         extra_fields,

--- a/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
@@ -119,7 +119,6 @@
       v-if="canDownloadContent"
       :files="content.files"
       :nodeTitle="content.title"
-      :contentKind="content.kind"
       class="download-button"
       data-test="download-button"
     />

--- a/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/CurrentlyViewedResourceMetadata.vue
@@ -116,9 +116,10 @@
     </div>
 
     <DownloadButton
-      v-if="canDownload"
-      :files="downloadableFiles"
+      v-if="canDownloadContent"
+      :files="content.files"
       :nodeTitle="content.title"
+      :contentKind="content.kind"
       class="download-button"
       data-test="download-button"
     />
@@ -130,10 +131,9 @@
 
 <script>
 
-  import { ContentNodeKinds, ContentLevels } from 'kolibri.coreVue.vuex.constants';
+  import { ContentLevels } from 'kolibri.coreVue.vuex.constants';
   import camelCase from 'lodash/camelCase';
 
-  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
   import LearnerNeeds from 'kolibri-constants/labels/Needs';
   import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
@@ -189,19 +189,6 @@
           get(this, 'content.license_name', null),
           get(this, 'content.license_description', null)
         );
-      },
-      downloadableFiles() {
-        return this.content.files.filter(file => !file.preset.endsWith('thumbnail'));
-      },
-      canDownload() {
-        if (this.canDownloadContent) {
-          return (
-            this.downloadableFiles.length &&
-            this.content.kind !== ContentNodeKinds.EXERCISE &&
-            !isEmbeddedWebView
-          );
-        }
-        return false;
       },
     },
     mounted() {

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/domPolyfills.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/domPolyfills.js
@@ -1,0 +1,52 @@
+/*
+ * Polyfills for Element.append and Element.prepend
+ * Because Babel and corejs do not polyfill Web APIs, only language features.
+ */
+
+const toPolyfill = [Element.prototype, Document.prototype, DocumentFragment.prototype];
+
+for (const item of toPolyfill) {
+  if (Object.prototype.hasOwnProperty.call(item, 'append')) {
+    continue;
+  }
+  Object.defineProperty(item, 'append', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function append() {
+      const argArr = Array.prototype.slice.call(arguments);
+      const docFrag = document.createDocumentFragment();
+
+      for (const argItem of argArr) {
+        docFrag.appendChild(
+          argItem instanceof Node ? argItem : document.createTextNode(String(argItem))
+        );
+      }
+
+      this.appendChild(docFrag);
+    },
+  });
+}
+
+for (const item of toPolyfill) {
+  if (Object.prototype.hasOwnProperty.call(item, 'prepend')) {
+    continue;
+  }
+  Object.defineProperty(item, 'prepend', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: function prepend() {
+      const argArr = Array.prototype.slice.call(arguments);
+      const docFrag = document.createDocumentFragment();
+
+      for (const argItem of argArr) {
+        docFrag.appendChild(
+          argItem instanceof Node ? argItem : document.createTextNode(String(argItem))
+        );
+      }
+
+      this.insertBefore(docFrag, this.firstChild);
+    },
+  });
+}

--- a/kolibri/plugins/pdf_viewer/assets/src/utils/domPolyfills.js
+++ b/kolibri/plugins/pdf_viewer/assets/src/utils/domPolyfills.js
@@ -9,6 +9,7 @@ for (const item of toPolyfill) {
   if (Object.prototype.hasOwnProperty.call(item, 'append')) {
     continue;
   }
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/append
   Object.defineProperty(item, 'append', {
     configurable: true,
     enumerable: true,
@@ -32,6 +33,7 @@ for (const item of toPolyfill) {
   if (Object.prototype.hasOwnProperty.call(item, 'prepend')) {
     continue;
   }
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Element/prepend
   Object.defineProperty(item, 'prepend', {
     configurable: true,
     enumerable: true,

--- a/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/PdfRendererIndex.spec.js
@@ -85,7 +85,7 @@ describe('PdfRendererIndex', () => {
       makeWrapper({
         data: { defaultFile: { storage_url: DUMMY_PDF_URL } },
       });
-      expect(mockPDFJS.getDocument).toHaveBeenCalledWith(DUMMY_PDF_URL);
+      expect(mockPDFJS.getDocument.mock.calls[0][0].url).toEqual(DUMMY_PDF_URL);
     });
 
     it('should get the pdf Document Outline', async () => {

--- a/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
+++ b/kolibri/plugins/pdf_viewer/assets/tests/mocks/pdfjsMock.js
@@ -42,4 +42,10 @@ export const AnnotationMode = {
   ENABLE_FORMS: 'ENABLE_FORMS',
 };
 
+export class PDFWorker {
+  constructor() {
+    this.promise = Promise.resolve();
+  }
+}
+
 /* eslint-enable */

--- a/packages/kolibri-tools/babel.config.js
+++ b/packages/kolibri-tools/babel.config.js
@@ -4,9 +4,10 @@ module.exports = {
       '@babel/preset-env',
       {
         useBuiltIns: 'entry',
-        corejs: '3.13',
+        corejs: '3.31',
       },
     ],
   ],
   plugins: ['@babel/plugin-syntax-import-assertions'],
+  sourceType: 'unambiguous',
 };

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -71,7 +71,11 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
     rules.push({
       test: /\.(js|mjs)$/,
       loader: 'babel-loader',
-      exclude: { and: [/(node_modules\/vue|dist|core-js)/, { not: [/\.(esm\.js|mjs)$/] }] },
+      exclude: [
+        // \\ for Windows, / for macOS and Linux
+        /node_modules[\\/]core-js/,
+        /node_modules[\\/]webpack[\\/]buildin/,
+      ],
       options: {
         cacheDirectory: cache,
         cacheCompression: false,

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -72,6 +72,7 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
       test: /\.(js|mjs)$/,
       loader: 'babel-loader',
       exclude: [
+        // From: https://webpack.js.org/loaders/babel-loader/#exclude-libraries-that-should-not-be-transpiled
         // \\ for Windows, / for macOS and Linux
         /node_modules[\\/]core-js/,
         /node_modules[\\/]webpack[\\/]buildin/,

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -31,7 +31,7 @@
     "chokidar": "^3.5.3",
     "cli-table": "^0.3.11",
     "commander": "^11.0.0",
-    "core-js": "3",
+    "core-js": "^3",
     "css-loader": "6.8.1",
     "css-minimizer-webpack-plugin": "5.0.1",
     "csv-parse": "^5.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3949,7 +3949,7 @@ core-js-compat@^3.31.0:
   dependencies:
     browserslist "^4.21.9"
 
-core-js@3, core-js@3.31, core-js@^3.31:
+core-js@3.31, core-js@^3, core-js@^3.31:
   version "3.31.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.31.1.tgz#f2b0eea9be9da0def2c5fece71064a7e5d687653"
   integrity sha512-2sKLtfq1eFST7l7v62zaqXacPc7uG8ZAya8ogijLhTtaKNcpzpB4TMoTw2Si+8GYKRwFPMMtUT0263QFWFfqyQ==


### PR DESCRIPTION
## Summary
* Transpiles all frontend code, only excluding very specific modules as per documentation recommendations
* Switches babel preset-env to insert polyfills at usage, rather than importing polyfills for every single ECMA version in the core bundle - this should reduce the size of the core bundle slightly, and may lead to some duplication across bundles, but overall should ensure that we are polyfilling the right things
* Cleans up Download button logic to encapsulate more in the component
* Fixes an issue where the errored reactive state was not exposed on the component in `ContentPage` to be toggled when an error occurred
* Removes use of content kind in the download button and instead exclude exercise files based on their preset
* Puts the DownloadButton into the ContentRenderError component giving people the option to download the file instead
* Tweaks the PDFJS rendering to ensure that errors during Worker loading on IE11 are properly reported in a way that can expose the ContentRendererError component

## References
Fixes [#10707](https://github.com/learningequality/kolibri/issues/10707)
Fixes [#10692](https://github.com/learningequality/kolibri/issues/10692)

## Reviewer guidance
Test on IE11, view a PDF, and see this:
![Screenshot from 2023-07-20 12-25-49](https://github.com/learningequality/kolibri/assets/1680573/ac28d545-b795-4f72-bc18-28627360e63a)

Test on Chrome/Safari on older iOS devices (as detailed in #10692).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
