### PR TITLE
Filters out devices with Conflict and ConnectionFailure connection statuses

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -75,7 +75,6 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonLearnStrings from '../commonLearnStrings';
-  import { ConnectionStatus } from '../../../../../../core/assets/src/views/sync/SelectDeviceModalGroup/constants';
   import useChannels from '../../composables/useChannels';
   import useContentLink from '../../composables/useContentLink';
   import useDevices from '../../composables/useDevices';
@@ -128,12 +127,9 @@
         );
       },
       networkDevicesWithChannels() {
-        return this.networkDevices.filter(device => {
-          const connectionStatus = device['connection_status'];
-          const unallowedStatuses = [ConnectionStatus.Conflict, ConnectionStatus.ConnectionFailure];
-          const connectionIsOkay = !unallowedStatuses.includes(connectionStatus);
-          return device.channels?.length > 0 && connectionIsOkay;
-        });
+        return this.networkDevices.filter(
+          device => device.channels?.length > 0 && Boolean(device['available'])
+        );
       },
       pageHeaderStyle() {
         return {

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -75,6 +75,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
   import commonLearnStrings from '../commonLearnStrings';
+  import { ConnectionStatus } from '../../../../../../core/assets/src/views/sync/SelectDeviceModalGroup/constants';
   import useChannels from '../../composables/useChannels';
   import useContentLink from '../../composables/useContentLink';
   import useDevices from '../../composables/useDevices';
@@ -127,7 +128,12 @@
         );
       },
       networkDevicesWithChannels() {
-        return this.networkDevices.filter(device => device.channels?.length > 0);
+        return this.networkDevices.filter(device => {
+          const connectionStatus = device['connection_status'];
+          const unallowedStatuses = [ConnectionStatus.Conflict, ConnectionStatus.ConnectionFailure];
+          const connectionIsOkay = !unallowedStatuses.includes(connectionStatus);
+          return device.channels?.length > 0 && connectionIsOkay;
+        });
       },
       pageHeaderStyle() {
         return {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -255,6 +255,7 @@
   import { currentLanguage } from 'kolibri.utils.i18n';
   import SidePanelModal from '../SidePanelModal';
   import SearchFiltersPanel from '../SearchFiltersPanel';
+  import { ConnectionStatus } from '../../../../../../core/assets/src/views/sync/SelectDeviceModalGroup/constants';
   import { KolibriStudioId } from '../../constants';
   import useCardViewStyle from '../../composables/useCardViewStyle';
   import useContentLink from '../../composables/useContentLink';
@@ -404,10 +405,13 @@
         return this.windowIsSmall ? 3 : 7;
       },
       devicesWithChannels() {
-        //display Kolibri studio for superusers only
         return cloneDeep(this.devices).filter(device => {
+          const connectionStatus = device['connection_status'];
+          const unallowedStatuses = [ConnectionStatus.Conflict, ConnectionStatus.ConnectionFailure];
+          const connectionIsOkay = !unallowedStatuses.includes(connectionStatus);
+
           device['channels'] = device.channels?.slice(0, this.channelsToDisplay);
-          return device.channels?.length > 0;
+          return device.channels?.length > 0 && connectionIsOkay;
         });
       },
       devicesWithChannelsExist() {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -404,7 +404,6 @@
         return this.windowIsSmall ? 3 : 7;
       },
       devicesWithChannels() {
-        console.log(this.devices);
         return cloneDeep(this.devices).filter(device => {
           device['channels'] = device.channels?.slice(0, this.channelsToDisplay);
           return device.channels?.length > 0 && Boolean(device['available']);

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -255,7 +255,6 @@
   import { currentLanguage } from 'kolibri.utils.i18n';
   import SidePanelModal from '../SidePanelModal';
   import SearchFiltersPanel from '../SearchFiltersPanel';
-  import { ConnectionStatus } from '../../../../../../core/assets/src/views/sync/SelectDeviceModalGroup/constants';
   import { KolibriStudioId } from '../../constants';
   import useCardViewStyle from '../../composables/useCardViewStyle';
   import useContentLink from '../../composables/useContentLink';
@@ -405,13 +404,10 @@
         return this.windowIsSmall ? 3 : 7;
       },
       devicesWithChannels() {
+        console.log(this.devices);
         return cloneDeep(this.devices).filter(device => {
-          const connectionStatus = device['connection_status'];
-          const unallowedStatuses = [ConnectionStatus.Conflict, ConnectionStatus.ConnectionFailure];
-          const connectionIsOkay = !unallowedStatuses.includes(connectionStatus);
-
           device['channels'] = device.channels?.slice(0, this.channelsToDisplay);
-          return device.channels?.length > 0 && connectionIsOkay;
+          return device.channels?.length > 0 && Boolean(device['available']);
         });
       },
       devicesWithChannelsExist() {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr filters out all devices with Conflict and ConnectionFailure connection statuses displayed on the **Library Page** and **Explore Libraries** pages.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/11139

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- The **Library** and **Explore Libraries** pages should not contain devices with statuses  `Conflict` and `ConnectionFailure`. You will need to inspect the logs alongside the displayed channels.
- Check that introduced code has not regressed the **Library Page** and **Explore Libraries** pages.

To test, restrict access to port 8080;
**On Ubuntu:**
```
# first delete any allow rule
sudo ufw delete allow 8080
# test
# then re-allow access
sudo ufw allow 8080
```

**On WIndows:**
- Click "Start | Control Panel | System and Security | Windows Firewall."
- Select "Advanced Settings." Click "Inbound Rules" to block an inbound port; click "Outbound Rules" to block an outbound port.
- Select "New Rule." Choose "Port" from the options and then click "Next."
- Choose "TCP" or "UDP," depending on which protocol the port uses. Click "Specific Local Ports."
- Enter the port number or numbers into the available field; separate multiple numbers with a comma (e.g., "80, 20, 443"). Click "Next."
- Click "Block the Connection," then "Next." Choose which network location or locations – public, private or domain – the rule applies to and then click "Next."
- Create a name for the rule and enter an optional description. Click "Finish" to block the ports on the computer.
- Remember to re-enable the port once testing is done.

**On Mac:**
- Follow [this link](https://support.apple.com/en-tm/guide/mac-help/mh34041/mac)
- Remember to re-enable the port once testing is done.
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
