### PR TITLE
updated KDS reference & testing after changes to useKResponsiveWindow

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#3ab9801a442b20ddf63248b17ca0d83fe21133fb",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -5,7 +5,9 @@ import LearningActivityBar from '../../src/views/LearningActivityBar';
 
 jest.mock('kolibri.coreVue.componentSets.sync');
 function makeWrapper({ propsData } = {}) {
-  return mount(LearningActivityBar, { propsData });
+  // stubbing out KCircularLoader, as using the actual component led to errors related to
+  // Vue Composition API - stub may not be needed once we upgrade to Vue 2.7
+  return mount(LearningActivityBar, { propsData, stubs: ['KCircularLoader'] });
 }
 
 describe('LearningActivityBar', () => {
@@ -293,7 +295,7 @@ describe('LearningActivityBar', () => {
 
       it(`doesn't show the downloading loader by default`, () => {
         const wrapper = makeWrapper();
-        expect(wrapper.find("[data-test='downloadingLoader'] svg").exists()).toBeFalsy();
+        expect(wrapper.find("[data-test='downloadingLoader']").vm.shouldShow).toBeFalsy();
       });
 
       it(`shows the downloading loader for truthy 'isDownloading'`, () => {
@@ -302,7 +304,7 @@ describe('LearningActivityBar', () => {
             isDownloading: true,
           },
         });
-        expect(wrapper.find("[data-test='downloadingLoader'] svg").exists()).toBeTruthy();
+        expect(wrapper.find("[data-test='downloadingLoader']").vm.shouldShow).toBeTruthy();
       });
     });
   });

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#3ab9801a442b20ddf63248b17ca0d83fe21133fb",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,9 +7640,9 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#3ab9801a442b20ddf63248b17ca0d83fe21133fb":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#3ab9801a442b20ddf63248b17ca0d83fe21133fb"
+  resolved "https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9"
   dependencies:
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"


### PR DESCRIPTION
## Summary
this links Kolibri to KDS PR 453 - ["useKResponsiveWindow update fixing resizing behavior in Learn > Library"](https://github.com/learningequality/kolibri-design-system/pull/453) which fixes #11212 and potentially other pages where windowBreakpoint miscalculations were occurring under the hood. 

[the KDS PR](https://github.com/learningequality/kolibri-design-system/pull/453) fixes a bug observed during QA review in `Learn` > `Library` - in certain cases, rapidly resizing the browser window would cause the sidepanel to automatically display when the screen was small, behavior we did not expect nor want at that screen size. beneath the surface, the components were receiving conflicting information about the current screen size because `useKResponsiveWindow` was not updating in the way we expected. 

to address those issues, the KDS PR introduces changes to the scope of variables within `useKResponsiveWindow` and to the way the composable uses `useKWindowDimensions`. 

## References
closes #11212 

### before

https://github.com/learningequality/kolibri/assets/79847249/0b63d243-e140-4830-b9b9-0a915bddfd61


### after

https://github.com/learningequality/kolibri-design-system/assets/43046460/b67220e5-2fcb-45b1-94bf-8cbe29866df3



## Reviewer guidance
- with at least one channel imported, visit `Learn` > `Library`
- quickly resize the window dimensions (see "before" video to replicate exact behavior that once triggered the bug)
- when window is resized to be smaller than 601px, side panel should **not** automatically display - responsive elements & layout should resize & adjust as expected

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included


## PR process

- [ ] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
