### PR TITLE
Add padding to the bottom of the page, to prevent app bar covering links

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -635,6 +635,7 @@
   .main-grid {
     margin-top: 110px;
     margin-right: 24px;
+    margin-bottom: 96px;
   }
 
   .channels-label {


### PR DESCRIPTION
## Summary
Extremely small change to fix the bottom app bars from covering the "view more" link on particular library page layouts (such as search result with > 25 results)

## References
Fixes https://github.com/learningequality/kolibri/issues/11079

![Screenshot 2023-09-05 at 3 01 18 PM](https://github.com/learningequality/kolibri/assets/17235236/c9a3dbda-9c1c-470d-8ce7-4ce9b3f50d73)


## Reviewer guidance
In app mode, search on the Library page where there is a search with > 25 results (therefore, would display "view more" at the bottom) 

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
