### PR TITLE
prevented importing of facility from lod

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -177,7 +177,7 @@
       } else if (props.filterLODAvailable) {
         useDevicesResult = useDevicesForLearnOnlyDevice();
       } else {
-        useDevicesResult = useDevices();
+        useDevicesResult = useDevices({ subset_of_users_device: false });
       }
 
       const {


### PR DESCRIPTION


## Summary
This PR prevents importing of a facility from LOD.

Closes #11121

## References
#11121
…

## Reviewer guidance
> Navigate to device plugin on the facilities tab
> Click on the import learning facility button and observe.
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
