### PR TITLE
Remove all use of pkg_resources in Kolibri run time code.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,5 +31,6 @@ Click==7.0
 whitenoise==4.1.4
 idna==2.8
 ifaddr==0.1.7  # Pin as version 0.2.0 only supports Python 3.7 and above
+importlib-metadata==2.1.1
 importlib_resources==3.3.1
 json-schema-validator==2.4.1


### PR DESCRIPTION
## Summary
* pkg_resources is very time consuming to import and causes considerable slowdowns in a lot of our runtime code
* The importlib_metadata package provides a backport of the importlib.metadata functionality released in Python 3.10 that covers all the use cases that we currently use pkg_resources for
* This may help with #10102 and allow proper enumeration on Android - will test with the whl file from this PR to be sure.

## References
Might deal with #10102

## Reviewer guidance
Does `kolibri plugin list` still work? Does upgrading a plugin still work?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
