### PR TITLE
Disabling additional user import until multiple user syncing is working

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -150,6 +150,9 @@
         return this.wizardService.state.context.importedUsers;
       },
       pollImportTask() {
+        if (this.wizardService.state.context.importedUsers.length > 0) {
+          this.wizardService.send('LOADING');
+        }
         TaskResource.list({ queue: SoudQueue }).then(tasks => {
           if (tasks.length) {
             tasks.forEach(task => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -32,6 +32,7 @@
               v-if="!isImported(userRow.user) && !isImporting(userRow.user)"
               :text="coreString('importAction')"
               appearance="flat-button"
+              :disabled="isImportingUserDisabled"
               @click="startImport(userRow.user)"
             />
             <KCircularLoader
@@ -91,6 +92,8 @@
         isPolling: false,
         // array of user/learner ids
         learnersBeingImported: [],
+        // To be removed
+        isImportingUserDisabled: false,
       };
     },
     inject: ['wizardService'],
@@ -140,6 +143,7 @@
     beforeMount() {
       this.isPolling = true;
       this.pollImportTask();
+      this.checkImportedUser();
     },
     methods: {
       importedLearners() {
@@ -186,6 +190,7 @@
         }
       },
       startImport(learner) {
+        this.isImportingUserDisabled = true;
         // Push the learner into being imported, we'll remove it if we get an error later on
         this.learnersBeingImported.push(learner.id);
 
@@ -207,13 +212,20 @@
         }
         TaskResource.startTask(params).catch(() => {
           this.learnersBeingImported = this.learnersBeingImported.filter(id => id != learner.id);
+          this.isImportingUserDisabled = false;
         });
       },
       isImported(learner) {
         return this.importedLearners().find(u => u === learner.username);
       },
       isImporting(learner) {
+        this.checkImportedUser(learner);
         return this.learnersBeingImported.includes(learner.id);
+      },
+      checkImportedUser(learner) {
+        if (this.learnersBeingImported.length > 0 || this.isImported(learner)) {
+          this.isImportingUserDisabled = true;
+        }
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -151,7 +151,10 @@
       },
       pollImportTask() {
         // TO DO :: This has to be removed once the multiple user syncing has been fixed.
-        if (this.wizardService.state.context.importedUsers.length > 0) {
+        if (
+          this.learnersBeingImported.length > 0 ||
+          this.wizardService.state.context.importedUsers.length > 0
+        ) {
           this.wizardService.send('LOADING');
         }
         TaskResource.list({ queue: SoudQueue }).then(tasks => {

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -150,7 +150,7 @@
         return this.wizardService.state.context.importedUsers;
       },
       pollImportTask() {
-        // TO DO :: This has to be removed once the multiple user syncing has been fixed.
+        // TODO :: This has to be removed once the multiple user syncing has been fixed.
         if (
           this.learnersBeingImported.length > 0 ||
           this.wizardService.state.context.importedUsers.length > 0

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -150,6 +150,7 @@
         return this.wizardService.state.context.importedUsers;
       },
       pollImportTask() {
+        // TO DO :: This has to be removed once the multiple user syncing has been fixed.
         if (this.wizardService.state.context.importedUsers.length > 0) {
           this.wizardService.send('LOADING');
         }

--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -35,7 +35,7 @@
       </template>
       <span v-else></span>
     </template>
-    <!-- To DO: to be roled back when multiple user syncing is working in the upcoming release -->
+    <!-- TODO: to be roled back when multiple user syncing is working in the upcoming release -->
     <!-- <KButton
       v-if="loadingTask.status === 'COMPLETED' && isImportingSoud"
       appearance="basic-link"
@@ -130,7 +130,7 @@
       isSoud() {
         return this.queue === SoudQueue;
       },
-      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // TODO: role this back when multiple user syncing is working in the upcoming release!
       // isImportingSoud() {
       //   return this.wizardService.state.context.lodImportOrJoin === LodTypePresets.IMPORT;
       // },
@@ -150,7 +150,7 @@
       this.pollTask();
     },
     methods: {
-      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // TODO: role this back when multiple user syncing is working in the upcoming release!
       // importAnother() {
       //   this.isPolling = false;
       //   this.wizardService.send('IMPORT_ANOTHER');
@@ -234,7 +234,7 @@
       },
     },
     $trs: {
-      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // TODO: role this back when multiple user syncing is working in the upcoming release!
       // importAnother: {
       //   message: 'Import another user account',
       //   context: 'Link to restart the import step for another user. ',

--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -35,12 +35,13 @@
       </template>
       <span v-else></span>
     </template>
-    <KButton
+    <!-- To DO: to be roled back when multiple user syncing is working in the upcoming release -->
+    <!-- <KButton
       v-if="loadingTask.status === 'COMPLETED' && isImportingSoud"
       appearance="basic-link"
       :text="$tr('importAnother')"
       @click="importAnother"
-    />
+    /> -->
   </OnboardingStepBase>
 
 </template>
@@ -53,7 +54,12 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { TaskResource } from 'kolibri.resources';
   import { TaskStatuses } from 'kolibri.utils.syncTaskUtils';
-  import { DeviceTypePresets, LodTypePresets, SoudQueue, FooterMessageTypes } from '../constants';
+  import {
+    DeviceTypePresets,
+    // LodTypePresets,
+    SoudQueue,
+    FooterMessageTypes,
+  } from '../constants';
   import OnboardingStepBase from './OnboardingStepBase';
 
   export default {
@@ -124,9 +130,10 @@
       isSoud() {
         return this.queue === SoudQueue;
       },
-      isImportingSoud() {
-        return this.wizardService.state.context.lodImportOrJoin === LodTypePresets.IMPORT;
-      },
+      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // isImportingSoud() {
+      //   return this.wizardService.state.context.lodImportOrJoin === LodTypePresets.IMPORT;
+      // },
       queue() {
         return this.wizardService.state.context.fullOrLOD === DeviceTypePresets.LOD
           ? SoudQueue
@@ -143,10 +150,11 @@
       this.pollTask();
     },
     methods: {
-      importAnother() {
-        this.isPolling = false;
-        this.wizardService.send('IMPORT_ANOTHER');
-      },
+      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // importAnother() {
+      //   this.isPolling = false;
+      //   this.wizardService.send('IMPORT_ANOTHER');
+      // },
       pushCompletedToWizardMachine() {
         this.completedTasks.forEach(task => {
           if (!this.wizardService.state.context.importedUsers.includes(task.username)) {
@@ -226,10 +234,11 @@
       },
     },
     $trs: {
-      importAnother: {
-        message: 'Import another user account',
-        context: 'Link to restart the import step for another user. ',
-      },
+      // To Do: role this back when multiple user syncing is working in the upcoming release!
+      // importAnother: {
+      //   message: 'Import another user account',
+      //   context: 'Link to restart the import step for another user. ',
+      // },
       loadUserTitle: {
         message: 'Load user account',
         context: 'Title of a page where user is waiting for a user to be imported',


### PR DESCRIPTION

## Summary
This PR disables the multiple-learner-import on LOD on the setup wizard until multiple user syncing feature is fixed in the upcoming release.

## References
#11223

## Reviewer guidance
On setting up an LOD navigate to import facility and click on "Don't have the user credentials? Use an admin account" link
Try importing a user and observe.

![Screenshot 2023-09-14 at 19 44 08](https://github.com/learningequality/kolibri/assets/103313919/905b59e0-53bd-46fd-8dd3-fad2b66b63f9)


Closes #11223


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
