### PR TITLE
Fix menu button icon overlap

### DIFF
--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -20,7 +20,6 @@
     </div>
     <span v-if="overflowMenuLinks && overflowMenuLinks.length > 0">
       <KIconButton
-        class="menu-icon"
         :tooltip="coreString('moreOptions')"
         tooltipPosition="top"
         :ariaLabel="coreString('moreOptions')"
@@ -118,10 +117,6 @@
 <style lang="scss" scoped>
 
   @import '~kolibri-design-system/lib/styles/definitions';
-
-  .menu-icon {
-    right: 4px;
-  }
 
   .navcontainer {
     display: flex;

--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -120,7 +120,6 @@
   @import '~kolibri-design-system/lib/styles/definitions';
 
   .menu-icon {
-    position: absolute;
     right: 4px;
   }
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/learningequality/kolibri/issues/10533 (sort of... the original problem is no longer replicable, but this one was. See issue for more) 

| | display |
|---|---|
| before: icons collide at certain screen widths  | ![icon-overlaps](https://github.com/learningequality/kolibri/assets/17235236/ab61afe6-f4a6-4d18-b37e-b37eb4e97cba) |
|  after: no overlap | ![no-icon-overlap](https://github.com/learningequality/kolibri/assets/17235236/62aaaa5e-3605-44ac-8638-cdaa69319847) |

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
Adjust the screen size and observe that the menu icon no longer overlaps with the navigation tab

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
