### PR TITLE
Fix caching issues for remote content API calls

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -108,6 +108,9 @@ def metadata_cache(view_func):
         except IndexError:
             request = kwargs.get("request", None)
         key_prefix = get_cache_key()
+        # Prevent the Django caching middleware from caching
+        # this response, as we want to cache it ourselves
+        request._cache_update_cache = False
         url_key = hashlib.md5(
             force_bytes(iri_to_uri(request.build_absolute_uri()))
         ).hexdigest()

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -91,31 +91,38 @@ from kolibri.utils.urls import validator
 logger = logging.getLogger(__name__)
 
 
+REMOTE_ETAG_CACHE_KEY = "remote_content_etag_{}"
+
+REMOTE_URL_PARAM = "baseurl"
+
+
 def get_cache_key(*args, **kwargs):
     return str(ContentCacheKey.get_cache_key())
 
 
-def metadata_cache(view_func):
+def metadata_cache(view_func, cache_key_func=get_cache_key):
     """
-    Decorator for patch_response_headers function
+    Decorator to apply an Etag sensitive page cache
     """
 
-    @etag(get_cache_key)
+    @etag(cache_key_func)
     def wrapper_func(*args, **kwargs):
         try:
             request = args[0]
             request = kwargs.get("request", request)
         except IndexError:
             request = kwargs.get("request", None)
-        key_prefix = get_cache_key()
         # Prevent the Django caching middleware from caching
         # this response, as we want to cache it ourselves
         request._cache_update_cache = False
+        key_prefix = get_cache_key(request)
         url_key = hashlib.md5(
             force_bytes(iri_to_uri(request.build_absolute_uri()))
         ).hexdigest()
-        cache_key = "{}:{}".format(key_prefix, url_key)
-        response = cache.get(cache_key)
+        response = None
+        if key_prefix is not None:
+            cache_key = "{}:{}".format(key_prefix, url_key)
+            response = cache.get(cache_key)
         if response is None:
             response = view_func(*args, **kwargs)
             if (
@@ -123,24 +130,38 @@ def metadata_cache(view_func):
                 and hasattr(response, "render")
                 and callable(response.render)
             ):
-                response.add_post_render_callback(
-                    lambda r: cache.set(cache_key, r, timeout=3600)
-                )
+                if key_prefix is None:
+                    key_prefix = get_cache_key(request)
+                    cache_key = "{}:{}".format(key_prefix, url_key)
+                if key_prefix is not None:
+                    response.add_post_render_callback(
+                        lambda r: cache.set(cache_key, r, timeout=3600)
+                    )
         return response
 
-    return session_exempt(wrapper_func)
+    return wrapper_func
+
+
+def get_remote_cache_key(request, *args, **kwargs):
+    if REMOTE_URL_PARAM in request.GET:
+        return cache.get(REMOTE_ETAG_CACHE_KEY.format(request.GET[REMOTE_URL_PARAM]))
+    return get_cache_key(*args, **kwargs)
+
+
+def remote_metadata_cache(view_func):
+    return session_exempt(
+        metadata_cache(view_func, cache_key_func=get_remote_cache_key)
+    )
 
 
 class RemoteMixin(object):
-    remote_url_param = "baseurl"
-
     def _should_proxy_request(self, request):
-        return self.remote_url_param in request.GET
+        return REMOTE_URL_PARAM in request.GET
 
     def _get_request_headers(self, request):
         return {
             "Accept": request.META.get("HTTP_ACCEPT"),
-            # Don't proxy client's accept headers as it may include br for brotli
+            # Don't proxy client's accept encoding headers as it may include br for brotli
             # that we cannot rely on having decompression for available on the server.
             "Accept-Language": request.META.get("HTTP_ACCEPT_LANGUAGE"),
             "Content-Type": request.META.get("CONTENT_TYPE"),
@@ -148,10 +169,16 @@ class RemoteMixin(object):
         }
 
     def _get_response_headers(self, response):
-        return {
-            "Cache-Control": response.headers.get("cache-control"),
-            "Etag": response.headers.get("etag"),
-        }
+        headers = {}
+        header_names = ["Cache-Control", "Etag", "Expires", "Date", "Last-Modified"]
+        for header_name in header_names:
+            if header_name in response.headers:
+                headers[header_name] = response.headers[header_name.lower()]
+        return headers
+
+    def _cache_etag(self, baseurl, headers):
+        cache_key = REMOTE_ETAG_CACHE_KEY.format(baseurl)
+        cache.set(cache_key, headers["Etag"], 3600)
 
     def update_data(self, response_data, baseurl):
         return response_data
@@ -164,9 +191,9 @@ class RemoteMixin(object):
             ),
             "/api/public/v2/",
         )
-        baseurl = request.GET[self.remote_url_param]
+        baseurl = request.GET[REMOTE_URL_PARAM]
         qs = request.GET.copy()
-        del qs[self.remote_url_param]
+        del qs[REMOTE_URL_PARAM]
         try:
             validator(baseurl)
         except ValidationError:
@@ -185,10 +212,12 @@ class RemoteMixin(object):
                 content = self.update_data(response.json(), baseurl)
             except ValueError:
                 content = response.content
+            headers = self._get_response_headers(response)
+            self._cache_etag(baseurl, headers)
             return Response(
                 content,
                 status=response.status_code,
-                headers=self._get_response_headers(response),
+                headers=headers,
             )
         except RequestException:
             # If any sort of error due to connection or timeout, raise a resource gone error
@@ -316,7 +345,7 @@ class BaseChannelMetadataMixin(object):
         return Response(data)
 
 
-@method_decorator(metadata_cache, name="dispatch")
+@method_decorator(remote_metadata_cache, name="dispatch")
 class ChannelMetadataViewSet(BaseChannelMetadataMixin, RemoteViewSet):
     pass
 
@@ -698,9 +727,9 @@ class InternalContentNodeMixin(BaseContentNodeMixin):
                 # This is a paginated object
                 if response_data["more"] is not None:
                     if type(response_data["more"].get("params", None)) is dict:
-                        response_data["more"]["params"][self.remote_url_param] = baseurl
+                        response_data["more"]["params"][REMOTE_URL_PARAM] = baseurl
                     else:
-                        response_data["more"][self.remote_url_param] = baseurl
+                        response_data["more"][REMOTE_URL_PARAM] = baseurl
                 response_data["results"] = self.update_data(
                     response_data["results"], baseurl
                 )
@@ -721,7 +750,7 @@ class InternalContentNodeMixin(BaseContentNodeMixin):
         return response_data
 
     def add_base_url_to_node(self, node, baseurl):
-        baseurl_querystring = "?{}={}".format(self.remote_url_param, baseurl)
+        baseurl_querystring = "?{}={}".format(REMOTE_URL_PARAM, baseurl)
         if node["thumbnail"]:
             node["thumbnail"] += baseurl_querystring
         for file in node["files"]:
@@ -774,7 +803,7 @@ class OptionalContentNodePagination(OptionalPagination):
         }
 
 
-@method_decorator(metadata_cache, name="dispatch")
+@method_decorator(remote_metadata_cache, name="dispatch")
 class ContentNodeViewset(InternalContentNodeMixin, RemoteMixin, ReadOnlyValuesViewset):
     pagination_class = OptionalContentNodePagination
 
@@ -1118,7 +1147,7 @@ class BaseContentNodeTreeViewset(
         return Response(parent)
 
 
-@method_decorator(metadata_cache, name="dispatch")
+@method_decorator(remote_metadata_cache, name="dispatch")
 class ContentNodeTreeViewset(BaseContentNodeTreeViewset, RemoteMixin):
     def retrieve(self, request, pk=None):
         if pk is None:

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -115,9 +115,14 @@ def metadata_cache(view_func):
         response = cache.get(cache_key)
         if response is None:
             response = view_func(*args, **kwargs)
-            response.add_post_render_callback(
-                lambda r: cache.set(cache_key, r, timeout=3600)
-            )
+            if (
+                response.status_code == 200
+                and hasattr(response, "render")
+                and callable(response.render)
+            ):
+                response.add_post_render_callback(
+                    lambda r: cache.set(cache_key, r, timeout=3600)
+                )
         return response
 
     return session_exempt(wrapper_func)


### PR DESCRIPTION
## Summary
* Fixes issue whereby non-200 responses would get cached
* Fixes content API caching to bypass Django caching middleware, as bespoke caching mechanisms are being used instead
* Fixes public content API endpoints to use matching cache headers to the same endpoints on Studio
* Fixes Etag checking on access to remote libraries by keeping a cache of Etags by baseurl to allow quick 304 responses without having to go to the remote

## References
Fixes https://github.com/learningequality/kolibri/issues/11457

## Reviewer guidance
Load e.g. http://127.0.0.1:8000/api/public/v2/contentnode_tree/d6e3b856125f5e6aa5fb40c8b112d5e9/?format=json and check that refreshes result in a 304 immediately

Likewise for access to remote URLs, such as http://localhost:8000/api/content/contentnode_tree/d6e3b856125f5e6aa5fb40c8b112d5e9/?include_coach_content=true&baseurl=https%3A%2F%2Fstudio.learningequality.org&format=json

Also follow the steps outlined in the issue to ensure that 410s are not being cached.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
