### PR TITLE
Adds a touch events check before showing the bottom navigation on touch devices

### DIFF
--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -84,6 +84,12 @@ export default {
     isLearnerOnlyImport(state) {
       return !state.full_facility_import;
     },
+    isTouchDevice() {
+      // Check for presence of the touch event in DOM or multi-touch capabilities
+      return (
+        'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
+      );
+    },
   },
   mutations: {
     CORE_SET_SESSION(state, value) {

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -104,7 +104,7 @@
     <!-- Window size and app context. Changes may need to be made -->
     <!-- in parallel in both files for non-breaking updates -->
     <div
-      v-if="!windowIsLarge && !isAppContext"
+      v-if="!windowIsLarge && (!isAppContext || (isAppContext && !isTouchDevice))"
       class="subpage-nav"
     >
       <slot name="sub-nav"></slot>

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -10,7 +10,7 @@
 
       <UiToolbar
         :title="title"
-        :removeNavIcon="isAppContext && !windowIsLarge"
+        :removeNavIcon="isAppContext && isTouchDevice"
         type="clear"
         textColor="white"
         class="app-bar"
@@ -151,7 +151,13 @@
       };
     },
     computed: {
-      ...mapGetters(['isUserLoggedIn', 'totalPoints', 'isLearner', 'isAppContext']),
+      ...mapGetters([
+        'isUserLoggedIn',
+        'totalPoints',
+        'isLearner',
+        'isAppContext',
+        'isTouchDevice',
+      ]),
       ...mapState({
         username: state => state.core.session.username,
         fullName: state => state.core.session.full_name,

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -19,7 +19,7 @@
         :removeBrandDivider="true"
       >
         <template
-          v-if="windowIsLarge || !isAppContext"
+          v-if="windowIsLarge || !isAppContext || !isTouchDevice"
           #icon
         >
           <KIconButton

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -173,7 +173,7 @@
             </div>
           </div>
           <div
-            v-if="!isAppContext || windowIsLarge"
+            v-if="!isAppContext || !isTouchDevice || windowIsLarge"
             class="side-nav-header"
             :style="{
               height: topBarHeight + 'px',

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -320,6 +320,7 @@
         'getUserKind',
         'isAppContext',
         'isUserLoggedIn',
+        'isTouchDevice',
       ]),
       ...mapState({
         username: state => state.core.session.username,
@@ -342,12 +343,6 @@
         // In browser based contexts, and large screen app view
         // use the "non-app" upper navigation bar
         return this.isAppContext && this.isTouchDevice;
-      },
-      isTouchDevice() {
-        // Check for presence of the touch event in DOM or multi-touch capabilities
-        return (
-          'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
-        );
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version });

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -337,11 +337,11 @@
         //  Window size and app context. Changes may need to be made
         // in parallel in both files for non-breaking updates
         // The expected behavior is:
-        // In an app context, on small and medium screens
-        // with touch capabilities, show the app Nav
+        // In an app context, on screens with touch capabilities,
+        // show the app Nav.
         // In browser based contexts, and large screen app view
         // use the "non-app" upper navigation bar
-        return this.isAppContext && !this.windowIsLarge && this.isTouchDevice;
+        return this.isAppContext && this.isTouchDevice;
       },
       isTouchDevice() {
         // Check for presence of the touch event in DOM or multi-touch capabilities

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -337,11 +337,17 @@
         //  Window size and app context. Changes may need to be made
         // in parallel in both files for non-breaking updates
         // The expected behavior is:
-        // In an app context, on small and medium screens,
-        // show the app Nav
+        // In an app context, on small and medium screens
+        // with touch capabilities, show the app Nav
         // In browser based contexts, and large screen app view
         // use the "non-app" upper navigation bar
-        return this.isAppContext && !this.windowIsLarge;
+        return this.isAppContext && !this.windowIsLarge && this.isTouchDevice;
+      },
+      isTouchDevice() {
+        // Check for presence of the touch event in DOM or multi-touch capabilities
+        return (
+          'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
+        );
       },
       footerMsg() {
         return this.$tr('poweredBy', { version: __version });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr adds a check that determines whether the device is touch enabled or not before showing the bottom navigation bar on touch-enabled devices.
**Before:**
![image](https://github.com/learningequality/kolibri/assets/5203639/2538214b-fe5c-448d-bf2a-b64cf8142dd0)

**After:**
![image](https://github.com/learningequality/kolibri/assets/5203639/913fbe07-1678-4649-8a5f-81b3a08b7913)
![image](https://github.com/learningequality/kolibri/assets/5203639/ce320574-09d9-49c9-83ce-8fff7b175f55)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/11363

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Download and run the build artifacts(`.apk` and `.dmg`) to ensure that the bottom navigation bar is only displayed when the interacting with a touch-enabled device. The display is no longer based on breakpoints as before.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
