### PR TITLE
Issue 8532 replace text Truncator topics in TopicsMobileHeader.vue

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsMobileHeader.vue
@@ -9,9 +9,9 @@
       :layout4="{ span: 3 }"
     >
       <h1 class="mobile-title" data-test="mobile-title">
-        <TextTruncator
+        <TextTruncatorCss
           :text="topic.title"
-          :maxHeight="110"
+          :maxLines="2"
         />
       </h1>
     </KGridItem>
@@ -30,11 +30,11 @@
 
 <script>
 
-  import TextTruncator from 'kolibri.coreVue.components.TextTruncator';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
 
   export default {
     name: 'TopicsMobileHeader',
-    components: { TextTruncator },
+    components: { TextTruncatorCss },
     props: {
       topic: {
         type: Object,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->


Replace the `Texttruncator` with `TextTruncatorCss`. 

| Before | After |
|---------|------|
|![TopicsMobileHeaderBefore](https://github.com/learningequality/kolibri/assets/74391865/7a9be38a-cdc7-487b-a63f-3cd82530e181) |![TopicsMobileHeaderAfter](https://github.com/learningequality/kolibri/assets/74391865/15b057b7-6c51-483d-a854-4150cda554cb)  |

**Update the title for testing with chrome dev tools through inspect element. Don't know  in Before why title is overflowing though fixed after using TextTruncatorCss**

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#8532 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To review: 
- Go to Learn --> Home --> Select Kolibri QA channel --> Videos --> Atomic Interactions in Chapters. 
- Toggle the device to a mobile screen.
- The **Atomic Interactions in Chapters** is truncated.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
