### PR TITLE
kolibri-tools: Add support for pyproject.toml

### DIFF
--- a/packages/kolibri-tools/lib/i18n/utils.py
+++ b/packages/kolibri-tools/lib/i18n/utils.py
@@ -138,13 +138,19 @@ def json_dump_formatted(data, file_path, file_name):
 
 def read_config_file():
     output = {}
-    config_file = os.path.join(os.getcwd(), "setup.cfg")
+    config_file = os.path.join(os.getcwd(), "pyproject.toml")
+    section_name = "tool.kolibri.i18n"
+
+    if not os.path.exists(config_file):
+        config_file = os.path.join(os.getcwd(), "setup.cfg")
+        section_name = "kolibri:i18n"
+
     if os.path.exists(config_file):
         config = configparser.ConfigParser()
         config.read(config_file)
-        if "kolibri:i18n" in config:
-            for key in config["kolibri:i18n"]:
-                output[key] = config["kolibri:i18n"][key]
+        if section_name in config:
+            for key in config[section_name]:
+                output[key] = config[section_name][key]
     return output
 
 

--- a/packages/kolibri-tools/package.json
+++ b/packages/kolibri-tools/package.json
@@ -83,6 +83,7 @@
     "stylelint-scss": "5.1.0",
     "temp": "^0.8.3",
     "terser-webpack-plugin": "^5.3.9",
+    "toml": "^3.0.0",
     "url-loader": "^4.1.1",
     "vue-jest": "^3.0.0",
     "vue-loader": "^15.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11072,6 +11072,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 toposort-class@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toposort-class/-/toposort-class-1.0.1.tgz#7ffd1f78c8be28c3ba45cd4e1a3f5ee193bd9988"


### PR DESCRIPTION
## Summary

kolibri-tools currently hard-codes a search for a Python-style `setup.cfg` in the project’s directory, to load locale configuration from.

As per PEP-621, `pyproject.toml` is now a recommended replacement for `setup.cfg`, though both are going to be supported for a while. A number of tools now support `pyproject.toml`, and others don’t.

This commit adds support for `pyproject.toml` to `kolibri-tools`, using it in preference to `setup.cfg`, but falling back to the latter if the former doesn’t exist. It doesn’t attempt to load some keys from one file and some from the other: it’s all or nothing.

This allows for i18n configuration to now be specified in `pyproject.toml` something like this:
```
[tool.kolibri.i18n]
project = "kolibri_explore_plugin"
locale_data_folder = "kolibri_explore_plugin/locale"
\# Glob to exclude node_modules and static folders
ignore = ["**/node_modules/**", "**/static/**"]
```

This differs slightly from the equivalent in `setup.cfg`, as:
 - `pyproject.toml` conventions require a section name prefixed by `tool.`.
 - TOML allows for more strongly typed values.

It adds a dependency on the node `toml` module.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://github.com/learningequality/kolibri/issues/11146

## References

https://github.com/learningequality/kolibri/issues/11146

## Reviewer guidance

 * Adds a new dependency.
 * Is it OK to do all-or-nothing loading? If `pyproject.toml` exists, then the i18n keys must be specified there; fallback to `setup.cfg` will only happen if `pyproject.toml` doesn’t exist.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
