### PR TITLE
Fix mastery log after ending quiz

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
+++ b/kolibri/plugins/learn/assets/src/composables/useProgressTracking.js
@@ -352,10 +352,13 @@ export default function useProgressTracking(store) {
         data.extra_fields = extraFields;
       }
       // Don't try to make a new save until the previous save
-      // has completed.
-      savingPromise = savingPromise.then(() => {
-        return makeRequestWithRetry(makeSessionUpdateRequest, data);
-      });
+      // has completed or there's no data to sent because the quiz has already
+      // been completed.
+      if (Object.keys(data).length !== 0) {
+        savingPromise = savingPromise.then(() => {
+          return makeRequestWithRetry(makeSessionUpdateRequest, data);
+        });
+      }
     }
     // Splice all the resolve/reject handlers off the stack
     // so that only those that have already been added by the time of this


### PR DESCRIPTION
## Summary
When the user clicks to send a finished quiz:

- complete the frontend PUT to add final progress
- avoid backend rejecting the PUT if a previous trackprogress has already marked the quiz as completed

## References
Closes: #11045

## Reviewer guidance
Do the steps described at #11045

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
