### PR TITLE
Keep current back link when navigating through the topics folder side panel

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
+++ b/kolibri/plugins/learn/assets/src/views/AlsoInThis.vue
@@ -5,12 +5,14 @@
     <div
       v-if="contentNodes.length"
       class="content-list"
-      :class="nextContent ? 'bottom-link' : ''"
+      :class="nextFolder ? 'bottom-link' : ''"
     >
       <KRouterLink
         v-for="content in contentNodes"
         :key="content.id"
-        :to="genContentLinkKeepCurrentBackLink(content.id, content.is_leaf)"
+        :to="content.is_leaf ?
+          genContentLinkKeepCurrentBackLink(content.id, content.is_leaf) :
+          genContentLinkKeepPreviousBackLink(content.id)"
         class="item"
         :class="[windowIsSmall && 'small',
                  content.id === currentResourceId &&
@@ -67,8 +69,8 @@
     </div>
 
     <KRouterLink
-      v-if="nextContent"
-      :to="genContentLinkKeepCurrentBackLink(nextContent.id, nextContent.is_leaf)"
+      v-if="nextFolder"
+      :to="genContentLinkKeepPreviousBackLink(nextFolder.id)"
       class="next-content-link"
       :style="{
         borderTop: '1px solid ' + $themeTokens.fineLine,
@@ -81,7 +83,7 @@
         {{ nextFolderMessage }}
       </div>
       <div class="next-title">
-        {{ nextContent.title }}
+        {{ nextFolder.title }}
       </div>
       <KIcon class="forward-icon" icon="forward" />
     </KRouterLink>
@@ -114,8 +116,15 @@
     mixins: [KResponsiveWindowMixin],
     setup() {
       const { contentNodeProgressMap } = useContentNodeProgress();
-      const { genContentLinkKeepCurrentBackLink } = useContentLink();
-      return { contentNodeProgressMap, genContentLinkKeepCurrentBackLink };
+      const {
+        genContentLinkKeepCurrentBackLink,
+        genContentLinkKeepPreviousBackLink,
+      } = useContentLink();
+      return {
+        contentNodeProgressMap,
+        genContentLinkKeepCurrentBackLink,
+        genContentLinkKeepPreviousBackLink,
+      };
     },
     props: {
       /**
@@ -128,7 +137,7 @@
         default: () => [],
       },
       /** Content node with the following properties: id, is_leaf, title */
-      nextContent: {
+      nextFolder: {
         type: Object, // or falsy
         required: false,
         default: () => {},
@@ -188,16 +197,12 @@
         };
       },
       emptyMessage() {
-        /* eslint-disable kolibri/vue-no-undefined-string-uses */
         return this.isLesson
           ? this.$tr('noOtherLessonResources')
           : this.$tr('noOtherTopicResources');
-        /* eslint-enable */
       },
       nextFolderMessage() {
-        /* eslint-disable kolibri/vue-no-undefined-string-uses */
         return this.$tr('nextFolder');
-        /* eslint-enable */
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -129,7 +129,7 @@
       <AlsoInThis
         style="margin-top: 8px"
         :contentNodes="viewResourcesContents"
-        :nextContent="nextContent"
+        :nextFolder="nextFolder"
         :isLesson="lessonContext"
         :loading="resourcesSidePanelLoading"
         :currentResourceId="currentResourceId"
@@ -369,7 +369,7 @@
         bookmark: null,
         sidePanelContent: null,
         showViewResourcesSidePanel: false,
-        nextContent: null,
+        nextFolder: null,
         viewResourcesContents: [],
         resourcesSidePanelFetched: false,
         resourcesSidePanelLoading: false,
@@ -513,7 +513,7 @@
       initializeState() {
         this.bookmark = null;
         this.showViewResourcesSidePanel = false;
-        this.nextContent = null;
+        this.nextFolder = null;
         this.viewResourcesContents = [];
         this.resourcesSidePanelFetched = false;
         this.resourcesSidePanelLoading = false;
@@ -579,7 +579,7 @@
        * is a topic.
        *
        * @modifies this.viewResourcesContents - Sets it to the progress-mapped nodes
-       * @modifies this.nextContent - Sets the value with this.content's parents next sibling folder
+       * @modifies this.nextFolder - Sets the value with this.content's parents next sibling folder
        * if found
        * @modifies useContentNodeProgress.contentNodeProgressMap (indirectly) if the user
        * is logged in
@@ -603,19 +603,19 @@
         }
         return ContentNodeResource.fetchTree(treeParams).then(ancestor => {
           let parent;
-          let nextContents;
+          let nextFolders;
           if (fetchGrandparent) {
             const parentIndex = ancestor.children.results.findIndex(
               c => c.id === this.content.parent
             );
             parent = ancestor.children.results[parentIndex];
-            nextContents = ancestor.children.results.slice(parentIndex + 1);
+            nextFolders = ancestor.children.results.slice(parentIndex + 1);
           } else {
             parent = ancestor;
             const contentIndex = ancestor.children.results.findIndex(c => c.id === this.content.id);
-            nextContents = ancestor.children.results.slice(contentIndex + 1);
+            nextFolders = ancestor.children.results.slice(contentIndex + 1);
           }
-          this.nextContent = nextContents.find(c => c.kind === ContentNodeKinds.TOPIC) || null;
+          this.nextFolder = nextFolders.find(c => c.kind === ContentNodeKinds.TOPIC) || null;
           this.viewResourcesContents = parent.children.results.filter(n => n.id);
         });
       },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsPanelModal.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicsPanelModal.vue
@@ -25,7 +25,7 @@
           :text="t.title"
           class="side-panel-folder-link"
           :appearanceOverrides="{ color: $themeTokens.text }"
-          :to="genContentLinkBackLinkCurrentPage(t.id, false)"
+          :to="genContentLinkKeepCurrentBackLink(t.id, false)"
         />
       </div>
       <KButton
@@ -56,9 +56,9 @@
     mixins: [commonLearnStrings, commonCoreStrings],
     setup() {
       const { windowIsLarge } = useKResponsiveWindow();
-      const { genContentLinkBackLinkCurrentPage } = useContentLink();
+      const { genContentLinkKeepCurrentBackLink } = useContentLink();
       return {
-        genContentLinkBackLinkCurrentPage,
+        genContentLinkKeepCurrentBackLink,
         windowIsLarge,
       };
     },


### PR DESCRIPTION
## Summary
* Fixes error in link generation in folder side navigation panel and ensures that the current back link is preserved during navigation - to be identical to clicking on a folder card in the main navigation panel

## References
Fixes [#11432](https://github.com/learningequality/kolibri/issues/11432)

## Reviewer guidance
Click on a folder in the left side panel.
Press the X to close out the immersive modal, ensure that it does close.

Do the same when exploring a remote library and ensure navigation occurs correctly.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [x] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
