### PR TITLE
Fix selection behaviour on the My Downloads page

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -156,6 +156,12 @@ export default function useDownloadRequests(store) {
       id: contentRequest.id,
     });
     Vue.delete(downloadRequestMap, contentRequest.contentnode_id);
+    store.commit('CORE_CREATE_SNACKBAR', {
+      text: downloadRequestsTranslator.$tr('resourceRemoved'),
+      backdrop: false,
+      forceReuse: true,
+      autoDismiss: true,
+    });
     return Promise.resolve();
   }
 

--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -147,7 +147,11 @@ export default function useDownloadRequests(store) {
     return Promise.resolve();
   }
 
-  function removeDownloadRequest(contentRequest) {
+  function removeDownloadRequest(contentNodeId) {
+    const contentRequest = downloadRequestMap[contentNodeId];
+    if (!contentRequest) {
+      return Promise.resolve();
+    }
     ContentRequestResource.deleteModel({
       id: contentRequest.id,
     });

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/DownloadsList/index.vue
@@ -313,12 +313,10 @@
         }
       },
       markSingleResourceForRemoval(download) {
-        this.resourcesToDelete.push(download);
+        this.resourcesToDelete.push(download.contentnode_id);
       },
       removeSelectedResources() {
-        this.resourcesToDelete = this.downloads.filter(download =>
-          Boolean(this.selectedDownloadsMap[download.contentnode_id])
-        );
+        this.resourcesToDelete = Object.keys(this.selectedDownloadsMap);
       },
       emitCurrentlySelectedResourcesForRemoval() {
         this.$emit('removeResources', this.resourcesToDelete);

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -119,9 +119,9 @@
           return bytesForHumans(0);
         }
       },
-      removeResources(resources) {
-        for (const resource of resources) {
-          this.removeDownloadRequest(resource);
+      removeResources(contentNodeIds) {
+        for (const contentNodeId of contentNodeIds) {
+          this.removeDownloadRequest(contentNodeId);
         }
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -196,7 +196,7 @@
         this.disableRequestButtons = false;
       },
       confirmRemoveRequest() {
-        this.removeDownloadRequest(this.contentNode).then(() => {
+        this.removeDownloadRequest(this.contentNode.id).then(() => {
           this.removeConfirmationModalOpen = false;
         });
       },


### PR DESCRIPTION
## Summary
* Updates the `removeDownloadRequest` function to accept a contentnode_id as its only argument (in the process, fixing the latter part of #11378)
* Removes duplication in the responsive view of the My Downloads page to make it easier to reason about
* Updates the resource selection to be a map from `contentnode_id` for the request to `true` to enable easy lookup in the `downloadRequestMap` and to be compatible with the updated `removeDownloadRequest` function
* Adds indeterminate selection determination to the select all checkbox
* Updates deletion setting to use the new map
* Updates checked setting to use the new map

## References
Fixes [#11389](https://github.com/learningequality/kolibri/issues/11389)
Fixes #11378 - now that the z-index issue has been fixed by @LianaHarris360 

## Reviewer guidance
Ensure that all selection behaviour behaves as expected:
* Selecting one should toggle the Select All checkbox to an indeterminate state
* Selections should be preserved across page navigation, but the Select All checkbox state and effect should be scoped to the current page
* Clicking on the Select All checkbox in an indeterminate state will Select All on the page
* Clicking on the Select All checkbox in a checked state will deselect all on the page
* Clicking on the Select All checkbox in an unchecked state will select all on the page
* Table should render properly in smaller screen sizes

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
