### PR TITLE
Add customized themes feature into EPUB renderer

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -1,0 +1,321 @@
+<template>
+
+  <div>
+    <!-- Modal of theme options -->
+    <KModal
+      v-if="!showColorPicker"
+      :title="generateTitle"
+      :submitText="coreString('saveAction')"
+      :cancelText="coreString('cancelAction')"
+      :disabled="submitting"
+      @submit="handleSubmit"
+      @cancel="$emit('cancel')"
+    >
+
+      <KTextbox
+        ref="customThemeName"
+        v-model.trim="customThemeName"
+        class="theme-name"
+        type="text"
+        :label="$tr('customThemeNameLabel')"
+        :autofocus="true"
+        :disabled="submitting"
+        :invalid="customThemeNameIsInvalid"
+        :invalidText="customThemeNameIsInvalidText"
+        :maxlength="50"
+        @blur="customThemeNameBlurred = true"
+      />
+
+      <UiAlert
+        v-if="showUIAlert"
+        :dismissible="false"
+        :removeIcon="true"
+        type="warning"
+        :style="{ margin: '8px 24px 12px 24px', width: 'auto' }"
+      >
+        {{ $tr('signIn') }}
+      </UiAlert>
+
+      <h3 id="theme-preview-h3">
+        {{ $tr('customThemePreview') }}
+      </h3>
+
+      <div
+        class="theme-preview"
+        :style="{ backgroundColor: tempTheme.backgroundColor, color: tempTheme.textColor }"
+      >
+        <p>
+          The quick brown fox jumps over the lazy dog.
+          <a :style="{ color: tempTheme.linkColor }">This is a link</a>
+        </p>
+      </div>
+
+      <div :class="{ 'color-select-container-mobile': windowIsSmall }">
+        <div class="theme-option-container">
+          <KButton
+            class="theme-color-button"
+            :appearanceOverrides="themeColorOptionStyles(tempTheme.backgroundColor)"
+            @click="showColorPicker = 'backgroundColor'"
+          />
+          <p>{{ $tr('themeBackgroundColorButtonDescription') }}</p>
+        </div>
+
+        <div class="theme-option-container">
+          <KButton
+            class="theme-color-button"
+            :appearanceOverrides="themeColorOptionStyles(tempTheme.textColor)"
+            @click="showColorPicker = 'textColor'"
+          />
+          <p>{{ $tr('themeTextColorButtonDescription') }}</p>
+        </div>
+
+        <div class="theme-option-container">
+          <KButton
+            class="theme-color-button"
+            :appearanceOverrides="themeColorOptionStyles(tempTheme.linkColor)"
+            @click="showColorPicker = 'linkColor'"
+          />
+          <p>{{ $tr('themeLinkColorButtonDescription') }}</p>
+        </div>
+      </div>
+
+    </KModal>
+
+    <!-- modal of color picker -->
+    <ColorPickerModal
+      v-if="showColorPicker"
+      :colorPicker="showColorPicker"
+      :color="tempTheme[showColorPicker]"
+      @submit="setThemeColor($event)"
+      @cancel="showColorPicker = null"
+    />
+    <!-- @submit="setThemeColor($event)" -->
+
+  </div>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import Lockr from 'lockr';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
+  import { mapGetters } from 'vuex';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
+  import ColorPickerModal from './ColorPickerModal';
+
+  export default {
+    name: 'AddEditCustomThemeModal',
+    components: {
+      ColorPickerModal,
+      UiAlert,
+    },
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsLarge, windowIsMedium, windowIsSmall } = useKResponsiveWindow();
+      return {
+        windowIsLarge,
+        windowIsMedium,
+        windowIsSmall,
+      };
+    },
+    props: {
+      modalMode: {
+        type: String,
+        required: true,
+      },
+      theme: {
+        type: Object,
+        required: true,
+      },
+      themeName: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        customThemeName: this.themeName,
+        customThemeNameBlurred: false,
+        submitting: false,
+        formSubmitted: false,
+        tempTheme: {
+          backgroundColor: this.theme.backgroundColor,
+          textColor: this.theme.textColor,
+          linkColor: this.theme.linkColor || '#0000EE', //because fixed themes dont have a link color
+        },
+        showColorPicker: null,
+        existingCustomThemeNames: [],
+        showUIAlert: false,
+      };
+    },
+    computed: {
+      ...mapGetters(['isUserLoggedIn']),
+      generateTitle() {
+        if (this.modalMode === 'add') {
+          return this.$tr('addCustomThemeTitle');
+        } else if (this.modalMode === 'edit') {
+          return this.$tr('editCustomThemeTitle');
+        } else {
+          return ''; // not supposed to happen
+        }
+      },
+      customThemeNameIsInvalidText() {
+        if (!this.formSubmitted) {
+          if (this.customThemeName === '') {
+            return this.coreString('requiredFieldError');
+          }
+          if (this.existingCustomThemeNames.includes(this.customThemeName)) {
+            return this.$tr('duplicateCustomThemeName');
+          }
+        }
+        return '';
+      },
+      customThemeNameIsInvalid() {
+        return Boolean(this.customThemeNameIsInvalidText);
+      },
+      formIsValid() {
+        return !this.customThemeNameIsInvalid;
+      },
+    },
+    mounted() {
+      this.existingCustomThemeNames = Object.keys(
+        Lockr.get('kolibriEpubRendererCustomThemes') || {}
+      );
+      //if the modalMode is 'edit',
+      //remove the name of the theme being edited from the list of existing names
+      if (this.modalMode === 'edit') {
+        const selectedThemeIndex = this.existingCustomThemeNames.indexOf(this.themeName);
+        this.existingCustomThemeNames.splice(selectedThemeIndex, 1);
+      }
+    },
+    methods: {
+      handleSubmit() {
+        this.submitting = true;
+        if (this.formIsValid && this.isUserLoggedIn) {
+          this.formSubmitted = true;
+          this.$emit('submit', { ...this.tempTheme, name: this.customThemeName });
+        } else {
+          this.showUIAlert = !this.isUserLoggedIn;
+          this.submitting = false;
+          this.$refs.customThemeName.focus();
+        }
+      },
+      themeColorOptionStyles(bgColor) {
+        return {
+          backgroundColor: bgColor,
+          ':hover': {
+            backgroundColor: bgColor,
+            opacity: 0.9,
+            boxShadow: '0 1px 4px',
+          },
+        };
+      },
+      setThemeColor(color) {
+        if (this.showColorPicker == 'backgroundColor') {
+          this.tempTheme.backgroundColor = color.hex;
+        } else if (this.showColorPicker == 'textColor') {
+          this.tempTheme.textColor = color.hex;
+        } else if (this.showColorPicker == 'linkColor') {
+          this.tempTheme.linkColor = color.hex;
+        }
+        this.showColorPicker = null;
+      },
+    },
+    $trs: {
+      customThemePreview: {
+        message: 'Theme preview',
+        context: 'Heading for the preview of the custom theme that is being created or edited',
+      },
+      themeBackgroundColorButtonDescription: {
+        message: 'Background',
+        context: 'Description of the button to change the background color of the custom theme',
+      },
+      themeTextColorButtonDescription: {
+        message: 'Text',
+        context: 'Description of the button to change the text color of the custom theme',
+      },
+      themeLinkColorButtonDescription: {
+        message: 'Links',
+        context: 'Description of the button to change the link color of the custom theme',
+      },
+      addCustomThemeTitle: {
+        message: 'Add new theme',
+        context: 'Title of the modal to add a new custom theme',
+      },
+      editCustomThemeTitle: {
+        message: 'Edit theme',
+        context: 'Title of the modal to edit an existing custom theme',
+      },
+      duplicateCustomThemeName: {
+        message: 'A theme with this name already exists',
+        context: 'Error message when trying to add a custom theme with a name that already exists',
+      },
+      customThemeNameLabel: {
+        message: 'Theme name',
+        context: 'Label for the textbox to enter the name of the custom theme',
+      },
+      signIn: {
+        message: 'Sign in or create an account to save your new theme',
+        context:
+          'Message that a learner will see upon trying to save a custom theme if they are not signed in to Kolibri.',
+      },
+    },
+  };
+
+</script>
+
+
+<style>
+
+  .theme-name {
+    margin: 24px;
+  }
+
+  .theme-preview {
+    padding: 24px;
+    margin: 12px 24px;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+  }
+
+  #theme-preview-h3 {
+    margin: 0 24px;
+  }
+
+  .theme-option-container {
+    float: left;
+    width: 33.33%;
+    padding: 10px;
+    text-align: center;
+  }
+
+  .theme-color-button {
+    width: 75px;
+    height: 6vh;
+    margin: 0 auto;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    transition: 'box-shadow 0.3s ease-in-out';
+  }
+
+  .color-select-container-mobile {
+    display: flex;
+    flex-direction: column;
+    width: 90%;
+    margin: auto;
+  }
+
+  .color-select-container-mobile .theme-option-container {
+    display: flex;
+    flex-direction: row-reverse;
+    width: 100%;
+    margin-left: 10px;
+  }
+
+  .color-select-container-mobile .theme-option-container .theme-color-button {
+    margin-right: 10px;
+  }
+
+</style>

--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -46,7 +46,7 @@
       >
         <p>
           The quick brown fox jumps over the lazy dog.
-          <a :style="{ color: tempTheme.linkColor }">This is a link</a>
+          <a :style="{ color: tempTheme.linkColor }">{{ $tr('linkPreviewText') }}</a>
         </p>
       </div>
 
@@ -54,7 +54,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="generateSelectColorAriaLabel('backgroundColor')"
+            :aria-label="$tr('select', { color: $tr('themeBackgroundColorButtonDescription') })"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.backgroundColor)"
             @click="showColorPicker = 'backgroundColor'"
           />
@@ -64,7 +64,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="generateSelectColorAriaLabel('textColor')"
+            :aria-label="$tr('select', { color: $tr('themeTextColorButtonDescription') })"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.textColor)"
             @click="showColorPicker = 'textColor'"
           />
@@ -74,7 +74,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="generateSelectColorAriaLabel('linkColor')"
+            :aria-label="$tr('select', { color: $tr('themeLinkColorButtonDescription') })"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.linkColor)"
             @click="showColorPicker = 'linkColor'"
           />
@@ -92,7 +92,6 @@
       @submit="setThemeColor($event)"
       @cancel="showColorPicker = null"
     />
-    <!-- @submit="setThemeColor($event)" -->
 
   </div>
 
@@ -225,9 +224,6 @@
         }
         this.showColorPicker = null;
       },
-      generateSelectColorAriaLabel(color) {
-        return this.$tr('select', { color });
-      },
     },
     $trs: {
       customThemePreview: {
@@ -268,8 +264,12 @@
           'Message that a learner will see upon trying to save a custom theme if they are not signed in to Kolibri.',
       },
       select: {
-        message: 'Select {color}',
+        message: 'Select {color} color',
         context: 'Aria label for the button to select a color for a custom theme',
+      },
+      linkPreviewText: {
+        message: 'This is a link',
+        context: 'Text that is a link in the preview of the custom theme',
       },
     },
   };

--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -36,14 +36,15 @@
         {{ $tr('signIn') }}
       </UiAlert>
 
-      <h3 id="theme-preview-h3">
+      <h2 id="theme-preview-h3">
         {{ $tr('customThemePreview') }}
-      </h3>
+      </h2>
 
       <div
         class="theme-preview"
         :style="{ backgroundColor: tempTheme.backgroundColor, color: tempTheme.textColor }"
       >
+        <h3>{{ $tr('thisIsASampleText') }}</h3>
         <p>
           The quick brown fox jumps over the lazy dog.
           <a :style="{ color: tempTheme.linkColor }">{{ $tr('linkPreviewText') }}</a>
@@ -274,6 +275,10 @@
         message: 'This is a link',
         context: 'Text that is a link in the preview of the custom theme',
       },
+      thisIsASampleText: {
+        message: 'This is a sample text.',
+        context: 'Language specific sample text in the preview of the custom theme',
+      },
     },
   };
 
@@ -293,7 +298,7 @@
     border-radius: 4px;
   }
 
-  #theme-preview-h3 {
+  #theme-preview-h2 {
     margin: 0 24px;
   }
 

--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -54,6 +54,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
+            :aria-label="generateSelectColorAriaLabel('backgroundColor')"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.backgroundColor)"
             @click="showColorPicker = 'backgroundColor'"
           />
@@ -63,6 +64,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
+            :aria-label="generateSelectColorAriaLabel('textColor')"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.textColor)"
             @click="showColorPicker = 'textColor'"
           />
@@ -72,6 +74,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
+            :aria-label="generateSelectColorAriaLabel('linkColor')"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.linkColor)"
             @click="showColorPicker = 'linkColor'"
           />
@@ -222,6 +225,9 @@
         }
         this.showColorPicker = null;
       },
+      generateSelectColorAriaLabel(color) {
+        return this.$tr('select', { color });
+      },
     },
     $trs: {
       customThemePreview: {
@@ -260,6 +266,10 @@
         message: 'Sign in or create an account to save your new theme',
         context:
           'Message that a learner will see upon trying to save a custom theme if they are not signed in to Kolibri.',
+      },
+      select: {
+        message: 'Select {color}',
+        context: 'Aria label for the button to select a color for a custom theme',
       },
     },
   };

--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -54,7 +54,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="$tr('select', { color: $tr('themeBackgroundColorButtonDescription') })"
+            :aria-label="generateAriaLabel($tr('themeBackgroundColorButtonDescription'))"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.backgroundColor)"
             @click="showColorPicker = 'backgroundColor'"
           />
@@ -64,7 +64,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="$tr('select', { color: $tr('themeTextColorButtonDescription') })"
+            :aria-label="generateAriaLabel($tr('themeTextColorButtonDescription'))"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.textColor)"
             @click="showColorPicker = 'textColor'"
           />
@@ -74,7 +74,7 @@
         <div class="theme-option-container">
           <KButton
             class="theme-color-button"
-            :aria-label="$tr('select', { color: $tr('themeLinkColorButtonDescription') })"
+            :aria-label="generateAriaLabel($tr('themeLinkColorButtonDescription'))"
             :appearanceOverrides="themeColorOptionStyles(tempTheme.linkColor)"
             @click="showColorPicker = 'linkColor'"
           />
@@ -223,6 +223,9 @@
           this.tempTheme.linkColor = color.hex;
         }
         this.showColorPicker = null;
+      },
+      generateAriaLabel(color) {
+        return this.$tr('select', { color: color.toLowerCase() });
       },
     },
     $trs: {

--- a/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/AddEditCustomThemeModal.vue
@@ -226,7 +226,13 @@
         this.showColorPicker = null;
       },
       generateAriaLabel(color) {
-        return this.$tr('select', { color: color.toLowerCase() });
+        if (color === 'Background') {
+          return this.$tr('selectBackgroundColor');
+        } else if (color === 'Text') {
+          return this.$tr('selectTextColor');
+        } else if (color === 'Links') {
+          return this.$tr('selectLinkColor');
+        }
       },
     },
     $trs: {
@@ -267,9 +273,17 @@
         context:
           'Message that a learner will see upon trying to save a custom theme if they are not signed in to Kolibri.',
       },
-      select: {
-        message: 'Select {color} color',
-        context: 'Aria label for the button to select a color for a custom theme',
+      selectBackgroundColor: {
+        message: 'Select background color',
+        context: 'Aria label for the button to select the background color of the custom theme',
+      },
+      selectTextColor: {
+        message: 'Select text color',
+        context: 'Aria label for the button to select the text color of the custom theme',
+      },
+      selectLinkColor: {
+        message: 'Select link color',
+        context: 'Aria label for the button to select the link color of the custom theme',
       },
       linkPreviewText: {
         message: 'This is a link',

--- a/kolibri/plugins/epub_viewer/assets/src/views/ColorPickerModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/ColorPickerModal.vue
@@ -1,0 +1,108 @@
+<template>
+
+  <KModal
+    :title="title"
+    :submitText="$tr('selectAction')"
+    :cancelText="coreString('cancelAction')"
+    @submit="$emit('submit', selectedColor)"
+    @cancel="$emit('cancel')"
+  >
+    <div id="color-picker"></div>
+    <div class="picker-box"></div>
+
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import Alwan from 'alwan';
+  import 'alwan/dist/css/alwan.min.css';
+
+  export default {
+    name: 'ColorPickerModal',
+    mixins: [commonCoreStrings],
+    props: {
+      colorPicker: {
+        type: String,
+        default: null,
+      },
+      color: {
+        type: String,
+        default: '#000000',
+      },
+    },
+    data() {
+      return {
+        selectedColor: this.color,
+      };
+    },
+    computed: {
+      title() {
+        if (this.colorPicker == 'background') {
+          return this.$tr('titleSelectBackground');
+        }
+        if (this.colorPicker == 'text') {
+          return this.$tr('titleSelectText');
+        }
+        if (this.colorPicker == 'link') {
+          return this.$tr('titleSelectLink');
+        } else {
+          return this.$tr('titleSelectColor');
+        }
+      },
+    },
+    mounted() {
+      const alwan = new Alwan('#color-picker', {
+        theme: 'light',
+        toggle: false,
+        popover: false,
+        preset: false,
+        color: this.color,
+        default: this.color,
+        target: '.picker-box',
+        opacity: false,
+      });
+      alwan.on('change', color => {
+        this.selectedColor = color;
+      });
+    },
+    $trs: {
+      titleSelectBackground: {
+        message: 'Select background color',
+        context:
+          'Title of window that displays when a user tries to select a new background color.',
+      },
+      titleSelectText: {
+        message: 'Select text color',
+        context: 'Title of window that displays when a user tries to select a new text color.',
+      },
+      titleSelectLink: {
+        message: 'Select link color',
+        context: 'Title of window that displays when a user tries to select a new link color.',
+      },
+      titleSelectColor: {
+        message: 'Select theme color',
+        context: 'Title of window that displays when a user tries to select a new theme color.',
+      },
+      selectAction: {
+        message: 'Select',
+        context: 'Button that selects a color.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped>
+
+  .picker-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+</style>

--- a/kolibri/plugins/epub_viewer/assets/src/views/DeleteCustomThemeModal.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/DeleteCustomThemeModal.vue
@@ -1,0 +1,52 @@
+<template>
+
+  <KModal
+    :title="title"
+    :submitText="coreString('deleteAction')"
+    :cancelText="coreString('cancelAction')"
+    @submit="$emit('submit')"
+    @cancel="$emit('cancel')"
+  >
+    <p v-if="themeName">
+      {{ $tr('confirmationQuestion', { themeName }) }}
+    </p>
+    <p>{{ coreString('cannotUndoActionWarning') }}</p>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+
+  export default {
+    name: 'DeleteCustomThemeModal',
+    mixins: [commonCoreStrings],
+    props: {
+      themeName: {
+        type: String,
+        default: null,
+      },
+    },
+    computed: {
+      title() {
+        return this.$tr('titleDeleteTheme');
+      },
+    },
+    $trs: {
+      confirmationQuestion: {
+        message: `Are you sure you want to delete '{themeName}' from your device?`,
+        context: 'Confirmation of delete message.',
+      },
+      titleDeleteTheme: {
+        message: 'Delete Theme',
+        context: 'Title of window that displays when a user tries to delete a custom theme.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -282,6 +282,9 @@
       textColor() {
         return this.theme.textColor;
       },
+      linkColor() {
+        return this.theme.linkColor || '#0000EE'; //default to blue
+      },
       themeStyle() {
         const colorStyle = {
           'background-color': `${this.backgroundColor}!important`,
@@ -320,6 +323,7 @@
           // help media not overflow their columns
           video: { 'max-width': '100%' },
           img: { 'max-width': '100%' },
+          a: { color: `${this.linkColor}!important` },
         };
       },
       tocSideBarIsOpen() {

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -119,6 +119,14 @@
 
         </KFixedGridItem>
       </KFixedGrid>
+
+      <!-- Modal to confirm deletion of a custom theme -->
+      <DeleteCustomThemeModal
+        v-if="deleteCustomThemeName"
+        :themeName="deleteCustomThemeName"
+        @submit="deleteTheme(deleteCustomThemeName)"
+        @cancel="deleteCustomThemeName = null"
+      />
     </div>
   </SideBar>
 
@@ -130,11 +138,13 @@
   import Lockr from 'lockr';
   import { THEMES } from './EpubConstants';
   import SideBar from './SideBar';
+  import DeleteCustomThemeModal from './DeleteCustomThemeModal.vue';
 
   export default {
     name: 'SettingsSideBar',
     components: {
       SideBar,
+      DeleteCustomThemeModal,
     },
     props: {
       theme: {
@@ -225,6 +235,16 @@
         Lockr.set('kolibriEpubRendererCustomThemes', { ...savedCustomThemes });
         this.customThemes = savedCustomThemes;
         this.$emit('setTheme', tempTheme);
+      },
+      deleteTheme(themeName) {
+        const savedCustomThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};
+        delete savedCustomThemes[themeName];
+        Lockr.set('kolibriEpubRendererCustomThemes', { ...savedCustomThemes });
+        this.customThemes = savedCustomThemes;
+        this.deleteCustomThemeName = null;
+        if (themeName === this.theme.name) {
+          this.$emit('setTheme', this.themes.WHITE); // apply the default theme
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -324,17 +324,17 @@
           "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to black.",
       },
       setCustomTheme: {
-        message: 'Set custom theme {themeName}',
+        message: "Set custom theme '{themeName}'",
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be set to {themeName}.",
       },
       deleteCustomTheme: {
-        message: 'Delete custom theme {themeName}',
+        message: "Delete custom theme '{themeName}'",
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be deleted.",
       },
       editCustomTheme: {
-        message: 'Edit custom theme {themeName}',
+        message: "Edit custom theme '{themeName}'",
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be edited.",
       },

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -62,6 +62,29 @@
         </KFixedGridItem>
       </KFixedGrid>
     </div>
+
+    <div class="o-f-h">
+      <h3>{{ $tr('customTheme') }}</h3>
+      <KFixedGrid numCols="4" gutter="8">
+        <!-- Button to add a new custom theme -->
+        <KFixedGridItem
+          v-if="Object.keys(customThemes).length < 8"
+          span="1"
+        >
+          <KButton
+            class="settings-button theme-button"
+            :aria-label="$tr('addNewTheme')"
+            @click="addCustomTheme = 'myTheme' + ((Object.keys(customThemes).length + 1))"
+          >
+            <KIcon
+              icon="plus"
+              style="top: 0; width: 24px; height: 24px;"
+            />
+          </KButton>
+
+        </KFixedGridItem>
+      </KFixedGrid>
+    </div>
   </SideBar>
 
 </template>
@@ -92,6 +115,12 @@
         required: false,
         default: false,
       },
+    },
+    data() {
+      return {
+        customThemes: {},
+        addCustomTheme: null,
+      };
     },
     computed: {
       themes() {
@@ -156,6 +185,16 @@
         message: 'Theme',
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option.",
+      },
+      customTheme: {
+        message: 'My themes',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option.",
+      },
+      addNewTheme: {
+        message: 'Add new theme',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to add a new theme.",
       },
       setWhiteTheme: {
         message: 'Set white theme',

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -66,6 +66,41 @@
     <div class="o-f-h">
       <h3>{{ $tr('customTheme') }}</h3>
       <KFixedGrid numCols="4" gutter="8">
+        <!-- Buttons for already created custom themes -->
+        <KFixedGridItem
+          v-for="(value, key) in customThemes"
+          :key="key"
+          span="1"
+          style="margin-bottom: 8px;"
+        >
+          <KButton
+            class="settings-button theme-button"
+            :aria-label="generateCustomThemeAriaLabel(key)"
+            :appearanceOverrides="generateStyle(value)"
+            @click="$emit('setTheme', value)"
+          >
+            <KIcon
+              v-if="isCurrentlySelectedTheme(value) "
+              icon="check"
+              :style="{ fill: value.textColor }"
+              style="top: 0; width: 24px; height: 24px;"
+            />
+          </KButton>
+          <KButton
+            class="delete-edit-button"
+            :text="$tr('delete')"
+            :primary="true"
+            @click="deleteCustomThemeName = key"
+          />
+          <KButton
+            class="delete-edit-button"
+            :text="$tr('edit')"
+            :secondary="true"
+            @click="editCustomThemeName = key, editCustomTheme = value"
+          />
+
+        </KFixedGridItem>
+
         <!-- Button to add a new custom theme -->
         <KFixedGridItem
           v-if="Object.keys(customThemes).length < 8"
@@ -120,6 +155,9 @@
     data() {
       return {
         customThemes: {},
+        deleteCustomThemeName: null,
+        editCustomThemeName: null,
+        editCustomTheme: null,
         addCustomTheme: null,
       };
     },
@@ -154,6 +192,9 @@
           default:
             return '';
         }
+      },
+      generateCustomThemeAriaLabel(themeName) {
+        return this.$tr('setCustomTheme', { themeName });
       },
       isCurrentlySelectedTheme(theme) {
         return (
@@ -215,6 +256,16 @@
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to add a new theme.",
       },
+      delete: {
+        message: 'Delete',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to delete a theme.",
+      },
+      edit: {
+        message: 'Edit',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'Custom Themes' option. This button allows learners to edit a theme.",
+      },
       setWhiteTheme: {
         message: 'Set white theme',
         context:
@@ -234,6 +285,11 @@
         message: 'Set black theme',
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of colors using the 'Theme' option. In this case it can be set to black.",
+      },
+      setCustomTheme: {
+        message: 'Set custom theme {themeName}',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be set to {themeName}.",
       },
     },
   };
@@ -258,6 +314,17 @@
     height: 44.5px;
     border-style: solid;
     border-width: 2px;
+  }
+
+  .delete-edit-button {
+    width: calc(100% - 4px);
+    min-width: unset;
+    height: calc(100% - 4px);
+    padding: 0;
+    margin: 2px;
+    font-size: 10px;
+    line-height: unset;
+    transition: none;
   }
 
   .o-f-h {

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -88,12 +88,14 @@
           </KButton>
           <KButton
             class="delete-edit-button"
+            :aria-label="generateCustomThemeDeleteAriaLabel(key)"
             :text="$tr('delete')"
             :primary="true"
             @click="deleteCustomThemeName = key"
           />
           <KButton
             class="delete-edit-button"
+            :aria-label="generateCustomThemeEditAriaLabel(key)"
             :text="$tr('edit')"
             :secondary="true"
             @click="editCustomThemeName = key, editCustomTheme = value"
@@ -218,6 +220,12 @@
       generateCustomThemeAriaLabel(themeName) {
         return this.$tr('setCustomTheme', { themeName });
       },
+      generateCustomThemeDeleteAriaLabel(themeName) {
+        return this.$tr('deleteCustomTheme', { themeName });
+      },
+      generateCustomThemeEditAriaLabel(themeName) {
+        return this.$tr('editCustomTheme', { themeName });
+      },
       isCurrentlySelectedTheme(theme) {
         return (
           theme.backgroundColor === this.theme.backgroundColor &&
@@ -316,6 +324,16 @@
         message: 'Set custom theme {themeName}',
         context:
           "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be set to {themeName}.",
+      },
+      deleteCustomTheme: {
+        message: 'Delete custom theme {themeName}',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be deleted.",
+      },
+      editCustomTheme: {
+        message: 'Edit custom theme {themeName}',
+        context:
+          "The EPUB reader allows learners to set the background of the reader to different shades of user preferred colors using the 'My themes' option. In this case it can be edited.",
       },
     },
   };

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -127,6 +127,16 @@
         @submit="deleteTheme(deleteCustomThemeName)"
         @cancel="deleteCustomThemeName = null"
       />
+
+      <!-- Modal to configure a custom theme -->
+      <AddEditCustomThemeModal
+        v-if="addCustomTheme || editCustomThemeName"
+        :modalMode="addCustomTheme ? 'add' : 'edit'"
+        :theme="addCustomTheme ? theme : editCustomTheme"
+        :themeName="addCustomTheme ? addCustomTheme : editCustomThemeName"
+        @submit="addNewTheme($event)"
+        @cancel="addCustomTheme = null, editCustomThemeName = null, editCustomTheme = null"
+      />
     </div>
   </SideBar>
 
@@ -139,12 +149,14 @@
   import { THEMES } from './EpubConstants';
   import SideBar from './SideBar';
   import DeleteCustomThemeModal from './DeleteCustomThemeModal.vue';
+  import AddEditCustomThemeModal from './AddEditCustomThemeModal.vue';
 
   export default {
     name: 'SettingsSideBar',
     components: {
       SideBar,
       DeleteCustomThemeModal,
+      AddEditCustomThemeModal,
     },
     props: {
       theme: {
@@ -221,13 +233,7 @@
           },
         };
       },
-      /**
-       * Save a new custom theme in local storage.
-       *
-       * @public
-       */
       addNewTheme(tempTheme) {
-        // console.log(tempTheme);
         this.addCustomTheme = null;
         this.editCustomThemeName = null;
         const savedCustomThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -242,13 +242,16 @@
         };
       },
       addNewTheme(tempTheme) {
-        this.addCustomTheme = null;
-        this.editCustomThemeName = null;
         const savedCustomThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};
+        if (this.editCustomThemeName && this.editCustomThemeName !== tempTheme.name) {
+          delete savedCustomThemes[this.editCustomThemeName];
+        }
         savedCustomThemes[tempTheme.name] = tempTheme;
         Lockr.set('kolibriEpubRendererCustomThemes', { ...savedCustomThemes });
         this.customThemes = savedCustomThemes;
         this.$emit('setTheme', tempTheme);
+        this.addCustomTheme = null;
+        this.editCustomThemeName = null;
       },
       deleteTheme(themeName) {
         const savedCustomThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};

--- a/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/SettingsSideBar.vue
@@ -92,6 +92,7 @@
 
 <script>
 
+  import Lockr from 'lockr';
   import { THEMES } from './EpubConstants';
   import SideBar from './SideBar';
 
@@ -136,6 +137,9 @@
         };
       },
     },
+    mounted() {
+      this.customThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};
+    },
     methods: {
       generateThemeAriaLabel(themeName) {
         switch (themeName) {
@@ -165,6 +169,21 @@
             backgroundColor: theme.hoverColor,
           },
         };
+      },
+      /**
+       * Save a new custom theme in local storage.
+       *
+       * @public
+       */
+      addNewTheme(tempTheme) {
+        // console.log(tempTheme);
+        this.addCustomTheme = null;
+        this.editCustomThemeName = null;
+        const savedCustomThemes = Lockr.get('kolibriEpubRendererCustomThemes') || {};
+        savedCustomThemes[tempTheme.name] = tempTheme;
+        Lockr.set('kolibriEpubRendererCustomThemes', { ...savedCustomThemes });
+        this.customThemes = savedCustomThemes;
+        this.$emit('setTheme', tempTheme);
       },
     },
     $trs: {

--- a/kolibri/plugins/epub_viewer/package.json
+++ b/kolibri/plugins/epub_viewer/package.json
@@ -8,6 +8,7 @@
     "epubjs": "0.3.84",
     "mark.js": "^8.11.1",
     "vue-focus-lock": "^1.2.0",
-    "web-streams-polyfill": "^3.2.1"
+    "web-streams-polyfill": "^3.2.1",
+    "alwan": "^1.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2206,6 +2206,11 @@ ajv@^8.9.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+alwan@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/alwan/-/alwan-1.3.0.tgz#11e6cab7692f53e2eb5cee1b99b60c2ed645d152"
+  integrity sha512-Mr6LLac+708IVnUQKqtzhrCJlfyV3TZwxb9nxVY5cshlQOWc+Chm5ixJCSCpx9QW5hLmStP/Ko82qQWpgDCe9g==
+
 amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Kolibri EPUB renderer currently has 6 fixed built in themes, which cannot be edited by users. Also, Kolibri does not allow adding new color themes to the EPUB renderer with the colors of user's preference. Changes in this PR will bring the ability for the users to add, edit and delete custom color themes for the epub viewer as they prefer.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Resolves the issue: #10741 
Color picker used : [Alwan-color-picker](https://github.com/SofianChouaib/alwan)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Can try the following features

- Adding a new theme by selecting preferred colors for the text, background, links, and giving it a preferred name
- Deleting a custom created theme
- Applying a custom created theme to the EPUB viewer
- Editing a custom created theme to change the colors and the name

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
