### PR TITLE
Change the way we check for Android to use Python internals.

### DIFF
--- a/kolibri/utils/android.py
+++ b/kolibri/utils/android.py
@@ -1,4 +1,4 @@
-from os import environ
+import sys
 
 
 # A constant to be used in place of Python's platform.system()
@@ -8,7 +8,9 @@ ANDROID_PLATFORM_SYSTEM_VALUE = "Android"
 
 # Android is based on the Linux kernel, but due to security issues, we cannot
 # run the /proc command there, so we need a way to distinguish between the two.
-# Python for Android always sets some Android environment variables, so we check
-# for one of them to differentiate. This is how Kivy detects Android as well.
+# When Python is built against a specific version of the Android API, this method
+# is defined. Otherwise it is not. Note that this cannot be used to distinguish
+# between the current runtime versions of Android, as this value is set to the minimum
+# API level that this Python version was compiled against.
 def on_android():
-    return "ANDROID_ARGUMENT" in environ
+    return hasattr(sys, "getandroidapilevel")


### PR DESCRIPTION
## Summary
* Switches from the Python for Android specific environment variable checking to checking if an Android only sys call is present

## References
https://docs.python.org/3/library/sys.html#sys.getandroidapilevel

## Reviewer guidance
I have tested this in an Android installer build, and a call to this API returns the Android API version against which it was compiled (so the minimum API version of 23 that we currently support). This suggests to me this is a robust check, as it is not dependent on anything at runtime.

This should also allow for easier experimentation with a non-P4A based implementation like chaquopy in the future.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
