### PR TITLE
Updated base.dockerfile for all architectures

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:bionic
 
 ENV NODE_VERSION=16.20.0
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
 
 # install required packages
 RUN apt-get update && \
@@ -11,9 +13,9 @@ RUN apt-get update && \
     git \
     git-lfs \
     psmisc \
-    python2.7 \
-    python-pip \
-    python-sphinx
+    python3 \
+    python3-pip \
+    python3-sphinx
 
 # add yarn ppa
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
@@ -21,19 +23,24 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 
 # install nodejs and yarn
 RUN apt-get update && \
-    curl -sSO https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_$NODE_VERSION-1nodesource1_amd64.deb && \
-    dpkg -i ./nodejs_$NODE_VERSION-1nodesource1_amd64.deb && \
-    rm nodejs_$NODE_VERSION-1nodesource1_amd64.deb && \
+    ARCH=$(dpkg --print-architecture) && \
+    curl -sSO https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/nodejs_$NODE_VERSION-1nodesource1_$ARCH.deb && \
+    dpkg -i ./nodejs_$NODE_VERSION-1nodesource1_$ARCH.deb && \
+    rm nodejs_$NODE_VERSION-1nodesource1_$ARCH.deb && \
     apt-get install yarn
 
 RUN git lfs install
+
+# Check if symbolic links exist before creating them
+RUN if [ ! -f /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python; fi \
+ && if [ ! -f /usr/bin/pip ]; then ln -s /usr/bin/pip3 /usr/bin/pip; fi
 
 # copy Kolibri source code into image
 COPY . /kolibri
 
 # do the time-consuming base install commands
 RUN cd /kolibri \
-    && pip install -r requirements/dev.txt \
-    && pip install -r requirements/build.txt \
-    && pip install -r requirements/test.txt \
+    && pip3 install -r requirements/dev.txt \
+    && pip3 install -r requirements/build.txt \
+    && pip3 install -r requirements/test.txt \
     && yarn install --network-timeout 100000

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ENV NODE_VERSION=16.20.0
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
 
 # install required packages
 RUN apt-get update && \
@@ -41,6 +39,5 @@ COPY . /kolibri
 # do the time-consuming base install commands
 RUN cd /kolibri \
     && pip3 install -r requirements/dev.txt \
-    && pip3 install -r requirements/build.txt \
     && pip3 install -r requirements/test.txt \
     && yarn install --network-timeout 100000

--- a/docker/demoserver.dockerfile
+++ b/docker/demoserver.dockerfile
@@ -2,7 +2,6 @@ FROM learningequality/kolibribase
 
 ENV KOLIBRI_RUN_MODE=demoserver
 ENV KOLIBRI_PROVISIONDEVICE_FACILITY="Kolibri Demo"
-ENV WHICH_PYTHON=python2
 
 COPY docker/entrypoint.py /docker/entrypoint.py
 

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -38,7 +38,7 @@ DEFAULT_KOLIBRI_PEX_URL = "https://learningequality.org/r/kolibri-pex-latest"
 # - KOLIBRI_PROVISIONDEVICE_FACILITY  if set, provision facility with this name
 # - CHANNELS_TO_IMPORT if set, comma separated list of channel IDs to import
 DEFAULT_ENVS = {
-    "WHICH_PYTHON": "python2",  # or python3 if you prefer; Kolibri don't care
+    "WHICH_PYTHON": "python3",  # or python3 if you prefer; Kolibri don't care
     "KOLIBRI_HOME": "/kolibrihome",
     "KOLIBRI_HTTP_PORT": "8080",
     "KOLIBRI_LANG": "en",


### PR DESCRIPTION
## Summary

* Modified installation of nodejs,node packages for all architectures.
* Modified python version to python3 to deal with compatibility issue of sqlalchemy 1.4.49 with python 2.7.18 
<img width="811" alt="Screenshot 2023-10-10 at 6 14 02 PM" src="https://github.com/learningequality/kolibri/assets/117556787/f87f16a3-e23a-4420-a328-a4aa06ec9acf">

* Added symbolic links to make sure that the commands "python" and "pip" point to the appropriate Python 3 versions.
* Exported environment variable. [ ENV LC_ALL C.UTF-8    ,     ENV LANG C.UTF-8 ]    to set the locale to C.UTF-8 

<img width="876" alt="Screenshot 2023-10-13 at 6 11 44 PM" src="https://github.com/learningequality/kolibri/assets/117556787/c5f01e9c-11a6-4dea-8457-b9f2cb1f4c7e">

## References

Discussions https://github.com/learningequality/kolibri/discussions/11353
## Reviewer guidance
is it possible to add  hacktoberfest-accepted label in this PR ?
Go to the kolibri directory 
* make docker-build-base
* make docker-devserver

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
