### PR TITLE
objectSpec sub-spec on arrays fix; themeSpec fix

### DIFF
--- a/kolibri/core/assets/src/objectSpecs.js
+++ b/kolibri/core/assets/src/objectSpecs.js
@@ -75,10 +75,18 @@ function _validateObjectData(data, options, dataKey) {
 
   // object sub-spec
   if (hasData && options.spec) {
+    // If it is an array, we will validate each item in the array
+    if (isArray(data)) {
+      for (const item of data) {
+        if (!validateObject(item, options.spec)) {
+          return _fail('Object in Array sub-spec failed', dataKey, data);
+        }
+      }
+    }
     if (!isObject(data)) {
       return _fail('Only objects can have sub-specs', dataKey, data);
     }
-    if (!validateObject(data, options.spec)) {
+    if (isObject(data) && !isArray(data) && !validateObject(data, options.spec)) {
       return _fail('Validator sub-spec failed', dataKey, data);
     }
   }

--- a/kolibri/core/assets/src/objectSpecs.js
+++ b/kolibri/core/assets/src/objectSpecs.js
@@ -75,16 +75,16 @@ function _validateObjectData(data, options, dataKey) {
 
   // object sub-spec
   if (hasData && options.spec) {
+    if (!isObject(data) && !isArray(data)) {
+      return _fail('Only objects or arrays can have sub-specs', dataKey, data);
+    }
     // If it is an array, we will validate each item in the array
     if (isArray(data)) {
       for (const item of data) {
-        if (!validateObject(item, options.spec)) {
-          return _fail('Object in Array sub-spec failed', dataKey, data);
+        if (!validateObject(item, options.spec.spec)) {
+          return _fail('Object in Array sub-spec failed', dataKey, item);
         }
       }
-    }
-    if (!isObject(data)) {
-      return _fail('Only objects can have sub-specs', dataKey, data);
     }
     if (isObject(data) && !isArray(data) && !validateObject(data, options.spec)) {
       return _fail('Validator sub-spec failed', dataKey, data);

--- a/kolibri/core/assets/src/objectSpecs.js
+++ b/kolibri/core/assets/src/objectSpecs.js
@@ -78,6 +78,7 @@ function _validateObjectData(data, options, dataKey) {
     if (!isObject(data) && !isArray(data)) {
       return _fail('Only objects or arrays can have sub-specs', dataKey, data);
     }
+
     // If it is an array, we will validate each item in the array
     if (isArray(data)) {
       for (const item of data) {
@@ -86,6 +87,9 @@ function _validateObjectData(data, options, dataKey) {
         }
       }
     }
+
+    // Here we know it is an Object, but we need to be sure it isn't an Array to avoid
+    // checking it again after we already validated the Array in the block above.
     if (isObject(data) && !isArray(data) && !validateObject(data, options.spec)) {
       return _fail('Validator sub-spec failed', dataKey, data);
     }

--- a/kolibri/core/assets/src/objectSpecs.js
+++ b/kolibri/core/assets/src/objectSpecs.js
@@ -41,7 +41,7 @@ import isArray from 'lodash/isArray';
 import isBoolean from 'lodash/isBoolean';
 import isDate from 'lodash/isDate';
 import isFunction from 'lodash/isFunction';
-import isObject from 'lodash/isObject';
+import isPlainObject from 'lodash/isPlainObject';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import isSymbol from 'lodash/isSymbol';
@@ -75,7 +75,7 @@ function _validateObjectData(data, options, dataKey) {
 
   // object sub-spec
   if (hasData && options.spec) {
-    if (!isObject(data) && !isArray(data)) {
+    if (!isPlainObject(data) && !isArray(data)) {
       return _fail('Only objects or arrays can have sub-specs', dataKey, data);
     }
 
@@ -90,7 +90,7 @@ function _validateObjectData(data, options, dataKey) {
 
     // Here we know it is an Object, but we need to be sure it isn't an Array to avoid
     // checking it again after we already validated the Array in the block above.
-    if (isObject(data) && !isArray(data) && !validateObject(data, options.spec)) {
+    if (isPlainObject(data) && !validateObject(data, options.spec)) {
       return _fail('Validator sub-spec failed', dataKey, data);
     }
   }
@@ -110,7 +110,7 @@ function _validateObjectData(data, options, dataKey) {
       return _fail('Expected Date', dataKey, data);
     } else if (options.type === Function && !isFunction(data)) {
       return _fail('Expected Function', dataKey, data);
-    } else if (options.type === Object && !isObject(data)) {
+    } else if (options.type === Object && !isPlainObject(data)) {
       return _fail('Expected Object', dataKey, data);
     } else if (options.type === Number && !isNumber(data)) {
       return _fail('Expected Number', dataKey, data);
@@ -154,7 +154,7 @@ export function validateObject(object, spec) {
   let isValid = true;
   for (const dataKey in spec) {
     const options = spec[dataKey];
-    if (!isObject(options)) {
+    if (!isPlainObject(options)) {
       logging.error(`Expected an Object for '${dataKey}' in spec. Got:`, options);
       isValid = false;
       continue;

--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -172,7 +172,7 @@ export default {
   },
   logos: {
     type: Array,
-    default: [],
+    default: () => [],
     spec: _imageSpec,
   },
 };

--- a/kolibri/core/assets/test/objectSpecs.spec.js
+++ b/kolibri/core/assets/test/objectSpecs.spec.js
@@ -46,6 +46,26 @@ const simpleSpec = {
       };
     },
   },
+  arrayOfNum: {
+    type: Array,
+    default: () => [],
+    spec: {
+      type: Number,
+      required: true,
+    },
+  },
+  arrayOfObj: {
+    type: Array,
+    default: () => [],
+    spec: {
+      type: Object,
+      required: true,
+      spec: {
+        prop_C: 'val_C',
+        prop_D: 'val_D',
+      },
+    },
+  },
 };
 
 describe('validateObject basic operation', () => {
@@ -99,6 +119,13 @@ describe('validateObject basic operation', () => {
     };
     expect(validateObject(obj, simpleSpec)).toBe(true);
   });
+  test('validateObject should test all children of an Array that has a spec', () => {
+    const obj = {
+      arrayOfNum: [1, 2, 3, 4, 5],
+      arrayOfObj: { prop_C: 'val_C', prop_D: 'val_D' },
+    };
+    expect(validateObject(obj, simpleSpec)).toBe(true);
+  });
 });
 
 describe('validateObject rejects bad specs', () => {
@@ -126,7 +153,7 @@ describe('validateObject rejects bad specs', () => {
     };
     expect(validateObject(obj, badSpec)).toBe(false);
   });
-  test('non-object cannot have sub-spec', () => {
+  test('non-object/array cannot have sub-spec', () => {
     const badSpec = {
       str1: {
         type: String,
@@ -155,6 +182,16 @@ describe('validateObject rejects bad specs', () => {
       str1: 'A',
     };
     expect(validateObject(obj, badSpec)).toBe(false);
+  });
+  test('A specced array rejects an array even if any value is bad', () => {
+    const badNumArrayObj = {
+      arrayOfNum: [1, 2, 3, 4, 5, 'A'],
+    };
+    expect(validateObject(badNumArrayObj, simpleSpec)).toBe(false);
+    const badObjArrayObj = {
+      arrayOfObj: [{ foo: 'bar', prop_c: 'val_c' }],
+    };
+    expect(validateObject(badObjArrayObj, simpleSpec)).toBe(false);
   });
 });
 

--- a/kolibri/core/assets/test/objectSpecs.spec.js
+++ b/kolibri/core/assets/test/objectSpecs.spec.js
@@ -59,10 +59,10 @@ const simpleSpec = {
     default: () => [],
     spec: {
       type: Object,
-      required: true,
+      default: null,
       spec: {
-        prop_C: 'val_C',
-        prop_D: 'val_D',
+        prop_C: { type: String, default: 'val_C' },
+        prop_D: { type: String, default: 'val_D' },
       },
     },
   },
@@ -121,8 +121,9 @@ describe('validateObject basic operation', () => {
   });
   test('validateObject should test all children of an Array that has a spec', () => {
     const obj = {
+      str1: 'A',
       arrayOfNum: [1, 2, 3, 4, 5],
-      arrayOfObj: { prop_C: 'val_C', prop_D: 'val_D' },
+      arrayOfObj: [{ prop_C: 'val_C', prop_D: 'val_D' }],
     };
     expect(validateObject(obj, simpleSpec)).toBe(true);
   });


### PR DESCRIPTION
## Summary

The `objectSpec` utility was not properly validating an `Array`-type spec's items against the given spec, this ensures that the spec is tested against all child items when given.

The `themeSpec` had an `Array`-type property with a default that was not a function as it ought to be, this is fixed.

This eliminates the benign but annoying console errors about the above.


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Start the server, go to Kolibri, you should not see objectSpec errors in the devtools console.

