### PR TITLE
Solved the page title Error

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/LessonOptionsDropdownMenu.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/LessonOptionsDropdownMenu.vue
@@ -45,7 +45,9 @@
               label: this.$tr('copyLessonAction'),
               value: 'COPY',
             },
-            { label: this.coreString('deleteAction'), value: 'DELETE' },
+            { label: this.coreString('deleteAction'),
+              value: 'DELETE',
+            },
           ];
         }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -116,7 +116,7 @@
         return LessonResource.deleteModel({ id })
           .then(() => {
             this.$router.replace(  
-              this.$router.getRoute('PLAN_LESSONS_ROOT'),
+              this.$router.getRoute('PLAN_LESSONS_ROOT', this.id ? { classId: this.classId } : {}),
               () => {
                 this.showSnackbarNotification('lessonDeleted');
               }

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/ManageLessonModals.vue
@@ -115,8 +115,8 @@
         const { id } = this.currentLesson;
         return LessonResource.deleteModel({ id })
           .then(() => {
-            this.$router.replace(
-              this.$router.getRoute('PLAN_LESSONS_ROOT', { classId: this.classId }),
+            this.$router.replace(  
+              this.$router.getRoute('PLAN_LESSONS_ROOT'),
               () => {
                 this.showSnackbarNotification('lessonDeleted');
               }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

This PR solves the overly aggressive errors from page title logic as state is changing in Coach.

<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->


https://github.com/learningequality/kolibri/assets/114716075/585ab0ab-ea09-4b49-b39b-ba3ce8901f2d


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

This PR fixes #11291 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

on the lesson's Summary page, Options > Delete lesson & confirm choice in the modal
should be automatically navigated back to class's Plan > Lessons page

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
