### PR TITLE
Add regression test and fix for empty querysets being passed to get_content_nodes_data

### DIFF
--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -444,6 +444,15 @@ class GetContentNodesDataTestCase(TestCase):
         self.assertCountEqual(files, expected_files_list)
         self.assertEqual(total_bytes_to_transfer, 5)
 
+    def test_empty_query(self):
+        (total_resource_count, files, total_bytes_to_transfer) = get_content_nodes_data(
+            self.the_channel_id, [ContentNode.objects.none()], available=True
+        )
+
+        self.assertEqual(total_resource_count, 0)
+        self.assertCountEqual(files, [])
+        self.assertEqual(total_bytes_to_transfer, 0)
+
 
 @patch(
     "kolibri.core.content.management.commands.importchannel.channel_import.import_channel_from_local_db"

--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -250,26 +250,33 @@ def get_content_nodes_data(  # noqa: C901
             segment_boundaries = nodes_query.aggregate(
                 min_boundary=Min("lft"), max_boundary=Max("rght")
             )
-            segment_topics = ContentNode.objects.filter(
-                channel_id=channel_id, kind=content_kinds.TOPIC
-            ).filter(
-                Q(
-                    lft__lte=segment_boundaries["min_boundary"],
-                    rght__gte=segment_boundaries["max_boundary"],
+            # If the nodes_query queryset was empty, these aggregated values will be None
+            # and Django does not let us do lte and gte queries against None,
+            # plus even trying is a waste of our time, because the query should return nothing.
+            if (
+                segment_boundaries["min_boundary"] is not None
+                and segment_boundaries["max_boundary"] is not None
+            ):
+                segment_topics = ContentNode.objects.filter(
+                    channel_id=channel_id, kind=content_kinds.TOPIC
+                ).filter(
+                    Q(
+                        lft__lte=segment_boundaries["min_boundary"],
+                        rght__gte=segment_boundaries["max_boundary"],
+                    )
+                    | Q(
+                        lft__lte=segment_boundaries["max_boundary"],
+                        rght__gte=segment_boundaries["min_boundary"],
+                    )
                 )
-                | Q(
-                    lft__lte=segment_boundaries["max_boundary"],
-                    rght__gte=segment_boundaries["min_boundary"],
-                )
-            )
 
-            file_objects = LocalFile.objects.filter(
-                files__contentnode__in=segment_topics,
-            ).values("id", "file_size", "extension")
-            if available is not None:
-                file_objects = file_objects.filter(available=available)
-            for f in file_objects:
-                queried_file_objects[f["id"]] = f
+                file_objects = LocalFile.objects.filter(
+                    files__contentnode__in=segment_topics,
+                ).values("id", "file_size", "extension")
+                if available is not None:
+                    file_objects = file_objects.filter(available=available)
+                for f in file_objects:
+                    queried_file_objects[f["id"]] = f
 
     files_to_download = list(queried_file_objects.values())
 


### PR DESCRIPTION
## Summary
* It is possible with partial metadata import for empty querysets to get generated during our file import queries
* Fixes this by doing a defensive check for the queryset being empty (by checking the aggregations return any value)
* Adds a regression test to ensure this behaviour

## References
Fixes [#11488](https://github.com/learningequality/kolibri/issues/11488)

## Reviewer guidance
Check the test. See the test pass. Rejoice!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
