### PR TITLE
Commit job state change before running update hooks

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -577,6 +577,10 @@ class Storage(object):
                 self._update_job_fields(job, **kwargs)
                 orm_job.saved_job = job.to_json()
                 session.add(orm_job)
+                try:
+                    session.commit()
+                except Exception as e:
+                    logger.error("Got an error running session.commit(): {}".format(e))
                 for hook in self._hooks:
                     hook.update(
                         job,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Without this, the state queried by `job_storage` will not match the updated state. This can cause a problem if a hook tries to restart a canceled job because `job_storage` will still see the state as `CANCELING`.

Fixes: #11169

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#11169

This fixes the case I was seeing. Before:

```
[python-devserver] INFO     2023-08-28 16:22:58,428 Restarting incomplete BackgroundTask func: kolibri_explore_plugin.tasks.remotecontentimport, params: {"channel_id": "2f95235c3709511fa12d007f31ed6a7b", "channel_name": "STEAM", "node_ids": [], "exclude_node_ids": [], "all_thumbnails": true, "fail_on_error": true}, job_id: 3bce247d8c034ea0b694b87f6c2e292c, job_state: CANCELED
[python-devserver] ERROR    2023-08-28 16:22:58,429 exception calling callback for <Future at 0x7f824032a670 state=finished raised JobNotRestartable>
```

With this change, the job is queued and the server shuts down cleanly.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See the description in #11169. Unfortunately, testing the job worker + `StorageHook` is not easy.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
