### PR TITLE
Always run plugin upgrades separately from core Kolibri upgrades.

### DIFF
--- a/kolibri/core/upgrade.py
+++ b/kolibri/core/upgrade.py
@@ -118,7 +118,9 @@ def matches_version(version, version_range):
 
 def get_upgrades(app_configs=None):
     if app_configs is None:
-        app_configs = apps.get_app_configs()
+        app_configs = filter(
+            lambda x: not getattr(x, "kolibri_plugin", False), apps.get_app_configs()
+        )
     version_upgrades = []
     for app_config in app_configs:
         try:

--- a/kolibri/plugins/utils/settings.py
+++ b/kolibri/plugins/utils/settings.py
@@ -95,6 +95,7 @@ def _apply_base_settings(plugin_instance, settings_module):
     # or Kolibri core plugins.
     app_config = AppConfig.create(plugin_instance.module_path)
     app_config.label = plugin_instance.module_path
+    app_config.kolibri_plugin = True
     # Register the plugin as an installed app
     _set_setting_value("INSTALLED_APPS", (app_config,), settings_module)
     plugin_instance.INSTALLED_APPS.append(app_config)


### PR DESCRIPTION
## Summary
* Currently all upgrades are run using the old and new Kolibri versions
* This is not appropriate for plugins external to Kolibri, as they may have completely different versioning
* Adds a `kolibri_plugin` property to generated AppConfig objects in the plugin machinery
* Fixes the above issue by excluding kolibri plugins from the app configs used when app_configs is set to None when gathering upgrades to run

## References
Addresses oversight from #5957

## Reviewer guidance
Do upgrades still run as expected?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
