### PR TITLE
[DO NOT MERGE] Fix textbox being unexpectedly focused after the first page load

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#f20bdad20de52666caa77b41a9a19a8dba6a9003",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#f20bdad20de52666caa77b41a9a19a8dba6a9003",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7642,9 +7642,9 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#f20bdad20de52666caa77b41a9a19a8dba6a9003":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#2e5c1e8fc9a5239eaf3780639953619f34b6a2be"
+  resolved "https://github.com/learningequality/kolibri-design-system#f20bdad20de52666caa77b41a9a19a8dba6a9003"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
@radinamatic @pcenov 

This links Kolibri to this KDS PR https://github.com/learningequality/kolibri-design-system/pull/449 which fixes https://github.com/learningequality/kolibri/issues/9077 and possibly other pages where focus ring appears around textbox on its own when a page loads.

This was caused by
> So when ProfileEditPage is first loaded there is api call for user data, which then updates the textbox value which causes it to have coreOutline. It can confirmed this by stopping this api call, then the page will not have it when loaded. ~ @thesujai (https://github.com/learningequality/kolibri/issues/9077#issuecomment-1717541887) 

so it's particularly relevant to pages where we load some data for a text box.

Code changes make sense to me and I haven't noticed any issues when I clicked through it briefly, however it's a significant change in the core logic of the component and I'd like to be more confident we don't introduce unexpected regressions. Historically, any updates around focus rings tend to produce bugs in situations we perhaps didn't think of before.

Could you please test textbox keyboard and mouse navigation and outlines thoroughly? Also, if you find any issues, it'd be helpful to check whether it was present on `develop` before so we can be sure that this change is indeed the real cause. In this case, it will really help with debugging. Thank you.
