### PR TITLE
Fixes performance regression

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
@@ -26,9 +26,6 @@ export default {
     },
   },
   getters: {
-    getDeviceOS(state) {
-      return state.deviceInfo.os;
-    },
     getDataLoading(state) {
       return state.dataLoading;
     },

--- a/kolibri/plugins/device/assets/src/routes/index.js
+++ b/kolibri/plugins/device/assets/src/routes/index.js
@@ -137,9 +137,6 @@ const routes = [
     path: '/settings',
     handler: ({ name }) => {
       store.dispatch('preparePage', { name });
-      if (store.getters['deviceInfo/getDeviceOS'] === undefined) {
-        showDeviceInfoPage(store).then(hideLoadingScreen);
-      }
     },
   },
   {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/__test__/DeviceSettingsPage.spec.js
@@ -61,14 +61,6 @@ const store = new Vuex.Store({
   actions: {
     createSnackbar() {},
   },
-  modules: {
-    deviceInfo: {
-      namespaced: true,
-      getters: {
-        getDeviceOS: () => 'linux',
-      },
-    },
-  },
 });
 
 async function makeWrapper() {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -109,7 +109,7 @@
           </div>
         </div>
 
-        <div v-if="deviceIsAndroid" class="fieldset">
+        <div v-if="canCheckMeteredConnection" class="fieldset">
           <h2>
             <label>{{ $tr('allowDownloadOnMeteredConnection') }}</label>
           </h2>
@@ -285,7 +285,7 @@
         </ul>
       </section>
 
-      <section v-if="deviceIsAndroid || isAppContext" class="android-bar">
+      <section v-if="isAppContext" class="android-bar">
         <KButton
           :text="coreString('saveChangesAction')"
           appearance="raised-button"
@@ -344,7 +344,6 @@
 
 <script>
 
-  import store from 'kolibri.coreVue.vuex.store';
   import { mapGetters } from 'vuex';
   import find from 'lodash/find';
   import urls from 'kolibri.urls';
@@ -355,13 +354,13 @@
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import { checkCapability } from 'kolibri.utils.appCapabilities';
   import commonDeviceStrings from '../commonDeviceStrings';
   import DeviceAppBarPage from '../DeviceAppBarPage';
   import { LandingPageChoices, MeteredConnectionDownloadOptions } from '../../constants';
   import { getFreeSpaceOnServer } from '../AvailableChannelsPage/api';
   import useDeviceRestart from '../../composables/useDeviceRestart';
   import usePlugins from '../../composables/usePlugins';
-  import { showDeviceInfoPage } from '../../modules/deviceInfo/handlers';
   import { getDeviceSettings, getPathsPermissions, saveDeviceSettings, getDeviceURLs } from './api';
   import PrimaryStorageLocationModal from './PrimaryStorageLocationModal';
   import AddStorageLocationModal from './AddStorageLocationModal';
@@ -460,7 +459,7 @@
     },
     computed: {
       ...mapGetters(['isAppContext', 'isPageLoading']),
-      ...mapGetters('deviceInfo', ['getDeviceOS', 'canRestart', 'isRemoteContent']),
+      ...mapGetters('deviceInfo', ['canRestart', 'isRemoteContent']),
       pageTitle() {
         return this.deviceString('deviceManagementTitle');
       },
@@ -537,16 +536,9 @@
           };
         }
       },
-      deviceIsAndroid() {
-        if (this.deviceInfo === undefined) {
-          showDeviceInfoPage(store);
-        }
-        if (this.getDeviceOS === undefined) {
-          return true;
-        }
-        return this.getDeviceOS.includes('Android');
+      canCheckMeteredConnection() {
+        return checkCapability('check_is_metered');
       },
-
       showDisabledAlert() {
         return this.isRemoteContent || !this.canRestart;
       },


### PR DESCRIPTION
## Summary
* Uses capabilities to properly check if metered connection setting should be displayed.
* Removes invocation of async function inside a computed prop that was causing continuous fetches

## References
Cleanup from #11178

## Reviewer guidance
Does the Device Settings page no longer make 2500 requests in 30 seconds?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
