### PR TITLE
Fix resource viewing wasted vertical spacing for smaller devices

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -147,8 +147,7 @@ oriented data synchronization.
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
-  import { createTranslator } from 'kolibri.utils.i18n';
-  import { defaultLanguage } from 'kolibri-design-system/lib/utils/i18n';
+  import { createTranslator, defaultLanguage } from 'kolibri.utils.i18n';
   import LessonMasteryBar from './LessonMasteryBar';
   import ExerciseAttempts from './ExerciseAttempts';
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -522,6 +522,8 @@
           style = {
             minHeight: '900px',
           };
+        } else {
+          style.top = '60px';
         }
         if (this.isRtl) {
           style.marginRight = `${this.sidePanelWidth + 24}px`;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the display of resources on android/smaller device screens that had too much spacing on top. 

This pr also updates the import of `defaultLanguage` from `kolibri-design-system/lib/utils/i18n` to be imported from `kolibri.utils.i18n` instead within the file `kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue` instead to fix the error 

> `Module not found: Error: Can't resolve 'kolibri-design-system/lib/utils/i18n' in '/Users/lianaharris/kolibri/kolibri/plugins/learn/assets/src/views/AssessmentWrapper'` 

received when running the dev server.


Before:
<img width="309" alt="SmallScreenBefore" src="https://github.com/learningequality/kolibri/assets/46411498/16902567-5632-4852-bff6-18b58de4bfe5">


<img width="536" alt="MediumScreenBefore" src="https://github.com/learningequality/kolibri/assets/46411498/9a52f12e-1a11-4320-ac53-a1f8da5f5750">

After:
<img width="312" alt="SmallScreenAfter" src="https://github.com/learningequality/kolibri/assets/46411498/f1ac4913-41b3-447e-b5bf-64075253d16b">
<img width="574" alt="MediumScreenAfter" src="https://github.com/learningequality/kolibri/assets/46411498/99b69f8d-63ed-4085-9b6e-efcebfd22af8">

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11074 

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
