### PR TITLE
Feature  quiz section tabs with overflow

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#50a07f361febc643505e8d6991b6a037d1432c63",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -128,6 +128,7 @@ export default () => {
     if (updatedSections.length === 0) {
       const newSection = addSection();
       setActiveSection(newSection.section_id);
+      updatedSections.push(newSection);
     } else {
       setActiveSection(get(updatedSections)[0].section_id);
     }

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
 import uniq from 'lodash/uniq';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { ChannelResource, ExamResource } from 'kolibri.resources';
@@ -46,8 +47,11 @@ export default () => {
    * The questions that are currently selected for action in the active section */
   const _selectedQuestions = ref([]);
 
-  /** @type {ref<>} A list of all channels available which have exercises */
+  /** @type {ref<Array>} A list of all channels available which have exercises */
   const _channels = ref([]);
+
+  /** @type {ref<Number>} A counter for use in naming new sections */
+  const _sectionLabelCounter = ref(1);
 
   // ------------------
   // Section Management
@@ -112,6 +116,9 @@ export default () => {
    * Adds a section to the quiz and returns it */
   function addSection() {
     const newSection = objectWithDefaults({ section_id: uuidv4() }, QuizSection);
+    const { sectionLabel$ } = enhancedQuizManagementStrings;
+    newSection.section_title = `${sectionLabel$()} ${_sectionLabelCounter.value}`;
+    _sectionLabelCounter.value++;
     updateQuiz({ question_sources: [...get(quiz).question_sources, newSection] });
     setActiveSection(newSection.section_id);
     return newSection;

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -113,6 +113,7 @@ export default () => {
   function addSection() {
     const newSection = objectWithDefaults({ section_id: uuidv4() }, QuizSection);
     updateQuiz({ question_sources: [...get(quiz).question_sources, newSection] });
+    setActiveSection(newSection.section_id);
     return newSection;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -43,7 +43,9 @@
           tabsId="quizSectionTabs"
           :tabs="tabs"
           :appearanceOverrides="{ padding: '0px', overflow: 'hidden' }"
-          :activeTabId="quizForge.activeSection && quizForge.activeSection.value.section_id"
+          :activeTabId="quizForge.activeSection.value ?
+            quizForge.activeSection.value.section_id :
+            '' "
           backgroundColor="transparent"
           hoverBackgroundColor="transparent"
         >
@@ -77,6 +79,7 @@
           <template #overflow="{ overflowTabs }">
             <KIconButton
               v-if="overflowTabs.length"
+              tabindex="-1"
               icon="optionsHorizontal"
               :style="overflowButtonStyles(overflowTabs)"
             >
@@ -133,7 +136,7 @@
           icon="plus"
           @click="handleAddSection"
         >
-          {{ ($tr('addSection')).toUpperCase() }}
+          {{ (eqmStrings.$tr('addSectionLabel')) }}
         </KButton>
       </KGridItem>
 
@@ -142,9 +145,10 @@
     <hr class="bottom-border">
 
     <KTabsPanel
+      v-if="quizForge.activeSection.value"
       class="no-question-layout"
       tabsId="quizSectionTabs"
-      :activeTabId="quizForge.activeSection.value.section_id"
+      :activeTabId="quizForge.activeSection.value ? quizForge.activeSection.value.section_id : ''"
     >
 
       <p>{{ quizForge.activeSection.value.section_id }}</p>
@@ -180,32 +184,22 @@
 
   import { get } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoach from '../../common';
   import TabsWithOverflow from './TabsWithOverflow.vue';
 
-  /*
-    import DragHandle from 'kolibri.coreVue.components.DragHandle';
-    import Draggable from 'kolibri.coreVue.components.Draggable';
-    import DragContainer from 'kolibri.coreVue.components.DragContainer';
-    import DragSortWidget from 'kolibri.coreVue.components.DragSortWidget';
-    import AccordionContainer from './AccordionContainer.vue';
-    import AccordionItem from './AccordionItem.vue';
-    */
   export default {
     name: 'CreateQuizSection',
     components: {
       TabsWithOverflow,
-      /*
-        AccordionContainer,
-        AccordionItem,
-        DragHandle,
-        Draggable,
-        DragContainer,
-        DragSortWidget,
-        */
     },
     mixins: [commonCoreStrings, commonCoach],
     inject: ['quizForge'],
+    data() {
+      return {
+        eqmStrings: enhancedQuizManagementStrings,
+      };
+    },
     computed: {
       noKgridItemPadding() {
         return {
@@ -218,9 +212,7 @@
           const id = section.section_id;
           // TODO The "Section N" label should probably be set directly on the Section object
           // at creation rather than this
-          const label = section.section_title
-            ? section.section_title
-            : `Section asdfjla askjljf lasjdfkj aslf${index + 1}`;
+          const label = section.section_title ? section.section_title : `Section ${index + 1}`;
 
           return { id, label };
         });
@@ -301,10 +293,6 @@
             */
     },
     $trs: {
-      addSection: {
-        message: 'add section',
-        context: 'Label for adding the number of quiz sections',
-      },
       noQuestionsLabel: {
         message: 'There are no questions in this section',
         context: 'Indicates that there is no question in the particular section',

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -42,7 +42,7 @@
         <TabsWithOverflow
           tabsId="quizSectionTabs"
           :tabs="tabs"
-          :appearanceOverrides="{ padding: '0px' }"
+          :appearanceOverrides="{ padding: '0px', overflow: 'hidden' }"
           :activeTabId="quizForge.activeSection && quizForge.activeSection.value.section_id"
           backgroundColor="transparent"
           hoverBackgroundColor="transparent"
@@ -51,7 +51,7 @@
             <KButton
               v-show="tabIsVisible"
               appearance="flat-button"
-              style="flex: 1;"
+              style="display: inline-block;"
               :appearanceOverrides="tabStyles"
               @click="() => quizForge.setActiveSection(tab.id)"
             >
@@ -77,6 +77,7 @@
 
           <template #overflow="{ overflowTabs }">
             <KIconButton
+              v-if="overflowTabs.length"
               icon="optionsHorizontal"
               style="height: 40px; width: 40px;"
             >
@@ -86,7 +87,7 @@
                   :disabled="false"
                   :hasIcons="true"
                   :options="overflowTabs"
-                  @select="opt => handleSectionOptionSelect(opt, tab.id)"
+                  @select="opt => quizForge.setActiveSection(opt.id)"
                 />
               </template>
             </KIconButton>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -59,6 +59,7 @@
             <KIconButton
               icon="optionsVertical"
               class="options-button"
+              size="small"
               @click="() => null"
             >
               <template #menu>
@@ -77,7 +78,7 @@
             <KIconButton
               v-if="overflowTabs.length"
               icon="optionsHorizontal"
-              style="height: 40px; width: 40px;"
+              :style="overflowButtonStyles(overflowTabs)"
             >
               <template #menu>
                 <KDropdownMenu
@@ -88,17 +89,20 @@
                   @select="opt => quizForge.setActiveSection(opt.id)"
                 >
                   <template #option="{ option }">
+                    <!-- TODO Clean this up by moving it to another component -->
+                    <!-- Maybe not so easy since they're styled differently -->
                     <KButton
                       appearance="flat-button"
-                      style="display: inline-block;"
+                      :primary="quizForge.activeSection.value.section_id === option.id"
                       :appearanceOverrides="tabStyles"
+                      class="menu-button"
                       @click="() => quizForge.setActiveSection(option.id)"
                     >
                       {{ option.label }}
                     </KButton>
                     <KIconButton
                       icon="optionsVertical"
-                      style="position: absolute; right: 0;"
+                      style="position: absolute; right: 0; border-radius: 0!important;"
                       @click="() => null"
                     >
                       <template #menu>
@@ -214,7 +218,9 @@
           const id = section.section_id;
           // TODO The "Section N" label should probably be set directly on the Section object
           // at creation rather than this
-          const label = section.section_title ? section.section_title : `Section ${index + 1}`;
+          const label = section.section_title
+            ? section.section_title
+            : `Section asdfjla askjljf lasjdfkj aslf${index + 1}`;
 
           return { id, label };
         });
@@ -222,6 +228,8 @@
       tabStyles() {
         return {
           margin: '0px',
+          textOverflow: 'ellipsis',
+          maxWidth: '160px',
         };
       },
       sectionOptions() {
@@ -240,6 +248,19 @@
       },
     },
     methods: {
+      activeSectionIsHidden(overflow) {
+        const ids = overflow.map(i => i.id);
+        return ids.includes(get(this.quizForge.activeSection).section_id);
+      },
+      overflowButtonStyles(overflow) {
+        return {
+          height: '40px',
+          width: '40px',
+          border: this.activeSectionIsHidden(overflow)
+            ? '2px solid ' + this.$themeTokens.primary
+            : 'none',
+        };
+      },
       handleAddSection() {
         const newSection = this.quizForge.addSection();
         this.quizForge.setActiveSection(get(newSection).section_id);
@@ -508,6 +529,17 @@
     height: 36px !important;
     margin: 0;
     border-radius: 0 !important;
+  }
+
+  /deep/ .ui-menu {
+    min-width: 17rem;
+    max-width: 25rem;
+  }
+
+  .menu-button {
+    width: calc(100% - 40px);
+    max-width: calc(100% - 40px) !important;
+    min-height: 40px;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -39,23 +39,26 @@
         :layout12="{ span: 10 }"
         :style="noKgridItemPadding"
       >
-        <KTabsList
+        <TabsWithOverflow
           tabsId="quizSectionTabs"
+          :tabs="tabs"
           :appearanceOverrides="{ padding: '0px' }"
           :activeTabId="quizForge.activeSection && quizForge.activeSection.value.section_id"
           backgroundColor="transparent"
           hoverBackgroundColor="transparent"
-          :tabs="tabs"
         >
-          <template #tab="{ tab }">
+          <template #tab="{ tab, tabIsVisible }">
             <KButton
+              v-show="tabIsVisible"
               appearance="flat-button"
+              style="flex: 1;"
               :appearanceOverrides="tabStyles"
               @click="() => quizForge.setActiveSection(tab.id)"
             >
               {{ tab.label }}
             </KButton>
             <KIconButton
+              v-show="tabIsVisible"
               icon="optionsVertical"
               class="options-button"
               @click="() => null"
@@ -71,7 +74,24 @@
               </template>
             </KIconButton>
           </template>
-        </KTabsList>
+
+          <template #overflow="{ overflowTabs }">
+            <KIconButton
+              icon="optionsHorizontal"
+              style="height: 40px; width: 40px;"
+            >
+              <template #menu>
+                <KDropdownMenu
+                  :primary="false"
+                  :disabled="false"
+                  :hasIcons="true"
+                  :options="overflowTabs"
+                  @select="opt => handleSectionOptionSelect(opt, tab.id)"
+                />
+              </template>
+            </KIconButton>
+          </template>
+        </TabsWithOverflow>
       </KGridItem>
 
       <KGridItem
@@ -152,6 +172,11 @@
       DragSortWidget,
     },
     */
+  import TabsWithOverflow from './TabsWithOverflow.vue';
+
+  export default {
+    name: 'CreateQuizSection',
+    components: { TabsWithOverflow },
     mixins: [commonCoreStrings, commonCoach],
     inject: ['quizForge'],
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -151,32 +151,29 @@
   import { get } from '@vueuse/core';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../../common';
-  /*
-  import DragHandle from 'kolibri.coreVue.components.DragHandle';
-  import Draggable from 'kolibri.coreVue.components.Draggable';
-  import DragContainer from 'kolibri.coreVue.components.DragContainer';
-  import DragSortWidget from 'kolibri.coreVue.components.DragSortWidget';
-  import AccordionContainer from './AccordionContainer.vue';
-  import AccordionItem from './AccordionItem.vue';
-  */
-
-  export default {
-    name: 'CreateQuizSection',
-    /*
-    components: {
-      AccordionContainer,
-      AccordionItem,
-      DragHandle,
-      Draggable,
-      DragContainer,
-      DragSortWidget,
-    },
-    */
   import TabsWithOverflow from './TabsWithOverflow.vue';
 
+  /*
+    import DragHandle from 'kolibri.coreVue.components.DragHandle';
+    import Draggable from 'kolibri.coreVue.components.Draggable';
+    import DragContainer from 'kolibri.coreVue.components.DragContainer';
+    import DragSortWidget from 'kolibri.coreVue.components.DragSortWidget';
+    import AccordionContainer from './AccordionContainer.vue';
+    import AccordionItem from './AccordionItem.vue';
+    */
   export default {
     name: 'CreateQuizSection',
-    components: { TabsWithOverflow },
+    components: {
+      TabsWithOverflow,
+      /*
+        AccordionContainer,
+        AccordionItem,
+        DragHandle,
+        Draggable,
+        DragContainer,
+        DragSortWidget,
+        */
+    },
     mixins: [commonCoreStrings, commonCoach],
     inject: ['quizForge'],
     computed: {
@@ -235,26 +232,26 @@
         this.$router.replace({ path: 'new/' + section_id + '/select-resources' });
       },
       /*
-      handleOrderChange(event) {
-        const reorderedList = event.newArray.map(x => {
-          if (x.isPlaceholder) {
-            return this.placeholderList.find(item => item.id === x.id);
-          }
-          return x;
-        });
-        this.placeholderList = reorderedList;
-        localStorage.setItem('reorderedList', JSON.stringify(reorderedList));
-        this.$store.dispatch('createSnackbar', this.$tr('successNotification'));
-      },
-      shiftOne(index, delta) {
-        const newArray = [...this.placeholderList];
-        const adjacentItem = newArray[index + delta];
-        newArray[index + delta] = newArray[index];
-        newArray[index] = adjacentItem;
+        handleOrderChange(event) {
+          const reorderedList = event.newArray.map(x => {
+            if (x.isPlaceholder) {
+              return this.placeholderList.find(item => item.id === x.id);
+            }
+            return x;
+          });
+          this.placeholderList = reorderedList;
+          localStorage.setItem('reorderedList', JSON.stringify(reorderedList));
+          this.$store.dispatch('createSnackbar', this.$tr('successNotification'));
+        },
+        shiftOne(index, delta) {
+          const newArray = [...this.placeholderList];
+          const adjacentItem = newArray[index + delta];
+          newArray[index + delta] = newArray[index];
+          newArray[index] = adjacentItem;
 
-        this.handleOrderChange({ newArray });
-      },
-          */
+          this.handleOrderChange({ newArray });
+        },
+            */
     },
     $trs: {
       addSection: {
@@ -279,43 +276,43 @@
           'This message indicates that more than one section can be added when creating a quiz.',
       },
       /*
-      questionPhrase: {
-        message: 'Select the word that has the following vowel sound.',
-        context: 'Placholder for the question',
-      },
-      questionSubtitle: {
-        message: ' Short <e>, [e]</e>',
-        context: 'Placholder content for the question description',
-      },
-      chooseQuestionLabel: {
-        message: 'Choose 1 answer:',
-        context: 'Label to indicate the question to be chosen',
-      },
-      addAnswer: {
-        message: 'Add answer',
-        context: 'Button text to indicate that more answers can be added to the question.',
-      },
-      selectAllLabel: {
-        message: 'Select all',
-        context: 'Label indicates that all available options can be chosen at once.',
-      },
-      upLabel: {
-        message: 'Move {name} up one',
-        context: 'Label to rearrange question order. Not seen on UI.',
-      },
-      downLabel: {
-        message: 'Move {name} down one',
-        context: 'Label to rearrange question order. Not seen on UI.',
-      },
-      checkBoxLabel: {
-        message: 'Select {name} question"',
-        context: 'Checkbox to select the question',
-      },
-      successNotification: {
-        message: 'Question order saved',
-        context: 'Success message shown when the admin re-orders question',
-      },
-        */
+        questionPhrase: {
+          message: 'Select the word that has the following vowel sound.',
+          context: 'Placholder for the question',
+        },
+        questionSubtitle: {
+          message: ' Short <e>, [e]</e>',
+          context: 'Placholder content for the question description',
+        },
+        chooseQuestionLabel: {
+          message: 'Choose 1 answer:',
+          context: 'Label to indicate the question to be chosen',
+        },
+        addAnswer: {
+          message: 'Add answer',
+          context: 'Button text to indicate that more answers can be added to the question.',
+        },
+        selectAllLabel: {
+          message: 'Select all',
+          context: 'Label indicates that all available options can be chosen at once.',
+        },
+        upLabel: {
+          message: 'Move {name} up one',
+          context: 'Label to rearrange question order. Not seen on UI.',
+        },
+        downLabel: {
+          message: 'Move {name} down one',
+          context: 'Label to rearrange question order. Not seen on UI.',
+        },
+        checkBoxLabel: {
+          message: 'Select {name} question"',
+          context: 'Checkbox to select the question',
+        },
+        successNotification: {
+          message: 'Question order saved',
+          context: 'Success message shown when the admin re-orders question',
+        },
+          */
     },
   };
 
@@ -476,10 +473,6 @@
   .limit-height {
     margin-top: 0.5em;
     margin-bottom: 0.5em;
-    margin-bottom: -8px;
-    text-align: left;
-  }
-
     margin-bottom: -8px;
     text-align: left;
   }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -455,6 +455,10 @@
     text-align: left;
   }
 
+    margin-bottom: -8px;
+    text-align: left;
+  }
+
   .options-button {
     width: 36px !important;
     height: 36px !important;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -51,6 +51,7 @@
         >
           <template #tab="{ tab }">
             <KButton
+              :ref="tabRefLabel(tab.id)"
               appearance="flat-button"
               style="display: inline-block;"
               :appearanceOverrides="tabStyles"
@@ -175,6 +176,7 @@
 
     </KTabsPanel>
 
+    <SectionSidePanel @closePanel="focusActiveSectionTab()" />
   </div>
 
 </template>
@@ -187,12 +189,14 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoach from '../../common';
+  import SectionSidePanel from './SectionSidePanel.vue';
   import TabsWithOverflow from './TabsWithOverflow.vue';
 
   export default {
     name: 'CreateQuizSection',
     components: {
       TabsWithOverflow,
+      SectionSidePanel,
     },
     mixins: [commonCoreStrings, commonCoach],
     setup() {
@@ -260,6 +264,25 @@
       },
     },
     methods: {
+      tabRefLabel(section_id) {
+        return `section-tab-${section_id}`;
+      },
+      focusActiveSectionTab() {
+        const label = this.tabRefLabel(this.quizForge.activeSection.value.section_id);
+        const tabRef = this.$refs[label];
+        // TODO Consider the "Delete section" button on the side panel; maybe we need to await
+        // nextTick if we're getting the error
+        if (tabRef) {
+          tabRef.$el.focus();
+        } else {
+          console.error(
+            'Tried to focus active tab id: ',
+            label,
+            ' - but the tab is not in the refs: ',
+            this.$refs
+          );
+        }
+      },
       activeSectionIsHidden(overflow) {
         const ids = overflow.map(i => i.id);
         return ids.includes(get(this.quizForge.activeSection).section_id);
@@ -279,6 +302,9 @@
         this.sectionCreationCount++;
       },
       handleSectionOptionSelect({ label }, section_id) {
+        // Always set the active section to the one that is having its side panel opened
+        this.quizForge.setActiveSection(section_id);
+
         switch (label) {
           case this.editSectionLabel$():
             this.$router.replace({ path: 'new/' + section_id + '/edit' });

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -47,9 +47,8 @@
           backgroundColor="transparent"
           hoverBackgroundColor="transparent"
         >
-          <template #tab="{ tab, tabIsVisible }">
+          <template #tab="{ tab }">
             <KButton
-              v-show="tabIsVisible"
               appearance="flat-button"
               style="display: inline-block;"
               :appearanceOverrides="tabStyles"
@@ -58,7 +57,6 @@
               {{ tab.label }}
             </KButton>
             <KIconButton
-              v-show="tabIsVisible"
               icon="optionsVertical"
               class="options-button"
               @click="() => null"
@@ -88,7 +86,34 @@
                   :hasIcons="true"
                   :options="overflowTabs"
                   @select="opt => quizForge.setActiveSection(opt.id)"
-                />
+                >
+                  <template #option="{ option }">
+                    <KButton
+                      appearance="flat-button"
+                      style="display: inline-block;"
+                      :appearanceOverrides="tabStyles"
+                      @click="() => quizForge.setActiveSection(option.id)"
+                    >
+                      {{ option.label }}
+                    </KButton>
+                    <KIconButton
+                      icon="optionsVertical"
+                      style="position: absolute; right: 0;"
+                      @click="() => null"
+                    >
+                      <template #menu>
+                        <KDropdownMenu
+                          :primary="false"
+                          :disabled="false"
+                          :hasIcons="true"
+                          :containFocus="false"
+                          :options="sectionOptions"
+                          @select="opt => handleSectionOptionSelect(opt, option.id)"
+                        />
+                      </template>
+                    </KIconButton>
+                  </template>
+                </KDropdownMenu>
               </template>
             </KIconButton>
           </template>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -39,9 +39,6 @@
       };
     },
     computed: {
-      quizRootRoute() {
-        return { name: PageNames.EXAM_CREATION_ROOT };
-      },
       panel() {
         return pageNameComponentMap[this.$route.name];
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -39,6 +39,9 @@
       };
     },
     computed: {
+      quizRootRoute() {
+        return { name: PageNames.EXAM_CREATION_ROOT };
+      },
       panel() {
         return pageNameComponentMap[this.$route.name];
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -5,7 +5,7 @@
     ref="resourcePanel"
     alignment="right"
     :closeButtonIconType="closeIcon"
-    @closePanel="$router.replace(closePanelRoute)"
+    @closePanel="handleClosePanel"
     @shouldFocusFirstEl="findFirstEl()"
   >
     <p>{{ quizForge.activeSection.value.section_id }}</p>
@@ -69,6 +69,10 @@
       },
     },
     methods: {
+      handleClosePanel() {
+        this.$emit('closePanel');
+        this.$router.replace(this.closePanelRoute);
+      },
       /**
        * Calls the currently displayed ref's focusFirstEl method.
        */

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
@@ -62,6 +62,7 @@
       tabs() {
         this.$nextTick(() => {
           this.setOverflowTabs();
+          this.setWrappingButtonTabIndex();
         });
       },
     },
@@ -85,6 +86,7 @@
               })
             : [];
       },
+      // The buttons are wrapped with a button that we aren't going to use due to KTabsList
       setWrappingButtonTabIndex() {
         for (const child of this.$refs.tabsWrapper.$el.children) {
           child.setAttribute('tabindex', -1);

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
@@ -1,0 +1,92 @@
+<template>
+
+  <KTabsList
+    ref="tabsWrapper"
+    class="tabs-wrapper"
+    v-bind="$attrs"
+    :tabs="tabs"
+  >
+    <template #tab="{ tab }">
+      <slot name="tab" :tab="tab" :tabIsVisible="tabIsVisible(tab)"></slot>
+    </template>
+    <slot name="overflow" :overflowTabs="overflowTabs"></slot>
+  </KTabsList>
+
+</template>
+
+
+<script>
+
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
+
+  /**
+   * @typedef   {Object}    Tab
+   * @property  {string}    label
+   * @property  {string}    id
+   */
+
+  export default {
+    // TODO Rename this to TabsListWithOverflow as it will wrap stuff in a KTabsList
+    name: 'TabsWithOverflow',
+    setup() {
+      const { windowWidth } = useKResponsiveWindow();
+      return {
+        windowWidth,
+      };
+    },
+    props: {
+      pxReservedForOverflowButton: {
+        type: Number,
+        default: 40,
+      },
+      tabs: {
+        type: Array,
+        required: true,
+      },
+    },
+    data() {
+      return { mounted: false };
+    },
+    computed: {
+      overflowTabs() {
+        return this.mounted && this.windowWidth
+          ? this.tabs.filter((_, idx) => {
+              const tabRef = this.$refs.tabsWrapper.$children[idx].$el;
+              const tabRefTop = tabRef.offsetTop;
+
+              const containerTop = this.$refs.tabsWrapper.$el.offsetTop;
+              const containerBottom = containerTop + this.$refs.tabsWrapper.$el.clientHeight;
+
+              return tabRefTop >= containerBottom;
+            })
+          : [];
+      },
+    },
+    mounted() {
+      this.mounted = true;
+      this.$nextTick(() => {
+        console.log(this.$slots);
+        console.log(this.$refs);
+      });
+    },
+    methods: {
+      tabIsVisible(tab) {
+        return !this.overflowTabs.map(t => t.id).includes(tab.id);
+      },
+    },
+  };
+
+</script>
+
+
+<style scoped lang="scss">
+
+  .tabs-wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    max-height: 40px;
+    overflow: hidden;
+  }
+
+</style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
@@ -35,10 +35,10 @@
       };
     },
     props: {
-      pxReservedForOverflowButton: {
-        type: Number,
-        default: 40,
-      },
+      //pxReservedForOverflowButton: {
+      //type: Number,
+      //default: 40,
+      //},
       tabs: {
         type: Array,
         required: true,
@@ -64,12 +64,14 @@
     },
     mounted() {
       this.mounted = true;
-      this.$nextTick(() => {
-        console.log(this.$slots);
-        console.log(this.$refs);
-      });
+      this.setWrappingButtonTabIndex();
     },
     methods: {
+      setWrappingButtonTabIndex() {
+        for (const child of this.$refs.tabsWrapper.$el.children) {
+          child.setAttribute('tabindex', -1);
+        }
+      },
       tabIsVisible(tab) {
         return !this.overflowTabs.map(t => t.id).includes(tab.id);
       },
@@ -82,11 +84,15 @@
 <style scoped lang="scss">
 
   .tabs-wrapper {
+    z-index: 24;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    max-height: 40px;
-    overflow: hidden;
+    max-height: 6em;
+  }
+
+  /deep/ .tab {
+    overflow: visible; // Keep outline fully visible
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/TabsWithOverflow.vue
@@ -6,7 +6,7 @@
       class="tabs-wrapper"
       v-bind="$attrs"
       :activeTabId="activeTabId"
-      :tabs="visibleTabs"
+      :tabs="tabs"
     >
       <template #tab="{ tab }">
         <slot name="tab" :tab="tab" :tabIsVisible="tabIsVisible(tab)"></slot>
@@ -57,11 +57,6 @@
     },
     data() {
       return { mounted: false, overflowTabs: [] };
-    },
-    computed: {
-      visibleTabs() {
-        return this.tabs.filter(this.tabIsVisible);
-      },
     },
     watch: {
       tabs() {
@@ -114,7 +109,8 @@
     overflow: hidden;
   }
 
-  /deep/ .tab > button {
+  /deep/ .tab > button,
+  .tab {
     max-width: calc(200px - 40px);
     text-overflow: ellipsis;
 
@@ -125,7 +121,7 @@
   }
 
   /deep/ .tab {
-    flex: 0 0 auto;
+    display: inline-block;
     height: 2.5em;
     overflow: visible; // Keep outline fully visible
   }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -59,36 +59,6 @@
     },
     mixins: [commonCoreStrings, commonCoach, responsiveWindowMixin],
     data() {
-      /**
-       * TODO
-       * const {
-          // Methods
-          saveQuiz,
-          updateSection,
-          replaceSelectedQuestions,
-          addSection,
-          removeSection,
-          setActiveSection,
-          initializeQuiz,
-          updateQuiz,
-          addQuestionToSelection,
-          removeQuestionFromSelection,
-
-          // Computed
-          channels,
-          quiz,
-          allSections,
-          activeSection,
-          activeExercisePool,
-          activeQuestionsPool,
-          activeQuestions,
-          selectedActiveQuestions,
-          replacementQuestionPool,
-          } = quizForge;
-
-          or can I just ...quizForge in the return?
-      **/
-
       return {
         quizForge,
       };
@@ -115,20 +85,7 @@
         bookmarksCount: 0,
         bookmarks: [],
         more: null,
-        quizForge,
         // showSectionSettingsMenu:false
-      };
-    },
-    /**
-     * @returns {object}
-     * @property {object} quizForge - see useQuizCreation for details; this is a reflection of
-     *                                the object returned by that function which is initialized
-     *                                within this component
-     * add `inject: ['quizForge']` to any descendant component to access this
-     */
-    provide() {
-      return {
-        quizForge: this.quizForge,
       };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -27,8 +27,6 @@
 
     </KPageContainer>
 
-    <SectionSidePanel />
-
   </CoachImmersivePage>
 
 </template>
@@ -45,14 +43,12 @@
   import CoachImmersivePage from '../../CoachImmersivePage';
   import useQuizCreation from '../../../composables/useQuizCreation';
   import CreateQuizSection from './CreateQuizSection.vue';
-  import SectionSidePanel from './SectionSidePanel.vue';
 
   const quizForge = useQuizCreation();
 
   export default {
     name: 'CreateExamPage',
     components: {
-      SectionSidePanel,
       CoachImmersivePage,
       BottomAppBar,
       CreateQuizSection,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -59,8 +59,64 @@
     },
     mixins: [commonCoreStrings, commonCoach, responsiveWindowMixin],
     data() {
+      /**
+       * TODO
+       * const {
+          // Methods
+          saveQuiz,
+          updateSection,
+          replaceSelectedQuestions,
+          addSection,
+          removeSection,
+          setActiveSection,
+          initializeQuiz,
+          updateQuiz,
+          addQuestionToSelection,
+          removeQuestionFromSelection,
+
+          // Computed
+          channels,
+          quiz,
+          allSections,
+          activeSection,
+          activeExercisePool,
+          activeQuestionsPool,
+          activeQuestions,
+          selectedActiveQuestions,
+          replacementQuestionPool,
+          } = quizForge;
+
+          or can I just ...quizForge in the return?
+      **/
+
       return {
         quizForge,
+      };
+    },
+    /**
+     * @returns {object}
+     * @property {object} quizForge - see useQuizCreation for details; this is a reflection of
+     *                                the object returned by that function which is initialized
+     *                                within this component
+     * add `inject: ['quizForge']` to any descendant component to access this
+     */
+    provide() {
+      return {
+        quizForge: this.quizForge,
+        showError: false,
+        moreResultsState: null,
+        // null corresponds to 'All' filter value
+        filters: {
+          channel: this.$route.query.channel || null,
+          kind: this.$route.query.kind || null,
+          role: this.$route.query.role || null,
+        },
+        // numQuestionsBlurred: false,
+        bookmarksCount: 0,
+        bookmarks: [],
+        more: null,
+        quizForge,
+        // showSectionSettingsMenu:false
       };
     },
     /**

--- a/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
+++ b/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
@@ -122,8 +122,9 @@ describe('useQuizCreation', () => {
 
       it('Can change the activeSection', () => {
         const addedSection = addSection();
+        addSection(); // This automatically sets the added section as active, but we won't use it
         expect(get(activeSection).section_id).not.toEqual(addedSection.section_id);
-        setActiveSection(addedSection.section_id);
+        setActiveSection(addedSection.section_id); // Now we set the first added section as active
         expect(get(activeSection).section_id).toEqual(addedSection.section_id);
       });
 

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -1,6 +1,9 @@
 import { createTranslator } from 'kolibri.utils.i18n';
 
 export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManagementStrings', {
+  sectionLabel: {
+    message: 'Section',
+  },
   createNewQuiz: {
     message: 'Create new quiz',
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7640,6 +7640,22 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#50a07f361febc643505e8d6991b6a037d1432c63":
+  version "1.3.0"
+  resolved "https://github.com/learningequality/kolibri-design-system#50a07f361febc643505e8d6991b6a037d1432c63"
+  dependencies:
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "^3.0.21"
+    css-element-queries "^1.2.0"
+    frame-throttle "^3.0.0"
+    fuzzysearch "^1.0.3"
+    keen-ui "^1.3.0"
+    lodash "^4.17.15"
+    popper.js "^1.14.6"
+    purecss "^0.6.2"
+    tippy.js "^4.2.1"
+    vue-intl "^3.1.0"
+
 "kolibri-design-system@https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#ab03c5e257a7806c67cf6250310e3e6ccb5119c9"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Introduces a component to accommodate design requiring that tabs stay on one line such that overflowing tabs are presented in a drop-down menu. This involved what feels a little bit like `<slots>` Inception so hopefully it isn't too squirrely
- The natural way that I found to accommodate keyboard users accessibly jives with the inspiration I took from the `HorizontalMenuWithOverflow` component where we use `overflow: hidden` and `flex-wrap` to allow the tabs to render out of sight. We calculate "which tabs are out of sight?" then present those items in the dropdown menu. The accessible solution here seemed to be to put `tabindex=-1` onto the overflow dropdown such that it will not be focused. Instead, the focus just continues onto the hidden tabs, showing them visibly. 
- Changes to the side panel so that it is in a better context for managing focus on close
- Uses the new `messageLabel$` convention for strings.

**NOTE: This uses [this KDS PR](https://github.com/learningequality/kolibri-design-system/pull/465)**

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #11274

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Apologies for lack of videos - I am having issues recording things right now.

- Please test screen reader and keyboard navigation from top to bottom.
- Test opening/closing and navigating each section tab's context menu and each of the actions available there
- Add enough sections to the quiz such that the overflow dropdown appears. 
- The dropdown and its option should not be focusable by tabbing. As you navigate through the section tabs while the overflow is present, you should still be able to keyboard navigate to all of the tabs.
- You should be able to access context menus for sections in the overflow dropdown
- @tomiwaoLE note that to indicate that a focused item is in the overflow list, a primary colored circle surrounds the dropdown icon button:
![image](https://github.com/learningequality/kolibri/assets/6356129/eb932971-cbcd-4265-b999-4d6946ed9ad1)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
