### PR TITLE
Do a more robust check that peer_id does not correspond to the CENTRAL_CONTENT_BASE_INSTANCE_ID.

### DIFF
--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -16,6 +16,7 @@ from kolibri.core.content.utils.importability_annotation import (
 from kolibri.core.content.utils.importability_annotation import (
     get_channel_stats_from_peer,
 )
+from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 
 
 CHUNKSIZE = 10000
@@ -83,7 +84,7 @@ def filter_by_file_availability(nodes_to_include, channel_id, drive_id, peer_id)
             channel_id, drive_id
         ).keys()
 
-    if peer_id:
+    if peer_id and peer_id != CENTRAL_CONTENT_BASE_INSTANCE_ID:
         file_based_node_id_list = get_channel_stats_from_peer(
             channel_id, peer_id
         ).keys()


### PR DESCRIPTION
## Summary
* Some backend code assumed that `peer_id = None` was the way to express that Studio was being connected to, this assumption is now false
* Updates this to compare to the precomputed CENTRAL_CONTENT_BASE_INSTANCE_ID

## References
Fixes issues observed during testing of #11083

## Reviewer guidance
Does importing with hotfixes set as the CENTRAL_CONTENT_BASE_URL work.

N.B. this will not fix an issue that will still arise if a Studio instance is added as a StaticNetworkLocation.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
