### PR TITLE
MyDownloads bug fixes

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -50,6 +50,7 @@ from kolibri.core.content import models
 from kolibri.core.content import serializers
 from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentRemovalRequest
+from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.permissions import CanManageContent
 from kolibri.core.content.tasks import automatic_resource_import
@@ -1349,7 +1350,9 @@ class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
     )
 
     def get_queryset(self):
-        return ContentDownloadRequest.objects.filter(source_id=self.request.user.id)
+        return ContentDownloadRequest.objects.filter(
+            source_id=self.request.user.id, reason=ContentRequestReason.UserInitiated
+        )
 
     def annotate_queryset(self, queryset):
         return queryset.annotate(
@@ -1373,11 +1376,12 @@ class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
             )
 
         existing_download_request = (
-            existing_deletion_request
-        ) = ContentRemovalRequest.objects.filter(
-            id=request_id,
-            source_id=request.user.id,
-        ).first()
+            self.get_queryset()
+            .filter(
+                id=request_id,
+            )
+            .first()
+        )
 
         if existing_download_request is None:
             return Response(
@@ -1386,7 +1390,8 @@ class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
             )
 
         existing_deletion_request = ContentRemovalRequest.objects.filter(
-            id=request_id,
+            contentnode_id=existing_download_request.contentnode_id,
+            reason=existing_download_request.reason,
             source_id=request.user.id,
         ).first()
 

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -4,7 +4,6 @@
 
 import { getCurrentInstance, reactive, ref } from 'kolibri.lib.vueCompositionApi';
 import { ContentRequestResource } from 'kolibri.resources';
-import Vue from 'kolibri.lib.vue';
 import { createTranslator } from 'kolibri.utils.i18n';
 import { get, set } from '@vueuse/core';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
@@ -40,7 +39,11 @@ export default function useDownloadRequests(store) {
   function fetchUserDownloadRequests(params) {
     return ContentRequestResource.list(params)
       .then(downloadRequests => {
-        set(downloadRequestMap, downloadRequests);
+        const downloads = downloadRequests.reduce((acc, obj) => {
+          acc[obj.id] = obj;
+          return acc;
+        }, {});
+        set(downloadRequestMap, downloads);
         set(loading, false);
       })
       .then(store.dispatch('notLoading'));
@@ -100,7 +103,7 @@ export default function useDownloadRequests(store) {
     ContentRequestResource.deleteModel({
       id: content.id,
       contentnode_id: content.contentnode_id,
-    }).then(Vue.delete(downloadRequestMap, content.id));
+    });
     return Promise.resolve();
   }
 
@@ -109,7 +112,7 @@ export default function useDownloadRequests(store) {
       ContentRequestResource.deleteModel({
         id: content.id,
         contentnode_id: content.contentnode_id,
-      }).then(Vue.delete(downloadRequestMap, content.id));
+      });
     });
     return Promise.resolve();
   }

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -9,6 +9,7 @@ import { get, set } from '@vueuse/core';
 import redirectBrowser from 'kolibri.utils.redirectBrowser';
 import urls from 'kolibri.urls';
 import client from 'kolibri.client';
+import Vue from 'kolibri.lib.vue';
 import useDevices from './useDevices';
 
 const downloadRequestsTranslator = createTranslator('DownloadRequests', {
@@ -39,11 +40,9 @@ export default function useDownloadRequests(store) {
   function fetchUserDownloadRequests(params) {
     return ContentRequestResource.list(params)
       .then(downloadRequests => {
-        const downloads = downloadRequests.reduce((acc, obj) => {
-          acc[obj.id] = obj;
-          return acc;
-        }, {});
-        set(downloadRequestMap, downloads);
+        for (const obj of downloadRequests) {
+          set(downloadRequestMap, obj.id, obj);
+        }
         set(loading, false);
       })
       .then(store.dispatch('notLoading'));
@@ -104,16 +103,7 @@ export default function useDownloadRequests(store) {
       id: content.id,
       contentnode_id: content.contentnode_id,
     });
-    return Promise.resolve();
-  }
-
-  function removeDownloadsRequest(contentList) {
-    contentList.forEach(content => {
-      ContentRequestResource.deleteModel({
-        id: content.id,
-        contentnode_id: content.contentnode_id,
-      });
-    });
+    Vue.delete(downloadRequestMap, content.id);
     return Promise.resolve();
   }
 
@@ -141,7 +131,6 @@ export default function useDownloadRequests(store) {
     addDownloadRequest,
     loading,
     removeDownloadRequest,
-    removeDownloadsRequest,
     downloadRequestsTranslator,
     isDownloadingByLearner,
     isDownloadedByLearner,

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -68,7 +68,7 @@
                   v-else
                   :text="coreString('viewAction')"
                   appearance="flat-button"
-                  :href="genExternalContentURLBackLinkCurrentPage(download.id)"
+                  :href="genExternalContentURLBackLinkCurrentPage(download.contentnode_id)"
                 />
               </td>
               <td class="resource-action">
@@ -143,8 +143,15 @@
       const sortedFilteredDownloads = () => {
         let downloadsToDisplay = [];
         if (downloadRequestMap) {
-          for (const [, value] of Object.entries(downloadRequestMap.value)) {
+          for (const [, value] of Object.entries(downloadRequestMap)) {
             downloadsToDisplay.push(value);
+          }
+          if (activityType) {
+            if (activityType.value !== 'all') {
+              downloadsToDisplay = downloadsToDisplay.filter(download =>
+                download.metadata.learning_activities.includes(activityType.value)
+              );
+            }
           }
           if (sort) {
             switch (sort.value) {
@@ -167,13 +174,6 @@
               default:
                 // If no valid sort option provided, return unsorted array
                 break;
-            }
-          }
-          if (activityType) {
-            if (activityType.value !== 'all') {
-              downloadsToDisplay = downloadsToDisplay.filter(download =>
-                download.metadata.learning_activities.includes(activityType.value)
-              );
             }
           }
         }
@@ -295,10 +295,8 @@
       },
       removeResources() {
         this.$emit('removeResources', this.resourcesToDelete);
-        this.selectedDownloads = this.selectedDownloads.filter(
-          resourceId => !this.resourcesToDelete.includes(resourceId)
-        );
         this.resourcesToDelete = [];
+        this.sortedFilteredDownloads();
       },
       getIcon(activities) {
         return this.getLearningActivityIcon(activities);

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -52,13 +52,12 @@
 
 <script>
 
-  import { get, set } from '@vueuse/core';
+  import { get } from '@vueuse/core';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { computed, getCurrentInstance, watch, ref } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
-  import Vue from 'kolibri.lib.vue';
   import useDownloadRequests from '../../composables/useDownloadRequests';
   import DownloadsList from './DownloadsList';
   import ActivityFilter from './Filters/ActivityFilter.vue';
@@ -81,7 +80,6 @@
         fetchAvailableFreespace,
         availableSpace,
         removeDownloadRequest,
-        removeDownloadsRequest,
       } = useDownloadRequests();
 
       const store = getCurrentInstance().proxy.$store;
@@ -105,9 +103,6 @@
       fetchDownloads();
       fetchAvailableFreespace();
       watch(route, fetchDownloads);
-      watch(downloadRequestMap, () => {
-        set(totalPageNumber, downloadRequestMap.totalPageNumber);
-      });
 
       return {
         downloadRequestMap,
@@ -117,19 +112,14 @@
         fetchAvailableFreespace,
         sort,
         removeDownloadRequest,
-        removeDownloadsRequest,
       };
     },
     computed: {
       sizeOfMyDownloads() {
-        let size;
-        if (this.downloadRequestMap && this.downloadRequestMap.value) {
-          size = Object.values(this.downloadRequestMap.value).reduce(
-            (acc, object) => acc + object.metadata.file_size,
-            0
-          );
-        }
-        return size;
+        return Object.values(this.downloadRequestMap).reduce(
+          (acc, object) => acc + object.metadata.file_size,
+          0
+        );
       },
     },
     methods: {
@@ -143,11 +133,9 @@
       removeResources(resources) {
         if (resources.length === 1) {
           this.removeDownloadRequest(resources[0]);
-          Vue.delete(this.downloadRequestMap.value, resources[0].id);
         } else {
-          resources.map(resource => {
-            this.removeDownloadsRequest({ id: resource.id });
-            Vue.delete(this.downloadRequestMap.value, resource.id);
+          resources.forEach(resource => {
+            this.removeDownloadRequest({ id: resource.id });
           });
         }
       },


### PR DESCRIPTION
## Summary
This PR generally: 
Cleans up/improves reactivity on the frontend 
Fixes broken remove download functionality 


## References
Fixes [#11026](https://github.com/learningequality/kolibri/issues/11026)
Fixes [#11044](https://github.com/learningequality/kolibri/issues/11044)


https://github.com/learningequality/kolibri/assets/17235236/bf41fd4c-3fec-4bc6-817a-da438a6f2805



## Reviewer guidance

1. Import a LOD from an existing facility
2. Import resources from that facility over the "local network"
3. Sort and filter requests
4. Remove requests - removing a single or a selection on download items should work 

there will be a follow up PR on Monday that manages: 
- polling for status updates on the downloads 
- error handling for errors when the source device is no longer on the network
- ensure that the "download" icon is properly reactive both on the content cards and within the content renderer (still inconsistent)

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
