### PR TITLE
Catch and redirect 401 errors when browsing remotely

### DIFF
--- a/kolibri/core/assets/src/core-app/client.js
+++ b/kolibri/core/assets/src/core-app/client.js
@@ -36,7 +36,7 @@ baseClient.interceptors.response.use(
     // client code is still trying to access data that they would be allowed to see
     // if they were logged in.
     if (error.response) {
-      if (error.response.status === 403) {
+      if (error.response.status === 403 || error.response.status === 401) {
         if (!store.state.core.session.id) {
           // Don't have any session information, so assume that this
           // page has just been reopened and the session has expired.


### PR DESCRIPTION
## Summary

This PR fixes the issue where in when a user gets signed out due to inactivity, there were unhandled 401 errors from the kolibri studio status endpoint. This PR fixes that issue.



## References

Closes https://github.com/learningequality/kolibri/issues/10996.

## Reviewer guidance

1. Comment out the cache decorator of kolibri studio status endpoint on serverside.
2. Open kolibri, sign in, do remote browsing.
3. Delete kolibri cookie to simulate user session time out.
4. Wait for a few seconds for the next kolibri studio status poll.
5. Observe that the 401 returned by the kolibri studio status poll redirects us to log in.  

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
