### PR TITLE
Replace KResponseWindow with useKResponseWindow in Learn plugin

### DIFF
--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
@@ -10,10 +10,10 @@
     @change="handleActivityTypeChange($event.value)"
   >
     <template #display>
-      <KLabeledIcon
-        :label="selected.label"
-        :icon="selected.icon"
-      />
+        <KLabeledIcon
+          :label="selected.label"
+          :icon="selected.icon"
+        />
     </template>
     <template #option="{ option }">
       <KLabeledIcon

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
@@ -10,10 +10,10 @@
     @change="handleActivityTypeChange($event.value)"
   >
     <template #display>
-        <KLabeledIcon
-          :label="selected.label"
-          :icon="selected.icon"
-        />
+      <KLabeledIcon
+        :label="selected.label"
+        :icon="selected.icon"
+      />
     </template>
     <template #option="{ option }">
       <KLabeledIcon

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
@@ -10,10 +10,10 @@
     @change="handleActivityTypeChange($event.value)"
   >
     <template #display>
-      <KLabeledIcon
-        :label="selected.label"
-        :icon="selected.icon"
-      />
+        <KLabeledIcon
+          :label="selected.label"
+          :icon="selected.icon"
+        />
     </template>
     <template #option="{ option }">
       <KLabeledIcon
@@ -32,18 +32,19 @@
   import pickBy from 'lodash/pickBy';
   import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import useLearningActivities from '../../../composables/useLearningActivities';
 
   export default {
     name: 'ActivityFilter',
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const { getLearningActivityLabel, getLearningActivityIcon } = useLearningActivities();
-
+      const { windowIsLarge } = useKResponsiveWindow();
       return {
         getLearningActivityLabel,
         getLearningActivityIcon,
+        windowIsLarge,
       };
     },
     data() {

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
@@ -17,11 +17,17 @@
 
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';;
 
   export default {
     name: 'SortFilter',
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsLarge } = useKResponsiveWindow();
+      return {
+        windowIsLarge,
+      };
+    },
     data() {
       return {
         sortOptions: [

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
@@ -17,7 +17,7 @@
 
   import pickBy from 'lodash/pickBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';;
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 
   export default {
     name: 'SortFilter',

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -57,7 +57,6 @@
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import plugin_data from 'plugin_data';
   import useDownloadRequests from '../../composables/useDownloadRequests';
   import useDevices from '../../composables/useDevices';
@@ -73,7 +72,7 @@
       ActivityFilter,
       SortFilter,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const {
         downloadRequestMap,

--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -97,7 +97,7 @@
   import isBoolean from 'lodash/isBoolean';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
-  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import useContentNodeProgress from '../composables/useContentNodeProgress';
   import useContentLink from '../composables/useContentLink';
@@ -113,17 +113,18 @@
       TimeDuration,
       MissingResourceAlert,
     },
-    mixins: [KResponsiveWindowMixin],
     setup() {
       const { contentNodeProgressMap } = useContentNodeProgress();
       const {
         genContentLinkKeepCurrentBackLink,
         genContentLinkKeepPreviousBackLink,
       } = useContentLink();
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         contentNodeProgressMap,
         genContentLinkKeepCurrentBackLink,
         genContentLinkKeepPreviousBackLink,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/LessonMasteryBar.vue
@@ -21,7 +21,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import BaseToolbar from 'kolibri.coreVue.components.BaseToolbar';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
-  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 
   export default {
     name: 'LessonMasteryBar',
@@ -29,7 +29,13 @@
       BaseToolbar,
       TextTruncatorCss,
     },
-    mixins: [KResponsiveWindowMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     props: {
       // typically this would be "m" from "m of n" mastery model
       requiredCorrectAnswers: {

--- a/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/AssessmentWrapper/index.vue
@@ -144,7 +144,7 @@ oriented data synchronization.
   import { MasteryModelGenerators } from 'kolibri.coreVue.vuex.constants';
   import shuffled from 'kolibri.utils.shuffled';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import CoreInfoIcon from 'kolibri.coreVue.components.CoreInfoIcon';
   import { createTranslator, defaultLanguage } from 'kolibri.utils.i18n';
@@ -176,7 +176,13 @@ oriented data synchronization.
       LessonMasteryBar,
       CoreInfoIcon,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
+      return {
+        windowIsSmall,
+      };
+    },
     props: {
       lang: {
         type: Object,

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -86,7 +86,7 @@
 
   import { mapActions } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import { ContentNodeResource } from 'kolibri.resources';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
@@ -117,12 +117,18 @@
       LearnAppBarPage,
       HybridLearningFooter,
     },
-    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup() {
       const { canDownloadExternally } = useCoreLearn();
       const { fetchContentNodeProgress } = useContentNodeProgress();
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
-      return { canDownloadExternally, fetchContentNodeProgress, genContentLinkBackLinkCurrentPage };
+      const { windowIsSmall } = useKResponsiveWindow();
+      return { 
+        canDownloadExternally, 
+        fetchContentNodeProgress, 
+        genContentLinkBackLinkCurrentPage,
+        windowIsSmall,
+      };
     },
     data() {
       return {

--- a/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/BookmarkPage.vue
@@ -123,9 +123,9 @@
       const { fetchContentNodeProgress } = useContentNodeProgress();
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
       const { windowIsSmall } = useKResponsiveWindow();
-      return { 
-        canDownloadExternally, 
-        fetchContentNodeProgress, 
+      return {
+        canDownloadExternally,
+        fetchContentNodeProgress,
         genContentLinkBackLinkCurrentPage,
         windowIsSmall,
       };

--- a/kolibri/plugins/learn/assets/src/views/CardList.vue
+++ b/kolibri/plugins/learn/assets/src/views/CardList.vue
@@ -103,7 +103,7 @@
   import { now } from 'kolibri.utils.serverClock';
   import { ContentLevels, Categories } from 'kolibri.coreVue.vuex.constants';
   import camelCase from 'lodash/camelCase';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import useChannels from '../composables/useChannels';
   import LearningActivityLabel from './LearningActivityLabel';
   import LearningActivityDuration from './LearningActivityDuration';
@@ -118,12 +118,14 @@
       LearningActivityLabel,
       LearningActivityDuration,
     },
-    mixins: [responsiveWindowMixin, commonLearnStrings, commonCoreStrings],
+    mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const { getChannelThumbnail, getChannelTitle } = useChannels();
+      const { windowIsLarge } = useKResponsiveWindow();
       return {
         getChannelThumbnail,
         getChannelTitle,
+        windowIsLarge,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCard.vue
@@ -82,7 +82,7 @@
 
   import { mapGetters } from 'vuex';
   import { validateLinkObject } from 'kolibri.utils.validators';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import ChannelThumbnail from './ChannelThumbnail';
@@ -94,7 +94,12 @@
       CoachContentLabel,
       TextTruncatorCss,
     },
-    mixins: [responsiveWindowMixin],
+    setup() {
+      const { windowGutter } = useKResponsiveWindow();
+      return {
+        windowGutter,
+      };
+    },
     props: {
       title: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/CompletionModalSection.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/CompletionModalSection.vue
@@ -80,7 +80,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 
   /**
    * A responsive section of the completion modal.
@@ -94,7 +94,12 @@
    */
   export default {
     name: 'CompletionModalSection',
-    mixins: [KResponsiveWindowMixin],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     props: {
       title: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/CompletionModal/index.vue
@@ -144,7 +144,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { MaxPointsPerContent } from 'kolibri.coreVue.vuex.constants';
   import FocusTrap from 'kolibri.coreVue.components.FocusTrap';
@@ -178,17 +178,21 @@
       ResourceItem,
       UiAlert,
     },
-    mixins: [KResponsiveWindowMixin, commonLearnStrings, commonCoreStrings],
+    mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const { canAccessUnassignedContent } = useDeviceSettings();
       const { fetchLesson } = useLearnerResources();
       const { genContentLinkKeepCurrentBackLink } = useContentLink();
       const { baseurl } = currentDeviceData();
+      const { windowBreakpoint, windowHeight, windowWidth } = useKResponsiveWindow();
       return {
         baseurl,
         canAccessUnassignedContent,
         fetchLesson,
         genContentLinkKeepCurrentBackLink,
+        windowBreakpoint,
+        windowHeight,
+        windowWidth,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -107,7 +107,7 @@
   import { mapState, mapGetters } from 'vuex';
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import { ContentNodeResource } from 'kolibri.resources';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import router from 'kolibri.coreVue.router';
   import Modalities from 'kolibri-constants/Modalities';
   import { setContentNodeProgress } from '../composables/useContentNodeProgress';
@@ -135,7 +135,7 @@
       QuizRenderer,
       MarkAsCompleteModal,
     },
-    mixins: [commonLearnStrings, responsiveWindowMixin],
+    mixins: [commonLearnStrings],
     setup() {
       const {
         progress,
@@ -158,7 +158,7 @@
         }
         return Promise.resolve();
       };
-
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         errored,
         progress,
@@ -173,6 +173,7 @@
         startTracking: startTrackingProgress,
         stopTracking: stopTrackingProgress,
         genContentLinkKeepCurrentBackLink,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -220,11 +220,7 @@
         startTrackingProgress,
         stopTrackingProgress,
       } = useProgressTracking();
-      const { 
-        windowBreakpoint,
-        windowIsLarge,
-        windowIsSmall,
-      } = useKResponsiveWindow();
+      const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       return {
         pastattempts,
         time_spent,

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -181,7 +181,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import SuggestedTime from 'kolibri.coreVue.components.SuggestedTime';
   import TimeDuration from 'kolibri.coreVue.components.TimeDuration';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -220,6 +220,11 @@
         startTrackingProgress,
         stopTrackingProgress,
       } = useProgressTracking();
+      const { 
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsSmall,
+      } = useKResponsiveWindow();
       return {
         pastattempts,
         time_spent,
@@ -227,6 +232,9 @@
         updateContentSession,
         startTrackingProgress,
         stopTrackingProgress,
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsSmall,
       };
     },
     data() {

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -210,7 +210,7 @@
       ImmersivePage,
       ResourceSyncingUiAlert,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
     setup() {
       const {
         pastattempts,

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -200,7 +200,6 @@
       SuggestedTime,
       DeviceConnectionStatus,
     },
-    mixins: [KResponsiveWindowMixin, commonLearnStrings],
     filters: {
       truncateText(value, maxLength) {
         if (value && value.length > maxLength) {
@@ -209,6 +208,7 @@
         return value;
       },
     },
+    mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const { windowBreakpoint } = useKResponsiveWindow();
       return {

--- a/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearningActivityBar.vue
@@ -169,7 +169,7 @@
 
 <script>
 
-  import KResponsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import CoachContentLabel from 'kolibri.coreVue.components.CoachContentLabel';
   import CoreMenu from 'kolibri.coreVue.components.CoreMenu';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
@@ -200,6 +200,7 @@
       SuggestedTime,
       DeviceConnectionStatus,
     },
+    mixins: [KResponsiveWindowMixin, commonLearnStrings],
     filters: {
       truncateText(value, maxLength) {
         if (value && value.length > maxLength) {
@@ -208,7 +209,12 @@
         return value;
       },
     },
-    mixins: [KResponsiveWindowMixin, commonLearnStrings, commonCoreStrings],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     /**
      * Emits the following events:
      * - `navigateBack` on back button click

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -50,6 +50,8 @@
       ResourceCard,
     },
 
+    mixins: [responsiveWindowMixin],
+
     setup() {
       const {
         genContentLinkBackLinkCurrentPage,
@@ -88,7 +90,7 @@
     },
     computed: {
       componentType() {
-        if (this.windowIsSmall) {
+        if (!this.windowIsSmall) {
           return 'ResourceCard';
         }
         if (this.currentCardViewStyle === 'card') {

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -90,7 +90,7 @@
     },
     computed: {
       componentType() {
-        if (!this.windowIsSmall) {
+        if (this.windowIsSmall) {
           return 'ResourceCard';
         }
         if (this.currentCardViewStyle === 'card') {

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -30,7 +30,7 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import useContentLink from '../composables/useContentLink';
   import CardGrid from './cards/CardGrid';
   import ResourceCard from './cards/ResourceCard';
@@ -50,14 +50,18 @@
       ResourceCard,
     },
 
-    mixins: [responsiveWindowMixin],
 
     setup() {
       const {
         genContentLinkBackLinkCurrentPage,
         genContentLinkKeepCurrentBackLink,
       } = useContentLink();
-      return { genContentLinkBackLinkCurrentPage, genContentLinkKeepCurrentBackLink };
+      const { windowIsSmall } = useKResponsiveWindow();
+      return {
+        genContentLinkBackLinkCurrentPage, 
+        genContentLinkKeepCurrentBackLink,
+        windowIsSmall,
+      };
     },
 
     props: {
@@ -85,7 +89,7 @@
     },
     computed: {
       componentType() {
-        if (this.windowIsSmall) {
+        if (!this.windowIsSmall) {
           return 'ResourceCard';
         }
         if (this.currentCardViewStyle === 'card') {

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -89,7 +89,7 @@
     },
     computed: {
       componentType() {
-        if (!this.windowIsSmall) {
+        if (this.windowIsSmall) {
           return 'ResourceCard';
         }
         if (this.currentCardViewStyle === 'card') {

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -50,8 +50,6 @@
       ResourceCard,
     },
 
-    mixins: [responsiveWindowMixin],
-
     setup() {
       const {
         genContentLinkBackLinkCurrentPage,

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -50,7 +50,6 @@
       ResourceCard,
     },
 
-
     setup() {
       const {
         genContentLinkBackLinkCurrentPage,
@@ -58,7 +57,7 @@
       } = useContentLink();
       const { windowIsSmall } = useKResponsiveWindow();
       return {
-        genContentLinkBackLinkCurrentPage, 
+        genContentLinkBackLinkCurrentPage,
         genContentLinkKeepCurrentBackLink,
         windowIsSmall,
       };

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -59,7 +59,7 @@
 
   import { ref } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import useLearnerResources from '../../composables/useLearnerResources';
   import CopiesModal from '../CopiesModal';
   import LibraryAndChannelBrowserMainContent from '../LibraryAndChannelBrowserMainContent';
@@ -70,7 +70,7 @@
       CopiesModal,
       LibraryAndChannelBrowserMainContent,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const {
         resumableContentNodes,
@@ -90,7 +90,7 @@
           activityKeys[firstActivity].value.focusFirstEl();
         }
       };
-
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         activityRefs,
         findFirstEl,
@@ -99,6 +99,7 @@
         resumableContentNodes,
         moreResumableContentNodes,
         fetchMoreResumableContentNodes,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -158,7 +158,7 @@
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import UiIconButton from 'kolibri.coreVue.components.UiIconButton';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import shuffled from 'kolibri.utils.shuffled';
   import { LearnerClassroomResource } from '../../apiResources';
@@ -174,7 +174,19 @@
       BottomAppBar,
       QuizReport,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { 
+        windowBreakpoint, 
+        windowIsLarge, 
+        windowIsSmall,
+      } = useKResponsiveWindow();
+      return {
+        windowBreakpoint, 
+        windowIsLarge, 
+        windowIsSmall,
+      };
+    },
     props: {
       content: {
         type: Object,

--- a/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/QuizRenderer/index.vue
@@ -176,14 +176,10 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { 
-        windowBreakpoint, 
-        windowIsLarge, 
-        windowIsSmall,
-      } = useKResponsiveWindow();
+      const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       return {
-        windowBreakpoint, 
-        windowIsLarge, 
+        windowBreakpoint,
+        windowIsLarge,
         windowIsSmall,
       };
     },

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/CategorySearchOptions.vue
@@ -60,12 +60,11 @@
 
   import camelCase from 'lodash/camelCase';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { injectSearch } from '../../../composables/useSearch';
 
   export default {
     name: 'CategorySearchOptions',
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const { activeSearchTerms, availableLibraryCategories, searchableLabels } = injectSearch();
       return {

--- a/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchFiltersPanel/CategorySearchModal/index.vue
@@ -34,7 +34,7 @@
 
   import Teleport from 'vue2-teleport';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import CategorySearchOptions from './CategorySearchOptions';
 
   export default {
@@ -43,7 +43,13 @@
       CategorySearchOptions,
       Teleport,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsLarge } = useKResponsiveWindow();
+      return {
+        windowIsLarge,
+      };
+    },
     props: {
       selectedCategory: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
@@ -70,7 +70,7 @@
 <script>
 
   import { ref } from 'kolibri.lib.vueCompositionApi';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import CopiesModal from './CopiesModal';
   import SearchChips from './SearchChips';
@@ -83,14 +83,15 @@
       LibraryAndChannelBrowserMainContent,
       SearchChips,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
     setup() {
       const sidePanelContent = ref(null);
       const toggleInfoPanel = content => (sidePanelContent.value = content);
-
+      const { windowIsSmall } = useKResponsiveWindow();
       return {
         sidePanelContent,
         toggleInfoPanel,
+        windowIsSmall,
       };
     },
     props: {

--- a/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/SidePanelModal/index.vue
@@ -64,7 +64,7 @@
 
   import Backdrop from 'kolibri.coreVue.components.Backdrop';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import FocusTrap from 'kolibri.coreVue.components.FocusTrap';
   import commonLearnStrings from '../commonLearnStrings.js';
 
@@ -74,7 +74,13 @@
       Backdrop,
       FocusTrap,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     props: {
       /* CloseButtonIconType icon from parent component */
       closeButtonIconType: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -157,6 +157,7 @@
   import { get, set } from '@vueuse/core';
   import lodashGet from 'lodash/get';
   import { getCurrentInstance, ref, watch } from 'kolibri.lib.vueCompositionApi';
+  import Modalities from 'kolibri-constants/Modalities';
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import { ContentNodeResource } from 'kolibri.resources';

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -156,9 +156,7 @@
   import { mapState } from 'vuex';
   import { get, set } from '@vueuse/core';
   import lodashGet from 'lodash/get';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { getCurrentInstance, ref, watch } from 'kolibri.lib.vueCompositionApi';
-  import Modalities from 'kolibri-constants/Modalities';
 
   import AuthMessage from 'kolibri.coreVue.components.AuthMessage';
   import { ContentNodeResource } from 'kolibri.resources';
@@ -224,7 +222,7 @@
       CurrentlyViewedResourceMetadata,
       SkipNavigationLink,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup(props) {
       const currentInstance = getCurrentInstance().proxy;
       const store = currentInstance.$store;

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/ToggleHeaderTabs.vue
@@ -50,13 +50,19 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { PageNames } from '../../constants';
 
   export default {
     name: 'ToggleHeaderTabs',
-    mixins: [responsiveWindowMixin, commonCoreStrings],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsLarge } = useKResponsiveWindow();
+      return {
+        windowIsLarge,
+      };
+    },
     props: {
       topic: {
         type: Object,

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsHeader.vue
@@ -76,7 +76,7 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
   import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import ChannelThumbnail from '../ChannelThumbnail';
   import commonLearnStrings from './../commonLearnStrings';
 
@@ -87,7 +87,13 @@
       KBreadcrumbs,
       TextTruncatorCss,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
+    setup() {
+      const { windowIsSmall } = useKResponsiveWindow();
+      return {
+        windowIsSmall,
+      };
+    },
     props: {
       title: {
         type: String,

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -360,11 +360,7 @@
         currentRoute,
       } = useSearch(topic);
       const { back, genContentLinkKeepCurrentBackLink } = useContentLink();
-      const {
-        windowBreakpoint,
-        windowIsLarge,
-        windowIsSmall,
-      } =useKResponsiveWindow();
+      const { windowBreakpoint, windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       const { channelsMap, fetchChannels } = useChannels();
       const { fetchContentNodeProgress, fetchContentNodeTreeProgress } = useContentNodeProgress();
       const { isUserLoggedIn, isCoach, isAdmin, isSuperuser } = useUser();

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -247,7 +247,7 @@
   import lodashGet from 'lodash/get';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
   import { getCurrentInstance, ref, watch } from 'kolibri.lib.vueCompositionApi';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import useUser from 'kolibri.coreVue.composables.useUser';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -339,7 +339,7 @@
       ImmersivePage,
       DeviceConnectionStatus,
     },
-    mixins: [responsiveWindowMixin, commonCoreStrings, commonLearnStrings],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup(props) {
       const { canAddDownloads, canDownloadExternally } = useCoreLearn();
       const currentInstance = getCurrentInstance().proxy;
@@ -360,6 +360,11 @@
         currentRoute,
       } = useSearch(topic);
       const { back, genContentLinkKeepCurrentBackLink } = useContentLink();
+      const {
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsSmall,
+      } =useKResponsiveWindow();
       const { channelsMap, fetchChannels } = useChannels();
       const { fetchContentNodeProgress, fetchContentNodeTreeProgress } = useContentNodeProgress();
       const { isUserLoggedIn, isCoach, isAdmin, isSuperuser } = useUser();
@@ -524,6 +529,9 @@
         clearSearch,
         back,
         genContentLinkKeepCurrentBackLink,
+        windowBreakpoint,
+        windowIsLarge,
+        windowIsSmall,
         isRoot,
         channel,
         topic,

--- a/kolibri/plugins/learn/assets/src/views/cards/CardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/CardGrid.vue
@@ -9,14 +9,19 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 
   const GRID_TYPE_1 = 1;
   const GRID_TYPE_2 = 2;
 
   export default {
     name: 'CardGrid',
-    mixins: [responsiveWindowMixin],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     props: {
       /**
        * `1` or `2`

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -85,8 +85,8 @@
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
       const { contentNodeProgressMap } = useContentNodeProgress();
       const { windowIsSmall } = useKResponsiveWindow();
-      return { 
-        contentNodeProgressMap, 
+      return {
+        contentNodeProgressMap,
         genContentLinkBackLinkCurrentPage,
         windowIsSmall,
       };

--- a/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/LessonPlaylistPage.vue
@@ -53,7 +53,7 @@
 
   import { mapMutations, mapState } from 'vuex';
   import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import ProgressIcon from 'kolibri.coreVue.components.ProgressIcon';
   import ContentIcon from 'kolibri.coreVue.components.ContentIcon';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -80,11 +80,16 @@
       LearnAppBarPage,
       ResourceSyncingUiAlert,
     },
-    mixins: [commonCoreStrings, commonLearnStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings, commonLearnStrings],
     setup() {
       const { genContentLinkBackLinkCurrentPage } = useContentLink();
       const { contentNodeProgressMap } = useContentNodeProgress();
-      return { contentNodeProgressMap, genContentLinkBackLinkCurrentPage };
+      const { windowIsSmall } = useKResponsiveWindow();
+      return { 
+        contentNodeProgressMap, 
+        genContentLinkBackLinkCurrentPage,
+        windowIsSmall,
+      };
     },
     computed: {
       ...mapState('lessonPlaylist', ['contentNodesMap', 'currentLesson']),

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -1,13 +1,25 @@
 import { shallowMount, mount } from '@vue/test-utils';
+import Vuex from 'vuex';
 import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
 import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import LearningActivityBar from '../../src/views/LearningActivityBar';
 
 jest.mock('kolibri.coreVue.componentSets.sync');
 function makeWrapper({ propsData } = {}) {
+  const store = new Vuex.Store({
+    state: { core: { loading: false } },
+    mutations: {
+      SET_SHOW_COMPLETE_CONTENT_MODAL: jest.fn(),
+    },
+  });
   // stubbing out KCircularLoader, as using the actual component led to errors related to
   // Vue Composition API - stub may not be needed once we upgrade to Vue 2.7
-  return mount(LearningActivityBar, { propsData, stubs: ['KCircularLoader'] });
+  return mount(LearningActivityBar, {
+    propsData,
+    stubs: ['KCircularLoader'],
+    data: () => ({ windowBreakpoint: 6 }),
+    store,
+  });
 }
 
 describe('LearningActivityBar', () => {

--- a/kolibri/plugins/learn/assets/test/views/resumable-content-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/resumable-content-grid.spec.js
@@ -30,14 +30,14 @@ describe('when there are nodes with progress that can be resumed', () => {
 
   it('displays grid / list toggle buttons when on medium or larger screens', () => {
     const wrapper = shallowMount(ResumableContentGrid, {
-      computed: { windowIsMedium: () => true },
+      data: () => ({ windowIsSmall: false }),
     });
     expect(wrapper.find('[data-test="toggle-view-buttons"]').element).toBeTruthy();
   });
 
   it('does not show the grid / list toggle buttons when on extra small screens', async () => {
     const wrapper = shallowMount(ResumableContentGrid, {
-      computed: { windowIsSmall: () => true },
+      data: () => ({ windowIsSmall: true }),
     });
     expect(wrapper.find('[data-test="toggle-view-buttons"]').element).toBeFalsy();
   });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
**For testing:**

1. First Identified where ResponsiveWindow elements are are used
2. Then play with CSS class of components that will be used when `windowBreakpoint` is reached.
3. Then verify that the CSS tweaks is consistent with both `KResponsiveWindow` and `userKResponsiveWindow`
4. Roll back the CSS tweaks made while testing

**Page and component effected:**

- /en/learn/my-downloads#/
- /en/learn/#/library
- /en/learn/#/home/classes (All subpages like /lesson,/quizes)
- Content Pages(quizes, lessons, activitybar etc)
- Exam page
- Select a topic -> View Folder Resources

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11324 

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Would it be possible to add a `hacktoberfest-accepted` label in this PR?
Here is the link: https://hacktoberfest.com/participation/#maintainers
Its fine if for some reasons you aren't able to do so:)
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
