### PR TITLE
kolibri-tools: Accept multiple --namespace/--searchPath arguments

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -513,7 +513,7 @@ function _generatePathInfo({
       })
     );
   }
-  if (namespace && searchPath) {
+  if (namespace.length && namespace.length == searchPath.length) {
     let aliases;
     if (webpackConfig) {
       const webpack = require('webpack');
@@ -528,19 +528,25 @@ function _generatePathInfo({
       }
       aliases = buildConfig.resolve.alias;
     }
-    pathInfoArray.push({
-      moduleFilePath: searchPath,
-      namespace: namespace,
-      name: namespace,
-      aliases,
-    });
+    for (let i = 0; i < namespace.length; i++) {
+      pathInfoArray.push({
+        moduleFilePath: searchPath[i],
+        namespace: namespace[i],
+        name: namespace[i],
+        aliases,
+      });
+    }
   }
   if (pathInfoArray.length) {
     return pathInfoArray;
   }
   cliLogging.error('This command requires one or more of the following combinations of arguments:');
   cliLogging.error('1) The --pluginFile, --plugins, or --pluginPath argument.');
-  cliLogging.error('2) The --searchPath argument along with the --namespace argument.');
+  cliLogging.error('2) One or more pairs of the --searchPath and --namespace arguments.');
+}
+
+function _collect(value, previous) {
+  return previous.concat([value]);
 }
 
 function _addPathOptions(cmd) {
@@ -564,7 +570,12 @@ function _addPathOptions(cmd) {
       list,
       langIgnoreDefaults.length ? langIgnoreDefaults : ignoreDefaults
     )
-    .option('-n , --namespace <namespace>', 'Set namespace for string extraction')
+    .option(
+      '-n , --namespace <namespace>',
+      'Set namespace for string extraction; this may be specified multiple times, but there must be an equal number of --searchPath arguments',
+      _collect,
+      []
+    )
     .option(
       '--localeDataFolder <localeDataFolder>',
       'Set path to write locale files to',
@@ -573,7 +584,9 @@ function _addPathOptions(cmd) {
     )
     .option(
       '--searchPath <searchPath>',
-      'Set path to search for files containing strings to be extracted'
+      'Set path to search for files containing strings to be extracted; this may be specified multiple times, but there must be an equal number of --namespace arguments',
+      _collect,
+      []
     )
     .option(
       '--webpackConfig <webpackConfig>',


### PR DESCRIPTION
## Summary

This is needed when a plugin has more than one sub-package which contains translatable strings. All the strings from all the packages need to be pulled into the `*-messages.json` file which is injected into the frontend output — but currently only at most one sub-package is supported. For Kolibri itself, this is kolibri-common. The kolibri-explore-plugin, however, has at least two sub-packages.

This commit changes the `--namespace` and `--searchPath` options to allow them to be specified multiple times. For example, `--namespace ek-components --searchPath ./packages/ek-components --namespace template-ui --searchPath ./packages/template-ui`. It shouldn’t change the behaviour when they are passed zero or one times, as before, so this change should be backwards-compatible.

The strings from each namespace are still outputted into a per-namespace
CSV file, with the assumption that the translation step (when CSVs are
turned into JSON files) will combine them all into a single JSON file
suitable for webpack to load.

See https://github.com/endlessm/kolibri-explore-plugin/issues/846

## References

 * https://github.com/endlessm/kolibri-explore-plugin/issues/846

## Reviewer guidance

```
yarn exec kolibri-tools i18n-extract-messages --plugins kolibri_explore_plugin --namespace ek-components --searchPath ./packages/ek-components --namespace template-ui --searchPath ./packages/template-ui
```
vs
```
yarn exec kolibri-tools i18n-extract-messages --plugins kolibri_explore_plugin && kolibri-tools i18n-extract-messages --namespace ek-components --searchPath ./packages/ek-components && kolibri-tools i18n-extract-messages --namespace template-ui --searchPath ./packages/template-ui
```

(This relies on running in [kolibri-explore-plugin](https://github.com/endlessm/kolibri-explore-plugin/), as that’s the motivator for this fix.)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
