### PR TITLE
Add download button to BrowseResourceMetadata

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/filePresetStrings.js
@@ -41,6 +41,9 @@ export function getFilePresetString(file) {
   if (preset.endsWith('thumbnail')) {
     return filePresetTranslator.$tr('thumbnail', params);
   }
+  if (preset === 'h5p') {
+    return filePresetTranslator.$tr('html5_zip', params);
+  }
   if (filePresetStrings[preset]) {
     return filePresetTranslator.$tr(preset, params);
   }

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -74,6 +74,7 @@
         ref="resourcePanel"
         :content="sidePanelContent"
         :showLocationsInChannel="true"
+        :canDownloadContent="canDownload"
       />
     </SidePanelModal>
   </LearnAppBarPage>
@@ -91,6 +92,7 @@
   import urls from 'kolibri.urls';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import useContentLink from '../composables/useContentLink';
+  import useCoreLearn from '../composables/useCoreLearn';
   import SidePanelModal from './SidePanelModal';
   import commonLearnStrings from './commonLearnStrings';
   import LearnAppBarPage from './LearnAppBarPage';
@@ -117,9 +119,10 @@
     },
     mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
     setup() {
+      const { canDownload } = useCoreLearn();
       const { fetchContentNodeProgress } = useContentNodeProgress();
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
-      return { fetchContentNodeProgress, genContentLinkBackLinkCurrentPage };
+      return { canDownload, fetchContentNodeProgress, genContentLinkBackLinkCurrentPage };
     },
     data() {
       return {

--- a/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
+++ b/kolibri/plugins/learn/assets/src/views/BrowseResourceMetadata.vue
@@ -188,6 +188,13 @@
       </div>
     </div>
 
+    <div v-if="canDownloadContent" class="section" data-test="download">
+      <DownloadButton
+        :files="content.files"
+        :nodeTitle="content.title"
+      />
+    </div>
+
   </section>
 
 </template>
@@ -199,6 +206,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import camelCase from 'lodash/camelCase';
   import { ContentLevels } from 'kolibri.coreVue.vuex.constants';
+  import DownloadButton from 'kolibri.coreVue.components.DownloadButton';
   import get from 'lodash/get';
   import {
     licenseShortName,
@@ -215,6 +223,7 @@
   export default {
     name: 'BrowseResourceMetadata',
     components: {
+      DownloadButton,
       LearningActivityIcon,
       TimeDuration,
       ContentNodeThumbnail,
@@ -230,6 +239,10 @@
         required: true,
       },
       showLocationsInChannel: {
+        type: Boolean,
+        default: false,
+      },
+      canDownloadContent: {
         type: Boolean,
         default: false,
       },

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -234,6 +234,7 @@
         ref="resourcePanel"
         :content="metadataSidePanelContent"
         :showLocationsInChannel="true"
+        :canDownloadContent="canDownload && !deviceId"
       />
     </SidePanelModal>
   </LearnAppBarPage>
@@ -255,6 +256,7 @@
   import { KolibriStudioId } from '../../constants';
   import useCardViewStyle from '../../composables/useCardViewStyle';
   import useContentLink from '../../composables/useContentLink';
+  import useCoreLearn from '../../composables/useCoreLearn';
   import useDevices from '../../composables/useDevices';
   import usePinnedDevices from '../../composables/usePinnedDevices';
   import useSearch from '../../composables/useSearch';
@@ -316,6 +318,7 @@
         windowIsMedium,
         windowIsSmall,
       } = useKResponsiveWindow();
+      const { canDownload } = useCoreLearn();
       const { currentCardViewStyle } = useCardViewStyle();
       const { back } = useContentLink();
       const { baseurl, deviceName, fetchDevices } = useDevices();
@@ -330,6 +333,7 @@
       });
 
       return {
+        canDownload,
         displayingSearchResults,
         searchTerms,
         searchLoading,

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -203,7 +203,6 @@
       v-if="metadataSidePanelContent"
       data-test="side-panel-modal"
       alignment="right"
-      :closeButtonIconType="close"
       @closePanel="metadataSidePanelContent = null"
       @shouldFocusFirstEl="findFirstEl()"
     >

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -231,6 +231,7 @@
           ref="resourcePanel"
           :content="metadataSidePanelContent"
           :showLocationsInChannel="true"
+          :canDownloadContent="canDownload && !deviceId"
         />
       </SidePanelModal>
 
@@ -257,6 +258,7 @@
   import { PageNames } from '../../constants';
   import useSearch from '../../composables/useSearch';
   import useContentLink from '../../composables/useContentLink';
+  import useCoreLearn from '../../composables/useCoreLearn';
   import LibraryAndChannelBrowserMainContent from '../LibraryAndChannelBrowserMainContent';
   import SearchFiltersPanel from '../SearchFiltersPanel';
   import BrowseResourceMetadata from '../BrowseResourceMetadata';
@@ -306,6 +308,7 @@
     },
     mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
     setup() {
+      const { canDownload } = useCoreLearn();
       const store = getCurrentInstance().proxy.$store;
       const topic = computed(() => store.state.topicsTree && store.state.topicsTree.topic);
       const {
@@ -322,6 +325,7 @@
       } = useSearch(topic);
       const { back, genContentLinkKeepCurrentBackLink } = useContentLink();
       return {
+        canDownload,
         searchTerms,
         displayingSearchResults,
         searchLoading,

--- a/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/browse-resource-metadata.spec.js
@@ -78,9 +78,9 @@ function makeContentNode(metadata = {}) {
   return { ...baseContentNode, ...metadata };
 }
 
-function makeWrapper(metadata = {}, options = {}) {
+function makeWrapper(metadata = {}, options = {}, canDownloadContent = false) {
   const content = makeContentNode(metadata);
-  const propsData = { content };
+  const propsData = { content, canDownloadContent };
   return shallowMount(BrowseResourceMetadata, {
     localVue,
     propsData,
@@ -192,6 +192,16 @@ describe('BrowseResourceMetadata', () => {
 
     it('does not show license description section without the data', () => {
       expect(wrapper.find("[data-test='license-desc']").exists()).toBeFalsy();
+    });
+  });
+  describe('download button gets toggled by prop', () => {
+    it('should display the button when canDownloadContent is true', () => {
+      const wrapper = makeWrapper({}, {}, true);
+      expect(wrapper.find("[data-test='download']").exists()).toBeTruthy();
+    });
+    it('should not display the button when canDownloadContent is false', () => {
+      const wrapper = makeWrapper({}, {}, false);
+      expect(wrapper.find("[data-test='download']").exists()).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Summary
* Adds download button previously omitted from the browse resource metadata component
* Cleans up an unnecessary and improperly passed prop value
* Uses the HTML5 translation string for HTML5 app download for H5Ps

## References
Fixes #11027

## Reviewer guidance
Does the download button display properly? Does it not display for remote browsing?

For local:
![Screenshot from 2023-08-02 14-34-47](https://github.com/learningequality/kolibri/assets/1680573/75f4a009-4d02-41f0-adda-e98a2f8140c3)

For remote:
![Screenshot from 2023-08-02 14-35-52](https://github.com/learningequality/kolibri/assets/1680573/8faa3d91-0a72-486e-9ceb-d244090e9ec7)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
