### PR TITLE
Do not enable continue button if it is not possible to use it

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -289,7 +289,7 @@
       },
       isDeviceAvailable() {
         return function(deviceId) {
-          return Boolean(this.availableDeviceIds.find(id => id === deviceId));
+          return this.availableDeviceIds.some(id => id === deviceId);
         };
       },
       submitDisabled() {
@@ -298,6 +298,8 @@
             this.isDeleting ||
             this.fetchFailed ||
             this.isSubmitChecking ||
+            !this.canLearnerSignUp(this.selectedDeviceId) ||
+            !this.isDeviceAvailable(this.selectedDeviceId) ||
             this.availableDeviceIds.length === 0
         );
       },


### PR DESCRIPTION

## Summary
When available devices are shown, `Continue` button must not be enabled if the selected device is not actually usable

![image](https://github.com/learningequality/kolibri/assets/1008178/20bdf389-27d2-43ea-bc38-aef6e09dc866)
![image](https://github.com/learningequality/kolibri/assets/1008178/fa307ff5-5ee7-4ece-b77f-2d37908099d5)
![image](https://github.com/learningequality/kolibri/assets/1008178/c1699967-379e-44f1-b7ba-f548d99fbd57)



## References
Closes #11175

## Reviewer guidance
Look for devices in the network and ensure the button `Continue` is enabled only in case the process can continue.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
