### PR TITLE
utils: Ignore path errors when importing plugins for i18n

### DIFF
--- a/kolibri/utils/i18n.py
+++ b/kolibri/utils/i18n.py
@@ -23,7 +23,7 @@ def get_installed_app_locale_path(appname):
 
         if os.path.isdir(module_locale_path):
             return module_locale_path
-    except ImportError:
+    except (ImportError, TypeError):
         pass
     return None
 


### PR DESCRIPTION
Fixes:
```
$ kolibri plugin list
INFO     2023-08-22 13:19:35,023 Option DEBUG in section [Server] being overridden by environment variable KOLIBRI_DEBUG
INFO     2023-08-22 13:19:35,023 Option DEBUG_LOG_DATABASE in section [Server] being overridden by environment variable KOLIBRI_DEBUG_LOG_DATABASE
kolibri_explore_plugin
<module 'kolibri_explore_plugin' (<_frozen_importlib_external.NamespaceLoader object at 0x7fb4ccdac1d0>)>
None
Traceback (most recent call last):
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/bin/kolibri", line 33, in <module>
    sys.exit(load_entry_point('kolibri', 'console_scripts', 'kolibri')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/utils/cli.py", line 172, in invoke
    return super(KolibriGroupCommand, self).invoke(ctx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/utils/cli.py", line 453, in list
    max_name_len = max((len(plugin.name(lang)) for plugin in plugins))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/utils/cli.py", line 453, in <genexpr>
    max_name_len = max((len(plugin.name(lang)) for plugin in plugins))
                            ^^^^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/plugins/coach/kolibri_plugin.py", line 28, in name
    with translation.override(lang):
  File "/home/philip/Projects/kolibri/kolibri/utils/translation.py", line 116, in __enter__
    self.old_language = get_language()
                        ^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/utils/translation.py", line 58, in wrapped
    return getattr(django_translation_module, fn.__name__)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/django/utils/translation/__init__.py", line 195, in get_language
    return _trans.get_language()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/django/utils/translation/__init__.py", line 59, in __getattr__
    if settings.USE_I18N:
       ^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/django/conf/__init__.py", line 41, in _setup
    self._wrapped = Settings(settings_module)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/.local/bin/pyenv.git/versions/kolibri-py3.9/lib/python3.11/site-packages/django/conf/__init__.py", line 110, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/philip/Projects/kolibri/kolibri/deployment/default/settings/base.py", line 422, in <module>
    apply_settings(sys.modules[__name__])
  File "/home/philip/Projects/kolibri/kolibri/plugins/utils/settings.py", line 133, in apply_settings
    _apply_base_settings(plugin_instance, settings_module)
  File "/home/philip/Projects/kolibri/kolibri/plugins/utils/settings.py", line 106, in _apply_base_settings
    ) and i18n.get_installed_app_locale_path(plugin_instance.module_path):
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/philip/Projects/kolibri/kolibri/utils/i18n.py", line 24, in get_installed_app_locale_path
    module_path = os.path.dirname(m.__file__)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 152, in dirname
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
