### PR TITLE
setup_wizard: only set firstImportedLodUser if task starts without errors

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
@@ -254,13 +254,6 @@
           }
         }
 
-        if (!this.wizardService.state.context.firstImportedLodUser) {
-          this.wizardService.send({
-            type: 'SET_FIRST_LOD',
-            value: { username: this.username, password },
-          });
-        }
-
         TaskResource.startTask(params)
           .then(task => {
             let user = {};
@@ -271,6 +264,14 @@
             }
             task['device_id'] = this.deviceId;
             task['facility_name'] = this.facility.name;
+
+            if (!this.wizardService.state.context.firstImportedLodUser) {
+              this.wizardService.send({
+                type: 'SET_FIRST_LOD',
+                value: { username: this.username, password },
+              });
+            }
+
             this.wizardService.send({
               type: 'CONTINUE',
               value: { ...task, ...user },


### PR DESCRIPTION
## Summary

When the user tried to submit the form to import an admin/coach to an LOD and then canceled the subsequent "Device Limitations" modal, the user they entered first would be forever immortalized as the `firstImportedLodUser` even if they weren't supposed to be imported which sets them as the admin user.

So the fix here was to just set that `firstImportedLodUser` only once we've started the task without errors - which will happen when we override the "Device limitations" modal or import another user altogether.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10675 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Setup or access a device such that you have the credentials for two admin/coach users
- Start this build on a fresh KOLIBRI_HOME and go through the onboarding as follows:
  - Group Learning
  - Learn-only device
  - Import one or more existing users... (select the device you have the credentials for)
  - Enter one of the users' credentials
  - Dismiss / cancel the "Device limitations" modal (if you don't get this, then your user doesn't have the right permissions for this test)
  - Enter the other user's credentials and click "Import" when you see the "Device limitations" modal
  - When import completes, finish the provisioning and you should be logged in as the user you actually imported (the second one) and the other user will not be on the device (you should not be able to log in as the first user whose credentials you entered during provisioning)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
