### PR TITLE
Set full name when creating a remote learner account.

### DIFF
--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -42,6 +42,7 @@ class SetupWizardResource(ViewSet):
         facility_id = request.data.get("facility_id", None)
         username = request.data.get("username", None)
         password = request.data.get("password", None)
+        full_name = request.data.get("full_name", "")
         baseurl = request.data.get("baseurl", None)
 
         api_url = reverse("kolibri:core:publicsignup-list")
@@ -52,6 +53,7 @@ class SetupWizardResource(ViewSet):
             "facility_id": facility_id,
             "username": username,
             "password": password,
+            "full_name": full_name,
         }
 
         r = requests.post(url, data=payload)

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -10,11 +10,12 @@ export const SetupWizardResource = new Resource({
   name: 'setupwizard',
   namespace: 'kolibri.plugins.setup_wizard',
 
-  createuseronremote({ facility_id, username, password, baseurl }) {
+  createuseronremote({ facility_id, username, password, full_name, baseurl }) {
     return this.postListEndpoint('createuseronremote', {
       facility_id,
       username,
       password,
+      full_name,
       baseurl,
     });
   },

--- a/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LodJoinFacility.vue
@@ -54,6 +54,7 @@
         const user = {
           username: this.$store.state.onboardingData.user.username,
           password: this.$store.state.onboardingData.user.password,
+          full_name: this.$store.state.onboardingData.user.full_name,
         };
 
         this.loading = true;


### PR DESCRIPTION
## Summary
* Ensures that the full_name entered is actually passed through to the backend and then to the public sign up endpoint

## References
Fixes #11188

## Reviewer guidance
[Screencast from 09-15-2023 04:26:26 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/b0adc436-e1f9-4ed2-8f83-439b7d2a5cbe)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
