### PR TITLE
Raise when the channel cannot be found on the remote.

### DIFF
--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -47,6 +47,10 @@ def lookup_channel_listing_status(channel_id, baseurl=None):
     """
     resp = requests.get(get_channel_lookup_url(identifier=channel_id, baseurl=baseurl))
 
+    # Raise here to prevent trying to fetch a channel from a remote that it is not
+    # available from.
+    resp.raise_for_status()
+
     if resp.status_code != 200:
         return None
 

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -49,7 +49,12 @@ def lookup_channel_listing_status(channel_id, baseurl=None):
 
     # Raise here to prevent trying to fetch a channel from a remote that it is not
     # available from.
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.RequestException:
+        raise LocationError(
+            "Channel {} not found on remote {}".format(channel_id, baseurl)
+        )
 
     if resp.status_code != 200:
         return None


### PR DESCRIPTION
## Summary
* Small tweak to abort resource import earlier when channel is not available on the remote

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
