### PR TITLE
NewBadge missing when downloading channel

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -49,7 +49,6 @@ export default {
 
       return channels.map(channel => {
         const taskIndex = findLastIndex(getters.managedTasks, task => {
-          console.log(task.extra_metadata.channel_id);
           return (
             ![TaskTypes.DISKCONTENTEXPORT, TaskTypes.DISKEXPORT, TaskTypes.DELETECHANNEL].includes(
               task.type

--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -49,11 +49,12 @@ export default {
 
       return channels.map(channel => {
         const taskIndex = findLastIndex(getters.managedTasks, task => {
+          console.log(task.extra_metadata.channel_id);
           return (
             ![TaskTypes.DISKCONTENTEXPORT, TaskTypes.DISKEXPORT, TaskTypes.DELETECHANNEL].includes(
               task.type
             ) &&
-            task.channel_id === channel.id &&
+            task.extra_metadata.channel_id === channel.id &&
             task.status === TaskStatuses.COMPLETED
           );
         });


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
`task.channel_id` was undefined here
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Related to #6730
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
It is clear that this addresses the bug due to which #6730 was not being able to reproduced
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
