### PR TITLE
Add conditional display of device plugin facility tab

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceManagementSideNavEntry.js
@@ -14,39 +14,45 @@ const sideNavConfig = {
     return urls['kolibri:kolibri.plugins.device:device_management']();
   },
   get routes() {
-    const { canManageContent, isSuperuser } = useUser();
+    const { canManageContent, isSuperuser, isLearnerOnlyImport } = useUser();
     const routes = [];
-    if (get(canManageContent) || get(isSuperuser)) {
-      routes.push({
+    const routeDefs = [
+      {
         label: coreStrings.$tr('channelsLabel'),
         route: baseRoutes.content.path,
         name: baseRoutes.content.name,
-      });
-    }
-    if (get(isSuperuser)) {
-      routes.push(
-        {
-          label: deviceString('permissionsLabel'),
-          route: baseRoutes.permissions.path,
-          name: baseRoutes.permissions.name,
-        },
-        {
-          label: coreStrings.$tr('facilitiesLabel'),
-          route: baseRoutes.facilities.path,
-          name: baseRoutes.facilities.name,
-        },
-        {
-          label: coreStrings.$tr('infoLabel'),
-          route: baseRoutes.info.path,
-          name: baseRoutes.info.name,
-        },
-        {
-          label: coreStrings.$tr('settingsLabel'),
-          route: baseRoutes.settings.path,
-          name: baseRoutes.settings.name,
-        }
-      );
-    }
+        condition: get(canManageContent) || get(isSuperuser),
+      },
+      {
+        label: coreStrings.$tr('facilitiesLabel'),
+        route: baseRoutes.facilities.path,
+        name: baseRoutes.facilities.name,
+        condition: get(isSuperuser) && !get(isLearnerOnlyImport),
+      },
+      {
+        label: deviceString('permissionsLabel'),
+        route: baseRoutes.permissions.path,
+        name: baseRoutes.permissions.name,
+        condition: get(isSuperuser),
+      },
+      {
+        label: coreStrings.$tr('infoLabel'),
+        route: baseRoutes.info.path,
+        name: baseRoutes.info.name,
+        condition: get(isSuperuser),
+      },
+      {
+        label: coreStrings.$tr('settingsLabel'),
+        route: baseRoutes.settings.path,
+        name: baseRoutes.settings.name,
+        condition: get(isSuperuser),
+      },
+    ];
+    routeDefs.forEach(routeDef => {
+      if (routeDef.condition) {
+        routes.push(routeDef);
+      }
+    });
     return routes;
   },
   get label() {

--- a/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceTopNav.vue
@@ -22,45 +22,51 @@
     },
     mixins: [commonCoreStrings, commonDeviceStrings],
     computed: {
-      ...mapGetters(['canManageContent', 'isSuperuser']),
+      ...mapGetters(['canManageContent', 'isSuperuser', 'isLearnerOnlyImport']),
       links() {
         const list = [];
-        if (this.canManageContent) {
-          list.push({
+        const linkDefs = [
+          {
             title: this.coreString('channelsLabel'),
             link: this.$router.getRoute('MANAGE_CONTENT_PAGE'),
             icon: 'channel',
             color: this.$themeTokens.textInverted,
-          });
-        }
-        if (this.isSuperuser) {
-          list.push([
-            {
-              title: this.deviceString('permissionsLabel'),
-              link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
-              icon: 'permissions',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.coreString('facilitiesLabel'),
-              link: this.$router.getRoute('FACILITIES_PAGE'),
-              icon: 'facility',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.coreString('infoLabel'),
-              link: this.$router.getRoute('DEVICE_INFO_PAGE'),
-              icon: 'deviceInfo',
-              color: this.$themeTokens.textInverted,
-            },
-            {
-              title: this.coreString('settingsLabel'),
-              link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
-              icon: 'settings',
-              color: this.$themeTokens.textInverted,
-            },
-          ]);
-        }
+            condition: this.canManageContent,
+          },
+          {
+            title: this.deviceString('permissionsLabel'),
+            link: this.$router.getRoute('MANAGE_PERMISSIONS_PAGE'),
+            icon: 'permissions',
+            color: this.$themeTokens.textInverted,
+            condition: this.isSuperuser,
+          },
+          {
+            title: this.coreString('facilitiesLabel'),
+            link: this.$router.getRoute('FACILITIES_PAGE'),
+            icon: 'facility',
+            color: this.$themeTokens.textInverted,
+            condition: this.isSuperuser && !this.isLearnerOnlyImport,
+          },
+          {
+            title: this.coreString('infoLabel'),
+            link: this.$router.getRoute('DEVICE_INFO_PAGE'),
+            icon: 'deviceInfo',
+            color: this.$themeTokens.textInverted,
+            condition: this.isSuperuser,
+          },
+          {
+            title: this.coreString('settingsLabel'),
+            link: this.$router.getRoute('DEVICE_SETTINGS_PAGE'),
+            icon: 'settings',
+            color: this.$themeTokens.textInverted,
+            condition: this.isSuperuser,
+          },
+        ];
+        linkDefs.forEach(linkDefs => {
+          if (linkDefs.condition) {
+            list.push(linkDefs);
+          }
+        });
         return list.flat();
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR hides the Device plugin facility tab if the user is imported as a subset of users.
-`isLearnerOnlyImport` from composable `useUser` is used to conditionally display the facility tab

Side and top navigation for users imported as subset of users on learn only devices
![Screenshot 2023-09-08 at 10 23 43 AM](https://github.com/learningequality/kolibri/assets/46411498/897b9a24-e489-40c6-a09a-0e140de07396)
![Screenshot 2023-09-08 at 10 24 17 AM](https://github.com/learningequality/kolibri/assets/46411498/7004131c-2d7e-4049-96b1-80da7b26b4ec)

## References

<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #11210 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Go through 'LOD> Import one or more existing user accounts from an existing facility' user flow
2. The side and top navigation under the Device plugin should not include the `Facility` tab

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
