### PR TITLE
 Fix eternal KCircularLoader when no downloads exist

### DIFF
--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -37,7 +37,7 @@
           <SortFilter />
         </KGridItem>
       </KGrid>
-      <KCircularLoader v-if="loading" />
+      <KCircularLoader v-if="shouldStopSpinning" />
       <DownloadsList
         v-else
         :downloads="sortedFilteredDownloads()"
@@ -165,6 +165,20 @@
           );
         }
         return totalSize;
+      },
+      shouldStopSpinning() {
+        return (
+          this.loading && this.sortedFilteredDownloads && this.sortedFilteredDownloads.length === 0
+        );
+      },
+    },
+    watch: {
+      shouldStopSpinning(newValue) {
+        if (newValue) {
+          setTimeout(() => {
+            this.loading = false;
+          }, 100);
+        }
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -37,7 +37,21 @@
           <SortFilter />
         </KGridItem>
       </KGrid>
-      <KCircularLoader v-if="shouldStopSpinning" />
+
+
+
+      <div v-if="loading">
+        <!-- <KCircularLoader v-if="setLazyLoading" /> -->
+
+        <p
+          class="text-center"
+        >
+          {{ coreString('noResourcesDownloaded') }}
+        </p>
+
+      </div>
+
+      <!--  -->
       <DownloadsList
         v-else
         :downloads="sortedFilteredDownloads()"
@@ -166,20 +180,9 @@
         }
         return totalSize;
       },
-      shouldStopSpinning() {
-        return (
-          this.loading && this.sortedFilteredDownloads && this.sortedFilteredDownloads.length === 0
-        );
-      },
     },
-    watch: {
-      shouldStopSpinning(newValue) {
-        if (newValue) {
-          setTimeout(() => {
-            this.loading = false;
-          }, 100);
-        }
-      },
+    beforeMount() {
+      this.setLazyLoading();
     },
     methods: {
       formattedSize(size) {
@@ -195,6 +198,13 @@
         } else {
           this.removeDownloadsRequest(resources.map(resource => ({ id: resource })));
         }
+      },
+      setLazyLoading() {
+        var isloading = true;
+        setTimeout(function() {
+          isloading = false;
+          return isloading;
+        }, 1000);
       },
     },
   };
@@ -231,6 +241,10 @@
     height: 2em;
     padding-right: 24px;
     font-size: 14px;
+  }
+
+  .text-center {
+    text-align: center;
   }
 
 </style>


### PR DESCRIPTION

## Summary
This pull request resolve problem of an eternal KCircularLoader being displayed on the myDownloads page when there are no downloads available.

## References
Fixes #11029
## Reviewer guidance

- Navigate to the myDownloads page when no downloaded items are present.
- Ensured that  the correct message is displayed.
- Verified that the KCircularLoader no longer persists when there are no downloads

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
