### PR TITLE
Fix lesson visibility toggling for single user syncing

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.2.1
 jsonfield==2.0.2
 requests-toolbelt==0.9.1
-morango==0.6.16
+morango==0.6.18
 tzlocal==2.1
 pytz==2022.1
 python-dateutil==2.8.2


### PR DESCRIPTION
## Summary
* Updates morango to prevent merge conflicts arising when deleted models are recreated
* Adds morango ecosystem tests to ensure that object recreation propagates, and that deletion propagation is still working as intended

## References
Fixes [#11208](https://github.com/learningequality/kolibri/issues/11208)

## Reviewer guidance
* Setup a learner only device from a server device
* On the server device toggle a lesson to be visible
* Let the sync to the learner only device happen
* Toggle the lesson to be invisible
* Let the sync to the learner only device happen
* Toggle the lesson to be visible again
* Let the sync to the learner only device happen

After each sync confirm the lesson is correctly displayed or not on the learner only device.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
