### PR TITLE
Consolidate logic to prevent polling for non learner only imports.

### DIFF
--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -3,6 +3,9 @@ import { UserSyncStatusResource } from 'kolibri.resources';
 import store from 'kolibri.coreVue.vuex.store';
 import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
 import { get, useTimeoutPoll } from '@vueuse/core';
+import useUser from './useUser';
+
+const { isLearnerOnlyImport, isUserLoggedIn } = useUser();
 
 const status = ref(SyncStatus.NOT_CONNECTED);
 const queued = ref(false);
@@ -34,7 +37,7 @@ export function fetchUserSyncStatus(params) {
 }
 
 export function pollUserSyncStatusTask() {
-  if (!store.state.core.session.user_id) {
+  if (!get(isUserLoggedIn) || !get(isLearnerOnlyImport)) {
     return Promise.resolve();
   }
   return fetchUserSyncStatus({ user: store.state.core.session.user_id }).then(syncData => {
@@ -58,7 +61,7 @@ export default function useUserSyncStatus() {
   onMounted(() => {
     usageCount.value++;
     if (usageCount.value === 1) {
-      if (store.state.core.session.user_id) {
+      if (get(isUserLoggedIn) && get(isLearnerOnlyImport)) {
         pollUserSyncStatusTask();
       }
       resume();

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -55,14 +55,12 @@
 <script>
 
   import { mapGetters } from 'vuex';
-  import { get } from '@vueuse/core';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import SideNav from 'kolibri.coreVue.components.SideNav';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import useUser from 'kolibri.coreVue.composables.useUser';
   import MeteredConnectionNotificationModal from 'kolibri-common/components/MeteredConnectionNotificationModal';
   import AppBar from '../AppBar';
   import StorageNotification from '../StorageNotification';
@@ -80,11 +78,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      let userDeviceStatus = null;
-      const { isLearnerOnlyImport } = useUser();
-      if (get(isLearnerOnlyImport)) {
-        userDeviceStatus = useUserSyncStatus().deviceStatus;
-      }
+      const userDeviceStatus = useUserSyncStatus().deviceStatus;
       const { windowBreakpoint, windowIsSmall } = useKResponsiveWindow();
       return {
         userDeviceStatus,

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -234,7 +234,6 @@
 <script>
 
   import { mapGetters, mapState } from 'vuex';
-  import { get } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { UserKinds, NavComponentSections } from 'kolibri.coreVue.vuex.constants';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
@@ -287,15 +286,14 @@
     },
     mixins: [commonCoreStrings, responsiveWindowMixin, responsiveElementMixin, navComponentsMixin],
     setup() {
-      let userSyncStatus = null;
-      let userLastSynced = null;
       const { isLearnerOnlyImport } = useUser();
-      if (get(isLearnerOnlyImport)) {
-        const { status, lastSynced } = useUserSyncStatus();
-        userSyncStatus = status;
-        userLastSynced = lastSynced;
-      }
-      return { isLearnerOnlyImport, themeConfig, userSyncStatus, userLastSynced };
+      const { status, lastSynced } = useUserSyncStatus();
+      return {
+        isLearnerOnlyImport,
+        themeConfig,
+        userSyncStatus: status,
+        userLastSynced: lastSynced,
+      };
     },
     props: {
       navShown: {


### PR DESCRIPTION
## Summary
* Prevents polling for user sync status when user is not a learner only import

## References
Fixes [#11069](https://github.com/learningequality/kolibri/issues/11069)

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
