### PR TITLE
Reaplce TextTruncator with TextTruncatorCss in HybridLearningLessonCard.vue

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningLessonCard.vue
@@ -18,9 +18,9 @@
         />
       </div>
       <h3 class="title">
-        <TextTruncator
+        <TextTruncatorCss
           :text="content.title"
-          :maxHeight="maxTitleHeight"
+          :maxLines="1"
           :style="{ color: $themeTokens.text }"
         />
       </h3>
@@ -41,7 +41,7 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ProgressBar from './ProgressBar';
   import LearningActivityLabel from './LearningActivityLabel';
@@ -52,7 +52,7 @@
     name: 'HybridLearningLessonCard',
     components: {
       CardThumbnail,
-      TextTruncator,
+      TextTruncatorCss,
       LearningActivityLabel,
       ProgressBar,
     },
@@ -70,11 +70,6 @@
       isMobile: {
         type: Boolean,
         default: false,
-      },
-    },
-    computed: {
-      maxTitleHeight() {
-        return 40;
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Replace the `Texttruncator` with `TextTruncatorCss`. The PR also removes the `maxTitleHeight` computed property.

| Before | After |
|---------|------|
| ![HybridLearningLessonCardBefore](https://github.com/learningequality/kolibri/assets/74391865/0731dfd3-a19e-4110-814c-e17ebd5f9b5e) | ![HybridLearningLessonCardAfter](https://github.com/learningequality/kolibri/assets/74391865/9867d74e-a009-44d8-bae3-ee7f59436c43) |

**Update the title content for testing with chrome dev tools through inspect element**
## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#8532 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To Review:
- Go to Learn --> Home --> Select Kolibri QA channel. The video card (or other HybridLearningLessonCard) **titles** are Truncated.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
