### PR TITLE
Disable scroll on main page if side panel is open

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -462,8 +462,20 @@
         }
       },
       showViewResourcesSidePanel(newVal, oldVal) {
+        if (newVal === true) {
+          this.stopMainScroll(true);
+        } else {
+          this.stopMainScroll(false);
+        }
         if (newVal && !oldVal) {
           this.getSidebarInfo();
+        }
+      },
+      sidePanelContent(newVal) {
+        if (newVal !== null) {
+          this.stopMainScroll(true);
+        } else {
+          this.stopMainScroll(false);
         }
       },
     },
@@ -644,6 +656,14 @@
       },
       goToAllLibraries() {
         this.$router.push({ name: PageNames.EXPLORE_LIBRARIES });
+      },
+      stopMainScroll(sidePanelVisible) {
+        const mainWrapperElement = this.$refs.mainWrapper;
+        if (sidePanelVisible) {
+          mainWrapperElement.style.position = 'fixed';
+        } else {
+          mainWrapperElement.style.position = null;
+        }
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
I have added a function that sets the position of the main wrapper to fixed when the side panel is open and resets it to null when the side panel is closed.

Initially:
https://github.com/learningequality/kolibri/assets/77184239/0ba285dc-c08e-49f6-9120-d1d48a6227e0

After adding the function:
https://github.com/learningequality/kolibri/assets/77184239/8ae95aac-c594-4e83-9268-d173de6e928f


…

## References
#9095 
…

## Reviewer guidance
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
