### PR TITLE
Bug hunt fixes

### DIFF
--- a/kolibri/core/content/utils/settings.py
+++ b/kolibri/core/content/utils/settings.py
@@ -35,7 +35,7 @@ def allow_non_local_download():
     from kolibri.core.device.utils import get_device_setting
 
     return not using_metered_connection() or get_device_setting(
-        "allow_download_on_metered_connection"
+        "allow_download_on_metered_connection", default=False
     )
 
 
@@ -52,7 +52,7 @@ def get_free_space_for_downloads(completed_size=0):
     free_space = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
 
     # if a limit is set, subtract the total content storage size from the limit
-    if get_device_setting("set_limit_for_autodownload", False):
+    if get_device_setting("set_limit_for_autodownload", default=False):
         # compute total space used by automatic and learner initiated downloads
         # convert limit_for_autodownload from GB to bytes
         auto_download_limit = bytes_from_humans(

--- a/kolibri/core/discovery/test/test_api.py
+++ b/kolibri/core/discovery/test/test_api.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import uuid
+
 import mock
 import requests
 from django.urls import reverse
@@ -43,6 +45,31 @@ class NetworkLocationAPITestCase(APITestCase):
         self.client.login(
             username=user.username, password=DUMMY_PASSWORD, facility=user.facility
         )
+
+    def test_get__pk(self):
+        self.login(self.superuser)
+        response = self.client.get(
+            reverse(
+                "kolibri:core:staticnetworklocation-detail",
+                kwargs={"pk": self.existing_happy_netloc.pk},
+            )
+        )
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.data["base_url"], self.existing_happy_netloc.base_url)
+
+    def test_get__instance_id(self):
+        self.login(self.superuser)
+        self.existing_happy_netloc.instance_id = uuid.uuid4().hex
+        self.existing_happy_netloc.save()
+
+        response = self.client.get(
+            reverse(
+                "kolibri:core:staticnetworklocation-detail",
+                kwargs={"pk": self.existing_happy_netloc.instance_id},
+            )
+        )
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.data["base_url"], self.existing_happy_netloc.base_url)
 
     def test_creating_good_address(self):
         self.login(self.superuser)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes issue accessing `is_push` on `TransferSession`-- should be just `push`
- Fixes issue not passing defaults to `get_device_setting` which can throw errors if unprovisioned
- Fixes issue with size calculation only counting one node
- Fixes issue with completed queryset producing 0 results causing size calculation to produce `0`
- Fixes issues processing content removal requests
- Ensures that we only calculate size for parent's thumbnail and node's non-supplementary files
- Prevents traceback logging with `NoPeerAvailable` exception
- Prevents download processing if a node is already available
- Adds a few more tests for content request handling
- Adds a couple tests for NetworkLocation api

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://www.notion.so/learningequality/Kolibri-bug-hunt-v0-16-0-beta2-dev-focus-44ba46b299b743e0a03925e990b90ec6?pvs=4

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
 - Remotely browse Studio (hotfixes) and download content
 - Run a sync for a user or facility which has assigned lesson materials

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
