### PR TITLE
Fix unwanted welcomeModal display

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -85,7 +85,7 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.sessionStorage.getItem(welcomeDismissalKey) !== 'true'
+          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
         );
       },
       pageName() {
@@ -112,7 +112,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        window.sessionStorage.setItem(welcomeDismissalKey, true);
+        window.localStorage.setItem(welcomeDismissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
       closePinModal() {

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -33,6 +33,7 @@
 
 
 <script>
+
   import { mapGetters } from 'vuex';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { SelectDeviceForm } from 'kolibri.coreVue.componentSets.sync';

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -2,7 +2,7 @@
 
   <div>
     <WelcomeModal
-      v-if="step === Steps.WELCOME"
+      v-if="step === Steps.WELCOME && isUserLoggedIn"
       :importedFacility="importedFacility"
       :isOnMyOwnUser="isOnMyOwnUser"
       @submit="handleSubmit"
@@ -33,7 +33,7 @@
 
 
 <script>
-
+  import { mapGetters } from 'vuex';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { SelectDeviceForm } from 'kolibri.coreVue.componentSets.sync';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
@@ -68,6 +68,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isUserLoggedIn']),
       // Assume that if first facility has non-null 'last_successful_sync'
       // field, then it was imported in Setup Wizard.
       // This used to determine Select Source workflow to enter into

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -44,7 +44,7 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.sessionStorage.getItem(welcomeDismissalKey) !== 'true'
+          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
         );
       },
       userIsAuthorized() {
@@ -58,7 +58,7 @@
     },
     methods: {
       hideWelcomeModal() {
-        window.sessionStorage.setItem(welcomeDismissalKey, true);
+        window.localStorage.setItem(welcomeDismissalKey, true);
         this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
       },
     },


### PR DESCRIPTION
## Summary
- Fix Incorrect welcomeModal display for guest users in learn tab.
- Change session storage to local storage for welcomeDismissalKey.

## Screen shots
Before:
![image](https://github.com/learningequality/kolibri/assets/51698593/ff20d04b-ed9d-456f-99dc-a92dc69dd0e2)

After:
![image](https://github.com/learningequality/kolibri/assets/51698593/9071f7eb-759d-4d73-8d00-759341078ba0)


## References
closes #11202 

## Reviewer guidance
- Import a channel.
- Sign out explore as guest.
- Go to learn tab .
- welcomeModal does not appear.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
