### PR TITLE
Reset to page 1 of download pagination when a filter is selected.

### DIFF
--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/ActivityFilter.vue
@@ -98,6 +98,7 @@
             query: pickBy({
               ...this.$route.query,
               activity: value,
+              page: 1,
             }),
           });
         },

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/Filters/SortFilter.vue
@@ -70,6 +70,7 @@
             query: pickBy({
               ...this.$route.query,
               sort: value,
+              page: 1,
             }),
           });
         },


### PR DESCRIPTION
## Summary
* If either an activity type filter or sorting is applied to the download list page, move back to page 1

## References
Fixes #11388

## Reviewer guidance
Ensure you have more than 25 download requests.
Go to the second page in the My Downloads page
Activate either a learning activity filter or a new sort.
See that you go back to the first page.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
