### PR TITLE
Separate signal attachment between morango core and kolibri sync logic

### DIFF
--- a/kolibri/core/auth/apps.py
+++ b/kolibri/core/auth/apps.py
@@ -15,8 +15,14 @@ class KolibriAuthConfig(AppConfig):
         from .signals import cascade_delete_user  # noqa: F401
 
         from kolibri.core.auth.sync_event_hook_utils import (
-            register_sync_event_handlers,
+            pre_sync_transfer_handler,
+            post_sync_transfer_handler,
         )  # noqa: F401
         from morango.api.viewsets import session_controller  # noqa: F401
 
-        register_sync_event_handlers(session_controller.signals)
+        # attach to `initializing.completed` signal so that the context has all information needed
+        # for the handler and any hooks invoked by it
+        session_controller.signals.initializing.completed.connect(
+            pre_sync_transfer_handler
+        )
+        session_controller.signals.cleanup.completed.connect(post_sync_transfer_handler)

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -26,7 +26,8 @@ from kolibri.core.auth.constants.morango_sync import State
 from kolibri.core.auth.models import dataset_cache
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.sync_event_hook_utils import register_sync_event_handlers
+from kolibri.core.auth.sync_event_hook_utils import post_sync_transfer_handler
+from kolibri.core.auth.sync_event_hook_utils import pre_sync_transfer_handler
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_device
@@ -403,7 +404,8 @@ class MorangoSyncCommand(AsyncCommand):
         client_cert = sync_session_client.sync_session.client_certificate
         # we create a custom signals, so we can fire them outside of transaction blocks
         custom_signals = SessionControllerSignals()
-        register_sync_event_handlers(custom_signals)
+        custom_signals.initializing.started.connect(pre_sync_transfer_handler)
+        custom_signals.cleanup.completed.connect(post_sync_transfer_handler)
 
         filter_scope, scope_params = get_sync_filter_scope(client_cert, user_id=user_id)
         dataset_id = scope_params.get("dataset_id")

--- a/kolibri/core/auth/sync_event_hook_utils.py
+++ b/kolibri/core/auth/sync_event_hook_utils.py
@@ -97,7 +97,10 @@ def _local_event_handler(func):
 
 
 @_local_event_handler
-def _pre_transfer_handler(**kwargs):
+def pre_sync_transfer_handler(**kwargs):
+    """
+    Used to attach to signals like those on morango.sync.controller.SessionControllerSignals
+    """
     for hook in FacilityDataSyncHook.registered_hooks:
         # we catch all errors because as a rule of thumb, we don't want hooks to fail
         try:
@@ -110,7 +113,10 @@ def _pre_transfer_handler(**kwargs):
 
 
 @_local_event_handler
-def _post_transfer_handler(**kwargs):
+def post_sync_transfer_handler(**kwargs):
+    """
+    Used to attach to signals like those on morango.sync.controller.SessionControllerSignals
+    """
     for hook in FacilityDataSyncHook.registered_hooks:
         # we catch all errors because as a rule of thumb, we don't want hooks to fail
         try:
@@ -120,14 +126,3 @@ def _post_transfer_handler(**kwargs):
                 "{}.post_transfer hook failed".format(hook.__class__.__name__),
                 exc_info=e,
             )
-
-
-def register_sync_event_handlers(signals):
-    """
-    Attaches the pre and post transfer handlers to the morango session controller signals.
-
-    :param signals: The signals object from the morango session controller
-    :type signals: morango.sync.controller.SessionControllerSignals
-    """
-    signals.initializing.started.connect(_pre_transfer_handler)
-    signals.cleanup.completed.connect(_post_transfer_handler)

--- a/kolibri/core/auth/test/test_sync_event_hook_utils.py
+++ b/kolibri/core/auth/test/test_sync_event_hook_utils.py
@@ -3,8 +3,8 @@ from django.test import SimpleTestCase
 from morango.sync.context import CompositeSessionContext
 from morango.sync.context import LocalSessionContext
 
-from kolibri.core.auth.sync_event_hook_utils import _post_transfer_handler
-from kolibri.core.auth.sync_event_hook_utils import _pre_transfer_handler
+from kolibri.core.auth.sync_event_hook_utils import post_sync_transfer_handler
+from kolibri.core.auth.sync_event_hook_utils import pre_sync_transfer_handler
 
 
 MODULE_NAME = "kolibri.core.auth.sync_event_hook_utils"
@@ -33,7 +33,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
     def test_pre_transfer(self, mock_hook_registry):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
-        _pre_transfer_handler(self.context)
+        pre_sync_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called_once_with(
             context=self.local_context,
             dataset_id="123",
@@ -46,7 +46,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         self.context.children = [mock.Mock()]
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
-        _pre_transfer_handler(self.context)
+        pre_sync_transfer_handler(self.context)
         self.hook.pre_transfer.assert_not_called()
 
     @mock.patch("kolibri.core.auth.sync_event_hook_utils.logger")
@@ -54,7 +54,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
         self.hook.pre_transfer.side_effect = RuntimeError()
-        _pre_transfer_handler(self.context)
+        pre_sync_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called()
         mock_logger.error.assert_called_once_with(
             "TestHook.pre_transfer hook failed",
@@ -65,13 +65,13 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.pre_transfer.assert_not_called()
         self.hook.pre_transfer.side_effect = RuntimeError()
-        _pre_transfer_handler(self.context)
+        pre_sync_transfer_handler(self.context)
         self.hook.pre_transfer.assert_called()
 
     def test_post_transfer(self, mock_hook_registry):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
-        _post_transfer_handler(self.context)
+        post_sync_transfer_handler(self.context)
         self.hook.post_transfer.assert_called_once_with(
             context=self.local_context,
             dataset_id="123",
@@ -84,7 +84,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         self.context.children = [mock.Mock()]
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
-        _post_transfer_handler(self.context)
+        post_sync_transfer_handler(self.context)
         self.hook.post_transfer.assert_not_called()
 
     @mock.patch("kolibri.core.auth.sync_event_hook_utils.logger")
@@ -92,7 +92,7 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
         self.hook.post_transfer.side_effect = RuntimeError()
-        _post_transfer_handler(self.context)
+        post_sync_transfer_handler(self.context)
         self.hook.post_transfer.assert_called()
         mock_logger.error.assert_called_once_with(
             "TestHook.post_transfer hook failed",
@@ -103,5 +103,5 @@ class FacilityDataSyncHooksTestCase(SimpleTestCase):
         mock_hook_registry.registered_hooks = [self.hook]
         self.hook.post_transfer.assert_not_called()
         self.hook.post_transfer.side_effect = RuntimeError()
-        _post_transfer_handler(self.context)
+        post_sync_transfer_handler(self.context)
         self.hook.post_transfer.assert_called()


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates sync command logic to attach to `initializing.started` signal manually, which itself was hacked to fire manually
- Updates the Kolibri app logic to attach to the `initializing.completed` signal, which is supported in morango and was the [original implementation](https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/core/auth/sync_event_hook_utils.py#L104)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes https://github.com/learningequality/morango/pull/201
https://github.com/learningequality/kolibri/pull/11244

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
See https://github.com/learningequality/kolibri/pull/11244

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
