### PR TITLE
Fixes retry_in behaviour. Adds tests.

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -131,13 +131,13 @@ class Job(object):
         "progress",
         "total_progress",
         "result",
+        "args",
+        "kwargs",
     }
 
     JSON_KEYS = UPDATEABLE_KEYS | {
         "job_id",
         "facility_id",
-        "args",
-        "kwargs",
         "func",
         "long_running",
     }

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -79,6 +79,9 @@ class ORMJob(Base):
     __table_args__ = (Index("queue__scheduled_time", "queue", "scheduled_time"),)
 
 
+NO_VALUE = object()
+
+
 class Storage(object):
     def __init__(self, connection, Base=Base):
         self.engine = connection
@@ -516,26 +519,73 @@ class Storage(object):
                         self._now() + timedelta(seconds=orm_job.interval)
                     )
 
-    def _update_job(self, job_id, state=None, priority=None, **kwargs):
+    def _update_orm_job_fields(
+        self,
+        orm_job,
+        priority=None,
+        interval=None,
+        repeat=NO_VALUE,
+        retry_interval=NO_VALUE,
+    ):
+        if priority is not None:
+            orm_job.priority = priority
+        if interval is not None:
+            orm_job.interval = interval
+        if repeat is not NO_VALUE:
+            orm_job.repeat = repeat
+        if retry_interval is not NO_VALUE:
+            orm_job.retry_interval = retry_interval
+
+    def _update_job_fields(self, job, **kwargs):
+        for kwarg in kwargs:
+            if kwarg in Job.UPDATEABLE_KEYS:
+                setattr(job, kwarg, kwargs[kwarg])
+            else:
+                logger.error(
+                    "Tried to update job with id {} with non-updateable key {}".format(
+                        job.job_id, kwarg
+                    )
+                )
+
+    def _update_job(
+        self,
+        job_id,
+        state=None,
+        priority=None,
+        interval=None,
+        repeat=NO_VALUE,
+        retry_interval=NO_VALUE,
+        **kwargs
+    ):
+        """
+        Because repeat and retry_interval are nullable, None is a semantic value, so we need to use a sentinel value NO_VALUE
+        as the default when no value is passed in.
+        """
         with self.session_scope() as session:
             try:
                 job, orm_job = self._get_job_and_orm_job(job_id, session)
                 self._handle_state_update(orm_job, job, state)
-                if priority is not None:
-                    orm_job.priority = priority
-                for kwarg in kwargs:
-                    if kwarg in Job.UPDATEABLE_KEYS:
-                        setattr(job, kwarg, kwargs[kwarg])
-                    else:
-                        logger.error(
-                            "Tried to update job with id {} with non-updateable key {}".format(
-                                job_id, kwarg
-                            )
-                        )
+                self._update_orm_job_fields(
+                    orm_job,
+                    priority=priority,
+                    interval=interval,
+                    repeat=repeat,
+                    retry_interval=retry_interval,
+                )
+                self._update_job_fields(job, **kwargs)
                 orm_job.saved_job = job.to_json()
                 session.add(orm_job)
                 for hook in self._hooks:
-                    hook.update(job, orm_job, state=state, **kwargs)
+                    hook.update(
+                        job,
+                        orm_job,
+                        state=state,
+                        priority=priority,
+                        interval=interval,
+                        repeat=repeat,
+                        retry_interval=retry_interval,
+                        **kwargs
+                    )
                 return job, orm_job
             except JobNotFound:
                 if state:

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -56,6 +56,11 @@ class JobTest(TestCase):
         with self.assertRaises(ReferenceError):
             self.job.save_as_cancellable(cancellable=cancellable)
 
+    def test_job_retry_in(self):
+        dt = timedelta(seconds=15)
+        self.job.retry_in(dt)
+        self.job.storage.retry_job_in.assert_called_once_with(self.job.job_id, dt)
+
 
 class TestRegisteredTask(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
* Allows args and kwargs to be updated on already created jobs
* Properly updates repeat and interval values when using the `retry_in` Job method and `retry_job_in` Storage method
* Adds the tests for this behaviour that I should have added in the first place
* Does some small refactor within the Storage `_update_job` method, in order to prevent complexity linting errors

## References
Fixes an issue that became very apparent during a bug bash

Fixes [#11046](https://github.com/learningequality/kolibri/issues/11046)

## Reviewer guidance
Ensure that single user syncing is properly repeating

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
