### PR TITLE
Prevent learner only imported superadmins from seeing studio.

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useDevices.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDevices.js
@@ -6,6 +6,7 @@ import { computed, getCurrentInstance, ref } from 'kolibri.lib.vueCompositionApi
 import { NetworkLocationResource, RemoteChannelResource } from 'kolibri.resources';
 import { get, set } from '@vueuse/core';
 import useMinimumKolibriVersion from 'kolibri.coreVue.composables.useMinimumKolibriVersion';
+import useUser from 'kolibri.coreVue.composables.useUser';
 import plugin_data from 'plugin_data';
 import { KolibriStudioId } from '../constants';
 import { learnStrings } from '../views/commonLearnStrings';
@@ -24,21 +25,29 @@ const KolibriStudioDeviceData = {
 
 const { isMinimumKolibriVersion } = useMinimumKolibriVersion(0, 16, 0);
 
+const { isLearnerOnlyImport, canManageContent } = useUser();
+
+function canAccessStudio() {
+  return !get(isLearnerOnlyImport) && get(canManageContent);
+}
+
 function fetchDevices() {
   return Promise.all([
-    RemoteChannelResource.getKolibriStudioStatus(),
+    canAccessStudio() ? RemoteChannelResource.getKolibriStudioStatus() : Promise.resolve(null),
     NetworkLocationResource.list(),
   ]).then(([studioResponse, devices]) => {
-    const studio = studioResponse.data;
-    devices = devices.filter(device => isMinimumKolibriVersion(device.kolibri_version));
-    if (studio.available && isMinimumKolibriVersion(studio.kolibri_version || '0.15.0')) {
-      return [
-        {
-          ...studio,
-          ...KolibriStudioDeviceData,
-        },
-        ...devices,
-      ];
+    if (canAccessStudio()) {
+      const studio = studioResponse.data;
+      devices = devices.filter(device => isMinimumKolibriVersion(device.kolibri_version));
+      if (studio.available && isMinimumKolibriVersion(studio.kolibri_version || '0.15.0')) {
+        return [
+          {
+            ...studio,
+            ...KolibriStudioDeviceData,
+          },
+          ...devices,
+        ];
+      }
     }
     return devices;
   });
@@ -46,6 +55,9 @@ function fetchDevices() {
 
 export function setCurrentDevice(id) {
   if (id === KolibriStudioId) {
+    if (!canAccessStudio()) {
+      return Promise.reject('Cannot access Kolibri Studio');
+    }
     set(currentDevice, KolibriStudioDeviceData);
     return Promise.resolve(KolibriStudioDeviceData);
   }

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -106,7 +106,9 @@ export default [
       if (unassignedContentGuard()) {
         return unassignedContentGuard();
       }
-      showLibrary(store, to.query, to.params.deviceId);
+      showLibrary(store, to.query, to.params.deviceId).catch(() => {
+        router.replace({ name: PageNames.ROOT });
+      });
     },
     component: LibraryPage,
     props: route => {
@@ -159,7 +161,9 @@ export default [
       if (toRoute.params.id === fromRoute.params.id) {
         return;
       }
-      showTopicsTopic(store, toRoute);
+      showTopicsTopic(store, toRoute).catch(() => {
+        router.replace({ name: PageNames.ROOT });
+      });
     },
     component: TopicsPage,
     props: true,
@@ -176,7 +180,9 @@ export default [
       if (toRoute.params.id === fromRoute.params.id) {
         return;
       }
-      showTopicsTopic(store, toRoute);
+      showTopicsTopic(store, toRoute).catch(() => {
+        router.replace({ name: PageNames.ROOT });
+      });
     },
     component: TopicsPage,
     props: true,
@@ -185,7 +191,9 @@ export default [
     name: PageNames.TOPICS_CONTENT,
     path: `/topics${optionalDeviceIdPathSegment}/c/:id`,
     handler: toRoute => {
-      showTopicsContent(store, toRoute.params.id, toRoute.params.deviceId);
+      showTopicsContent(store, toRoute.params.id, toRoute.params.deviceId).catch(() => {
+        router.replace({ name: PageNames.ROOT });
+      });
     },
     component: TopicsContentPage,
     props: true,

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -70,8 +70,6 @@
 
 <script>
 
-  import { mapGetters } from 'vuex';
-
   import ImmersivePage from 'kolibri.coreVue.components.ImmersivePage';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
@@ -116,7 +114,6 @@
       };
     },
     computed: {
-      ...mapGetters(['isSuperuser']),
       areMoreDevicesAvailable() {
         return this.unpinnedDevices?.length > 0;
       },
@@ -129,12 +126,7 @@
         );
       },
       networkDevicesWithChannels() {
-        //display Kolibri studio for superusers only
-        return this.networkDevices.filter(
-          device =>
-            device.channels?.length > 0 &&
-            (device.instance_id !== this.studioId || this.isSuperuser)
-        );
+        return this.networkDevices.filter(device => device.channels?.length > 0);
       },
       pageHeaderStyle() {
         return {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -375,7 +375,7 @@
     },
     computed: {
       ...mapState(['rootNodes']),
-      ...mapGetters(['isSuperuser', 'isUserLoggedIn', 'getRootNodesLoading']),
+      ...mapGetters(['isUserLoggedIn', 'getRootNodesLoading']),
       appBarTitle() {
         return this.learnString(this.deviceId ? 'exploreLibraries' : 'learnLabel');
       },
@@ -397,10 +397,7 @@
         //display Kolibri studio for superusers only
         return cloneDeep(this.devices).filter(device => {
           device['channels'] = device.channels?.slice(0, this.channelsToDisplay);
-          return (
-            device.channels?.length > 0 &&
-            (device.instance_id !== this.studioId || this.isSuperuser)
-          );
+          return device.channels?.length > 0;
         });
       },
       devicesWithChannelsExist() {


### PR DESCRIPTION
## Summary
* Tweak that became apparent during demonstration of new remote browsing feature
* Hides Studio from learner only imported superadmins
* Consolidates logic for this in the useDevices composable to prevent having to repeat it across components
* Adds guards to prevent users from attempting to manually navigate to browser kolibri-studio by putting the unique id in the URL