### PR TITLE
Fix bottom bar alignment and menu label which was previously offscreen

### DIFF
--- a/kolibri/core/assets/src/views/BottomNavigationBar.vue
+++ b/kolibri/core/assets/src/views/BottomNavigationBar.vue
@@ -36,10 +36,17 @@
       <KIconButton
         icon="menu"
         :ariaLabel="coreString('menuLabel')"
+        size="small"
         :color="navShown ? $themeTokens.primary : $themeTokens.annotation"
         @click="$emit('toggleNav')"
       />
-      <p :style="{ color: $themeTokens.primary }">{{ coreString('menuLabel') }}</p>
+      <p
+        v-if="navShown"
+        class="nav-menu-label"
+        :style="{ color: $themeTokens.primary }"
+      >
+        {{ coreString('menuLabel') }}
+      </p>
     </span>
   </div>
 


### PR DESCRIPTION
## Summary
Adjust app bar navigation UI 

## References
Fixes https://github.com/learningequality/kolibri/issues/11115
(originally this was going to be a tracking issue, but after some investigation, it seems like the menu problems with regard to spacing/alignment/making sure everything was present have been resolved incidentally)


## Reviewer guidance


| | Before   |  After |
|---|---|---|
| Incorrect placement | <img width="502" alt="Screenshot 2023-10-13 at 4 06 43 PM" src="https://github.com/learningequality/kolibri/assets/17235236/69b578ec-8d8d-45f6-8647-e4d38fbf8080"> | <img width="501" alt="Screenshot 2023-10-13 at 4 05 53 PM" src="https://github.com/learningequality/kolibri/assets/17235236/dca8c630-f328-4745-8d2c-0d5450f723f6">  |  
| No menu label |  <img width="497" alt="Screenshot 2023-10-13 at 4 06 48 PM" src="https://github.com/learningequality/kolibri/assets/17235236/b97741b1-a8c3-4634-8c4a-986a7328091e">  | <img width="493" alt="Screenshot 2023-10-13 at 4 05 46 PM" src="https://github.com/learningequality/kolibri/assets/17235236/b2629960-82a8-42ea-accc-f23193e654e7"> |






----


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
