### PR TITLE
Clean up renderer height styling behaviour

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/CoachImmersivePage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachImmersivePage.vue
@@ -120,12 +120,3 @@
   };
 
 </script>
-
-
-<style lang="scss" scoped>
-
-  .coach-main {
-    margin: 85px auto 0;
-  }
-
-</style>

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -1,12 +1,11 @@
 <template>
 
-  <section :style="{ backgroundColor: isExercise ? $themeTokens.surface : '' }">
+  <section>
     <h2 v-if="isExercise" class="header">
       {{ header }}
     </h2>
     <KContentRenderer
       v-if="content.available"
-      :class="{ hof: isExercise }"
       :showCorrectAnswer="true"
       :itemId="selectedQuestion"
       :allowHints="false"
@@ -58,10 +57,6 @@
 
 
 <style lang="scss" scoped>
-
-  .content-area-exercise {
-    padding: 16px;
-  }
 
   .hof {
     overflow-x: hidden; // .solutionarea's negative margin oversteps

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonContentPreviewPage/ContentArea.vue
@@ -6,6 +6,7 @@
     </h2>
     <KContentRenderer
       v-if="content.available"
+      class="content-renderer"
       :showCorrectAnswer="true"
       :itemId="selectedQuestion"
       :allowHints="false"
@@ -58,8 +59,8 @@
 
 <style lang="scss" scoped>
 
-  .hof {
-    overflow-x: hidden; // .solutionarea's negative margin oversteps
+  .content-renderer {
+    height: 100vh;
   }
 
   .header {

--- a/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
+++ b/kolibri/plugins/html5_viewer/assets/src/views/Html5AppRendererIndex.vue
@@ -234,7 +234,6 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
   $frame-topbar-height: 37px;
-  $ui-toolbar-height: 56px;
 
   .fullscreen-header {
     text-align: right;
@@ -261,7 +260,7 @@
     @extend %momentum-scroll;
 
     width: 100%;
-    height: calc(100vh - #{$frame-topbar-height} - #{$ui-toolbar-height});
+    height: calc(100% - #{$frame-topbar-height});
     margin-bottom: -8px;
     overflow: hidden;
   }

--- a/kolibri/plugins/learn/assets/src/views/ContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/ContentPage.vue
@@ -352,9 +352,11 @@
 
 <style lang="scss" scoped>
 
-  .content {
-    z-index: 0;
-    max-height: 100vh;
+  .content-renderer {
+    // 61 pixels is the height of the Learning Activity Bar + 5px.
+    // This seems to be the largest height that the content renderer can be
+    // without causing the page to scroll.
+    height: calc(100vh - 61px);
   }
 
 </style>

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -62,15 +62,17 @@
           </div>
         </div>
       </transition>
-      <KGrid gutter="0">
+      <KGrid class="full-height-container" gutter="0">
         <KGridItem
           v-if="showSideBar"
+          class="full-height-container"
           :layout8="{ span: 2 }"
           :layout12="{ span: 3 }"
-          class="sidebar-container"
-          :class="{ 'mt-40': showControls }"
         >
           <SideBar
+            id="sidebar-container"
+            class="scroller-height"
+            :style="{ position: 'sticky', top: 0 }"
             :outline="outline || []"
             :goToDestination="goToDestination"
             :focusDestPage="focusDestPage"
@@ -78,16 +80,17 @@
         </KGridItem>
         <KGridItem
           ref="pdfContainer"
+          class="full-height-container"
           :layout8="{ span: showSideBar ? 6 : 8 }"
           :layout12="{ span: showSideBar ? 9 : 12 }"
         >
           <RecycleList
+            id="pdf-container"
             ref="recycleList"
             :items="pdfPages"
             :itemHeight="itemHeight"
             :emitUpdate="true"
-            :style="{ height: `${elementHeight - 40}px` }"
-            class="pdf-container"
+            class="pdf-container scroller-height"
             keyField="index"
             @update="handleUpdate"
           >
@@ -124,7 +127,6 @@
   // polyfill necessary for recycle list
   import 'intersection-observer';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveElementMixin from 'kolibri.coreVue.mixins.responsiveElementMixin';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import CoreFullscreen from 'kolibri.coreVue.components.CoreFullscreen';
   import '../utils/domPolyfills';
@@ -144,7 +146,7 @@
       RecycleList,
       CoreFullscreen,
     },
-    mixins: [responsiveWindowMixin, responsiveElementMixin, commonCoreStrings],
+    mixins: [responsiveWindowMixin, commonCoreStrings],
     data: () => ({
       progress: null,
       scale: null,
@@ -271,15 +273,7 @@
       PDFJSLib.GlobalWorkerOptions.workerSrc =
         __webpack_public_path__ + `pdfJSWorker-${__version}.js`;
     },
-    destroyed() {
-      // Reset the overflow on the HTML tag that we set to hidden in created()
-      window.document.getElementsByTagName('html')[0].style.overflow = 'auto';
-    },
     created() {
-      // Override, only on this component, the overflow style of the HTML tag
-      // so that PDFRenderer can scroll itself.
-      window.document.getElementsByTagName('html')[0].style.overflow = 'hidden';
-
       this.worker = new PDFJSLib.PDFWorker();
 
       this.worker.promise.catch(error => {
@@ -660,21 +654,22 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
   $controls-height: 40px;
-  $top-bar-height: 32px;
-  $tool-bar-height: 56px;
 
   .pdf-renderer {
     @extend %momentum-scroll;
     @extend %dropshadow-2dp;
 
     position: relative;
-    height: calc(100vh - #{$top-bar-height} - #{$controls-height} + 16px);
     overflow-y: hidden;
   }
 
   .pdf-container {
     position: relative;
-    top: $controls-height;
+    overflow-y: auto;
+  }
+
+  .scroller-height {
+    height: calc(100% - #{$controls-height});
   }
 
   .controls {
@@ -712,11 +707,6 @@
   }
 
   .fullscreen-header {
-    position: absolute;
-    top: 0;
-    right: 0;
-    left: 0;
-    z-index: 7;
     display: flex;
     height: $controls-height;
   }
@@ -738,27 +728,11 @@
     transform: translateY(-40px);
   }
 
-  .mt-40 {
-    margin-top: 40px;
+  .full-height-container {
+    height: 100%;
   }
 
-  .sidebar-container {
-    height: calc(100vh - #{$tool-bar-height});
-  }
-
-  .pdf-renderer.pdf-controls-open .sidebar-container {
-    height: calc(100vh - #{$tool-bar-height} - #{$controls-height});
-  }
-
-  .pdf-renderer.pdf-full-screen .sidebar-container {
-    height: 100vh;
-  }
-
-  .pdf-renderer.pdf-full-screen.pdf-controls-open .sidebar-container {
-    height: calc(100vh - #{$controls-height});
-  }
-
-  /deep/ .sidebar-container > div {
+  /deep/ .full-height-container > div {
     height: 100%;
   }
 

--- a/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/PdfRendererIndex.vue
@@ -254,11 +254,6 @@
           });
         }
       },
-      elementHeight() {
-        if (this.recycleListIsMounted) {
-          this.debounceForceUpdateRecycleList();
-        }
-      },
       showSideBar() {
         this.$nextTick(() => {
           if (!this.$refs.pdfContainer || !this.$refs.pdfContainer.$el) {
@@ -309,7 +304,7 @@
             const viewPort = firstPage.getViewport({ scale: 1 });
             this.firstPageHeight = viewPort.height;
             this.firstPageWidth = viewPort.width;
-            this.scale = this.elementWidth / (this.firstPageWidth * this.screenSizeMultiplier);
+            this.scale = this.$el.clientWidth / (this.firstPageWidth * this.screenSizeMultiplier);
 
             // Set the firstPageToRender into the pdfPages object so that we do not refetch the page
             // from PDFJS when we do our initial render
@@ -322,6 +317,9 @@
             pdfDocument.getOutline().then(outline => {
               this.outline = outline;
               this.showSideBar = outline && outline.length > 0 && this.windowIsLarge; // Remove if other tabs are already implemented
+              // Reduce the scale slightly if we are showing the sidebar
+              // at first load.
+              this.scale = this.showSideBar ? 0.75 * this.scale : this.scale;
             });
           });
         })
@@ -467,11 +465,10 @@
       calculateRecycleListHeight() {
         return this.$refs.recycleList.$el.scrollHeight;
       },
-      debounceForceUpdateRecycleList: debounce(function() {
-        this.forceUpdateRecycleList();
-      }, renderDebounceTime),
       forceUpdateRecycleList() {
-        this.$refs.recycleList.updateVisibleItems(false);
+        if (this.$refs.recycleList) {
+          this.$refs.recycleList.updateVisibleItems(false);
+        }
       },
       updateProgress() {
         if (this.forceDurationBasedProgress) {

--- a/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
+++ b/kolibri/plugins/pdf_viewer/assets/src/views/SideBar/index.vue
@@ -6,7 +6,7 @@
       background: $themeTokens.surface,
     }"
   >
-    <nav :style="{ height: '100%' }">
+    <nav>
       <div v-if="tabs.filter(t => !t.disabled).length > 1" :style="{ display: 'flex' }">
         <div
           v-for="tab in tabs"
@@ -144,10 +144,8 @@
 
 <style scoped lang="scss">
 
-  $sidebar-nav-height: 48px;
-
   .pdf-sidebar {
-    height: 100%;
+    overflow-y: auto;
     box-shadow: inset -1px 2px 8px rgba(0, 0, 0, 0.16);
   }
 
@@ -159,7 +157,6 @@
   }
 
   .sidebar-content {
-    height: calc(100% - #{$sidebar-nav-height});
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## Summary
* Removes use of Learn specific height remediations from HTML5 app renderer and PDF renderer
* Reworks styling of PDF renderer to no longer require a global attribute setting on the page html tag, which was causing an issue when the PDF renderer was embedded in pages that needed to scroll independently of the PDF
* Makes styling of the PDF renderer consistent as long as the embedded use of the KContentRenderer has a specified height

## References
Fixes #11311

## Reviewer guidance
Create a lesson
Manage resources
Try to add a PDF and preview it
Observe that the page can still scroll
![image](https://github.com/learningequality/kolibri/assets/1680573/3bba2b72-bc5c-4a85-a104-cd6986652c0d)



View a PDF in Learn, ensure that it behaves as expected
![image](https://github.com/learningequality/kolibri/assets/1680573/6ab5564f-7537-4603-acbb-2ce588fd43d7)


View an HTML5 app in Learn ensure that it behaves as expected

![image](https://github.com/learningequality/kolibri/assets/1680573/20d1d7ee-8c86-4fa5-98ff-1e95149a2c92)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
