### PR TITLE
Bugfix- birth year selction on profile edit page

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -85,8 +85,12 @@
     methods: {
       makeYearOptions(max, min) {
         return range(max, min, -1).map(n => {
+          // Because of timezone, year could be mismatched when localized in any timezone that less than UTC
+          // for ex- 2022 will be shown instead of 2023
+          let date = new Date();
+          date.setFullYear(n);
           return {
-            label: this.$formatDate(String(n), { year: 'numeric' }),
+            label: this.$formatDate(String(date), { year: 'numeric' }),
             value: String(n),
           };
         });

--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -85,8 +85,8 @@
     methods: {
       makeYearOptions(max, min) {
         return range(max, min, -1).map(n => {
-          // Because of timezone, year could be mismatched when localized in any timezone that less than UTC
-          // for ex- 2022 will be shown instead of 2023
+          // Because of timezone, year could be mismatched when localized in any
+          // timezone that less than UTC. for ex- 2022 will be shown instead of 2023
           let date = new Date();
           date.setFullYear(n);
           return {

--- a/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
+++ b/kolibri/core/assets/src/views/userAccounts/BirthYearSelect.vue
@@ -87,7 +87,7 @@
         return range(max, min, -1).map(n => {
           // Because of timezone, year could be mismatched when localized in any
           // timezone that less than UTC. for ex- 2022 will be shown instead of 2023
-          let date = new Date();
+          const date = new Date();
           date.setFullYear(n);
           return {
             label: this.$formatDate(String(date), { year: 'numeric' }),


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary

After selecting birth year the value gets mismatched because of incorrect label. This is because of timezone, when localized in any timezone that is less than UTC, ex- `new Date('2023') `the date will be shown 2022 instead of 2023

![Screenshot from 2023-09-23 01-03-16(1)](https://github.com/learningequality/kolibri/assets/76952588/8b8b06f0-b263-4282-8655-c6d7dd6c13e3)

So, instead of passing year directly to `$fomatDate`('2023'), setting full year to it so there is no effect of timezone

![Screenshot from 2023-09-29 13-15-44](https://github.com/learningequality/kolibri/assets/76952588/17c82afe-2c8c-4f95-b400-552737941f60)

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
Fixes #11292 
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
- Go to profile edit page
- Try to change the birth year
- After saving check if the year is showing correctly

<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
