### PR TITLE
Add connection status filter in useDevices composable

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useDevices.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDevices.js
@@ -115,7 +115,9 @@ export default function useDevices(store) {
     const newNetworkDevices = {};
     const devices = await fetchDevices();
     for (const device of devices) {
-      newNetworkDevices[device.instance_id] = device;
+      if (device['available']) {
+        newNetworkDevices[device.instance_id] = device;
+      }
     }
     networkDevices.value = newNetworkDevices;
     isLoading.value = false;


### PR DESCRIPTION
## Summary
Filters networkDevices is useDevices composable


## References
Supersedes #11199  
Fixes https://github.com/learningequality/kolibri/issues/11139

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
