### PR TITLE
Fix global loading state on root Coach pages

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -28,6 +28,7 @@ class CoachToolsModule extends KolibriApp {
         redirectBrowser();
         return;
       }
+      this.store.dispatch('loading');
       const promises = [];
       // Clear the snackbar at every navigation to prevent it from re-appearing
       // when the next page component mounts.

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -26,7 +26,8 @@ export default [
     path: '/classes',
     component: CoachClassListPage,
     handler(toRoute) {
-      store.dispatch('loading');
+      // loading state is handled locally
+      store.dispatch('notLoading');
       // if user only has access to one facility, facility_id will not be accessible from URL,
       // but always defaulting to userFacilityId would cause problems for multi-facility admins
       const facilityId = toRoute.query.facility_id || store.getters.userFacilityId;
@@ -41,7 +42,6 @@ export default [
             });
             return;
           }
-          store.dispatch('notLoading');
         },
         error => store.dispatch('handleApiError', { error, reloadOnReconnect: true })
       );


### PR DESCRIPTION
## Summary

- Removes global loader from the Coach Classes page since there is already the local one
- Fixes missing global loader on root Coach pages and tabs

See commit messages for more details.

| Before | After |
| -------- | ------ |
| ![coach-before](https://github.com/learningequality/kolibri/assets/13509191/2f293fac-87e3-4a8d-a6af-75b3c9290b44) | ![coach-after](https://github.com/learningequality/kolibri/assets/13509191/72517fa4-1ee6-4537-985b-7120841ecafa) |

## Comments

Further improvements in the Coach loading states and navigation overall are needed. See https://github.com/learningequality/kolibri/issues/11219.

## References

Closes https://github.com/learningequality/kolibri/issues/10729

## Reviewer guidance

On slow network, navigate the root Coach pages and tabs

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
