### PR TITLE
Add and use enqueue if not

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1393,7 +1393,7 @@ class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
             content_request.contentnode_id = existing_download_request.contentnode_id
             content_request.save()
 
-        automatic_resource_import.enqueue()
+        automatic_resource_import.enqueue_if_not()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -84,4 +84,4 @@ class ContentSyncHook(FacilityDataSyncHook):
         # TODO: we need determine total space for new downloads and if there isn't sufficient space
         # save the `LearnerDeviceStatus` with the insufficient storage status
 
-        automatic_resource_import.enqueue()
+        automatic_resource_import.enqueue_if_not()

--- a/kolibri/core/content/serializers.py
+++ b/kolibri/core/content/serializers.py
@@ -309,5 +309,5 @@ class ContentDownloadRequestSeralizer(serializers.ModelSerializer):
         content_request.contentnode_id = validated_data["contentnode_id"]
 
         content_request.save()
-        automatic_resource_import.enqueue()
+        automatic_resource_import.enqueue_if_not()
         return content_request

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -41,7 +41,6 @@ from kolibri.utils.translation import ugettext as _
 from kolibri.utils.version import version_matches_range
 
 QUEUE = "content"
-SYNC_CANCEL_STATIC_ID = "783"
 
 
 def get_status(job):
@@ -357,7 +356,6 @@ def automatic_resource_import():
 
 
 @register_task(
-    job_id=SYNC_CANCEL_STATIC_ID,
     long_running=True,
     status_fn=get_status,
 )

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -377,7 +377,7 @@ def automatic_synchronize_content_requests_and_import():
         for dataset_id in dataset_ids:
             synchronize_content_requests(dataset_id, None)
 
-        automatic_resource_import.enqueue()
+        automatic_resource_import.enqueue_if_not()
 
 
 class ExportChannelResourcesValidator(LocalMixin, ChannelResourcesValidator):

--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -341,4 +341,4 @@ def synchronize_content_requests_upgrade():
     for dataset_id in dataset_ids:
         synchronize_content_requests(dataset_id, None)
 
-    automatic_resource_import.enqueue()
+    automatic_resource_import.enqueue_if_not()

--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -9,15 +9,14 @@ from kolibri.core.auth.constants.facility_presets import choices
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.serializers import FacilitySerializer
+from kolibri.core.content.tasks import automatic_resource_import
 from kolibri.core.content.tasks import automatic_synchronize_content_requests_and_import
-from kolibri.core.content.tasks import SYNC_CANCEL_STATIC_ID
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.models import DeviceSettings
 from kolibri.core.device.utils import APP_AUTH_TOKEN_COOKIE_NAME
 from kolibri.core.device.utils import provision_device
 from kolibri.core.device.utils import provision_single_user_device
 from kolibri.core.device.utils import valid_app_key_on_request
-from kolibri.core.tasks.main import job_storage
 from kolibri.plugins.app.utils import GET_OS_USER
 from kolibri.plugins.app.utils import interface
 from kolibri.utils.filesystem import check_is_directory
@@ -278,15 +277,15 @@ class DeviceSettingsSerializer(DeviceSerializerMixin, serializers.ModelSerialize
                 automatic_download_enabled = updated_extra_settings.get(
                     "enable_automatic_download"
                 )
-                if (
-                    automatic_download_enabled
-                    and automatic_download_enabled
-                    != initial_extra_settings.get("enable_automatic_download")
+                if automatic_download_enabled != initial_extra_settings.get(
+                    "enable_automatic_download"
                 ):
-                    automatic_synchronize_content_requests_and_import.enqueue()
-                else:
-                    # If the trigger is switched from on to off we need to cancle any ongoing syncing of resources
-                    job_storage.cancel_if_exists(SYNC_CANCEL_STATIC_ID)
+                    if automatic_download_enabled:
+                        automatic_synchronize_content_requests_and_import.enqueue_if_not()
+                    else:
+                        # If the trigger is switched from on to off we need to cancel any ongoing syncing of resources
+                        automatic_synchronize_content_requests_and_import.cancel_all()
+                        automatic_resource_import.cancel_all()
 
         instance = super(DeviceSettingsSerializer, self).update(
             instance, validated_data

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -121,6 +121,27 @@ class Job(object):
     to the workers.
     """
 
+    UPDATEABLE_KEYS = {
+        "state",
+        "exception",
+        "traceback",
+        "track_progress",
+        "cancellable",
+        "extra_metadata",
+        "progress",
+        "total_progress",
+        "result",
+    }
+
+    JSON_KEYS = UPDATEABLE_KEYS | {
+        "job_id",
+        "facility_id",
+        "args",
+        "kwargs",
+        "func",
+        "long_running",
+    }
+
     def to_json(self):
         """
         Creates and returns a JSON-serialized string representing this Job.
@@ -128,26 +149,8 @@ class Job(object):
         This storage method is why task exceptions are stored as strings.
         """
 
-        keys = [
-            "job_id",
-            "facility_id",
-            "state",
-            "exception",
-            "traceback",
-            "track_progress",
-            "cancellable",
-            "extra_metadata",
-            "progress",
-            "total_progress",
-            "args",
-            "kwargs",
-            "func",
-            "result",
-            "long_running",
-        ]
-
         working_dictionary = {
-            key: self.__dict__[key] for key in keys if key in self.__dict__
+            key: self.__dict__[key] for key in self.JSON_KEYS if key in self.__dict__
         }
 
         try:

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -8,9 +8,9 @@ from collections import namedtuple
 from six import string_types
 
 from kolibri.core.tasks.exceptions import UserCancelledError
+from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.utils import current_state_tracker
-from kolibri.core.tasks.utils import import_stringified_func
-from kolibri.core.tasks.utils import stringify_func
+from kolibri.core.tasks.utils import import_path_to_callable
 from kolibri.utils import translation
 from kolibri.utils.translation import ugettext as _
 
@@ -241,7 +241,7 @@ class Job(object):
         self.args = args
         self.kwargs = kwargs or {}
         self._storage = None
-        self.func = stringify_func(func)
+        self.func = callable_to_import_path(func)
 
     def _check_storage_attached(self):
         if self._storage is None:
@@ -328,7 +328,7 @@ class Job(object):
 
         We don't bother caching this property, as we rely on the Python module import cache instead.
         """
-        return import_stringified_func(self.func)
+        return import_path_to_callable(self.func)
 
     @property
     def percentage_progress(self):

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -291,6 +291,21 @@ class RegisteredTask(object):
             retry_interval=retry_interval,
         )
 
+    def enqueue_if_not(
+        self, job=None, retry_interval=None, priority=None, **job_kwargs
+    ):
+        """
+        Enqueue the function with arguments passed to this method if a job of this type is not already enqueued.
+
+        :return: enqueued job's id.
+        """
+        return job_storage.enqueue_job_if_not_enqueued(
+            job or self._ready_job(**job_kwargs),
+            queue=self.queue,
+            priority=priority or self.priority,
+            retry_interval=retry_interval,
+        )
+
     def enqueue_in(
         self,
         delta_time,

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -240,6 +240,10 @@ class RegisteredTask(object):
     def __repr__(self):
         return "<RegisteredJob: {func}>".format(func=self.func)
 
+    @property
+    def func_string(self):
+        return stringify_func(self)
+
     def _validate_permissions_classes(self, permission_classes):
         for permission_class in permission_classes:
             if not isinstance(permission_class, BasePermission) and not issubclass(
@@ -263,7 +267,7 @@ class RegisteredTask(object):
     def validate_job_data(self, user, data):
         # Run validator with `user` and `data` as its argument.
         if "type" not in data:
-            data["type"] = stringify_func(self)
+            data["type"] = self.func_string
         validator = self.validator(data=data, context={"user": user})
         validator.is_valid(raise_exception=True)
         validated_data = validator.validated_data
@@ -277,6 +281,9 @@ class RegisteredTask(object):
             )
 
         return job, enqueue_args_validated_data
+
+    def cancel_all(self):
+        return job_storage.cancel_jobs(func=self.func_string)
 
     def enqueue(self, job=None, retry_interval=None, priority=None, **job_kwargs):
         """

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -12,7 +12,7 @@ from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.permissions import BasePermission
-from kolibri.core.tasks.utils import stringify_func
+from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.validation import JobValidator
 
 
@@ -100,7 +100,7 @@ class _registry(dict):
                 pass
 
     def _register_task(self, registered_task):
-        funcstring = stringify_func(registered_task)
+        funcstring = callable_to_import_path(registered_task)
         self[funcstring] = registered_task
         logger.debug("Successfully registered '%s' as task.", funcstring)
 
@@ -242,7 +242,7 @@ class RegisteredTask(object):
 
     @property
     def func_string(self):
-        return stringify_func(self)
+        return callable_to_import_path(self)
 
     def _validate_permissions_classes(self, permission_classes):
         for permission_class in permission_classes:

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -487,7 +487,14 @@ class Storage(object):
                 if priority is not None:
                     orm_job.priority = priority
                 for kwarg in kwargs:
-                    setattr(job, kwarg, kwargs[kwarg])
+                    if kwarg in Job.UPDATEABLE_KEYS:
+                        setattr(job, kwarg, kwargs[kwarg])
+                    else:
+                        logger.error(
+                            "Tried to update job with id {} with non-updateable key {}".format(
+                                job_id, kwarg
+                            )
+                        )
                 orm_job.saved_job = job.to_json()
                 session.add(orm_job)
                 for hook in self._hooks:

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -186,6 +186,25 @@ class Storage(object):
             )
             return job.job_id
 
+    def enqueue_job_if_not_enqueued(
+        self, job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
+    ):
+        """
+        Enqueue the function with arguments passed to this method if there is no queued job for the same task.
+
+        N.B. This method does not curently match by job arguments (args and kwargs) but only by the function name.
+
+        :return: enqueued job's id.
+        """
+
+        queued_jobs = self.filter_jobs(func=job.func, queue=queue, state=State.QUEUED)
+        if queued_jobs:
+            return queued_jobs[0].job_id
+
+        return self.enqueue_job(
+            job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
+        )
+
     def mark_job_as_canceled(self, job_id):
         """
         Mark the job as canceled. Does not actually try to cancel a running job.

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -401,6 +401,16 @@ class Storage(object):
         except JobNotFound:
             pass
 
+    def cancel_jobs(
+        self, queue=None, queues=None, state=None, repeating=None, func=None
+    ):
+        """
+        Cancel all jobs matching the given criteria.
+        """
+        jobs = self.filter_jobs(queue=queue, queues=queues, state=state, func=func)
+        for job in jobs:
+            self.cancel(job.job_id)
+
     def clear(self, queue=None, job_id=None, force=False):
         """
         Clear the queue and the job data.

--- a/kolibri/core/tasks/test/taskrunner/test_job_running.py
+++ b/kolibri/core/tasks/test/taskrunner/test_job_running.py
@@ -9,9 +9,9 @@ from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.test.base import connection
+from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.utils import get_current_job
-from kolibri.core.tasks.utils import import_stringified_func
-from kolibri.core.tasks.utils import stringify_func
+from kolibri.core.tasks.utils import import_path_to_callable
 from kolibri.core.tasks.worker import Worker
 
 
@@ -233,8 +233,8 @@ class TestJobStorage(object):
         assert job.state == State.FAILED
 
     def test_stringify_func_is_importable(self):
-        funcstring = stringify_func(set_flag)
-        func = import_stringified_func(funcstring)
+        funcstring = callable_to_import_path(set_flag)
+        func = import_path_to_callable(funcstring)
 
         assert set_flag == func
 

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -15,7 +15,7 @@ from kolibri.core.tasks.job import State
 from kolibri.core.tasks.registry import TaskRegistry
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.test.base import connection
-from kolibri.core.tasks.utils import stringify_func
+from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.utils.time_utils import local_now
 
 
@@ -56,7 +56,7 @@ class TestBackend:
         new_job = defaultbackend.get_job(job_id)
 
         # Does the returned job record the function we set to run?
-        assert str(new_job.func) == stringify_func(func)
+        assert str(new_job.func) == callable_to_import_path(func)
 
         # Does the job have the right state (QUEUED)?
         assert new_job.state == State.QUEUED

--- a/kolibri/core/tasks/utils.py
+++ b/kolibri/core/tasks/utils.py
@@ -36,7 +36,7 @@ def get_current_job():
     return getattr(current_state_tracker, "job", None)
 
 
-def stringify_func(func):
+def callable_to_import_path(func):
     if callable(func):
         funcstring = "{module}.{funcname}".format(
             module=func.__module__, funcname=func.__name__
@@ -49,7 +49,7 @@ def stringify_func(func):
     return funcstring
 
 
-def import_stringified_func(funcstring):
+def import_path_to_callable(funcstring):
     """
     Import a string that represents a module and function, e.g. {module}.{funcname}.
 


### PR DESCRIPTION
## Summary
* Consolidates job filtering into `filter_jobs` function
* Prevent updates to certain job arguments
* Add a database table column to store the func to allow filtering by task types
* Add enqueue_if_not method for registered tasks to allow a task to be queued if a task of the same type is not currently queued for running
* Use this new method for every invocation of `automatic_resource_import`
* Fix `else` logic to handle setting being turned off
* Add method to allow cancelling all jobs of a type, use it to clean up syncing tasks when device setting is turned off.

## References
Fixes [#11007](https://github.com/learningequality/kolibri/issues/11007)

## Reviewer guidance
I think this covers all the bases for what is needed - it does the simplest implementation of enqueue_if_not at the moment and doesn't uniquefy by args/kwargs, but I could add that, but it wasn't needed for either of these tasks here.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
