### PR TITLE
Update redirect behaviour to limit redirects for on_my_own_setup.

### DIFF
--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -864,6 +864,12 @@ class FacilityUser(KolibriAbstractBaseUser, AbstractFacilityDataModel):
             .exists()
         )
 
+    @cached_property
+    def full_facility_on_my_own_setup(self):
+        if self.dataset.extra_fields is not None:
+            return self.dataset.extra_fields.get("on_my_own_setup", False)
+        return False
+
     @property
     def can_manage_content(self):
         return self.get_permission("can_manage_content")

--- a/kolibri/core/hooks.py
+++ b/kolibri/core/hooks.py
@@ -37,6 +37,10 @@ class RoleBasedRedirectHook(KolibriHook):
     # of a full facility import
     require_full_facility = False
 
+    # If True, will only be used to redirect if the user is not
+    # in an 'on my own' facility
+    require_no_on_my_own_facility = False
+
     # User role to redirect for
     @abstractproperty
     def roles(self):

--- a/kolibri/core/views.py
+++ b/kolibri/core/views.py
@@ -99,7 +99,7 @@ def get_urls_by_role(role):
             yield hook.url
 
 
-def get_url_by_role(role, full_facility_import=False):
+def get_url_by_role(role, full_facility_import=False, on_my_own_device=False):
     obj = next(
         (
             hook
@@ -107,6 +107,7 @@ def get_url_by_role(role, full_facility_import=False):
             if role in hook.roles
             and hook.url
             and (full_facility_import or not hook.require_full_facility)
+            and (not on_my_own_device or not hook.require_no_on_my_own_facility)
         ),
         None,
     )
@@ -150,6 +151,7 @@ class RootURLRedirectView(View):
                 url = url or get_url_by_role(
                     user_kinds.SUPERUSER,
                     full_facility_import=request.user.full_facility_import,
+                    on_my_own_device=request.user.full_facility_on_my_own_setup,
                 )
             roles = set(
                 Role.objects.filter(user_id=request.user.id)
@@ -160,15 +162,18 @@ class RootURLRedirectView(View):
                 url = url or get_url_by_role(
                     user_kinds.ADMIN,
                     full_facility_import=request.user.full_facility_import,
+                    on_my_own_device=request.user.full_facility_on_my_own_setup,
                 )
             if user_kinds.COACH in roles or user_kinds.ASSIGNABLE_COACH in roles:
                 url = url or get_url_by_role(
                     user_kinds.COACH,
                     full_facility_import=request.user.full_facility_import,
+                    on_my_own_device=request.user.full_facility_on_my_own_setup,
                 )
             url = url or get_url_by_role(
                 user_kinds.LEARNER,
                 full_facility_import=request.user.full_facility_import,
+                on_my_own_device=request.user.full_facility_on_my_own_setup,
             )
         else:
             url = get_url_by_role(user_kinds.ANONYMOUS)

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -33,6 +33,7 @@ class Coach(KolibriPluginBase):
 class CoachRedirect(RoleBasedRedirectHook):
     roles = (COACH,)
     require_full_facility = True
+    require_no_on_my_own_facility = True
 
     @property
     def url(self):

--- a/kolibri/plugins/device/kolibri_plugin.py
+++ b/kolibri/plugins/device/kolibri_plugin.py
@@ -48,6 +48,9 @@ class DeviceRedirect(RoleBasedRedirectHook):
     # more likely to be a superuser managing a device rather than a learner
     # with on their own device.
     require_full_facility = True
+    # Also only do this redirect if the user is not using the 'on my own'
+    # facility setup flow.
+    require_no_on_my_own_facility = True
 
     @property
     def url(self):

--- a/kolibri/plugins/facility/kolibri_plugin.py
+++ b/kolibri/plugins/facility/kolibri_plugin.py
@@ -31,6 +31,7 @@ class FacilityManagementAsset(WebpackBundleHook):
 class FacilityRedirect(RoleBasedRedirectHook):
     roles = (ADMIN,)
     require_full_facility = True
+    require_no_on_my_own_facility = True
 
     @property
     def url(self):


### PR DESCRIPTION
## Summary
* Adds redirect behaviour to allow handling redirects in on_my_own_setup differently, parallel to the exception for full_facility_import versus not
* Decided to implement as a separate flag rather than conflating, which adds a small amount of additional complexity, but adds explicitness

## References
Fixes the first part of https://github.com/learningequality/kolibri/issues/10760

## Reviewer guidance
When doing on my own setup, it should now redirect to the learn plugin by default

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
