### PR TITLE
Task scheduling updates for Android

### DIFF
--- a/kolibri/core/tasks/constants.py
+++ b/kolibri/core/tasks/constants.py
@@ -1,1 +1,21 @@
 DEFAULT_QUEUE = "kolibri"
+
+
+class Priority(object):
+    """
+    This class defines the priority levels and their corresponding integer values.
+
+    REGULAR priority is for tasks that can wait for some time before it actually
+    starts executing. Tasks that are tracked on task manager should use this priority.
+
+    HIGH priority is for tasks that want execution as soon as possible. Tasks that
+    might affect user experience (e.g. on screen loading animation) like importing
+    channel metadata.
+    """
+
+    LOW = 15
+    REGULAR = 10
+    HIGH = 5
+
+    # A set of all valid priorities
+    Priorities = {HIGH, REGULAR, LOW}

--- a/kolibri/core/tasks/decorators.py
+++ b/kolibri/core/tasks/decorators.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
-from kolibri.core.tasks.job import Priority
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.validation import JobValidator
 

--- a/kolibri/core/tasks/exceptions.py
+++ b/kolibri/core/tasks/exceptions.py
@@ -23,7 +23,3 @@ class JobRunning(Exception):
 
 class JobNotRunning(Exception):
     pass
-
-
-class JobAlreadyRetrying(Exception):
-    pass

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -8,6 +8,9 @@ from collections import namedtuple
 from six import raise_from
 from six import string_types
 
+from kolibri.core.tasks.constants import (  # noqa F401 - imported for backwards compatibility
+    Priority,
+)
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.utils import callable_to_import_path
 from kolibri.core.tasks.utils import current_state_tracker
@@ -70,26 +73,6 @@ class State(object):
         CANCELED,
         COMPLETED,
     }
-
-
-class Priority(object):
-    """
-    This class defines the priority levels and their corresponding integer values.
-
-    REGULAR priority is for tasks that can wait for some time before it actually
-    starts executing. Tasks that are tracked on task manager should use this priority.
-
-    HIGH priority is for tasks that want execution as soon as possible. Tasks that
-    might affect user experience (e.g. on screen loading animation) like importing
-    channel metadata.
-    """
-
-    LOW = 15
-    REGULAR = 10
-    HIGH = 5
-
-    # A set of all valid priorities
-    Priorities = {HIGH, REGULAR, LOW}
 
 
 JobStatus = namedtuple("Status", ("title", "text"))

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -313,6 +313,7 @@ class Job(object):
             )
             self.storage.mark_job_as_failed(self.job_id, e, traceback_str)
 
+        self.storage.reschedule_job_if_needed(self.job_id)
         setattr(current_state_tracker, "job", None)
 
     @property

--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -289,6 +289,8 @@ class Job(object):
     def execute(self):
         self._check_storage_attached()
 
+        self.storage.mark_job_as_running(self.job_id)
+
         setattr(current_state_tracker, "job", self)
 
         func = self.task

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -8,8 +8,8 @@ from rest_framework.exceptions import PermissionDenied
 from six import string_types
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.main import job_storage
 from kolibri.core.tasks.permissions import BasePermission
 from kolibri.core.tasks.utils import callable_to_import_path

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.exceptions import JobAlreadyRetrying
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
@@ -26,7 +27,6 @@ from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
 from kolibri.utils.sql_alchemy import db_matches_schema
 from kolibri.utils.time_utils import local_now

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -19,15 +19,16 @@ from sqlalchemy.orm import sessionmaker
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.constants import Priority
-from kolibri.core.tasks.exceptions import JobAlreadyRetrying
 from kolibri.core.tasks.exceptions import JobNotFound
 from kolibri.core.tasks.exceptions import JobNotRestartable
-from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.exceptions import JobRunning
-from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.hooks import StorageHook
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
+from kolibri.core.tasks.validation import validate_interval
+from kolibri.core.tasks.validation import validate_priority
+from kolibri.core.tasks.validation import validate_repeat
+from kolibri.core.tasks.validation import validate_timedelay
 from kolibri.utils.sql_alchemy import db_matches_schema
 from kolibri.utils.time_utils import local_now
 from kolibri.utils.time_utils import naive_utc_datetime
@@ -207,7 +208,7 @@ class Storage(object):
             return queued_jobs[0].job_id
 
         return self.enqueue_job(
-            job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
+            job, queue=queue, priority=priority, retry_interval=retry_interval
         )
 
     def mark_job_as_canceled(self, job_id):
@@ -490,98 +491,105 @@ class Storage(object):
     def save_job_as_cancellable(self, job_id, cancellable=True):
         self._update_job(job_id, cancellable=cancellable)
 
-    def retry_job_in(self, job_id, delta_t, **kwargs):
-        if not isinstance(delta_t, timedelta):
-            raise TypeError("Time argument must be a timedelta object.")
-        orm_job = self.get_orm_job(job_id)
-        if orm_job.state == State.CANCELING:
-            raise UserCancelledError("Job has been marked for cancellation.")
-        if orm_job.state != State.RUNNING:
-            raise JobNotRunning("Job is not running, cannot retry.")
-        if orm_job.retry_interval is not None or orm_job.repeat != 0:
-            raise JobAlreadyRetrying("Job is already retrying.")
-        # Update the job to repeat once after delta_t seconds.
-        self._update_job(job_id, interval=delta_t.total_seconds(), repeat=1, **kwargs)
-
-    def reschedule_job_if_needed(self, job_id):
-        orm_job = self.get_orm_job(job_id)
-        kwargs = dict(
-            queue=orm_job.queue,
-            priority=orm_job.priority,
-            interval=orm_job.interval,
-            repeat=orm_job.repeat,
-            retry_interval=orm_job.retry_interval,
-        )
-        new_scheduled_time = None
-        if orm_job.state == State.FAILED and orm_job.retry_interval is not None:
-            new_scheduled_time = self._now() + timedelta(seconds=orm_job.retry_interval)
-
-        elif (
-            orm_job.state in {State.COMPLETED, State.FAILED, State.CANCELED}
-            and orm_job.repeat != 0
-        ):
-            if orm_job.repeat is not None:
-                kwargs["repeat"] = orm_job.repeat - 1
-            new_scheduled_time = self._now() + timedelta(seconds=orm_job.interval)
-        if new_scheduled_time is not None:
-            job = self._orm_to_job(orm_job)
-            self.schedule(new_scheduled_time, job, **kwargs)
-
-    def _update_orm_job_fields(
-        self,
-        orm_job,
-        priority=None,
-        interval=None,
-        repeat=NO_VALUE,
-        retry_interval=NO_VALUE,
-    ):
-        if priority is not None:
-            orm_job.priority = priority
-        if interval is not None:
-            orm_job.interval = interval
-        if repeat is not NO_VALUE:
-            orm_job.repeat = repeat
-        if retry_interval is not NO_VALUE:
-            orm_job.retry_interval = retry_interval
-
-    def _update_job_fields(self, job, **kwargs):
-        for kwarg in kwargs:
-            if kwarg in Job.UPDATEABLE_KEYS:
-                setattr(job, kwarg, kwargs[kwarg])
-            else:
-                logger.error(
-                    "Tried to update job with id {} with non-updateable key {}".format(
-                        job.job_id, kwarg
-                    )
-                )
-
-    def _update_job(
+    # Turning off the complexity warning for this function as moving the conditional validation checks
+    # inline would be the simplest way to 'reduce' the complexity, but would make it less readable.
+    def reschedule_finished_job_if_needed(  # noqa: C901
         self,
         job_id,
-        state=None,
+        delay=None,
         priority=None,
         interval=None,
         repeat=NO_VALUE,
         retry_interval=NO_VALUE,
-        **kwargs
     ):
         """
         Because repeat and retry_interval are nullable, None is a semantic value, so we need to use a sentinel value NO_VALUE
         as the default when no value is passed in.
         """
+
+        # Validate all passed in values that have been set.
+        if repeat is not NO_VALUE:
+            validate_repeat(repeat)
+
+        if interval is not None:
+            validate_interval(interval)
+
+        if retry_interval is not NO_VALUE:
+            validate_interval(retry_interval)
+
+        if priority is not None:
+            validate_priority(priority)
+
+        if delay is not None:
+            validate_timedelay(delay)
+
+        orm_job = self.get_orm_job(job_id)
+
+        # Only allow this function to be run on a job that is in a finished state.
+        if orm_job.state not in {State.COMPLETED, State.FAILED, State.CANCELED}:
+            raise JobNotRestartable(
+                "Cannot reschedule job with state={}".format(orm_job.state)
+            )
+
+        # Create the schedule kwargs by reading from the database, and overriding with any passed in values.
+        kwargs = dict(
+            queue=orm_job.queue,
+            priority=priority if priority is not None else orm_job.priority,
+            interval=interval if interval is not None else orm_job.interval,
+            repeat=repeat if repeat is not NO_VALUE else orm_job.repeat,
+            retry_interval=retry_interval
+            if retry_interval is not NO_VALUE
+            else orm_job.retry_interval,
+        )
+
+        # Set a null new_scheduled_time so that we finish processing if none of the cases below pertain.
+        new_scheduled_time = None
+        if delay is not None:
+            # If delay is specified, all other logic is overridden, and we just schedule the job
+            # as specified with the delay.
+            # This is to allow for the job just to be re-run after a delay, without any other
+            # enqueuing changes - so if it is still set to repeat, it will repeat again after the
+            # delayed rerun.
+            new_scheduled_time = self._now() + delay
+        elif orm_job.state == State.FAILED and kwargs["retry_interval"] is not None:
+            # If the task has failed, and a retry interval has been specified (either in the original enqueue,
+            # or from the passed in kwargs) then requeue as a retry.
+            new_scheduled_time = self._now() + timedelta(
+                seconds=kwargs["retry_interval"]
+            )
+
+        elif (
+            orm_job.state in {State.COMPLETED, State.FAILED, State.CANCELED}
+            and kwargs["repeat"] != 0
+        ):
+            # Otherwise, if we are in a finished state and repeat is not 0, then we can reschedule, either because
+            # repeat is None, or because repeat is not None and is greater than 0.
+            if kwargs["repeat"] is not None:
+                # If repeat is not None, then we are 'consuming' one of our repeats by rescheduling, so decrement now.
+                kwargs["repeat"] = kwargs["repeat"] - 1
+            # Set the new scheduled time based on the specified interval.
+            new_scheduled_time = self._now() + timedelta(seconds=kwargs["interval"])
+        if new_scheduled_time is not None:
+            # Convert the orm job to a job object for requeuing.
+            job = self._orm_to_job(orm_job)
+            # Use the schedule method so that any scheduling hooks are run for this next run of the job.
+            self.schedule(new_scheduled_time, job, **kwargs)
+
+    def _update_job(self, job_id, state=None, **kwargs):
         with self.session_scope() as session:
             try:
                 job, orm_job = self._get_job_and_orm_job(job_id, session)
                 if state is not None:
                     orm_job.state = job.state = state
-                self._update_orm_job_fields(
-                    orm_job,
-                    priority=priority,
-                    interval=interval,
-                    repeat=repeat,
-                    retry_interval=retry_interval,
-                )
-                self._update_job_fields(job, **kwargs)
+                for kwarg in kwargs:
+                    if kwarg in Job.UPDATEABLE_KEYS:
+                        setattr(job, kwarg, kwargs[kwarg])
+                    else:
+                        logger.error(
+                            "Tried to update job with id {} with non-updateable key {}".format(
+                                job.job_id, kwarg
+                            )
+                        )
                 orm_job.saved_job = job.to_json()
                 session.add(orm_job)
                 try:
@@ -589,16 +597,7 @@ class Storage(object):
                 except Exception as e:
                     logger.error("Got an error running session.commit(): {}".format(e))
                 for hook in self._hooks:
-                    hook.update(
-                        job,
-                        orm_job,
-                        state=state,
-                        priority=priority,
-                        interval=interval,
-                        repeat=repeat,
-                        retry_interval=retry_interval,
-                        **kwargs
-                    )
+                    hook.update(job, orm_job, state=state, **kwargs)
                 return job, orm_job
             except JobNotFound:
                 if state:
@@ -687,10 +686,9 @@ class Storage(object):
         """
         if not isinstance(dt, datetime):
             raise ValueError("Time argument must be a datetime object.")
-        if repeat is not None and repeat < 0:
-            raise ValueError(
-                "Must specify repeat greater than equal to 0 or None (repeat forever)"
-            )
+
+        validate_repeat(repeat)
+
         if not interval and repeat != 0:
             raise ValueError("Must specify an interval if the task is repeating")
         if dt.tzinfo is None:

--- a/kolibri/core/tasks/test/taskrunner/test_scheduler.py
+++ b/kolibri/core/tasks/test/taskrunner/test_scheduler.py
@@ -102,6 +102,7 @@ class TestScheduler(object):
         now = local_now()
         old_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(old_id)
+        job_storage.reschedule_job_if_needed(old_id)
         new_id = job_storage.get_all_jobs()[0].job_id
         assert old_id == new_id
 
@@ -111,6 +112,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
+        job_storage.reschedule_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
@@ -120,6 +122,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
+        job_storage.reschedule_job_if_needed(job_id)
         assert job_storage.get_job(job_id).job_id == job_id
 
     def test_scheduled_repeating_function_sets_new_job_with_one_fewer_repeats(
@@ -128,6 +131,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage.complete_job(job_id)
+        job_storage.reschedule_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
@@ -140,6 +144,7 @@ class TestScheduler(object):
         job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage._now = lambda: now
         job_storage.complete_job(job_id)
+        job_storage.reschedule_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
@@ -156,6 +161,7 @@ class TestScheduler(object):
         )
         job_storage._now = lambda: now
         job_storage.mark_job_as_failed(job_id, "Exception", "Traceback")
+        job_storage.reschedule_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time

--- a/kolibri/core/tasks/test/taskrunner/test_scheduler.py
+++ b/kolibri/core/tasks/test/taskrunner/test_scheduler.py
@@ -102,7 +102,7 @@ class TestScheduler(object):
         now = local_now()
         old_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(old_id)
-        job_storage.reschedule_job_if_needed(old_id)
+        job_storage.reschedule_finished_job_if_needed(old_id)
         new_id = job_storage.get_all_jobs()[0].job_id
         assert old_id == new_id
 
@@ -112,7 +112,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
-        job_storage.reschedule_job_if_needed(job_id)
+        job_storage.reschedule_finished_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
@@ -122,7 +122,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=None)
         job_storage.complete_job(job_id)
-        job_storage.reschedule_job_if_needed(job_id)
+        job_storage.reschedule_finished_job_if_needed(job_id)
         assert job_storage.get_job(job_id).job_id == job_id
 
     def test_scheduled_repeating_function_sets_new_job_with_one_fewer_repeats(
@@ -131,7 +131,7 @@ class TestScheduler(object):
         now = local_now()
         job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage.complete_job(job_id)
-        job_storage.reschedule_job_if_needed(job_id)
+        job_storage.reschedule_finished_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             repeat = scheduled_job.repeat
@@ -144,7 +144,7 @@ class TestScheduler(object):
         job_id = job_storage.schedule(now, job, interval=1000, repeat=1)
         job_storage._now = lambda: now
         job_storage.complete_job(job_id)
-        job_storage.reschedule_job_if_needed(job_id)
+        job_storage.reschedule_finished_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time
@@ -161,7 +161,7 @@ class TestScheduler(object):
         )
         job_storage._now = lambda: now
         job_storage.mark_job_as_failed(job_id, "Exception", "Traceback")
-        job_storage.reschedule_job_if_needed(job_id)
+        job_storage.reschedule_finished_job_if_needed(job_id)
         with job_storage.session_scope() as session:
             _, scheduled_job = job_storage._get_job_and_orm_job(job_id, session)
             scheduled_time = scheduled_job.scheduled_time

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -7,12 +7,12 @@ import pytz
 from mock import patch
 
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobAlreadyRetrying
 from kolibri.core.tasks.exceptions import JobNotRestartable
 from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.registry import TaskRegistry
 from kolibri.core.tasks.storage import Storage

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -9,9 +9,7 @@ from mock import patch
 from kolibri.core.tasks.constants import DEFAULT_QUEUE
 from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.decorators import register_task
-from kolibri.core.tasks.exceptions import JobAlreadyRetrying
 from kolibri.core.tasks.exceptions import JobNotRestartable
-from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.registry import TaskRegistry
@@ -266,65 +264,384 @@ class TestBackend:
         with pytest.raises(ValueError):
             defaultbackend.enqueue_at(tz_aware_now, simplejob, repeat=-1, interval=1)
 
-    def test_can_retry_running_job(self, defaultbackend, simplejob):
+    def test_reschedule_finished_job_no_delay(self, defaultbackend, simplejob):
         job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
-        defaultbackend.mark_job_as_running(job_id)
+        defaultbackend.complete_job(job_id)
 
-        job = defaultbackend.get_job(job_id)
+        orm_job = defaultbackend.get_orm_job(job_id)
 
-        # is the job marked as running?
-        assert job.state == State.RUNNING
+        previous_scheduled_time = orm_job.scheduled_time
 
-        defaultbackend.retry_job_in(simplejob.job_id, datetime.timedelta(seconds=5))
-        requeued_job = defaultbackend.get_orm_job(job_id)
+        defaultbackend.reschedule_finished_job_if_needed(simplejob.job_id)
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
 
-        assert requeued_job.repeat == 1
-        assert requeued_job.interval == 5
+        assert requeued_job.state == State.COMPLETED
+        assert requeued_orm_job.scheduled_time == previous_scheduled_time
 
-    def test_cant_retry_queued_job(self, defaultbackend, simplejob):
+    def test_can_reschedule_finished_job(self, defaultbackend, simplejob):
         job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
 
-        job = defaultbackend.get_job(job_id)
+        orm_job = defaultbackend.get_orm_job(job_id)
 
-        assert job.state == State.QUEUED
-        with pytest.raises(JobNotRunning):
-            defaultbackend.retry_job_in(simplejob.job_id, datetime.timedelta(seconds=5))
+        previous_scheduled_time = orm_job.scheduled_time
 
-    def test_cant_retry_already_retrying_job(self, defaultbackend, simplejob):
-        job_id = defaultbackend.enqueue_job(simplejob, QUEUE, retry_interval=5)
-        defaultbackend.mark_job_as_running(job_id)
+        defaultbackend.reschedule_finished_job_if_needed(
+            simplejob.job_id, delay=datetime.timedelta(seconds=5)
+        )
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
 
-        job = defaultbackend.get_job(job_id)
+        assert requeued_job.state == State.QUEUED
+        assert requeued_orm_job.scheduled_time > previous_scheduled_time
 
-        # is the job marked as running?
-        assert job.state == State.RUNNING
-        with pytest.raises(JobAlreadyRetrying):
-            defaultbackend.retry_job_in(simplejob.job_id, datetime.timedelta(seconds=5))
+    def test_reschedule_finished_job_canceled(self, defaultbackend, simplejob):
+        # Test case where the job is canceled.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_canceled(job_id)
 
-    def test_cant_retry_already_indefinitely_repeating_job(
+        orm_job = defaultbackend.get_orm_job(job_id)
+
+        previous_scheduled_time = orm_job.scheduled_time
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            simplejob.job_id, delay=datetime.timedelta(seconds=5)
+        )
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert requeued_orm_job.scheduled_time > previous_scheduled_time
+
+    def test_reschedule_finished_job_failed(self, defaultbackend, simplejob):
+        # Test case where the job is failed.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_failed(job_id, RuntimeError(), "Traceback")
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+
+        previous_scheduled_time = orm_job.scheduled_time
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            simplejob.job_id, delay=datetime.timedelta(seconds=5)
+        )
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert requeued_orm_job.scheduled_time > previous_scheduled_time
+
+    def test_reschedule_finished_job_invalid_state_queued(
         self, defaultbackend, simplejob
     ):
-        job_id = defaultbackend.enqueue_in(
-            datetime.timedelta(seconds=5), simplejob, QUEUE, repeat=None, interval=30
-        )
+        # Test case where the job state is not finished.
+        # Ensure an error is raised since only finished jobs can be rescheduled.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
+        with pytest.raises(JobNotRestartable):
+            defaultbackend.reschedule_finished_job_if_needed(job_id)
+
+    def test_reschedule_finished_job_invalid_state_running(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job state is not finished.
+        # Ensure an error is raised since only finished jobs can be rescheduled.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+
         defaultbackend.mark_job_as_running(job_id)
 
-        job = defaultbackend.get_job(job_id)
+        with pytest.raises(JobNotRestartable):
+            defaultbackend.reschedule_finished_job_if_needed(job_id)
 
-        # is the job marked as running?
-        assert job.state == State.RUNNING
-        with pytest.raises(JobAlreadyRetrying):
-            defaultbackend.retry_job_in(simplejob.job_id, datetime.timedelta(seconds=5))
-
-    def test_cant_retry_already_finitely_repeating_job(self, defaultbackend, simplejob):
-        job_id = defaultbackend.enqueue_in(
-            datetime.timedelta(seconds=5), simplejob, QUEUE, repeat=3, interval=30
+    def test_reschedule_finished_job_failed_retry_interval_scheduled(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job has failed and a retry_interval is specified.
+        # Ensure the job is scheduled with a retry_interval.
+        retry_interval = 60 * 30
+        job_id = defaultbackend.enqueue_job(
+            simplejob, QUEUE, retry_interval=retry_interval
         )
-        defaultbackend.mark_job_as_running(job_id)
+        defaultbackend.mark_job_as_failed(job_id, RuntimeError(), "Traceback")
 
-        job = defaultbackend.get_job(job_id)
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
 
-        # is the job marked as running?
-        assert job.state == State.RUNNING
-        with pytest.raises(JobAlreadyRetrying):
-            defaultbackend.retry_job_in(simplejob.job_id, datetime.timedelta(seconds=5))
+        defaultbackend.reschedule_finished_job_if_needed(job_id)
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=retry_interval)
+        )
+
+    def test_reschedule_finished_job_failed_retry_interval(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job has failed and a retry_interval is specified.
+        # Ensure the job is scheduled with a retry_interval.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_failed(job_id, RuntimeError(), "Traceback")
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        retry_interval = 60 * 30
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            job_id, retry_interval=retry_interval
+        )
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=retry_interval)
+        )
+
+    def test_reschedule_finished_job_failed_retry_interval_scheduled_override(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job has failed and a retry_interval is specified.
+        # Ensure the job is scheduled with a retry_interval.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE, retry_interval=3)
+        defaultbackend.mark_job_as_failed(job_id, RuntimeError(), "Traceback")
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        retry_interval = 60 * 30
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            job_id, retry_interval=retry_interval
+        )
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=retry_interval)
+        )
+
+    def test_reschedule_finished_job_completed_with_repeat(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job is completed, repeat is not 0, and other parameters are None.
+        # Ensure the job is scheduled with the correct interval.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        interval = 60 * 10
+        repeat = 3
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            job_id, interval=interval, repeat=repeat
+        )
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=interval)
+        )
+        assert requeued_orm_job.repeat == repeat - 1
+
+    def test_reschedule_finished_job_invalid_priority(self, defaultbackend, simplejob):
+        # Test case where an invalid priority is specified.
+        # Ensure an error is raised for invalid priority.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        with pytest.raises(ValueError):
+            defaultbackend.reschedule_finished_job_if_needed(
+                job_id, priority="invalid_priority"
+            )
+
+    def test_reschedule_finished_job_invalid_interval(self, defaultbackend, simplejob):
+        # Test case where an invalid interval is specified.
+        # Ensure an error is raised for invalid interval.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        with pytest.raises(ValueError):
+            defaultbackend.reschedule_finished_job_if_needed(job_id, interval=-1)
+
+    def test_reschedule_finished_job_invalid_retry_interval(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where an invalid retry_interval is specified.
+        # Ensure an error is raised for invalid retry_interval.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.mark_job_as_failed(job_id, RuntimeError(), "Traceback")
+
+        with pytest.raises(ValueError):
+            defaultbackend.reschedule_finished_job_if_needed(job_id, retry_interval=0)
+
+    def test_reschedule_finished_job_invalid_repeat(self, defaultbackend, simplejob):
+        # Test case where an invalid repeat is specified.
+        # Ensure an error is raised for invalid repeat.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        with pytest.raises(ValueError):
+            defaultbackend.reschedule_finished_job_if_needed(job_id, repeat=-1)
+
+    def test_reschedule_finished_scheduled_job_override_repeat(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job is completed, repeat is set to something other than the scheduled repeat.
+        # Ensure the job is scheduled with the correct repeat.
+        job_id = defaultbackend.schedule(
+            defaultbackend._now(), simplejob, queue=QUEUE, repeat=1, interval=3
+        )
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        repeat = 3
+
+        defaultbackend.reschedule_finished_job_if_needed(job_id, repeat=repeat)
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=3)
+        )
+        assert requeued_orm_job.repeat == repeat - 1
+
+    def test_reschedule_finished_scheduled_job_override_interval(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job is completed, interval is not None.
+        # Ensure the job is scheduled with the correct interval.
+        job_id = defaultbackend.schedule(
+            defaultbackend._now(), simplejob, queue=QUEUE, repeat=1, interval=3
+        )
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        interval = 60 * 10
+
+        defaultbackend.reschedule_finished_job_if_needed(job_id, interval=interval)
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=interval)
+        )
+        assert requeued_orm_job.repeat == 0
+
+    def test_reschedule_finished_scheduled_job_override_priority(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where the job is completed, priority is not None.
+        # Ensure the job is scheduled with the correct priority.
+        job_id = defaultbackend.schedule(
+            defaultbackend._now(), simplejob, queue=QUEUE, repeat=1, interval=3
+        )
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        assert orm_job.priority == Priority.REGULAR
+
+        defaultbackend.reschedule_finished_job_if_needed(job_id, priority=Priority.HIGH)
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=3)
+        )
+        assert requeued_orm_job.priority == Priority.HIGH
+        assert requeued_orm_job.repeat == 0
+
+    def test_reschedule_finished_job_with_zero_repeat(self, defaultbackend, simplejob):
+        # Test case where repeat is set to 0.
+        # Ensure the job is not rescheduled.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        defaultbackend.reschedule_finished_job_if_needed(simplejob.job_id, repeat=0)
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        assert requeued_job.state == State.COMPLETED
+        assert requeued_orm_job.scheduled_time == previous_scheduled_time
+
+    def test_reschedule_finished_job_with_negative_repeat(
+        self, defaultbackend, simplejob
+    ):
+        # Test case where repeat is set to a negative value.
+        # Ensure an error is raised.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        with pytest.raises(ValueError):
+            defaultbackend.reschedule_finished_job_if_needed(
+                simplejob.job_id, repeat=-1
+            )
+
+    def test_reschedule_finished_job_combined(self, defaultbackend, simplejob):
+        # Test a combination of parameters to cover different branches in the method.
+        job_id = defaultbackend.enqueue_job(simplejob, QUEUE)
+        defaultbackend.complete_job(job_id)
+
+        orm_job = defaultbackend.get_orm_job(job_id)
+        previous_scheduled_time = orm_job.scheduled_time
+
+        # Specify custom values for priority, interval, repeat, and retry_interval
+        priority = Priority.HIGH
+        interval = 60 * 15
+        repeat = 2
+        retry_interval = 30
+
+        defaultbackend.reschedule_finished_job_if_needed(
+            simplejob.job_id,
+            priority=priority,
+            interval=interval,
+            repeat=repeat,
+            retry_interval=retry_interval,
+        )
+
+        requeued_orm_job = defaultbackend.get_orm_job(job_id)
+        requeued_job = defaultbackend.get_job(job_id)
+
+        # Ensure that the job is scheduled with the specified parameters
+        assert requeued_job.state == State.QUEUED
+        assert (
+            requeued_orm_job.scheduled_time
+            >= previous_scheduled_time + datetime.timedelta(seconds=interval)
+        )
+        assert requeued_orm_job.priority == priority
+        assert requeued_orm_job.repeat == repeat - 1
+        assert requeued_orm_job.retry_interval == retry_interval

--- a/kolibri/core/tasks/test/taskrunner/test_worker.py
+++ b/kolibri/core/tasks/test/taskrunner/test_worker.py
@@ -3,8 +3,8 @@ import time
 
 import pytest
 
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.job import State
 from kolibri.core.tasks.test.base import connection
 from kolibri.core.tasks.test.taskrunner.test_job_running import EventProxy

--- a/kolibri/core/tasks/test/test_decorators.py
+++ b/kolibri/core/tasks/test/test_decorators.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 from mock import patch
 
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.decorators import register_task
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.validation import JobValidator
 

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -5,9 +5,11 @@ import mock
 from django.test.testcases import TestCase
 
 from kolibri.core.tasks.constants import Priority
+from kolibri.core.tasks.exceptions import JobNotRunning
 from kolibri.core.tasks.job import Job
 from kolibri.core.tasks.permissions import IsSuperAdmin
 from kolibri.core.tasks.registry import RegisteredTask
+from kolibri.core.tasks.utils import current_state_tracker
 from kolibri.core.tasks.validation import JobValidator
 
 
@@ -56,10 +58,128 @@ class JobTest(TestCase):
         with self.assertRaises(ReferenceError):
             self.job.save_as_cancellable(cancellable=cancellable)
 
-    def test_job_retry_in(self):
+    def test_job_retry_in_not_running(self):
         dt = timedelta(seconds=15)
-        self.job.retry_in(dt)
-        self.job.storage.retry_job_in.assert_called_once_with(self.job.job_id, dt)
+        with self.assertRaises(JobNotRunning):
+            self.job.retry_in(dt)
+
+    def test_job_retry_in_running(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        try:
+            self.job.retry_in(dt)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual({}, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_unexpected_keyword_argument(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        kwargs = {"invalid_arg": "value"}
+        with self.assertRaises(ValueError):
+            self.job.retry_in(dt, **kwargs)
+        setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_with_priority(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        kwargs = {"priority": Priority.LOW}
+        try:
+            self.job.retry_in(dt, **kwargs)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual(kwargs, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_with_repeat(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        kwargs = {"repeat": 3}
+        try:
+            self.job.retry_in(dt, **kwargs)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual(kwargs, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_with_interval(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        kwargs = {"interval": 5 * 60}
+        try:
+            self.job.retry_in(dt, **kwargs)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual(kwargs, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_with_retry_interval(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        kwargs = {"retry_interval": 60 * 60}
+        try:
+            self.job.retry_in(dt, **kwargs)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual(kwargs, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_invalid_priority(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        invalid_priority = "invalid_priority"
+        kwargs = {"priority": invalid_priority}
+        with self.assertRaises(ValueError):
+            self.job.retry_in(dt, **kwargs)
+        setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_invalid_interval(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        invalid_interval = -1  # Invalid negative interval
+        kwargs = {"interval": invalid_interval}
+        with self.assertRaises(ValueError):
+            self.job.retry_in(dt, **kwargs)
+        setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_invalid_retry_interval(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        invalid_retry_interval = 0  # Invalid zero retry interval
+        kwargs = {"retry_interval": invalid_retry_interval}
+        with self.assertRaises(ValueError):
+            self.job.retry_in(dt, **kwargs)
+        setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_invalid_repeat(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        invalid_repeat = -1  # Invalid negative repeat
+        kwargs = {"repeat": invalid_repeat}
+        with self.assertRaises(ValueError):
+            self.job.retry_in(dt, **kwargs)
+        setattr(current_state_tracker, "job", None)
+
+    def test_job_retry_in_all_allowable_values(self):
+        setattr(current_state_tracker, "job", self.job)
+        dt = timedelta(seconds=15)
+        priority = Priority.HIGH
+        interval = 60 * 5
+        retry_interval = 60 * 60
+        repeat = 3
+        kwargs = {
+            "priority": priority,
+            "interval": interval,
+            "retry_interval": retry_interval,
+            "repeat": repeat,
+        }
+        try:
+            self.job.retry_in(dt, **kwargs)
+            self.assertEqual(self.job._retry_in_delay, dt)
+            self.assertEqual(kwargs, self.job._retry_in_kwargs)
+        except Exception:
+            setattr(current_state_tracker, "job", None)
 
 
 class TestRegisteredTask(TestCase):

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 import mock
 from django.test.testcases import TestCase
 
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.job import Job
-from kolibri.core.tasks.job import Priority
 from kolibri.core.tasks.permissions import IsSuperAdmin
 from kolibri.core.tasks.registry import RegisteredTask
 from kolibri.core.tasks.validation import JobValidator

--- a/kolibri/core/tasks/validation.py
+++ b/kolibri/core/tasks/validation.py
@@ -1,8 +1,36 @@
+from datetime import timedelta
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from .job import Priority
+
+
+def validate_repeat(value):
+    if value is not None and (not isinstance(value, int) or value < 0):
+        raise ValueError(
+            "Must specify repeat greater than equal to 0 or None (repeat forever)"
+        )
+
+
+def validate_interval(value):
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError("intervals must be a positive integer number of seconds")
+
+
+def validate_priority(value):
+    if value not in Priority.Priorities:
+        raise ValueError(
+            "priority must be one of {}".format(
+                ", ".join(str(pri) for pri in Priority.Priorities)
+            )
+        )
+
+
+def validate_timedelay(value):
+    if not isinstance(value, timedelta):
+        raise TypeError("time delay must be a datetime.timedelta object")
 
 
 class EnqueueArgsSerializer(serializers.Serializer):

--- a/kolibri/core/tasks/validation.py
+++ b/kolibri/core/tasks/validation.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from .job import Priority
+from kolibri.core.tasks.constants import Priority
 
 
 def validate_repeat(value):

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -24,8 +24,6 @@ def execute_job(job_id):
 
     job = storage.get_job(job_id)
 
-    storage.mark_job_as_running(job_id)
-
     job.execute()
 
     connection.dispose()

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -4,7 +4,7 @@ from concurrent.futures import CancelledError
 from django.db import connection as django_connection
 
 from kolibri.core.tasks.compat import PoolExecutor
-from kolibri.core.tasks.job import Priority
+from kolibri.core.tasks.constants import Priority
 from kolibri.core.tasks.storage import Storage
 from kolibri.core.tasks.utils import db_connection
 from kolibri.core.tasks.utils import InfiniteLoopThread


### PR DESCRIPTION
## Summary
* Moves the marking of a job as running inside the job execute method so that it happens independent of task runner
* Make the rescheduling of a task after it has completed (either for repeat or retry behaviour) separate from the updating of the status
* Most importantly, uses the schedule method to reschedule the new task, rather than the update methods, so that schedule hooks are called
* Adds some reusable validation functions for commonly used scheduling arguments
* Move Priority enum to constants to avoid a circular import
* Fixes unnoticed bug in enqueue_if_not that failed to pass through passed in arguments.
* Updates how retry_in works to defer setting until after the job has completed, and then passing the new arguments to the reschedule job - allows the scheduling to be deferred until task completion, and to allow the retry_in behaviour to be used more liberally

## References
Should resolve Android syncing issues that were caused by the combination of the existing retry_in behaviour (which set `repeat` to 1) and the update hooks that pass the orm_job to the update hooks after the orm_job has been modified (so repeat would be 0, and no repeat would be scheduled by the Android hook).

Does this by making sure that all job scheduling events trigger the schedule hook, and that the update hook is only for processing state updates. This feels like it makes a lot more sense anyway!

## Reviewer guidance
The APK generated here will probably mostly work as it is - but I have some correlated changes for Android which I will open in a PR on the Android repo. I will also build an APK from this PR with those changes for testing.

Further testing on Android has shown some issues, but not related to this PR, it seems to have uncovered some weirdness that I hadn't previously observed in properly reading the job_id within the WorkManager context. This PR can be reviewed independently.

@pcenov and @radinamatic please make sure that these changes cause no regressions in existing syncing behaviour.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
