### PR TITLE
Update device settings page to better handle server reload and force page refresh for settings changes

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/index.js
@@ -29,9 +29,6 @@ export default {
     getDataLoading(state) {
       return state.dataLoading;
     },
-    canRestart() {
-      return plugin_data.canRestart;
-    },
     isRemoteContent() {
       return plugin_data.isRemoteContent;
     },

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/ServerRestartModal.vue
@@ -2,8 +2,8 @@
 
   <KModal
     :title="$tr('serverRestart')"
-    :submitText="coreString('continueAction')"
-    :cancelText="coreString('cancelAction')"
+    :submitText="restarting ? null : coreString('continueAction')"
+    :cancelText="restarting ? null : coreString('cancelAction')"
     @submit="handleSubmit"
     @cancel="$emit('cancel')"
   >
@@ -13,6 +13,11 @@
     <p class="description">
       {{ getMessage() }}
     </p>
+    <template v-if="restarting">
+      &nbsp;
+      <KCircularLoader />
+      &nbsp;
+    </template>
     <div v-if="changedSetting === 'add' && path.writable === true">
       <KCheckbox
         :checked="confirmationChecked"
@@ -37,12 +42,16 @@
     props: {
       changedSetting: {
         type: String, // primary, remove, add, plugins
-        required: true,
+        default: null,
       },
       path: {
         type: Object,
         required: false,
         default: null,
+      },
+      restarting: {
+        type: Boolean,
+        default: false,
       },
     },
     data() {
@@ -52,6 +61,9 @@
     },
     methods: {
       getMessage() {
+        if (!this.changedSetting) {
+          return this.$tr('serverRestartDescription');
+        }
         let message = '';
         switch (this.changedSetting) {
           case 'primary':

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
@@ -24,7 +24,9 @@ export function getDeviceSettings() {
         ...data.extra_settings,
       },
       primaryStorageLocation: data.primary_storage_location,
-      secondaryStorageLocations: data.secondary_storage_locations,
+      // Spread the secondary storage locations array to ensure
+      // we are returning a novel array from the one stored in the _dataCache
+      secondaryStorageLocations: [...data.secondary_storage_locations],
     };
   });
 }
@@ -50,6 +52,9 @@ export function saveDeviceSettings(settings) {
     url,
     method: 'PATCH',
     data,
+  }).then(response => {
+    Object.assign(_dataCache, response.data); // Update the cache
+    return true;
   });
 }
 

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/api.js
@@ -1,10 +1,15 @@
+import isEqual from 'lodash/isEqual';
+import pickBy from 'lodash/pickBy';
 import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 
 const url = urls['kolibri:core:devicesettings']();
 
+const _dataCache = {};
+
 export function getDeviceSettings() {
   return client({ url }).then(({ data }) => {
+    Object.assign(_dataCache, data);
     return {
       languageId: data.language_id,
       landingPage: data.landing_page,
@@ -12,7 +17,12 @@ export function getDeviceSettings() {
       allowLearnerUnassignedResourceAccess: data.allow_learner_unassigned_resource_access,
       allowPeerUnlistedChannelImport: data.allow_peer_unlisted_channel_import,
       allowOtherBrowsersToConnect: data.allow_other_browsers_to_connect,
-      extraSettings: data.extra_settings,
+      extraSettings: {
+        // Destructure the extra_settings object
+        // to ensure we are returning a novel object
+        // from the one stored in the _dataCache
+        ...data.extra_settings,
+      },
       primaryStorageLocation: data.primary_storage_location,
       secondaryStorageLocations: data.secondary_storage_locations,
     };
@@ -21,20 +31,25 @@ export function getDeviceSettings() {
 
 // PATCH to /api/device/devicesettings with a new settings
 export function saveDeviceSettings(settings) {
+  const serverSettings = {
+    language_id: settings.languageId,
+    landing_page: settings.landingPage,
+    allow_guest_access: settings.allowGuestAccess,
+    allow_learner_unassigned_resource_access: settings.allowLearnerUnassignedResourceAccess,
+    allow_peer_unlisted_channel_import: settings.allowPeerUnlistedChannelImport,
+    allow_other_browsers_to_connect: settings.allowOtherBrowsersToConnect,
+    extra_settings: settings.extraSettings,
+    primary_storage_location: settings.primaryStorageLocation,
+    secondary_storage_locations: settings.secondaryStorageLocations,
+  };
+  const data = pickBy(serverSettings, (value, key) => !isEqual(value, _dataCache[key]));
+  if (Object.keys(data).length === 0) {
+    return Promise.resolve(false);
+  }
   return client({
     url,
     method: 'PATCH',
-    data: {
-      language_id: settings.languageId,
-      landing_page: settings.landingPage,
-      allow_guest_access: settings.allowGuestAccess,
-      allow_learner_unassigned_resource_access: settings.allowLearnerUnassignedResourceAccess,
-      allow_peer_unlisted_channel_import: settings.allowPeerUnlistedChannelImport,
-      allow_other_browsers_to_connect: settings.allowOtherBrowsersToConnect,
-      extra_settings: settings.extraSettings,
-      primary_storage_location: settings.primaryStorageLocation,
-      secondary_storage_locations: settings.secondaryStorageLocations,
-    },
+    data,
   });
 }
 

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -144,22 +144,22 @@
               :text="$tr('changeLocation')"
               :primary="true"
               appearance="basic-link"
-              :disabled="!multipleWritablePaths || isRemoteContent"
+              :disabled="!multipleWritablePaths || isRemoteContent || !canRestart"
               :class="{ 'disabled': !multipleWritablePaths }"
               @click="showChangePrimaryLocationModal = true"
             />
           </p>
           <KButton
-            v-if="browserLocationMatchesServerURL && (secondaryStorageLocations.length === 0)"
+            v-if="secondaryStorageLocations.length === 0"
             :text="$tr('addLocation')"
-            :disabled="isRemoteContent"
+            :disabled="isRemoteContent || !canRestart"
             appearance="raised-button"
             secondary
             @click="showAddStorageLocationModal = true"
           />
         </div>
 
-        <div v-show="browserLocationMatchesServerURL && (secondaryStorageLocations.length > 0)">
+        <div v-show="secondaryStorageLocations.length > 0">
           <h2>
             {{ $tr('secondaryStorage') }}
           </h2>
@@ -173,7 +173,7 @@
             hasDropdown
             secondary
             appearance="raised-button"
-            :disabled="isRemoteContent"
+            :disabled="isRemoteContent || !canRestart"
             :text="coreString('optionsLabel')"
           >
             <template #menu>
@@ -487,12 +487,6 @@
       },
       storageLocationOptions() {
         return [this.$tr('addStorageLocation'), this.$tr('removeStorageLocation')];
-      },
-      browserLocationMatchesServerURL() {
-        return (
-          window.location.hostname.includes('127.0.0.1') ||
-          window.location.hostname.includes('localhost')
-        );
       },
       notEnoughFreeSpace() {
         return this.freeSpace === 0;

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -767,6 +767,8 @@
         } = this.getContentSettings();
         this.getExtraSettings();
 
+        const pluginsChanged = this.checkPluginChanges();
+
         this.checkAndTogglePlugins();
 
         this.saveDeviceSettings({
@@ -780,12 +782,19 @@
           secondaryStorageLocations: this.secondaryStorageLocations,
           primaryStorageLocation: this.primaryStorageLocation,
         })
-          .then(() => {
+          .then(didSave => {
+            didSave = didSave || pluginsChanged;
             this.$store.dispatch('createSnackbar', this.$tr('saveSuccessNotification'));
             this.showRestartModal = false;
-            if (this.restartSetting !== null) {
-              this.restart();
+            if (this.canRestart && this.restartSetting !== null) {
               this.restartSetting = null;
+              return this.restart().then(() => didSave);
+            }
+            return didSave;
+          })
+          .then(shouldReload => {
+            if (shouldReload) {
+              window.location.reload();
             }
           })
           .catch(() => {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -336,6 +336,11 @@
         @submit="handleServerRestart"
       />
 
+      <ServerRestartModal
+        v-if="restarting"
+        :restarting="true"
+      />
+
     </KPageContainer>
   </DeviceAppBarPage>
 
@@ -391,7 +396,7 @@
     },
     mixins: [commonCoreStrings, commonDeviceStrings],
     setup() {
-      const { restart } = useDeviceRestart();
+      const { canRestart, restart, restarting } = useDeviceRestart();
       const { plugins, fetchPlugins, togglePlugin } = usePlugins();
       const dataPlugins = ref(null);
 
@@ -419,7 +424,14 @@
         return !unchanged;
       }
 
-      return { restart, dataPlugins, checkPluginChanges, checkAndTogglePlugins };
+      return {
+        canRestart,
+        restart,
+        restarting,
+        dataPlugins,
+        checkPluginChanges,
+        checkAndTogglePlugins,
+      };
     },
     data() {
       return {
@@ -459,7 +471,7 @@
     },
     computed: {
       ...mapGetters(['isAppContext', 'isPageLoading']),
-      ...mapGetters('deviceInfo', ['canRestart', 'isRemoteContent']),
+      ...mapGetters('deviceInfo', ['isRemoteContent']),
       pageTitle() {
         return this.deviceString('deviceManagementTitle');
       },


### PR DESCRIPTION
## Summary
* Updates the useDeviceRestart composable to play better with the Kolibri global disconnection state checking
* Prevent users from editing paths based on whether the device can be restarted, as well as whether content is remotely managed
* Remove restriction for content path editing for non-loopback IPs
* Do a proper PATCH in the device setting api.js to prevent unnecessary saves
* Display a modal to the user while the device is restarting
* If a save has happened, refresh the page - if the device was restarted, wait until the restart happened before refreshing.

## References
Fixes #11400

## Reviewer guidance
Go to the device settings page.
Press the save button, see that nothing happens (except a pop up - maybe we should stop that too?)
Make a change to the settings that doesn't require a restart - see that the page refreshes after.
Make a change to the settings that _does_ require a restart - see that a modal displays while the restart is happening, and that the page refreshes after.

[Screencast from 10-12-2023 04:08:02 PM.webm](https://github.com/learningequality/kolibri/assets/1680573/6079990a-01b6-45e8-9bdf-7c77d1c6188a)


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
