### PR TITLE
Update download request fetching on topic and topic content pages

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1329,9 +1329,19 @@ class ContentNodeBookmarksViewset(
         return sorted_items
 
 
+class ContentRequestFilter(FilterSet):
+    contentnode_id = UUIDFilter()
+    contentnode_id__in = UUIDInFilter(field_name="contentnode_id")
+
+    class Meta:
+        model = ContentDownloadRequest
+        fields = ("contentnode_id", "contentnode_id__in")
+
+
 class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
     serializer_class = serializers.ContentDownloadRequestSerializer
-
+    filter_backends = (DjangoFilterBackend,)
+    filter_class = ContentRequestFilter
     pagination_class = OptionalPageNumberPagination
 
     values = (

--- a/kolibri/plugins/learn/assets/src/composables/__mocks__/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/__mocks__/useDownloadRequests.js
@@ -35,13 +35,10 @@ const MOCK_DEFAULTS = {
   downloadRequestsTranslator: {
     $tr: jest.fn(),
   },
-  downloadRequestMap: {
-    downloads: {},
-  },
-  isDownloadedByLearner: jest.fn(),
-  isDownloadingByLearner: jest.fn(),
+  downloadRequestMap: {},
   addDownloadRequest: jest.fn(),
   fetchUserDownloadRequests: jest.fn(() => Promise.resolve([])),
+  loading: false,
 };
 
 export function useDownloadRequestsMock(overrides = {}) {

--- a/kolibri/plugins/learn/assets/src/composables/__mocks__/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/__mocks__/useDownloadRequests.js
@@ -38,6 +38,7 @@ const MOCK_DEFAULTS = {
   downloadRequestMap: {},
   addDownloadRequest: jest.fn(),
   fetchUserDownloadRequests: jest.fn(() => Promise.resolve([])),
+  pollUserDownloadRequests: jest.fn(),
   loading: false,
 };
 

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -38,21 +38,17 @@ export default function useDownloadRequests(store) {
   const { instanceId } = currentDeviceData(store);
 
   function fetchUserDownloadRequests(params) {
-    return ContentRequestResource.list(params)
-      .then(downloadRequests => {
-        if (downloadRequests.results) {
-          downloadRequests = downloadRequests.results;
-        }
-        for (const obj of downloadRequests) {
-          set(downloadRequestMap, obj.contentnode_id, obj);
-        }
-        set(loading, false);
-        return downloadRequests;
-      })
-      .then(downloadRequests => {
-        store.dispatch('notLoading');
-        return downloadRequests;
-      });
+    return ContentRequestResource.list(params).then(downloadRequests => {
+      if (downloadRequests.results) {
+        downloadRequests = downloadRequests.results;
+      }
+      for (const obj of downloadRequests) {
+        set(downloadRequestMap, obj.contentnode_id, obj);
+      }
+      store.dispatch('notLoading');
+      set(loading, false);
+      return downloadRequests;
+    });
   }
 
   function fetchAvailableFreespace() {
@@ -85,11 +81,12 @@ export default function useDownloadRequests(store) {
       metadata,
       source_id: store.getters.currentUserId,
       source_instance_id: get(instanceId),
-      reason: 'UserInitiated',
+      reason: 'USER_INITIATED',
       facility: store.getters.currentFacilityId,
-      status: 'Pending',
+      status: 'PENDING',
       date_added: new Date(),
     };
+    set(downloadRequestMap, contentNode.id, data);
     ContentRequestResource.create(data).then(downloadRequest => {
       set(downloadRequestMap, downloadRequest.contentnode_id, downloadRequest);
     });
@@ -113,22 +110,6 @@ export default function useDownloadRequests(store) {
     return Promise.resolve();
   }
 
-  function isDownloadingByLearner(content) {
-    if (!content || !content.id) {
-      return false;
-    }
-    const downloadRequest = downloadRequestMap[content.id];
-    return Boolean(downloadRequest && !downloadRequest.status === 'COMPLETED');
-  }
-
-  function isDownloadedByLearner(content) {
-    if (!content || !content.id) {
-      return false;
-    }
-    const downloadRequest = downloadRequestMap[content.id];
-    return Boolean(downloadRequest && downloadRequest.status === 'COMPLETED');
-  }
-
   return {
     fetchUserDownloadRequests,
     fetchAvailableFreespace,
@@ -138,7 +119,5 @@ export default function useDownloadRequests(store) {
     loading,
     removeDownloadRequest,
     downloadRequestsTranslator,
-    isDownloadingByLearner,
-    isDownloadedByLearner,
   };
 }

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -405,9 +405,7 @@
         return this.getLearningActivityIcon(activities);
       },
       sourceDeviceIsAvailable(download) {
-        return (
-          this.networkDevices.filter(device => device.instance_id == download.source_id).length > 0
-        );
+        return Boolean(this.networkDevices[download.source_id]);
       },
       downloadStatusIcon(download) {
         let icon;

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -77,7 +77,7 @@
       const {
         downloadRequestMap,
         loading,
-        fetchUserDownloadRequests,
+        pollUserDownloadRequests,
         fetchAvailableFreespace,
         availableSpace,
         removeDownloadRequest,
@@ -91,11 +91,11 @@
       const sort = computed(() => query.value.sort);
 
       fetchAvailableFreespace();
+      pollUserDownloadRequests();
 
       return {
         downloadRequestMap,
         loading,
-        fetchDownloads: fetchUserDownloadRequests,
         availableSpace,
         fetchAvailableFreespace,
         fetchDevices,
@@ -111,12 +111,6 @@
         );
       },
     },
-    mounted() {
-      this.startPolling();
-    },
-    beforeDestroy() {
-      clearInterval(this.pollingInterval);
-    },
     methods: {
       formattedSize(size) {
         if (size > 0) {
@@ -128,36 +122,6 @@
       removeResources(resources) {
         for (const resource of resources) {
           this.removeDownloadRequest(resource);
-        }
-      },
-      startPolling() {
-        this.fetchDownloads();
-        this.pollingInterval = setInterval(async () => {
-          await this.fetchDownloads();
-          this.calculatePollingInterval();
-        }, 1000); // Initial interval of 1 second
-      },
-      calculatePollingInterval() {
-        let pollingInterval = 30000; // Default interval of 30 seconds
-
-        for (const download in this.downloadRequestMap) {
-          const status = this.downloadRequestMap[download].status;
-
-          if (status === 'PENDING' || status === 'FAILED') {
-            pollingInterval = 5000; // Poll every 5 seconds
-            break;
-          } else if (status === 'IN_PROGRESS') {
-            pollingInterval = 1000; // Poll every 1 second
-            break;
-          }
-        }
-
-        if (pollingInterval !== this.pollingInterval) {
-          clearInterval(this.pollingInterval);
-          this.pollingInterval = setInterval(async () => {
-            await this.fetchDownloads();
-            this.calculatePollingInterval();
-          }, pollingInterval);
         }
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -243,7 +243,7 @@
         addDownloadRequest,
         downloadRequestMap,
         downloadRequestsTranslator,
-        fetchUserDownloadRequests,
+        pollUserDownloadRequests,
         loading: downloadRequestLoading,
       } = useDownloadRequests();
       const deviceFormTranslator = crossComponentTranslator(AddDeviceForm);
@@ -292,7 +292,7 @@
           promise = setCurrentDevice(deviceId).then(device => {
             const baseurl = device.base_url;
             if (get(canAddDownloads)) {
-              fetchUserDownloadRequests({ contentnode_id: props.id });
+              pollUserDownloadRequests({ contentnode_id: props.id });
             }
             return _loadTopicsContent(shouldResolve, baseurl);
           });

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -154,7 +154,7 @@
 <script>
 
   import { mapState } from 'vuex';
-  import { set } from '@vueuse/core';
+  import { get, set } from '@vueuse/core';
   import lodashGet from 'lodash/get';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
   import { getCurrentInstance, ref, watch } from 'kolibri.lib.vueCompositionApi';
@@ -244,6 +244,7 @@
         isDownloadedByLearner,
         isDownloadingByLearner,
         downloadRequestsTranslator,
+        fetchUserDownloadRequests,
       } = useDownloadRequests();
       const deviceFormTranslator = crossComponentTranslator(AddDeviceForm);
       const { currentUserId, isUserLoggedIn, isCoach, isAdmin, isSuperuser } = useUser();
@@ -290,8 +291,9 @@
         if (deviceId) {
           promise = setCurrentDevice(deviceId).then(device => {
             const baseurl = device.base_url;
-            const { fetchUserDownloadRequests } = useDownloadRequests(store);
-            fetchUserDownloadRequests({ page: 1, pageSize: 20 });
+            if (get(canAddDownloads)) {
+              fetchUserDownloadRequests({ contentnode_id: props.id });
+            }
             return _loadTopicsContent(shouldResolve, baseurl);
           });
         } else {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -361,13 +361,39 @@
       } = useSearch(topic);
       const { back, genContentLinkKeepCurrentBackLink } = useContentLink();
       const { channelsMap, fetchChannels } = useChannels();
-      const { fetchContentNodeTreeProgress } = useContentNodeProgress();
+      const { fetchContentNodeProgress, fetchContentNodeTreeProgress } = useContentNodeProgress();
       const { isUserLoggedIn, isCoach, isAdmin, isSuperuser } = useUser();
+      const { fetchUserDownloadRequests } = useDownloadRequests(store);
 
       const isRoot = ref(false);
       const channel = ref(null);
       const contents = ref([]);
       const loading = ref(true);
+
+      const _getAllDescendantChildren = topic => {
+        const contentnode_id__in = [];
+        const children = topic.children ? topic.children.results : [];
+        for (const child of children) {
+          if (child.kind === ContentNodeKinds.TOPIC) {
+            contentnode_id__in.push(..._getAllDescendantChildren(child));
+          } else {
+            contentnode_id__in.push(child.id);
+          }
+        }
+        return contentnode_id__in;
+      };
+
+      const fetchRemoteBrowsingContentNodeUserData = topic => {
+        if (get(isUserLoggedIn) && props.deviceId) {
+          const contentnode_id__in = _getAllDescendantChildren(topic);
+          if (contentnode_id__in.length) {
+            if (get(canAddDownloads)) {
+              fetchUserDownloadRequests({ contentnode_id__in });
+            }
+            fetchContentNodeProgress({ ids: contentnode_id__in });
+          }
+        }
+      };
 
       function _handleTopicRedirect(route, children, id, skipped) {
         if (!children.some(c => !c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
@@ -378,7 +404,6 @@
             params: { ...route.params, id },
             query: route.query,
           });
-          return true;
         } else if (skipped) {
           // If we have skipped down the topic tree, replace to the new top level topic
           router.replace({ name: route.name, params: { ...route.params, id }, query: route.query });
@@ -419,7 +444,16 @@
 
             id = childrenResults.id;
 
-            _handleTopicRedirect(route, children, id, skipped);
+            const redirectedToNewTopic = _handleTopicRedirect(route, children, id, skipped);
+
+            if (redirectedToNewTopic) {
+              // If we have encountered the skip logic, we need to reload the topic
+              // with the new id, which will be triggered by our watch statement below
+              // so we can just return here
+              return;
+            }
+
+            fetchRemoteBrowsingContentNodeUserData(fetchedTopic);
 
             set(isRoot, rootTopic);
 
@@ -451,8 +485,6 @@
           if (props.deviceId) {
             promise = setCurrentDevice(props.deviceId).then(device => {
               const baseurl = device.base_url;
-              const { fetchUserDownloadRequests } = useDownloadRequests(store);
-              fetchUserDownloadRequests({ page: 1, pageSize: 100 });
               return _loadTopicsTopic({ baseurl, shouldResolve });
             });
           } else {
@@ -477,6 +509,7 @@
       showTopicsTopic();
 
       return {
+        fetchRemoteBrowsingContentNodeUserData,
         canAddDownloads,
         canDownloadExternally,
         searchTerms,
@@ -827,7 +860,7 @@
         const parent = parentIndex > -1 ? this.contents[parentIndex] : null;
         const more = parent && parent.children && parent.children.more;
         if (more) {
-          if (this.isUserLoggedIn) {
+          if (this.isUserLoggedIn && !this.deviceId) {
             this.fetchContentNodeTreeProgress(more);
           }
           return ContentNodeResource.fetchTree(more)
@@ -840,6 +873,7 @@
                 child,
                 ...this.contents.slice(parentIndex + 1),
               ];
+              this.fetchRemoteBrowsingContentNodeUserData(data);
             })
             .catch(err => {
               this.$store.dispatch('handleApiError', { error: err });
@@ -855,7 +889,7 @@
       loadMoreTopics() {
         const more = this.topic.children.more;
         if (more) {
-          if (this.isUserLoggedIn) {
+          if (this.isUserLoggedIn && !this.deviceId) {
             this.fetchContentNodeTreeProgress(more);
           }
           return ContentNodeResource.fetchTree(more)
@@ -868,6 +902,7 @@
                   more: data.children.more,
                 },
               };
+              this.fetchRemoteBrowsingContentNodeUserData(data);
             })
             .catch(err => {
               this.$store.dispatch('handleApiError', { error: err });

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -563,7 +563,7 @@
     },
     computed: {
       allowDownloads() {
-        return this.canAddDownloads && Boolean(this.deviceId);
+        return this.isUserLoggedIn && this.canAddDownloads && Boolean(this.deviceId);
       },
       barTitle() {
         return this.deviceId

--- a/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topic-content.spec.js
@@ -192,7 +192,12 @@ describe('TopicsContentPage', () => {
         beforeEach(async () => {
           useDownloadRequests.mockImplementation(() =>
             useDownloadRequestsMock({
-              isDownloadedByLearner: () => true,
+              downloadRequestMap: {
+                [CONTENT_ID]: {
+                  id: CONTENT_ID,
+                  status: 'COMPLETED',
+                },
+              },
             })
           );
           wrapper = await makeAuthWrapperWithRemoteContent();
@@ -212,7 +217,12 @@ describe('TopicsContentPage', () => {
         beforeEach(async () => {
           useDownloadRequests.mockImplementation(() =>
             useDownloadRequestsMock({
-              isDownloadingByLearner: () => true,
+              downloadRequestMap: {
+                [CONTENT_ID]: {
+                  id: CONTENT_ID,
+                  status: 'PENDING',
+                },
+              },
             })
           );
           useCoreLearn.mockImplementation(() =>


### PR DESCRIPTION
## Summary
* Makes the ContentRequest endpoint accept contentnode_id and contentnode_ids filtering parameters
* Fetches download requests on the topics page by passing the loaded contentnode_ids and further when doing requests for 'more'
* Fetches just the download request for the specific resource on the content page
* Cleans up reactivity on topic content page when a resource is downloaded
* Fixes an unnoticed bug where the networkDevices map was being filtered on, rather than just being looked up in
* Refactors the MyDownload page polling behaviour into the downloadRequest composable
* Reuses this polling behaviour on the TopicsContentPage to ensure we get timely status updates of individual resource downloads

## References
Fixes [#10564](https://github.com/learningequality/kolibri/issues/10564)
Fixes [#11239](https://github.com/learningequality/kolibri/issues/11239)

## Reviewer guidance
Ensure there are no regressions on the MyDownloads page.
Ensure that Download Requests are properly displayed on the topics page and the topics content page.
Ensure that adding a new download in both places properly updates the frontend in a timely fashion.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
