### PR TITLE
UI cleanup of side panel 

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -289,6 +289,8 @@
   .text-and-time {
     display: inline-block;
     width: calc(100% - #{$icon-size} - #{$progress-width});
+    display: flex;
+    flex-direction: column;
   }
 
   .progress {
@@ -322,6 +324,7 @@
     // Without the progress on the same line, don't incl it in calcs
     .content-meta {
       width: calc(100% - #{$icon-size});
+       display: flex;
     }
 
     .time-duration {
@@ -339,7 +342,6 @@
     .progress {
       position: relative;
       display: block;
-      width: 100%;
       margin-top: 8px;
     }
 
@@ -347,7 +349,7 @@
       right: auto;
       bottom: 0;
       left: 0;
-    }
+    } 
   }
 
   /** Most of the styles for the footer piece */

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -288,9 +288,9 @@
 
   .text-and-time {
     display: inline-block;
-    width: calc(100% - #{$icon-size} - #{$progress-width});
     display: flex;
     flex-direction: column;
+    width: calc(100% - #{$icon-size} - #{$progress-width});
   }
 
   .progress {
@@ -323,8 +323,8 @@
     }
     // Without the progress on the same line, don't incl it in calcs
     .content-meta {
+      display: flex;
       width: calc(100% - #{$icon-size});
-       display: flex;
     }
 
     .time-duration {
@@ -349,7 +349,7 @@
       right: auto;
       bottom: 0;
       left: 0;
-    } 
+    }
   }
 
   /** Most of the styles for the footer piece */


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Did the UI cleanup of resource duration in Content Renderer side panel

before
![266347589-b53df362-292a-46db-8f7c-21b39187c521](https://github.com/learningequality/kolibri/assets/114716075/81442fac-1dd6-45ad-a983-c3a09224270b)

after
<img width="337" alt="266353269-fdbe0345-ef47-477b-9af2-a9600cbb0939" src="https://github.com/learningequality/kolibri/assets/114716075/2d331e03-5f8f-4128-82ea-552fba814c81">


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#11206 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
