### PR TITLE
Navigation tweaks

### DIFF
--- a/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
+++ b/kolibri/core/assets/src/views/CoreMenu/CoreMenuOption.vue
@@ -58,7 +58,7 @@
               class="link"
               :href="href"
               :class="isActive ? subRouteActiveClass : subRouteInactiveClass"
-              @click="e => isActive ? toggleAndroidMenu() : navigate(e)"
+              @click="e => isActive ? toggleMenu() : toggleMenu() && navigate(e)"
             >
               {{ subRoute.label }}
             </a>
@@ -197,11 +197,11 @@
         }
         return false;
       },
-      toggleAndroidMenu() {
-        if (this.disabled) {
-          return;
+      toggleMenu() {
+        if (!this.disabled) {
+          this.$emit('toggleMenu');
         }
-        this.$emit('toggleAndroidMenu');
+        return true;
       },
       generateNavRoute(route) {
         const params = this.$route.params;

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -95,6 +95,7 @@
                   :link="component.url"
                   :icon="component.icon"
                   data-test="side-nav-component"
+                  @toggleMenu="toggleNav"
                 />
                 <SideNavDivider />
                 <CoreMenuOption
@@ -106,13 +107,15 @@
                   :icon="component.icon"
                   style="cursor: pointer;"
                   data-test="side-nav-component"
+                  @toggleMenu="toggleNav"
                 />
                 <LogoutSideNavEntry v-if="isUserLoggedIn" />
                 <CoreMenuOption
                   :label="coreString('changeLanguageOption')"
                   icon="language"
                   class="pointer"
-                  @select="handleShowLanguageModal()"
+                  @select="handleShowLanguageModal"
+                  @toggleMenu="toggleNav"
                 />
                 <SideNavDivider />
               </template>
@@ -201,7 +204,7 @@
       v-if="showAppNavView"
       :bottomMenuOptions="bottomMenuOptions"
       :navShown="navShown"
-      @toggleNav="toggleNav()"
+      @toggleNav="toggleNav"
     />
 
 
@@ -418,6 +421,7 @@
       },
       handleClickPrivacyLink() {
         this.privacyModalVisible = true;
+        this.toggleNav();
       },
       compareMenuComponents(navComponentA, navComponentB) {
         // Compare menu items to allow sorting by the following priority:

--- a/kolibri/plugins/coach/assets/src/routes/index.js
+++ b/kolibri/plugins/coach/assets/src/routes/index.js
@@ -58,8 +58,8 @@ export default [
     name: PageNames.HOME_PAGE,
     path: '/:classId?/home',
     component: HomePage,
-    handler: toRoute => {
-      if (classIdParamRequiredGuard(toRoute, HomePage.name)) {
+    handler: (toRoute, fromRoute, next) => {
+      if (classIdParamRequiredGuard(toRoute, HomePage.name, next)) {
         return;
       }
       store.dispatch('notLoading');

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -40,8 +40,8 @@ export default [
     name: LessonsPageNames.PLAN_LESSONS_ROOT,
     path: path(CLASS, ALL_LESSONS),
     component: LessonsRootPage,
-    handler(toRoute) {
-      if (classIdParamRequiredGuard(toRoute, 'PLAN_PAGE')) {
+    handler(toRoute, fromRoute, next) {
+      if (classIdParamRequiredGuard(toRoute, 'PLAN_PAGE', next)) {
         return;
       }
       showLessonsRootPage(store, toRoute.params.classId);

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -10,6 +10,7 @@ import {
 } from '../modules/lessonResources/handlers';
 import { showLessonSummaryPage } from '../modules/lessonSummary/handlers';
 import { LessonsPageNames } from '../constants/lessonsConstants';
+import { PageNames } from '../constants';
 
 import { useLessons } from '../composables/useLessons';
 
@@ -41,7 +42,7 @@ export default [
     path: path(CLASS, ALL_LESSONS),
     component: LessonsRootPage,
     handler(toRoute, fromRoute, next) {
-      if (classIdParamRequiredGuard(toRoute, 'PLAN_PAGE', next)) {
+      if (classIdParamRequiredGuard(toRoute, PageNames.PLAN_PAGE, next)) {
         return;
       }
       showLessonsRootPage(store, toRoute.params.classId);

--- a/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
@@ -446,8 +446,8 @@ export default [
   {
     path: path(CLASS, LESSONS),
     component: pages.ReportsLessonListPage,
-    handler: toRoute => {
-      if (classIdParamRequiredGuard(toRoute, 'ReportsLessonListPage')) {
+    handler: (toRoute, fromRoute, next) => {
+      if (classIdParamRequiredGuard(toRoute, 'ReportsLessonListPage', next)) {
         return;
       }
       defaultHandler();

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -10,6 +10,7 @@ export function classIdParamRequiredGuard(toRoute, subtopicName, next) {
       name: redirectPage,
       params: { subtopicName },
     });
+    store.commit('CORE_SET_PAGE_LOADING', false);
     return true;
   }
 }

--- a/kolibri/plugins/coach/assets/src/routes/utils.js
+++ b/kolibri/plugins/coach/assets/src/routes/utils.js
@@ -1,13 +1,12 @@
 import store from 'kolibri.coreVue.vuex.store';
-import router from 'kolibri.coreVue.router';
 
-export function classIdParamRequiredGuard(toRoute, subtopicName) {
+export function classIdParamRequiredGuard(toRoute, subtopicName, next) {
   if (!toRoute.params.classId) {
     const redirectPage = store.getters.userIsMultiFacilityAdmin
       ? 'AllFacilitiesPage'
       : 'CoachClassListPage';
 
-    router.replace({
+    next({
       name: redirectPage,
       params: { subtopicName },
     });

--- a/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/ClassLearnersListPage.vue
@@ -92,9 +92,11 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
   import { mapState, mapActions } from 'vuex';
+  // TODO: Cleanup this import by moving it into kolibri-common
   import SyncStatusDisplay from '../../../../../core/assets/src/views/SyncStatusDisplay';
   import SyncStatusDescription from '../../../../../core/assets/src/views/SyncStatusDescription';
   import CoachImmersivePage from '../views/CoachImmersivePage';
+  import { PageNames } from '../constants';
   import StorageNotificationBanner from './StorageNotificationBanner';
 
   export default {
@@ -133,13 +135,11 @@
         return options;
       },
       backlink() {
-        let backRoute;
         if (this.$route.query.last === 'homepage') {
-          backRoute = this.$router.getRoute('HomePage');
+          return { name: PageNames.HOME_PAGE, params: { classId: this.$route.params.classId } };
         } else {
-          backRoute = this.$router.getRoute('ReportsQuizListPage');
+          return { name: 'ReportsQuizListPage', params: { classId: this.$route.params.classId } };
         }
-        return backRoute;
       },
       learnerHasInsufficientStorage() {
         for (const learner in this.learnerMap) {

--- a/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachClassListPage.vue
@@ -69,6 +69,7 @@
   import find from 'lodash/find';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import urls from 'kolibri.urls';
+  import { PageNames } from '../constants';
   import CoachAppBarPage from './CoachAppBarPage';
   import commonCoach from './common';
 
@@ -114,7 +115,7 @@
         return '';
       },
       getNextPageName() {
-        return this.subtopicName || 'HomePage';
+        return this.subtopicName || PageNames.HOME_PAGE;
       },
       appBarTitle() {
         let facilityName;


### PR DESCRIPTION
## Summary
* Prevents redundant navigation errors by using `next` rather than `router.replace` for synchronous navigation guards
* Ensures that the side nav always closes for navigation events, now that it always displays as a modal
* Ensures backlink gets properly generated for Home Page by passing classId parameter

## References
Fixes #11253

## Reviewer guidance
Are all the behaviours working as one might expect?
Did I miss any instances where Home, Reports, or Plan links are being generated without a classId (now that the parameter is optional, it does not automatically get supplied by the `getRoute` method.

New side nav behaviour - only does the toggle behaviour when navigating within an SPA, otherwise it looked a bit janky:
[Screencast from 09-15-2023 04:03:30 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/047c32ea-388d-4ec9-a258-84ff0be10a17)



Bug fix for back route:
[Screencast from 09-15-2023 04:00:21 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/226c7704-a19d-4813-aac9-f87cf88fa239)


No redundant navigation errors:
[Screencast from 09-15-2023 04:01:35 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/c102e022-9aa8-44da-8b03-be1fa2640fe0)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
