### PR TITLE
Conform code to E721 for flake8.

### DIFF
--- a/kolibri/core/auth/management/commands/bulkimportusers.py
+++ b/kolibri/core/auth/management/commands/bulkimportusers.py
@@ -237,7 +237,7 @@ def reverse_dict(original):
     """
     final = {}
     for k, value in original.items():
-        if type(value) == list:
+        if isinstance(value, list):
             for v in value:
                 final.setdefault(v, []).append(k)
         else:

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -458,7 +458,7 @@ def _check_file_availability(files):
 
 
 def set_local_file_availability_from_disk(checksums=None, destination=None):
-    if type(checksums) == list and len(checksums) > CHUNKSIZE:
+    if isinstance(checksums, list) and len(checksums) > CHUNKSIZE:
         for i in range(0, len(checksums), CHUNKSIZE):
             set_local_file_availability_from_disk(
                 checksums=checksums[i : i + CHUNKSIZE], destination=destination
@@ -477,7 +477,7 @@ def set_local_file_availability_from_disk(checksums=None, destination=None):
         logger.info(
             "Setting availability of LocalFile objects based on disk availability"
         )
-    elif type(checksums) == list:
+    elif isinstance(checksums, list):
         logger.info(
             "Setting availability of {number} LocalFile objects based on disk availability".format(
                 number=len(checksums)

--- a/kolibri/core/notifications/test/test_api.py
+++ b/kolibri/core/notifications/test/test_api.py
@@ -152,7 +152,7 @@ class NotificationsAPITestCase(APITestCase):
         # user1 has one lesson:
         lessons = get_assignments(self.user1, self.summarylog1, attempt=False)
         assert len(lessons) > 0
-        assert type(lessons[0][0]) == dict
+        assert isinstance(lessons[0][0], dict)
         assert "assignment_collections" in lessons[0][0]
         # being the node an Exercise, it should be available for attempts:
         lessons = get_assignments(self.user1, self.summarylog1, attempt=True)


### PR DESCRIPTION
## Summary
* Fixes existing code that tripped a new flake8 linting error

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
