### PR TITLE
Fix device setting saving in a plugin antagonistic environment (like PyInstaller)

### DIFF
--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -474,7 +474,7 @@ def check_plugin_config_file_location(version):
 def iterate_plugins():
     # Use to dedupe plugins
     plugin_ids = set()
-    for entry_point in entry_points()["kolibri.plugins"]:
+    for entry_point in entry_points().get("kolibri.plugins", []):
         name = entry_point.name
         if name not in plugin_ids:
             plugin_ids.add(name)


### PR DESCRIPTION
## Summary
* Don't throw an error just because we happen to be in an environment where we can't iterate plugins.


## References
Internal server error noted in the logs of [#11076](https://github.com/learningequality/kolibri/issues/11076)

This fixes #11076 - manually confirmed by replicating the error locally, and then switching to the fix.

## Reviewer guidance
Test that device setting saving works in the mac app.

Note this does not fix actually listing the plugins properly, that's filed in a separate issue.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
