### PR TITLE
Disables caching for the kolibri studio status check

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -20,6 +20,7 @@ from django.utils.encoding import force_bytes
 from django.utils.encoding import iri_to_uri
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_page
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import etag
 from django_filters.rest_framework import BaseInFilter
 from django_filters.rest_framework import BooleanFilter
@@ -121,6 +122,13 @@ def metadata_cache(view_func):
         return response
 
     return session_exempt(wrapper_func)
+
+
+def no_cache_on_method(view_func):
+    """
+    Decorator to disable caching for a particular method
+    """
+    return method_decorator(never_cache, name="dispatch")(view_func)
 
 
 class RemoteMixin(object):
@@ -1824,6 +1832,7 @@ class RemoteChannelViewSet(viewsets.ViewSet):
         return Response(channels[0])
 
     @action(detail=False)
+    @no_cache_on_method
     def kolibri_studio_status(self, request, **kwargs):
         try:
             resp = requests.get(get_info_url())


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the **Disconnected** indicator that is displayed when there is no internet connection on the host device by disabling caching on the `kolibri_studio_status` view, the root cause of the reported issue.

https://github.com/learningequality/kolibri/assets/5203639/2141dc64-8b4d-4d33-bd1c-07f06ee93241

https://github.com/learningequality/kolibri/assets/5203639/df2fca02-35db-4450-9236-2be05166c7d7

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/11437

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Go to the Library page.
2. Turn off your wi-fi.
3. Keep attempting to explore the 'Kolibri Library' section under 'Other libraries'

**Note:** Some strange behavior was picked up around caching of failed requests and is being or will be addressed with [this separately filed issue](https://github.com/learningequality/kolibri/issues/11457)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
