### PR TITLE
added functionality to create new facility on existing kolibri

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -186,3 +186,10 @@ export const ApplicationTypes = {
   KOLIBRI: 'kolibri',
   STUDIO: 'studio',
 };
+
+// aliasing 'informal' to 'personal' since it's how we talk about it
+export const Presets = Object.freeze({
+  PERSONAL: 'informal',
+  FORMAL: 'formal',
+  NONFORMAL: 'nonformal',
+});

--- a/kolibri/core/assets/src/mixins/notificationStrings.js
+++ b/kolibri/core/assets/src/mixins/notificationStrings.js
@@ -139,6 +139,10 @@ export default createTranslator('NotificationStrings', {
     message: 'Device not removed',
     context: 'Snackbar message when a device fails to be removed from he sync schedule',
   },
+  newLearningFacilityCreated: {
+    message: 'New learning facility created',
+    context: 'Snackbar message when a new facility created',
+  },
   // TODO move more messages into this namespace:
   // - "Quiz started"
   // - "Quiz Ended"

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -75,6 +75,7 @@ from kolibri.core.api import ValuesViewset
 from kolibri.core.auth.constants.demographics import NOT_SPECIFIED
 from kolibri.core.auth.permissions.general import _user_is_admin_for_own_facility
 from kolibri.core.auth.permissions.general import DenyAll
+from kolibri.core.device.permissions import IsSuperuser
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import allow_other_browsers_to_connect
 from kolibri.core.device.utils import valid_app_key_on_request
@@ -622,7 +623,7 @@ class FacilityViewSet(ValuesViewset):
             )
         )
 
-    @decorators.action(methods=["post"], detail=False)
+    @decorators.action(methods=["post"], detail=False, permission_classes=[IsSuperuser])
     def create_facility(self, request):
         serializer = CreateFacilitySerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -16,6 +16,7 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
@@ -60,6 +61,7 @@ from .models import LearnerGroup
 from .models import Membership
 from .models import Role
 from .serializers import ClassroomSerializer
+from .serializers import CreateFacilitySerializer
 from .serializers import ExtraFieldsSerializer
 from .serializers import FacilityDatasetSerializer
 from .serializers import FacilitySerializer
@@ -620,6 +622,20 @@ class FacilityViewSet(ValuesViewset):
                 )
             )
         )
+
+    @decorators.action(methods=["post"], detail=False)
+    def create_facility(self, request):
+        serializer = CreateFacilitySerializer(data=request.data)
+        if serializer.is_valid():
+            with transaction.atomic():
+                facility_dataset = FacilityDataset.objects.create(
+                    preset=serializer.validated_data.get("preset")
+                )
+                Facility.objects.create(
+                    name=serializer.validated_data.get("name"), dataset=facility_dataset
+                )
+            return Response()
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class PublicFacilityViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -16,7 +16,6 @@ from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
 from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
@@ -626,16 +625,9 @@ class FacilityViewSet(ValuesViewset):
     @decorators.action(methods=["post"], detail=False)
     def create_facility(self, request):
         serializer = CreateFacilitySerializer(data=request.data)
-        if serializer.is_valid():
-            with transaction.atomic():
-                facility_dataset = FacilityDataset.objects.create(
-                    preset=serializer.validated_data.get("preset")
-                )
-                Facility.objects.create(
-                    name=serializer.validated_data.get("name"), dataset=facility_dataset
-                )
-            return Response()
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response()
 
 
 class PublicFacilityViewSet(viewsets.ReadOnlyModelViewSet):

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.core.validators import MinLengthValidator
+from django.db import transaction
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 
@@ -144,6 +145,17 @@ class CreateFacilitySerializer(serializers.ModelSerializer):
     class Meta:
         model = Facility
         fields = ("id", "name", "preset")
+
+    def create(self, validated_data):
+        with transaction.atomic():
+            facility_dataset = FacilityDataset.objects.create(
+                preset=validated_data.get("preset")
+            )
+            facility = Facility.objects.create(
+                name=validated_data.get("name"), dataset=facility_dataset
+            )
+            facility.dataset.reset_to_default_settings(validated_data.get("preset"))
+        return facility
 
 
 class PublicFacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -6,6 +6,7 @@ from django.core.validators import MinLengthValidator
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
 
+from .constants import facility_presets
 from .errors import IncompatibleDeviceSettingError
 from .errors import InvalidCollectionHierarchy
 from .errors import InvalidMembershipError
@@ -135,6 +136,14 @@ class FacilitySerializer(serializers.ModelSerializer):
         model = Facility
         extra_kwargs = {"id": {"read_only": True}}
         fields = ("id", "name")
+
+
+class CreateFacilitySerializer(serializers.ModelSerializer):
+    preset = serializers.ChoiceField(choices=facility_presets.choices)
+
+    class Meta:
+        model = Facility
+        fields = ("id", "name", "preset")
 
 
 class PublicFacilitySerializer(serializers.ModelSerializer):

--- a/kolibri/plugins/device/assets/src/constants.js
+++ b/kolibri/plugins/device/assets/src/constants.js
@@ -71,3 +71,8 @@ export const MeteredConnectionDownloadOptions = {
   DISALLOW_DOWNLOAD_ON_METERED_CONNECTION: 'DISALLOW_DOWNLOAD_ON_METERED_CONNECTION',
   ALLOW_DOWNLOAD_ON_METERED_CONNECTION: 'ALLOW_DOWNLOAD_ON_METERED_CONNECTION',
 };
+
+export const Presets = Object.freeze({
+  FORMAL: 'formal',
+  NONFORMAL: 'nonformal',
+});

--- a/kolibri/plugins/device/assets/src/constants.js
+++ b/kolibri/plugins/device/assets/src/constants.js
@@ -72,7 +72,6 @@ export const MeteredConnectionDownloadOptions = {
   ALLOW_DOWNLOAD_ON_METERED_CONNECTION: 'ALLOW_DOWNLOAD_ON_METERED_CONNECTION',
 };
 
-export const Presets = Object.freeze({
-  FORMAL: 'formal',
-  NONFORMAL: 'nonformal',
-});
+export const ImportFacility = 'import_facility';
+
+export const CreateNewFacility = 'create_new_facility';

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
@@ -1,0 +1,121 @@
+<template>
+
+  <KModal
+    :title="$tr('createFacilityLabel')"
+    :submitText="$tr('createFacilityButtonLabel')"
+    :cancelText="coreString('closeAction')"
+    size="medium"
+    @submit="handleSubmit"
+    @cancel="$emit('cancel')"
+  >
+    <p>{{ coreString('learningFacilityDescription') }}</p>
+    <KTextbox
+      ref="facilityNameTextBox"
+      v-model="facilityName"
+      :label="$tr('facilityNameFieldLabel')"
+      :invalid="facilityNameInvalid"
+      :invalidText="coreString('requiredFieldError')"
+      :maxlength="50"
+    />
+    <b>{{ $tr('learningEnvironmentHeader') }}</b>
+    <KRadioButton
+      v-model="preset"
+      class="permission-preset-radio-button"
+      :value="Presets.NONFORMAL"
+      :label="$tr('nonFormalLabel')"
+      :description="$tr('nonFormalDescription')"
+    />
+    <KRadioButton
+      v-model="preset"
+      class="permission-preset-radio-button"
+      :value="Presets.FORMAL"
+      :label="$tr('formalLabel')"
+      :description="$tr('formalDescription')"
+    />
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import { Presets } from '../../constants';
+  import { createFacility } from './api';
+
+  export default {
+    name: 'CreateNewFacilityModal',
+    mixins: [commonCoreStrings, commonSyncElements],
+    data() {
+      return {
+        facilityName: '',
+        preset: 'nonformal',
+        Presets,
+      };
+    },
+    computed: {
+      facilityNameInvalid() {
+        return !this.facilityName || this.facilityName.trim() === '';
+      },
+    },
+    methods: {
+      handleSubmit() {
+        if (this.facilityNameInvalid) {
+          return this.$refs.facilityNameTextBox.focus();
+        }
+        const payload = {
+          name: this.facilityName,
+          preset: this.preset,
+        };
+        createFacility(payload)
+          .then(() => {
+            this.$emit('success');
+          })
+          .catch(error => {
+            this.$store.dispatch('handleApiError', error);
+          });
+      },
+    },
+    $trs: {
+      facilityNameFieldLabel: {
+        message: 'Learning facility name',
+        context: 'The field where the admin adds the name of their facility.',
+      },
+      learningEnvironmentHeader: {
+        message: 'What kind of environment is your facility?',
+        context: 'Title for facility environment.',
+      },
+      formalLabel: {
+        message: 'Formal',
+        context: 'Label for the radio button option in the facility setup.',
+      },
+      formalDescription: {
+        message: 'Schools and other formal learning contexts.',
+        context: "Option description text for 'Formal' facility types.",
+      },
+      nonFormalLabel: {
+        message: 'Non-formal',
+        context: 'Label for the radio button option in the facility setup',
+      },
+      nonFormalDescription: {
+        message:
+          'Libraries, orphanages, youth centers, computer labs, and other non-formal learning contexts.',
+
+        context: "Option description text for 'Non-formal' facility types.",
+      },
+      createFacilityLabel: {
+        message: 'Create a new learning facility',
+        context: 'Title for create facility modal',
+      },
+      createFacilityButtonLabel: {
+        message: 'create facility',
+        context: 'Label for create facility submit button.',
+      },
+    },
+  };
+
+</script>
+
+
+<style lang="scss" scoped></style>

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
@@ -41,7 +41,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { Presets } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
   import { createFacility } from './api';
 
   export default {

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
@@ -71,6 +71,7 @@
         createFacility(payload)
           .then(() => {
             this.$emit('success');
+            this.showSnackbarNotification('newLearningFacilityCreated');
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', error);

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
@@ -50,7 +50,7 @@
     data() {
       return {
         facilityName: '',
-        preset: 'nonformal',
+        preset: Presets.NONFORMAL,
         Presets,
       };
     },

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/api.js
@@ -1,0 +1,12 @@
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
+
+const url = urls['kolibri:core:facility-create-facility']();
+
+export function createFacility(payload) {
+  return client({
+    url,
+    method: 'POST',
+    data: payload,
+  });
+}

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -207,7 +207,7 @@
   import { TaskStatuses, TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import some from 'lodash/some';
   import DeviceAppBarPage from '../DeviceAppBarPage';
-  import { PageNames } from '../../constants';
+  import { PageNames, ImportFacility, CreateNewFacility } from '../../constants';
   import { deviceString } from '../commonDeviceStrings';
   import TasksBar from '../ManageContentPage/TasksBar';
   import HeaderWithOptions from '../HeaderWithOptions';
@@ -263,12 +263,12 @@
       options() {
         return [
           {
-            label: 'Import facility',
-            value: 'import_facility',
+            label: this.$tr('importFacilityLabel'),
+            value: ImportFacility,
           },
           {
-            label: 'Create new facility',
-            value: 'create_new_facility',
+            label: this.$tr('createNewFacilityLabel'),
+            value: CreateNewFacility,
           },
         ];
       },
@@ -421,7 +421,7 @@
           });
       },
       handleSelect(option) {
-        if (option.value == 'import_facility') {
+        if (option.value == ImportFacility) {
           this.showImportModal = true;
         } else {
           this.showCreateFacilityModal = true;
@@ -442,6 +442,14 @@
       createFacilityLabel: {
         message: 'ADD FACILITY',
         context: 'Label for a button used to create new facility.',
+      },
+      importFacilityLabel: {
+        message: 'Import facility',
+        context: 'Label for the dropdown option of import facility',
+      },
+      createNewFacilityLabel: {
+        message: 'Create new facility',
+        context: 'Label for the dropdown option of create new facility',
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -14,11 +14,18 @@
               @click="showSyncAllModal = true"
             />
             <KButton
-              :text="getCommonSyncString('importFacilityAction')"
+              hasDropdown
+              :text="$tr('createFacilityLabel')"
               primary
               style="margin-top: 16px; margin-bottom: -16px;"
-              @click="showImportModal = true"
-            />
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :options="options"
+                  @select="handleSelect"
+                />
+              </template>
+            </KButton>
           </KButtonGroup>
         </template>
       </HeaderWithOptions>
@@ -144,6 +151,11 @@
         @success="handleStartImportSuccess"
         @cancel="showImportModal = false"
       />
+      <CreateNewFacilityModal
+        v-if="showCreateFacilityModal"
+        @success="handleCreateFacilitySuccess"
+        @cancel="showCreateFacilityModal = false"
+      />
 
       <!-- NOTE similar code for KDP Registration in SyncInterface -->
       <template v-if="Boolean(facilityForRegister)">
@@ -202,6 +214,7 @@
   import RemoveFacilityModal from './RemoveFacilityModal';
   import SyncAllFacilitiesModal from './SyncAllFacilitiesModal';
   import ImportFacilityModalGroup from './ImportFacilityModalGroup';
+  import CreateNewFacilityModal from './CreateNewFacilityModal';
   import facilityTaskQueue from './facilityTasksQueue';
 
   const Options = Object.freeze({
@@ -221,6 +234,7 @@
       DeviceAppBarPage,
       ConfirmationRegisterModal,
       CoreTable,
+      CreateNewFacilityModal,
       HeaderWithOptions,
       FacilityNameAndSyncStatus,
       ImportFacilityModalGroup,
@@ -235,6 +249,7 @@
       return {
         showSyncAllModal: false,
         showImportModal: false,
+        showCreateFacilityModal: false,
         facilities: [],
         facilityForSync: null,
         facilityForRemoval: null,
@@ -245,6 +260,18 @@
       };
     },
     computed: {
+      options() {
+        return [
+          {
+            label: 'Import facility',
+            value: 'import_facility',
+          },
+          {
+            label: 'Create new facility',
+            value: 'create_new_facility',
+          },
+        ];
+      },
       pageTitle() {
         return deviceString('deviceManagementTitle');
       },
@@ -344,6 +371,10 @@
         });
         this.showImportModal = false;
       },
+      handleCreateFacilitySuccess() {
+        this.showCreateFacilityModal = false;
+        this.fetchFacilites();
+      },
       manageSync(facilityId) {
         return {
           name: PageNames.MANAGE_SYNC_SCHEDULE,
@@ -389,6 +420,13 @@
             this.$emit('failure');
           });
       },
+      handleSelect(option) {
+        if (option.value == 'import_facility') {
+          this.showImportModal = true;
+        } else {
+          this.showCreateFacilityModal = true;
+        }
+      },
     },
     $trs: {
       syncAllAction: {
@@ -400,6 +438,10 @@
         message: "Removed '{facilityName}' from this device",
         context:
           "Notification that appears after a facility has been deleted. For example, \"Removed 'Zuk Village' from this device'.",
+      },
+      createFacilityLabel: {
+        message: 'ADD FACILITY',
+        context: 'Label for a button used to create new facility.',
       },
     },
   };

--- a/kolibri/plugins/setup_wizard/assets/src/constants.js
+++ b/kolibri/plugins/setup_wizard/assets/src/constants.js
@@ -1,12 +1,5 @@
 import permissionPresets from '../../../../core/auth/constants/facility_configuration_presets.json';
 
-// aliasing 'informal' to 'personal' since it's how we talk about it
-const Presets = Object.freeze({
-  PERSONAL: 'informal',
-  FORMAL: 'formal',
-  NONFORMAL: 'nonformal',
-});
-
 /**
  * enum identifying whether the user has gone to the on my own flow or not
  */
@@ -43,7 +36,6 @@ export {
   permissionPresets,
   DeviceTypePresets,
   FacilityTypePresets,
-  Presets,
   UsePresets,
   SoudQueue,
   LodTypePresets,

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
@@ -35,8 +35,9 @@
 <script>
 
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
   import OnboardingStepBase from '../OnboardingStepBase';
-  import { Presets, FooterMessageTypes } from '../../constants';
+  import { FooterMessageTypes } from '../../constants';
 
   export default {
     name: 'CreateLearnerAccountForm',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -42,7 +42,8 @@
 
 <script>
 
-  import { Presets, FooterMessageTypes } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
+  import { FooterMessageTypes } from '../../constants';
   import OnboardingStepBase from '../OnboardingStepBase';
   import FacilityNameTextbox from './FacilityNameTextbox';
 

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GettingStartedForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GettingStartedForm.vue
@@ -24,7 +24,7 @@
 <script>
 
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { Presets } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
   import OnboardingForm from './OnboardingForm';
 
   const Options = Object.freeze({

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GettingStartedFormAlt.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GettingStartedFormAlt.vue
@@ -32,7 +32,7 @@
 <script>
 
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { Presets } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
   import OnboardingForm from './OnboardingForm';
 
   export default {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
@@ -33,7 +33,8 @@
 
 <script>
 
-  import { Presets, FooterMessageTypes } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
+  import { FooterMessageTypes } from '../../constants';
   import OnboardingStepBase from '../OnboardingStepBase';
 
   export default {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -27,8 +27,9 @@
 <script>
 
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
   import OnboardingStepBase from '../OnboardingStepBase';
-  import { Presets, UsePresets } from '../../constants';
+  import { UsePresets } from '../../constants';
 
   export default {
     name: 'HowAreYouUsingKolibri',

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
@@ -34,7 +34,8 @@
 <script>
 
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { Presets, FooterMessageTypes } from '../../constants';
+  import { Presets } from 'kolibri.coreVue.vuex.constants';
+  import { FooterMessageTypes } from '../../constants';
   import OnboardingStepBase from '../OnboardingStepBase';
 
   export default {


### PR DESCRIPTION
## Summary
closes #10826 
Added functionality to create a new facility on the existing Kolibri
 * Added a modal to create new facility
 * Implemented backend APIs to create facility
 * screenshots
 
![image](https://github.com/learningequality/kolibri/assets/69707565/8329caee-b5e2-4e5e-987e-81584102e6af)

![image](https://github.com/learningequality/kolibri/assets/69707565/f02086a7-ac03-46b2-92bd-1dbaf2f05091)

![image](https://github.com/learningequality/kolibri/assets/69707565/2262f601-5bf5-4c17-ae9e-7660c78b6c2e)
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
