### PR TITLE
facility routing naming fix + query param removal

### DIFF
--- a/kolibri/plugins/facility/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/facility/assets/src/modules/pluginModule.js
@@ -95,7 +95,7 @@ export default {
           name: PageNames.DATA_EXPORT_PAGE,
           params,
         },
-        FacilitiesConfigPage: {
+        FacilityConfigPage: {
           name: PageNames.FACILITY_CONFIG_PAGE,
           params,
         },

--- a/kolibri/plugins/facility/assets/src/routes.js
+++ b/kolibri/plugins/facility/assets/src/routes.js
@@ -9,7 +9,7 @@ import CoachClassAssignmentPage from './views/CoachClassAssignmentPage';
 import LearnerClassEnrollmentPage from './views/LearnerClassEnrollmentPage';
 import DataPage from './views/DataPage';
 import ImportCsvPage from './views/ImportCsvPage';
-import FacilitiesConfigPage from './views/FacilityConfigPage';
+import FacilityConfigPage from './views/FacilityConfigPage';
 import ManageClassPage from './views/ManageClassPage';
 import UserPage from './views/UserPage';
 import UserCreatePage from './views/UserCreatePage';
@@ -31,7 +31,6 @@ function facilityParamRequiredGuard(toRoute, subtopicName) {
     router
       .replace({
         name: 'ALL_FACILITIES_PAGE',
-        query: { subtopicName },
         params: { subtopicName },
       })
       .catch(e => {
@@ -141,10 +140,10 @@ export default [
   },
   {
     name: PageNames.FACILITY_CONFIG_PAGE,
-    component: FacilitiesConfigPage,
+    component: FacilityConfigPage,
     path: '/:facility_id?/settings',
     handler: toRoute => {
-      if (facilityParamRequiredGuard(toRoute, FacilitiesConfigPage.name)) {
+      if (facilityParamRequiredGuard(toRoute, FacilityConfigPage.name)) {
         return;
       }
       showFacilityConfigPage(store, toRoute);

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -10,7 +10,7 @@
           v-if="userIsMultiFacilityAdmin"
           :to="{
             name: facilityPageLinks.AllFacilitiesPage.name,
-            params: { subtopicName: 'FacilitiesConfigPage' }
+            params: { subtopicName: 'FacilityConfigPage' }
           }"
           icon="back"
           :text="coreString('changeLearningFacility')"


### PR DESCRIPTION
## Summary
this PR removes a subtopic-specific query param from `Facility` urls (as we are able to persist the subtopic selection using just the url param) and has renamed instances of `FacilitiesConfigPage` to `FacilityConfigPage` (as inconsistent naming was causing issues with persisting subtopic information in certain user flows).

## References
(not tied to a reported issue)

## Reviewer guidance
- to evaluate previous behavior: 
     - as a multi-facility user on `release-v0.16.x`, begin in a non-`Facility` plugin & select `Facility > Settings` from the sidenav
     - after redirect to "All Facilities" page, note the current url -- `facility/#/FacilityConfigPage/facilities?subtopicName=FacilityConfigPage` which contains two references to `FacilityConfigPage`
     - hovering over or clicking the links on the page for each facility, note that they resolve to `/classes` and not `/settings`, which is what we intend
- on this branch:
     - as a multi-facility user, begin in a non-`Facility` plugin & select `Facility > Settings` from the sidenav
     - after redirect to "All Facilities" page, note the current url -- `facility/#/FacilityConfigPage/facilities`
     - hovering over or clicking the links on the page for each facility, note that they resolve to `/settings`

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
