### PR TITLE
Some minor linting fixes that became apparent after linting updates

### DIFF
--- a/kolibri/core/assets/src/views/sortable/DragContainer.vue
+++ b/kolibri/core/assets/src/views/sortable/DragContainer.vue
@@ -115,12 +115,9 @@
   }
 
   @keyframes bounce-in {
-    from {
-      animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
-    }
-
     0% {
       transform: scale3d(1.05, 1.05, 1.05);
+      animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
 
     50% {
@@ -128,7 +125,7 @@
       animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
 
-    to {
+    100% {
       transform: scale3d(1, 1, 1);
       animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/OverviewBlock.vue
@@ -43,7 +43,7 @@
               :text="$tr('viewLearners')"
               appearance="basic-link"
               :to="classLearnersListRoute"
-              style="margin-left: 24 px;"
+              style="margin-left: 24px;"
             />
           </template>
         </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/BookmarkIcon.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/BookmarkIcon.vue
@@ -2,7 +2,7 @@
 
   <KIcon
     icon="bookmark"
-    style="top:50;left:75; width: 34px; height: 34px;"
+    style="top: 50px;left: 75px; width: 34px; height: 34px;"
   />
 
 </template>

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -40,7 +40,7 @@
             <template v-for="(facility, idx) in facilities">
               <tr
                 :key="idx"
-                style="border: none!important"
+                style="border: 0 !important"
               >
                 <td>
                   <FacilityNameAndSyncStatus
@@ -52,8 +52,7 @@
                   />
                 </td>
               </tr>
-              <!-- May cause error on device with > 10000 facilities... -->
-              <tr :key="idx + 10000">
+              <tr :key="idx + facilities.length">
                 <td style="padding: 0 0 16px 0;">
                   <!-- Gives most space possible to buttons and aligns them with text -->
                   <KButtonGroup style="margin-left: -16px; margin-right: -16px; max-width: 100%">

--- a/kolibri/plugins/learn/assets/src/views/CardList.vue
+++ b/kolibri/plugins/learn/assets/src/views/CardList.vue
@@ -37,7 +37,7 @@
               </h3>
               <p
                 v-if="contentNode.description"
-                style="font-size: 14px; marginTop: 4px; marginBottom: 4px;"
+                style="font-size: 14px; margin-top: 4px; margin-bottom: 4px;"
               >
                 <TextTruncatorCss :text="contentNode.description" :maxLines="2" />
               </p>

--- a/kolibri/plugins/media_player/assets/src/utils/settings.js
+++ b/kolibri/plugins/media_player/assets/src/utils/settings.js
@@ -14,7 +14,7 @@ class Settings {
   }
 
   set playerMuted(playerMuted) {
-    return this.save({ playerMuted });
+    this.save({ playerMuted });
   }
 
   get playerMuted() {
@@ -22,7 +22,7 @@ class Settings {
   }
 
   set playerRate(playerRate) {
-    return this.save({ playerRate });
+    this.save({ playerRate });
   }
 
   get playerRate() {
@@ -30,7 +30,7 @@ class Settings {
   }
 
   set playerVolume(playerVolume) {
-    return this.save({ playerVolume });
+    this.save({ playerVolume });
   }
 
   get playerVolume() {
@@ -38,7 +38,7 @@ class Settings {
   }
 
   set captionLanguage(captionLanguage) {
-    return this.save({ captionLanguage });
+    this.save({ captionLanguage });
   }
 
   get captionLanguage() {
@@ -46,7 +46,7 @@ class Settings {
   }
 
   set captionSubtitles(captionSubtitles) {
-    return this.save({ captionSubtitles });
+    this.save({ captionSubtitles });
   }
 
   get captionSubtitles() {
@@ -54,7 +54,7 @@ class Settings {
   }
 
   set captionTranscript(captionTranscript) {
-    return this.save({ captionTranscript });
+    this.save({ captionTranscript });
   }
 
   get captionTranscript() {
@@ -62,7 +62,7 @@ class Settings {
   }
 
   set videoLangCode(videoLangCode) {
-    return this.save({ videoLangCode });
+    this.save({ videoLangCode });
   }
 
   get videoLangCode() {


### PR DESCRIPTION
## Summary
* Some linting fixes that seemed like they might be impactful that occurred during local runs of linting using code from #9698

## Reviewer guidance

Before:
![Screenshot from 2023-09-29 16-28-45](https://github.com/learningequality/kolibri/assets/1680573/21d12f8b-dfd2-4f1d-ada1-c8468f3859ab)

After:
![Screenshot from 2023-09-29 16-28-52](https://github.com/learningequality/kolibri/assets/1680573/22a43b55-f056-49cd-bc55-8a6d43d91223)


No change for bookmarks icon:
![Screenshot from 2023-09-29 16-29-57](https://github.com/learningequality/kolibri/assets/1680573/2b651e76-4231-4290-8eef-54e7ca5271f0)

No change for facilities list:
![Screenshot from 2023-09-29 16-41-56](https://github.com/learningequality/kolibri/assets/1680573/fa241bca-cefb-4be7-ab6a-8322dd0248d1)

CardList change was also a no op, apparently either Vue or the browser coerced from camelCase to kebab-case.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
