### PR TITLE
Fix links to issues in the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 
 1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
 2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
-3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aopen+label%3A%22TAG%3A+help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22+no%3Aassignee).
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee).
 4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
 
 Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you have found a bug and are comfortable using Github and Markdown, you can c
 
 1. 📙 Skim through the [Kolibri developer documentation](https://kolibri-dev.readthedocs.io) to understand where to refer later on.
 2. 💻 Follow [Getting started](https://kolibri-dev.readthedocs.io/en/develop/getting_started.html) to set up your development server. Some of the [How To Guides](https://kolibri-dev.readthedocs.io/en/develop/howtos/index.html#howtos) may be handy too.
-3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aopen+label%3A%22TAG%3A+help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22TAG%3A+good+first+issue%22+no%3Aassignee).
+3. 🔍 Search for issues tagged as [help wanted](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22+no%3Aassignee) or [good first issue](https://github.com/learningequality/kolibri/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee).
 4. 🗣️ Ask us for an assignment in the comments of an issue you've chosen.
 
 Note that in times of increased contributions activity, it may take us a few days to reply. If you don't hear from us within a week, please reach out via [Kolibri GitHub Discussions](https://github.com/learningequality/kolibri/discussions).


### PR DESCRIPTION
## Summary

Links need to be updated from the obsolete "TAG: help wanted" and "TAG: good first issue" to "help wanted" and "good first issue" to correspond to the latest updates of the two GitHub labels (motivated by GitHub promotion of "good first issue" label in this literal format)

## Reviewer guidance

Links should take you to correct search results

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
