### PR TITLE
Add APK building to PR asset building and release pipelines

### DIFF
--- a/.github/githubUtils.js
+++ b/.github/githubUtils.js
@@ -3,6 +3,11 @@ const path = require('path');
 
 
 const file_manifest = {
+  "apk": {
+    "extension": "apk",
+    "description": "Android Package (APK)",
+    "content_type": "application/vnd.android.package-archive",
+  },
   "deb": {
     "extension": "deb",
     "description": "Debian Package",
@@ -46,6 +51,7 @@ const file_order = [
   "exe",
   "deb",
   "dmg",
+  "apk",
   "zip",
   "gz",
 ]

--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -52,3 +52,14 @@ jobs:
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       ref: develop
+  apk:
+    name: Build APK file
+    needs: whl
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@develop
+    with:
+      tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
+      ref: develop
+    secrets:
+      KOLIBRI_ANDROID_APP_DEVELOPER_KEYSTORE: ${{ secrets.KOLIBRI_ANDROID_APP_DEVELOPER_KEYSTORE }}
+      KOLIBRI_ANDROID_APP_DEVELOPER_KEYSTORE_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_DEVELOPER_KEYSTORE_PASSWORD }}
+      KOLIBRI_ANDROID_APP_DEVELOPER_KEYALIAS_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_DEVELOPER_KEYALIAS_PASSWORD }}

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -96,6 +96,25 @@ jobs:
     with:
       filename: ${{ needs.zip.outputs.zip-file-name }}
       release_id: ${{ github.event.release.id }}
+  apk:
+    name: Build Android APK
+    needs: whl
+    uses: learningequality/kolibri-installer-android/.github/workflows/build_apk.yml@develop
+    with:
+      tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
+      release: true
+      ref: develop
+    secrets:
+      KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE }}
+      KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYSTORE_PASSWORD }}
+      KOLIBRI_ANDROID_APP_PRODUCTION_KEYALIAS_PASSWORD: ${{ secrets.KOLIBRI_ANDROID_APP_PRODUCTION_KEYALIAS_PASSWORD }}
+      KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON: ${{ secrets.KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON }}
+  upload_apk:
+    uses: ./.github/workflows/upload_github_release_asset.yml
+    needs: apk
+    with:
+      filename: ${{ needs.apk.outputs.apk-file-name }}
+      release_id: ${{ github.event.release.id }}
   test_pypi_upload:
     name: Upload to TestPyPi
     needs: whl
@@ -138,7 +157,7 @@ jobs:
     name: Upload to Google Cloud Storage
     if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
-    needs: [block_release_step, whl, pex, dmg, deb, exe, zip]
+    needs: [block_release_step, whl, pex, dmg, deb, exe, zip, apk]
     strategy:
       matrix:
         filename: [
@@ -149,6 +168,7 @@ jobs:
           '${{ needs.deb.outputs.deb-file-name }}',
           '${{ needs.exe.outputs.exe-file-name }}',
           '${{ needs.zip.outputs.zip-file-name }}',
+          '${{ needs.apk.outputs.apk-file-name }}',
         ]
     steps:
     - name: Download ${{ matrix.filename }} artifact
@@ -172,3 +192,13 @@ jobs:
       with:
         path: 'dist/${{ matrix.filename }}'
         destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}/${{ matrix.filename }}'
+  android_release:
+    name: Release Android App
+    if: ${{ !github.event.release.prerelease }}
+    needs: [apk, block_release_step]
+    uses: learningequality/kolibri-installer-android/.github/workflows/release_apk.yml@develop
+    with:
+      version-code: ${{ needs.apk.outputs.version-code }}
+      ref: develop
+    secrets:
+      KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON: ${{ secrets.KOLIBRI_ANDROID_PLAY_STORE_API_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
## Summary
* Adds building of a release asset for all Kolibri releases which will get released to the internal testing track on the play store
* Adds promoting of internal testing track asset to open testing track for final releases
* Adds building and uploading of non-release APK files to PR assets

## References
Integrates https://github.com/learningequality/kolibri-installer-android/pull/152 into Kolibri

## Reviewer guidance
The only real way to test the release part of this is to merge it, but please double check my yml.

PR build showing an APK should be a sign of success for the other part!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
