### PR TITLE
Catch errors that can happen when a network location is announced on more than one network.

### DIFF
--- a/kolibri/core/discovery/tasks.py
+++ b/kolibri/core/discovery/tasks.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.db.utils import OperationalError
 
 from kolibri.core.device.task_notifications import status_fn
@@ -78,6 +79,12 @@ def _store_dynamic_instance(broadcast_id, instance):
             raise
         logger.debug(
             "Encountered locked database while creating `DynamicNetworkLocation`"
+        )
+    except IntegrityError as e:
+        if "UNIQUE constraint failed: discovery_networklocation.id" not in str(e):
+            raise
+        logger.debug(
+            "Encountered unique constraint error while creating `DynamicNetworkLocation` - instance is probably being announced twice on the network"
         )
     return network_location
 


### PR DESCRIPTION
## Summary
* Catches integrity errors due to id collisions when creating networklocation entries

## Reviewer guidance
Does the catch make sense? Is it too specific?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
