### PR TITLE
Add z-index to fix display of HybridLearningFooter dropdown menu

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/HybridLearningFooter.vue
@@ -57,7 +57,8 @@
         :style="{
           left: isRtl ? '16px' : 'auto',
           right: isRtl ? 'auto' : '16px',
-          position: 'absolute'
+          position: 'absolute',
+          zIndex: 7,
         }"
         :raised="true"
         :isOpen="isMenuOpen"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates the `CoreMenu` styling within the `HybridLearningFooter` component to include `z-index: 7` so that the menu displays on top of other cards, instead of behind.

Before:
![Screenshot 2023-10-12 at 2 59 59 PM](https://github.com/learningequality/kolibri/assets/46411498/f24ee785-e175-45dd-b253-798fbea8663e)

After: 
![Screenshot 2023-10-12 at 2 18 23 PM](https://github.com/learningequality/kolibri/assets/46411498/a0b08f09-ea76-4c63-89ea-65a620baa72e)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11378 
The functionality of the 'Remove from my library' option is fixed in PR #11397 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Go to Explore libraries and click the download icon on a card.
2. Observe the position of 'Remove from my library'.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
