### PR TITLE
Fix tab styles on large and medium-large topics pages

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
@@ -5,7 +5,7 @@
     class="tab-block"
     :style="{
       backgroundColor: $themeTokens.surface,
-      borderBottom: `1px solid ${$themeTokens.fineLine}`
+      borderBottom: `1px solid ${$themeTokens.fineLine}`,
     }"
   >
     <router-link
@@ -13,7 +13,11 @@
       :to="foldersLink"
       class="header-tab"
       :activeClass="activeTabClasses"
-      :style="{ color: $themeTokens.annotation }"
+      :style="{
+        color: $themeTokens.annotation,
+        marginLeft: (width > 234) ? '12px' : '0',
+        marginRight: (width > 234) ? '12px' : '0',
+      }"
       :replace="true"
       :class="defaultTabStyles"
     >
@@ -27,7 +31,11 @@
       :to="topics.length ? searchTabLink : {}"
       class="header-tab"
       :activeClass="activeTabClasses"
-      :style="{ color: $themeTokens.annotation }"
+      :style="{
+        color: $themeTokens.annotation,
+        marginLeft: width > 234 ? '12px' : '0',
+        marginRight: width > 234 ? '12px' : '0',
+      }"
       :replace="true"
       :class="defaultTabStyles"
     >
@@ -59,6 +67,10 @@
         default() {
           return [];
         },
+      },
+      width: {
+        type: Number,
+        required: true,
       },
     },
     computed: {
@@ -124,7 +136,6 @@
     max-width: 100%;
     min-height: 36px;
     padding: 0 12px;
-    margin: 0 12px;
     overflow: hidden;
     font-size: 14px;
     font-weight: bold;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -42,7 +42,7 @@
               v-if="!!windowIsLarge"
               :topic="topic"
               :topics="topics"
-              :style="tabPosition"
+              :width="sidePanelWidth"
             />
             <SearchFiltersPanel
               v-if="!!windowIsLarge && searchActive"
@@ -353,7 +353,6 @@
     data: function() {
       return {
         sidePanelStyleOverrides: {},
-        tabPosition: {},
         showMoreResources: false,
         sidePanelIsOpen: false,
         metadataSidePanelContent: null,


### PR DESCRIPTION
## Summary
Small fix to update tab styles on medium-large page sizes (i.e. narrow search and filter panel) on the Topics page

## References
Fixes [#10904](https://github.com/learningequality/kolibri/issues/10904)

It does not address the recommendation to use `TextTruncator` in the placeholder, because currently we are making use of the semantic `input` and I think this might be a more complicated recommendation than @thanksameeelian was intending, although I think it's a great idea.

## Reviewer guidance
Preview the tabs on a full-desktop, and medium-large (i.e. making the window smaller) screen. The tab spacing should shift to make the tabs aligned with the sidebar, rather than "hanging over"

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
