### PR TITLE
Retain the position of save button on tab switch

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -344,6 +344,7 @@
 
 <script>
 
+  import store from 'kolibri.coreVue.vuex.store';
   import { mapGetters } from 'vuex';
   import find from 'lodash/find';
   import urls from 'kolibri.urls';
@@ -360,6 +361,7 @@
   import { getFreeSpaceOnServer } from '../AvailableChannelsPage/api';
   import useDeviceRestart from '../../composables/useDeviceRestart';
   import usePlugins from '../../composables/usePlugins';
+  import { showDeviceInfoPage } from '../../modules/deviceInfo/handlers';
   import { getDeviceSettings, getPathsPermissions, saveDeviceSettings, getDeviceURLs } from './api';
   import PrimaryStorageLocationModal from './PrimaryStorageLocationModal';
   import AddStorageLocationModal from './AddStorageLocationModal';
@@ -536,6 +538,9 @@
         }
       },
       deviceIsAndroid() {
+        if (this.deviceInfo === undefined) {
+          showDeviceInfoPage(store);
+        }
         if (this.getDeviceOS === undefined) {
           return true;
         }


### PR DESCRIPTION
## Summary
After switching tabs to the info page, the device information stored in the store was getting removed. In the function that checks if the device is Android, I have added a condition to reset the device info if it is undefined.

https://github.com/learningequality/kolibri/assets/77184239/87e8ab47-d25d-4b2c-be4f-52b576993bf0

…

## References
#11178 
…

## Reviewer guidance

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
