### PR TITLE
Maintain the zoom settings for the PDF viewer

### DIFF
--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -423,6 +423,10 @@
           if (currentPage === this.totalPages - 1 && this.scrolledToEnd()) {
             this.storeVisitedPage(currentPage + 1);
           }
+          // If users has already zoomed then set the scale to that particular zoom scale.
+          if (localStorage.getItem('pdf_scale') != null) {
+            this.setScale(parseFloat(localStorage.getItem('pdf_scale')));
+          }
           this.storeVisitedPage(currentPage);
           this.updateProgress();
           this.updateContentState();
@@ -447,6 +451,7 @@
       },
       setScale: throttle(function(scaleValue) {
         this.scale = scaleValue;
+        localStorage.setItem('pdf_scale', scaleValue);
       }, 500),
       toggleSideBar() {
         this.showSideBar = !this.showSideBar;


### PR DESCRIPTION
## Summary
If a user changes the zoom setting in the browser, the zoom settings will be preserved when reopening the PDF using local storage.

...

## References
Issue: #11110 

…

## Reviewer guidance

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
