### PR TITLE
Updates AppBar styles to be consistent on desktop

### DIFF
--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -10,7 +10,7 @@
 
       <UiToolbar
         :title="title"
-        :removeNavIcon="isAppContext"
+        :removeNavIcon="isAppContext && !windowIsLarge"
         type="clear"
         textColor="white"
         class="app-bar"
@@ -19,7 +19,7 @@
         :removeBrandDivider="true"
       >
         <template
-          v-if="!isAppContext"
+          v-if="windowIsLarge || !isAppContext"
           #icon
         >
           <KIconButton
@@ -41,7 +41,7 @@
         </template>
 
         <template
-          v-if="windowIsLarge && !isAppContext"
+          v-if="windowIsLarge"
           #navigation
         >
           <slot name="sub-nav"></slot>
@@ -330,5 +330,9 @@
     margin-left: 8px;
     font-size: 14px;
   }
+
+  // .subpage-nav {
+  //   margin-top: 0;
+  // }
 
 </style>

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -99,6 +99,10 @@
         </template>
       </UiToolbar>
     </header>
+    <!-- IF making changes to the sub nav, make sure to make -->
+    <!-- corresponding changes in SideNav.vue in regards to  -->
+    <!-- Window size and app context. Changes may need to be made -->
+    <!-- in parallel in both files for non-breaking updates -->
     <div
       v-if="!windowIsLarge && !isAppContext"
       class="subpage-nav"
@@ -330,9 +334,5 @@
     margin-left: 8px;
     font-size: 14px;
   }
-
-  // .subpage-nav {
-  //   margin-top: 0;
-  // }
 
 </style>

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -329,6 +329,15 @@
         return this.isLearnerOnlyImport && (this.isSuperuser || this.isAdmin || this.isCoach);
       },
       showAppNavView() {
+        // IF making changes to the sub nav, make sure to make
+        // corresponding changes in SideNav.vue in regards to
+        //  Window size and app context. Changes may need to be made
+        // in parallel in both files for non-breaking updates
+        // The expected behavior is:
+        // In an app context, on small and medium screens,
+        // show the app Nav
+        // In browser based contexts, and large screen app view
+        // use the "non-app" upper navigation bar
         return this.isAppContext && !this.windowIsLarge;
       },
       footerMsg() {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -6,11 +6,11 @@
     tabindex="0"
     @keyup.esc="toggleNav"
   >
-    <transition :name="isAppContext ? 'bottom-nav' : 'side-nav'">
+    <transition :name="showAppNavView ? 'bottom-nav' : 'side-nav'">
       <div
         v-show="navShown"
         class="side-nav"
-        :class="isAppContext ? 'bottom-offset' : ''"
+        :class="showAppNavView ? 'bottom-offset' : ''"
         :style="{
           width: `${width}`,
           color: $themeTokens.text,
@@ -26,8 +26,8 @@
 
 
           <div
-            :class="isAppContext ? 'bottom-nav-scrollable-area' : 'side-nav-scrollable-area'"
-            :style="isAppContext ?
+            :class="showAppNavView ? 'bottom-nav-scrollable-area' : 'side-nav-scrollable-area'"
+            :style="showAppNavView ?
               { width: `${width}` } :
               { top: `${topBarHeight}px`, width: `${width}` }"
           >
@@ -40,8 +40,8 @@
             >
 
 
-            <div v-if="userIsLearner || isAppContext" class="user-information">
-              <div v-if="isAppContext" style="margin-bottom:10px;margin-left:-15px">
+            <div v-if="userIsLearner || showAppNavView" class="user-information">
+              <div v-if="showAppNavView" style="margin-bottom:10px;margin-left:-15px">
                 <KIconButton
                   ref="closeButton"
                   icon="close"
@@ -170,7 +170,7 @@
             </div>
           </div>
           <div
-            v-if="!isAppContext"
+            v-if="!isAppContext || windowIsLarge"
             class="side-nav-header"
             :style="{
               height: topBarHeight + 'px',
@@ -198,7 +198,7 @@
     </transition>
 
     <BottomNavigationBar
-      v-if="isAppContext"
+      v-if="showAppNavView"
       :bottomMenuOptions="bottomMenuOptions"
       :navShown="navShown"
       @toggleNav="toggleNav()"
@@ -323,10 +323,13 @@
         fullName: state => state.core.session.full_name,
       }),
       width() {
-        return this.isAppContext ? '100vw' : `${this.topBarHeight * 4.5}px`;
+        return this.showAppNavView ? '100vw' : `${this.topBarHeight * 4.5}px`;
       },
       showSoudNotice() {
         return this.isLearnerOnlyImport && (this.isSuperuser || this.isAdmin || this.isCoach);
+      },
+      showAppNavView() {
+        return this.isAppContext && !this.windowIsLarge;
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version });


### PR DESCRIPTION
Following a conversation with in Slack with Endless/LE and after checking in with @tomiwaoLE - we decided that the desktop navigation experience should be consistent across browser and app, and the new "app navigation" should be only for app + mobile/tablet screen size combination.

## Summary
Adjusts the 

## References
Remediates https://github.com/learningequality/kolibri/issues/11079

[Slack conversation](https://learningequality.slack.com/archives/C01EAFKS6KH/p1688690764581949)

| Browser (no changes)  |  App (desktop view uses "traditional" nav) |
|---|---|
| ![browser-same](https://github.com/learningequality/kolibri/assets/17235236/2bc88c35-58ff-4f9d-998b-80fafd2c6d24) | ![app-updated](https://github.com/learningequality/kolibri/assets/17235236/9e0bdf31-e7db-4ba9-88ec-a5792072e0a5) |

## Reviewer guidance
Confirm in app and desktop that the new criteria are met - the only thing that should be different is that on app + desktop, we have the traditional top bar menu tab navigation, not the "app" menu. Everything else should remain the same.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
