### PR TITLE
Replace TextTruncator with TextTruncatorCss in TopicsHeader.vue

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -27,9 +27,9 @@
         :layout12="{ span: 12, alignment: 'auto' }"
       >
         <h1 class="title" data-test="header-title">
-          <TextTruncator
+          <TextTruncatorCss
             :text="title"
-            :maxHeight="60"
+            :maxLines="1"
           />
         </h1>
       </KGridItem>
@@ -56,10 +56,10 @@
         :layout8="{ span: thumbnail ? 6 : 8, alignment: 'auto' }"
         :layout12="{ span: thumbnail ? 10 : 12, alignment: 'auto' }"
       >
-        <TextTruncator
+        <TextTruncatorCss
           class="text-description"
           :text="description"
-          :maxHeight="110"
+          :maxLines="4"
         />
       </KGridItem>
     </KGrid>
@@ -75,7 +75,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import ChannelThumbnail from '../ChannelThumbnail';
   import commonLearnStrings from './../commonLearnStrings';
@@ -85,7 +85,7 @@
     components: {
       ChannelThumbnail,
       KBreadcrumbs,
-      TextTruncator,
+      TextTruncatorCss,
     },
     mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
     props: {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Replace the `Texttruncator` with `TextTruncatorCss`. 

| Before | After |
|---------|------|
| ![TopicsHeaderBefore](https://github.com/learningequality/kolibri/assets/74391865/f8b0a03e-29c0-43c9-a7d8-303568e7edf1) | ![TopicsHeadersAfter](https://github.com/learningequality/kolibri/assets/74391865/5804d9b8-d819-420c-83a6-ac84b14df4c9) |

**Update the title and description for testing with chrome dev tools through inspect element. Don't know  in Before why title is overflowing though fixed after using TextTruncatorCss**

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#8532

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To review: 
- Go to Learn --> Home --> Select Kolibri QA channel --> Videos --> Atomic Interactions in Chapters. 
- The ** Atomic Interactions in Chapters** and its description are truncated.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
