### PR TITLE
update coach routing

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -41,7 +41,8 @@ class CoachToolsModule extends KolibriApp {
           to.name
         )
       ) {
-        promises.push(this.store.dispatch('initClassInfo', to.params.classId));
+        if (to.params.classId)
+          promises.push(this.store.dispatch('initClassInfo', to.params.classId));
       } else {
         this.store.dispatch('coachNotifications/stopPolling');
       }

--- a/kolibri/plugins/coach/assets/src/routes/baseRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/baseRoutes.js
@@ -7,15 +7,15 @@ export default {
   },
   classHome: {
     name: PageNames.HOME_PAGE,
-    path: '/:classId/home',
+    path: '/:classId?/home',
   },
   plan: {
     name: PageNames.PLAN_PAGE,
-    path: '/:classId/plan',
-    redirect: '/:classId/plan/lessons',
+    path: '/:classId?/plan',
+    redirect: '/:classId?/plan/lessons',
   },
   reports: {
     name: PageNames.REPORTS_PAGE,
-    path: '/:classId/reports',
+    path: '/:classId?/reports',
   },
 };

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -26,7 +26,7 @@ export default [
     },
   },
   {
-    path: '/:facility_id?/classes',
+    path: '/:subtopicName?/:facility_id?/classes',
     component: CoachClassListPage,
     props: true,
     handler(toRoute) {

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -18,7 +18,7 @@ export default [
   ...reportRoutes,
   {
     name: 'AllFacilitiesPage',
-    path: '/:subtopicName?/facilities',
+    path: '/facilities/:subtopicName?',
     component: AllFacilitiesPage,
     props: true,
     handler() {
@@ -26,7 +26,7 @@ export default [
     },
   },
   {
-    path: '/:subtopicName?/:facility_id?/classes',
+    path: '/:facility_id?/classes/:subtopicName?',
     component: CoachClassListPage,
     props: true,
     handler(toRoute) {

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -12,31 +12,44 @@ import { PageNames } from '../constants';
 import reportRoutes from './reportRoutes';
 import planRoutes from './planRoutes';
 
+function classIdParamRequiredGuard(toRoute, subtopicName) {
+  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
+    router.replace({
+      name: 'AllFacilitiesPage',
+      params: { subtopicName },
+    });
+    return true;
+  }
+}
+
 export default [
   ...planRoutes,
   ...reportRoutes,
   {
-    path: '/facilities',
+    name: 'AllFacilitiesPage',
+    path: '/:subtopicName?/facilities',
     component: AllFacilitiesPage,
+    props: true,
     handler() {
       store.dispatch('notLoading');
     },
   },
   {
-    path: '/classes',
+    path: '/:facility_id?/classes',
     component: CoachClassListPage,
+    props: true,
     handler(toRoute) {
       store.dispatch('loading');
       // if user only has access to one facility, facility_id will not be accessible from URL,
       // but always defaulting to userFacilityId would cause problems for multi-facility admins
-      const facilityId = toRoute.query.facility_id || store.getters.userFacilityId;
+      const facilityId = toRoute.params.facility_id || store.getters.userFacilityId;
       store.dispatch('setClassList', facilityId).then(
         () => {
           if (!store.getters.classListPageEnabled) {
-            // If no class list page, redirect to
-            // the first (and only) class.
+            // If no class list page, redirect to the first (and only) class and
+            // to the originally-selected subtopic, if available
             router.replace({
-              name: HomePage.name,
+              name: toRoute.params.subtopicName || HomePage.name,
               params: { classId: store.state.classList[0].id },
             });
             return;
@@ -52,9 +65,12 @@ export default [
   },
   {
     name: PageNames.HOME_PAGE,
-    path: '/:classId/home',
+    path: '/:classId?/home',
     component: HomePage,
-    handler() {
+    handler: toRoute => {
+      if (classIdParamRequiredGuard(toRoute, HomePage.name)) {
+        return;
+      }
       store.dispatch('notLoading');
     },
     meta: {
@@ -71,7 +87,6 @@ export default [
       titleParts: ['activityLabel', 'CLASS_NAME'],
     },
   },
-
   {
     name: ClassesPageNames.CLASS_LEARNERS_LIST_VIEWER,
     path: '/:classId/learners',

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -11,16 +11,7 @@ import { ClassesPageNames } from '../../../../learn/assets/src/constants';
 import { PageNames } from '../constants';
 import reportRoutes from './reportRoutes';
 import planRoutes from './planRoutes';
-
-function classIdParamRequiredGuard(toRoute, subtopicName) {
-  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
-    router.replace({
-      name: 'AllFacilitiesPage',
-      params: { subtopicName },
-    });
-    return true;
-  }
-}
+import { classIdParamRequiredGuard } from './utils';
 
 export default [
   ...planRoutes,

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -1,5 +1,4 @@
 import store from 'kolibri.coreVue.vuex.store';
-import router from 'kolibri.coreVue.router';
 import {
   showLessonResourceContentPreview,
   showLessonResourceSelectionRootPage,
@@ -20,6 +19,7 @@ import LessonResourceSelectionPage from '../views/plan/LessonResourceSelectionPa
 import PlanLessonSelectionContentPreview from '../views/plan/PlanLessonSelectionContentPreview';
 import LessonEditDetailsPage from '../views/plan/LessonEditDetailsPage';
 import LessonCreationPage from '../views/plan/LessonCreationPage';
+import { classIdParamRequiredGuard } from './utils';
 
 const CLASS = '/:classId?/plan';
 const LESSON = '/lessons/:lessonId';
@@ -34,16 +34,6 @@ function path(...args) {
 }
 
 const { showLessonsRootPage } = useLessons();
-
-function classIdParamRequiredGuard(toRoute, subtopicName) {
-  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
-    router.replace({
-      name: 'AllFacilitiesPage',
-      params: { subtopicName },
-    });
-    return true;
-  }
-}
 
 export default [
   {

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -1,4 +1,5 @@
 import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
 import {
   showLessonResourceContentPreview,
   showLessonResourceSelectionRootPage,
@@ -20,7 +21,7 @@ import PlanLessonSelectionContentPreview from '../views/plan/PlanLessonSelection
 import LessonEditDetailsPage from '../views/plan/LessonEditDetailsPage';
 import LessonCreationPage from '../views/plan/LessonCreationPage';
 
-const CLASS = '/:classId/plan';
+const CLASS = '/:classId?/plan';
 const LESSON = '/lessons/:lessonId';
 const ALL_LESSONS = '/lessons';
 const SELECTION = '/selection';
@@ -34,12 +35,25 @@ function path(...args) {
 
 const { showLessonsRootPage } = useLessons();
 
+function classIdParamRequiredGuard(toRoute, subtopicName) {
+  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
+    router.replace({
+      name: 'AllFacilitiesPage',
+      params: { subtopicName },
+    });
+    return true;
+  }
+}
+
 export default [
   {
     name: LessonsPageNames.PLAN_LESSONS_ROOT,
     path: path(CLASS, ALL_LESSONS),
     component: LessonsRootPage,
     handler(toRoute) {
+      if (classIdParamRequiredGuard(toRoute, 'PLAN_PAGE')) {
+        return;
+      }
       showLessonsRootPage(store, toRoute.params.classId);
     },
     meta: {

--- a/kolibri/plugins/coach/assets/src/routes/planRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planRoutes.js
@@ -14,8 +14,8 @@ export default [
   ...planExamRoutes,
   {
     name: PageNames.PLAN_PAGE,
-    path: '/:classId/plan',
-    redirect: '/:classId/plan/lessons',
+    path: '/:classId?/plan',
+    redirect: '/:classId?/plan/lessons',
   },
   {
     name: GroupsPage.name,

--- a/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
@@ -1,5 +1,4 @@
 import store from 'kolibri.coreVue.vuex.store';
-import router from 'kolibri.coreVue.router';
 import { PageNames } from '../constants';
 import pages from '../views/reports/allReportsPages';
 import {
@@ -15,6 +14,7 @@ import { generateQuestionListHandler } from '../modules/questionList/handlers';
 import { generateResourceHandler } from '../modules/resourceDetail/handlers';
 import LessonEditDetailsPage from '../views/plan/LessonEditDetailsPage';
 import QuizEditDetailsPage from '../views/plan/QuizEditDetailsPage';
+import { classIdParamRequiredGuard } from './utils';
 
 const ACTIVITY = '/activity';
 const CLASS = '/:classId?/reports';
@@ -40,16 +40,6 @@ function path(...args) {
 
 function defaultHandler() {
   store.dispatch('notLoading');
-}
-
-function classIdParamRequiredGuard(toRoute, subtopicName) {
-  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
-    router.replace({
-      name: 'AllFacilitiesPage',
-      params: { subtopicName },
-    });
-    return true;
-  }
 }
 
 export default [

--- a/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
@@ -1,4 +1,5 @@
 import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
 import { PageNames } from '../constants';
 import pages from '../views/reports/allReportsPages';
 import {
@@ -16,7 +17,7 @@ import LessonEditDetailsPage from '../views/plan/LessonEditDetailsPage';
 import QuizEditDetailsPage from '../views/plan/QuizEditDetailsPage';
 
 const ACTIVITY = '/activity';
-const CLASS = '/:classId/reports';
+const CLASS = '/:classId?/reports';
 const GROUPS = '/groups';
 const GROUP = '/groups/:groupId';
 const LEARNERS = '/learners';
@@ -39,6 +40,16 @@ function path(...args) {
 
 function defaultHandler() {
   store.dispatch('notLoading');
+}
+
+function classIdParamRequiredGuard(toRoute, subtopicName) {
+  if (store.getters.userIsMultiFacilityAdmin && !toRoute.params.classId) {
+    router.replace({
+      name: 'AllFacilitiesPage',
+      params: { subtopicName },
+    });
+    return true;
+  }
 }
 
 export default [
@@ -445,7 +456,13 @@ export default [
   {
     path: path(CLASS, LESSONS),
     component: pages.ReportsLessonListPage,
-    handler: defaultHandler,
+    handler: toRoute => {
+      if (classIdParamRequiredGuard(toRoute, 'ReportsLessonListPage')) {
+        return;
+      }
+      defaultHandler();
+    },
+
     meta: {
       titleParts: ['lessonsLabel', 'CLASS_NAME'],
     },

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -3,17 +3,14 @@ import router from 'kolibri.coreVue.router';
 
 export function classIdParamRequiredGuard(toRoute, subtopicName) {
   if (!toRoute.params.classId) {
-    if (store.getters.userIsMultiFacilityAdmin) {
-      router.replace({
-        name: 'AllFacilitiesPage',
-        params: { subtopicName },
-      });
-      return true;
-    } else {
-      router.replace({
-        name: 'CoachClassListPage',
-        params: { subtopicName },
-      });
-    }
+    const redirectPage = store.getters.userIsMultiFacilityAdmin
+      ? 'AllFacilitiesPage'
+      : 'CoachClassListPage';
+
+    router.replace({
+      name: redirectPage,
+      params: { subtopicName },
+    });
+    return true;
   }
 }

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -1,0 +1,19 @@
+import store from 'kolibri.coreVue.vuex.store';
+import router from 'kolibri.coreVue.router';
+
+export function classIdParamRequiredGuard(toRoute, subtopicName) {
+  if (!toRoute.params.classId) {
+    if (store.getters.userIsMultiFacilityAdmin) {
+      router.replace({
+        name: 'AllFacilitiesPage',
+        params: { subtopicName },
+      });
+      return true;
+    } else {
+      router.replace({
+        name: 'CoachClassListPage',
+        params: { subtopicName },
+      });
+    }
+  }
+}

--- a/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/AllFacilitiesPage.vue
@@ -53,27 +53,35 @@
       CoreTable,
     },
     mixins: [commonCoach, commonCoreStrings],
+    props: {
+      subtopicName: {
+        type: String,
+        required: false,
+        default: null,
+      },
+    },
     computed: {
       facilities() {
         return this.$store.state.core.facilities;
       },
     },
     beforeMount() {
-      // Redirect to single-facility landing page if user/device isn't supposed
-      // to manage multiple facilities
       if (!this.$store.getters.userIsMultiFacilityAdmin) {
-        this.$router.replace(this.coachClassListPageLink());
+        const singleFacility = { id: this.$store.getters.userFacilityId };
+        this.$router.replace(this.coachClassListPageLink(singleFacility));
       }
     },
     methods: {
       coachClassListPageLink(facility) {
-        const query = {};
+        const params = {};
         if (facility) {
-          query.facility_id = facility.id;
+          params.facility_id = facility.id;
         }
+        params.subtopicName = this.subtopicName;
+
         return {
           name: 'CoachClassListPage',
-          query,
+          params,
         };
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -43,7 +43,7 @@
               <td>
                 <KRouterLink
                   :text="classObj.name"
-                  :to="$router.getRoute('HomePage', { classId: classObj.id })"
+                  :to="$router.getRoute(getNextPageName, { classId: classObj.id })"
                   icon="classes"
                 />
               </td>
@@ -78,6 +78,13 @@
       CoachAppBarPage,
     },
     mixins: [commonCoach, commonCoreStrings],
+    props: {
+      subtopicName: {
+        type: String,
+        required: false,
+        default: null,
+      },
+    },
     computed: {
       ...mapGetters(['isAdmin', 'isClassCoach', 'isFacilityCoach', 'userIsMultiFacilityAdmin']),
       ...mapState(['classList', 'dataLoading']),
@@ -99,16 +106,20 @@
         const facilityUrl = urls['kolibri:kolibri.plugins.facility:facility_management'];
         if (facilityUrl) {
           if (this.userIsMultiFacilityAdmin) {
-            return `${facilityUrl()}#/${this.$route.query.facility_id}/classes`;
+            return `${facilityUrl()}#/${this.$route.params.facility_id}/classes`;
           }
           return facilityUrl();
         }
 
         return '';
       },
+      getNextPageName() {
+        return this.subtopicName || 'HomePage';
+      },
       appBarTitle() {
         let facilityName;
-        const { facility_id } = this.$route.query;
+        const { facility_id } = this.$route.params;
+
         if (facility_id) {
           const match = find(this.$store.state.core.facilities, { id: facility_id }) || {};
           facilityName = match.name;

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -79,7 +79,7 @@
         if (this.$store.getters.userIsMultiFacilityAdmin) {
           facility_id = this.$store.state.classSummary.facility_id;
         }
-        return this.$router.getRoute('CoachClassListPage', {}, { facility_id });
+        return this.$router.getRoute('CoachClassListPage', { facility_id });
       },
       classLearnersListRoute() {
         const { query } = this.$route;

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -4,7 +4,7 @@
     <p>
       <BackLink
         v-if="classListPageEnabled || userIsMultiFacilityAdmin"
-        :to="$router.getRoute('HomePage')"
+        :to="$router.getRoute('HomePage', { classId: this.$route.params.classId })"
         :text="coreString('classHome')"
       />
     </p>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -4,7 +4,7 @@
     <p>
       <BackLink
         v-if="classListPageEnabled || userIsMultiFacilityAdmin"
-        :to="$router.getRoute('HomePage')"
+        :to="$router.getRoute('HomePage', { classId: this.$route.params.classId })"
         :text="coreString('classHome')"
       />
     </p>


### PR DESCRIPTION
## Summary
this PR updates routing in `Coach`, making it more parallel to `Facility` in terms of its behavior upon subtopic selection in the sidenav. 

previously, if a user was working elsewhere in kolibri and selected a `Coach` subtopic from the sidenav, we'd only retain & apply that subtopic information if they had a single facility holding single class. otherwise, they'd be redirected to `All Facilities` or `All Classes` as appropriate and, once making the necessary selection, would be redirected to the class they wanted, but always to the home page regardless of their initially chosen subtopic.

with the changes introduced here, now if a user selects a subtopic in the sidenav, that subtopic information will persist within the url as the user selects a facility and/or specific class, and once class selection is made the user is redirected to that selected subtopic, rather than the home page by default. 

## References
fixes #10650 
fixes #10855 

## Reviewer guidance

there are four cases to be considered:
1. multi-facility user, in a facility with one class
2. multi-facility user, in a facility with multiple classes
3. single facility user, in a facility with one class
4. single facility user, in a facility with multiple classes

for each case, 
- from another plugin in kolibri, select a `Coach` subtopic - `Plan` or `Reports` will show the changed behavior
- navigation should behave as normal for the case you are testing - a redirect to "All facilities" and/or "All classes" as needed to winnow down class selection
- the subtopic initially selected should persist within the current page's url & also be included in the facility- or class-specific links on the "All facilities" and "All classes" pages
- once class selection is made, user should be redirected to the subtopic initially selected (rather than "Class home," as was previously always the case)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
