### PR TITLE
Replaced KResponsiveWindow to useKResponsiveWindow

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -90,7 +90,7 @@
   import JSZip from 'jszip';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
   import scriptLoader from 'kolibri-common/utils/scriptLoader';
   import perseus from '../../dist/perseus';
   import icu from '../KAGlobals/icu';
@@ -125,7 +125,6 @@
 
   export default {
     name: 'PerseusRendererIndex',
-    mixins: [responsiveWindowMixin],
     data: () => ({
       // Is the perseus item renderer loading?
       loading: true,
@@ -138,6 +137,14 @@
       // Store a copy of the blank state of a question to clear set answers later
       blankState: null,
     }),
+    setup(){
+      const {
+        windowBreakpoint
+      } = useKResponsiveWindow();
+      return {
+        windowBreakpoint
+      };
+    },
     computed: {
       isMobile() {
         return this.windowBreakpoint < 3;

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -125,6 +125,12 @@
 
   export default {
     name: 'PerseusRendererIndex',
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return {
+        windowBreakpoint,
+      };
+    },
     data: () => ({
       // Is the perseus item renderer loading?
       loading: true,
@@ -137,14 +143,6 @@
       // Store a copy of the blank state of a question to clear set answers later
       blankState: null,
     }),
-    setup(){
-      const {
-        windowBreakpoint
-      } = useKResponsiveWindow();
-      return {
-        windowBreakpoint
-      };
-    },
     computed: {
       isMobile() {
         return this.windowBreakpoint < 3;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This PR replaced the `KResponsiveWindow` to `useKResponsiveWindow` in (kolibri/plugins/perseus_viewer)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#11329 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
