### PR TITLE
Migrates the OSUser associated with a facility user when migrating users.

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -1,5 +1,4 @@
 import requests
-from django.core.exceptions import RelatedObjectDoesNotExist
 from django.core.management import call_command
 from morango.errors import MorangoError
 from rest_framework import serializers
@@ -165,7 +164,7 @@ def mergeuser(command, **kwargs):
         os_user = local_user.os_user
         os_user.user = remote_user
         os_user.save()
-    except RelatedObjectDoesNotExist:
+    except FacilityUser.os_user.RelatedObjectDoesNotExist:
         pass
 
     # check if current user should be set as superuser:


### PR DESCRIPTION
## Summary
* Migrates the OSUser associated with a local user when migrating them to a user imported from remote
* Should maintain os user based login for apps using the `get_os_user` capability

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
* Run using the app integration testing script in a fresh KOLIBRI_HOME
* Open Kolibri using the special URL printed by the app integration script
* Use the 'on my own' workflow
* Go the user profile page
* Join a facility
* Logout
* Reopen Kolibri using the special URL
* Confirm that you are now logged in as the migrated user in the facility (and that it hasn't created a new user)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
