### PR TITLE
Avoid stalling LOD syncs during immediate enqueues and discovery hooks

### DIFF
--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -452,7 +452,8 @@ def enqueue_soud_sync_processing(force=False):
             converted_next_run = naive_utc_datetime(timezone.now() + next_run)
             orm_job = job_storage.get_orm_job(SOUD_SYNC_PROCESSING_JOB_ID)
             if (
-                orm_job.state == State.QUEUED
+                orm_job.state == State.RUNNING
+                or orm_job.state == State.QUEUED
                 and orm_job.scheduled_time <= converted_next_run
             ):
                 # Already queued sooner or at the same time as the next run

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -430,7 +430,7 @@ def soud_sync_processing():
     soud.execute_syncs()
     # schedule next run
     next_run = soud.get_time_to_next_attempt()
-    if next_run:
+    if next_run is not None:
         job = get_current_job()
         job.retry_in(next_run)
 
@@ -440,7 +440,7 @@ def enqueue_soud_sync_processing(force=False):
     Enqueue a task to process SoUD syncs, if necessary
     """
     next_run = soud.get_time_to_next_attempt()
-    if not next_run:
+    if next_run is None:
         # No need to enqueue, as there is no next run
         return
 

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -1,12 +1,18 @@
 """
 Subset of Users Device (SOUD) tests
 """
+import time
 import uuid
 
+import mock
 from django.test import TestCase
 
 from ..soud import Context
+from ..soud import request_sync_hook
+from kolibri.core.device.models import SyncQueue
+from kolibri.core.device.models import SyncQueueStatus
 from kolibri.core.discovery.models import ConnectionStatus
+from kolibri.core.discovery.models import DynamicNetworkLocation
 from kolibri.core.discovery.models import StaticNetworkLocation
 
 
@@ -41,3 +47,100 @@ class SoudContextTestCase(TestCase):
             instance_id=self.context.instance_id,
         )
         self.assertIsNone(self.context.network_location)
+
+
+class SoudRequestSyncHookHandlerTestCase(TestCase):
+    multi_db = True
+
+    def setUp(self):
+        super(SoudRequestSyncHookHandlerTestCase, self).setUp()
+        self.instance_id = uuid.uuid4().hex
+        self.user_ids = [
+            uuid.uuid4().hex,
+        ]
+
+        self.mock_network_location = mock.Mock(
+            spec=DynamicNetworkLocation,
+            instance_id=self.instance_id,
+        )
+
+        get_all_user_ids = mock.patch("kolibri.core.device.soud.get_all_user_ids")
+        self.mock_get_all_user_ids = get_all_user_ids.start()
+        self.mock_get_all_user_ids.return_value = self.user_ids
+        self.addCleanup(get_all_user_ids.stop)
+
+        request_sync = mock.patch("kolibri.core.device.soud.request_sync")
+        self.mock_request_sync = request_sync.start()
+        self.addCleanup(request_sync.stop)
+
+    def assertRequestSyncCalled(self, user_id, call_index=0):
+        calls = self.mock_request_sync.mock_calls
+        _, args, kwargs = calls[call_index]
+        self.assertIsInstance(args[0], Context)
+        self.assertEqual(args[0].user_id, user_id)
+        self.assertEqual(args[0].instance_id, self.instance_id)
+        self.assertEqual(kwargs, {"network_location": self.mock_network_location})
+
+    def assertPendingQueue(self, user_id):
+        queue = SyncQueue.objects.get(user_id=user_id)
+        self.assertEqual(queue.instance_id, self.instance_id)
+        self.assertEqual(queue.status, SyncQueueStatus.Pending)
+        self.assertGreaterEqual(queue.updated, time.time() - 1)
+
+    def test_single_user__no_queue(self):
+        request_sync_hook(self.mock_network_location)
+        self.assertRequestSyncCalled(self.user_ids[0])
+        self.assertPendingQueue(self.user_ids[0])
+
+    def test_single_user__existing_queue__active(self):
+        queue = SyncQueue.objects.create(
+            user_id=self.user_ids[0],
+            instance_id=self.instance_id,
+            status=SyncQueueStatus.Syncing,
+        )
+        request_sync_hook(self.mock_network_location)
+        self.mock_request_sync.assert_not_called()
+        updated = queue.updated
+        queue.refresh_from_db()
+        self.assertEqual(queue.status, SyncQueueStatus.Syncing)
+        self.assertEqual(queue.updated, updated)
+
+    def test_single_user__existing_queue__inactive(self):
+        SyncQueue.objects.create(
+            user_id=self.user_ids[0],
+            instance_id=self.instance_id,
+            status=SyncQueueStatus.Syncing,
+            updated=time.time() - 100,
+        )
+        request_sync_hook(self.mock_network_location)
+        self.assertRequestSyncCalled(self.user_ids[0])
+        self.assertPendingQueue(self.user_ids[0])
+
+    def test_multiple_users(self):
+        self.user_ids.extend([uuid.uuid4().hex, uuid.uuid4().hex])
+        user_a, user_b, user_c = self.user_ids
+
+        # user_a stale
+        SyncQueue.objects.create(
+            user_id=user_a,
+            instance_id=self.instance_id,
+            status=SyncQueueStatus.Pending,
+            updated=time.time() - 100,
+        )
+        # user_b active
+        queue = SyncQueue.objects.create(
+            user_id=user_b,
+            instance_id=self.instance_id,
+            status=SyncQueueStatus.Syncing,
+        )
+        # user_c no queue
+        request_sync_hook(self.mock_network_location)
+        self.assertEqual(self.mock_request_sync.call_count, 2)
+        self.assertRequestSyncCalled(user_a, call_index=0)
+        self.assertRequestSyncCalled(user_c, call_index=1)
+        self.assertPendingQueue(user_a)
+        self.assertPendingQueue(user_c)
+        updated = queue.updated
+        queue.refresh_from_db()
+        self.assertEqual(queue.status, SyncQueueStatus.Syncing)
+        self.assertEqual(queue.updated, updated)


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- A python `datetime.timedelta` can be falsy if the time delta is 0, so this ensures we reschedule the LOD syncing tasks when they should be scheduled immediately (in 0 seconds)
- Adds logic to prevent network discovery hooks from interfering with ongoing sync queue scheduling
- Adds tests

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/11487

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Have a LOD sync with a server
2. Disconnect the LOD from the network or stop its Kolibri for at least 1 minute
3. Reconnect the LOD and verify it syncs upon connecting

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
