### PR TITLE
Layout tweaks for Learn

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/index.vue
@@ -177,7 +177,11 @@
 <style lang="scss" scoped>
 
   .section:not(:first-child) {
-    margin-top: 42px;
+    margin-top: 32px;
+  }
+
+  .section:first-child {
+    margin-top: 16px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -4,7 +4,6 @@
     <component
       :is="!windowIsSmall && currentCardViewStyle === 'list' ? 'div' : 'CardGrid'"
       :data-test="`${windowIsSmall ? '' : 'non-'}mobile-card-grid`"
-      :gridType="grid"
     >
       <component
         :is="componentType"
@@ -74,14 +73,6 @@
           return ['card', 'list'].includes(value);
         },
       },
-      // Used to define the "type" (number of columns) for <CardGrid />
-      // Currently only either `1` or `2`
-      // See props in CardGrid.vue for more details on # of cards per level
-      gridType: {
-        type: Number,
-        required: true,
-        default: 1,
-      },
       keepCurrentBackLink: {
         type: Boolean,
         default: false,
@@ -101,12 +92,6 @@
           return 'HybridLearningContentCard';
         }
         return 'CardList';
-      },
-      grid() {
-        if (this.windowIsSmall) {
-          return 1;
-        }
-        return this.gridType;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -35,7 +35,6 @@
       :contents="topic.children"
       :allowDownloads="allowDownloads"
       currentCardViewStyle="card"
-      :gridType="2"
       :keepCurrentBackLink="true"
       @toggleInfoPanel="$emit('toggleInfoPanel', $event)"
     />

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -122,7 +122,6 @@
               <!-- display all resources at the top level of the folder -->
               <LibraryAndChannelBrowserMainContent
                 v-if="resources.length"
-                :gridType="2"
                 :allowDownloads="allowDownloads"
                 data-test="search-results"
                 :contents="resourcesDisplayed"


### PR DESCRIPTION
## Summary
* Adds top spacing for the Home page
* Uses KDS standard spacing for sections
* Switches all TopicsPage displays to use only GridType 1 to avoid squashed cards on breakpoint 4

## Reviewer guidance
Desktop:
![Screenshot from 2023-08-04 14-25-27](https://github.com/learningequality/kolibri/assets/1680573/9b8fa6c9-36ce-4439-8878-c7494a8e4b4d)

Mobile:
![Screenshot from 2023-08-04 14-26-48](https://github.com/learningequality/kolibri/assets/1680573/857c6e0d-5740-4435-8031-ba8fde3c31db)


![Screenshot from 2023-08-04 14-53-56](https://github.com/learningequality/kolibri/assets/1680573/d27e30ac-4416-4e54-aec9-a450f7e520b4)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
