### PR TITLE
Do general replacement for str instance checking for string_types.

### DIFF
--- a/kolibri/core/api.py
+++ b/kolibri/core/api.py
@@ -17,6 +17,7 @@ from rest_framework.serializers import UUIDField
 from rest_framework.serializers import ValidationError
 from rest_framework.status import HTTP_201_CREATED
 from rest_framework.status import HTTP_503_SERVICE_UNAVAILABLE
+from six import string_types
 
 from .utils.portal import registerfacility
 from kolibri.core.auth.models import Facility
@@ -75,7 +76,9 @@ class ValuesViewsetOrderingFilter(OrderingFilter):
         # All the fields that we have field maps defined for - this only allows for simple mapped fields
         # where the field is essentially a rename, as we have no good way of doing ordering on a field that
         # that is doing more complex function based mapping.
-        mapped_fields = {v: k for k, v in view.field_map.items() if isinstance(v, str)}
+        mapped_fields = {
+            v: k for k, v in view.field_map.items() if isinstance(v, string_types)
+        }
         # All the fields of the model
         model_fields = {f.name for f in queryset.model._meta.get_fields()}
         # Loop through every value in the view's values tuple
@@ -106,7 +109,9 @@ class ValuesViewsetOrderingFilter(OrderingFilter):
         to do filtering based on valuesviewset setup
         """
         # We filter the mapped fields to ones that do simple string mappings here, any functional maps are excluded.
-        mapped_fields = {k: v for k, v in view.field_map.items() if isinstance(v, str)}
+        mapped_fields = {
+            k: v for k, v in view.field_map.items() if isinstance(v, string_types)
+        }
         valid_fields = [
             item[0]
             for item in self.get_valid_fields(queryset, view, {"request": request})
@@ -162,7 +167,9 @@ class BaseValuesViewset(viewsets.GenericViewSet):
         model = getattr(queryset, "model", None)
         if model is None:
             return Serializer
-        mapped_fields = {v: k for k, v in self.field_map.items() if isinstance(v, str)}
+        mapped_fields = {
+            v: k for k, v in self.field_map.items() if isinstance(v, string_types)
+        }
         fields = []
         extra_kwargs = {}
         for value in self.values:

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -205,7 +205,7 @@ class ParamValidator(object):
             self.default = value
 
         elif suffix == "field":
-            if not isinstance(suffix, str):
+            if not isinstance(suffix, string_types):
                 raise AssertionError
             self.field = value
         else:

--- a/kolibri/core/discovery/utils/network/broadcast.py
+++ b/kolibri/core/discovery/utils/network/broadcast.py
@@ -87,8 +87,8 @@ class KolibriInstance(object):
     ):
         # Zeroconf wants socket.inet_aton() format, so make sure we have string with this class
         # which we convert when interfacing with Zeroconf
-        if ip is not None and not isinstance(ip, str):
-            raise TypeError("IP must be a string")
+        if ip is not None and not isinstance(ip, string_types):
+            raise TypeError("IP must be a string, not {}".format(type(ip)))
 
         self.id = instance_id
         self.zeroconf_id = instance_id

--- a/kolibri/core/discovery/utils/network/ipaddress.py
+++ b/kolibri/core/discovery/utils/network/ipaddress.py
@@ -64,7 +64,7 @@ def _is_ascii(string):
 
 
 def _is_number(x):
-    return str(x).isdigit() if not isinstance(x, str) else False
+    return str(x).isdigit() if not isinstance(x, six.string_types) else False
 
 
 def _to_bytes(n, length=1, byteorder="big"):

--- a/kolibri/plugins/utils/__init__.py
+++ b/kolibri/plugins/utils/__init__.py
@@ -11,6 +11,7 @@ from django.core.exceptions import AppRegistryNotReady
 from django.core.management import call_command
 from django.urls import reverse
 from semver import VersionInfo
+from six import string_types
 
 if sys.version_info < (3, 10):
     from importlib_metadata import entry_points
@@ -323,7 +324,7 @@ class PluginUpdateManager(object):
             )
             return
         for app in plugin_instance.INSTALLED_APPS:
-            if not isinstance(app, AppConfig) and isinstance(app, str):
+            if not isinstance(app, AppConfig) and isinstance(app, string_types):
                 app = apps.get_containing_app_config(app)
             app_configs.append(app)
         old_version = config["PLUGIN_VERSIONS"].get(plugin_name, "")

--- a/kolibri/plugins/utils/settings.py
+++ b/kolibri/plugins/utils/settings.py
@@ -3,6 +3,7 @@ import warnings
 from types import ModuleType
 
 from django.apps import AppConfig
+from six import string_types
 
 from kolibri.plugins.registry import registered_plugins
 from kolibri.plugins.utils import is_external_plugin
@@ -10,7 +11,7 @@ from kolibri.utils import i18n
 
 
 def _validate_settings_module(settings_module):
-    if isinstance(settings_module, str):
+    if isinstance(settings_module, string_types):
         try:
             return importlib.import_module(settings_module)
         except ImportError:


### PR DESCRIPTION
## Summary
* This first came up when I noticed that an instance running Python 2.7 would raise a TypeError when a new server joined the network - this was because the IP address was unicode, rather than a string.
* Did a search to check for other instances when we might be doing a py2.7 incompatible instance check and updated them all.
* Only the broadcast.py and ipaddress.py port are vital here, but it seemed worthwhile to do this as a blanket change

## Reviewer guidance
Run Kolibri on py2.7 and confirm that it no longer errors when another server joins the network.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
