### PR TITLE
Update documentation for contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Kolibri GitHub Discussions
+    url: https://github.com/learningequality/kolibri/discussions
+    about: Please ask general questions about contributing to Kolibri or report development server issues here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Kolibri GitHub Discussions
     url: https://github.com/learningequality/kolibri/discussions
     about: Please ask general questions about contributing to Kolibri or report development server issues here.
+  - name: Learning Equality Community Forum
+    url: https://community.learningequality.org/
+    about: Ask and answer questions about Learning Equality's products and tools, share your experiences using Kolibri, and connect with users around the world.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,7 +38,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Geoff Rich | geoffrey1218 |
 | Hans Gamboa | HansGam |
 | Devon Rueckner | indirectlylit |
-| inflrscns | inflrscns |
+| - | inflrscns |
 | Ivan Savov | ivanistheone |
 | Jamie Alexandre | jamalex |
 | Jason Tame | JasonTame |
@@ -55,7 +55,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Paul Luna | luna215 |
 | Lingyi Wang | lyw07 |
 | Magali Boizot-Roche | magali-br |
-| manuq | manuq |
+| - | manuq |
 | Marcella Maki | marcellamaki |
 | Maureen Hernandez | MauHernandez |
 | Michael Gallaspy | MCGallaspy |
@@ -80,7 +80,7 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Richard Tibbles | rtibbles |
 | Sairina Merino Tsui | sairina |
 | Shanavas M | shanavas786 |
-| shivangtripathi | shivangtripathi |
+| - | shivangtripathi |
 | Udith Prabhu | udithprabhu |
 | Vivek Agrawal | vkWeb |
 | Whitney Zhu | whitzhu |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,19 @@
 
-# Contributing
+<!-- Also update README.md (duplicate) -->
 
-First of all, thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference.
+# How can I contribute?
 
-Before your first contribution, please make sure to check out our [Kolibri developer documentation](https://kolibri-dev.readthedocs.io), where you will find detailed guidance on [getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html), [how-to guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html), and much more.
+1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
+2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22).
+4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
 
-We encourage you to visit [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions) to ask questions about contributing to Kolibri, troubleshoot development server issues, or connect with other contributors.
+Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).
 
-Even though you're welcome to ask for an assignment of any issue you find interesting, we recommend especially issues tagged as [help wanted](https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted). If you're looking for your first issue or a smaller, self-contained issue, issues tagged as [beginner friendly](https://github.com/learningequality/kolibri/labels/TAG%3A%20beginner%20friendly) are a good place to start.
+**❓ Where to ask questions**
 
-For questions related to a specific issue or assignment requests, feel free to use the issue's comment section. Note that in times of increased contributor activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out through [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).
+- For anything development related, refer to the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) at first. Some answers may already be there.
+- For questions related to a specific issue or assignment requests, use the corresponding issue's comments section.
+- Visit [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions) to ask about anything related to contributing to Kolibri, troubleshoot development server issues, or connect with other contributors.
+
+*Thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 
 1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
 2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
-3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22).
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aopen+label%3A%22TAG%3A+help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22+no%3Aassignee).
 4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
 
 Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Developed with and for the community by [Learning Equality](https://learningequa
 
 1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
 2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
-3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22).
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aopen+label%3A%22TAG%3A+help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22+no%3Aassignee).
 4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
 
 Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ This repository is for software developers wishing to contribute to Kolibri. If 
 
 Developed with and for the community by [Learning Equality](https://learningequality.org/).
 
+<!-- Also update CONTRIBUTING.md (duplicate) -->
+## How can I contribute?
+
+1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
+2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22).
+4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
+
+Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).
+
+**❓ Where to ask questions**
+
+- For anything development related, refer to the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) at first. Some answers may already be there.
+- For questions related to a specific issue or assignment requests, use the corresponding issue's comments section.
+- Visit [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions) to ask about anything related to contributing to Kolibri, troubleshoot development server issues, or connect with other contributors.
+
+*Thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference.*
 
 ## How can I use it?
 
@@ -31,8 +48,3 @@ Kolibri is [available for download](https://learningequality.org/download/) from
 You can ask questions, make suggestions, and report issues in the [community forums](https://community.learningequality.org/).
 
 If you have found a bug and are comfortable using Github and Markdown, you can create a [Github issue](https://github.com/learningequality/kolibri/issues) following the instructions in the issue template.
-
-
-## How can I contribute?
-
-Please see the 'contributing' section of our [developer documentation](http://kolibri-dev.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This repository is for software developers wishing to contribute to Kolibri. If 
 
 Developed with and for the community by [Learning Equality](https://learningequality.org/).
 
+## How can I use it?
+
+Kolibri is [available for download](https://learningequality.org/download/) from our website.
+
+## How do I get help or give feedback?
+
+You can ask questions, make suggestions, and report issues in the [community forums](https://community.learningequality.org/).
+
+If you have found a bug and are comfortable using Github and Markdown, you can create a [Github issue](https://github.com/learningequality/kolibri/issues) following the instructions in the issue template.
+
 <!-- Also update CONTRIBUTING.md (duplicate) -->
 ## How can I contribute?
 
@@ -37,14 +47,3 @@ Note that in times of increased contributions activity, it may take us a few day
 - Visit [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions) to ask about anything related to contributing to Kolibri, troubleshoot development server issues, or connect with other contributors.
 
 *Thank you for your interest in contributing to Kolibri! The project was founded by volunteers dedicated to helping make educational materials more accessible to those in need, and every contribution makes a difference.*
-
-## How can I use it?
-
-Kolibri is [available for download](https://learningequality.org/download/) from our website.
-
-
-## How do I get help or give feedback?
-
-You can ask questions, make suggestions, and report issues in the [community forums](https://community.learningequality.org/).
-
-If you have found a bug and are comfortable using Github and Markdown, you can create a [Github issue](https://github.com/learningequality/kolibri/issues) following the instructions in the issue template.

--- a/docs/contributing/ways_to_contribute.rst
+++ b/docs/contributing/ways_to_contribute.rst
@@ -10,7 +10,8 @@ little bit helps, and credit will always be given.
 Talk to us
 ----------
 
-* Get support in our `Community Forums <http://community.learningequality.org/>`__.
+* Get product support in our `Community Forums <http://community.learningequality.org/>`__.
+* Get development contributions support in `Kolibri GitHub Discussions <https://github.com/learningequality/kolibri/discussions>`__.
 * Email us at info@learningequality.org
 * Visit the ``#kolibri`` room on Freenode IRC
 
@@ -36,15 +37,7 @@ Please make sure to use the template. Replace the HTML comments (the ``<!-- ... 
 Write code
 ----------
 
-Before your first contribution, please make sure to check out :ref:`getting_started`. In addition to that, :ref:`howtos` have step by step guides for common tasks in getting started and working on Kolibri.
-
-We encourage you to visit `Kolibri GitHub Discussions <https://github.com/learningequality/kolibri/discussions>`__ to ask questions about contributing to Kolibri, troubleshoot development server issues, or connect with other contributors.
-
-Even though you're welcome to ask for an assignment of any issue you find interesting, we recommend especially issues tagged as `help wanted <https://github.com/learningequality/kolibri/labels/TAG%3A%20help%20wanted>`__. If you're looking for your first issue or a smaller, self-contained issue, issues tagged as `beginner friendly <https://github.com/learningequality/kolibri/labels/TAG%3A%20beginner%20friendly>`__ are a good place to start.
-
-For questions related to a specific issue or assignment requests, feel free to use the issue's comment section. Note that in times of increased contributor activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out through `Kolibri GitHub Discussions <https://github.com/learningequality/kolibri/discussions>`__.
-
-Note that since Kolibri is still in development, the APIs are subject to change, and a lot of code is still in flux.
+See `How can I contribute? <https://github.com/learningequality/kolibri/blob/develop/CONTRIBUTING.md>`__
 
 Write documentation
 -------------------

--- a/docs/contributing/ways_to_contribute.rst
+++ b/docs/contributing/ways_to_contribute.rst
@@ -13,7 +13,6 @@ Talk to us
 * Get product support in our `Community Forums <http://community.learningequality.org/>`__.
 * Get development contributions support in `Kolibri GitHub Discussions <https://github.com/learningequality/kolibri/discussions>`__.
 * Email us at info@learningequality.org
-* Visit the ``#kolibri`` room on Freenode IRC
 
 Translate
 ---------

--- a/docs/stack.rst
+++ b/docs/stack.rst
@@ -5,6 +5,7 @@ Tech stack overview
 
 Kolibri is a web application built primarily using `Python <https://www.python.org/>`__ on the server-side and `JavaScript <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference>`__ on the client-side.
 
+Note that since Kolibri is still in development, the APIs are subject to change, and a lot of code is still in flux.
 
 Server
 ------


### PR DESCRIPTION
## Summary

- Updates CONTRIBUTING.md to be easier to navigate and hopefully more engaging
- Adds the same to README.md
- Adds Kolibri GitHub Discussions link to the "Talk to us" section of the developer documentation
- Removes detailed information from the "Write code" section of the developer documentation and instead links to CONTRIBUTING.md
- Uses "-" when full name is not available in AUTHORS.md (agreed on in https://github.com/learningequality/kolibri/pull/10902, to align style with the new automated script)
- Adds redirect from GH Issues to GH Discussions to the issue template chooser

**Why**
It seems it was hard for contributors to discover guidance in the developer docs => this puts more emphasis on GitHub files.

|     | Before | After |
| -- | --------- | ------ |
| CONTRIBUTING.md | ![contributing-before](https://github.com/learningequality/kolibri/assets/13509191/2a2d38db-2cf1-48a6-88a1-1f5a2d49cd1f) | ![contributing-after](https://github.com/learningequality/kolibri/assets/13509191/12cf8e60-cce4-494b-87a3-568ee87b5ebd) |
| README.md | ![readme-before](https://github.com/learningequality/kolibri/assets/13509191/77687b02-31cb-4ac7-88d4-bbfe226bc354) | ![readme-after](https://github.com/learningequality/kolibri/assets/13509191/9bec22d0-f3e1-4d22-b14d-66af5aef850d) |
| Dev docs - Talk to us | ![docs-talk-before](https://github.com/learningequality/kolibri/assets/13509191/950718ed-a762-4cd9-a6fc-f9272d5376af) | ![docs-talk-after](https://github.com/learningequality/kolibri/assets/13509191/00037e87-608b-47c1-b843-b7fd51045a59) |
| Dev docs - Write code | ![docs-write-before](https://github.com/learningequality/kolibri/assets/13509191/ad340c57-341f-4869-a166-ced7b35d5fe6) | ![docs-write-after](https://github.com/learningequality/kolibri/assets/13509191/da23cb8c-4682-48ff-a343-ac7efb095aa1) |

## Comments

Including some information on how to contribute in README.md alongside CONTRIBUTING.md is based on the feedback collected from the team. It's looking good to me as our README.md is not that long anyways and I enjoy the way it stands out now.

I also experimented with shorter summary in README.md (e.g. just mentioning GitHub issues labels) but I didn't find it sufficient especially because I believe it's important to encourage people to use existing documentation before they start asking us for guidance on something that's already written. It is also easier to just copy CONTRIBUTING.md and paste it to README.md.

In general, I am trying to balance maintenance time with discoverability.

## Reviewer guidance

Preview before/after screenshots.
- Does this organization makes sense?
- Is all provided guidance clear?
- Any grammar issues or typos?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
