### PR TITLE
coach routing - handle lesson creation and deletion

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -332,4 +332,5 @@ export function showExamCreationQuestionSelectionPage(store, toRoute, fromRoute)
   store.commit('SET_PAGE_NAME', 'EXAM_CREATION_QUESTION_SELECTION');
   store.commit('SET_TOOLBAR_ROUTE', { name: fromRoute.name, params: fromRoute.params });
   store.dispatch('examCreation/updateSelectedQuestions');
+  store.dispatch('notLoading');
 }

--- a/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/planLessonsRoutes.js
@@ -22,7 +22,8 @@ import LessonEditDetailsPage from '../views/plan/LessonEditDetailsPage';
 import LessonCreationPage from '../views/plan/LessonCreationPage';
 import { classIdParamRequiredGuard } from './utils';
 
-const CLASS = '/:classId?/plan';
+const OPTIONAL_CLASS = '/:classId?/plan';
+const CLASS = '/:classId/plan';
 const LESSON = '/lessons/:lessonId';
 const ALL_LESSONS = '/lessons';
 const SELECTION = '/selection';
@@ -39,7 +40,7 @@ const { showLessonsRootPage } = useLessons();
 export default [
   {
     name: LessonsPageNames.PLAN_LESSONS_ROOT,
-    path: path(CLASS, ALL_LESSONS),
+    path: path(OPTIONAL_CLASS, ALL_LESSONS),
     component: LessonsRootPage,
     handler(toRoute, fromRoute, next) {
       if (classIdParamRequiredGuard(toRoute, PageNames.PLAN_PAGE, next)) {

--- a/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
+++ b/kolibri/plugins/coach/assets/src/routes/reportRoutes.js
@@ -17,7 +17,8 @@ import QuizEditDetailsPage from '../views/plan/QuizEditDetailsPage';
 import { classIdParamRequiredGuard } from './utils';
 
 const ACTIVITY = '/activity';
-const CLASS = '/:classId?/reports';
+const OPTIONAL_CLASS = '/:classId?/reports';
+const CLASS = '/:classId/reports';
 const GROUPS = '/groups';
 const GROUP = '/groups/:groupId';
 const LEARNERS = '/learners';
@@ -45,7 +46,7 @@ function defaultHandler() {
 export default [
   {
     name: PageNames.REPORTS_PAGE,
-    path: path(CLASS),
+    path: path(OPTIONAL_CLASS),
     redirect: { name: 'ReportsLessonListPage' },
   },
   {
@@ -444,7 +445,7 @@ export default [
     },
   },
   {
-    path: path(CLASS, LESSONS),
+    path: path(OPTIONAL_CLASS, LESSONS),
     component: pages.ReportsLessonListPage,
     handler: (toRoute, fromRoute, next) => {
       if (classIdParamRequiredGuard(toRoute, 'ReportsLessonListPage', next)) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -115,9 +115,12 @@
         const { id } = this.currentLesson;
         return LessonResource.deleteModel({ id })
           .then(() => {
-            this.$router.replace(this.$router.getRoute('PLAN_LESSONS_ROOT'), () => {
-              this.showSnackbarNotification('lessonDeleted');
-            });
+            this.$router.replace(
+              this.$router.getRoute('PLAN_LESSONS_ROOT', { classId: this.classId }),
+              () => {
+                this.showSnackbarNotification('lessonDeleted');
+              }
+            );
           })
           .catch(error => {
             this.$store.dispatch('handleApiError', { error });


### PR DESCRIPTION
## Summary
this PR addresses:
- lesson creation bug caused by an over-application of making `classId` optional - it should only be optional in the base `Coach` routes but other URLs were also initially (& unintentionally) effected
- redirect bug after lesson deletion, which surfaced after the above bug was addressed
- appearance of perpetual loading bar in `Coach` > `Plan` > `Quiz` > [resource selection] > Quiz Preview (final step before a new quiz is saved)

## References
- fixes #11267 
- closes PR #11279 which set out to address the same issue

<br />

**Quiz preview before (no throttling)**
_note loading bar running perpetually while on quiz preview page, but very quickly resolved on other pages_

https://github.com/learningequality/kolibri/assets/43046460/87337f96-7660-405f-991d-10e60a197d87

<br />

**Quiz preview after (throttled to Slow 3G)**
_note loading bar runs during page transitions (including when transitioning from Quiz preview to the Quiz page upon saving)_

https://github.com/learningequality/kolibri/assets/43046460/058f6c43-34b2-4fff-ad89-f32871437533

----

## Reviewer guidance
📌 the existence of more than one class in a facility (or more than one facility assigned to the user) means that URLs for page links & buttons are constructed a bit differently behind the scenes and user-facing behavior differs. 

behind the scenes, the `facility_id` and `classId` potentially needed for a URL are determined and applied differently in the different cases. UX-wise, a single facility user with one class will go directly to that class's details when clicking on a sidenav `Coach` subtopic, while a multi-facility user will first land on the "All Facilities" page and, if they select a facility with multiple classes, will next land on that facility's "All Classes" page, and information about the initially-selected subtopic should persist and ultimately be automatically navigated to only upon making that class selection. 

with these differences in mind, please consider the 4 potential cases when testing: multi-facility user in facility with 1 class, multi-facility user in facility with 2+ classes, single facility user with 1 class, and single facility user with 2+ classes. 📌

**Lesson creation & deletion**
- check for successful navigation through `Coach` > `Plan` > `New Lesson` > [enter details] > `Save changes` to the new lesson's `Lesson Summary` page
- check for successful lesson deletion from a lesson's `Lesson Summary` page, `Options` > `Delete` and automatic navigation to the containing class's `Plan` > `Lessons` page


**Quiz Preview loading state**
- following `Coach` > `Plan` > `Quizzes` > `New Quiz` > `Create Quiz` > [select resources] > `Continue`, check "Preview Quiz" page top bar to confirm it is no longer constant loading 
- if you're throttling the connection or have a slow connection already, loading indicator should be present within the nested questions component during initial loading and/or if you choose to randomize the questions via the on-screen button.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
