### PR TITLE
Fix learner sync status reporting on server device

### DIFF
--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -76,17 +76,19 @@ def _local_event_handler(func):
         :type context: CompositeSessionContext|LocalSessionContext
         """
         local_context = context if isinstance(context, LocalSessionContext) else None
-
-        try:
-            if not local_context and isinstance(context, CompositeSessionContext):
-                local_context = next(
-                    c for c in context.children if isinstance(c, LocalSessionContext)
-                )
-            else:
-                raise StopIteration("No local context found")
-        except StopIteration:
-            # no local context, so we can't do anything
-            return
+        if local_context is None:
+            try:
+                if isinstance(context, CompositeSessionContext):
+                    local_context = next(
+                        c
+                        for c in context.children
+                        if isinstance(c, LocalSessionContext)
+                    )
+                else:
+                    raise StopIteration("No local context found")
+            except StopIteration:
+                # no local context, so we can't do anything
+                return
 
         kwargs = _extract_kwargs_from_context(local_context)
         return func(**kwargs)

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -5,6 +5,7 @@ from sys import version_info
 from django.conf import settings
 from django.contrib.auth import login
 from django.db.models import Exists
+from django.db.models import F
 from django.db.models import Max
 from django.db.models import OuterRef
 from django.db.models.expressions import Subquery
@@ -283,8 +284,7 @@ def map_status(record):
         return RECENTLY_SYNCED
     elif queued:
         return QUEUED
-    elif record["last_synced"] and not recent:
-        return NOT_RECENTLY_SYNCED
+    return NOT_RECENTLY_SYNCED
 
 
 class UserSyncStatusViewSet(ReadOnlyValuesViewset):
@@ -323,7 +323,7 @@ class UserSyncStatusViewSet(ReadOnlyValuesViewset):
     def annotate_queryset(self, queryset):
 
         queryset = queryset.annotate(
-            last_synced=Max("sync_session__last_activity_timestamp")
+            last_synced=F("sync_session__last_activity_timestamp")
         )
 
         most_recent_sync_status = (

--- a/kolibri/core/device/test/test_api.py
+++ b/kolibri/core/device/test/test_api.py
@@ -836,6 +836,29 @@ class UserSyncStatusTestCase(APITestCase):
             response.data[0]["status"], user_sync_statuses.NOT_RECENTLY_SYNCED
         )
 
+    def test_usersyncstatus_list_learner_no_sync_session(self):
+        self.client.login(
+            username=self.user1.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+        self.syncstatus1.queued = False
+        previous_sync_session = self.syncstatus1.sync_session
+        self.syncstatus1.sync_session = None
+        self.syncstatus1.save()
+
+        try:
+            response = self.client.get(reverse("kolibri:core:usersyncstatus-list"))
+            self.assertEqual(len(response.data), 1)
+            self.assertEqual(response.data[0]["user"], self.user1.id)
+            self.assertEqual(
+                response.data[0]["status"], user_sync_statuses.NOT_RECENTLY_SYNCED
+            )
+        finally:
+            # Not doing this leads to weird unexpected test contagion.
+            self.syncstatus1.sync_session = previous_sync_session
+            self.syncstatus1.save()
+
     def test_usersyncstatus_list__insufficient_storage(self):
         self.client.login(
             username=self.user1.username,


### PR DESCRIPTION
## Summary
* Ensures that we always return a non-null sync status
* This should show up in the frontend as a sync being shown as 'not recently synced' - additional fixes are needed in Morango to ensure that the sync session gets properly attached to the user sync status.
* Fixes the check for whether we have a local context, which previously was always erroneously early returning.
* Combined with https://github.com/learningequality/morango/pull/201 this fixes the setting of learner sync status sync session foreign keys

## References
Fixes [#10588](https://github.com/learningequality/kolibri/issues/10588)

## Reviewer guidance
Do tests pass? Does the new test cover the scenario of a sync session not being assigned to the status?

Use the morango code in the linked PR and do pip install -e `<path to morango repo>` to do a full manual test of this.

Install an LOD learner from a server running this PR, and once it has synced, the sync status should properly display.

See screenshot of the active sync updating properly:

![Screenshot from 2023-09-14 16-47-28](https://github.com/learningequality/kolibri/assets/1680573/68c7e7af-dbe6-411b-a943-baa23f32874e)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
