### PR TITLE
Decrease time-to-sync for learn-only devices joining the network

### DIFF
--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -46,6 +46,7 @@ from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.job import JobStatus
+from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.permissions import IsAdminForJob
@@ -627,9 +628,7 @@ def stop_request_soud_sync(server, user):
     stoppeerusersync(server, user)
 
 
-@register_task(
-    queue=soud_sync_queue,
-)
+@register_task(queue=soud_sync_queue, priority=Priority.HIGH, status_fn=status_fn)
 def request_soud_sync(server, user, queue_id=None, ttl=4):
     """
     Make a request to the serverurl endpoint to sync this SoUD (Subset of Users Device)

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -1,6 +1,7 @@
 import mock
 from django.test import TransactionTestCase
 
+from ..utils.network.broadcast import KolibriBroadcast
 from ..utils.network.broadcast import KolibriInstance
 from ..utils.network.search import NetworkLocationListener
 from kolibri.core.tasks.job import Priority
@@ -9,6 +10,10 @@ MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555
 MOCK_ID = "abba"
 SEARCH_MODULE = "kolibri.core.discovery.utils.network.search."
+DYNAMIC_NETWORK_LOCATION_TASK_PRIORITY_METHOD = (
+    SEARCH_MODULE
+    + "NetworkLocationListener._get_dynamic_network_location_task_priority"
+)
 
 
 class NetworkLocationListenerTestCase(TransactionTestCase):
@@ -24,30 +29,76 @@ class NetworkLocationListenerTestCase(TransactionTestCase):
                 "instance_id": MOCK_ID,
             },
         )
-        self.mock_broadcast = mock.MagicMock(id="abc123")
-        self.listener = NetworkLocationListener(self.mock_broadcast)
+        self.broadcast_instance = KolibriInstance(
+            "abcd",
+            ip=MOCK_INTERFACE_IP,
+            port=MOCK_PORT,
+            device_info={
+                "instance_id": "abcd",
+            },
+        )
+
+        self.broadcast = KolibriBroadcast(instance=self.broadcast_instance)
+        self.broadcast.id = "abc123"
+
+        self.listener = NetworkLocationListener(self.broadcast)
 
     @mock.patch(SEARCH_MODULE + "reset_connection_states.enqueue")
     def test_register_instance(self, mock_enqueue):
         self.listener.register_instance(self.instance)
-        mock_enqueue.assert_called_once_with(args=(self.mock_broadcast.id,))
+        mock_enqueue.assert_called_once_with(args=(self.broadcast.id,))
+
+    def test_dynamic_network_location_task_priority_self_no_lod(self):
+        # The current device is not a LOD.
+        self.broadcast_instance.device_info["subset_of_users_device"] = False
+
+        priority = self.listener._get_dynamic_network_location_task_priority(
+            self.instance
+        )
+        self.assertEqual(priority, Priority.HIGH)
+
+    def test_dynamic_network_location_task_priority_self_discovered_both_lod(self):
+        # The current device is a LOD.
+        self.broadcast_instance.device_info["subset_of_users_device"] = True
+        # The discovered device is LOD as well.
+        self.instance.device_info["subset_of_users_device"] = True
+
+        priority = self.listener._get_dynamic_network_location_task_priority(
+            self.instance
+        )
+        self.assertEqual(priority, Priority.REGULAR)
+
+    def test_dynamic_network_location_task_priority_self_lod_discovered_not_lod(self):
+        # The current device is a LOD.
+        self.broadcast_instance.device_info["subset_of_users_device"] = True
+        # The discovered device is not a LOD.
+        self.instance.device_info["subset_of_users_device"] = False
+
+        priority = self.listener._get_dynamic_network_location_task_priority(
+            self.instance
+        )
+        self.assertEqual(priority, Priority.HIGH)
 
     @mock.patch(SEARCH_MODULE + "add_dynamic_network_location.enqueue")
-    def test_add_instance(self, mock_enqueue):
+    @mock.patch(DYNAMIC_NETWORK_LOCATION_TASK_PRIORITY_METHOD)
+    def test_add_instance(self, mock_priority_method, mock_enqueue):
         self.listener.add_instance(self.instance)
+        mock_priority_method.assert_called_once_with(self.instance)
         mock_enqueue.assert_called_once_with(
             job_id="9e89d3ea5256721c9cd631eac36feafe",
-            args=(self.mock_broadcast.id, self.instance.to_dict()),
-            priority=Priority.HIGH,
+            args=(self.broadcast.id, self.instance.to_dict()),
+            priority=mock_priority_method(),
         )
 
     @mock.patch(SEARCH_MODULE + "add_dynamic_network_location.enqueue")
-    def test_update_instance(self, mock_enqueue):
+    @mock.patch(DYNAMIC_NETWORK_LOCATION_TASK_PRIORITY_METHOD)
+    def test_update_instance(self, mock_priority_method, mock_enqueue):
         self.listener.update_instance(self.instance)
+        mock_priority_method.assert_called_once_with(self.instance)
         mock_enqueue.assert_called_once_with(
             job_id="9e89d3ea5256721c9cd631eac36feafe",
-            args=(self.mock_broadcast.id, self.instance.to_dict()),
-            priority=Priority.HIGH,
+            args=(self.broadcast.id, self.instance.to_dict()),
+            priority=mock_priority_method(),
         )
 
     @mock.patch(SEARCH_MODULE + "remove_dynamic_network_location.enqueue")
@@ -55,5 +106,5 @@ class NetworkLocationListenerTestCase(TransactionTestCase):
         self.listener.remove_instance(self.instance)
         mock_enqueue.assert_called_once_with(
             job_id="c5e88d1cb4a342ad3d23081022248fbc",
-            args=(self.mock_broadcast.id, self.instance.to_dict()),
+            args=(self.broadcast.id, self.instance.to_dict()),
         )

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -3,7 +3,7 @@ from django.test import TransactionTestCase
 
 from ..utils.network.broadcast import KolibriInstance
 from ..utils.network.search import NetworkLocationListener
-
+from kolibri.core.tasks.job import Priority
 
 MOCK_INTERFACE_IP = "111.222.111.222"
 MOCK_PORT = 555
@@ -38,6 +38,7 @@ class NetworkLocationListenerTestCase(TransactionTestCase):
         mock_enqueue.assert_called_once_with(
             job_id="9e89d3ea5256721c9cd631eac36feafe",
             args=(self.mock_broadcast.id, self.instance.to_dict()),
+            priority=Priority.HIGH
         )
 
     @mock.patch(SEARCH_MODULE + "add_dynamic_network_location.enqueue")

--- a/kolibri/core/discovery/test/test_network_search.py
+++ b/kolibri/core/discovery/test/test_network_search.py
@@ -38,7 +38,7 @@ class NetworkLocationListenerTestCase(TransactionTestCase):
         mock_enqueue.assert_called_once_with(
             job_id="9e89d3ea5256721c9cd631eac36feafe",
             args=(self.mock_broadcast.id, self.instance.to_dict()),
-            priority=Priority.HIGH
+            priority=Priority.HIGH,
         )
 
     @mock.patch(SEARCH_MODULE + "add_dynamic_network_location.enqueue")
@@ -47,6 +47,7 @@ class NetworkLocationListenerTestCase(TransactionTestCase):
         mock_enqueue.assert_called_once_with(
             job_id="9e89d3ea5256721c9cd631eac36feafe",
             args=(self.mock_broadcast.id, self.instance.to_dict()),
+            priority=Priority.HIGH,
         )
 
     @mock.patch(SEARCH_MODULE + "remove_dynamic_network_location.enqueue")

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -47,7 +47,7 @@ class NetworkLocationListener(KolibriInstanceListener):
         priority = Priority.REGULAR
         is_current_device_lod = get_device_setting("subset_of_users_device")
         discovered_device = DynamicNetworkLocation.objects.filter(
-            broadcast_id=self.broadcast.id
+            broadcast_id=self.broadcast.id, pk=instance.zeroconf_id
         ).first()
 
         # If the current device is not an LOD,

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -41,9 +41,11 @@ class NetworkLocationListener(KolibriInstanceListener):
     def _get_dynamic_network_location_task_priority(self, instance):
         priority = Priority.REGULAR
         is_current_device_lod = self.broadcast.instance.device_info.get(
-            "subset_of_users_device"
+            "subset_of_users_device", False
         )
-        is_discovered_device_lod = instance.device_info.get("subset_of_users_device")
+        is_discovered_device_lod = instance.device_info.get(
+            "subset_of_users_device", False
+        )
 
         # If the current device is not an LOD,
         # OR

--- a/kolibri/core/discovery/utils/network/search.py
+++ b/kolibri/core/discovery/utils/network/search.py
@@ -1,7 +1,5 @@
 import logging
 
-from kolibri.core.device.utils import get_device_setting
-from kolibri.core.discovery.models import DynamicNetworkLocation
 from kolibri.core.discovery.tasks import add_dynamic_network_location
 from kolibri.core.discovery.tasks import dispatch_broadcast_hooks
 from kolibri.core.discovery.tasks import generate_job_id
@@ -45,17 +43,17 @@ class NetworkLocationListener(KolibriInstanceListener):
         :type instance: kolibri.core.discovery.utils.network.broadcast.KolibriInstance
         """
         priority = Priority.REGULAR
-        is_current_device_lod = get_device_setting("subset_of_users_device")
-        discovered_device = DynamicNetworkLocation.objects.filter(
-            broadcast_id=self.broadcast.id, pk=instance.zeroconf_id
-        ).first()
+        is_current_device_lod = self.broadcast.instance.device_info.get(
+            "subset_of_users_device"
+        )
+        is_discovered_device_lod = instance.device_info.get("subset_of_users_device")
 
         # If the current device is not an LOD,
         # OR
         # the current device is an LOD and the discovered device is not an LOD,
         # then enqueue with high priority.
         if (not is_current_device_lod) or (
-            is_current_device_lod and not discovered_device.subset_of_users_device
+            is_current_device_lod and not is_discovered_device_lod
         ):
             priority = Priority.HIGH
 


### PR DESCRIPTION
## Summary

Decreases the time-to-sync for learn-only devices joining the network by playing with some task's priorities.

Developed together with @akolson :heart:  



## References
Closes https://github.com/learningequality/kolibri/issues/11220.



## Reviewer guidance
Make sure the if condition is as specified in https://github.com/learningequality/kolibri/issues/11220.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
