### PR TITLE
Avoid syncing with non-kolibris

### DIFF
--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -64,7 +64,9 @@ class Context(object):
     @cached_property
     def network_location(self):
         return NetworkLocation.objects.filter(
-            instance_id=self.instance_id, connection_status=ConnectionStatus.Okay
+            instance_id=self.instance_id,
+            connection_status=ConnectionStatus.Okay,
+            application="kolibri",
         ).first()
 
     @property

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -1,0 +1,43 @@
+"""
+Subset of Users Device (SOUD) tests
+"""
+import uuid
+
+from django.test import TestCase
+
+from ..soud import Context
+from kolibri.core.discovery.models import ConnectionStatus
+from kolibri.core.discovery.models import StaticNetworkLocation
+
+
+class SoudContextTestCase(TestCase):
+    def setUp(self):
+        super(SoudContextTestCase, self).setUp()
+        self.context = Context(uuid.uuid4().hex, uuid.uuid4().hex)
+
+    def test_property__network_location(self):
+        netloc = StaticNetworkLocation.objects.create(
+            base_url="https://kolibrihappyurl.qqq/",
+            connection_status=ConnectionStatus.Okay,
+            application="kolibri",
+            instance_id=self.context.instance_id,
+        )
+        self.assertEqual(self.context.network_location, netloc)
+
+    def test_property__network_location__not_kolibri(self):
+        StaticNetworkLocation.objects.create(
+            base_url="https://kolibrihappyurl.qqq/",
+            connection_status=ConnectionStatus.Okay,
+            application="studio",
+            instance_id=self.context.instance_id,
+        )
+        self.assertIsNone(self.context.network_location)
+
+    def test_property__network_location__not_connected(self):
+        StaticNetworkLocation.objects.create(
+            base_url="https://kolibrihappyurl.qqq/",
+            connection_status=ConnectionStatus.ConnectionFailure,
+            application="kolibri",
+            instance_id=self.context.instance_id,
+        )
+        self.assertIsNone(self.context.network_location)

--- a/kolibri/core/discovery/models.py
+++ b/kolibri/core/discovery/models.py
@@ -101,6 +101,18 @@ class NetworkLocation(models.Model):
     # Determines whether device is local or on the internet
     is_local = models.BooleanField(default=False)
 
+    def __init__(self, *args, **kwargs):
+        super(NetworkLocation, self).__init__(*args, **kwargs)
+        self._set_fields_for_type()
+
+    def save(self, *args, **kwargs):
+        self._set_fields_for_type()
+        return super(NetworkLocation, self).save(*args, **kwargs)
+
+    def _set_fields_for_type(self):
+        """Abstract method to set fields for type"""
+        pass
+
     @property
     def since_last_accessed(self):
         """
@@ -133,6 +145,10 @@ class NetworkLocation(models.Model):
     def reserved(self):
         return self.location_type == LocationTypes.Reserved
 
+    @property
+    def is_kolibri(self):
+        return self.application == "kolibri"
+
     @classmethod
     def has_field(cls, field):
         try:
@@ -161,12 +177,11 @@ class StaticNetworkLocationManager(models.Manager):
 class StaticNetworkLocation(NetworkLocation):
     objects = StaticNetworkLocationManager()
 
+    def _set_fields_for_type(self):
+        self.location_type = LocationTypes.Static
+
     class Meta:
         proxy = True
-
-    def save(self, *args, **kwargs):
-        self.location_type = LocationTypes.Static
-        return super(StaticNetworkLocation, self).save(*args, **kwargs)
 
 
 class DynamicNetworkLocationManager(models.Manager):
@@ -189,13 +204,14 @@ class DynamicNetworkLocationManager(models.Manager):
 class DynamicNetworkLocation(NetworkLocation):
     objects = DynamicNetworkLocationManager()
 
+    def _set_fields_for_type(self):
+        self.location_type = LocationTypes.Dynamic
+        self.is_local = True  # all dynamic locations are local
+
     class Meta:
         proxy = True
 
     def save(self, *args, **kwargs):
-        self.location_type = LocationTypes.Dynamic
-        self.is_local = True
-
         if self.id and self.instance_id and self.id != self.instance_id:
             raise ValidationError(
                 {"instance_id": "`instance_id` and `id` must be the same"}

--- a/kolibri/core/discovery/test/test_models.py
+++ b/kolibri/core/discovery/test/test_models.py
@@ -1,0 +1,45 @@
+from django.test import TestCase
+
+from ..models import ConnectionStatus
+from ..models import DynamicNetworkLocation
+from ..models import LocationTypes
+from ..models import NetworkLocation
+from ..models import StaticNetworkLocation
+
+
+class NetworkLocationTestCase(TestCase):
+    multi_db = True
+
+    def test_property__available(self):
+        location = NetworkLocation()
+        self.assertFalse(location.available)
+        location.connection_status = ConnectionStatus.Okay
+        self.assertFalse(location.available)
+        location.base_url = "https://kolibrihappyurl.qqq/"
+        self.assertTrue(location.available)
+        location.connection_status = ConnectionStatus.ConnectionFailure
+        self.assertFalse(location.available)
+
+    def test_property__is_kolibri(self):
+        location = NetworkLocation()
+        self.assertFalse(location.is_kolibri)
+        location.application = "kdp"
+        self.assertFalse(location.is_kolibri)
+        location.application = "kolibri"
+        self.assertTrue(location.is_kolibri)
+
+    def test_property__dynamic(self):
+        static = StaticNetworkLocation()
+        self.assertFalse(static.dynamic)
+        dynamic = DynamicNetworkLocation()
+        self.assertTrue(dynamic.dynamic)
+        reserved = NetworkLocation(location_type=LocationTypes.Reserved)
+        self.assertFalse(reserved.dynamic)
+
+    def test_property__reserved(self):
+        static = StaticNetworkLocation()
+        self.assertFalse(static.reserved)
+        dynamic = DynamicNetworkLocation()
+        self.assertFalse(dynamic.reserved)
+        reserved = NetworkLocation(location_type=LocationTypes.Reserved)
+        self.assertTrue(reserved.reserved)

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -116,7 +116,7 @@ def request_soud_sync(network_location):
     from kolibri.core.auth.tasks import enqueue_soud_sync_processing
     from kolibri.core.device.soud import request_sync_hook
 
-    if not network_location.subset_of_users_device:
+    if not network_location.subset_of_users_device and network_location.is_kolibri:
         request_sync_hook(network_location)
         enqueue_soud_sync_processing()
 

--- a/kolibri/plugins/learn/test/test_hooks.py
+++ b/kolibri/plugins/learn/test/test_hooks.py
@@ -12,6 +12,7 @@ class NetworkDiscoveryForSoUDHookTestCase(TestCase):
             "kolibri.plugins.learn.NetworkDiscoveryForSoUDHook"
         )
         self.mock_location = mock.MagicMock(spec=NetworkLocation())
+        self.mock_location.is_kolibri = True
         begin_patcher = mock.patch("kolibri.core.device.soud.request_sync_hook")
         self.mock_begin = begin_patcher.start()
         self.addCleanup(begin_patcher.stop)
@@ -31,6 +32,12 @@ class NetworkDiscoveryForSoUDHookTestCase(TestCase):
         self.mock_location.subset_of_users_device = False
         self.hook.on_connect(self.mock_location)
         self.mock_begin.assert_called_once_with(self.mock_location)
+
+    def test_on_connect__location_is_not_soud__but_not_kolibri(self):
+        self.mock_location.subset_of_users_device = False
+        self.mock_location.is_kolibri = False
+        self.hook.on_connect(self.mock_location)
+        self.mock_begin.assert_not_called()
 
     def test_on_connect__self_not_soud__location_not_soud(self):
         self.mock_get_setting.return_value = False


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds property to `NetworkLocation` for checking if it's a kolibri
- Updates learner discovery hooks to ensure location is a kolibri
- Updates SoUD context logic to ensure location is a kolibri
- Adds tests

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/11468

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Start Kolibri

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
