### PR TITLE
Adds error handling for badly formed UUIDs sent to API endpoints

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -8,6 +8,8 @@ from django.conf import settings
 from django.db.backends.signals import connection_created
 from django.db.models.query import F
 from django.db.utils import DatabaseError
+from django_filters.filters import UUIDFilter
+from django_filters.rest_framework.filterset import FilterSet
 
 from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
 from kolibri.core.sqlite.pragmas import START_PRAGMAS
@@ -40,6 +42,11 @@ class KolibriCoreConfig(AppConfig):
             )
         )
         self.check_redis_settings()
+        # Do this to add an automapping from the Morango UUIDField to the UUIDFilter so that it automatically
+        # maps to this filter when using the UUIDField in a filter.
+        from morango.models import UUIDField
+
+        FilterSet.FILTER_DEFAULTS.update({UUIDField: {"filter_class": UUIDFilter}})
         # Register any django apps that may have kolibri plugin
         # modules inside them
         registered_plugins.register_non_plugins(settings.INSTALLED_APPS)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 from datetime import timedelta
 from itertools import groupby
+from uuid import UUID
 from uuid import uuid4
 
 from django.contrib.auth import authenticate
@@ -337,9 +338,13 @@ class PublicFacilityUserViewSet(ReadOnlyValuesViewset):
     }
 
     def get_queryset(self):
-        facility_id = self.request.query_params.get("facility_id", None)
-        if facility_id is None:
-            facility_id = self.request.user.facility_id
+        facility_id = self.request.query_params.get(
+            "facility_id", self.request.user.facility_id
+        )
+        try:
+            facility_id = UUID(facility_id).hex
+        except ValueError:
+            return self.queryset.none()
 
         # if user has admin rights for the facility returns the list of users
         queryset = self.queryset.filter(facility_id=facility_id)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -824,7 +824,7 @@ class SetNonSpecifiedPasswordView(views.APIView):
 
         try:
             user = FacilityUser.objects.get(username=username, facility=facility_id)
-        except ObjectDoesNotExist:
+        except (ValueError, ObjectDoesNotExist):
             raise Http404(error_message)
 
         if user.password != NOT_SPECIFIED:
@@ -859,7 +859,7 @@ class SessionViewSet(viewsets.ViewSet):
             unauthenticated_user = FacilityUser.objects.get(
                 username__iexact=username, facility=facility_id
             )
-        except ObjectDoesNotExist:
+        except (ValueError, ObjectDoesNotExist):
             return Response(
                 [
                     {

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1278,6 +1278,17 @@ class FacilityDatasetAPITestCase(APITestCase):
         response = self.client.get(reverse("kolibri:core:facilitydataset-list"))
         self.assertEqual(len(response.data), len(models.FacilityDataset.objects.all()))
 
+    def test_filter_facility_id_for_an_admin(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+        response = self.client.get(
+            reverse("kolibri:core:facilitydataset-list"),
+            {"facility_id": self.facility.id},
+        )
+        self.assertEqual(
+            len(response.data),
+            len(models.FacilityDataset.objects.filter(collection=self.facility.id)),
+        )
+
     def test_admin_can_edit_dataset_for_which_they_are_admin(self):
         self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
         response = self.client.patch(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -675,6 +675,11 @@ class FacilityAPITestCase(APITestCase):
             models.FacilityUser.objects.filter(facility_id=self.facility1.id).count(),
             len(response.data),
         )
+        for item in response.data:
+            self.assertEqual(
+                self.facility1.id,
+                item["facility"],
+            )
 
 
 class UserCreationTestCase(APITestCase):

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -975,11 +975,17 @@ class TreeQueryMixin(object):
     def get_tree_queryset(self, request, pk):
         # Get the model for the parent node here - we do this so that we trigger a 404 immediately if the node
         # does not exist (or exists but is not available, or is filtered).
-        parent_id = (
-            pk
-            if pk and self.filter_queryset(self.get_queryset()).filter(id=pk).exists()
-            else None
-        )
+        try:
+            parent_id = (
+                pk
+                if pk
+                and self.filter_queryset(self.get_queryset()).filter(id=pk).exists()
+                else None
+            )
+        except ValueError:
+            # If the pk is a badly formed uuid, we will get a ValueError here, so we catch it and set to None
+            # so that it raises a 404 below.
+            parent_id = None
 
         if parent_id is None:
             raise Http404

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -425,6 +425,15 @@ class ContentNodeAPIBase(object):
         )
         self.assertEqual(response.status_code, 404)
 
+    def test_contentnode_tree_bad_pk(self):
+        response = self.client.get(
+            reverse(
+                "kolibri:core:contentnode_tree-detail",
+                kwargs={"pk": "this is not a UUID"},
+            )
+        )
+        self.assertEqual(response.status_code, 404)
+
     @unittest.skipIf(
         getattr(settings, "DATABASES")["default"]["ENGINE"]
         == "django.db.backends.postgresql",

--- a/kolibri/core/content/test/test_content_app.py
+++ b/kolibri/core/content/test/test_content_app.py
@@ -1122,6 +1122,23 @@ class ContentNodeAPITestCase(ContentNodeAPIBase, APITestCase):
         for i in range(len(titles)):
             self.assertEqual(response.data[i]["title"], titles[i])
 
+    def test_contentnode_content_id(self):
+        node = content.ContentNode.objects.get(title="c2c2")
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"content_id": node.content_id},
+        )
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["title"], node.title)
+
+    def test_contentnode_bad_content_id(self):
+        response = self.client.get(
+            reverse("kolibri:core:contentnode-list"),
+            data={"content_id": "this is not a uuid"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
     def test_contentnode_parent(self):
         parent = content.ContentNode.objects.get(title="c2")
         children = parent.get_children()

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -771,7 +771,7 @@ class ProgressTrackingViewSet(viewsets.GenericViewSet):
                 return ContentSessionLog.objects.get(id=session_id, user__isnull=True)
             else:
                 return ContentSessionLog.objects.get(id=session_id, user=user)
-        except ContentSessionLog.DoesNotExist:
+        except (ValueError, ContentSessionLog.DoesNotExist):
             raise Http404(
                 "ContentSessionLog with id {} does not exist".format(session_id)
             )


### PR DESCRIPTION
## Summary
* Uses django_filters filtering where possible for filtering by UUID fields
* Adds default UUIDFilter for morango UUIDField
* Handles ValueErrors arising during database queries to return the appropriate response that isn't a 500

## References
Fixes #10999 - actual Sentry reports includes multiple endpoints, all of which should be addressed here (some of which are addressed by previous work).

## Reviewer guidance
Where needed I have added additional test coverage, but most of this is just defensive programming.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
