### PR TITLE
Add loader to YourClasses component

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/YourClasses/__tests__/YourClasses.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/YourClasses/__tests__/YourClasses.spec.js
@@ -43,6 +43,11 @@ function makeWrapper(propsData) {
     propsData,
     localVue,
     router,
+    data() {
+      return {
+        loading: false,
+      };
+    },
   });
 }
 

--- a/kolibri/plugins/learn/assets/src/views/YourClasses/__tests__/YourClasses.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/YourClasses/__tests__/YourClasses.spec.js
@@ -43,11 +43,6 @@ function makeWrapper(propsData) {
     propsData,
     localVue,
     router,
-    data() {
-      return {
-        loading: false,
-      };
-    },
   });
 }
 

--- a/kolibri/plugins/learn/assets/src/views/YourClasses/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/YourClasses/index.vue
@@ -39,10 +39,10 @@
       </CardLink>
     </CardGrid>
 
-    <p v-else>
+    <p v-else-if="!loading">
       {{ $tr('noClasses') }}
     </p>
-
+    <KCircularLoader v-else />
   </section>
 
 </template>
@@ -84,6 +84,7 @@
     data() {
       return {
         classAssignmentsLink,
+        loading: true,
       };
     },
     computed: {
@@ -102,6 +103,15 @@
       displayAllClassesLink() {
         return this.classes && this.classes.length > this.visibleClasses.length;
       },
+    },
+    mounted() {
+      // Wait some time for array of classes to completely load
+      setTimeout(
+        () => {
+          this.loading = false;
+        },
+        this.classes && this.classes.length === 0 ? 2200 : 0
+      );
     },
     $trs: {
       yourClassesHeader: {

--- a/kolibri/plugins/learn/assets/src/views/YourClasses/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/YourClasses/index.vue
@@ -42,7 +42,6 @@
     <p v-else-if="!loading">
       {{ $tr('noClasses') }}
     </p>
-    <KCircularLoader v-else />
   </section>
 
 </template>
@@ -80,11 +79,14 @@
         required: false,
         default: false,
       },
+      loading: {
+        type: Boolean,
+        default: null,
+      },
     },
     data() {
       return {
         classAssignmentsLink,
-        loading: true,
       };
     },
     computed: {
@@ -103,15 +105,6 @@
       displayAllClassesLink() {
         return this.classes && this.classes.length > this.visibleClasses.length;
       },
-    },
-    mounted() {
-      // Wait some time for array of classes to completely load
-      setTimeout(
-        () => {
-          this.loading = false;
-        },
-        this.classes && this.classes.length === 0 ? 2200 : 0
-      );
     },
     $trs: {
       yourClassesHeader: {

--- a/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/AllClassesPage.vue
@@ -7,6 +7,7 @@
     <YourClasses
       v-if="isUserLoggedIn"
       :classes="classrooms"
+      :loading="loading"
     />
     <AuthMessage v-else authorizedRole="learner" />
   </LearnAppBarPage>
@@ -42,6 +43,9 @@
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       ...mapState('classes', ['classrooms']),
+      ...mapState({
+        loading: state => state.core.loading,
+      }),
       breadcrumbs() {
         return [
           {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This pr adds a loader to the `YourClasses` component to fix flash of text stating "You are not enrolled in any classes" that would previously display before list of classes finished loading.

Page loading with throttling preset Fast 3G:


https://github.com/learningequality/kolibri/assets/46411498/b06e8cf6-4330-438a-b220-1df9baa88444


Page loading with throttling Slow 3G:

https://github.com/learningequality/kolibri/assets/46411498/9c81d6be-1bcf-405b-9aa5-dc3c058a0f0e


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11043 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Close an assigned lesson, and go to view of user's assigned classes. 
2. May have to open `Network` tab after inspecting the page and change `No throttling` to a different browser speed
3. Confirm that no brief flash of the text displays before classes load.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
