### PR TITLE
Delete user initiated ContentDownloadRequests and mark others as pending when the associated contentnode is deleted.

### DIFF
--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -6,6 +6,7 @@ from django.db.models import Sum
 from le_utils.constants import content_kinds
 
 from kolibri.core.content.models import ChannelMetadata
+from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
@@ -21,15 +22,20 @@ logger = logging.getLogger(__name__)
 
 
 def delete_metadata(
-    channel, node_ids, exclude_node_ids, force_delete, ignore_admin_flags
+    channel,
+    node_ids,
+    exclude_node_ids,
+    force_delete,
+    ignore_admin_flags,
+    update_content_requests,
 ):
     # Only delete all metadata if we are not doing selective deletion
     delete_all_metadata = not (node_ids or exclude_node_ids)
 
-    resources_before = (
+    resources_before = set(
         ContentNode.objects.filter(channel_id=channel.id, available=True)
         .exclude(kind=content_kinds.TOPIC)
-        .count()
+        .values_list("id", flat=True)
     )
 
     # If we have been passed node ids do not do a full deletion pass
@@ -39,12 +45,15 @@ def delete_metadata(
     # If everything has been made invisible, delete all the metadata
     delete_all_metadata = delete_all_metadata or not channel.root.available
 
-    total_resource_number = (
-        resources_before
-        - ContentNode.objects.filter(channel_id=channel.id, available=True)
+    resources_after = set(
+        ContentNode.objects.filter(channel_id=channel.id, available=True)
         .exclude(kind=content_kinds.TOPIC)
-        .count()
+        .values_list("id", flat=True)
     )
+
+    removed_resources = resources_before.difference(resources_after)
+
+    total_resource_number = len(removed_resources)
 
     if force_delete:
         # Do this before we delete all the metadata, as otherwise we lose
@@ -62,7 +71,7 @@ def delete_metadata(
         )
 
         with db_lock():
-            propagate_forced_localfile_removal(unused_files)
+            removed_resources.update(propagate_forced_localfile_removal(unused_files))
         # Separate these operations as running the SQLAlchemy code in the latter
         # seems to cause the Django ORM interactions in the former to roll back
         # Not quite sure what is causing it, but presumably due to transaction
@@ -73,6 +82,9 @@ def delete_metadata(
         logger.info("Deleting all channel metadata")
         with db_lock():
             channel.delete_content_tree_and_files()
+
+    if update_content_requests and removed_resources:
+        ContentDownloadRequest.objects.propagate_removal(list(removed_resources))
 
     # Clear any previously set channel availability stats for this channel
     clear_channel_stats(channel.id)
@@ -135,12 +147,21 @@ class Command(AsyncCommand):
             help="Don't modify admin_imported values when deleting content",
         )
 
+        parser.add_argument(
+            "--update_content_requests",
+            action="store_false",
+            dest="update_content_requests",
+            default=True,
+            help="Don't modify the status of ContentDownloadRequests pointing at the deleted content",
+        )
+
     def handle_async(self, *args, **options):
         channel_id = options["channel_id"]
         node_ids = options["node_ids"]
         exclude_node_ids = options["exclude_node_ids"]
         force_delete = options["force_delete"]
         ignore_admin_flags = options["ignore_admin_flags"]
+        update_content_requests = options["update_content_requests"]
 
         try:
             channel = ChannelMetadata.objects.get(pk=channel_id)
@@ -150,7 +171,12 @@ class Command(AsyncCommand):
             )
 
         (total_resource_number, delete_all_metadata,) = delete_metadata(
-            channel, node_ids, exclude_node_ids, force_delete, ignore_admin_flags
+            channel,
+            node_ids,
+            exclude_node_ids,
+            force_delete,
+            ignore_admin_flags,
+            update_content_requests,
         )
         unused_files = LocalFile.objects.get_unused_files()
         # Get the number of files that are being deleted

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -6,8 +6,8 @@ from django.db.models import Sum
 from le_utils.constants import content_kinds
 
 from kolibri.core.content.models import ChannelMetadata
-from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentNode
+from kolibri.core.content.models import ContentRequest
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import reannotate_all_channels
@@ -84,7 +84,9 @@ def delete_metadata(
             channel.delete_content_tree_and_files()
 
     if update_content_requests and removed_resources:
-        ContentDownloadRequest.objects.propagate_removal(list(removed_resources))
+        ContentRequest.objects.propagate_removal_to_learner_initiated_requests(
+            list(removed_resources)
+        )
 
     # Clear any previously set channel availability stats for this channel
     clear_channel_stats(channel.id)
@@ -152,7 +154,7 @@ class Command(AsyncCommand):
             action="store_false",
             dest="update_content_requests",
             default=True,
-            help="Don't modify the status of ContentDownloadRequests pointing at the deleted content",
+            help="Don't modify the status of ContentRequests pointing at the deleted content",
         )
 
     def handle_async(self, *args, **options):

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -7,11 +7,11 @@ from le_utils.constants import content_kinds
 
 from kolibri.core.content.models import ChannelMetadata
 from kolibri.core.content.models import ContentNode
-from kolibri.core.content.models import ContentRequest
 from kolibri.core.content.models import LocalFile
 from kolibri.core.content.utils.annotation import propagate_forced_localfile_removal
 from kolibri.core.content.utils.annotation import reannotate_all_channels
 from kolibri.core.content.utils.annotation import set_content_invisible
+from kolibri.core.content.utils.content_request import propagate_contentnode_removal
 from kolibri.core.content.utils.importability_annotation import clear_channel_stats
 from kolibri.core.content.utils.paths import get_content_database_file_path
 from kolibri.core.tasks.management.commands.base import AsyncCommand
@@ -84,7 +84,7 @@ def delete_metadata(
             channel.delete_content_tree_and_files()
 
     if update_content_requests and removed_resources:
-        ContentRequest.objects.propagate_removal(list(removed_resources))
+        propagate_contentnode_removal(list(removed_resources))
 
     # Clear any previously set channel availability stats for this channel
     clear_channel_stats(channel.id)

--- a/kolibri/core/content/management/commands/deletecontent.py
+++ b/kolibri/core/content/management/commands/deletecontent.py
@@ -84,9 +84,7 @@ def delete_metadata(
             channel.delete_content_tree_and_files()
 
     if update_content_requests and removed_resources:
-        ContentRequest.objects.propagate_removal_to_learner_initiated_requests(
-            list(removed_resources)
-        )
+        ContentRequest.objects.propagate_removal(list(removed_resources))
 
     # Clear any previously set channel availability stats for this channel
     clear_channel_stats(channel.id)

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -459,27 +459,6 @@ class ContentRequestManager(models.Manager):
             queryset = queryset.filter(type=self.request_type)
         return queryset
 
-    def propagate_removal(self, contentnode_ids):
-        """
-        Deletes all learner initiated ContentRequests for the passed in contentnode_ids
-        Matching learner initiated ContentRequests will be deleted - this means that if
-        resources are deleted by an admin, we remove any associated learner initiated requests.
-        Also updates the status of any COMPLETED non-learner initiated ContentDownloadRequests to PENDING
-        """
-        BATCH_SIZE = 250
-        for i in range(0, len(contentnode_ids), BATCH_SIZE):
-            batch = contentnode_ids[i : i + BATCH_SIZE]
-            self.filter(
-                contentnode_id__in=batch, reason=ContentRequestReason.UserInitiated
-            ).delete()
-            self.filter(
-                contentnode_id__in=batch,
-                type=ContentRequestType.Download,
-                status=ContentRequestStatus.Completed,
-            ).exclude(reason=ContentRequestReason.UserInitiated).update(
-                status=ContentRequestStatus.Pending
-            )
-
 
 class ContentRequest(models.Model):
     """

--- a/kolibri/core/content/models.py
+++ b/kolibri/core/content/models.py
@@ -459,11 +459,12 @@ class ContentRequestManager(models.Manager):
             queryset = queryset.filter(type=self.request_type)
         return queryset
 
-    def propagate_removal_to_learner_initiated_requests(self, contentnode_ids):
+    def propagate_removal(self, contentnode_ids):
         """
         Deletes all learner initiated ContentRequests for the passed in contentnode_ids
         Matching learner initiated ContentRequests will be deleted - this means that if
         resources are deleted by an admin, we remove any associated learner initiated requests.
+        Also updates the status of any COMPLETED non-learner initiated ContentDownloadRequests to PENDING
         """
         BATCH_SIZE = 250
         for i in range(0, len(contentnode_ids), BATCH_SIZE):
@@ -471,6 +472,13 @@ class ContentRequestManager(models.Manager):
             self.filter(
                 contentnode_id__in=batch, reason=ContentRequestReason.UserInitiated
             ).delete()
+            self.filter(
+                contentnode_id__in=batch,
+                type=ContentRequestType.Download,
+                status=ContentRequestStatus.Completed,
+            ).exclude(reason=ContentRequestReason.UserInitiated).update(
+                status=ContentRequestStatus.Pending
+            )
 
 
 class ContentRequest(models.Model):

--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -884,6 +884,7 @@ class ProcessContentRemovalRequestsTestCase(BaseQuerysetTestCase):
             self.node.channel_id,
             node_ids=[self.request.contentnode_id],
             ignore_admin_flags=True,
+            update_content_requests=False,
         )
         self.assertEqual(self.qs.count(), 0)
         self.assertEqual(ContentDownloadRequest.objects.count(), 0)

--- a/kolibri/core/content/utils/annotation.py
+++ b/kolibri/core/content/utils/annotation.py
@@ -690,6 +690,7 @@ def propagate_forced_localfile_removal(localfiles_dict_list):
     # if we have too many UUIDs it is possible we might still generate too much SQL
     # and cause issues - so we batch the ids here.
     batch_size = 10000
+    removed_nodes = []
     while i < total:
         file_slice = localfiles_dict_list[i : i + batch_size]
         files = File.objects.filter(
@@ -698,8 +699,12 @@ def propagate_forced_localfile_removal(localfiles_dict_list):
                 [f["id"] for f in file_slice]
             ),
         )
+        removed_nodes += ContentNode.objects.filter(files__in=files).values_list(
+            "id", flat=True
+        )
         ContentNode.objects.filter(files__in=files).update(available=False)
         i += batch_size
+    return removed_nodes
 
 
 def reannotate_all_channels():

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -930,6 +930,7 @@ def process_content_removal_requests(queryset):
                 channel_id,
                 node_ids=contentnode_ids,
                 ignore_admin_flags=True,
+                update_content_requests=False,
             )
             # mark all as completed
             channel_requests.update(status=ContentRequestStatus.Completed)

--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -22,6 +22,7 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.content.models import ContentDownloadRequest
 from kolibri.core.content.models import ContentNode
 from kolibri.core.content.models import ContentRemovalRequest
+from kolibri.core.content.models import ContentRequest
 from kolibri.core.content.models import ContentRequestReason
 from kolibri.core.content.models import ContentRequestStatus
 from kolibri.core.content.models import File
@@ -945,6 +946,27 @@ def process_content_removal_requests(queryset):
     remaining_pending = queryset.filter(status=ContentRequestStatus.Pending)
     _remove_corresponding_download_requests(remaining_pending)
     remaining_pending.update(status=ContentRequestStatus.Completed)
+
+
+def propagate_contentnode_removal(contentnode_ids):
+    """
+    Deletes all learner initiated ContentRequests for the passed in contentnode_ids
+    Matching learner initiated ContentRequests will be deleted - this means that if
+    resources are deleted by an admin, we remove any associated learner initiated requests.
+    Also updates the status of any COMPLETED non-learner initiated ContentDownloadRequests to PENDING
+    """
+    BATCH_SIZE = 250
+    for i in range(0, len(contentnode_ids), BATCH_SIZE):
+        batch = contentnode_ids[i : i + BATCH_SIZE]
+        ContentRequest.objects.filter(
+            contentnode_id__in=batch, reason=ContentRequestReason.UserInitiated
+        ).delete()
+        ContentDownloadRequest.objects.filter(
+            contentnode_id__in=batch,
+            status=ContentRequestStatus.Completed,
+        ).exclude(reason=ContentRequestReason.UserInitiated).update(
+            status=ContentRequestStatus.Pending
+        )
 
 
 class StorageCalculator:


### PR DESCRIPTION
## Summary
* Adds a `propagate_removal` method to the ContentDownloadRequest manager to update any completed requests for specific contentnode_ids to Pending.
* Adds an optional argument to deletecontent to use this to update the status of ContentDownloadRequests when content is deleted from the device
* In content download request managed removal, toggles this feature off to prevent double action

## References
Fixes #11364

## Reviewer guidance
* Mark resources for download, let them download
* Delete the same resources an admin
* Observe that the status is properly updated on the MyDownloads page

Status should update for the affected contentnodes:

![Screenshot from 2023-10-08 16-53-12](https://github.com/learningequality/kolibri/assets/1680573/22f80287-827e-4213-bf23-9f3911420f26)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
