### PR TITLE
Revert "Disabling additional user import until multiple user syncing is working"

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportMultipleUsers.vue
@@ -32,7 +32,6 @@
               v-if="!isImported(userRow.user) && !isImporting(userRow.user)"
               :text="coreString('importAction')"
               appearance="flat-button"
-              :disabled="isImportingUserDisabled"
               @click="startImport(userRow.user)"
             />
             <KCircularLoader
@@ -92,8 +91,6 @@
         isPolling: false,
         // array of user/learner ids
         learnersBeingImported: [],
-        // To be removed
-        isImportingUserDisabled: false,
       };
     },
     inject: ['wizardService'],
@@ -143,20 +140,12 @@
     beforeMount() {
       this.isPolling = true;
       this.pollImportTask();
-      this.checkImportedUser();
     },
     methods: {
       importedLearners() {
         return this.wizardService.state.context.importedUsers;
       },
       pollImportTask() {
-        // TODO :: This has to be removed once the multiple user syncing has been fixed.
-        if (
-          this.learnersBeingImported.length > 0 ||
-          this.wizardService.state.context.importedUsers.length > 0
-        ) {
-          this.wizardService.send('LOADING');
-        }
         TaskResource.list({ queue: SoudQueue }).then(tasks => {
           if (tasks.length) {
             tasks.forEach(task => {
@@ -197,7 +186,6 @@
         }
       },
       startImport(learner) {
-        this.isImportingUserDisabled = true;
         // Push the learner into being imported, we'll remove it if we get an error later on
         this.learnersBeingImported.push(learner.id);
 
@@ -219,20 +207,13 @@
         }
         TaskResource.startTask(params).catch(() => {
           this.learnersBeingImported = this.learnersBeingImported.filter(id => id != learner.id);
-          this.isImportingUserDisabled = false;
         });
       },
       isImported(learner) {
         return this.importedLearners().find(u => u === learner.username);
       },
       isImporting(learner) {
-        this.checkImportedUser(learner);
         return this.learnersBeingImported.includes(learner.id);
-      },
-      checkImportedUser(learner) {
-        if (this.learnersBeingImported.length > 0 || this.isImported(learner)) {
-          this.isImportingUserDisabled = true;
-        }
       },
     },
     $trs: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/LoadingTaskPage.vue
@@ -35,13 +35,12 @@
       </template>
       <span v-else></span>
     </template>
-    <!-- TODO: to be roled back when multiple user syncing is working in the upcoming release -->
-    <!-- <KButton
+    <KButton
       v-if="loadingTask.status === 'COMPLETED' && isImportingSoud"
       appearance="basic-link"
       :text="$tr('importAnother')"
       @click="importAnother"
-    /> -->
+    />
   </OnboardingStepBase>
 
 </template>
@@ -54,12 +53,7 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import { TaskResource } from 'kolibri.resources';
   import { TaskStatuses } from 'kolibri.utils.syncTaskUtils';
-  import {
-    DeviceTypePresets,
-    // LodTypePresets,
-    SoudQueue,
-    FooterMessageTypes,
-  } from '../constants';
+  import { DeviceTypePresets, LodTypePresets, SoudQueue, FooterMessageTypes } from '../constants';
   import OnboardingStepBase from './OnboardingStepBase';
 
   export default {
@@ -130,10 +124,9 @@
       isSoud() {
         return this.queue === SoudQueue;
       },
-      // TODO: role this back when multiple user syncing is working in the upcoming release!
-      // isImportingSoud() {
-      //   return this.wizardService.state.context.lodImportOrJoin === LodTypePresets.IMPORT;
-      // },
+      isImportingSoud() {
+        return this.wizardService.state.context.lodImportOrJoin === LodTypePresets.IMPORT;
+      },
       queue() {
         return this.wizardService.state.context.fullOrLOD === DeviceTypePresets.LOD
           ? SoudQueue
@@ -150,11 +143,10 @@
       this.pollTask();
     },
     methods: {
-      // TODO: role this back when multiple user syncing is working in the upcoming release!
-      // importAnother() {
-      //   this.isPolling = false;
-      //   this.wizardService.send('IMPORT_ANOTHER');
-      // },
+      importAnother() {
+        this.isPolling = false;
+        this.wizardService.send('IMPORT_ANOTHER');
+      },
       pushCompletedToWizardMachine() {
         this.completedTasks.forEach(task => {
           if (!this.wizardService.state.context.importedUsers.includes(task.username)) {
@@ -234,11 +226,10 @@
       },
     },
     $trs: {
-      // TODO: role this back when multiple user syncing is working in the upcoming release!
-      // importAnother: {
-      //   message: 'Import another user account',
-      //   context: 'Link to restart the import step for another user. ',
-      // },
+      importAnother: {
+        message: 'Import another user account',
+        context: 'Link to restart the import step for another user. ',
+      },
       loadUserTitle: {
         message: 'Load user account',
         context: 'Title of a page where user is waiting for a user to be imported',


### PR DESCRIPTION
Reverts learningequality/kolibri#11242, as the core issue has been resolved by https://github.com/learningequality/kolibri/pull/11390