### PR TITLE
Video transcripts flow based on windowBreakpoint

### DIFF
--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerIndex.vue
@@ -206,7 +206,6 @@
       defaultDuration() {
         return this.player.duration();
       },
-      /* eslint-enable kolibri/vue-no-unused-properties */
       transcriptWrap() {
         return this.windowIsPortrait || (!this.isFullscreen && this.windowIsSmall);
       },
@@ -656,6 +655,7 @@
   }
 
   .wrapper:not(.transcript-wrap) .media-player-transcript {
+    position: absolute;
     top: 0;
     width: 33.333%;
 
@@ -665,6 +665,7 @@
   }
 
   .wrapper.transcript-wrap .media-player-transcript {
+    position: relative;
     left: 0;
     height: #{$transcript-wrap-height};
 

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
@@ -3,7 +3,7 @@
   <section
     :dir="languageDir"
     :class="['media-player-transcript', { showing }]"
-    :style="{ background: $themeTokens.surface, position: cssPosition }"
+    :style="{ background: $themeTokens.surface }"
     :aria-hidden="(!showing).toString()"
     :aria-label="coreString('transcript')"
     @mouseenter="hovering = true"

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
@@ -3,7 +3,7 @@
   <section
     :dir="languageDir"
     :class="['media-player-transcript', { showing }]"
-    :style="{ background: $themeTokens.surface }"
+    :style="{ background: $themeTokens.surface, position: cssPosition }"
     :aria-hidden="(!showing).toString()"
     :aria-label="coreString('transcript')"
     @mouseenter="hovering = true"
@@ -52,12 +52,17 @@
   import { throttle } from 'frame-throttle';
   import { getLangDir } from 'kolibri.utils.i18n';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import TranscriptCue from './TranscriptCue';
 
   export default {
     name: 'MediaPlayerTranscript',
     components: { TranscriptCue },
     mixins: [commonCoreStrings],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
     data() {
       return {
         // TODO figure if this is supposed to be used
@@ -70,6 +75,9 @@
     computed: {
       ...mapState('mediaPlayer', ['player']),
       ...mapState('mediaPlayer/captions', ['transcript', 'language', 'cues', 'activeCueIds']),
+      cssPosition() {
+        return this.windowBreakpoint >= 3 ? 'absolute' : 'relative';
+      },
       showing() {
         return this.player && this.transcript;
       },

--- a/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
+++ b/kolibri/plugins/media_player/assets/src/views/MediaPlayerTranscript/index.vue
@@ -52,17 +52,12 @@
   import { throttle } from 'frame-throttle';
   import { getLangDir } from 'kolibri.utils.i18n';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import TranscriptCue from './TranscriptCue';
 
   export default {
     name: 'MediaPlayerTranscript',
     components: { TranscriptCue },
     mixins: [commonCoreStrings],
-    setup() {
-      const { windowBreakpoint } = useKResponsiveWindow();
-      return { windowBreakpoint };
-    },
     data() {
       return {
         // TODO figure if this is supposed to be used
@@ -75,9 +70,6 @@
     computed: {
       ...mapState('mediaPlayer', ['player']),
       ...mapState('mediaPlayer/captions', ['transcript', 'language', 'cues', 'activeCueIds']),
-      cssPosition() {
-        return this.windowBreakpoint >= 3 ? 'absolute' : 'relative';
-      },
       showing() {
         return this.player && this.transcript;
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

On smaller screens the video transcript would overlay the video player. This was because the position was set to `absolute` which works just fine on larger screens, but it didn't flow underneath the video player properly because of it. 

This introduces a `cssPosition` computed property to set the inline styles on the root tag so that the `position` is set to make things work properly.

BEFORE:

[before.webm](https://github.com/learningequality/kolibri/assets/6356129/9fb208cd-7577-4c62-9f38-294b20250344)

AFTER (devtools errors unrelated 😄 ):

[after.webm](https://github.com/learningequality/kolibri/assets/6356129/444395b9-fced-462c-a653-be13188ed7a0)




## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #11375 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Watch a video that has a transcript and open the transcript. You should be able to see the video and the transcript at all screen sizes. When the screen shrinks, at one point it should smoothly transition to where the transcript is beneath the video player when smaller or to the side of it when larger.