### PR TITLE
Set insufficient storage DeviceStatus in ContentSyncHook.post_transfer

### DIFF
--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -84,7 +84,7 @@ class ContentSyncHook(FacilityDataSyncHook):
             process_metadata_import(incomplete_downloads_without_metadata)
 
         calc = StorageCalculator(incomplete_downloads)
-        if not calc.is_space_sufficient():
+        if local_is_single_user and not calc.is_space_sufficient():
             LearnerDeviceStatus.save_learner_status(
                 single_user_id, DeviceStatus.InsufficientStorage
             )

--- a/kolibri/core/content/kolibri_plugin.py
+++ b/kolibri/core/content/kolibri_plugin.py
@@ -84,7 +84,7 @@ class ContentSyncHook(FacilityDataSyncHook):
             process_metadata_import(incomplete_downloads_without_metadata)
 
         calc = StorageCalculator(incomplete_downloads)
-        if calc.free_space < sum([dl.total_size for dl in incomplete_downloads]):
+        if not calc.is_space_sufficient():
             LearnerDeviceStatus.save_learner_status(
                 single_user_id, DeviceStatus.InsufficientStorage
             )

--- a/kolibri/core/content/test/test_content_sync_hook.py
+++ b/kolibri/core/content/test/test_content_sync_hook.py
@@ -1,0 +1,48 @@
+import mock
+from morango.sync.context import SessionContext
+
+from kolibri.core.auth.sync_operations import KolibriSyncOperations
+from kolibri.core.content.kolibri_plugin import ContentSyncHook
+from kolibri.core.content.test.utils.test_content_request import (
+    IncompleteDownloadsQuerysetTestCase,
+)
+from kolibri.core.device.models import DeviceStatus
+
+
+class KolibriContentSyncHookTestCase(IncompleteDownloadsQuerysetTestCase):
+    def setUp(self):
+        super(KolibriContentSyncHookTestCase, self).setUp()
+        self.operation = KolibriSyncOperations()
+        self.context = mock.Mock(spec_set=SessionContext)()
+
+    @mock.patch("kolibri.core.device.models.LearnerDeviceStatus.save_learner_status")
+    @mock.patch("kolibri.core.content.utils.content_request.StorageCalculator")
+    @mock.patch("kolibri.core.content.kolibri_plugin.ContentSyncHook")
+    def test_post_transfer_sets_insufficient_storage(
+        self,
+        mock_hook,
+        mock_calc,
+        mock_save_learner_status,
+    ):
+        with mock.patch(
+            "kolibri.core.content.utils.settings.automatic_download_enabled",
+            return_value=True,
+        ):
+            with mock.patch(
+                "kolibri.core.content.utils.content_request.get_free_space_for_downloads",
+                return_value=0,
+            ):
+                self._create_resources(self.admin_request.contentnode_id)
+                mock_hook.post_transfer = lambda *args: ContentSyncHook.post_transfer(
+                    mock_hook, *args
+                )
+                mock_hook.post_transfer(
+                    self.facility.dataset_id,
+                    True,
+                    True,
+                    self.learner.id,
+                    self.context,
+                )
+                mock_save_learner_status.assert_called_with(
+                    self.learner.id, DeviceStatus.InsufficientStorage
+                )

--- a/kolibri/core/content/test/test_content_sync_hook.py
+++ b/kolibri/core/content/test/test_content_sync_hook.py
@@ -17,10 +17,8 @@ class KolibriContentSyncHookTestCase(IncompleteDownloadsQuerysetTestCase):
 
     @mock.patch("kolibri.core.device.models.LearnerDeviceStatus.save_learner_status")
     @mock.patch("kolibri.core.content.utils.content_request.StorageCalculator")
-    @mock.patch("kolibri.core.content.kolibri_plugin.ContentSyncHook")
     def test_post_transfer_sets_insufficient_storage(
         self,
-        mock_hook,
         mock_calc,
         mock_save_learner_status,
     ):
@@ -33,10 +31,8 @@ class KolibriContentSyncHookTestCase(IncompleteDownloadsQuerysetTestCase):
                 return_value=0,
             ):
                 self._create_resources(self.admin_request.contentnode_id)
-                mock_hook.post_transfer = lambda *args: ContentSyncHook.post_transfer(
-                    mock_hook, *args
-                )
-                mock_hook.post_transfer(
+                hook = ContentSyncHook()
+                hook.post_transfer(
                     self.facility.dataset_id,
                     True,
                     True,

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -969,8 +969,7 @@ class StorageCalculator:
         ).annotate(
             total_size=_total_size_annotation(available=True),
         )
-
-        self._calculate_space_available()
+        self.free_space = 0
 
     def _calculate_space_available(self):
         free_space = get_free_space_for_downloads(
@@ -984,4 +983,5 @@ class StorageCalculator:
         self.free_space = free_space
 
     def is_space_sufficient(self):
+        self._calculate_space_available()
         return self.free_space > _total_size(self.incomplete_downloads)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -982,3 +982,6 @@ class StorageCalculator:
         free_space += _total_size(self.complete_user_downloads)
 
         self.free_space = free_space
+
+    def is_space_sufficient(self):
+        return self.free_space > _total_size(self.incomplete_downloads)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -486,6 +486,7 @@ def process_content_requests():
         LearnerDeviceStatus.clear_statuses()
     except InsufficientStorage as e:
         logger.warning(str(e))
+
         LearnerDeviceStatus.save_statuses(DeviceStatus.InsufficientStorage)
     except NoPeerAvailable as e:
         logger.warning(str(e))
@@ -649,19 +650,14 @@ def _process_content_requests(incomplete_downloads):
     """
     Processes content requests, both for downloading and removing content
     """
-    incomplete_downloads_with_metadata = incomplete_downloads.filter(has_metadata=True)
+
+    calc = StorageCalculator(incomplete_downloads)
+
+    incomplete_downloads_with_metadata = calc.incomplete_downloads.filter(
+        has_metadata=True
+    )
 
     # obtain the incomplete removals, that do not have an associated download
-    incomplete_removals = incomplete_removals_queryset()
-    incomplete_sync_removals = incomplete_removals.filter(
-        reason=ContentRequestReason.SyncInitiated
-    )
-    incomplete_user_removals = incomplete_removals.filter(
-        reason=ContentRequestReason.UserInitiated
-    )
-    complete_user_downloads = ContentDownloadRequest.objects.filter(
-        status=ContentRequestStatus.Completed, reason=ContentRequestReason.UserInitiated
-    )
     # track failed so we can exclude them from the loop
     failed_ids = []
     has_processed_sync_removals = False
@@ -688,19 +684,28 @@ def _process_content_requests(incomplete_downloads):
                     free_space
                 )
             )
-            if not has_processed_sync_removals and incomplete_sync_removals.exists():
+            if (
+                not has_processed_sync_removals
+                and calc.incomplete_sync_removals.exists()
+            ):
                 # process, then repeat
                 has_processed_sync_removals = True
                 logger.info("Processing sync-initiated content removal requests")
-                process_content_removal_requests(incomplete_sync_removals)
+                process_content_removal_requests(calc.incomplete_sync_removals)
                 continue
-            if not has_processed_user_removals and incomplete_user_removals.exists():
+            if (
+                not has_processed_user_removals
+                and calc.incomplete_user_removals.exists()
+            ):
                 # process, then repeat
                 has_processed_user_removals = True
                 logger.info("Processing user-initiated content removal requests")
-                process_content_removal_requests(incomplete_user_removals)
+                process_content_removal_requests(calc.incomplete_user_removals)
                 continue
-            if not has_processed_user_downloads and complete_user_downloads.exists():
+            if (
+                not has_processed_user_downloads
+                and calc.complete_user_downloads.exists()
+            ):
                 # process, then repeat
                 has_processed_user_downloads = True
                 process_user_downloads_for_removal()
@@ -939,3 +944,41 @@ def process_content_removal_requests(queryset):
     remaining_pending = queryset.filter(status=ContentRequestStatus.Pending)
     _remove_corresponding_download_requests(remaining_pending)
     remaining_pending.update(status=ContentRequestStatus.Completed)
+
+
+class StorageCalculator:
+    def __init__(self, incomplete_downloads_queryset):
+        incomplete_removals = incomplete_removals_queryset()
+
+        self.incomplete_downloads = incomplete_downloads_queryset
+        self.incomplete_sync_removals = incomplete_removals.filter(
+            reason=ContentRequestReason.SyncInitiated
+        ).annotate(
+            total_size=_total_size_annotation(available=True),
+        )
+
+        self.incomplete_user_removals = incomplete_removals.filter(
+            reason=ContentRequestReason.UserInitiated
+        ).annotate(
+            total_size=_total_size_annotation(available=True),
+        )
+
+        self.complete_user_downloads = ContentDownloadRequest.objects.filter(
+            status=ContentRequestStatus.Completed,
+            reason=ContentRequestReason.UserInitiated,
+        ).annotate(
+            total_size=_total_size_annotation(available=True),
+        )
+
+        self._calculate_space_available()
+
+    def _calculate_space_available(self):
+        free_space = get_free_space_for_downloads(
+            completed_size=_total_size(completed_downloads_queryset())
+        )
+        free_space -= _total_size(self.incomplete_downloads)
+        free_space += _total_size(self.incomplete_sync_removals)
+        free_space += _total_size(self.incomplete_user_removals)
+        free_space += _total_size(self.complete_user_downloads)
+
+        self.free_space = free_space


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Moves the logic that calculates the total size of incomplete downloads from the request processing method into its own class.

That class then is imported to and used in ContentSyncHook.post_transfer to set the DeviceStatus to InsufficientStorage whenever there is not enough space available for the sync.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #10382 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Do we need to unset this when there _is_ enough space or anything like that?

Thoughts on test coverage would be appreciated. I pulled in and used some existing test classes to do the data setup for me. @rtibbles and I discussed a test case for the StorageCalculator class but it is kind of covered by way of the many integration tests using the `_process_content_requests` which repeatedly instantiate, use and rely on StorageCalculator. 