### PR TITLE
Garbage Collection Integration for Morango SyncSessions

### DIFF
--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -40,9 +40,10 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
                     sync_filter=sync_filter,
                     is_server=is_server,
                     instance_id=instance_id,
-                    instance_name=instance_name
+                    instance_name=instance_name,
                 )
             )
+
         return False
 
 

--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -1,6 +1,10 @@
+from morango.sync.operations import LocalOperation
+
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.sync_operations import KolibriSingleUserSyncOperation
+from kolibri.core.auth.sync_operations import KolibriSyncOperationMixin
+from kolibri.core.auth.tasks import cleanupsync
 from kolibri.plugins.hooks import register_hook
 
 
@@ -16,6 +20,32 @@ class SingleFacilityUserChangeClearingOperation(KolibriSingleUserSyncOperation):
         return False
 
 
+class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
+    def handle_initial(self, context):
+        if context.is_receiver:
+            is_pull = context.is_pull
+            is_push = context.is_push
+            sync_filter = str(context.filter)
+            is_server = context.is_server
+            instance_id = str(
+                context.sync_session.server_instance_id
+                if context.is_server
+                else context.sync_session.client_instance_id
+            )
+
+            cleanupsync.enqueue(
+                kwargs=dict(
+                    is_pull=is_pull,
+                    is_push=is_push,
+                    sync_filter=sync_filter,
+                    is_server=is_server,
+                    instance_id=instance_id,
+                )
+            )
+        return False
+
+
 @register_hook
 class AuthSyncHook(FacilityDataSyncHook):
     serializing_operations = [SingleFacilityUserChangeClearingOperation()]
+    cleanup_operations = [CleanUpTaskOperation()]

--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -28,11 +28,11 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
             sync_filter = str(context.filter)
             is_server = context.is_server
             instance_id = str(
-                context.sync_session.server_instance_id
+                context.sync_session.client_instance_id
                 if context.is_server
-                else context.sync_session.client_instance_id
+                else context.sync_session.server_instance_id
             )
-
+            instance_name = "client" if is_server else "server"
             cleanupsync.enqueue(
                 kwargs=dict(
                     is_pull=is_pull,
@@ -40,6 +40,7 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
                     sync_filter=sync_filter,
                     is_server=is_server,
                     instance_id=instance_id,
+                    instance_name=instance_name
                 )
             )
         return False

--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -22,25 +22,29 @@ class SingleFacilityUserChangeClearingOperation(KolibriSingleUserSyncOperation):
 
 class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
     def handle_initial(self, context):
+        """
+        :type context: morango.sync.context.LocalSessionContext
+        """
         if context.is_receiver:
             is_pull = context.is_pull
             is_push = context.is_push
             sync_filter = str(context.filter)
-            is_server = context.is_server
-            instance_id = str(
-                context.sync_session.client_instance_id
-                if context.is_server
-                else context.sync_session.server_instance_id
-            )
-            instance_name = "client" if is_server else "server"
+
+            instance_kwargs = {}
+            if context.is_server:
+                instance_kwargs[
+                    "client_instance_id"
+                ] = context.sync_session.client_instance_id
+            else:
+                instance_kwargs[
+                    "server_instance_id"
+                ] = context.sync_session.server_instance_id
             cleanupsync.enqueue(
                 kwargs=dict(
                     is_pull=is_pull,
                     is_push=is_push,
                     sync_filter=sync_filter,
-                    is_server=is_server,
-                    instance_id=instance_id,
-                    instance_name=instance_name,
+                    **instance_kwargs
                 )
             )
 

--- a/kolibri/core/auth/management/commands/cleanupsyncs.py
+++ b/kolibri/core/auth/management/commands/cleanupsyncs.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from kolibri.core.device.utils import device_provisioned
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        if not device_provisioned():
+            raise CommandError("Kolibri is unprovisioned")

--- a/kolibri/core/auth/management/commands/cleanupsyncs.py
+++ b/kolibri/core/auth/management/commands/cleanupsyncs.py
@@ -1,10 +1,12 @@
-from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
+from morango.management.commands.cleanupsyncs import Command as CleanupsyncCommand
 
 from kolibri.core.device.utils import device_provisioned
 
 
-class Command(BaseCommand):
+class Command(CleanupsyncCommand):
     def handle(self, *args, **options):
         if not device_provisioned():
             raise CommandError("Kolibri is unprovisioned")
+
+        return super().handle(*args, **options)

--- a/kolibri/core/auth/management/commands/cleanupsyncs.py
+++ b/kolibri/core/auth/management/commands/cleanupsyncs.py
@@ -9,4 +9,4 @@ class Command(CleanupsyncCommand):
         if not device_provisioned():
             raise CommandError("Kolibri is unprovisioned")
 
-        return super().handle(*args, **options)
+        return super(Command, self).handle(*args, **options)

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -599,3 +599,33 @@ def deletefacility(facility):
         facility=facility,
         noninteractive=True,
     )
+
+
+@register_task(
+    track_progress=False,
+    cancellable=False,
+    long_running=True,
+    queue=facility_task_queue,
+    status_fn=status_fn,
+)
+def cleanupsync(**kwargs):
+    is_pull = kwargs.get("is_pull")
+    is_push = kwargs.get("is_push")
+    sync_filter = kwargs.get("sync_filter")
+    is_server = kwargs.get("is_server")
+    instance_id = kwargs.get("instance_id")
+    instance_name = "server" if is_server else "client"
+    instance_attribute_name = f"{instance_name}-instance-id"
+    if (
+        is_pull is not None
+        and is_push is not None
+        and sync_filter is not None
+        and instance_id is not None
+    ):
+        call_command(
+            "cleanupsyncs",
+            push=is_push,
+            pull=is_pull,
+            sync_filter=str(sync_filter),
+            **{instance_attribute_name: instance_id},
+        )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -616,6 +616,9 @@ def cleanupsync(**kwargs):
     instance_id = kwargs.get("instance_id")
     instance_name = "server" if is_server else "client"
     instance_attribute_name = "{}-instance-id".format(instance_name)
+    instance_attribute = {
+        instance_attribute_name: instance_id,
+    }
     if (
         is_pull is not None
         and is_push is not None
@@ -627,5 +630,5 @@ def cleanupsync(**kwargs):
             push=is_push,
             pull=is_pull,
             sync_filter=str(sync_filter),
-            **{instance_attribute_name: instance_id},
+            **instance_attribute
         )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -615,7 +615,7 @@ def cleanupsync(**kwargs):
     is_server = kwargs.get("is_server")
     instance_id = kwargs.get("instance_id")
     instance_name = "server" if is_server else "client"
-    instance_attribute_name = f"{instance_name}-instance-id"
+    instance_attribute_name = "{}-instance-id".format(instance_name)
     if (
         is_pull is not None
         and is_push is not None

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -630,5 +630,6 @@ def cleanupsync(**kwargs):
             push=is_push,
             pull=is_pull,
             sync_filter=str(sync_filter),
-            **instance_attribute
+            **instance_attribute,
+            expiration=0,
         )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -612,12 +612,10 @@ def cleanupsync(**kwargs):
     is_pull = kwargs.get("is_pull")
     is_push = kwargs.get("is_push")
     sync_filter = kwargs.get("sync_filter")
-    is_server = kwargs.get("is_server")
     instance_id = kwargs.get("instance_id")
-    instance_name = "client" if is_server else "server"
-    instance_attribute_name = "{}-instance-id".format(instance_name)
+    instance_name = kwargs.get("instance_name")
     instance_attribute = {
-        instance_attribute_name: instance_id,
+        "{}-instance-id".format(instance_name): instance_id,
     }
     if (
         is_pull is not None

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -631,5 +631,5 @@ def cleanupsync(**kwargs):
             pull=is_pull,
             sync_filter=str(sync_filter),
             expiration=0,
-            **instance_attribute,
+            **instance_attribute
         )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -630,6 +630,6 @@ def cleanupsync(**kwargs):
             push=is_push,
             pull=is_pull,
             sync_filter=str(sync_filter),
-            **instance_attribute,
             expiration=0,
+            **instance_attribute,
         )

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -614,7 +614,7 @@ def cleanupsync(**kwargs):
     sync_filter = kwargs.get("sync_filter")
     is_server = kwargs.get("is_server")
     instance_id = kwargs.get("instance_id")
-    instance_name = "server" if is_server else "client"
+    instance_name = "client" if is_server else "server"
     instance_attribute_name = "{}-instance-id".format(instance_name)
     instance_attribute = {
         instance_attribute_name: instance_id,

--- a/kolibri/core/auth/test/test_hooks.py
+++ b/kolibri/core/auth/test/test_hooks.py
@@ -1,0 +1,65 @@
+import uuid
+
+import mock
+from django.test import TestCase
+from morango.sync.context import LocalSessionContext
+
+from kolibri.core.auth.kolibri_plugin import AuthSyncHook
+from kolibri.core.auth.kolibri_plugin import CleanUpTaskOperation
+
+
+@mock.patch("kolibri.core.auth.kolibri_plugin.cleanupsync")
+class CleanUpTaskOperationTestCase(TestCase):
+    def setUp(self):
+        self.context = mock.MagicMock(
+            spec=LocalSessionContext(),
+            filter=uuid.uuid4().hex,
+            is_push=True,
+            is_pull=False,
+            sync_session=mock.MagicMock(
+                spec="morango.sync.session.SyncSession",
+                client_instance_id=uuid.uuid4().hex,
+                server_instance_id=uuid.uuid4().hex,
+            ),
+        )
+        self.operation = CleanUpTaskOperation()
+
+    def test_handle_initial__not_receiver(self, mock_task):
+        self.context.is_receiver = False
+        result = self.operation.handle_initial(self.context)
+        self.assertFalse(result)
+        mock_task.enqueue.assert_not_called()
+
+    def test_handle_initial__is_server(self, mock_task):
+        self.context.is_receiver = True
+        self.context.is_server = True
+        result = self.operation.handle_initial(self.context)
+        self.assertFalse(result)
+        mock_task.enqueue.assert_called_once_with(
+            kwargs=dict(
+                is_pull=self.context.is_pull,
+                is_push=self.context.is_push,
+                sync_filter=str(self.context.filter),
+                client_instance_id=self.context.sync_session.client_instance_id,
+            )
+        )
+
+    def test_handle_initial__not_server(self, mock_task):
+        self.context.is_receiver = True
+        self.context.is_server = False
+        result = self.operation.handle_initial(self.context)
+        self.assertFalse(result)
+        mock_task.enqueue.assert_called_once_with(
+            kwargs=dict(
+                is_pull=self.context.is_pull,
+                is_push=self.context.is_push,
+                sync_filter=str(self.context.filter),
+                server_instance_id=self.context.sync_session.server_instance_id,
+            )
+        )
+
+
+class AuthSyncHookTestCase(TestCase):
+    def test_cleanup_operations(self):
+        operation = AuthSyncHook().cleanup_operations[0]
+        self.assertIsInstance(operation, CleanUpTaskOperation)


### PR DESCRIPTION
## Summary
- Added CleanUpTaskOperation for queuing cleanupsync task passing relevant attributes.
- Cleanupsync Task to call cleanupsync command recently added in morango
- Override the command according to #8238  

## Reviewer guidance
- Run the command using KOLIBRI_HOME=$(mktemp -d) kolibri manage cleanupsyncs
- Create two devices and try syncing, post_transfer hook gets triggered.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md


closes #8238 