### PR TITLE
Update touch detection in Perseus

### DIFF
--- a/kolibri/core/assets/src/state/modules/session.js
+++ b/kolibri/core/assets/src/state/modules/session.js
@@ -84,12 +84,6 @@ export default {
     isLearnerOnlyImport(state) {
       return !state.full_facility_import;
     },
-    isTouchDevice() {
-      // Check for presence of the touch event in DOM or multi-touch capabilities
-      return (
-        'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0
-      );
-    },
   },
   mutations: {
     CORE_SET_SESSION(state, value) {

--- a/kolibri/core/assets/src/utils/browserInfo.js
+++ b/kolibri/core/assets/src/utils/browserInfo.js
@@ -87,3 +87,9 @@ export const isMacWebView =
  * All web views
  */
 export const isEmbeddedWebView = isAndroidWebView || isMacWebView;
+
+// Check for presence of the touch event in DOM or multi-touch capabilities
+export const isTouchDevice =
+  'ontouchstart' in window ||
+  window.navigator?.maxTouchPoints > 0 ||
+  window.navigator?.msMaxTouchPoints > 0;

--- a/kolibri/core/assets/src/views/AppBar.vue
+++ b/kolibri/core/assets/src/views/AppBar.vue
@@ -121,6 +121,7 @@
   import UiToolbar from 'kolibri.coreVue.components.UiToolbar';
   import KIconButton from 'kolibri-design-system/lib/buttons-and-links/KIconButton';
   import themeConfig from 'kolibri.themeConfig';
+  import { isTouchDevice } from 'kolibri.utils.browserInfo';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import navComponentsMixin from '../mixins/nav-components';
   import SkipNavigationLink from './SkipNavigationLink';
@@ -151,13 +152,7 @@
       };
     },
     computed: {
-      ...mapGetters([
-        'isUserLoggedIn',
-        'totalPoints',
-        'isLearner',
-        'isAppContext',
-        'isTouchDevice',
-      ]),
+      ...mapGetters(['isUserLoggedIn', 'totalPoints', 'isLearner', 'isAppContext']),
       ...mapState({
         username: state => state.core.session.username,
         fullName: state => state.core.session.full_name,
@@ -165,6 +160,9 @@
       // temp hack for the VF plugin
       usernameForDisplay() {
         return !hashedValuePattern.test(this.username) ? this.username : this.fullName;
+      },
+      isTouchDevice() {
+        return isTouchDevice;
       },
     },
     created() {

--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -251,6 +251,7 @@
   import Backdrop from 'kolibri.coreVue.components.Backdrop';
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import TotalPoints from 'kolibri.coreVue.components.TotalPoints';
+  import { isTouchDevice } from 'kolibri.utils.browserInfo';
   import navComponentsMixin from '../mixins/nav-components';
   import useUser from '../composables/useUser';
   import useUserSyncStatus from '../composables/useUserSyncStatus';
@@ -320,12 +321,14 @@
         'getUserKind',
         'isAppContext',
         'isUserLoggedIn',
-        'isTouchDevice',
       ]),
       ...mapState({
         username: state => state.core.session.username,
         fullName: state => state.core.session.full_name,
       }),
+      isTouchDevice() {
+        return isTouchDevice;
+      },
       width() {
         return this.showAppNavView ? '100vw' : `${this.topBarHeight * 4.5}px`;
       },

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -91,6 +91,7 @@
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
   import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import { isTouchDevice } from 'kolibri.utils.browserInfo';
   import scriptLoader from 'kolibri-common/utils/scriptLoader';
   import perseus from '../../dist/perseus';
   import icu from '../KAGlobals/icu';
@@ -142,11 +143,8 @@
       isMobile() {
         return this.windowBreakpoint < 3;
       },
-      // this is a nasty hack. Will find a better way
       usesTouch() {
-        // using mdn suggestion for most compatibility
-        const isMobileBrowser = new RegExp(/Mobi*|Android/);
-        return isMobileBrowser.test(window.navigator.userAgent);
+        return isTouchDevice;
       },
       itemRenderData() {
         return {


### PR DESCRIPTION
## Summary
* Fixes oversight in review and moves isTouchDevice to the browserInfo utils rather than session state
* Updates touch detection in Perseus to use isTouchDevice

## References
Fixes #8359

## Reviewer guidance
All moves make sense?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
