### PR TITLE
Corrected output for filtered Quizzes and Lessons

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -119,19 +119,19 @@
           v-else-if="statusSelected.value === coachString('filterQuizStarted') &&
             !startedExams.length"
         >
-          {{ $tr('noStartedExams') }}
+          {{ coreString('noResultsLabel') }}
         </p>
         <p
           v-else-if=" statusSelected.value === coachString('filterQuizNotStarted') &&
             !notStartedExams.length"
         >
-          {{ coreString('noResults') }}
+          {{ coreString('noResultsLabel') }}
         </p>
         <p
           v-else-if=" statusSelected.value === coachString('filterQuizEnded') &&
             !endedExams.length"
         >
-          {{ coreString('noResults') }}
+          {{ coreString('noResultsLabel') }}
         </p>
 
         <!-- Modals for Close & Open of quiz from right-most column -->
@@ -338,11 +338,6 @@
       noExams: {
         message: 'You do not have any quizzes',
         context: 'Message displayed when there are no quizzes within a class.',
-      },
-      noStartedExams: {
-        message: 'No started quizzes',
-        context:
-          'Message displayed when there are no started quizes. Started quizzes are those that are in progress.',
       },
       newQuiz: {
         message: 'Create new quiz',

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -89,19 +89,7 @@
           </template>
         </CoreTable>
 
-        <p
-          v-if="!hasVisibleLessons &&
-            lessons.length"
-        >
-
-          {{ coreString('noResultsLabel') }}
-        </p>
-
-        <p
-          v-if="!hasNotVisibleLessons &&
-            lessons.length"
-        >
-
+        <p v-if="showNoResultsLabel">
           {{ coreString('noResultsLabel') }}
         </p>
 
@@ -250,14 +238,21 @@
         return { name: LessonsPageNames.LESSON_CREATION_ROOT };
       },
       hasVisibleLessons() {
-        return !(
-          !this.activeLessonCounts.true && this.filterSelection.value === 'filterLessonVisible'
-        );
+        return this.activeLessonCounts.true;
       },
-      hasNotVisibleLessons() {
-        return !(
-          !this.activeLessonCounts.false && this.filterSelection.value === 'filterLessonNotVisible'
-        );
+      hasNonVisibleLessons() {
+        return this.activeLessonCounts.false;
+      },
+      showNoResultsLabel() {
+        if (!this.lessons.length) {
+          return false;
+        } else if (this.filterSelection.value === 'filterLessonVisible') {
+          return !this.hasVisibleLessons;
+        } else if (this.filterSelection.value === 'filterLessonNotVisible') {
+          return !this.hasNonVisibleLessons;
+        } else {
+          return false;
+        }
       },
       calcTotalSizeOfVisibleLessons() {
         if (this.lessons && this.lessons.length) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonsRootPage/index.vue
@@ -89,7 +89,19 @@
           </template>
         </CoreTable>
 
-        <p v-if="!hasVisibleLessons">
+        <p
+          v-if="!hasVisibleLessons &&
+            lessons.length"
+        >
+
+          {{ coreString('noResultsLabel') }}
+        </p>
+
+        <p
+          v-if="!hasNotVisibleLessons &&
+            lessons.length"
+        >
+
           {{ coreString('noResultsLabel') }}
         </p>
 
@@ -240,6 +252,11 @@
       hasVisibleLessons() {
         return !(
           !this.activeLessonCounts.true && this.filterSelection.value === 'filterLessonVisible'
+        );
+      },
+      hasNotVisibleLessons() {
+        return !(
+          !this.activeLessonCounts.false && this.filterSelection.value === 'filterLessonNotVisible'
         );
       },
       calcTotalSizeOfVisibleLessons() {


### PR DESCRIPTION
## Summary

'No results' string for filtered Quizzes displays properly:

https://github.com/learningequality/kolibri/assets/1457929/1a0ed891-94fa-49af-b457-1c3a70df9158

There is probably a more elegant way of fixing the second reported issue, but seems to be working OK now 🙂  
On top of the 'No results' not being displayed for not visible lessons, it was displaying for visible ones even when there are no lessons at all, below the 'You do not have any lessons' message. 

Before | After
-- | --
https://github.com/learningequality/kolibri/assets/1457929/32cede85-7bd0-4e47-b40e-ab97da45cac1 | https://github.com/learningequality/kolibri/assets/1457929/bcdbb015-f039-482a-9053-5eb9e744760b

There may still be an underlying loading issue (brief flash of 'No results' until the lesson is loaded and appears in the table), but is probably out of the scope of this PR and definitely above my pay grade 😅 

## References
Fixes #11310 

…

## Reviewer guidance
Change the status of the quizzes (start/end) and lessons (visible/not visible), and check if the 'No results' message is displayed properly for all filtered cases.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
