### PR TITLE
Update ReadTheDocs builds configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+version: 2
+formats: all
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+  - requirements: requirements/docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,8 +136,6 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-# html_theme = "default"
-# on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,6 +9,7 @@ import sys
 from datetime import datetime
 
 import django
+import sphinx_rtd_theme
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
 
@@ -135,15 +136,11 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "default"
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+# html_theme = "default"
+# on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [".", sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary

- Starting on September 25, ReadTheDocs builds without configuration file won't work anymore. This adds the configuration file.
- Enables `sphinx-rtd-theme` for the production build
  - Previously, it was enabled only for local builds, probably because it was applied by default by ReadTheDocs. However, ReadTheDocs is generally moving towards requiring explicit configuration and having the theme disabled for production seems to be the cause of some recent troubles with theme on https://kolibri-dev.readthedocs.io/en/develop/

## References

https://blog.readthedocs.com/migrate-configuration-v2/

## Reviewer guidance

- Preview the configuration file
- Preview the production docs build: https://kolibri-dev--11179.org.readthedocs.build/en/11179/
- Preview the local docs build

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
