### PR TITLE
Update user agent for NetworkClient()

### DIFF
--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -308,7 +308,9 @@ class NetworkClientTestCase(TestCase):
         response = client.get("/")
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("Kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"])
+        self.assertTrue(
+            "Kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"]
+        )
 
     @mock.patch.object(
         requests.Session, "request", mock_happy_request("https://url.qqq/")

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -304,11 +304,11 @@ class NetworkClientTestCase(TestCase):
 
     @mock.patch.object(requests.Session, "get", mock_response(200))
     def test_request__user_agent(self):
-        client = NetworkClient()
-        response = client.get("https://example.com")
+        client = NetworkClient("https://example.com")
+        response = client.get("/")
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue("kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"])
+        self.assertTrue("Kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"])
 
     @mock.patch.object(
         requests.Session, "request", mock_happy_request("https://url.qqq/")

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -2,6 +2,7 @@ import mock
 import requests
 from django.test import TestCase
 
+import kolibri
 from ..models import ConnectionStatus
 from ..models import NetworkLocation
 from ..utils.network import errors
@@ -300,6 +301,14 @@ class NetworkClientTestCase(TestCase):
                 with self.assertRaises(errors.NetworkLocationResponseFailure):
                     with NetworkClient("http://sadurl.qqq") as nc:
                         nc.connect()
+
+    @mock.patch.object(requests.Session, "get", mock_response(200))
+    def test_request__user_agent(self):
+        client = NetworkClient()
+        response = client.get("https://example.com")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue("kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"])
 
     @mock.patch.object(
         requests.Session, "request", mock_happy_request("https://url.qqq/")

--- a/kolibri/core/discovery/test/test_network_utils.py
+++ b/kolibri/core/discovery/test/test_network_utils.py
@@ -308,8 +308,8 @@ class NetworkClientTestCase(TestCase):
         response = client.get("/")
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            "Kolibri/{0}".format(kolibri.__version__) in client.headers["User-Agent"]
+        self.assertIn(
+            "Kolibri/{0}".format(kolibri.__version__), client.headers["User-Agent"]
         )
 
     @mock.patch.object(

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -248,9 +248,4 @@ class NetworkClient(requests.Session):
 
 
 def get_user_agent():
-    # get requests default user agent
-    s = requests.Session()
-    requests_user_agent = s.headers['User-Agent']
-
-    # updated useragent format: User-Agent: <product>/<product-version> <requests user agent>
-    return "Kolibri/{0} {1}".format(kolibri.__version__, requests_user_agent)
+    return "Kolibri/{0} python-requests/{1}".format(kolibri.__version__, requests.__version__)

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -8,6 +8,7 @@ from . import errors
 from .urls import get_normalized_url_variations
 from .urls import HTTP_PORTS
 from .urls import HTTPS_PORTS
+import kolibri
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.urls import join_url
@@ -47,6 +48,9 @@ class NetworkClient(requests.Session):
         self.session = None
         self.device_info = None
         self.remote_ip = None
+        self.headers.update({
+            'User-Agent': get_user_agent(),
+        })
 
     @classmethod
     def build_for_address(cls, address, timeout=None):
@@ -241,3 +245,12 @@ class NetworkClient(requests.Session):
             return False
 
         return True
+
+
+def get_user_agent():
+    # get requests default user agent
+    s = requests.Session()
+    requests_user_agent = s.headers['User-Agent']
+
+    # updated useragent format: User-Agent: <product>/<product-version> <requests user agent>
+    return "Kolibri/{0} {1}".format(kolibri.__version__, requests_user_agent)

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -4,11 +4,11 @@ import requests
 from six import raise_from
 from six.moves.urllib.parse import urlparse
 
+import kolibri
 from . import errors
 from .urls import get_normalized_url_variations
 from .urls import HTTP_PORTS
 from .urls import HTTPS_PORTS
-import kolibri
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.tasks.utils import get_current_job
 from kolibri.core.utils.urls import join_url

--- a/kolibri/core/discovery/utils/network/client.py
+++ b/kolibri/core/discovery/utils/network/client.py
@@ -48,9 +48,11 @@ class NetworkClient(requests.Session):
         self.session = None
         self.device_info = None
         self.remote_ip = None
-        self.headers.update({
-            'User-Agent': get_user_agent(),
-        })
+        self.headers.update(
+            {
+                "User-Agent": get_user_agent(),
+            }
+        )
 
     @classmethod
     def build_for_address(cls, address, timeout=None):
@@ -248,4 +250,6 @@ class NetworkClient(requests.Session):
 
 
 def get_user_agent():
-    return "Kolibri/{0} python-requests/{1}".format(kolibri.__version__, requests.__version__)
+    return "Kolibri/{0} python-requests/{1}".format(
+        kolibri.__version__, requests.__version__
+    )


### PR DESCRIPTION
## Summary
Update user agent for `NetworkClient()` to include the project name with its current version.

I need guidance in deciding how to implement this change for files that includes `requests` directly. I have two approaches:
- Refactor these imports to use `NetworkClient()`
- If the above is not recommended for certain reasons then create a new factory for `requests` that have this custom user agent.

lmk what's the recommended approach.

## References
Fixes #10995 

## Reviewer guidance
- should be handled by the automated test

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
