### PR TITLE
Do better availability checks for individual resource import

### DIFF
--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -745,10 +745,8 @@ def process_download_request(download_request):
         for peer in chain(*peer_sets):
             import_manager = ContentDownloadRequestResourceImportManager(
                 node.channel_id,
-                peer_id=peer.id,
-                baseurl=peer.base_url,
-                node_ids=[download_request.contentnode_id],
-                download_request=download_request,
+                peer,
+                download_request,
                 fail_on_error=True,
             )
             _, count = import_manager.run()

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -137,6 +137,7 @@ def get_import_export_nodes(  # noqa: C901
     drive_id=None,
     peer_id=None,
     renderable_only=True,
+    check_file_availability=True,
 ):
     """
     Returns a list of queries for ContentNode objects matching the given
@@ -162,9 +163,10 @@ def get_import_export_nodes(  # noqa: C901
     if available is not None:
         nodes_to_include = nodes_to_include.filter(available=available)
 
-    nodes_to_include = filter_by_file_availability(
-        nodes_to_include, channel_id, drive_id, peer_id
-    )
+    if check_file_availability:
+        nodes_to_include = filter_by_file_availability(
+            nodes_to_include, channel_id, drive_id, peer_id
+        )
 
     while min_boundary < max_rght:
         max_boundary = min_boundary + dynamic_chunksize

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -17,6 +17,7 @@ from kolibri.core.content.utils import annotation
 from kolibri.core.content.utils import paths
 from kolibri.core.content.utils.channels import get_mounted_drive_by_id
 from kolibri.core.content.utils.content_manifest import ContentManifest
+from kolibri.core.content.utils.file_availability import generate_checksum_integer_mask
 from kolibri.core.content.utils.file_availability import LocationError
 from kolibri.core.content.utils.import_export_content import get_import_export_data
 from kolibri.core.content.utils.paths import get_channel_lookup_url
@@ -25,8 +26,11 @@ from kolibri.core.content.utils.upgrade import get_import_data_for_update
 from kolibri.core.discovery.models import NetworkLocation
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationNotFound
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseTimeout
 from kolibri.core.tasks.utils import fd_safe_executor
 from kolibri.core.tasks.utils import JobProgressMixin
+from kolibri.core.utils.urls import reverse_path
 from kolibri.utils import conf
 from kolibri.utils import file_transfer as transfer
 from kolibri.utils.system import get_free_space
@@ -512,28 +516,73 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
     def __init__(
         self,
         channel_id,
-        peer_id=None,
-        baseurl=None,
-        node_ids=None,
-        exclude_node_ids=None,
+        peer,
+        download_request,
         renderable_only=True,
         fail_on_error=False,
         content_dir=None,
-        download_request=None,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
         super(ContentDownloadRequestResourceImportManager, self).__init__(
             channel_id,
-            peer_id=peer_id,
-            baseurl=baseurl,
-            node_ids=node_ids,
-            exclude_node_ids=exclude_node_ids,
+            peer_id=peer.id,
+            baseurl=peer.baseurl,
+            node_ids=[download_request.node_id],
+            exclude_node_ids=None,
             renderable_only=renderable_only,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
             timeout=timeout,
         )
+        self.peer = peer
         self.download_request = download_request
+
+    def get_import_data(self):
+        return get_import_export_data(
+            self.channel_id,
+            self.node_ids,
+            self.exclude_node_ids,
+            False,
+            renderable_only=self.renderable_only,
+            all_thumbnails=self.all_thumbnails,
+            peer_id=self.peer_id,
+            check_file_availability=False,
+        )
+
+    def run(self):
+        node = ContentNode.objects.get(pk=self.download_request.contentnode_id)
+        required_checksums = (
+            node.files()
+            .filter(supplementary=False)
+            .values_list("local_file_id", flat=True)
+        )
+        with NetworkClient.build_from_network_location(self.peer) as client:
+            try:
+                response = client.post(
+                    reverse_path("get_public_file_checksums", kwargs={"version": "1"}),
+                    data=required_checksums,
+                )
+                integer_mask = int(response.content)
+
+                expected_mask = generate_checksum_integer_mask(
+                    required_checksums, required_checksums
+                )
+
+                if integer_mask != expected_mask:
+                    raise ValueError
+            except (
+                ValueError,
+                TypeError,
+                NetworkLocationResponseFailure,
+                NetworkLocationResponseTimeout,
+            ):
+                # Bad JSON parsing will throw ValueError
+                # If the result of the json.loads is not iterable, a TypeError will be thrown
+                # If we end up here, just set checksums to None to allow us to cleanly continue
+                if self.fail_on_error:
+                    raise LocationError("Required files not available from remote")
+
+        return super(ContentDownloadRequestResourceImportManager, self).run()
 
     def start_progress(self, total=100):
         super(ContentDownloadRequestResourceImportManager, self).start_progress(total)


### PR DESCRIPTION
## Summary
* Adds validation for checksums to public file checksum endpoint
* Updates individual content resource manager to check for file availability on remote before import
* Exempts Studio from these checks

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
