### PR TITLE
Actually cancel running jobs on worker shutdown to prevent blocking shutdown

### DIFF
--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -370,9 +370,13 @@ class KolibriBroadcast(object):
         self.register()
 
         # manually add our service browser to Zeroconf so it's automatically cleaned up on close
-        self.zeroconf.browsers["bus"] = ServiceBrowser(
-            self.zeroconf, SERVICE_TYPE, handlers=[self.events.publish_zeroconf_change]
-        )
+        # Check that the zeroconf attribute has not been set to None by a previous call to stop_broadcast
+        if self.zeroconf is not None:
+            self.zeroconf.browsers["bus"] = ServiceBrowser(
+                self.zeroconf,
+                SERVICE_TYPE,
+                handlers=[self.events.publish_zeroconf_change],
+            )
 
     def update_broadcast(self, instance=None, interfaces=None):
         """
@@ -504,7 +508,8 @@ class KolibriBroadcast(object):
 
         # very important to publish the event first, to avoid race conditions
         self.events.publish(EVENT_UNREGISTER_INSTANCE, self.instance)
-        self.zeroconf.unregister_service(self.instance.service_info)
+        if self.instance.service_info is not None:
+            self.zeroconf.unregister_service(self.instance.service_info)
         self.instance.reset_broadcasting()
 
     def add_listener(self, listener_cls):

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -23,6 +23,7 @@ from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.exceptions import JobRunning
+from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import Priority
@@ -493,6 +494,8 @@ class Storage(object):
         if not isinstance(delta_t, timedelta):
             raise TypeError("Time argument must be a timedelta object.")
         orm_job = self.get_orm_job(job_id)
+        if orm_job.state == State.CANCELING:
+            raise UserCancelledError("Job has been marked for cancellation.")
         if orm_job.state != State.RUNNING:
             raise JobNotRunning("Job is not running, cannot retry.")
         if orm_job.retry_interval is not None or orm_job.repeat != 0:


### PR DESCRIPTION
## Summary
* The worker code was only calling cancel on the stored future, but not interacting with the actual task cancellation mechanisms that are required to interrupt threads
* Marks any running jobs as canceling, and lets the existing cancellation handling logic finish up
* In the course of testing this, I ran into a couple of edge cases in our zeroconf handling where things would get cleaned up before certain code executed, so I added some defensive programming checks to handle these without errors

## References
Fixes #10249

## Reviewer guidance
Start then immediately stop the devserver - observe that it actually finishes up fairly quickly now rather than stalling for a while.

For a more acid test, run the server, start a long running content import task and then shut it down - it should still shut down relatively quickly.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
