### PR TITLE
long title button overlap resolved

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -202,7 +202,7 @@
     },
     filters: {
       truncateText(value, maxLength) {
-        if (value.length > maxLength) {
+        if (value && value.length > maxLength) {
           return value.substring(0, maxLength) + '...';
         }
         return value;

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -15,7 +15,13 @@
           />
         </template>
         <TextTruncatorCss
-          :text="resourceTitle"
+          v-if="windowBreakpoint <= 3"
+          :text="resourceTitle | truncateText(50)"
+          :maxLines="1"
+        />
+        <TextTruncatorCss
+          v-else
+          :text="resourceTitle | truncateText(70)"
           :maxLines="1"
         />
       </KLabeledIcon>
@@ -194,6 +200,14 @@
       SuggestedTime,
       DeviceConnectionStatus,
     },
+    filters: {
+      truncateText(value, maxLength) {
+        if (value.length > maxLength) {
+          return value.substring(0, maxLength) + '...';
+        }
+        return value;
+      },
+    },
     mixins: [KResponsiveWindowMixin, commonLearnStrings, commonCoreStrings],
     /**
      * Emits the following events:
@@ -343,6 +357,7 @@
         nextStepsAnimate: false,
       };
     },
+
     computed: {
       deviceId() {
         return get(this.$route, 'params.deviceId');
@@ -419,9 +434,9 @@
       },
       numBarActions() {
         let maxSize = 1;
-        if (this.windowBreakpoint === 1) {
+        if (this.windowBreakpoint === 1 || this.windowBreakpoint === 2) {
           maxSize = 2;
-        } else if (this.windowBreakpoint > 1) {
+        } else if (this.windowBreakpoint > 2) {
           // Ensure to hide the mark complete button in the dropdown
           // to prevent instinctive points grabbing!
           maxSize = this.showMarkComplete ? 3 : 4;


### PR DESCRIPTION
Fixes #11086 

## Summary

changes the default old breakpoint for the numBarActions to more suitable one.
also added a filter of text truncation on long title for different breakpoint  to prevent button issue as the size of the text content increases.

After :

[Transcripts - MIT Blossoms.webm](https://github.com/learningequality/kolibri/assets/82756460/aa0c0571-9200-4f99-bd12-c2e661d948ac)

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
