### PR TITLE
Replace KResponsiveWindow mixin by useKResponsiveWindow composable

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -154,8 +154,8 @@
     inject: ['wizardService'],
     mixins: [commonCoreStrings],
     setup() {
-      const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
-      return { windowIsSmall, windowIsPortrait };
+      const { windowIsSmall } = useKResponsiveWindow();
+      return { windowIsSmall };
     },
     props: {
       /**

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -144,7 +144,7 @@
   import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import AppError from 'kolibri-common/components/AppError';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import { FooterMessageTypes } from '../constants';
 
@@ -152,7 +152,11 @@
     name: 'OnboardingStepBase',
     components: { AppError, CoreLogo, LanguageSwitcherModal },
     inject: ['wizardService'],
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
+      return { windowIsSmall, windowIsPortrait };
+    },
     props: {
       /**
        * The event sent to the state machine when the user clicks GO BACK.

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -28,7 +28,7 @@
   import { interpret } from 'xstate';
   import { mapState } from 'vuex';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import responsiveWindowMixin from 'kolibri.coreVue.mixins.responsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import { checkCapability } from 'kolibri.utils.appCapabilities';
   import Lockr from 'lockr';
   import { wizardMachine } from '../machines/wizardMachine';
@@ -46,7 +46,11 @@
       LoadingPage,
       ErrorPage,
     },
-    mixins: [commonCoreStrings, responsiveWindowMixin],
+    mixins: [commonCoreStrings],
+    setup() {
+      const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
+      return { windowIsSmall, windowIsPortrait };
+    },
     data() {
       return {
         service: interpret(wizardMachine),

--- a/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SetupWizardIndex.vue
@@ -48,8 +48,8 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const { windowIsSmall, windowIsPortrait } = useKResponsiveWindow();
-      return { windowIsSmall, windowIsPortrait };
+      const { windowIsLarge } = useKResponsiveWindow();
+      return { windowIsLarge };
     },
     data() {
       return {


### PR DESCRIPTION
## Summary

This PR replaces `KResponsiveWindow` with `useKResponsiveWindow` in Setup Wizard plugin.

## References

This PR aims to resolve issue #11330 

## Reviewer guidance

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
