### PR TITLE
Handle partially imported channels in the device plugin

### DIFF
--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -609,6 +609,14 @@ class NaiveImportTestBase(ContentNodeTestBase):
         channel.refresh_from_db()
         self.assertEqual(channel.version, channel_version)
 
+    def test_update_current_partial(self):
+        channel = ChannelMetadata.objects.first()
+        channel.partial = True
+        channel.save()
+        self.set_content_fixture()
+        channel.refresh_from_db()
+        self.assertFalse(channel.partial)
+
     def test_localfile_available_remain_after_import(self):
         local_file = LocalFile.objects.get(pk="9f9438fe6b0d42dd8e913d7d04cfb2b2")
         local_file.available = True

--- a/kolibri/plugins/device/api.py
+++ b/kolibri/plugins/device/api.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.db.models import Case
 from django.db.models import When
+from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.exceptions import ParseError
@@ -87,10 +88,18 @@ class DeviceChannelMetadataSerializer(ChannelMetadataSerializer):
         return value
 
 
+class DeviceChannelMetadataFilter(ChannelMetadataFilter):
+    partial = BooleanFilter(field_name="partial", label="Partial")
+
+    class Meta:
+        model = ChannelMetadata
+        fields = ("partial", "available", "has_exercise")
+
+
 class DeviceChannelMetadataViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = DeviceChannelMetadataSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_class = ChannelMetadataFilter
+    filter_class = DeviceChannelMetadataFilter
     permission_classes = (CanManageContent,)
 
     def get_queryset(self):

--- a/kolibri/plugins/device/assets/src/modules/wizard/apiChannelMetadata.js
+++ b/kolibri/plugins/device/assets/src/modules/wizard/apiChannelMetadata.js
@@ -2,20 +2,24 @@ import ChannelResource from '../../apiResources/deviceChannel';
 
 // Gets Metadata for Channels whose DBs have been downloaded onto the server.
 // Response includes all of the file/resource sizes.
-export function getChannelWithContentSizes(channelId) {
+export function getChannelWithContentSizes(channelId, filterPartialChannels = true) {
+  const getParams = {
+    include_fields: [
+      'total_resources',
+      'total_file_size',
+      'on_device_resources',
+      'on_device_file_size',
+      'new_resource_count',
+      'new_resource_total_size',
+    ],
+  };
+  if (filterPartialChannels) {
+    getParams.partial = false;
+  }
   return new Promise((resolve, reject) => {
     ChannelResource.fetchModel({
       id: channelId,
-      getParams: {
-        include_fields: [
-          'total_resources',
-          'total_file_size',
-          'on_device_resources',
-          'on_device_file_size',
-          'new_resource_count',
-          'new_resource_total_size',
-        ],
-      },
+      getParams,
       force: true,
     }).then(resolve, reject);
   });

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ManageChannelContentsPage/api.js
@@ -18,7 +18,7 @@ export function fetchPageData(channelId) {
     });
   return Promise.all([
     getDeviceInfo(),
-    getChannelWithContentSizes(this.channelId),
+    getChannelWithContentSizes(channelId, false),
     studioChannelPromise,
   ]).then(([deviceInfo, channel, studioChannel]) => {
     return {


### PR DESCRIPTION
## Summary
* Channels can now be partially imported which means that the device plugin might still need to import the full channel metadata even if some channel metadata is present
* Fixes this by ensuring that a partially imported channel will still be imported by a channel import task - and adds a test to be sure of this
* Also by default filters requests for a single channels metadata for `partial=false` to ensure that only fully imported channels are displayed
* Exempts the channel status display page from this, as it is just showing the currently imported channel state, so the partial import is sufficient - all other usages seem to be for importing more, so need the full metadata.

## References
Fixes [#11185](https://github.com/learningequality/kolibri/issues/11185)

Note that this slightly exacerbates the situation for [#11225](https://github.com/learningequality/kolibri/issues/11225) as it will wipe any previously annotated `admin_imported=False` from anywhere, but I am assigned to that issue too, so it's my problem to clean up there :)

## Reviewer guidance
Ensure that partially imported channels (such as that produced by learner downloads or syncing of lessons/quizzes) do not prevent additional resources being imported in those channels.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
