### PR TITLE
Add LRU eviction mechanisms for streamed file chunks

### DIFF
--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -43,7 +43,9 @@ from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.connections import capture_connection_state
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.utils.urls import reverse_path
+from kolibri.utils.conf import OPTIONS
 from kolibri.utils.data import bytes_for_humans
+from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
 
 
 logger = logging.getLogger(__name__)
@@ -663,6 +665,7 @@ def _process_content_requests(incomplete_downloads):
     has_processed_sync_removals = False
     has_processed_user_removals = False
     has_processed_user_downloads = False
+    has_freed_space_in_stream_cache = False
     qs = incomplete_downloads_with_metadata.all()
 
     # loop while we have pending downloads
@@ -709,6 +712,16 @@ def _process_content_requests(incomplete_downloads):
                 # process, then repeat
                 has_processed_user_downloads = True
                 process_user_downloads_for_removal()
+                continue
+            if not has_freed_space_in_stream_cache:
+                # try to clear space, then repeat
+                has_freed_space_in_stream_cache = True
+                chunked_file_manager = ChunkedFileDirectoryManager(
+                    OPTIONS["Paths"]["CONTENT_DIR"]
+                )
+                chunked_file_manager.evict_files(
+                    calc.get_additional_free_space_needed()
+                )
                 continue
             raise InsufficientStorage(
                 "Content download requests need {} of free space".format(
@@ -986,3 +999,7 @@ class StorageCalculator:
     def is_space_sufficient(self):
         self._calculate_space_available()
         return self.free_space > self.incomplete_downloads_size
+
+    def get_additional_free_space_needed(self):
+        self._calculate_space_available()
+        return self.incomplete_downloads_size - self.free_space

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -970,12 +970,13 @@ class StorageCalculator:
             total_size=_total_size_annotation(available=True),
         )
         self.free_space = 0
+        self.incomplete_downloads_size = 0
 
     def _calculate_space_available(self):
+        self.incomplete_downloads_size = _total_size(self.incomplete_downloads)
         free_space = get_free_space_for_downloads(
             completed_size=_total_size(completed_downloads_queryset())
         )
-        free_space -= _total_size(self.incomplete_downloads)
         free_space += _total_size(self.incomplete_sync_removals)
         free_space += _total_size(self.incomplete_user_removals)
         free_space += _total_size(self.complete_user_downloads)
@@ -984,4 +985,4 @@ class StorageCalculator:
 
     def is_space_sufficient(self):
         self._calculate_space_available()
-        return self.free_space > _total_size(self.incomplete_downloads)
+        return self.free_space > self.incomplete_downloads_size

--- a/kolibri/core/deviceadmin/tasks.py
+++ b/kolibri/core/deviceadmin/tasks.py
@@ -84,15 +84,9 @@ def streamed_cache_cleanup():
 
 
 def schedule_streamed_cache_cleanup():
-    current_dt = local_now()
-    cleanup_time = current_dt.replace(hour=1, minute=0, second=0, microsecond=0)
-    if cleanup_time < current_dt:
-        # If it is past 1AM, change the day to tomorrow.
-        cleanup_time = cleanup_time + timedelta(days=1)
-    # Repeat indefinitely
     try:
-        streamed_cache_cleanup.enqueue_at(
-            cleanup_time, repeat=None, interval=24 * 60 * 60
+        streamed_cache_cleanup.enqueue_in(
+            timedelta(hours=1), repeat=None, interval=60 * 60
         )
     except JobRunning:
         pass

--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -122,14 +122,16 @@ class ChunkedFileDirectoryManager(object):
             for dir in dirs:
                 if dir.endswith(CHUNK_SUFFIX):
                     yield os.path.join(root, dir)
+                    # Don't continue to walk down the directory tree
+                    dirs.remove(dir)
 
     def _get_chunked_file_stats(self):
         stats = {}
         for chunked_file_dir in self._get_chunked_file_dirs():
             file_stats = {"last_access_time": 0, "size": 0}
-            for file in os.listdir(chunked_file_dir):
-                file_path = os.path.join(chunked_file_dir, file)
-                if os.path.isfile(file_path):
+            for dirpath, _, filenames in os.walk(chunked_file_dir):
+                for file in filenames:
+                    file_path = os.path.join(dirpath, file)
                     file_stats["last_access_time"] = max(
                         file_stats["last_access_time"], os.path.getatime(file_path)
                     )

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -404,6 +404,16 @@ base_option_spec = {
             "default": "",
             "description": "Eviction policy to use when using Redis for caching, Redis only.",
         },
+        "STREAMED_FILE_CACHE_SIZE": {
+            "type": "bytes",
+            "default": "500MB",
+            "description": """
+                Disk space to be used for caching streamed files. This is used for caching files that are
+                being streamed from remote libraries, if these files are later imported, these should be cleaned up,
+                and will no longer count to this cache size.
+                Value can either be a number suffixed with a unit (e.g. MB, GB, TB) or an integer number of bytes.
+            """,
+        },
     },
     "Database": {
         "DATABASE_ENGINE": {

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -248,13 +248,8 @@ class ZipContentServerPlugin(ServerPlugin):
     START.priority = 75
 
 
-class ServicesPlugin(SimplePlugin):
-    def __init__(self, bus):
-        self.bus = bus
-        self.worker = None
-
+class DefaultScheduledTasksPlugin(SimplePlugin):
     def START(self):
-        from kolibri.core.tasks.main import initialize_workers
         from kolibri.core.analytics.tasks import schedule_ping
         from kolibri.core.deviceadmin.tasks import schedule_vacuum
 
@@ -263,6 +258,15 @@ class ServicesPlugin(SimplePlugin):
 
         # schedule the vacuum job if not already scheduled
         schedule_vacuum()
+
+
+class ServicesPlugin(SimplePlugin):
+    def __init__(self, bus):
+        self.bus = bus
+        self.worker = None
+
+    def START(self):
+        from kolibri.core.tasks.main import initialize_workers
 
         # Initialize the iceqube engine to handle queued tasks
         self.worker = initialize_workers()
@@ -733,6 +737,9 @@ class BaseKolibriProcessBus(ProcessBus):
 
         reload_plugin = ProcessControlPlugin(self)
         reload_plugin.subscribe()
+
+        default_scheduled_tasks_plugin = DefaultScheduledTasksPlugin(self)
+        default_scheduled_tasks_plugin.subscribe()
 
     def run(self):
         self.graceful()

--- a/kolibri/utils/server.py
+++ b/kolibri/utils/server.py
@@ -252,12 +252,16 @@ class DefaultScheduledTasksPlugin(SimplePlugin):
     def START(self):
         from kolibri.core.analytics.tasks import schedule_ping
         from kolibri.core.deviceadmin.tasks import schedule_vacuum
+        from kolibri.core.deviceadmin.tasks import schedule_streamed_cache_cleanup
 
         # schedule the pingback job if not already scheduled
         schedule_ping()
 
         # schedule the vacuum job if not already scheduled
         schedule_vacuum()
+
+        # schedule the streamed cache cleanup job if not already scheduled
+        schedule_streamed_cache_cleanup()
 
 
 class ServicesPlugin(SimplePlugin):

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -318,14 +318,21 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
     def test_listing_chunked_files(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_get_chunked_file_stats(self):
@@ -347,8 +354,8 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 3))
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted([]),
         )
 
     def test_evict_files_more_than_file_size_sum(self):
@@ -357,46 +364,65 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
             TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 3 + 12)
         )
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted([]),
         )
 
     def test_evict_files_exact_file_size(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(TEST_FILE_SIZE, manager.evict_files(TEST_FILE_SIZE))
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_evict_files_less_than_file_size(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(TEST_FILE_SIZE, manager.evict_files(TEST_FILE_SIZE - 12))
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_evict_files_more_than_file_size(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(TEST_FILE_SIZE * 2, manager.evict_files(TEST_FILE_SIZE + 12))
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_evict_files_more_than_twice_file_size(self):
@@ -405,55 +431,76 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
             TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 2 + 12)
         )
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted([]),
         )
 
     def test_evict_files_zero_bytes(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         self.assertEqual(0, manager.evict_files(0))
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_limit_files_no_eviction_needed(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         manager.limit_files(TEST_FILE_SIZE * 3)
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_limit_files_some_eviction_needed(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         manager.limit_files(TEST_FILE_SIZE * 2)
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [
-                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
-                os.path.join(
-                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
-                ),
-            ],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted(
+                [
+                    os.path.join(
+                        self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX
+                    ),
+                    os.path.join(
+                        self.base_dir,
+                        "nested",
+                        "nested_twice",
+                        "file3.txt" + CHUNK_SUFFIX,
+                    ),
+                ]
+            ),
         )
 
     def test_limit_files_all_evicted(self):
         manager = ChunkedFileDirectoryManager(self.base_dir)
         manager.limit_files(TEST_FILE_SIZE - 12)
         self.assertEqual(
-            list(manager._get_chunked_file_dirs()),
-            [],
+            sorted(list(manager._get_chunked_file_dirs())),
+            sorted([]),
         )

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -422,3 +422,38 @@ class TestChunkedFileDirectoryManager(unittest.TestCase):
                 ),
             ],
         )
+
+    def test_limit_files_no_eviction_needed(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        manager.limit_files(TEST_FILE_SIZE * 3)
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_limit_files_some_eviction_needed(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        manager.limit_files(TEST_FILE_SIZE * 2)
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_limit_files_all_evicted(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        manager.limit_files(TEST_FILE_SIZE - 12)
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [],
+        )

--- a/kolibri/utils/tests/test_chunked_file.py
+++ b/kolibri/utils/tests/test_chunked_file.py
@@ -2,10 +2,33 @@ import hashlib
 import math
 import os
 import shutil
+import tempfile
 import unittest
 
+from kolibri.utils.file_transfer import CHUNK_SUFFIX
 from kolibri.utils.file_transfer import ChunkedFile
+from kolibri.utils.file_transfer import ChunkedFileDirectoryManager
 from kolibri.utils.file_transfer import ChunkedFileDoesNotExist
+
+
+def _write_test_data_to_chunked_file(chunked_file):
+    data = b""
+    for i in range(chunked_file.chunks_count):
+        with open(
+            os.path.join(chunked_file.chunk_dir, ".chunk_{}".format(i)), "wb"
+        ) as f:
+            size = (
+                chunked_file.chunk_size
+                if i < chunked_file.chunks_count - 1
+                else (chunked_file.file_size % chunked_file.chunk_size)
+            )
+            to_write = os.urandom(size)
+            f.write(to_write)
+            data += to_write
+    return data
+
+
+TEST_FILE_SIZE = (1024 * 1024) + 731
 
 
 class TestChunkedFile(unittest.TestCase):
@@ -13,29 +36,16 @@ class TestChunkedFile(unittest.TestCase):
         self.file_path = "test_file"
 
         self.chunk_size = ChunkedFile.chunk_size
-        self.file_size = (1024 * 1024) + 731
+        self.file_size = TEST_FILE_SIZE
 
         self.chunked_file = ChunkedFile(self.file_path)
+        self.chunked_file.file_size = self.file_size
 
         # Create dummy chunks
         self.chunks_count = int(
             math.ceil(float(self.file_size) / float(self.chunk_size))
         )
-        self.data = b""
-        for i in range(self.chunks_count):
-            with open(
-                os.path.join(self.chunked_file.chunk_dir, ".chunk_{}".format(i)), "wb"
-            ) as f:
-                size = (
-                    self.chunk_size
-                    if i < self.chunks_count - 1
-                    else (self.file_size % self.chunk_size)
-                )
-                to_write = os.urandom(size)
-                f.write(to_write)
-                self.data += to_write
-
-        self.chunked_file.file_size = self.file_size
+        self.data = _write_test_data_to_chunked_file(self.chunked_file)
 
     def tearDown(self):
         shutil.rmtree(self.chunked_file.chunk_dir, ignore_errors=True)
@@ -287,3 +297,128 @@ class TestChunkedFile(unittest.TestCase):
         with self.assertRaises(ChunkedFileDoesNotExist):
             with self.chunked_file.lock_chunks(0):
                 pass
+
+
+class TestChunkedFileDirectoryManager(unittest.TestCase):
+    def setUp(self):
+        self.base_dir = tempfile.mkdtemp()
+        for files in [
+            ["file1.txt"],
+            ["nested_once", "file2.txt"],
+            ["nested", "nested_twice", "file3.txt"],
+        ]:
+            file_path = os.path.join(self.base_dir, *files)
+            chunked_file = ChunkedFile(file_path)
+            chunked_file.file_size = TEST_FILE_SIZE
+            _write_test_data_to_chunked_file(chunked_file)
+
+    def tearDown(self):
+        shutil.rmtree(self.base_dir, ignore_errors=True)
+
+    def test_listing_chunked_files(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_get_chunked_file_stats(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        stats = manager._get_chunked_file_stats()
+
+        for file_path, file_stats in stats.items():
+            self.assertEqual(file_stats["size"], TEST_FILE_SIZE)
+            expected_last_access_time = 0
+            for file in os.listdir(file_path):
+                if os.path.isfile(os.path.join(file_path, file)):
+                    expected_last_access_time = max(
+                        expected_last_access_time,
+                        os.path.getatime(os.path.join(file_path, file)),
+                    )
+            self.assertEqual(file_stats["last_access_time"], expected_last_access_time)
+
+    def test_evict_files_exact_file_size_sum(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 3))
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [],
+        )
+
+    def test_evict_files_more_than_file_size_sum(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(
+            TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 3 + 12)
+        )
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [],
+        )
+
+    def test_evict_files_exact_file_size(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(TEST_FILE_SIZE, manager.evict_files(TEST_FILE_SIZE))
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_evict_files_less_than_file_size(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(TEST_FILE_SIZE, manager.evict_files(TEST_FILE_SIZE - 12))
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_evict_files_more_than_file_size(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(TEST_FILE_SIZE * 2, manager.evict_files(TEST_FILE_SIZE + 12))
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )
+
+    def test_evict_files_more_than_twice_file_size(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(
+            TEST_FILE_SIZE * 3, manager.evict_files(TEST_FILE_SIZE * 2 + 12)
+        )
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [],
+        )
+
+    def test_evict_files_zero_bytes(self):
+        manager = ChunkedFileDirectoryManager(self.base_dir)
+        self.assertEqual(0, manager.evict_files(0))
+        self.assertEqual(
+            list(manager._get_chunked_file_dirs()),
+            [
+                os.path.join(self.base_dir, "file1.txt" + CHUNK_SUFFIX),
+                os.path.join(self.base_dir, "nested_once", "file2.txt" + CHUNK_SUFFIX),
+                os.path.join(
+                    self.base_dir, "nested", "nested_twice", "file3.txt" + CHUNK_SUFFIX
+                ),
+            ],
+        )

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -159,22 +159,25 @@ class TestServerDefaultScheduledTasks(object):
             # two userdefined and two server defined (pingback and vacuum)
             from kolibri.core.analytics.tasks import DEFAULT_PING_JOB_ID
             from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
+            from kolibri.core.deviceadmin.tasks import STREAMED_CACHE_CLEANUP_JOB_ID
 
-            assert len(job_storage) == 4
+            assert len(job_storage) == 5
             assert job_storage.get_job(test1) is not None
             assert job_storage.get_job(test2) is not None
             assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
             assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
+            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
 
             # Restart services
             default_scheduled_tasks_plugin.START()
 
             # Make sure all scheduled jobs persist after restart
-            assert len(job_storage) == 4
+            assert len(job_storage) == 5
             assert job_storage.get_job(test1) is not None
             assert job_storage.get_job(test2) is not None
             assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
             assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
+            assert job_storage.get_job(STREAMED_CACHE_CLEANUP_JOB_ID) is not None
 
 
 class TestZeroConfPlugin(object):

--- a/kolibri/utils/tests/test_server.py
+++ b/kolibri/utils/tests/test_server.py
@@ -113,50 +113,6 @@ class TestServerServices(object):
 
         mock_kolibri_broadcast.assert_not_called()
 
-    @mock.patch("kolibri.core.tasks.main.initialize_workers")
-    @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
-    def test_scheduled_jobs_persist_on_restart(
-        self,
-        mock_kolibri_broadcast,
-        initialize_workers,
-        job_storage,
-    ):
-        with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
-
-            # Schedule two userdefined jobs
-            from kolibri.utils.time_utils import local_now
-            from datetime import timedelta
-
-            schedule_time = local_now() + timedelta(hours=1)
-            test1 = job_storage.schedule(schedule_time, Job(id))
-            test2 = job_storage.schedule(schedule_time, Job(id))
-
-            # Now, start services plugin
-            service_plugin = server.ServicesPlugin(mock.MagicMock(name="bus"))
-            service_plugin.START()
-
-            # Currently, we must have exactly four scheduled jobs
-            # two userdefined and two server defined (pingback and vacuum)
-            from kolibri.core.analytics.tasks import DEFAULT_PING_JOB_ID
-            from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
-
-            assert len(job_storage) == 4
-            assert job_storage.get_job(test1) is not None
-            assert job_storage.get_job(test2) is not None
-            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
-            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
-
-            # Restart services
-            service_plugin.STOP()
-            service_plugin.START()
-
-            # Make sure all scheduled jobs persist after restart
-            assert len(job_storage) == 4
-            assert job_storage.get_job(test1) is not None
-            assert job_storage.get_job(test2) is not None
-            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
-            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
-
     def test_services_shutdown_on_stop(self):
 
         # Initialize and ready services plugin for testing
@@ -174,6 +130,51 @@ class TestServerServices(object):
         assert services_plugin.worker.mock_calls == [
             mock.call.shutdown(wait=True),
         ]
+
+
+class TestServerDefaultScheduledTasks(object):
+    @mock.patch("kolibri.core.discovery.utils.network.broadcast.KolibriBroadcast")
+    def test_scheduled_jobs_persist_on_restart(
+        self,
+        mock_kolibri_broadcast,
+        job_storage,
+    ):
+        with mock.patch("kolibri.core.tasks.registry.job_storage", wraps=job_storage):
+
+            # Schedule two userdefined jobs
+            from kolibri.utils.time_utils import local_now
+            from datetime import timedelta
+
+            schedule_time = local_now() + timedelta(hours=1)
+            test1 = job_storage.schedule(schedule_time, Job(id))
+            test2 = job_storage.schedule(schedule_time, Job(id))
+
+            # Now, start services plugin
+            default_scheduled_tasks_plugin = server.DefaultScheduledTasksPlugin(
+                mock.MagicMock(name="bus")
+            )
+            default_scheduled_tasks_plugin.START()
+
+            # Currently, we must have exactly four scheduled jobs
+            # two userdefined and two server defined (pingback and vacuum)
+            from kolibri.core.analytics.tasks import DEFAULT_PING_JOB_ID
+            from kolibri.core.deviceadmin.tasks import SCH_VACUUM_JOB_ID
+
+            assert len(job_storage) == 4
+            assert job_storage.get_job(test1) is not None
+            assert job_storage.get_job(test2) is not None
+            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
+            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
+
+            # Restart services
+            default_scheduled_tasks_plugin.START()
+
+            # Make sure all scheduled jobs persist after restart
+            assert len(job_storage) == 4
+            assert job_storage.get_job(test1) is not None
+            assert job_storage.get_job(test2) is not None
+            assert job_storage.get_job(DEFAULT_PING_JOB_ID) is not None
+            assert job_storage.get_job(SCH_VACUUM_JOB_ID) is not None
 
 
 class TestZeroConfPlugin(object):


### PR DESCRIPTION
## Summary
* Adds a utility to get stats for all ChunkedFile objects in the file system
* Adds ability to evict a certain number of bytes of the least recently used files (but will always delete the entire ChunkedFile rather than trying to pick and choose chunks)
* Fixes a small bug in the StorageCalculation object that was double counting incomplete_downloads
* Adds additional logic to content request processing to attempt to evict files from the streamed file cache when we run out of space
* Adds capability to the new utility class to limit the total size of files to a set maximum
* Does a minor refactor to put all core scheduled tasks into a single plugin that always gets invoked (to prevent the Android app continually having to keep this up to date: https://github.com/learningequality/kolibri-installer-android/blob/develop/src/kolibri_tasks.py)
* Adds a new option to limit the size of the streamed files cache, defaults to 500MB
* Adds a scheduled task that runs daily to limit the files cache to this maximum
* Added a slight optimization to prevent os.walk descending into the chunked file directories at first
* Updated to include the files from the diskcache folder in the size calculations
* Updated to run the scheduled task hourly, rather than daily.

## References
Fixes [#9389](https://github.com/learningequality/kolibri/issues/9389)

## Reviewer guidance
Any concerns about the new option? Should the default value be lower?

I haven't benchmarked the os.walk performance on a large installed system, so I am unsure how slow it would get, there may be room for optimization there.

~This also ignores the small diskcache that is used inside each ChunkedFile for the purposes of counting how much is used - should I include this instead?~

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
