### PR TITLE
Properly set admin_imported flag at import and deletion.

### DIFF
--- a/kolibri/core/content/contentschema/versions/content_schema_current.py
+++ b/kolibri/core/content/contentschema/versions/content_schema_current.py
@@ -93,6 +93,7 @@ class ContentContentnode(Base):
     learner_needs_bitmask_0 = Column(BigInteger)
     learning_activities_bitmask_0 = Column(BigInteger)
     ancestors = Column(Text)
+    admin_imported = Column(Boolean)
     parent_id = Column(ForeignKey("content_contentnode.id"), index=True)
 
     lang = relationship("ContentLanguage")

--- a/kolibri/core/content/management/commands/generate_schema.py
+++ b/kolibri/core/content/management/commands/generate_schema.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import sessionmaker
 from kolibri.core.content.apps import KolibriContentConfig
 from kolibri.core.content.constants.schema_versions import CONTENT_SCHEMA_VERSION
 from kolibri.core.content.constants.schema_versions import CURRENT_SCHEMA_VERSION
-from kolibri.core.content.utils.channel_import import models_to_exclude
+from kolibri.core.content.utils.channel_import import no_schema_models
 from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_MODULE_NAME
 from kolibri.core.content.utils.sqlalchemybridge import __SQLALCHEMY_CLASSES_PATH
 from kolibri.core.content.utils.sqlalchemybridge import (
@@ -100,7 +100,7 @@ class Command(BaseCommand):
         table_names = [
             model._meta.db_table
             for name, model in app_config.models.items()
-            if name != "channelmetadatacache" and model not in models_to_exclude
+            if name != "channelmetadatacache" and model not in no_schema_models
         ]
         metadata.reflect(bind=engine, only=table_names)
         Base = prepare_base(metadata, name=version)

--- a/kolibri/core/content/management/commands/importchannel.py
+++ b/kolibri/core/content/management/commands/importchannel.py
@@ -206,6 +206,13 @@ class Command(AsyncCommand):
             # if upgrading, import the channel
             if not no_upgrade:
                 try:
+                    # In each case we need to evaluate the queryset now,
+                    # in order to get node ids as they currently are before
+                    # the import. If we did not coerce each of these querysets
+                    # to a list now, they would be lazily evaluated after the
+                    # import, and would reflect the state of the database
+                    # after the import.
+
                     # evaluate list so we have the current node ids
                     node_ids = list(
                         ContentNode.objects.filter(
@@ -214,6 +221,7 @@ class Command(AsyncCommand):
                         .exclude(kind=content_kinds.TOPIC)
                         .values_list("id", flat=True)
                     )
+                    # evaluate list so we have the current node ids
                     admin_imported_ids = list(
                         ContentNode.objects.filter(
                             channel_id=channel_id, available=True, admin_imported=True
@@ -221,6 +229,7 @@ class Command(AsyncCommand):
                         .exclude(kind=content_kinds.TOPIC)
                         .values_list("id", flat=True)
                     )
+                    # evaluate list so we have the current node ids
                     not_admin_imported_ids = list(
                         ContentNode.objects.filter(
                             channel_id=channel_id, available=True, admin_imported=False

--- a/kolibri/core/content/test/test_annotation.py
+++ b/kolibri/core/content/test/test_annotation.py
@@ -194,6 +194,28 @@ class SetContentNodesInvisibleTestCase(TransactionTestCase):
         node.refresh_from_db()
         self.assertTrue(node.available)
 
+    def test_all_leaves_clear_admin_imported(self):
+        ContentNode.objects.all().update(available=True)
+        set_leaf_nodes_invisible(test_channel_id, clear_admin_imported=True)
+        self.assertFalse(
+            any(
+                ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
+                    "admin_imported", flat=True
+                )
+            )
+        )
+
+    def test_all_leaves_no_clear_admin_imported(self):
+        ContentNode.objects.all().update(available=True, admin_imported=True)
+        set_leaf_nodes_invisible(test_channel_id)
+        self.assertTrue(
+            all(
+                ContentNode.objects.exclude(kind=content_kinds.TOPIC).values_list(
+                    "admin_imported", flat=True
+                )
+            )
+        )
+
     def tearDown(self):
         call_command("flush", interactive=False)
         super(SetContentNodesInvisibleTestCase, self).tearDown()

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -1007,6 +1007,7 @@ class ImportContentTestCase(TestCase):
             node_ids={self.c2c1_node_id},
             exclude_node_ids=None,
             public=False,
+            admin_imported=True,
         )
 
     @patch("kolibri.core.content.utils.resource_import.transfer.FileDownload")
@@ -1032,7 +1033,12 @@ class ImportContentTestCase(TestCase):
             manager = RemoteChannelResourceImportManager(self.the_channel_id)
             manager.run()
         self.annotation_mock.set_content_visibility.assert_called_with(
-            self.the_channel_id, [], node_ids=None, exclude_node_ids=None, public=False
+            self.the_channel_id,
+            [],
+            node_ids=None,
+            exclude_node_ids=None,
+            public=False,
+            admin_imported=True,
         )
 
     @patch("kolibri.core.content.utils.resource_import.get_free_space")
@@ -1140,6 +1146,7 @@ class ImportContentTestCase(TestCase):
             exclude_node_ids=None,
             node_ids=None,
             public=False,
+            admin_imported=True,
         )
 
     @patch("kolibri.utils.file_transfer.sleep")
@@ -1422,6 +1429,7 @@ class ImportContentTestCase(TestCase):
             exclude_node_ids=None,
             node_ids={self.c1_node_id},
             public=False,
+            admin_imported=True,
         )
 
     @patch(
@@ -1480,6 +1488,7 @@ class ImportContentTestCase(TestCase):
             exclude_node_ids=None,
             node_ids=None,
             public=False,
+            admin_imported=True,
         )
 
     def test_local_import_with_detected_manifest_file(
@@ -1988,6 +1997,7 @@ class ImportContentTestCase(TestCase):
             node_ids={self.c2c1_node_id},
             exclude_node_ids=None,
             public=False,
+            admin_imported=True,
         )
 
     @patch("kolibri.core.content.utils.resource_import.logger.warning")

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -883,7 +883,7 @@ class ProcessContentRemovalRequestsTestCase(BaseQuerysetTestCase):
             "deletecontent",
             self.node.channel_id,
             node_ids=[self.request.contentnode_id],
-            force_delete=True,
+            ignore_admin_flags=True,
         )
         self.assertEqual(self.qs.count(), 0)
         self.assertEqual(ContentDownloadRequest.objects.count(), 0)

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -49,12 +49,17 @@ merge_models = [ContentTag, LocalFile, Language]
 
 models_not_to_overwrite = [LocalFile]
 
-models_to_exclude = [
-    apps.get_model(CONTENT_APP_NAME, "ChannelMetadata_included_languages"),
+# Models that are in the content app, but for which we do not want to generate a schema
+# using SQLAlchemy.
+no_schema_models = [
     apps.get_model(CONTENT_APP_NAME, "ContentRequest"),
     apps.get_model(CONTENT_APP_NAME, "ContentDownloadRequest"),
     apps.get_model(CONTENT_APP_NAME, "ContentRemovalRequest"),
 ]
+
+models_to_exclude = [
+    apps.get_model(CONTENT_APP_NAME, "ChannelMetadata_included_languages"),
+] + no_schema_models
 
 
 SOURCE_DB_ALIAS = "sourcedb"

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -924,6 +924,7 @@ def process_content_removal_requests(queryset):
                 "deletecontent",
                 channel_id,
                 node_ids=contentnode_ids,
+                ignore_admin_flags=True,
             )
             # mark all as completed
             channel_requests.update(status=ContentRequestStatus.Completed)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -924,7 +924,6 @@ def process_content_removal_requests(queryset):
                 "deletecontent",
                 channel_id,
                 node_ids=contentnode_ids,
-                force_delete=True,
             )
             # mark all as completed
             channel_requests.update(status=ContentRequestStatus.Completed)

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -66,6 +66,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
+        admin_imported=True,
     ):
         self.channel_id = channel_id
 
@@ -81,6 +82,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
         self.all_thumbnails = all_thumbnails
         self.fail_on_error = fail_on_error
         self.content_dir = content_dir or conf.OPTIONS["Paths"]["CONTENT_DIR"]
+        self.admin_imported = admin_imported
         super(ResourceImportManagerBase, self).__init__()
 
     @classmethod
@@ -301,6 +303,7 @@ class ResourceImportManagerBase(with_metaclass(ABCMeta, JobProgressMixin)):
             node_ids=self.node_ids,
             exclude_node_ids=self.exclude_node_ids,
             public=self.public,
+            admin_imported=self.admin_imported,
         )
 
         self.resources_after_transfer = (
@@ -347,6 +350,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
         all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
+        admin_imported=True,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
     ):
         super(RemoteResourceImportManagerBase, self).__init__(
@@ -357,6 +361,7 @@ class RemoteResourceImportManagerBase(ResourceImportManagerBase):
             all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
+            admin_imported=admin_imported,
         )
         self.timeout = timeout
         self.peer_id = peer_id
@@ -405,6 +410,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
         all_thumbnails=False,
         fail_on_error=False,
         content_dir=None,
+        admin_imported=True,
     ):
         self.drive_id = drive_id
         if drive_id and not path:
@@ -420,6 +426,7 @@ class DiskResourceImportManagerBase(ResourceImportManagerBase):
             all_thumbnails=all_thumbnails,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
+            admin_imported=admin_imported,
         )
 
     @staticmethod
@@ -523,6 +530,9 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
         fail_on_error=False,
         content_dir=None,
         timeout=transfer.Transfer.DEFAULT_TIMEOUT,
+        # As this is primarily used for importing non-admin imported content
+        # we reverse the default here.
+        admin_imported=False,
     ):
         """
         :param channel_id: A hex UUID string
@@ -549,6 +559,7 @@ class ContentDownloadRequestResourceImportManager(RemoteChannelResourceImportMan
             renderable_only=renderable_only,
             fail_on_error=fail_on_error,
             content_dir=content_dir,
+            admin_imported=admin_imported,
             timeout=timeout,
         )
         self.peer = peer


### PR DESCRIPTION
## Summary
* Regenerates the SQLAlchemy reflection of the current channel schema as it had not been done previously.
* Removes the `force_delete` flag from content request handling deletions, as that could force deletions of admin imported resources to occur
* Updates the annotation logic to allow updating the admin_imported flag - uses a coalesce and OR function to ensure that the null Boolean value gets set to `False` or `True` (or left as is if `None`).
* Updates all resource import managers to default to setting admin_imported to True, except for the individual resource import class, which sets it to False by default
* Adds tests for the annotation behaviours
* Updates the node invisibility marking to allow explicit setting of admin_imported to False
* Adds an additional flag to the deletecontent command to disable this behaviour, but by default will always do this (which should maintain parity with the current 0.15 behaviour for the management command)
* Updates the use of the deletecontent command in the content request handling to not clear admin_imported flags
* Adds persistence of admin imported flag across channel upgrades - unfortunately, adding a test for this was challenging, because of the structure of our `importchannel` command, but the logic is very straight forward.

## References
Fixes [#11225](https://github.com/learningequality/kolibri/issues/11225)

## Reviewer guidance
This should cover all cases, including loading a full channel database import, after partial imports have happened - the only different will be that admin_imported will be `None` rather than `False` - but this is equivalent in how we are using it and should be workable. I think this may not cover where a full channel import has happened previously, then admin_imported is set to False for some nodes, while also being available - but then the channel metadata is upgraded.

admin_imported being set to `True` should persist across channel upgrades due to our existing upgrade processes that reannotate after the upgrade has happened.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
