### PR TITLE
Better handling of disconnected errors for API calls

### DIFF
--- a/kolibri/core/assets/src/composables/useUserSyncStatus.js
+++ b/kolibri/core/assets/src/composables/useUserSyncStatus.js
@@ -30,7 +30,7 @@ export function fetchUserSyncStatus(params) {
       return syncData;
     },
     error => {
-      store.dispatch('handleApiError', error);
+      store.dispatch('handleApiError', { error });
       return error;
     }
   );

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -225,6 +225,7 @@ export class HeartBeat {
     if (store.getters.connected) {
       // We have not already registered that we have been disconnected
       store.commit('CORE_SET_CONNECTED', false);
+      store.commit('CORE_SET_DISCONNECTED_WHILE_LOADING', store.state.core.loading);
       let reconnectionTime;
       if (store.state.pageVisible) {
         // If current page is not visible, back off completely
@@ -251,6 +252,11 @@ export class HeartBeat {
     store.commit('CORE_SET_CONNECTED', true);
     store.commit('CORE_SET_RECONNECT_TIME', null);
     createReconnectedSnackbar(store);
+    if (store.state.core.connection.disconnectedWhileLoading) {
+      // If we were disconnected while loading, we need to reload the page
+      // to ensure that we are in a consistent state.
+      window.location.reload();
+    }
     this._wait();
   }
   /*

--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -225,7 +225,6 @@ export class HeartBeat {
     if (store.getters.connected) {
       // We have not already registered that we have been disconnected
       store.commit('CORE_SET_CONNECTED', false);
-      store.commit('CORE_SET_DISCONNECTED_WHILE_LOADING', store.state.core.loading);
       let reconnectionTime;
       if (store.state.pageVisible) {
         // If current page is not visible, back off completely
@@ -252,7 +251,7 @@ export class HeartBeat {
     store.commit('CORE_SET_CONNECTED', true);
     store.commit('CORE_SET_RECONNECT_TIME', null);
     createReconnectedSnackbar(store);
-    if (store.state.core.connection.disconnectedWhileLoading) {
+    if (store.state.core.connection.reloadOnReconnect) {
       // If we were disconnected while loading, we need to reload the page
       // to ensure that we are in a consistent state.
       window.location.reload();

--- a/kolibri/core/assets/src/state/modules/connection.js
+++ b/kolibri/core/assets/src/state/modules/connection.js
@@ -2,7 +2,7 @@ export default {
   state: {
     connected: true,
     reconnectTime: null,
-    disconnectedWhileLoading: false,
+    reloadOnReconnect: false,
   },
   getters: {
     connected(state) {
@@ -19,8 +19,8 @@ export default {
     CORE_SET_RECONNECT_TIME(state, reconnectTime) {
       state.reconnectTime = reconnectTime;
     },
-    CORE_SET_DISCONNECTED_WHILE_LOADING(state, disconnectedWhileLoading) {
-      state.disconnectedWhileLoading = disconnectedWhileLoading;
+    CORE_SET_RELOAD_ON_RECONNECT(state, reloadOnReconnect) {
+      state.reloadOnReconnect = reloadOnReconnect;
     },
   },
 };

--- a/kolibri/core/assets/src/state/modules/connection.js
+++ b/kolibri/core/assets/src/state/modules/connection.js
@@ -2,6 +2,7 @@ export default {
   state: {
     connected: true,
     reconnectTime: null,
+    disconnectedWhileLoading: false,
   },
   getters: {
     connected(state) {
@@ -17,6 +18,9 @@ export default {
     },
     CORE_SET_RECONNECT_TIME(state, reconnectTime) {
       state.reconnectTime = reconnectTime;
+    },
+    CORE_SET_DISCONNECTED_WHILE_LOADING(state, disconnectedWhileLoading) {
+      state.disconnectedWhileLoading = disconnectedWhileLoading;
     },
   },
 };

--- a/kolibri/core/assets/src/views/sync/ConfirmationRegisterModal.vue
+++ b/kolibri/core/assets/src/views/sync/ConfirmationRegisterModal.vue
@@ -95,7 +95,7 @@
               this.submitting = false;
               this.alreadyRegistered = true;
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
           });
       },

--- a/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
+++ b/kolibri/core/assets/src/views/sync/RegisterFacilityModal.vue
@@ -102,7 +102,7 @@
               this.invalid = true;
               this.submitting = false;
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
           });
       },

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/AddDeviceForm.vue
@@ -129,7 +129,7 @@
               this.status = Statuses.INVALID_ADDRESS;
               this.$refs.address.focus();
             } else {
-              this.$store.dispatch('handleApiError', err);
+              this.$store.dispatch('handleApiError', { error: err });
             }
           })
           .then(() => {

--- a/kolibri/core/assets/test/state/store.spec.js
+++ b/kolibri/core/assets/test/state/store.spec.js
@@ -24,7 +24,7 @@ describe('Vuex store/actions for core module', () => {
       const store = makeStore();
       const apiError = { message: 'Too Bad' };
       try {
-        store.dispatch('handleApiError', apiError);
+        store.dispatch('handleApiError', { error: apiError });
       } catch (e) {
         expect(e.message).toBe(apiError.message);
       }

--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -50,7 +50,7 @@ class CoachToolsModule extends KolibriApp {
       }
       if (promises.length > 0) {
         Promise.all(promises).then(next, error => {
-          this.store.dispatch('handleApiError', error);
+          this.store.dispatch('handleApiError', { error });
         });
       } else {
         next();

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -54,12 +54,17 @@ export function useGroups() {
                 store.dispatch('clearError');
               }
             },
-            error => (shouldResolve() ? store.dispatch('handleApiError', error) : null)
+            error =>
+              shouldResolve()
+                ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+                : null
           );
         }
       },
       error => {
-        shouldResolve() ? store.dispatch('handleApiError', error) : null;
+        shouldResolve()
+          ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+          : null;
       }
     );
   }

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -54,12 +54,12 @@ export function useGroups() {
                 store.dispatch('clearError');
               }
             },
-            error => (shouldResolve() ? store.dispatch('handleError', error) : null)
+            error => (shouldResolve() ? store.dispatch('handleApiError', error) : null)
           );
         }
       },
       error => {
-        shouldResolve() ? store.dispatch('handleError', error) : null;
+        shouldResolve() ? store.dispatch('handleApiError', error) : null;
       }
     );
   }

--- a/kolibri/plugins/coach/assets/src/composables/useLessons.js
+++ b/kolibri/plugins/coach/assets/src/composables/useLessons.js
@@ -33,7 +33,7 @@ export function useLessons() {
         setLessonsLoading(false);
       },
       error => {
-        store.dispatch('handleApiError', error);
+        store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         setLessonsLoading(false);
       }
     );

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/index.js
@@ -476,7 +476,7 @@ export default {
             store.commit('SET_CLASS_LESSONS_SIZES', sizes);
           })
           .catch(error => {
-            return store.dispatch('handleApiError', error, { root: true });
+            return store.dispatch('handleApiError', { error }, { root: true });
           });
       }
       return Promise.resolve();
@@ -488,7 +488,7 @@ export default {
             store.commit('SET_CLASS_QUIZZES_SIZES', sizes);
           })
           .catch(error => {
-            return store.dispatch('handleApiError', error, { root: true });
+            return store.dispatch('handleApiError', { error }, { root: true });
           });
       }
       return Promise.resolve();

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -210,7 +210,7 @@ export function showExamCreationPreviewPage(store, params, fromRoute, query = {}
       })
       .catch(error => {
         store.dispatch('notLoading');
-        return store.dispatch('handleApiError', error);
+        return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       });
   });
 }
@@ -229,7 +229,7 @@ export function showPracticeQuizCreationPreviewPage(store, params) {
       })
       .catch(error => {
         store.dispatch('notLoading');
-        return store.dispatch('handleApiError', error);
+        return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       });
   });
 }
@@ -248,7 +248,7 @@ function _prepPracticeQuizContentPreview(store, classId, contentId) {
       return contentNode;
     },
     error => {
-      return store.dispatch('handleApiError', error);
+      return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
     }
   );
 }
@@ -266,7 +266,7 @@ function _prepExamContentPreview(store, classId, contentId) {
       return contentNode;
     },
     error => {
-      return store.dispatch('handleApiError', error);
+      return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
     }
   );
 }

--- a/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
@@ -30,6 +30,7 @@ export function showExamsPage(store, classId) {
         store.dispatch('notLoading');
       }
     },
-    error => (shouldResolve() ? store.dispatch('handleApiError', error) : null)
+    error =>
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null
   );
 }

--- a/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examsRoot/handlers.js
@@ -30,6 +30,6 @@ export function showExamsPage(store, classId) {
         store.dispatch('notLoading');
       }
     },
-    error => (shouldResolve() ? store.dispatch('handleError', error) : null)
+    error => (shouldResolve() ? store.dispatch('handleApiError', error) : null)
   );
 }

--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -32,7 +32,7 @@ export function createGroup(store, { groupName, classId }) {
       // to get that back up to date!
       return store.dispatch('classSummary/refreshClassSummary', null, { root: true });
     },
-    error => store.dispatch('handleError', error, { root: true })
+    error => store.dispatch('handleApiError', error, { root: true })
   );
 }
 
@@ -51,7 +51,7 @@ export function renameGroup(store, { groupId, newGroupName }) {
       store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
       store.commit('SET_GROUP_MODAL', '');
     },
-    error => store.dispatch('handleError', error, { root: true })
+    error => store.dispatch('handleApiError', error, { root: true })
   );
 }
 
@@ -62,7 +62,7 @@ export function deleteGroup(store, groupId) {
       const updatedGroups = groups.filter(group => group.id !== groupId);
       store.commit('SET_GROUPS', updatedGroups);
     },
-    error => store.dispatch('handleError', error, { root: true })
+    error => store.dispatch('handleApiError', error, { root: true })
   );
 }
 
@@ -128,7 +128,7 @@ export function addUsersToGroup(store, { groupId, userIds }) {
     store.commit('SET_GROUP_MODAL', '');
   };
   return _addMultipleUsersToGroup(store, groupId, userIds)
-    .catch(error => store.dispatch('handleError', error, { root: true }))
+    .catch(error => store.dispatch('handleApiError', error, { root: true }))
     .then(final, final);
 }
 
@@ -139,6 +139,6 @@ export function removeUsersFromGroup(store, { groupId, userIds }) {
     store.commit('SET_GROUP_MODAL', '');
   };
   return _removeMultipleUsersFromGroup(store, groupId, userIds)
-    .catch(error => store.dispatch('handleError', error, { root: true }))
+    .catch(error => store.dispatch('handleApiError', error, { root: true }))
     .then(final, final);
 }

--- a/kolibri/plugins/coach/assets/src/modules/groups/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/groups/actions.js
@@ -32,7 +32,7 @@ export function createGroup(store, { groupName, classId }) {
       // to get that back up to date!
       return store.dispatch('classSummary/refreshClassSummary', null, { root: true });
     },
-    error => store.dispatch('handleApiError', error, { root: true })
+    error => store.dispatch('handleApiError', { error }, { root: true })
   );
 }
 
@@ -51,7 +51,7 @@ export function renameGroup(store, { groupId, newGroupName }) {
       store.commit('CORE_SET_PAGE_LOADING', false, { root: true });
       store.commit('SET_GROUP_MODAL', '');
     },
-    error => store.dispatch('handleApiError', error, { root: true })
+    error => store.dispatch('handleApiError', { error }, { root: true })
   );
 }
 
@@ -62,7 +62,7 @@ export function deleteGroup(store, groupId) {
       const updatedGroups = groups.filter(group => group.id !== groupId);
       store.commit('SET_GROUPS', updatedGroups);
     },
-    error => store.dispatch('handleApiError', error, { root: true })
+    error => store.dispatch('handleApiError', { error }, { root: true })
   );
 }
 
@@ -128,7 +128,7 @@ export function addUsersToGroup(store, { groupId, userIds }) {
     store.commit('SET_GROUP_MODAL', '');
   };
   return _addMultipleUsersToGroup(store, groupId, userIds)
-    .catch(error => store.dispatch('handleApiError', error, { root: true }))
+    .catch(error => store.dispatch('handleApiError', { error }, { root: true }))
     .then(final, final);
 }
 
@@ -139,6 +139,6 @@ export function removeUsersFromGroup(store, { groupId, userIds }) {
     store.commit('SET_GROUP_MODAL', '');
   };
   return _removeMultipleUsersFromGroup(store, groupId, userIds)
-    .catch(error => store.dispatch('handleApiError', error, { root: true }))
+    .catch(error => store.dispatch('handleApiError', { error }, { root: true }))
     .then(final, final);
 }

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -234,7 +234,7 @@ export function showLessonSelectionContentPreview(store, params, query = {}) {
       })
       .catch(error => {
         store.dispatch('notLoading');
-        return store.dispatch('handleApiError', error);
+        return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       });
   });
 }
@@ -262,7 +262,7 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
       return contentNode;
     },
     error => {
-      return store.dispatch('handleApiError', error);
+      return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
     }
   );
 }

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/actions.js
@@ -26,7 +26,7 @@ export function updateCurrentLesson(store, lessonId) {
       return lesson;
     },
     error => {
-      return store.dispatch('handleApiError', error, { root: true });
+      return store.dispatch('handleApiError', { error }, { root: true });
     }
   );
 }

--- a/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonSummary/handlers.js
@@ -31,7 +31,7 @@ export function setLessonSummaryState(store, params) {
       });
     })
     .catch(error => {
-      return store.dispatch('handleApiError', error);
+      return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
     });
 }
 

--- a/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonsRoot/actions.js
@@ -26,7 +26,7 @@ export function refreshClassLessons(store, classId) {
       }
     })
     .catch(error => {
-      return store.dispatch('handleApiError', error, { root: true });
+      return store.dispatch('handleApiError', { error }, { root: true });
     });
 }
 
@@ -36,7 +36,7 @@ export function fetchLessonsSizes(store, classId) {
       store.commit('SET_CLASS_LESSONS_SIZES', sizes);
     })
     .catch(error => {
-      return store.dispatch('handleApiError', error, { root: true });
+      return store.dispatch('handleApiError', { error }, { root: true });
     });
 }
 

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -123,7 +123,7 @@ export default {
             .then(summary => store.dispatch('setClassList', summary.facility_id)),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
         ]).catch(error => {
-          store.dispatch('handleError', error);
+          store.dispatch('handleApiError', error);
         });
       } else {
         // otherwise refresh but don't block

--- a/kolibri/plugins/coach/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/coach/assets/src/modules/pluginModule.js
@@ -76,7 +76,7 @@ export default {
           store.commit('SET_DATA_LOADING', false);
         })
         .catch(error => {
-          store.dispatch('handleApiError', error);
+          store.dispatch('handleApiError', { error });
           store.commit('SET_DATA_LOADING', false);
         });
     },
@@ -89,9 +89,9 @@ export default {
       const authErrorCodes = [401, 403, 404, 407];
       logging.error(errorObject);
       if (errorObject.response.status && authErrorCodes.includes(errorObject.response.status)) {
-        store.dispatch('handleApiError', '');
+        store.dispatch('handleApiError', { error: '' });
       } else {
-        store.dispatch('handleApiError', errorObject);
+        store.dispatch('handleApiError', { error: errorObject, reloadOnReconnect: true });
       }
     },
     resetModuleState(store, { toRoute, fromRoute }) {
@@ -123,13 +123,13 @@ export default {
             .then(summary => store.dispatch('setClassList', summary.facility_id)),
           store.dispatch('coachNotifications/fetchNotificationsForClass', classId),
         ]).catch(error => {
-          store.dispatch('handleApiError', error);
+          store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         });
       } else {
         // otherwise refresh but don't block
         return store
           .dispatch('classSummary/loadClassSummary', classId)
-          .catch(error => store.dispatch('handleApiError', error));
+          .catch(error => store.dispatch('handleApiError', { error }));
       }
     },
   },

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -43,7 +43,7 @@ export default [
           }
           store.dispatch('notLoading');
         },
-        error => store.dispatch('handleApiError', error)
+        error => store.dispatch('handleApiError', { error, reloadOnReconnect: true })
       );
     },
     meta: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateExamPreview.vue
@@ -242,7 +242,7 @@
                 this.showTitleError = true;
                 this.$refs.title.focus();
               } else {
-                this.$store.dispatch('handleApiError', error);
+                this.$store.dispatch('handleApiError', { error });
               }
             });
         }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/PlanPracticeQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/PlanPracticeQuizPreviewPage.vue
@@ -80,7 +80,7 @@
               this.showError = true;
               this.showTitleError = true;
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
           });
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonEditDetailsPage/index.vue
@@ -122,7 +122,7 @@
       },
       // @public
       setError(error) {
-        this.$store.dispatch('handleApiError', error);
+        this.$store.dispatch('handleApiError', { error });
         this.loading = false;
         this.$store.dispatch('notLoading');
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -106,7 +106,7 @@
                 actionCallback: () => this.$store.commit('CORE_CLEAR_SNACKBAR'),
               });
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
             this.closeModal();
           });
@@ -120,7 +120,7 @@
             });
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizEditDetailsPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizEditDetailsPage.vue
@@ -97,7 +97,7 @@
       },
       // @public
       setError(error) {
-        this.$store.dispatch('handleApiError', error);
+        this.$store.dispatch('handleApiError', { error });
         this.loading = false;
         this.$store.dispatch('notLoading');
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -162,7 +162,7 @@
       },
       // @public
       setError(error) {
-        this.$store.dispatch('handleApiError', error);
+        this.$store.dispatch('handleApiError', { error });
         this.loading = false;
         this.$store.dispatch('notLoading');
       },
@@ -230,7 +230,7 @@
                 actionCallback: () => this.$store.commit('CORE_CLEAR_SNACKBAR'),
               });
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
             this.$store.dispatch('notLoading');
             this.closeModal();
@@ -245,7 +245,7 @@
             });
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentCopyModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentCopyModal.vue
@@ -144,7 +144,7 @@
             this.blockControls = false;
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
             logError(error);
             this.blockControls = false;
           });

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
@@ -94,7 +94,7 @@
         this.$store.dispatch('notLoading');
       },
       setError(error) {
-        this.$store.dispatch('handleApiError', error);
+        this.$store.dispatch('handleApiError', { error });
         this.loading = false;
         this.$store.dispatch('notLoading');
       },

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -52,7 +52,7 @@ export function showDeviceInfoPage(store) {
         }
       })
       .catch(function onFailure(error) {
-        shouldResolve() ? store.dispatch('handleError', error) : null;
+        shouldResolve() ? store.dispatch('handleApiError', error) : null;
       });
   }
   return Promise.resolve();

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -52,7 +52,9 @@ export function showDeviceInfoPage(store) {
         }
       })
       .catch(function onFailure(error) {
-        shouldResolve() ? store.dispatch('handleApiError', error) : null;
+        shouldResolve()
+          ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+          : null;
       });
   }
   return Promise.resolve();

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
@@ -34,6 +34,6 @@ export function showManagePermissionsPage(store) {
     })
     .catch(error => {
       store.commit('managePermissions/SET_LOADING_FACILITY_USERS', false);
-      return shouldResolve() ? store.dispatch('handleError', error) : null;
+      return shouldResolve() ? store.dispatch('handleApiError', error) : null;
     });
 }

--- a/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/managePermissions/handlers.js
@@ -34,6 +34,8 @@ export function showManagePermissionsPage(store) {
     })
     .catch(error => {
       store.commit('managePermissions/SET_LOADING_FACILITY_USERS', false);
-      return shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      return shouldResolve()
+        ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+        : null;
     });
 }

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/actions.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/actions.js
@@ -26,5 +26,5 @@ export function addOrUpdateUserPermissions(store, payload) {
         }
       );
     })
-    .catch(error => store.dispatch('handleApiError', error, { root: true }));
+    .catch(error => store.dispatch('handleApiError', { error }, { root: true }));
 }

--- a/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/userPermissions/handlers.js
@@ -64,7 +64,7 @@ export function showUserPermissionsPage(store, userId) {
         if (error.response.status === 404) {
           setUserPermissionsState({ user: null, permissions: {} });
         }
-        store.dispatch('handleApiError', error);
+        store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         stopLoading();
       }
     });

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -64,7 +64,7 @@ function handleError(store, error) {
   }
   // handle other errors generically
   store.commit('manageContent/wizard/RESET_STATE');
-  store.dispatch('handleApiError', error);
+  store.dispatch('handleApiError', { error });
 }
 
 // Handler for when user goes directly to the Available Channels URL.

--- a/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/handlers.js
@@ -63,8 +63,8 @@ function handleError(store, error) {
     return store.commit('manageContent/wizard/SET_WIZARD_STATUS', errorType);
   }
   // handle other errors generically
-  store.dispatch('handleApiError', error);
   store.commit('manageContent/wizard/RESET_STATE');
+  store.dispatch('handleApiError', error);
 }
 
 // Handler for when user goes directly to the Available Channels URL.

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/RemoveFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/RemoveFacilityModal.vue
@@ -90,7 +90,7 @@
               this.$emit('success', data.id);
             })
             .catch(error => {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             });
         } else {
           this.$emit('cancel');

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/SyncAllFacilitiesModal.vue
@@ -79,7 +79,7 @@
           })
           .catch(error => {
             // TODO handle failure gracefully
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/index.vue
@@ -202,7 +202,7 @@
           this.setUpPage(pageData);
         })
         .catch(error => {
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         });
     },
     methods: {
@@ -240,7 +240,7 @@
               }
             })
             .catch(error => {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             });
         }
       },
@@ -327,7 +327,7 @@
             if (error.response.status === 404) {
               this.$router.replace({ name: PageNames.MANAGE_CONTENT_PAGE });
             } else {
-              this.$store.dispatch('handleApiError', error);
+              this.$store.dispatch('handleApiError', { error });
             }
           });
       },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/NewChannelVersionPage.vue
@@ -264,7 +264,7 @@
             }
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
       setChannelData(installedChannel, sourceChannel) {
@@ -278,7 +278,7 @@
       loadChannelInfo() {
         return fetchChannelAtSource(this.params).catch(error => {
           // Useful errors will still appear on AppError
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error });
         });
       },
       startDiffStatsTask() {

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -38,7 +38,7 @@ export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null;
     }
   );
 }
@@ -81,7 +81,7 @@ export function showCoachClassAssignmentPage(store, toRoute, fromRoute) {
     },
     error => {
       store.dispatch('notLoading');
-      shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null;
     }
   );
 }

--- a/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classAssignMembers/handlers.js
@@ -38,7 +38,7 @@ export function showLearnerClassEnrollmentPage(store, toRoute, fromRoute) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', error) : null;
     }
   );
 }
@@ -81,7 +81,7 @@ export function showCoachClassAssignmentPage(store, toRoute, fromRoute) {
     },
     error => {
       store.dispatch('notLoading');
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', error) : null;
     }
   );
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/actions.js
@@ -15,7 +15,7 @@ export function removeClassLearner(store, { classId, userId }) {
       store.dispatch('displayModal', false);
     },
     error => {
-      store.dispatch('handleApiError', error, { root: true });
+      store.dispatch('handleApiError', { error }, { root: true });
     }
   );
 }
@@ -37,7 +37,7 @@ export function removeClassCoach(store, { classId, userId }) {
       store.dispatch('displayModal', false);
     },
     error => {
-      store.dispatch('handleApiError', error, { root: true });
+      store.dispatch('handleApiError', { error }, { root: true });
     }
   );
 }
@@ -61,7 +61,7 @@ export function updateClass(store, { id, updateData }) {
       store.dispatch('displayModal', false);
     },
     error => {
-      store.dispatch('handleApiError', error, { root: true });
+      store.dispatch('handleApiError', { error }, { root: true });
     }
   );
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -31,6 +31,6 @@ export function showClassEditPage(store, classId) {
     })
     .catch(error => {
       store.dispatch('notLoading');
-      store.dispatch('handleError', error);
+      store.dispatch('handleApiError', error);
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classEditManagement/handlers.js
@@ -31,6 +31,6 @@ export function showClassEditPage(store, classId) {
     })
     .catch(error => {
       store.dispatch('notLoading');
-      store.dispatch('handleApiError', error);
+      store.dispatch('handleApiError', { error, reloadOnReconnect: true });
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/actions.js
@@ -15,7 +15,7 @@ export function createClass(store, name) {
       store.commit('ADD_CLASS', classroom);
     },
     error => {
-      store.dispatch('handleApiError', error, { root: true });
+      store.dispatch('handleApiError', { error }, { root: true });
     }
   );
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -18,7 +18,7 @@ export function showClassesPage(store, toRoute) {
     })
     .catch(error => {
       store.dispatch('notLoading');
-      store.dispatch('handleApiError', error);
+      store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/classManagement/handlers.js
@@ -18,7 +18,7 @@ export function showClassesPage(store, toRoute) {
     })
     .catch(error => {
       store.dispatch('notLoading');
-      store.dispatch('handleError', error);
+      store.dispatch('handleApiError', error);
       store.commit('classManagement/SET_STATE', { dataLoading: false });
     });
 }

--- a/kolibri/plugins/facility/assets/src/modules/importCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/importCSV/actions.js
@@ -58,7 +58,7 @@ function checkTaskStatus(store, newTasks, taskType, taskId, commitStart, commitF
       store.commit(commitFinish, task);
     } else if (task && task.status === TaskStatuses.FAILED) {
       if (typeof task.extra_metadata.overall_error === 'undefined') {
-        store.dispatch('handleApiError', task.traceback, { root: true });
+        store.dispatch('handleApiError', { error: task.traceback }, { root: true });
       }
 
       store.commit('SET_FAILED', task);

--- a/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
+++ b/kolibri/plugins/facility/assets/src/modules/manageCSV/actions.js
@@ -28,7 +28,7 @@ function getCSVLogRequest(store, logType, facility) {
       }
     })
     .catch(error => {
-      return store.dispatch('handleApiError', error, { root: true });
+      return store.dispatch('handleApiError', { error }, { root: true });
     });
 }
 

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -32,7 +32,7 @@ export function showUserPage(store, toRoute, fromRoute) {
       store.dispatch('notLoading');
     })
     .catch(error => {
-      shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null;
       store.commit('userManagement/SET_STATE', { dataLoading: false });
       store.dispatch('notLoading');
     });

--- a/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
+++ b/kolibri/plugins/facility/assets/src/modules/userManagement/handlers.js
@@ -32,7 +32,7 @@ export function showUserPage(store, toRoute, fromRoute) {
       store.dispatch('notLoading');
     })
     .catch(error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', error) : null;
       store.commit('userManagement/SET_STATE', { dataLoading: false });
       store.dispatch('notLoading');
     });

--- a/kolibri/plugins/facility/assets/src/views/ManageClassPage/useDeleteClass.js
+++ b/kolibri/plugins/facility/assets/src/views/ManageClassPage/useDeleteClass.js
@@ -29,7 +29,7 @@ export default function useDeleteClass(classroomProp) {
         $store.commit('classManagement/DELETE_CLASS', deleteId);
       },
       error => {
-        $store.dispatch('handleApiError', error);
+        $store.dispatch('handleApiError', { error });
       }
     );
   }

--- a/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserCreatePage.vue
@@ -263,7 +263,7 @@
         if (this.caughtErrors.length > 0) {
           this.focusOnInvalidField();
         } else {
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error });
         }
       },
       focusOnInvalidField() {

--- a/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserEditPage.vue
@@ -237,7 +237,7 @@
         return this.editingSelf && this.newUserKind && this.newUserKind !== UserKinds.ADMIN;
       },
     },
-    mounted() {
+    created() {
       FacilityUserResource.fetchModel({
         id: this.$route.params.id,
       })
@@ -252,7 +252,7 @@
           this.loading = false;
         })
         .catch(error => {
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         });
     },
     methods: {
@@ -356,7 +356,7 @@
         if (this.caughtErrors.length > 0) {
           this.focusOnInvalidField();
         } else {
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error });
         }
       },
       focusOnInvalidField() {

--- a/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/DeleteUserModal.vue
@@ -49,7 +49,7 @@
             this.showSnackbarNotification('userDeleted');
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
     },

--- a/kolibri/plugins/facility/assets/src/views/UserPage/ResetUserPasswordModal.vue
+++ b/kolibri/plugins/facility/assets/src/views/UserPage/ResetUserPasswordModal.vue
@@ -72,7 +72,7 @@
             this.$emit('cancel');
             this.showSnackbarNotification('passwordReset');
           })
-          .catch(error => this.$store.dispatch('handleApiError', error));
+          .catch(error => this.$store.dispatch('handleApiError', { error }));
       },
       focusOnInvalidField() {
         this.$nextTick().then(() => {

--- a/kolibri/plugins/learn/assets/src/modules/classAssignments/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/classAssignments/handlers.js
@@ -12,7 +12,7 @@ export function showClassAssignmentsPage(store, classId) {
         store.dispatch('notLoading');
       })
       .catch(error => {
-        return store.dispatch('handleApiError', error);
+        return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       });
   });
 }

--- a/kolibri/plugins/learn/assets/src/modules/classes/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/classes/handlers.js
@@ -12,11 +12,11 @@ export function showAllClassesPage(store) {
       })
       .catch(error => {
         if (error instanceof Error) {
-          return store.dispatch('handleApiError', error);
+          return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
         }
 
         // Allows triggering of AuthMessage.vue
-        return store.dispatch('handleError', error);
+        return store.dispatch('handleError', { error, reloadOnReconnect: true });
       });
   });
 }

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -92,13 +92,17 @@ export function showExam(store, params, alreadyOnQuiz) {
               }
             },
             error => {
-              shouldResolve() ? store.dispatch('handleApiError', error) : null;
+              shouldResolve()
+                ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+                : null;
             }
           );
         }
       },
       error => {
-        shouldResolve() ? store.dispatch('handleApiError', error) : null;
+        shouldResolve()
+          ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
+          : null;
       }
     );
   }

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -92,13 +92,13 @@ export function showExam(store, params, alreadyOnQuiz) {
               }
             },
             error => {
-              shouldResolve() ? store.dispatch('handleError', error) : null;
+              shouldResolve() ? store.dispatch('handleApiError', error) : null;
             }
           );
         }
       },
       error => {
-        shouldResolve() ? store.dispatch('handleError', error) : null;
+        shouldResolve() ? store.dispatch('handleApiError', error) : null;
       }
     );
   }

--- a/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/lessonPlaylist/handlers.js
@@ -31,7 +31,7 @@ export function showLessonPlaylist(store, { lessonId }) {
         store.dispatch('notLoading');
       })
       .catch(error => {
-        return store.dispatch('handleApiError', error);
+        return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       });
   });
 }

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -51,7 +51,7 @@ function _showChannels(store, query, channels, baseurl) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null;
       store.commit('SET_ROOT_NODES_LOADING', false);
     }
   );

--- a/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/recommended/handlers.js
@@ -51,7 +51,7 @@ function _showChannels(store, query, channels, baseurl) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', error) : null;
       store.commit('SET_ROOT_NODES_LOADING', false);
     }
   );

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -30,7 +30,7 @@ function _loadTopicsContent(store, id, baseurl) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', error) : null;
     }
   );
 }
@@ -145,7 +145,7 @@ function _loadTopicsTopic(store, { route, baseurl } = {}) {
           router.replace({ name: PageNames.LIBRARY });
           return;
         }
-        store.dispatch('handleError', error);
+        store.dispatch('handleApiError', error);
       }
     }
   );
@@ -170,7 +170,7 @@ export function showTopicsTopic(store, route) {
                 router.replace({ name: PageNames.LIBRARY });
                 return;
               }
-              store.dispatch('handleError', error);
+              store.dispatch('handleApiError', error);
             }
           });
       });

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/handlers.js
@@ -30,7 +30,7 @@ function _loadTopicsContent(store, id, baseurl) {
       }
     },
     error => {
-      shouldResolve() ? store.dispatch('handleApiError', error) : null;
+      shouldResolve() ? store.dispatch('handleApiError', { error, reloadOnReconnect: true }) : null;
     }
   );
 }
@@ -145,7 +145,7 @@ function _loadTopicsTopic(store, { route, baseurl } = {}) {
           router.replace({ name: PageNames.LIBRARY });
           return;
         }
-        store.dispatch('handleApiError', error);
+        store.dispatch('handleApiError', { error, reloadOnReconnect: true });
       }
     }
   );
@@ -170,7 +170,7 @@ export function showTopicsTopic(store, route) {
                 router.replace({ name: PageNames.LIBRARY });
                 return;
               }
-              store.dispatch('handleApiError', error);
+              store.dispatch('handleApiError', { error, reloadOnReconnect: true });
             }
           });
       });

--- a/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/topicsTree/index.js
@@ -50,7 +50,7 @@ export default {
             store.commit('ADD_MORE_CONTENTS', data);
           })
           .catch(err => {
-            store.dispatch('handleApiError', err);
+            store.dispatch('handleApiError', { error: err });
           });
       }
     },
@@ -68,7 +68,7 @@ export default {
             store.commit('ADD_MORE_CHILD_CONTENTS', data);
           })
           .catch(err => {
-            store.dispatch('handleApiError', err);
+            store.dispatch('handleApiError', { error: err });
           });
       }
     },

--- a/kolibri/plugins/learn/assets/src/routes/index.js
+++ b/kolibri/plugins/learn/assets/src/routes/index.js
@@ -82,7 +82,7 @@ export default [
             store.dispatch('notLoading');
           })
           .catch(error => {
-            return store.dispatch('handleApiError', error);
+            return store.dispatch('handleApiError', { error, reloadOnReconnect: true });
           });
       });
     },

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -268,7 +268,7 @@
             this.$store.dispatch('createSnackbar', this.learnString('resourceCompletedLabel'));
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
       navigateTo(message) {
@@ -280,7 +280,7 @@
             );
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
       onFinished() {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -370,7 +370,7 @@
               },
             });
           }
-          this.$store.dispatch('handleApiError', err);
+          this.$store.dispatch('handleApiError', { error: err });
         });
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/setup_wizard/assets/src/modules/pluginModule.js
@@ -64,7 +64,7 @@ export default {
     **/
     showError(store, errorMsg) {
       store.commit('SET_ERROR', true);
-      store.dispatch('handleApiError', errorMsg);
+      store.dispatch('handleApiError', { error: errorMsg });
     },
   },
   mutations: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
@@ -339,7 +339,7 @@
             ]);
             if (errorsCaught) {
               this.error = true;
-            } else this.$store.dispatch('handleApiError', error);
+            } else this.$store.dispatch('handleApiError', { error });
           });
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -204,7 +204,7 @@
       },
       retryImport() {
         TaskResource.restart(this.loadingTask.id).catch(error => {
-          this.$store.dispatch('handleApiError', error);
+          this.$store.dispatch('handleApiError', { error });
         });
       },
       cancelTask() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
@@ -78,7 +78,7 @@
             TaskResource.startTask(params)
               .then(() => this.wizardService.send('CONTINUE'))
               .catch(err => {
-                this.$store.dispatch('handleApiError', err);
+                this.$store.dispatch('handleApiError', { error: err });
               });
           } else {
             const errorData = JSON.parse(data);

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
@@ -147,7 +147,7 @@
             this.loading = false;
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
       resetFormAndRefocus() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/PersonalDataConsentForm.vue
@@ -84,7 +84,7 @@
           const err =
             'Please provide the event you expect where you are using this Component in' +
             " the state machine in the meta field's `nextEvent` property.";
-          return this.$store.dispatch('handleApiError', err);
+          return this.$store.dispatch('handleApiError', { error: err });
         }
         // TODO Add an Error State with a "Start over" button? Something better than
         // "this silently fails" if something goes wrong for the user

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -194,7 +194,7 @@
           })
           .catch(e => {
             this.restart = e.response.status === 400;
-            this.$store.dispatch('handleApiError', e);
+            this.$store.dispatch('handleApiError', { error: e });
           });
       },
     },

--- a/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
+++ b/kolibri/plugins/user_auth/assets/src/modules/signUp/handlers.js
@@ -11,5 +11,5 @@ export function showSignUpPage(store, fromRoute) {
       store.commit('CORE_SET_FACILITIES', facilities);
       store.dispatch('reset');
     })
-    .catch(error => store.dispatch('handleApiError', error));
+    .catch(error => store.dispatch('handleApiError', { error, reloadOnReconnect: true }));
 }

--- a/kolibri/plugins/user_auth/assets/src/views/SignUpPage.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignUpPage.vue
@@ -208,7 +208,7 @@
           if (errorsCaught) {
             this.caughtErrors.push(ERROR_CONSTANTS.USERNAME_ALREADY_EXISTS);
           } else {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           }
         });
       },
@@ -286,7 +286,7 @@
                 this.goToFirstStep();
                 this.focusOnInvalidField();
               } else {
-                this.$store.dispatch('handleApiError', error);
+                this.$store.dispatch('handleApiError', { error });
               }
             });
         } else {

--- a/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfileEditPage.vue
@@ -200,7 +200,7 @@
               if (this.caughtErrors.length > 0) {
                 this.focusOnInvalidField();
               } else {
-                this.$store.dispatch('handleApiError', error);
+                this.$store.dispatch('handleApiError', { error });
               }
             });
         } else {

--- a/kolibri/plugins/user_profile/assets/src/views/ProfilePage/ChangeUserPasswordModal.vue
+++ b/kolibri/plugins/user_profile/assets/src/views/ProfilePage/ChangeUserPasswordModal.vue
@@ -59,7 +59,7 @@
             this.$store.dispatch('createSnackbar', this.$tr('passwordChangedNotification'));
           })
           .catch(error => {
-            this.$store.dispatch('handleApiError', error);
+            this.$store.dispatch('handleApiError', { error });
           });
       },
       focusOnInvalidField() {

--- a/packages/kolibri-common/components/AppError/index.vue
+++ b/packages/kolibri-common/components/AppError/index.vue
@@ -118,7 +118,7 @@
       },
     },
     methods: {
-      ...mapActions(['handleError']),
+      ...mapActions(['clearError']),
       revealDetailsModal() {
         this.showDetailsModal = true;
       },
@@ -130,7 +130,7 @@
         global.location.reload();
       },
       handleClickBackToHome() {
-        this.handleError('');
+        this.clearError();
         this.$router.push({ path: '/' });
       },
     },

--- a/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
+++ b/packages/kolibri-tools/test/fixtures/TestUserPermissions.js
@@ -94,7 +94,7 @@ export function showUserPermissionsPage(store, userId) {
           setAppBarTitle(translator.$tr('invalidUserTitle'));
           setUserPermissionsState({ user: null, permissions: {} });
         }
-        store.dispatch('handleApiError', error);
+        store.dispatch('handleApiError', { error });
         stopLoading();
       }
     });


### PR DESCRIPTION
## Summary
* Replaces all uses of the `handleError` action that was being inadvertently used for API errors with `handleApiError`
* When a disconnected state is detected, if the global loading state is currently true, then record that and force a page refresh on reconnection
* Clean up error clearing

## References
Fixes #10930

## Reviewer guidance
Browse a channel.
In the dev tools use network throttling to set as disconnected.
Attempt to navigate into a topic.
Confirm that no API error page appears.
Turn off network throttling.
Confirm on reconnect that the page refreshes.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
