### PR TITLE
Syncing fixes for automatic content syncing and regressions

### DIFF
--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -10,7 +10,7 @@ import os
 import random
 import uuid
 
-from django.test import TestCase
+from django.test import TransactionTestCase
 from le_utils.constants import content_kinds
 
 from kolibri.core.analytics.constants.nutrition_endpoints import PINGBACK
@@ -225,7 +225,7 @@ class BaseDeviceSetupMixin(object):
         DeviceSettings.objects.delete()
 
 
-class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
+class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_facility_statistics(self):
         provision_device(allow_guest_access=True)
         facility = self.facilities[0]
@@ -327,7 +327,7 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         assert actual["l"] is None
 
 
-class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
+class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     n_facilities = 1
     n_superusers = 0
     n_users = 2
@@ -344,7 +344,7 @@ class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         self.assertEqual(expected_soud_hash, actual.pop("sh"))
 
 
-class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
+class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     def test_extract_channel_statistics(self):
         actual = extract_channel_statistics(self.channel)
         birth_year_list_learners = [
@@ -392,7 +392,7 @@ class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
         assert actual == expected
 
 
-class CreateUpdateNotificationsTestCase(TestCase):
+class CreateUpdateNotificationsTestCase(TransactionTestCase):
     def setUp(self):
         self.msg = {
             "i18n": {},

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -10,7 +10,7 @@ import os
 import random
 import uuid
 
-from django.test import TransactionTestCase
+from django.test import TestCase
 from le_utils.constants import content_kinds
 
 from kolibri.core.analytics.constants.nutrition_endpoints import PINGBACK
@@ -27,12 +27,12 @@ from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_superuser
+from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.device.models import DeviceSettings
-from kolibri.core.device.utils import provision_device
 from kolibri.core.device.utils import provision_single_user_device
 from kolibri.core.exams.models import Exam
 from kolibri.core.lessons.models import Lesson
@@ -222,10 +222,10 @@ class BaseDeviceSetupMixin(object):
 
     def tearDown(self):
         super(BaseDeviceSetupMixin, self).tearDown()
-        DeviceSettings.objects.all().delete()
+        DeviceSettings.objects.delete()
 
 
-class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
+class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
     def test_extract_facility_statistics(self):
         provision_device(allow_guest_access=True)
         facility = self.facilities[0]
@@ -327,7 +327,7 @@ class FacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
         assert actual["l"] is None
 
 
-class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
+class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
     n_facilities = 1
     n_superusers = 0
     n_users = 2
@@ -344,7 +344,7 @@ class SoudFacilityStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
         self.assertEqual(expected_soud_hash, actual.pop("sh"))
 
 
-class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
+class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TestCase):
     def test_extract_channel_statistics(self):
         actual = extract_channel_statistics(self.channel)
         birth_year_list_learners = [
@@ -392,7 +392,7 @@ class ChannelStatisticsTestCase(BaseDeviceSetupMixin, TransactionTestCase):
         assert actual == expected
 
 
-class CreateUpdateNotificationsTestCase(TransactionTestCase):
+class CreateUpdateNotificationsTestCase(TestCase):
     def setUp(self):
         self.msg = {
             "i18n": {},

--- a/kolibri/core/analytics/test/test_utils.py
+++ b/kolibri/core/analytics/test/test_utils.py
@@ -25,6 +25,7 @@ from kolibri.core.auth.constants import demographics
 from kolibri.core.auth.constants import facility_presets
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import create_superuser
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
@@ -62,6 +63,7 @@ class BaseDeviceSetupMixin(object):
 
     def setUp(self):
         super(BaseDeviceSetupMixin, self).setUp()
+        clear_process_cache()
         # create dummy channel
         channel_id = uuid.uuid4().hex
         root = ContentNode.objects.create(

--- a/kolibri/core/analytics/utils.py
+++ b/kolibri/core/analytics/utils.py
@@ -295,7 +295,7 @@ def extract_facility_statistics(facility):
     # fmt: on
 
     # conditionally calculate and add soud_hash
-    if get_device_setting("subset_of_users_device", False):
+    if get_device_setting("subset_of_users_device"):
         user_ids = ":".join(
             facility.facilityuser_set.order_by("id").values_list("id", flat=True)
         )
@@ -427,7 +427,7 @@ def perform_ping(started, server=DEFAULT_SERVER_URL):
 
     instance, _ = InstanceIDModel.get_or_create_current_instance()
 
-    language = get_device_setting("language_id", "")
+    language = get_device_setting("language_id") or ""
 
     started = parser.isoparse(started)
 

--- a/kolibri/core/auth/apps.py
+++ b/kolibri/core/auth/apps.py
@@ -13,3 +13,10 @@ class KolibriAuthConfig(AppConfig):
     def ready(self):
         from .signals import cascade_delete_membership  # noqa: F401
         from .signals import cascade_delete_user  # noqa: F401
+
+        from kolibri.core.auth.sync_event_hook_utils import (
+            register_sync_event_handlers,
+        )  # noqa: F401
+        from morango.api.viewsets import session_controller  # noqa: F401
+
+        register_sync_event_handlers(session_controller)

--- a/kolibri/core/auth/apps.py
+++ b/kolibri/core/auth/apps.py
@@ -19,4 +19,4 @@ class KolibriAuthConfig(AppConfig):
         )  # noqa: F401
         from morango.api.viewsets import session_controller  # noqa: F401
 
-        register_sync_event_handlers(session_controller)
+        register_sync_event_handlers(session_controller.signals)

--- a/kolibri/core/auth/hooks.py
+++ b/kolibri/core/auth/hooks.py
@@ -23,7 +23,8 @@ class FacilityDataSyncHook(KolibriHook):
         context,
     ):
         """
-        Invoked before the initialization stage
+        Invoked before the initialization stage, and as such it won't have access to the
+        transfer session object since it is created during the initialization stage.
         :type dataset_id: str
         :type local_is_single_user: bool
         :type remote_is_single_user: bool

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -70,7 +70,7 @@ from kolibri.core.auth.constants.demographics import choices as GENDER_CHOICES
 from kolibri.core.auth.constants.demographics import DEFERRED
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
-from kolibri.core.device.utils import DeviceNotProvisioned
+from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import set_device_settings
 from kolibri.core.errors import KolibriValidationError
@@ -1408,11 +1408,12 @@ class Facility(Collection):
 
     @classmethod
     def get_default_facility(cls):
-        try:
-            default_facility = get_device_setting("default_facility")
-        except DeviceNotProvisioned:
+        if not device_provisioned():
             # device has not been provisioned yet, so just return None in this case
             return None
+
+        default_facility = get_device_setting("default_facility")
+
         if not default_facility:
             # Legacy databases will not have this explicitly set.
             # Set this here to ensure future default facility queries are

--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -108,6 +108,12 @@ def _post_transfer_handler(**kwargs):
             )
 
 
-def register_sync_event_handlers(session_controller):
-    session_controller.signals.initializing.completed.connect(_pre_transfer_handler)
-    session_controller.signals.cleanup.completed.connect(_post_transfer_handler)
+def register_sync_event_handlers(signals):
+    """
+    Attaches the pre and post transfer handlers to the morango session controller signals.
+
+    :param signals: The signals object from the morango session controller
+    :type signals: morango.sync.controller.SessionControllerSignals
+    """
+    signals.initializing.started.connect(_pre_transfer_handler)
+    signals.cleanup.completed.connect(_post_transfer_handler)

--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -83,13 +83,10 @@ def _local_event_handler(func):
 
 
 @_local_event_handler
-def pre_transfer_handler(**kwargs):
+def _pre_transfer_handler(**kwargs):
     for hook in FacilityDataSyncHook.registered_hooks:
         # we catch all errors because as a rule of thumb, we don't want hooks to fail
         try:
-            logger.debug(
-                "Invoking sync hook {}.pre_transfer".format(hook.__class__.__name__)
-            )
             hook.pre_transfer(**kwargs)
         except Exception as e:
             logger.error(
@@ -99,16 +96,18 @@ def pre_transfer_handler(**kwargs):
 
 
 @_local_event_handler
-def post_transfer_handler(**kwargs):
+def _post_transfer_handler(**kwargs):
     for hook in FacilityDataSyncHook.registered_hooks:
         # we catch all errors because as a rule of thumb, we don't want hooks to fail
         try:
-            logger.debug(
-                "Invoking sync hook {}.post_transfer".format(hook.__class__.__name__)
-            )
             hook.post_transfer(**kwargs)
         except Exception as e:
             logger.error(
                 "{}.post_transfer hook failed".format(hook.__class__.__name__),
                 exc_info=e,
             )
+
+
+def register_sync_event_handlers(session_controller):
+    session_controller.signals.initializing.completed.connect(_pre_transfer_handler)
+    session_controller.signals.cleanup.completed.connect(_post_transfer_handler)

--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -72,9 +72,11 @@ def _local_event_handler(func):
     @wraps(func)
     def wrapper(context):
         """
-        :type context: morango.sync.context.CompositeSessionContext
+        :type context:
+            morango.sync.context.CompositeSessionContext|morango.sync.context.LocalSessionContext
         """
-        for sub_context in context.children:
+        children = getattr(context, "children", [context])
+        for sub_context in children:
             if isinstance(sub_context, LocalSessionContext):
                 kwargs = _extract_kwargs_from_context(sub_context)
                 return func(**kwargs)

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -457,6 +457,8 @@ def peerusersync(command, **kwargs):
     cleanup = False
     resync_interval = kwargs["resync_interval"]
     kwargs["keep_alive"] = True
+    if command == "resumesync":
+        kwargs["id"] = kwargs["sync_session_id"]
     try:
         call_command(command, **kwargs)
     except Exception as e:

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -468,8 +468,8 @@ def peerusersync(command, **kwargs):
             # override to reschedule a sync sooner in this case
             resync_interval = 5
             logger.warning(
-                "Failed to resume sync session for user {} to server {}; queuing its cleanup".format(
-                    kwargs["user"], kwargs["baseurl"]
+                "Failed to resume sync session for user {} to server {}: {}".format(
+                    kwargs["user"], kwargs["baseurl"], str(e)
                 )
             )
         elif isinstance(e, UserCancelledError):
@@ -551,7 +551,6 @@ def stoppeerusersync(server, user_id):
     if sync_session is None:
         return
 
-    logger.debug("Enqueuing cleanup of SoUD sync session {}".format(sync_session.id))
     return queue_soud_sync_cleanup(sync_session.id)
 
 
@@ -786,6 +785,9 @@ def queue_soud_sync_cleanup(*sync_session_ids):
 
     :param sync_session_ids: ID's of sync sessions we should cleanup
     """
+    logger.info(
+        "Enqueueing cleanup of sync sessions: {}".format(", ".join(sync_session_ids))
+    )
     return soud_sync_cleanup.enqueue(kwargs=dict(pk__in=sync_session_ids))
 
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -755,12 +755,8 @@ def schedule_new_sync(server, user, interval=OPTIONS["Deployment"]["SYNC_INTERVA
         )
     )
     dt = datetime.timedelta(seconds=interval)
-    current_job = get_current_job()
-    if current_job:
-        current_job.retry_in(dt)
-    else:
-        JOB_ID = hashlib.md5("{}:{}".format(server, user).encode()).hexdigest()
-        request_soud_sync.enqueue_in(dt, args=(server, user), job_id=JOB_ID)
+    JOB_ID = hashlib.md5("{}:{}".format(server, user).encode()).hexdigest()
+    request_soud_sync.enqueue_in(dt, args=(server, user), job_id=JOB_ID)
 
 
 @register_task(

--- a/kolibri/core/auth/test/helpers.py
+++ b/kolibri/core/auth/test/helpers.py
@@ -11,7 +11,7 @@ from ..models import FacilityUser
 from ..models import LearnerGroup
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.device.models import DevicePermissions
-from kolibri.core.device.utils import provision_device  # noqa
+from kolibri.core.device.utils import provision_device as _provision_device  # noqa
 
 DUMMY_PASSWORD = "password"
 
@@ -22,6 +22,11 @@ def clear_process_cache():
         process_cache.clear()
     except InvalidCacheBackendError:
         pass
+
+
+def provision_device(*args, **kwargs):
+    clear_process_cache()
+    return _provision_device(*args, **kwargs)
 
 
 def create_superuser(facility, username="superuser"):

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -41,6 +41,7 @@ class KolibriServer(object):
         kolibri_home=None,
         seeded_kolibri_home=None,
         env=None,
+        enable_automatic_download=False,
     ):
         self.env = os.environ.copy()
         self.env["KOLIBRI_HOME"] = kolibri_home or tempfile.mkdtemp()
@@ -55,6 +56,7 @@ class KolibriServer(object):
         self.db_alias = uuid.uuid4().hex
         self.port = get_free_tcp_port()
         self.baseurl = "http://127.0.0.1:{}/".format(self.port)
+        self.enable_automatic_download = enable_automatic_download
         if seeded_kolibri_home is not None:
             shutil.rmtree(self.env["KOLIBRI_HOME"])
             shutil.copytree(seeded_kolibri_home, self.env["KOLIBRI_HOME"])
@@ -67,6 +69,8 @@ class KolibriServer(object):
             env=self.env,
         )
         self._wait_for_server_start()
+        if not self.enable_automatic_download:
+            self.manage("devicesettings", "set", "--disable-automatic-download")
 
     def manage(self, *args):
         subprocess.call(

--- a/kolibri/core/auth/test/test_models.py
+++ b/kolibri/core/auth/test/test_models.py
@@ -650,7 +650,7 @@ class StringMethodTestCase(TestCase):
 class FacilityTestCase(TestCase):
     def test_existing_facility_becomes_default_facility(self):
         self.facility = Facility.objects.create()
-        self.device_settings = DeviceSettings.objects.create()
+        self.device_settings = DeviceSettings.objects.create(is_provisioned=True)
         self.assertEqual(self.device_settings.default_facility, None)
         default_facility = Facility.get_default_facility()
         self.assertEqual(default_facility, self.facility)

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -102,6 +102,7 @@ class CertificateAuthenticationTestCase(TestCase):
             "--facilities",
             "2",
         )
+        server.manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility_1 = Facility.objects.using(server.db_alias).first()
         facility_2 = Facility.objects.using(server.db_alias).last()
@@ -180,6 +181,7 @@ class CertificateAuthenticationTestCase(TestCase):
         server.manage("loaddata", "scopedefinitions")
         server.manage("loaddata", "content_test")
         server.manage("generateuserdata", "--no-onboarding", "--num-content-items", "1")
+        server.manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility = Facility.objects.using(server.db_alias).first()
         facility.dataset.learner_can_login_with_no_password = True
@@ -464,7 +466,13 @@ class EcosystemTestCase(TestCase):
             Exam,
             title=exam_title,
             question_count=1,
-            question_sources=["a"],
+            question_sources=[
+                {
+                    "exercise_id": uuid.uuid4().hex,
+                    "question_id": uuid.uuid4().hex,
+                    "title": "a",
+                }
+            ],
             collection_id=classroom_id,
             creator_id=alto_user.id,
             active=True,
@@ -652,6 +660,7 @@ class EcosystemSingleUserTestCase(TestCase):
         servers[0].manage(
             "generateuserdata", "--no-onboarding", "--num-content-items", "1"
         )
+        servers[0].manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility_id = Facility.objects.using(s0_alias).get().id
 
@@ -1018,7 +1027,13 @@ class EcosystemSingleUserAssignmentTestCase(TestCase):
                 Exam,
                 title=title,
                 question_count=1,
-                question_sources=["a"],
+                question_sources=[
+                    {
+                        "exercise_id": uuid.uuid4().hex,
+                        "question_id": uuid.uuid4().hex,
+                        "title": "a",
+                    }
+                ],
                 collection_id=self.classroom.id,
                 creator_id=self.teacher.id,
                 active=True,
@@ -1034,7 +1049,13 @@ class EcosystemSingleUserAssignmentTestCase(TestCase):
             self.laptop_a.create_model(
                 Lesson,
                 title=title,
-                resources=["a"],
+                resources=[
+                    {
+                        "contentnode_id": uuid.uuid4().hex,
+                        "content_id": uuid.uuid4().hex,
+                        "channel_id": uuid.uuid4().hex,
+                    }
+                ],
                 collection_id=self.classroom.id,
                 created_by_id=self.teacher.id,
                 is_active=True,

--- a/kolibri/core/auth/test/test_morango_integration.py
+++ b/kolibri/core/auth/test/test_morango_integration.py
@@ -102,7 +102,6 @@ class CertificateAuthenticationTestCase(TestCase):
             "--facilities",
             "2",
         )
-        server.manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility_1 = Facility.objects.using(server.db_alias).first()
         facility_2 = Facility.objects.using(server.db_alias).last()
@@ -181,7 +180,6 @@ class CertificateAuthenticationTestCase(TestCase):
         server.manage("loaddata", "scopedefinitions")
         server.manage("loaddata", "content_test")
         server.manage("generateuserdata", "--no-onboarding", "--num-content-items", "1")
-        server.manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility = Facility.objects.using(server.db_alias).first()
         facility.dataset.learner_can_login_with_no_password = True
@@ -660,7 +658,6 @@ class EcosystemSingleUserTestCase(TestCase):
         servers[0].manage(
             "generateuserdata", "--no-onboarding", "--num-content-items", "1"
         )
-        servers[0].manage("devicesettings", "set", "--no-enable-automatic-download")
 
         facility_id = Facility.objects.using(s0_alias).get().id
 

--- a/kolibri/core/auth/test/test_sync_event_hook_utils.py
+++ b/kolibri/core/auth/test/test_sync_event_hook_utils.py
@@ -3,8 +3,8 @@ from django.test import SimpleTestCase
 from morango.sync.context import CompositeSessionContext
 from morango.sync.context import LocalSessionContext
 
-from kolibri.core.auth.sync_event_hook_utils import post_transfer_handler
-from kolibri.core.auth.sync_event_hook_utils import pre_transfer_handler
+from kolibri.core.auth.sync_event_hook_utils import _post_transfer_handler
+from kolibri.core.auth.sync_event_hook_utils import _pre_transfer_handler
 
 
 MODULE_NAME = "kolibri.core.auth.sync_event_hook_utils"
@@ -33,7 +33,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
     def test_pre_transfer(self, mock_hook_registry):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
-        pre_transfer_handler(self.context)
+        _pre_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called_once_with(
             context=self.local_context,
             dataset_id="123",
@@ -46,7 +46,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         self.context.children = [mock.Mock()]
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
-        pre_transfer_handler(self.context)
+        _pre_transfer_handler(self.context)
         self.hook.pre_transfer.assert_not_called()
 
     @mock.patch("kolibri.core.auth.sync_event_hook_utils.logger")
@@ -54,7 +54,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
         self.hook.pre_transfer.side_effect = RuntimeError()
-        pre_transfer_handler(self.context)
+        _pre_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called()
         mock_logger.error.assert_called_once_with(
             "TestHook.pre_transfer hook failed",
@@ -65,13 +65,13 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
         self.hook.pre_transfer.side_effect = RuntimeError()
-        pre_transfer_handler(self.context)
+        _pre_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called()
 
     def test_post_transfer(self, mock_hook_registry):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
-        post_transfer_handler(self.context)
+        _post_transfer_handler(self.context)
         self.hook.post_transfer.assert_called_once_with(
             context=self.local_context,
             dataset_id="123",
@@ -84,7 +84,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         self.context.children = [mock.Mock()]
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
-        post_transfer_handler(self.context)
+        _post_transfer_handler(self.context)
         self.hook.post_transfer.assert_not_called()
 
     @mock.patch("kolibri.core.auth.sync_event_hook_utils.logger")
@@ -92,7 +92,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
         self.hook.post_transfer.side_effect = RuntimeError()
-        post_transfer_handler(self.context)
+        _post_transfer_handler(self.context)
         self.hook.post_transfer.assert_called()
         mock_logger.error.assert_called_once_with(
             "TestHook.post_transfer hook failed",
@@ -103,5 +103,5 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
         self.hook.post_transfer.side_effect = RuntimeError()
-        post_transfer_handler(self.context)
+        _post_transfer_handler(self.context)
         self.hook.post_transfer.assert_called()

--- a/kolibri/core/auth/utils/migrate.py
+++ b/kolibri/core/auth/utils/migrate.py
@@ -221,7 +221,7 @@ def migrate_facility(facility):
     a new facility, and then deletes the old facility, including from the morango store.
     """
     new_dataset = fork_facility(facility)
-    default_facility = get_device_setting("default_facility", None)
+    default_facility = get_device_setting("default_facility")
     if default_facility and default_facility.id == facility.id:
         new_facility = Facility.objects.get(dataset_id=new_dataset.id)
         set_device_settings(default_facility=new_facility)

--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -90,7 +90,7 @@ class ContentSyncHook(FacilityDataSyncHook):
 class NetworkDiscoveryForAutomaticResourceImportHook(NetworkLocationDiscoveryHook):
     """
     Trigger automatic resource import when a new Kolibri instance is discovered, but only if
-    the local and remove devices are not a subset of the users device. If we're a SoUD, then
+    the local and remote devices are not a subset of the users device. If we're a SoUD, then
     we would trigger automatic syncing which would trigger automatic resource import anyway
     (see above hook).
     """

--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -5,10 +5,12 @@ from morango.sync.operations import LocalOperation
 from kolibri.core.auth.hooks import FacilityDataSyncHook
 from kolibri.core.auth.sync_event_hook_utils import get_dataset_id
 from kolibri.core.auth.sync_operations import KolibriSyncOperationMixin
-from kolibri.core.content.tasks import automatic_resource_import
+from kolibri.core.content.tasks import enqueue_automatic_resource_import_if_needed
 from kolibri.core.content.utils.content_request import incomplete_downloads_queryset
 from kolibri.core.content.utils.content_request import process_metadata_import
 from kolibri.core.content.utils.content_request import synchronize_content_requests
+from kolibri.core.device.utils import get_device_setting
+from kolibri.core.discovery.hooks import NetworkLocationDiscoveryHook
 from kolibri.plugins.hooks import register_hook
 
 
@@ -81,4 +83,26 @@ class ContentSyncHook(FacilityDataSyncHook):
         # TODO: we need determine total space for new downloads and if there isn't sufficient space
         # save the `LearnerDeviceStatus` with the insufficient storage status
 
-        automatic_resource_import.enqueue_if_not()
+        enqueue_automatic_resource_import_if_needed()
+
+
+@register_hook
+class NetworkDiscoveryForAutomaticResourceImportHook(NetworkLocationDiscoveryHook):
+    """
+    Trigger automatic resource import when a new Kolibri instance is discovered, but only if
+    the local and remove devices are not a subset of the users device. If we're a SoUD, then
+    we would trigger automatic syncing which would trigger automatic resource import anyway
+    (see above hook).
+    """
+
+    def on_connect(self, network_location):
+        """
+        :type network_location: kolibri.core.discovery.models.NetworkLocation
+        """
+        if (
+            not get_device_setting("subset_of_users_device")
+            and not network_location.subset_of_users_device
+        ):
+            enqueue_automatic_resource_import_if_needed(
+                instance_id=network_location.instance_id
+            )

--- a/kolibri/core/content/signals.py
+++ b/kolibri/core/content/signals.py
@@ -39,7 +39,7 @@ def add_download_requests(dataset_id, assignments):
     :param assignments: A list of assignments representing the content to be downloaded.
     :type assignments: list
     """
-    if get_device_setting("enable_automatic_download", default=False) is True:
+    if get_device_setting("enable_automatic_download"):
         facility = Facility.objects.get(dataset_id=dataset_id)
         create_content_download_requests(facility, assignments)
 
@@ -53,6 +53,6 @@ def add_removal_requests(dataset_id, assignments):
     :param assignments: A list of assignments representing the content to be removed.
     :type assignments: list
     """
-    if get_device_setting("enable_automatic_download", default=False) is True:
+    if get_device_setting("enable_automatic_download"):
         facility = Facility.objects.get(dataset_id=dataset_id)
         create_content_removal_requests(facility, assignments)

--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -1,12 +1,16 @@
 import requests
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
+from django.db.models import Q
 from rest_framework import serializers
 from six import with_metaclass
 from six.moves.urllib.parse import urljoin
 
 from kolibri.core.auth.models import FacilityDataset
 from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentRequest
+from kolibri.core.content.models import ContentRequestStatus
+from kolibri.core.content.models import ContentRequestType
 from kolibri.core.content.utils.channel_import import import_channel_from_data
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.channels import read_channel_metadata_from_db_file
@@ -345,6 +349,29 @@ def remoteresourceimport(
     import_manager.run()
 
 
+def enqueue_automatic_resource_import_if_needed(instance_id=None):
+    """
+    Enqueues automatic_resource_import if there are any pending content requests, and optionally
+    filters by instance_id for Downloads
+    :param instance_id: UUID of the instance to filter by for preferred instance downloads
+    :type instance_id: str
+    """
+    reqs = ContentRequest.objects.exclude(
+        status__in=[
+            ContentRequestStatus.Completed,
+            ContentRequestStatus.InProgress,
+        ]
+    )
+    if instance_id:
+        reqs = reqs.filter(
+            Q(type=ContentRequestType.Download, source_instance_id=instance_id)
+            | Q(type=ContentRequestType.Removal)
+        )
+
+    if reqs.exists():
+        automatic_resource_import.enqueue_if_not()
+
+
 class AutomaticDownloadValidator(JobValidator):
     def validate(self, data):
         job_data = super(AutomaticDownloadValidator, self).validate(data)
@@ -363,9 +390,8 @@ def automatic_resource_import():
     """
     Processes content download and removal requests
     """
-    if not automatic_download_enabled():
-        return
-    process_content_requests()
+    if automatic_download_enabled():
+        process_content_requests()
 
 
 @register_task(
@@ -392,7 +418,7 @@ def automatic_synchronize_content_requests_and_import():
             return
         synchronize_content_requests(dataset_id, None)
 
-    automatic_resource_import.enqueue_if_not()
+    enqueue_automatic_resource_import_if_needed()
 
 
 class ExportChannelResourcesValidator(LocalMixin, ChannelResourcesValidator):

--- a/kolibri/core/content/test/test_tasks.py
+++ b/kolibri/core/content/test/test_tasks.py
@@ -266,6 +266,10 @@ class ValidateLocalImportTaskTestCase(TestCase):
 
 
 class AutomaticDownloadTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.facility = Facility.objects.create(name="a")
+
     @mock.patch(
         "kolibri.core.content.tasks.automatic_download_enabled", return_value=True
     )
@@ -304,7 +308,7 @@ class AutomaticDownloadTestCase(TestCase):
             reason=ContentRequestReason.UserInitiated,
             source_model="test",
             source_id=uuid.uuid4().hex,
-            facility_id=uuid.uuid4().hex,
+            facility_id=self.facility.id,
             contentnode_id=uuid.uuid4().hex,
             status=ContentRequestStatus.Completed,
         ).save()
@@ -317,7 +321,7 @@ class AutomaticDownloadTestCase(TestCase):
             reason=ContentRequestReason.UserInitiated,
             source_model="test",
             source_id=uuid.uuid4().hex,
-            facility_id=uuid.uuid4().hex,
+            facility_id=self.facility.id,
             source_instance_id=uuid.uuid4().hex,
             contentnode_id=uuid.uuid4().hex,
             status=ContentRequestStatus.Completed,
@@ -332,7 +336,7 @@ class AutomaticDownloadTestCase(TestCase):
             reason=ContentRequestReason.UserInitiated,
             source_model="test",
             source_id=uuid.uuid4().hex,
-            facility_id=uuid.uuid4().hex,
+            facility_id=self.facility.id,
             contentnode_id=uuid.uuid4().hex,
             status=ContentRequestStatus.Pending,
         ).save()
@@ -345,7 +349,7 @@ class AutomaticDownloadTestCase(TestCase):
             reason=ContentRequestReason.UserInitiated,
             source_model="test",
             source_id=uuid.uuid4().hex,
-            facility_id=uuid.uuid4().hex,
+            facility_id=self.facility.id,
             source_instance_id=uuid.uuid4().hex,
             contentnode_id=uuid.uuid4().hex,
             status=ContentRequestStatus.Pending,

--- a/kolibri/core/content/test/test_tasks.py
+++ b/kolibri/core/content/test/test_tasks.py
@@ -7,9 +7,14 @@ from rest_framework import serializers
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import ContentRequestReason
+from kolibri.core.content.models import ContentRequestStatus
+from kolibri.core.content.tasks import AutomaticDownloadValidator
 from kolibri.core.content.tasks import ChannelResourcesValidator
 from kolibri.core.content.tasks import ChannelValidator
+from kolibri.core.content.tasks import enqueue_automatic_resource_import_if_needed
 from kolibri.core.content.tasks import LocalChannelImportValidator
 from kolibri.core.content.tasks import RemoteChannelImportValidator
 from kolibri.core.discovery.models import NetworkLocation
@@ -258,3 +263,93 @@ class ValidateLocalImportTaskTestCase(TestCase):
                 "kwargs": {},
             },
         )
+
+
+class AutomaticDownloadTestCase(TestCase):
+    @mock.patch(
+        "kolibri.core.content.tasks.automatic_download_enabled", return_value=True
+    )
+    def test_validator__enabled(self, _):
+        validator = AutomaticDownloadValidator(
+            data={"type": "kolibri.core.content.tasks.automatic_resource_import"}
+        )
+        try:
+            validator.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            self.fail("AutomaticDownloadValidator raised ValidationError unexpectedly!")
+
+    @mock.patch(
+        "kolibri.core.content.tasks.automatic_download_enabled", return_value=False
+    )
+    def test_validator__disabled(self, _):
+        validator = AutomaticDownloadValidator(
+            data={"type": "kolibri.core.content.tasks.automatic_resource_import"}
+        )
+        with self.assertRaises(serializers.ValidationError):
+            validator.is_valid(raise_exception=True)
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__no_reqs(self, mock_task):
+        enqueue_automatic_resource_import_if_needed()
+        mock_task.enqueue_if_not.assert_not_called()
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__instance_id__no_reqs(self, mock_task):
+        enqueue_automatic_resource_import_if_needed(instance_id=uuid.uuid4().hex)
+        mock_task.enqueue_if_not.assert_not_called()
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__completed_req(self, mock_task):
+        ContentDownloadRequest(
+            reason=ContentRequestReason.UserInitiated,
+            source_model="test",
+            source_id=uuid.uuid4().hex,
+            facility_id=uuid.uuid4().hex,
+            contentnode_id=uuid.uuid4().hex,
+            status=ContentRequestStatus.Completed,
+        ).save()
+        enqueue_automatic_resource_import_if_needed()
+        mock_task.enqueue_if_not.assert_not_called()
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__instance_id__completed_req(self, mock_task):
+        req = ContentDownloadRequest(
+            reason=ContentRequestReason.UserInitiated,
+            source_model="test",
+            source_id=uuid.uuid4().hex,
+            facility_id=uuid.uuid4().hex,
+            source_instance_id=uuid.uuid4().hex,
+            contentnode_id=uuid.uuid4().hex,
+            status=ContentRequestStatus.Completed,
+        )
+        req.save()
+        enqueue_automatic_resource_import_if_needed(instance_id=req.source_instance_id)
+        mock_task.enqueue_if_not.assert_not_called()
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__incomplete_req(self, mock_task):
+        ContentDownloadRequest(
+            reason=ContentRequestReason.UserInitiated,
+            source_model="test",
+            source_id=uuid.uuid4().hex,
+            facility_id=uuid.uuid4().hex,
+            contentnode_id=uuid.uuid4().hex,
+            status=ContentRequestStatus.Pending,
+        ).save()
+        enqueue_automatic_resource_import_if_needed()
+        mock_task.enqueue_if_not.assert_called_once()
+
+    @mock.patch("kolibri.core.content.tasks.automatic_resource_import")
+    def test_enqueue_helper__instance_id__incomplete_req(self, mock_task):
+        req = ContentDownloadRequest(
+            reason=ContentRequestReason.UserInitiated,
+            source_model="test",
+            source_id=uuid.uuid4().hex,
+            facility_id=uuid.uuid4().hex,
+            source_instance_id=uuid.uuid4().hex,
+            contentnode_id=uuid.uuid4().hex,
+            status=ContentRequestStatus.Pending,
+        )
+        req.save()
+        enqueue_automatic_resource_import_if_needed(instance_id=req.source_instance_id)
+        mock_task.enqueue_if_not.assert_called_once()

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -372,6 +372,7 @@ class BaseQuerysetTestCase(BaseTestCase):
             id=uuid.uuid4().hex,
             contentnode=parent,
             thumbnail=True,
+            supplementary=True,
             local_file=LocalFile.objects.create(
                 id=uuid.uuid4().hex,
                 file_size=10,
@@ -403,21 +404,8 @@ class BaseQuerysetTestCase(BaseTestCase):
                 extension="mp4",
             ),
         )
-        # supplementary node file
-        File.objects.create(
-            id=uuid.uuid4().hex,
-            contentnode=node,
-            preset="document",
-            supplementary=True,
-            local_file=LocalFile.objects.create(
-                id=uuid.uuid4().hex,
-                file_size=33,
-                available=available,
-                extension="pdf",
-            ),
-        )
         node.refresh_from_db()
-        self.assertEqual(node.files.all().count(), 3)
+        self.assertEqual(node.files.all().count(), 2)
         return (parent, node)
 
 
@@ -511,7 +499,6 @@ class CompletedDownloadsQuerysetTestCase(BaseQuerysetTestCase):
 
     def test_has_metadata__yes(self):
         _, node = self._create_resources(self.request.contentnode_id)
-        self.assertEqual(node.files.all().count(), 3)
         qs = completed_downloads_queryset().filter(has_metadata=True)
         self.assertEqual(
             qs.count(),

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -18,6 +18,7 @@ from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import File
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.content_request import _process_content_requests
+from kolibri.core.content.utils.content_request import _process_download
 from kolibri.core.content.utils.content_request import _total_size
 from kolibri.core.content.utils.content_request import completed_downloads_queryset
 from kolibri.core.content.utils.content_request import incomplete_downloads_queryset
@@ -26,8 +27,10 @@ from kolibri.core.content.utils.content_request import InsufficientStorage
 from kolibri.core.content.utils.content_request import PreferredDevices
 from kolibri.core.content.utils.content_request import PreferredDevicesWithClient
 from kolibri.core.content.utils.content_request import process_content_removal_requests
+from kolibri.core.content.utils.content_request import process_download_request
 from kolibri.core.content.utils.content_request import process_metadata_import
 from kolibri.core.content.utils.content_request import synchronize_content_requests
+from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.errors import NetworkError
@@ -906,3 +909,178 @@ class ProcessContentRemovalRequestsTestCase(BaseQuerysetTestCase):
         # should be marked completed
         self.assertEqual(self.qs.count(), 0)
         self.assertEqual(ContentDownloadRequest.objects.count(), 1)
+
+
+class ProcessDownloadRequestTestCase(BaseQuerysetTestCase):
+    def setUp(self):
+        super(ProcessDownloadRequestTestCase, self).setUp()
+        self.request = ContentDownloadRequest.build_for_user(self.learner)
+        self.request.contentnode_id = uuid.uuid4().hex
+        self.request.save()
+        self.node = ContentNode.objects.create(
+            pk=self.request.contentnode_id,
+            title="test",
+            available=False,
+            content_id=uuid.uuid4().hex,
+            channel_id=uuid.uuid4().hex,
+        )
+        mock_devices_patcher = mock.patch(_module + "PreferredDevices")
+        self.mock_devices = mock_devices_patcher.start()
+        self.addCleanup(mock_devices_patcher.stop)
+
+        self.mock_sync_peers = self.mock_devices.build_from_sync_sessions.return_value
+        self.mock_sync_peer = mock.MagicMock()
+        self.mock_sync_peers.__iter__.return_value = [self.mock_sync_peer]
+
+        self.mock_preferred_peers = self.mock_devices.return_value
+        self.mock_preferred_peer = mock.MagicMock()
+        self.mock_preferred_peers.__iter__.return_value = [self.mock_preferred_peer]
+
+    @mock.patch(_module + "_process_download")
+    def test_without_source_instance_id__fail(self, mock_process):
+        mock_process.return_value = False
+        process_download_request(self.request)
+        self.mock_devices.build_from_sync_sessions.assert_called_once()
+        self.mock_devices.assert_not_called()
+        mock_process.assert_called_once_with(
+            self.request,
+            self.node.channel_id,
+            self.mock_sync_peer,
+        )
+        self.request.refresh_from_db()
+        self.assertEqual(self.request.status, ContentRequestStatus.Failed)
+
+    @mock.patch(_module + "_process_download")
+    def test_without_source_instance_id__success(self, mock_process):
+        mock_process.return_value = True
+        process_download_request(self.request)
+        self.mock_devices.build_from_sync_sessions.assert_called_once()
+        self.mock_devices.assert_not_called()
+        mock_process.assert_called_once_with(
+            self.request,
+            self.node.channel_id,
+            self.mock_sync_peer,
+        )
+        self.request.refresh_from_db()
+        self.assertEqual(self.request.status, ContentRequestStatus.Completed)
+
+    @mock.patch(_module + "_process_download")
+    def test_with_source_instance_id__all_fail(self, mock_process):
+        self.request.source_instance_id = uuid.uuid4().hex
+        self.request.save()
+
+        mock_process.return_value = False
+        process_download_request(self.request)
+        self.mock_devices.build_from_sync_sessions.assert_called_once()
+        self.mock_devices.assert_called_once_with(
+            instance_ids=[self.request.source_instance_id]
+        )
+        mock_process.assert_has_calls(
+            [
+                # calls preferred peer first
+                mock.call(
+                    self.request,
+                    self.node.channel_id,
+                    self.mock_preferred_peer,
+                ),
+                mock.call(
+                    self.request,
+                    self.node.channel_id,
+                    self.mock_sync_peer,
+                ),
+            ]
+        )
+        self.request.refresh_from_db()
+        self.assertEqual(self.request.status, ContentRequestStatus.Failed)
+
+    @mock.patch(_module + "_process_download")
+    def test_with_source_instance_id__preferred_fail(self, mock_process):
+        self.request.source_instance_id = uuid.uuid4().hex
+        self.request.save()
+
+        mock_process.side_effect = [False, True]
+        process_download_request(self.request)
+        self.mock_devices.build_from_sync_sessions.assert_called_once()
+        self.mock_devices.assert_called_once_with(
+            instance_ids=[self.request.source_instance_id]
+        )
+        mock_process.assert_has_calls(
+            [
+                # calls preferred peer first
+                mock.call(
+                    self.request,
+                    self.node.channel_id,
+                    self.mock_preferred_peer,
+                ),
+                mock.call(
+                    self.request,
+                    self.node.channel_id,
+                    self.mock_sync_peer,
+                ),
+            ]
+        )
+        self.request.refresh_from_db()
+        self.assertEqual(self.request.status, ContentRequestStatus.Completed)
+
+    @mock.patch(_module + "_process_download")
+    def test_with_source_instance_id__preferred_success(self, mock_process):
+        self.request.source_instance_id = uuid.uuid4().hex
+        self.request.save()
+
+        mock_process.side_effect = [True]
+        process_download_request(self.request)
+        self.mock_devices.build_from_sync_sessions.assert_called_once()
+        self.mock_devices.assert_called_once_with(
+            instance_ids=[self.request.source_instance_id]
+        )
+        mock_process.assert_has_calls(
+            [
+                # calls preferred peer first
+                mock.call(
+                    self.request,
+                    self.node.channel_id,
+                    self.mock_preferred_peer,
+                ),
+            ]
+        )
+        self.request.refresh_from_db()
+        self.assertEqual(self.request.status, ContentRequestStatus.Completed)
+
+    @mock.patch(_module + "ContentDownloadRequestResourceImportManager")
+    def test_download__exception(self, mock_import_manager):
+        mock_import_manager.return_value.run.side_effect = Exception("test")
+        result = _process_download(
+            self.request, self.node.channel_id, self.mock_preferred_peer
+        )
+        mock_import_manager.return_value.run.assert_called_once()
+        self.assertFalse(result)
+
+    @mock.patch(_module + "ContentDownloadRequestResourceImportManager")
+    def test_download__manager_exception(self, mock_import_manager):
+        mock_import_manager.return_value.run.return_value = [None, None]
+        mock_import_manager.return_value.exception = LocationError("test")
+        result = _process_download(
+            self.request, self.node.channel_id, self.mock_preferred_peer
+        )
+        mock_import_manager.return_value.run.assert_called_once()
+        self.assertFalse(result)
+
+    @mock.patch(_module + "ContentDownloadRequestResourceImportManager")
+    def test_download__no_count(self, mock_import_manager):
+        mock_import_manager.return_value.run.return_value = [None, 0]
+        mock_import_manager.return_value.exception = None
+        result = _process_download(
+            self.request, self.node.channel_id, self.mock_preferred_peer
+        )
+        mock_import_manager.return_value.run.assert_called_once()
+        self.assertFalse(result)
+
+    @mock.patch(_module + "ContentDownloadRequestResourceImportManager")
+    def test_download__success(self, mock_import_manager):
+        mock_import_manager.return_value.run.return_value = [None, 1]
+        mock_import_manager.return_value.exception = None
+        result = _process_download(
+            self.request, self.node.channel_id, self.mock_preferred_peer
+        )
+        mock_import_manager.return_value.run.assert_called_once()
+        self.assertTrue(result)

--- a/kolibri/core/content/upgrade.py
+++ b/kolibri/core/content/upgrade.py
@@ -19,7 +19,7 @@ from kolibri.core.content.constants.kind_to_learningactivity import kind_activit
 from kolibri.core.content.kolibri_plugin import synchronize_content_requests
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
-from kolibri.core.content.tasks import automatic_resource_import
+from kolibri.core.content.tasks import enqueue_automatic_resource_import_if_needed
 from kolibri.core.content.utils.annotation import set_channel_ancestors
 from kolibri.core.content.utils.annotation import set_content_visibility_from_disk
 from kolibri.core.content.utils.channel_import import FutureSchemaError
@@ -332,13 +332,14 @@ def admin_imported_flag():
 @version_upgrade(old_version="<0.16.0")
 def synchronize_content_requests_upgrade():
     """
-    Synchronizes content requests for each dataset on the device, excluding datasets with a transfer_session_id.
+    Synchronizes content requests for each dataset on the device,
+    excluding datasets with a transfer_session_id.
     """
 
     dataset_ids = FacilityDataset.objects.values_list("id", flat=True)
 
     # Synchronize content requests for each dataset
     for dataset_id in dataset_ids:
-        synchronize_content_requests(dataset_id, None)
+        synchronize_content_requests(dataset_id, transfer_session=None)
 
-    automatic_resource_import.enqueue_if_not()
+    enqueue_automatic_resource_import_if_needed()

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -328,13 +328,17 @@ def _node_total_size(contentnode_id, thumbnail=False, available=False):
     :param thumbnail: Whether to filter on thumbnails
     :param available: Whether to filter on available files
     """
+    filters = {}
+    if thumbnail:
+        filters["thumbnail"] = True
+        filters["supplementary"] = True
+
     return Coalesce(
         Subquery(
             File.objects.filter(
                 contentnode_id=contentnode_id,
                 local_file__available=available,
-                thumbnail=thumbnail,
-                supplementary=False,
+                **filters
             )
             .values(
                 _no_group_by=Value(0)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -412,7 +412,7 @@ def incomplete_downloads_queryset():
         )
     )
     # if we're not allowing learner downloads, filter them out
-    if not get_device_setting("allow_learner_download_resources", default=False):
+    if not get_device_setting("allow_learner_download_resources"):
         qs = qs.exclude(is_learner_download=True)
     return qs
 

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -28,6 +28,7 @@ from kolibri.core.content.models import File
 from kolibri.core.content.utils.assignment import ContentAssignmentManager
 from kolibri.core.content.utils.assignment import DeletedAssignment
 from kolibri.core.content.utils.channel_import import import_channel_from_data
+from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.content.utils.resource_import import (
     ContentDownloadRequestResourceImportManager,
 )
@@ -747,27 +748,8 @@ def process_download_request(download_request):
 
         # we try to import from the source instance first
         for peer in chain(*peer_sets):
-            import_manager = ContentDownloadRequestResourceImportManager(
-                node.channel_id,
-                peer,
-                download_request,
-                fail_on_error=True,
-            )
-            _, count = import_manager.run()
-
-            # can't trust the count, fail if there's an exception
-            if getattr(import_manager, "exception", None):
-                raise getattr(import_manager, "exception")
-            elif not count or count == 0:
-                logger.warning(
-                    "ContentNode files may not have imported successfully: {}".format(
-                        download_request.contentnode_id
-                    )
-                )
-                # if we have no count, we should try the next peer
-                continue
-            else:
-                # without an exception, and positive count, we can assume the import was successful
+            if _process_download(download_request, node.channel_id, peer):
+                # if we successfully imported, break out of the loop
                 break
         else:
             raise NoPeerAvailable(
@@ -789,6 +771,49 @@ def process_download_request(download_request):
     download_request.status = ContentRequestStatus.Completed
     download_request.save()
     return True
+
+
+def _process_download(download_request, channel_id, peer):
+    """
+    Processes an import for a download request
+    :param download_request: The download request model instance
+    :type download_request: ContentDownloadRequest
+    :param channel_id: The channel id for the contentnode referenced by the download request
+    :type channel_id: str
+    :param peer: The peer to import from
+    :type peer: NetworkLocation
+    :return: True if the import was successful, False otherwise
+    :rtype: bool
+    """
+    try:
+        import_manager = ContentDownloadRequestResourceImportManager(
+            channel_id,
+            peer,
+            download_request,
+            fail_on_error=True,
+        )
+        _, count = import_manager.run()
+
+        # re-raise if there's an exception
+        if getattr(import_manager, "exception", None):
+            raise getattr(import_manager, "exception")
+        elif not count or count == 0:
+            logger.warning(
+                "ContentNode files may not have imported successfully: {}".format(
+                    download_request.contentnode_id
+                )
+            )
+            # if we have no count, we should try the next peer
+            return False
+        # without an exception, and non-zero count, we can assume the import was successful
+        return True
+    except LocationError:
+        # content not found on peer, try the next one
+        return False
+    except Exception as e:
+        # some other error occurred, log it and try the next peer
+        logger.exception(e)
+        return False
 
 
 def process_user_downloads_for_removal():

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -578,9 +578,10 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
                 try:
                     response = client.post(
                         reverse_path(
-                            "get_public_file_checksums", kwargs={"version": "1"}
+                            "kolibri:core:get_public_file_checksums",
+                            kwargs={"version": "v1"},
                         ),
-                        data=required_checksums,
+                        json=list(required_checksums),
                     )
                     integer_mask = int(response.content)
 
@@ -589,13 +590,16 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
                     )
 
                     if integer_mask != expected_mask:
-                        raise ValueError
+                        raise ValueError("Checksums do not match")
                 except (
                     ValueError,
                     TypeError,
                     NetworkLocationResponseFailure,
                     NetworkLocationResponseTimeout,
-                ):
+                ) as e:
+                    logging.debug(
+                        "Failed to retrieve or validate checksums: {}".format(e)
+                    )
                     # Bad JSON parsing will throw ValueError
                     # If the result of the json.loads is not iterable, a TypeError will be thrown
                     # If we end up here, just set checksums to None to allow us to cleanly continue

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -544,7 +544,7 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
             channel_id,
             peer_id=peer.id,
             baseurl=peer.base_url,
-            node_ids=[download_request.node_id],
+            node_ids=[download_request.contentnode_id],
             exclude_node_ids=None,
             renderable_only=renderable_only,
             fail_on_error=fail_on_error,

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -524,10 +524,26 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
         content_dir=None,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
+        """
+        :param channel_id: A hex UUID string
+        :type channel_id: str
+        :param peer: A NetworkLocation model object
+        :type peer: NetworkLocation
+        :param download_request: A ContentDownloadRequest model object
+        :type download_request: ContentDownloadRequest
+        :param renderable_only: Whether to only import renderable content
+        :type renderable_only: bool
+        :param fail_on_error: Whether to fail on import errors
+        :type fail_on_error: bool
+        :param content_dir: The directory to download content to
+        :type content_dir: str
+        :param timeout: The timeout for the download request
+        :type timeout: int
+        """
         super(ContentDownloadRequestResourceImportManager, self).__init__(
             channel_id,
             peer_id=peer.id,
-            baseurl=peer.baseurl,
+            baseurl=peer.base_url,
             node_ids=[download_request.node_id],
             exclude_node_ids=None,
             renderable_only=renderable_only,

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -570,7 +570,7 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
         node = ContentNode.objects.get(pk=self.download_request.contentnode_id)
         if self.peer.id != CENTRAL_CONTENT_BASE_INSTANCE_ID:
             required_checksums = (
-                node.files()
+                node.files.all()
                 .filter(supplementary=False)
                 .values_list("local_file_id", flat=True)
             )

--- a/kolibri/core/content/utils/settings.py
+++ b/kolibri/core/content/utils/settings.py
@@ -9,12 +9,9 @@ def automatic_download_enabled():
     provisioned, we allow this because the default will be True after provisioning
     :return: a boolean indicating whether automatic download is enabled
     """
-    from kolibri.core.device.utils import device_provisioned
     from kolibri.core.device.utils import get_device_setting
 
-    return get_device_setting(
-        "enable_automatic_download", default=not device_provisioned()
-    )
+    return get_device_setting("enable_automatic_download")
 
 
 def using_metered_connection():
@@ -35,7 +32,7 @@ def allow_non_local_download():
     from kolibri.core.device.utils import get_device_setting
 
     return not using_metered_connection() or get_device_setting(
-        "allow_download_on_metered_connection", default=False
+        "allow_download_on_metered_connection"
     )
 
 
@@ -52,11 +49,11 @@ def get_free_space_for_downloads(completed_size=0):
     free_space = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
 
     # if a limit is set, subtract the total content storage size from the limit
-    if get_device_setting("set_limit_for_autodownload", default=False):
+    if get_device_setting("set_limit_for_autodownload"):
         # compute total space used by automatic and learner initiated downloads
         # convert limit_for_autodownload from GB to bytes
         auto_download_limit = bytes_from_humans(
-            str(get_device_setting("limit_for_autodownload", "0")) + "GB"
+            str(get_device_setting("limit_for_autodownload") or "0") + "GB"
         )
         # returning smallest argument as to not exceed the space available on disk
         free_space = min(free_space, auto_download_limit - completed_size)

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -312,7 +312,7 @@ class UserSyncStatusViewSet(ReadOnlyValuesViewset):
         # If this is a subset of users device, we should just return no data
         # if there are no possible devices we could sync to.
         if (
-            get_device_setting("subset_of_users_device", False)
+            get_device_setting("subset_of_users_device")
             and not DynamicNetworkLocation.objects.filter(
                 subset_of_users_device=False
             ).exists()

--- a/kolibri/core/device/management/commands/devicesettings.py
+++ b/kolibri/core/device/management/commands/devicesettings.py
@@ -1,0 +1,153 @@
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+
+from kolibri.core.device.models import DeviceSettings
+from kolibri.core.device.models import extra_settings_schema
+from kolibri.core.device.utils import get_device_setting
+from kolibri.core.device.utils import set_device_settings
+
+logger = logging.getLogger(__name__)
+
+# model fields that can be set
+EDITABLE_FIELDS = [
+    "allow_guest_access",
+    "allow_peer_unlisted_channel_import",
+    "allow_learner_unassigned_resource_access",
+    "allow_other_browsers_to_connect",
+]
+EXTRA_PROPERTIES = extra_settings_schema.get("properties", {})
+EDITABLE_FIELDS.extend(EXTRA_PROPERTIES.keys())
+SCHEMA_TYPES = {
+    "boolean": bool,
+    "string": str,
+    "integer": int,
+}
+DJANGO_FIELD_TYPES = {
+    "BooleanField": bool,
+    "CharField": str,
+    "IntegerField": int,
+}
+
+
+class Command(BaseCommand):
+    """
+    This command can be used to get or set Kolibri's device settings.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "operation",
+            action="store",
+            choices=["get", "set"],
+            help="Get or set the device settings",
+        )
+
+        parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+        for field_name in EDITABLE_FIELDS:
+            field_type = self._get_type(field_name)
+            if field_type == bool:
+                parser.add_argument(
+                    "--{}".format(self._setting_to_arg(field_name)),
+                    action="store_true",
+                    default=None,
+                    help="Set '{}' to True".format(field_name),
+                )
+                parser.add_argument(
+                    "--{}".format(self._setting_to_arg(field_name, negate=True)),
+                    action="store_false",
+                    default=None,
+                    help="Set '{}' to False".format(field_name),
+                )
+            else:
+                parser.add_argument(
+                    "--{}".format(self._setting_to_arg(field_name)),
+                    action="store",
+                    default=None,
+                    type=field_type,
+                    help="Set '{}' to a value".format(field_name),
+                )
+
+    def handle(self, *args, **options):
+        operation = options["operation"]
+        if operation == "get":
+            self.handle_get(*args, **options)
+        elif operation == "set":
+            self.handle_set(*args, **options)
+
+    def handle_get(self, *args, **options):
+        data = [
+            (field_name, get_device_setting(field_name))
+            for field_name in EDITABLE_FIELDS
+        ]
+
+        if options["json"]:
+            print(json.dumps(dict(data), indent=2))
+        else:
+            header = ("Device setting", "Value")
+            self._tabulate(header, data)
+
+    def handle_set(self, *args, **options):
+        updated_settings = {}
+
+        for option_key, option_value in options.items():
+            setting, _ = self._arg_to_setting(option_key)
+            if option_value is not None and setting in EDITABLE_FIELDS:
+                updated_settings[setting] = option_value
+
+        set_device_settings(**updated_settings)
+        logger.info("Device settings updated")
+
+    def _get_type(self, field_name):
+        if field_name in EXTRA_PROPERTIES:
+            field_type = EXTRA_PROPERTIES[field_name]["type"]
+            return SCHEMA_TYPES[field_type]
+        field_type = DeviceSettings._meta.get_field(field_name).get_internal_type()
+        return DJANGO_FIELD_TYPES[field_type]
+
+    def _setting_to_arg(self, setting, negate=False):
+        arg = setting.replace("_", "-")
+        if negate:
+            if arg.startswith("allow"):
+                arg = arg.replace("allow", "disallow")
+            elif arg.startswith("enable"):
+                arg = arg.replace("enable", "disable")
+            elif arg.startswith("set"):
+                arg = arg.replace("set", "remove")
+        return arg
+
+    def _arg_to_setting(self, arg):
+        negated = False
+        setting = arg
+        if arg.startswith("disallow"):
+            setting = setting.replace("disallow", "allow")
+            negated = True
+        elif setting.startswith("disable"):
+            setting = setting.replace("disable", "enable")
+            negated = True
+        elif setting.startswith("remove"):
+            setting = setting.replace("remove", "set")
+            negated = True
+        return (setting, negated)
+
+    def _tabulate(self, header, data):
+        """
+        Prints a table with the given header and data.
+        """
+        col_length = [0] * len(header)
+        for i, col in enumerate(header):
+            col_length[i] = max(col_length[i], len(str(col)))
+        for row in data:
+            for i, col in enumerate(row):
+                col_length[i] = max(col_length[i], len(str(col)))
+
+        print(
+            " | ".join([str(col).ljust(col_length[i]) for i, col in enumerate(header)])
+        )
+        print("-+-".join(["-" * col_length[i] for i, col in enumerate(header)]))
+        for row in data:
+            print(
+                " | ".join([str(col).ljust(col_length[i]) for i, col in enumerate(row)])
+            )

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -128,7 +128,7 @@ class DeviceSettings(models.Model):
     is_provisioned = models.BooleanField(default=False)
     # What is the default language that Kolibri is displayed in for this device?
     language_id = models.CharField(
-        max_length=15, default=lambda: settings.LANGUAGE_CODE, blank=True, null=True
+        max_length=15, default=settings.LANGUAGE_CODE, blank=True, null=True
     )
     # What is the default facility for this device?
     default_facility = models.ForeignKey(

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -128,7 +128,7 @@ class DeviceSettings(models.Model):
     is_provisioned = models.BooleanField(default=False)
     # What is the default language that Kolibri is displayed in for this device?
     language_id = models.CharField(
-        max_length=15, default=settings.LANGUAGE_CODE, blank=True, null=True
+        max_length=15, default=lambda: settings.LANGUAGE_CODE, blank=True, null=True
     )
     # What is the default facility for this device?
     default_facility = models.ForeignKey(

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -275,6 +275,7 @@ class DeviceSettingsTestCase(APITestCase):
 
     def setUp(self):
         super(DeviceSettingsTestCase, self).setUp()
+        clear_process_cache()
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -321,6 +322,7 @@ class DeviceSettingsTestCase(APITestCase):
 class DevicePermissionsTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        clear_process_cache()
         provision_device()
         cls.facility = FacilityFactory.create()
         cls.superuser = create_superuser(cls.facility)
@@ -358,6 +360,7 @@ class DevicePermissionsTestCase(APITestCase):
 @override_option("Deployment", "MINIMUM_DISK_SPACE", 0)
 class FreeSpaceTestCase(APITestCase):
     def setUp(self):
+        clear_process_cache()
         provision_device()
         self.facility = FacilityFactory.create()
         self.superuser = create_superuser(self.facility)
@@ -403,6 +406,7 @@ class DeviceInfoTestCase(APITestCase):
         cls.superuser = create_superuser(cls.facility)
 
     def setUp(self):
+        clear_process_cache()
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,
@@ -501,6 +505,7 @@ class DeviceNameTestCase(APITestCase):
         cls.user = FacilityUserFactory.create(facility=cls.facility)
 
     def setUp(self):
+        clear_process_cache()
         super(DeviceNameTestCase, self).setUp()
         self.client.login(
             username=self.superuser.username,
@@ -620,6 +625,7 @@ class UserSyncStatusTestCase(APITestCase):
         )
 
     def setUp(self):
+        clear_process_cache()
         self.client.login(
             username=self.superuser.username,
             password=DUMMY_PASSWORD,

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -79,6 +79,7 @@ class DeviceProvisionCommandTestCase(TestCase):
     """
 
     def setUp(self):
+        clear_process_cache()
         self.preset = list(presets.keys())[0]
         call_command(
             "provisiondevice",

--- a/kolibri/core/device/test/test_device_provision.py
+++ b/kolibri/core/device/test/test_device_provision.py
@@ -47,8 +47,10 @@ class DeviceProvisionTestCase(TestCase):
         setup_device()
         default_facility = Facility.get_default_facility()
         self.assertIsNotNone(default_facility)
+
+    def test_setup_device_and_facility__no_facility_creation(self):
         setup_device_and_facility(None, None, None, None, {}, None, None)
-        self.assertEqual(Facility.objects.all().count(), 1)
+        self.assertEqual(Facility.objects.all().count(), 0)
 
     def test_create_device_settings_provisioned(self):
         facility = Facility.objects.create(name="Test")

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -2,39 +2,67 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from kolibri.core.device.models import DeviceSettings
+from kolibri.core.device.models import get_device_hostname
+from kolibri.core.device.utils import get_device_setting
+from kolibri.core.device.utils import LANDING_PAGE_SIGN_IN
 from kolibri.core.utils.cache import process_cache as cache
 
 
 class DeviceSettingsTestCase(TestCase):
-    def test_singleton(self):
+    def setUp(self):
         cache.clear()
+
+    def test_singleton(self):
         DeviceSettings.objects.create()
         with self.assertRaises(ValidationError):
             DeviceSettings.objects.create()
 
     def test_get_setting(self):
-        cache.clear()
         ds = DeviceSettings.objects.create()
         ds2 = DeviceSettings.objects.get()
         self.assertEqual(ds, ds2)
 
     def test_delete_setting(self):
-        cache.clear()
         ds = DeviceSettings.objects.create()
         ds.delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
 
     def test_delete_setting_queryset(self):
-        cache.clear()
         DeviceSettings.objects.create()
         DeviceSettings.objects.all().delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
 
     def test_delete_setting_manager(self):
-        cache.clear()
         DeviceSettings.objects.create()
         DeviceSettings.objects.delete()
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
+
+    def test_defaults(self):
+        with self.assertRaises(DeviceSettings.DoesNotExist):
+            DeviceSettings.objects.get()
+
+        defaults = {
+            # model fields
+            "is_provisioned": False,
+            "language_id": "en",
+            "default_facility": None,
+            "landing_page": LANDING_PAGE_SIGN_IN,
+            "allow_guest_access": True,
+            "allow_peer_unlisted_channel_import": False,
+            "allow_learner_unassigned_resource_access": True,
+            "name": get_device_hostname(),
+            "allow_other_browsers_to_connect": False,
+            "subset_of_users_device": False,
+            # extra settings
+            "allow_download_on_metered_connection": False,
+            "enable_automatic_download": True,
+            "allow_learner_download_resources": False,
+            "set_limit_for_autodownload": False,
+            "limit_for_autodownload": 0,
+        }
+
+        for setting_key, setting_default in defaults.items():
+            self.assertEqual(get_device_setting(setting_key), setting_default)

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -65,4 +65,10 @@ class DeviceSettingsTestCase(TestCase):
         }
 
         for setting_key, setting_default in defaults.items():
-            self.assertEqual(get_device_setting(setting_key), setting_default)
+            self.assertEqual(
+                get_device_setting(setting_key),
+                setting_default,
+                "Default value for setting '{}' is not '{}'".format(
+                    setting_key, setting_default
+                ),
+            )

--- a/kolibri/core/device/test/test_device_settings.py
+++ b/kolibri/core/device/test/test_device_settings.py
@@ -1,3 +1,4 @@
+import pytest
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
@@ -40,7 +41,10 @@ class DeviceSettingsTestCase(TestCase):
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
 
-    def test_defaults(self):
+    @pytest.mark.skip(
+        reason="Other tests enabling the App plugin are not properly isolated"
+    )
+    def test_defaults(self, _):
         with self.assertRaises(DeviceSettings.DoesNotExist):
             DeviceSettings.objects.get()
 
@@ -63,6 +67,11 @@ class DeviceSettingsTestCase(TestCase):
             "set_limit_for_autodownload": False,
             "limit_for_autodownload": 0,
         }
+
+        # TODO: the following fails when this test runs after test_api.py (assertion for clarity
+        #       already tested in assertions below)
+        ds = DeviceSettings()
+        self.assertFalse(ds.allow_other_browsers_to_connect)
 
         for setting_key, setting_default in defaults.items():
             self.assertEqual(

--- a/kolibri/core/device/test/test_models.py
+++ b/kolibri/core/device/test/test_models.py
@@ -7,6 +7,7 @@ from morango.models.core import InstanceIDModel
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.device.models import DeviceStatus
 from kolibri.core.device.models import LearnerDeviceStatus
 from kolibri.core.device.models import StatusSentiment
@@ -17,6 +18,7 @@ class SyncQueueTestCase(TestCase):
     multi_db = True
 
     def setUp(self):
+        clear_process_cache()
         self.facility = Facility.objects.create(name="Test")
 
     def test_create_queue_element(self):

--- a/kolibri/core/device/translation.py
+++ b/kolibri/core/device/translation.py
@@ -18,10 +18,14 @@ from django.utils.translation.trans_real import get_supported_language_variant
 from django.utils.translation.trans_real import language_code_re
 from django.utils.translation.trans_real import parse_accept_lang_header
 
+from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import get_device_setting
 
 
 def get_device_language():
+    if not device_provisioned():
+        return None
+
     language_id = get_device_setting("language_id")
     try:
         return get_supported_language_variant(language_id)

--- a/kolibri/core/device/translation.py
+++ b/kolibri/core/device/translation.py
@@ -22,7 +22,7 @@ from kolibri.core.device.utils import get_device_setting
 
 
 def get_device_language():
-    language_id = get_device_setting("language_id", None)
+    language_id = get_device_setting("language_id")
     try:
         return get_supported_language_variant(language_id)
     except LookupError:

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -96,9 +96,8 @@ def allow_other_browsers_to_connect():
 
 def set_device_settings(**kwargs):
     """
-    Set the device settings, or raise an exception if the device is not provisioned.
-    :param kwargs:
-    :return:
+    Set the device settings, even if unprovisioned.
+    :param kwargs: a dictionary of key-value pairs to set on the device settings model
     """
     from .models import DeviceSettings
     from .models import extra_settings_schema
@@ -107,7 +106,7 @@ def set_device_settings(**kwargs):
         device_settings = DeviceSettings.objects.get()
     except DeviceSettings.DoesNotExist:
         device_settings = DeviceSettings(
-            # model field's default is a static value, which could during unit tests
+            # model field's default is a static value, which could change during unit tests
             language_id=settings.LANGUAGE_CODE
         )
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -111,6 +111,8 @@ def set_device_settings(**kwargs):
             setattr(device_settings, key, value)
         else:
             extra_settings[key] = value
+
+    device_settings.extra_settings = extra_settings
     device_settings.save()
 
 

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -33,6 +33,10 @@ class DeviceNotProvisioned(Exception):
     pass
 
 
+class DeviceAlreadyProvisioned(Exception):
+    pass
+
+
 no_default_value = object()
 
 
@@ -69,7 +73,7 @@ def is_landing_page(landing_page):
 
 
 def allow_guest_access():
-    if not device_provisioned() and get_device_setting("allow_guest_access"):
+    if device_provisioned() and get_device_setting("allow_guest_access"):
         return True
 
     return is_landing_page(LANDING_PAGE_LEARN)
@@ -107,7 +111,7 @@ def set_device_settings(**kwargs):
             language_id=settings.LANGUAGE_CODE
         )
 
-    extra_settings_properties = extra_settings_schema.get("properties", {})
+    extra_settings_properties = extra_settings_schema.get("properties", {}).keys()
     extra_settings = device_settings.extra_settings or {}
 
     for key, value in kwargs.items():
@@ -122,6 +126,9 @@ def set_device_settings(**kwargs):
 
 def provision_device(device_name=None, is_provisioned=True, **kwargs):
     from .models import DeviceSettings
+
+    if is_provisioned and device_provisioned():
+        raise DeviceAlreadyProvisioned("Device has already been provisioned.")
 
     set_device_settings(**kwargs)
     device_settings = DeviceSettings.objects.get()

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -8,6 +8,7 @@ import logging
 import os
 import platform
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.utils import OperationalError
@@ -101,7 +102,10 @@ def set_device_settings(**kwargs):
     try:
         device_settings = DeviceSettings.objects.get()
     except DeviceSettings.DoesNotExist:
-        device_settings = DeviceSettings()
+        device_settings = DeviceSettings(
+            # model field's default is a static value, which could during unit tests
+            language_id=settings.LANGUAGE_CODE
+        )
 
     extra_settings_properties = extra_settings_schema.get("properties", {})
     extra_settings = device_settings.extra_settings or {}

--- a/kolibri/core/discovery/hooks.py
+++ b/kolibri/core/discovery/hooks.py
@@ -23,3 +23,19 @@ class NetworkLocationDiscoveryHook(KolibriHook):
         :type network_location: kolibri.core.discovery.models.NetworkLocation
         """
         pass
+
+
+@define_hook
+class NetworkLocationBroadcastHook(KolibriHook):
+    def on_renew(self, instance, network_locations):
+        """
+        Invoked when the current device's broadcast is renewed
+        (i.e. the information in the broadcast changes)
+
+        :param instance: The KolibriInstance for the current device
+        :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
+        :param network_locations: The list of NetworkLocation models for
+            other accessible Kolibri instances
+        :type network_locations: kolibri.core.discovery.models.NetworkLocation[]
+        """
+        pass

--- a/kolibri/core/discovery/hooks.py
+++ b/kolibri/core/discovery/hooks.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 from kolibri.plugins.hooks import define_hook
 from kolibri.plugins.hooks import KolibriHook
 
@@ -27,6 +29,7 @@ class NetworkLocationDiscoveryHook(KolibriHook):
 
 @define_hook
 class NetworkLocationBroadcastHook(KolibriHook):
+    @abstractmethod
     def on_renew(self, instance, network_locations):
         """
         Invoked when the current device's broadcast is renewed

--- a/kolibri/core/discovery/tasks.py
+++ b/kolibri/core/discovery/tasks.py
@@ -10,6 +10,7 @@ from django.db.utils import OperationalError
 
 from kolibri.core.device.task_notifications import status_fn
 from kolibri.core.device.utils import get_device_setting
+from kolibri.core.discovery.hooks import NetworkLocationBroadcastHook
 from kolibri.core.discovery.hooks import NetworkLocationDiscoveryHook
 from kolibri.core.discovery.models import ConnectionStatus
 from kolibri.core.discovery.models import DynamicNetworkLocation
@@ -89,7 +90,7 @@ def _store_dynamic_instance(broadcast_id, instance):
     return network_location
 
 
-def _dispatch_hooks(network_location, is_connected):
+def _dispatch_discovery_hooks(network_location, is_connected):
     """
     :type network_location: NetworkLocation
     :type is_connected: bool
@@ -144,7 +145,7 @@ def _update_connection_status(network_location):
         prior_status,
         new_status,
     ):
-        _dispatch_hooks(network_location, new_status == ConnectionStatus.Okay)
+        _dispatch_discovery_hooks(network_location, new_status == ConnectionStatus.Okay)
 
     return new_status
 
@@ -286,8 +287,47 @@ def remove_dynamic_network_location(broadcast_id, instance):
         return
 
     logger.debug("Removing network location {}".format(network_location.id))
-    _dispatch_hooks(network_location, False)
+    _dispatch_discovery_hooks(network_location, False)
     network_location.delete()
+
+
+@register_task(priority=Priority.HIGH, status_fn=status_fn)
+@hydrate_instance
+def dispatch_broadcast_hooks(hook_type, instance):
+    """
+    Handles dispatching hooks for the current instance's broadcast
+    :param hook_type: The name of the hook to dispatch
+    :type hook_type: str
+    :param instance: The current Kolibri instance that this device is broadcasting
+    :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
+    """
+    # find current accessible network locations
+    network_locations = NetworkLocation.objects.filter(
+        connection_status=ConnectionStatus.Okay
+    )
+    if not network_locations:
+        return
+
+    logger.debug(
+        "Dispatching {} broadcast hooks with {} network locations".format(
+            hook_type, network_locations.count()
+        )
+    )
+    for hook in NetworkLocationBroadcastHook.registered_hooks:
+        # we catch all errors because as a rule of thumb,
+        # we don't want hooks to fail everything else
+        try:
+            hook_method = getattr(hook, hook_type, None)
+            if hook_method is not None:
+                hook_method(instance, network_locations)
+        except Exception as e:
+            logger.error(
+                "{}.{} hook failed".format(
+                    hook_type,
+                    hook.__class__.__name__,
+                ),
+                exc_info=e,
+            )
 
 
 def _refresh_reserved_locations():
@@ -322,7 +362,7 @@ def reset_connection_states(broadcast_id):
         # cancel pending connect jobs
         job_storage.cancel_if_exists(generate_job_id(TYPE_CONNECT, network_location.id))
         # dispatch disconnect hooks
-        _dispatch_hooks(network_location, False)
+        _dispatch_discovery_hooks(network_location, False)
 
     # remove any dynamic locations that don't match the current broadcast
     DynamicNetworkLocation.objects.exclude(broadcast_id=broadcast_id).delete()

--- a/kolibri/core/discovery/tasks.py
+++ b/kolibri/core/discovery/tasks.py
@@ -251,7 +251,7 @@ def add_dynamic_network_location(broadcast_id, instance):
         return
 
     priority = Priority.REGULAR
-    is_self_soud = get_device_setting("subset_of_users_device", default=False)
+    is_self_soud = get_device_setting("subset_of_users_device")
     if is_self_soud and network_location.subset_of_users_device:
         # if we're both SoUDs, prioritize connection checks lower than normal
         priority = Priority.LOW

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -87,7 +87,7 @@ class KolibriInstance(object):
     ):
         # Zeroconf wants socket.inet_aton() format, so make sure we have string with this class
         # which we convert when interfacing with Zeroconf
-        if not isinstance(ip, str):
+        if ip is not None and not isinstance(ip, str):
             raise TypeError("IP must be a string")
 
         self.id = instance_id
@@ -161,11 +161,14 @@ class KolibriInstance(object):
             properties[key] = json.dumps(val)
         properties["prefix"] = json.dumps(self.prefix)
 
+        # convert to format Zeroconf wants
+        address = socket.inet_aton(self.ip) if self.ip else None
+
         return ServiceInfo(
             SERVICE_TYPE,
             self.name,
             server=self.server,
-            address=socket.inet_aton(self.ip),  # convert to format Zeroconf wants
+            address=address,
             port=self.port or DEFAULT_PORT,
             properties=properties,
         )

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -85,6 +85,11 @@ class KolibriInstance(object):
     def __init__(
         self, instance_id, ip=None, port=None, host=None, device_info=None, prefix="/"
     ):
+        # Zeroconf wants socket.inet_aton() format, so make sure we have string with this class
+        # which we convert when interfacing with Zeroconf
+        if not isinstance(ip, str):
+            raise TypeError("IP must be a string")
+
         self.id = instance_id
         self.zeroconf_id = instance_id
         self.ip = ip
@@ -160,7 +165,7 @@ class KolibriInstance(object):
             SERVICE_TYPE,
             self.name,
             server=self.server,
-            address=self.ip,
+            address=socket.inet_aton(self.ip),  # convert to format Zeroconf wants
             port=self.port or DEFAULT_PORT,
             properties=properties,
         )
@@ -249,7 +254,7 @@ def build_broadcast_instance(port):
         device_info.get("instance_id"),
         port=port,
         device_info=device_info,
-        ip=USE_IP_OF_OUTGOING_INTERFACE,
+        ip=socket.inet_ntoa(USE_IP_OF_OUTGOING_INTERFACE),
         prefix=OPTIONS["Deployment"]["URL_PATH_PREFIX"],
     )
 
@@ -257,9 +262,9 @@ def build_broadcast_instance(port):
 class KolibriBroadcastEvents(Bus):
     """Event bus for handling events from Zeroconf"""
 
-    # The base magicbus Bus requires this to exist in error handling
-    # but does not set a default value.
-    throws = tuple()
+    # Provides better stack traces for errors when you list potential exception types here.
+    # Adding `Exception` here will re-raise all errors, but making it easier to debug.
+    throws = (Exception,)
 
     event_map = {
         ServiceStateChange.Added: EVENT_ADD_SERVICE,

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -1,6 +1,7 @@
 import logging
 
 from kolibri.core.discovery.tasks import add_dynamic_network_location
+from kolibri.core.discovery.tasks import dispatch_broadcast_hooks
 from kolibri.core.discovery.tasks import generate_job_id
 from kolibri.core.discovery.tasks import remove_dynamic_network_location
 from kolibri.core.discovery.tasks import reset_connection_states
@@ -22,6 +23,12 @@ class NetworkLocationListener(KolibriInstanceListener):
         """
         # when we start broadcasting, enqueue task to reset all connection states
         reset_connection_states.enqueue(args=(self.broadcast.id,))
+
+    def renew_instance(self, instance):
+        """
+        :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
+        """
+        dispatch_broadcast_hooks.enqueue(args=("on_renew", instance.to_dict()))
 
     def unregister_instance(self, instance):
         """

--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -261,7 +261,7 @@ class SyncQueueViewSet(viewsets.ViewSet):
         return data
 
     def check_queue(self, request, pk=None):
-        is_SoUD = get_device_setting("subset_of_users_device", False)
+        is_SoUD = get_device_setting("subset_of_users_device")
         if is_SoUD:
             content = "I'm a Subset of users device. Nothing to do here"
             # would love to use HTTP 418, but it's not fully usable in browsers

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -14,7 +14,6 @@ from morango.models import SyncSession
 from morango.models import TransferSession
 from rest_framework import status
 from rest_framework.test import APITestCase
-from rest_framework.test import APITransactionTestCase
 from six import iteritems
 
 import kolibri
@@ -100,7 +99,7 @@ def create_mini_channel(
     )
 
 
-class PublicAPITestCase(APITransactionTestCase):
+class PublicAPITestCase(APITestCase):
     """
     IMPORTANT: These tests are to never be changed. They are enforcing a
     public API contract. If the tests fail, then the implementation needs
@@ -291,7 +290,6 @@ class SyncQueueViewSetTestCase(APITestCase):
     multi_db = True
 
     def setUp(self):
-        provision_device()
         setup_device()
         self.facility = Facility.get_default_facility()
         self.learner = FacilityUser.objects.create(

--- a/kolibri/core/public/test/test_api.py
+++ b/kolibri/core/public/test/test_api.py
@@ -14,6 +14,7 @@ from morango.models import SyncSession
 from morango.models import TransferSession
 from rest_framework import status
 from rest_framework.test import APITestCase
+from rest_framework.test import APITransactionTestCase
 from six import iteritems
 
 import kolibri
@@ -99,7 +100,7 @@ def create_mini_channel(
     )
 
 
-class PublicAPITestCase(APITestCase):
+class PublicAPITestCase(APITransactionTestCase):
     """
     IMPORTANT: These tests are to never be changed. They are enforcing a
     public API contract. If the tests fail, then the implementation needs

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -5,6 +5,7 @@ import traceback
 import uuid
 from collections import namedtuple
 
+from six import raise_from
 from six import string_types
 
 from kolibri.core.tasks.exceptions import UserCancelledError
@@ -159,9 +160,7 @@ class Job(object):
         except TypeError as e:
             # A Job's arguments, results, or metadata are prime suspects for
             # what might cause this error.
-            raise TypeError(
-                "Job objects need to be JSON-serializable: {}".format(str(e))
-            )
+            raise_from(TypeError("Job objects need to be JSON-serializable"), e)
         return string_result
 
     @classmethod

--- a/kolibri/plugins/app/test/helpers.py
+++ b/kolibri/plugins/app/test/helpers.py
@@ -6,6 +6,8 @@ from kolibri.plugins.app.utils import interface
 @contextmanager
 def register_capabilities(**capabilities):
     interface.register(**capabilities)
-    yield
-    for capability in capabilities:
-        del interface._capabilities[capability]
+    try:
+        yield
+    finally:
+        for capability in capabilities:
+            del interface._capabilities[capability]

--- a/kolibri/plugins/coach/kolibri_plugin.py
+++ b/kolibri/plugins/coach/kolibri_plugin.py
@@ -70,7 +70,7 @@ class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook):
         from kolibri.core.auth.tasks import queue_soud_server_sync_cleanup
 
         if (
-            not get_device_setting("subset_of_users_device", default=False)
+            not get_device_setting("subset_of_users_device")
             and network_location.subset_of_users_device
         ):
             logger.debug("SoUD listener: triggering cleanup of SoUD sync")

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -153,11 +153,14 @@ class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook, DiscoveryHookMix
         """
         :type network_location: kolibri.core.discovery.models.NetworkLocation
         """
+        from kolibri.core.auth.tasks import stop_request_soud_sync
+
         if (
             get_device_setting("subset_of_users_device")
             and not network_location.subset_of_users_device
         ):
-            self._begin_request_soud_sync(network_location)
+            for user_id in self._learner_ids():
+                stop_request_soud_sync(network_location.base_url, user_id)
 
 
 @register_hook

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -11,6 +11,7 @@ from kolibri.core.device.utils import allow_learner_unassigned_resource_access
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.device.utils import is_landing_page
 from kolibri.core.device.utils import LANDING_PAGE_LEARN
+from kolibri.core.discovery.hooks import NetworkLocationBroadcastHook
 from kolibri.core.discovery.hooks import NetworkLocationDiscoveryHook
 from kolibri.core.hooks import NavigationHook
 from kolibri.core.hooks import RoleBasedRedirectHook
@@ -116,39 +117,68 @@ class LearnContentNodeHook(ContentNodeDisplayHook):
             )
 
 
-def _learner_ids():
-    from kolibri.core.auth.models import FacilityUser
+class DiscoveryHookMixin(object):
+    def _learner_ids(self):
+        """
+        :return: A list of all learner ids
+        :rtype: str[]
+        """
+        from kolibri.core.auth.models import FacilityUser
 
-    return FacilityUser.objects.all().values_list("id", flat=True)
+        return FacilityUser.objects.all().values_list("id", flat=True)
 
-
-@register_hook
-class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook):
-    def on_connect(self, network_location):
+    def _begin_request_soud_sync(self, network_location):
         """
         :type network_location: kolibri.core.discovery.models.NetworkLocation
         """
         from kolibri.core.auth.tasks import begin_request_soud_sync
 
+        for user_id in self._learner_ids():
+            begin_request_soud_sync(network_location.base_url, user_id)
+
+
+@register_hook
+class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook, DiscoveryHookMixin):
+    def on_connect(self, network_location):
+        """
+        :type network_location: kolibri.core.discovery.models.NetworkLocation
+        """
         if (
             get_device_setting("subset_of_users_device")
             and not network_location.subset_of_users_device
         ):
-            for user_id in _learner_ids():
-                begin_request_soud_sync(network_location.base_url, user_id)
+            self._begin_request_soud_sync(network_location)
 
     def on_disconnect(self, network_location):
         """
         :type network_location: kolibri.core.discovery.models.NetworkLocation
         """
-        from kolibri.core.auth.tasks import stop_request_soud_sync
-
         if (
             get_device_setting("subset_of_users_device")
             and not network_location.subset_of_users_device
         ):
-            for user_id in _learner_ids():
-                stop_request_soud_sync(network_location.base_url, user_id)
+            self._begin_request_soud_sync(network_location)
+
+
+@register_hook
+class NetworkBroadcastForSoUDHook(NetworkLocationBroadcastHook):
+    """
+    This hook is used to hook into the broadcast of the SoUD status of this device to other
+    devices on the network. So when this device is updated, possibly to SoUD, it will
+    enqueue SoUD syncs to all other non-SoUD devices on the network.
+    """
+
+    def on_renew(self, instance, network_locations):
+        """
+        :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
+        :type network_locations: kolibri.core.discovery.models.NetworkLocation[]
+        """
+        if not get_device_setting("subset_of_users_device"):
+            return
+
+        for network_location in network_locations:
+            if not network_location.subset_of_users_device:
+                self._begin_request_soud_sync(network_location)
 
 
 @register_hook

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -164,7 +164,7 @@ class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook, DiscoveryHookMix
 
 
 @register_hook
-class NetworkBroadcastForSoUDHook(NetworkLocationBroadcastHook):
+class NetworkBroadcastForSoUDHook(NetworkLocationBroadcastHook, DiscoveryHookMixin):
     """
     This hook is used to hook into the broadcast of the SoUD status of this device to other
     devices on the network. So when this device is updated, possibly to SoUD, it will

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -131,7 +131,7 @@ class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook):
         from kolibri.core.auth.tasks import begin_request_soud_sync
 
         if (
-            get_device_setting("subset_of_users_device", default=False)
+            get_device_setting("subset_of_users_device")
             and not network_location.subset_of_users_device
         ):
             for user_id in _learner_ids():
@@ -144,7 +144,7 @@ class NetworkDiscoveryForSoUDHook(NetworkLocationDiscoveryHook):
         from kolibri.core.auth.tasks import stop_request_soud_sync
 
         if (
-            get_device_setting("subset_of_users_device", default=False)
+            get_device_setting("subset_of_users_device")
             and not network_location.subset_of_users_device
         ):
             for user_id in _learner_ids():

--- a/kolibri/plugins/learn/test/test_hooks.py
+++ b/kolibri/plugins/learn/test/test_hooks.py
@@ -23,7 +23,8 @@ def test_learner_ids():
 
 
 @mock.patch(
-    "kolibri.plugins.learn.kolibri_plugin._learner_ids", return_value=["abc123"]
+    "kolibri.plugins.learn.kolibri_plugin.DiscoveryHookMixin._learner_ids",
+    return_value=["abc123"],
 )
 class NetworkDiscoveryForSoUDHookTestCase(TestCase):
     def setUp(self):

--- a/kolibri/plugins/learn/test/test_hooks.py
+++ b/kolibri/plugins/learn/test/test_hooks.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 from django.test import TestCase
 
-from ..kolibri_plugin import _learner_ids
+from ..kolibri_plugin import DiscoveryHookMixin
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.test.helpers import create_superuser
@@ -12,11 +12,12 @@ from kolibri.core.discovery.models import NetworkLocation
 
 @pytest.mark.django_db(transaction=True)
 def test_learner_ids():
+    mixin = DiscoveryHookMixin()
     facility = Facility.objects.create()
     create_superuser(facility)
     user1 = FacilityUser.objects.create(username="buster.0", facility=facility)
     user2 = FacilityUser.objects.create(username="buster.1", facility=facility)
-    user_ids = list(_learner_ids())
+    user_ids = list(mixin._learner_ids())
     assert user1.pk in user_ids
     assert user2.pk in user_ids
 

--- a/kolibri/plugins/learn/test/test_learner_classroom.py
+++ b/kolibri/plugins/learn/test/test_learner_classroom.py
@@ -11,6 +11,7 @@ from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.exams.models import Exam
 from kolibri.core.exams.models import ExamAssignment
@@ -22,6 +23,7 @@ from kolibri.core.logger.models import MasteryLog
 
 class LearnerClassroomTestCase(APITestCase):
     def setUp(self):
+        clear_process_cache()
         provision_device()
         self.facility = Facility.objects.create(name="My Facility")
         self.coach_user = FacilityUser.objects.create(

--- a/kolibri/plugins/learn/test/test_learner_lesson.py
+++ b/kolibri/plugins/learn/test/test_learner_lesson.py
@@ -9,6 +9,7 @@ from kolibri.core.auth.models import Classroom
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.models import LearnerGroup
+from kolibri.core.auth.test.helpers import clear_process_cache
 from kolibri.core.auth.test.helpers import provision_device
 from kolibri.core.lessons.models import Lesson
 from kolibri.core.lessons.models import LessonAssignment
@@ -16,6 +17,7 @@ from kolibri.core.lessons.models import LessonAssignment
 
 class LearnerLessonTestCase(APITestCase):
     def setUp(self):
+        clear_process_cache()
         provision_device()
         self.facility = Facility.objects.create(name="My Facility")
         self.learner_user = FacilityUser.objects.create(

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -27,10 +27,7 @@ class HasPermissionDuringLODSetup(BasePermission):
     def has_permission(self, request, view):
         from kolibri.core.device.utils import get_device_setting
 
-        subset_of_users_device = get_device_setting(
-            "subset_of_users_device", default=False
-        )
-        return subset_of_users_device
+        return get_device_setting("subset_of_users_device")
 
 
 class SetupWizardResource(ViewSet):

--- a/kolibri/plugins/utils/test/helpers.py
+++ b/kolibri/plugins/utils/test/helpers.py
@@ -34,17 +34,17 @@ def _reset_plugin_dependent_modules():
 @contextmanager
 def plugin_enabled(*plugin_names):
     registered_plugins.register_plugins(plugin_names)
-
     _reset_plugin_dependent_modules()
 
-    yield
-
-    for plugin_name in plugin_names:
-        try:
-            del registered_plugins._apps[plugin_name]
-        except KeyError:
-            pass
-    _reset_plugin_dependent_modules()
+    try:
+        yield
+    finally:
+        for plugin_name in plugin_names:
+            try:
+                del registered_plugins._apps[plugin_name]
+            except KeyError:
+                pass
+        _reset_plugin_dependent_modules()
 
 
 @contextmanager
@@ -57,7 +57,8 @@ def plugin_disabled(*plugin_names):
 
     _reset_plugin_dependent_modules()
 
-    yield
-
-    registered_plugins.register_plugins(plugin_names)
-    _reset_plugin_dependent_modules()
+    try:
+        yield
+    finally:
+        registered_plugins.register_plugins(plugin_names)
+        _reset_plugin_dependent_modules()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes regression missing `id` argument in calling the `resumesync` command and corrects SoUD task queuing logic no longer compatible with its implementation (https://github.com/learningequality/kolibri/issues/10304)
- Fixes regression with pre/post transfer hooks not being invoked on server-side of a sync (https://github.com/learningequality/kolibri/issues/11102)
- Fixes regression with hooks into Zeroconf update post-setup (https://github.com/learningequality/kolibri/issues/10358)
- Adds `devicesettings` command that allows setting of a subset of device settings
- Allows `DeviceSettings` to exist when unprovisioned and aligns `get_device_setting` defaults with defaults on model itself
- Updates morango integration tests
- Removes `supplementary=False` filter for automatic content download size calculation unless filtering thumbnails

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/10304
Fixes https://github.com/learningequality/kolibri/issues/11102
Fixes https://github.com/learningequality/kolibri/issues/10358

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Run the morango integration tests with passing result.
- Carefully review logic for removing defaults in calls to `get_device_setting`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
