### PR TITLE
Make site title configurable via the theme hook.

### DIFF
--- a/kolibri/core/templates/kolibri/base.html
+++ b/kolibri/core/templates/kolibri/base.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google" content="notranslate">
   {% theme_favicon %}
-  <title>{% trans "Kolibri" %}</title>
+  <title>{% site_title %}</title>
   {% if LANGUAGE_CODE == "ach-ug" %}
     <script type="text/javascript">
       var _jipt = [];

--- a/kolibri/core/templates/kolibri/unsupported_browser.html
+++ b/kolibri/core/templates/kolibri/unsupported_browser.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="google" content="notranslate">
   {% theme_favicon %}
-  <title>{% trans "Kolibri" %}</title>
+  <title>{% site_title %}</title>
   <style>
     body {
       margin: 0;

--- a/kolibri/core/templatetags/core_tags.py
+++ b/kolibri/core/templatetags/core_tags.py
@@ -78,6 +78,7 @@ def theme_favicon():
 def site_title():
     """
     Return the text of the site title, if provided by the theme. If not, the
-    default will be returned.
+    default will be returned. The site title may be translated, to allow for
+    transliteration into other alphabets where needed.
     """
     return ThemeHook.get_theme().get("siteTitle", _("Kolibri"))

--- a/kolibri/core/templatetags/core_tags.py
+++ b/kolibri/core/templatetags/core_tags.py
@@ -14,6 +14,7 @@ from kolibri.core.hooks import FrontEndBaseASyncHook
 from kolibri.core.hooks import FrontEndBaseHeadHook
 from kolibri.core.hooks import FrontEndBaseSyncHook
 from kolibri.core.theme_hook import ThemeHook
+from kolibri.utils.translation import ugettext as _
 
 register = template.Library()
 
@@ -71,3 +72,12 @@ def theme_favicon():
     favicon_url = favicon_urls[0] if favicon_urls else static("assets/logo.ico")
 
     return format_html('<link rel="shortcut icon" href="{}">', favicon_url)
+
+
+@register.simple_tag()
+def site_title():
+    """
+    Return the text of the site title, if provided by the theme. If not, the
+    default will be returned.
+    """
+    return ThemeHook.get_theme().get("siteTitle", _("Kolibri"))

--- a/kolibri/plugins/pwa/templates/pwa/manifest.json
+++ b/kolibri/plugins/pwa/templates/pwa/manifest.json
@@ -5,8 +5,8 @@
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 {% get_current_language as LANGUAGE_CODE %}
 {
-  "name": "{% trans 'Kolibri'|escapejs %}",
-  "short_name": "{% trans 'Kolibri'|escapejs %}",
+  "name": "{% site_title|escapejs %}",
+  "short_name": "{% site_title|escapejs %}",
   "dir": "{{ LANGUAGE_BIDI|yesno:'rtl,ltr'|escapejs }}",
   "lang": "{{ LANGUAGE_CODE|escapejs }}",
   "icons": [


### PR DESCRIPTION
## Summary
* Allows a theme hook to specify a `siteTitle` to allow it be configured
* Creates a core template tag that uses this value or defaults to `_("Kolibri")`
* Updates usage of `Kolibri` in the base.html, unsupported_browser.html and pwa manifest.json to use this template tag

## References
Fixes #10958


## Reviewer guidance
This only affects the backend usages of the site title, and only standalone usages of `Kolibri` - a follow up issue will be filed to complete this work, but it would require string changes in order to accommodate fully.

To test this, probably the easiest thing is to go to http://127.0.0.1:8000/ar/unsupported/ and ensure that the page title still displays as `كوليبري`

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
