### PR TITLE
Adds connection error exception to handle redis connection failure

### DIFF
--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -10,6 +10,7 @@ from django.db.models.query import F
 from django.db.utils import DatabaseError
 from django_filters.filters import UUIDFilter
 from django_filters.rest_framework.filterset import FilterSet
+from six import raise_from
 
 from kolibri.core.errors import RedisConnectionError
 from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
@@ -169,7 +170,9 @@ class KolibriCoreConfig(AppConfig):
         except ConnectionError as e:
             logger.warning("Unable to connect to Redis: {}".format(str(e)))
 
-            raise RedisConnectionError("Unable to connect to Redis: {}".format(str(e)))
+            raise_from(
+                RedisConnectionError("Unable to connect to Redis: {}".format(str(e))), e
+            )
 
         except Exception as e:
             logger.warning("Unable to check Redis settings")

--- a/kolibri/core/apps.py
+++ b/kolibri/core/apps.py
@@ -11,6 +11,7 @@ from django.db.utils import DatabaseError
 from django_filters.filters import UUIDFilter
 from django_filters.rest_framework.filterset import FilterSet
 
+from kolibri.core.errors import RedisConnectionError
 from kolibri.core.sqlite.pragmas import CONNECTION_PRAGMAS
 from kolibri.core.sqlite.pragmas import START_PRAGMAS
 from kolibri.core.sqlite.utils import repair_sqlite_db
@@ -108,12 +109,15 @@ class KolibriCoreConfig(AppConfig):
             cursor.execute(START_PRAGMAS)
             connection.close()
 
-    @staticmethod
-    def check_redis_settings():
+    @staticmethod  # noqa C901
+    def check_redis_settings():  # noqa C901
         """
         Check that Redis settings are sensible, and use the lower level Redis client to make updates
         if we are configured to do so, and if we should, otherwise make some logging noise.
         """
+
+        from redis.exceptions import ConnectionError
+
         if OPTIONS["Cache"]["CACHE_BACKEND"] != "redis":
             return
         config_maxmemory = OPTIONS["Cache"]["CACHE_REDIS_MAXMEMORY"]
@@ -161,6 +165,12 @@ class KolibriCoreConfig(AppConfig):
                     "Problematic Redis settings detected, please see Redis configuration "
                     "documentation for details: https://redis.io/topics/config"
                 )
+
+        except ConnectionError as e:
+            logger.warning("Unable to connect to Redis: {}".format(str(e)))
+
+            raise RedisConnectionError("Unable to connect to Redis: {}".format(str(e)))
+
         except Exception as e:
             logger.warning("Unable to check Redis settings")
             logger.warning(e)

--- a/kolibri/core/errors.py
+++ b/kolibri/core/errors.py
@@ -17,3 +17,7 @@ class KolibriUpgradeError(KolibriError):
     """
 
     pass
+
+
+class RedisConnectionError(Exception):
+    pass


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds a defensive check to ensure that Kolibri execution is halted in case it fails to connect to Redis.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10551 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Ensure that `redis` is not running on any of the ports specified below
- Run `KOLIBRI_CACHE_BACKEND="redis" KOLIBRI_CACHE_LOCATION="redis:657" kolibri start` on a pex file or local environment setup
- Kolibri should not start. The logs returned should be similar to the below;
```
INFO     2023-09-26 21:14:03,723 Option CACHE_BACKEND in section [Cache] being overridden by environment variable KOLIBRI_CACHE_BACKEND
INFO     2023-09-26 21:14:03,723 Option CACHE_LOCATION in section [Cache] being overridden by environment variable KOLIBRI_CACHE_LOCATION
INFO     2023-09-26 21:14:03,724 Option DEBUG in section [Server] being overridden by environment variable KOLIBRI_DEBUG
INFO     2023-09-26 21:14:03,724 Option DEBUG_LOG_DATABASE in section [Server] being overridden by environment variable KOLIBRI_DEBUG_LOG_DATABASE
INFO     2023-09-26 21:14:03,943 Running Kolibri with the following settings: kolibri.deployment.default.settings.base
WARNING  2023-09-26 21:14:03,986 Unable to connect to Redis: Error 8 connecting to redis:657. nodename nor servname provided, or not known.
Error: Traceback (most recent call last):
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/connection.py", line 492, in connect
    sock = self._connect()
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/connection.py", line 519, in _connect
    for res in socket.getaddrinfo(self.host, self.port, self.socket_type,
  File "/Users/akol/.pyenv/versions/3.8.13/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/core/apps.py", line 132, in check_redis_settings
    maxmemory_policy = helper.get_maxmemory_policy()
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/core/utils/cache.py", line 51, in get_maxmemory_policy
    return self.get("maxmemory-policy", default_value="noeviction")
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/core/utils/cache.py", line 34, in get
    return self.client.config_get(key).get(key, default_value)
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/client.py", line 902, in config_get
    return self.execute_command('CONFIG GET', pattern)
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/client.py", line 772, in execute_command
    connection = pool.get_connection(command_name, **options)
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/connection.py", line 1142, in get_connection
    connection.connect()
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/redis/connection.py", line 497, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 8 connecting to redis:657. nodename nor servname provided, or not known.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/utils/cli.py", line 193, in invoke
    initialize(**get_initialize_params())
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/utils/main.py", line 295, in initialize
    _setup_django()
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/utils/main.py", line 153, in _setup_django
    django.setup()
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/Users/akol/.pyenv/versions/3.8.13/envs/kolibri-py3.8.13/lib/python3.8/site-packages/django/apps/registry.py", line 116, in populate
    app_config.ready()
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/core/apps.py", line 45, in ready
    self.check_redis_settings()
  File "/Users/akol/Desktop/leDev/kolibri/kolibri/core/apps.py", line 172, in check_redis_settings
    raise RedisConnectionError("Unable to connect to Redis: {}".format(str(e)))
kolibri.core.errors.RedisConnectionError: Unable to connect to Redis: Error 8 connecting to redis:657. nodename nor servname provided, or not known.
```
- Look out for the `Unable to connect to Redis...` in the list of logs(`RedisConnectionError ` should be raised)
- Also, running `KOLIBRI_CACHE_BACKEND="redis" KOLIBRI_CACHE_LOCATION="redis:657" kolibri services` should yield the same results
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
