### PR TITLE
Fixes My downloads - The 'Available storage' value not being calculated when I am signed in as a Learner

### DIFF
--- a/kolibri/core/content/utils/settings.py
+++ b/kolibri/core/content/utils/settings.py
@@ -43,7 +43,6 @@ def get_free_space_for_downloads(completed_size=0):
     from kolibri.core.device.utils import get_device_setting
     from kolibri.utils.conf import OPTIONS
 
-    from kolibri.utils.data import bytes_from_humans
     from kolibri.utils.system import get_free_space
 
     free_space = get_free_space(OPTIONS["Paths"]["CONTENT_DIR"])
@@ -51,10 +50,7 @@ def get_free_space_for_downloads(completed_size=0):
     # if a limit is set, subtract the total content storage size from the limit
     if get_device_setting("set_limit_for_autodownload"):
         # compute total space used by automatic and learner initiated downloads
-        # convert limit_for_autodownload from GB to bytes
-        auto_download_limit = bytes_from_humans(
-            str(get_device_setting("limit_for_autodownload") or "0") + "GB"
-        )
+        auto_download_limit = get_device_setting("limit_for_autodownload") or 0
         # returning smallest argument as to not exceed the space available on disk
         free_space = min(free_space, auto_download_limit - completed_size)
 

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -24,6 +24,7 @@ from rest_framework import mixins
 from rest_framework import status
 from rest_framework import views
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 import kolibri
@@ -116,7 +117,7 @@ class DeviceProvisionView(viewsets.GenericViewSet):
 
 
 class FreeSpaceView(mixins.ListModelMixin, viewsets.GenericViewSet):
-    permission_classes = (CanManageContent,)
+    permission_classes = (IsAuthenticated,)
 
     def list(self, request):
         path = request.query_params.get("path")

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -215,15 +215,16 @@
             >
               <KTextbox
                 ref="autoDownloadLimit"
-                v-model="limitForAutodownload"
+                v-model="limitForAutodownloadInput"
                 class="download-limit-textbox"
                 :disabled="notEnoughFreeSpace || isRemoteContent"
                 type="number"
                 :label="$tr('sizeInGigabytesLabel')"
                 :min="0"
-                :max="freeSpace"
+                :max="toGigabytes(freeSpace)"
                 :invalid="notEnoughFreeSpace"
                 :invalidText="$tr('notEnoughFreeSpace')"
+                @input="updateLimitForAutodownload"
               />
               <div class="slider-section">
                 <input
@@ -235,13 +236,14 @@
                   min="0"
                   :max="freeSpace"
                   step="1"
+                  @input="updateLimitForAutodownloadInput"
                 >
                 <div class="slider-constraints">
                   <p class="slider-min-max">
                     0
                   </p>
                   <p class="slider-min-max">
-                    {{ freeSpace }}
+                    {{ toGigabytes(freeSpace) }}
                   </p>
                 </div>
               </div>
@@ -560,6 +562,14 @@
         }
         return this.$tr('alertDisabledOptions');
       },
+      limitForAutodownloadInput: {
+        get() {
+          return this.toGigabytes(this.limitForAutodownload);
+        },
+        set(value) {
+          this.limitForAutodownload = this.toBytes(value);
+        },
+      },
     },
     created() {
       this.setDeviceURLs();
@@ -702,7 +712,7 @@
       },
       setFreeSpace() {
         return getFreeSpaceOnServer().then(({ freeSpace }) => {
-          this.freeSpace = parseInt(bytesForHumans(freeSpace).substring(0, 3));
+          this.freeSpace = freeSpace;
         });
       },
       handleLandingPageChange(option) {
@@ -900,6 +910,18 @@
           return this.$tr('readOnly');
         }
         return '';
+      },
+      updateLimitForAutodownload() {
+        this.limitForAutodownload = this.toBytes(this.limitForAutodownloadInput);
+      },
+      updateLimitForAutodownloadInput() {
+        this.limitForAutodownloadInput = this.toGigabytes(this.limitForAutodownload);
+      },
+      toBytes(gigabytes) {
+        return parseInt(Math.round(gigabytes * 10 ** 9));
+      },
+      toGigabytes(bytes) {
+        return parseInt(bytesForHumans(bytes).replace(/[^0-9.]/g, ''));
       },
     },
     $trs: {

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -224,6 +224,7 @@
                 :max="toGigabytes(freeSpace)"
                 :invalid="notEnoughFreeSpace"
                 :invalidText="$tr('notEnoughFreeSpace')"
+                :floatingLabel="false"
                 @input="updateLimitForAutodownload"
               />
               <div class="slider-section">

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -359,7 +359,6 @@
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
-  import bytesForHumans from 'kolibri.utils.bytesForHumans';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import { checkCapability } from 'kolibri.utils.appCapabilities';
   import commonDeviceStrings from '../commonDeviceStrings';
@@ -921,7 +920,7 @@
         return parseInt(Math.round(gigabytes * 10 ** 9));
       },
       toGigabytes(bytes) {
-        return parseInt(bytesForHumans(bytes).replace(/[^0-9.]/g, ''));
+        return parseInt(Math.round(bytes / 10 ** 9));
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -24,7 +24,7 @@
               <td
                 v-if="!loading"
               >
-                {{ formattedSize(availableSpace) }}
+                {{ formattedSize(availableStorage) }}
               </td>
             </tr>
           </table>
@@ -58,6 +58,7 @@
   import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import plugin_data from 'plugin_data';
   import useDownloadRequests from '../../composables/useDownloadRequests';
   import useDevices from '../../composables/useDevices';
   import DownloadsList from './DownloadsList';
@@ -90,17 +91,26 @@
 
       const sort = computed(() => query.value.sort);
 
+      const availableStorage = computed(() => {
+        let space = get(availableSpace);
+        if (plugin_data.setLimitForAutodownload) {
+          space = Math.min(space, plugin_data.limitForAutodownload);
+        }
+        return space;
+      });
+
       fetchAvailableFreespace();
       pollUserDownloadRequests();
 
       return {
         downloadRequestMap,
         loading,
-        availableSpace,
+        fetchDownloads: fetchUserDownloadRequests,
         fetchAvailableFreespace,
         fetchDevices,
         sort,
         removeDownloadRequest,
+        availableStorage,
       };
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
+++ b/kolibri/plugins/learn/assets/src/my_downloads/views/MyDownloads.vue
@@ -105,7 +105,7 @@
       return {
         downloadRequestMap,
         loading,
-        fetchDownloads: fetchUserDownloadRequests,
+        availableSpace,
         fetchAvailableFreespace,
         fetchDevices,
         sort,

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -82,6 +82,13 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
 class MyDownloadsAsset(webpack_hooks.WebpackBundleHook):
     bundle_id = "my_downloads_app"
 
+    @property
+    def plugin_data(self):
+        return {
+            "setLimitForAutodownload": get_device_setting("set_limit_for_autodownload"),
+            "limitForAutodownload": get_device_setting("limit_for_autodownload"),
+        }
+
 
 @register_hook
 class LearnContentNodeHook(ContentNodeDisplayHook):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the My Downloads-The 'Available storage' value not being calculated when I am signed in as a Learner. It also streamlines the use of storage size between the `backend` and `frontend` when setting the storage limit in the settings page. Initially, this was stored as `GB`. 

**After: Setting the storage limit**
![image](https://github.com/learningequality/kolibri/assets/5203639/e7292535-bbe5-46ee-a50b-dfb2e822f982)

**After: Available storage should be the set limit under learner account**
![image](https://github.com/learningequality/kolibri/assets/5203639/6688fd83-f843-4c8c-ac4a-cd8ca853b933)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/11377

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Login as a `superuser`
- Create a `learner` account to be used later.
- Go to `http://localhost:8000/en/device/#/settings`. 
- Under `Auto-download`, check the `Set storage limit for .....` option and proceed to set the limit.
- Click `SAVE CHANGES`. If you refresh the page(or navigate away and get back), your newly set limit should be loaded correctly.
- Logout of the `superuser` account and login with the `learner` account.
- Explore some remote libraries and download some resources.
- Go to `http://localhost:8000/en/learn/my-downloads#/`. If you set the storage limit, then it should be displayed as the `Available storage` else the actual available storage will be displayed. 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
