### PR TITLE
Handle queries that resolve to an empty result set in search utils.

### DIFF
--- a/kolibri/core/content/test/test_search.py
+++ b/kolibri/core/content/test/test_search.py
@@ -176,3 +176,13 @@ class ConstrainedMetadataLabelsTestCase(TestCase):
         self.assertEqual(
             set(metadata_labels[field]), set(expected), "{} {}".format(field, label)
         )
+
+    @parameterized.expand(
+        field for field in (list(metadata_lookup.keys()) + ["channels", "languages"])
+    )
+    def test_labels_empty_queryset(self, field):
+        try:
+            labels = get_available_metadata_labels(ContentNode.objects.none())
+        except Exception as e:
+            self.fail("get_available_metadata_labels raised {}".format(e))
+        self.assertEqual(labels[field], [])


### PR DESCRIPTION
## Summary
* When resolving a query value for a queryset in Django, if _a priori_ the query for the queryset would return an empty result, then Django raises an error rather than generating the query
* We are using this query value for caching purposes when returning all available metadata labels within a query
* This PR catches that error and instead returns an empty set of metadata labels, as an empty query will have none!
* Adds a regression test for this behaviour

## References
Fixes #10507

## Reviewer guidance
Do the tests make sense? Do they pass?

We should probably copy this to Studio once it is merged also.

If you would like to manually reproduce the error, then doing a query to the content node endpoint using the query parameters from the Sentry report or similar should do so. I'm not reproducing them here, as one of the sent parameters appears to be someone attempting an injection attack, so I don't want to publicize their URL.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
