### PR TITLE
docs on how to run another kolibri instance alongside the development server

### DIFF
--- a/docs/howtos/another_kolibri_instance.md
+++ b/docs/howtos/another_kolibri_instance.md
@@ -1,4 +1,4 @@
-## Running Another Kolibri Instance Alongside the Development Server
+## Running another kolibri instance alongside the development server
 
 This guide will walk you through the process of setting up and running another instance of Kolibri alongside your development server using the `pex` executable.
 
@@ -6,20 +6,15 @@ This guide will walk you through the process of setting up and running another i
 
 As Kolibri's features continue to expand into remote content browsing, it's often necessary to test and experiment with another Kolibri instance running alongside your development server. One effective approach is to use the `pex` executable. This workflow is straightforward and can be employed independently of ZeroTier or even internet network access. Documenting these steps will provide a handy reference for both new team members and contributors.
 
-## Prerequisites
-
-Before you begin, make sure you have the following:
-
-- A recent `pex` executable of Kolibri. You can download this from the Build Assets page of a workflow build.
-
 ## Steps
 
 - **Locate the .pex executable:**
 
   - Navigate to the [Kolibri GitHub repository](https://github.com/learningequality/kolibri).
   - Click on the "Actions" tab at the top of the repository.
+  - Select the "Kolibri Build Assets for Pull Request" option from the sidebar.
   - Select a workflow build from the list.
-  - Scroll down the workflow build page to find the "Artifacts" section. In this section, you will find the `.pex` file that you need to download. Click on the `.pex` file to initiate the download.
+  - Scroll down the workflow build page to find the "Artifacts" section. In this section, you will find the `.pex` file that you need to download.
 
 - **Save and unzip the .pex file:**
 
@@ -30,9 +25,15 @@ Before you begin, make sure you have the following:
   Open your terminal and navigate to the folder where you unzipped the `pex` file. Use the following command to start another Kolibri instance:
 
   ```sh
-  KOLIBRI_HOME="kolibri-home" python <filename>.pex start
+  KOLIBRI_HOME="<foldername>" python <filename>.pex start
   ```
-  Replace `<filename>` with the actual filename of the `pex` executable. You can choose any location for `KOLIBRI_HOME`, but ensure it's set so that it doesn't override your default `.kolibri` directory.
+  Replace `<filename>` with the actual filename of the `pex` executable and replace `<foldername>` with the desired name for the folder that will store the settings and data for this instance.
+
+  Be sure to choose a meaningful folder name and avoid leaving it blank to ensure it doesn't overwrite your default `.kolibri`directory.
+
+  **Note:** You don't need to create the folder beforehand; it will be automatically generated if not already present when you run the command.
+
+
 
 - **Complete initial setup:**
 
@@ -46,7 +47,7 @@ Before you begin, make sure you have the following:
 
   When you're done testing, you can stop the additional Kolibri instance using the following command:
   ```sh
-  KOLIBRI_HOME="kolibri-home" python <filename>.pex stop
+  python <filename>.pex stop
   ```
   This will gracefully shut down the instance.
 

--- a/docs/howtos/another_kolibri_instance.md
+++ b/docs/howtos/another_kolibri_instance.md
@@ -1,0 +1,55 @@
+## Running Another Kolibri Instance Alongside the Development Server
+
+This guide will walk you through the process of setting up and running another instance of Kolibri alongside your development server using the `pex` executable.
+
+## Introduction
+
+As Kolibri's features continue to expand into remote content browsing, it's often necessary to test and experiment with another Kolibri instance running alongside your development server. One effective approach is to use the `pex` executable. This workflow is straightforward and can be employed independently of ZeroTier or even internet network access. Documenting these steps will provide a handy reference for both new team members and contributors.
+
+## Prerequisites
+
+Before you begin, make sure you have the following:
+
+- A recent `pex` executable of Kolibri. You can download this from the Build Assets page of a workflow build.
+
+## Steps
+
+- **Locate the .pex executable:**
+
+  - Navigate to the [Kolibri GitHub repository](https://github.com/learningequality/kolibri).
+  - Click on the "Actions" tab at the top of the repository.
+  - Select a workflow build from the list.
+  - Scroll down the workflow build page to find the "Artifacts" section. In this section, you will find the `.pex` file that you need to download. Click on the `.pex` file to initiate the download.
+
+- **Save and unzip the .pex file:**
+
+  Save the downloaded `.pex` file to a suitable location on your machine. Unzip the downloaded `pex` file to a folder where you want to run the additional Kolibri instance from.
+
+- **Run another Kolibri instance:**
+
+  Open your terminal and navigate to the folder where you unzipped the `pex` file. Use the following command to start another Kolibri instance:
+
+  ```sh
+  KOLIBRI_HOME="kolibri-home" python <filename>.pex start
+  ```
+  Replace `<filename>` with the actual filename of the `pex` executable. You can choose any location for `KOLIBRI_HOME`, but ensure it's set so that it doesn't override your default `.kolibri` directory.
+
+- **Complete initial setup:**
+
+  In the terminal, you'll find the URL of the new Kolibri instance. Open the URL in your browser and complete the initial device setup as you would for a regular Kolibri instance. Additionally, import a few resources from desired channels.
+
+- **Run your development server:**
+
+  Once the additional Kolibri instance is up and running, start your development server as usual. You should now see the new device on your network.
+
+- **Stop the other Kolibri instance:**
+
+  When you're done testing, you can stop the additional Kolibri instance using the following command:
+  ```sh
+  KOLIBRI_HOME="kolibri-home" python <filename>.pex stop
+  ```
+  This will gracefully shut down the instance.
+
+## Conclusion
+
+Running another Kolibri instance alongside your development server using the `pex` executable is a convenient way to test and experiment with remote content browsing features. By following these steps, you can effectively simulate real-world scenarios and enhance your development workflow.

--- a/docs/howtos/another_kolibri_instance.rst
+++ b/docs/howtos/another_kolibri_instance.rst
@@ -1,0 +1,6 @@
+.. _another_kolibri_instance:
+
+Another Kolibri Instance
+========================
+
+.. mdinclude:: ./another_kolibri_instance.md

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -12,3 +12,4 @@ These guides are step by step guides for common tasks in getting started and wor
   installing_pyenv
   pyenv_virtualenv
   nodeenv
+  another_kolibri_instance


### PR DESCRIPTION
Fixes #11142 

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
 added docs  on how to run another kolibri instance alongside the development server using pex.

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
