### PR TITLE
Tweak logic for highlighting current node to use id rather than content_id

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -13,12 +13,12 @@
         :to="genContentLinkKeepCurrentBackLink(content.id, content.is_leaf)"
         class="item"
         :class="[windowIsSmall && 'small',
-                 currentResource(content.content_id) &&
+                 content.id === currentResourceId &&
                    $computedClass(currentlyViewedItemStyle)]"
         :style="linkStyles"
       >
         <p
-          v-if="currentResource(content.content_id)"
+          v-if="content.id === currentResourceId"
           :style="currentlyViewingTextStyle"
         >
           {{ $tr('currentlyViewing') }}
@@ -148,7 +148,7 @@
         type: Boolean,
         default: false,
       },
-      currentResourceID: {
+      currentResourceId: {
         type: String,
         required: true,
       },
@@ -203,9 +203,6 @@
     methods: {
       progressFor(node) {
         return this.contentNodeProgressMap[node.content_id] || 0;
-      },
-      currentResource(contentId) {
-        return contentId === this.currentResourceID || '';
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -132,7 +132,7 @@
         :nextContent="nextContent"
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
-        :currentResourceID="currentResourceID"
+        :currentResourceId="currentResourceId"
         :missingLessonResources="missingLessonResources"
       />
     </SidePanelModal>
@@ -437,8 +437,8 @@
       timeSpent() {
         return this.contentPageMounted ? this.$refs.contentPage.time_spent : 0;
       },
-      currentResourceID() {
-        return this.content ? this.content.content_id : '';
+      currentResourceId() {
+        return this.content ? this.content.id : '';
       },
       missingLessonResources() {
         return this.lesson && this.lesson.resources.some(c => !c.contentnode);


### PR DESCRIPTION
## Summary
* content_id can be duplicated across nodes, so in the rare event that two nodes with the same content_id were in the same lesson or folder, the highlighting by content_id would cause issues
* fixes this by using the id instead of the content_id