### PR TITLE
Remove unncessary focus on modal element that was breaking

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -329,7 +329,6 @@
       }
       Promise.all(promises).then(() => {
         this.loading = false;
-        this.$nextTick(this.$refs.modal.focus());
       });
     },
     beforeMount() {


### PR DESCRIPTION
## Summary
* Removes superfluous, unguarded focus on modal ref which could cause errors
* Defers to focusFirstEl in mounted hook instead

## References
Fixes #11003 

## Reviewer guidance
Does the completion modal still function as intended from an accessibility perspective?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
