### PR TITLE
Hide the table when data is loading

### DIFF
--- a/kolibri/core/assets/src/views/CoreTable.vue
+++ b/kolibri/core/assets/src/views/CoreTable.vue
@@ -82,7 +82,6 @@
           });
         }
       });
-
       // If we have loaded the data, but have no empty message and no rows, we log an error.
       if (!this.dataLoading && !this.emptyMessage && !tableHasRows) {
         logging.error('CoreTable: No rows in table, but no empty message provided.');
@@ -101,7 +100,7 @@
         createElement('table', { class: 'core-table' }, [
           ...(this.$slots.default || []),
           theadEl,
-          tbodyCopy,
+          this.dataLoading ? null : tbodyCopy,
         ]),
         dataStatusEl,
       ]);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Hides the table when `this.dataLoading` is true in `coreTable.vue`

![kolibri](https://github.com/learningequality/kolibri/assets/74391865/509e4964-c0cb-45cf-aa40-2d5d5aaa47a0)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10993 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Visit the Group section under plan under Coach in Kolibri. Throttle the network to slow 3g.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
