### PR TITLE
Fix order in which notification updates are commited to state

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/actions.spec.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/__test__/actions.spec.js
@@ -1,0 +1,65 @@
+import { NotificationObjects } from '../../../constants/notificationsConstants';
+import { updateWithNotifications } from '../actions';
+
+const { QUIZ } = NotificationObjects;
+
+describe('classSummary/actions', () => {
+  describe('updateWithNotifications', () => {
+    it('commits quiz notifications updates in a correct order (sorted by their datetime)', () => {
+      const state = {
+        learnerMap: { 'user-id': {} },
+        examMap: { 'quiz-id': {} },
+        contentNodeMap: {},
+        lessonMap: {},
+      };
+      const commit = jest.fn();
+      const dispatch = jest.fn();
+
+      const quizNotifications = [
+        {
+          id: 1,
+          user_id: 'user-id',
+          object: QUIZ,
+          event: 'Completed',
+          timestamp: '2023-10-05T13:35:00+02:00',
+          quiz_num_correct: 1,
+          quiz_num_answered: 2,
+          quiz_id: 'quiz-id',
+        },
+        {
+          id: 2,
+          user_id: 'user-id',
+          object: QUIZ,
+          event: 'Started',
+          timestamp: '2023-10-05T13:30:00+02:00',
+          quiz_num_correct: 2,
+          quiz_num_answered: 3,
+          quiz_id: 'quiz-id',
+        },
+      ];
+
+      updateWithNotifications({ state, commit, dispatch }, quizNotifications);
+
+      expect(commit).toHaveBeenCalledTimes(1);
+      expect(commit.mock.calls[0][0]).toBe('APPLY_NOTIFICATION_UPDATES');
+      expect(commit.mock.calls[0][1].examLearnerStatusMapUpdates).toEqual([
+        {
+          learner_id: 'user-id',
+          status: 'Started',
+          last_activity: new Date('2023-10-05T11:30:00.000Z'),
+          num_correct: 2,
+          num_answered: 3,
+          exam_id: 'quiz-id',
+        },
+        {
+          learner_id: 'user-id',
+          status: 'Completed',
+          last_activity: new Date('2023-10-05T11:35:00.000Z'),
+          num_correct: 1,
+          num_answered: 2,
+          exam_id: 'quiz-id',
+        },
+      ]);
+    });
+  });
+});

--- a/kolibri/plugins/coach/assets/src/modules/classSummary/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/classSummary/actions.js
@@ -9,8 +9,15 @@ export function updateWithNotifications(store, notifications) {
   const contentLearnerStatusMapUpdates = [];
   const { learnerMap, examMap, contentNodeMap, lessonMap } = store.state;
 
-  for (const nIdx in notifications) {
-    const notification = notifications[nIdx];
+  if (!notifications || !notifications.length) {
+    return;
+  }
+  const sortedNotifications = notifications.sort((n1, n2) => {
+    return new Date(n1.timestamp) - new Date(n2.timestamp);
+  });
+
+  for (const nIdx in sortedNotifications) {
+    const notification = sortedNotifications[nIdx];
     const { object } = notification;
 
     // Short-circuit the update if there are missing learners, exams, lessons,


### PR DESCRIPTION
## Summary

Commit updates to state sorted by timestamp.

## References

Fixes https://github.com/learningequality/kolibri/issues/11302 where "Completed" update was commited before "Started" update.

## Reviewer guidance

Start a quiz on a full device. Take the quiz on LoD device. Wait for sync to happen and confirm that https://github.com/learningequality/kolibri/issues/11302 is fixed.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
