### PR TITLE
Fix Welcome Modal for different browser sessions

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceIndex.vue
@@ -16,12 +16,7 @@
       />
     </transition>
 
-    <transition name="delay-entry">
-      <PostSetupModalGroup
-        v-if="welcomeModalVisible"
-        @cancel="hideWelcomeModal"
-      />
-    </transition>
+
 
     <router-view />
   </NotificationsRoot>
@@ -40,17 +35,14 @@
   import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import urls from 'kolibri.urls';
   import { PageNames } from '../constants';
-  import PostSetupModalGroup from './PostSetupModalGroup';
+
   import PinAuthenticationModal from './PinAuthenticationModal';
   import plugin_data from 'plugin_data';
-
-  const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'DeviceIndex',
     components: {
       NotificationsRoot,
-      PostSetupModalGroup,
       PinAuthenticationModal,
     },
     mixins: [commonCoreStrings],
@@ -63,9 +55,6 @@
     computed: {
       ...mapGetters(['isUserLoggedIn', 'userFacilityId']),
       ...mapState(['authenticateWithPin', 'grantPluginAccess']),
-      ...mapState({
-        welcomeModalVisibleState: 'welcomeModalVisible',
-      }),
       facilities() {
         return this.$store.state.core.facilities;
       },
@@ -80,12 +69,6 @@
         }
         return (
           (plugin_data.allowGuestAccess && this.$store.getters.allowAccess) || this.isUserLoggedIn
-        );
-      },
-      welcomeModalVisible() {
-        return (
-          this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
         );
       },
       pageName() {
@@ -111,10 +94,6 @@
       },
     },
     methods: {
-      hideWelcomeModal() {
-        window.localStorage.setItem(welcomeDismissalKey, true);
-        this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
-      },
       closePinModal() {
         redirectBrowser(urls['kolibri:kolibri.plugins.learn:learn']());
         return (this.showModal = false);

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -1,88 +1,85 @@
 <template>
 
-  <div>
+  <DeviceAppBarPage :title="pageTitle">
     <transition name="delay<-entry">
       <PostSetupModalGroup
-        v-if="welcomeModalVisible && !areChannelsImported"
+        v-if="!channelListLoading && welcomeModalVisible && !areChannelsImported"
         @cancel="hideWelcomeModal"
       />
     </transition>
 
-    <DeviceAppBarPage :title="pageTitle">
+    <KPageContainer class="device-container">
 
-      <KPageContainer class="device-container">
-
-        <div>
-          <HeaderWithOptions :headerText="coreString('channelsLabel')">
-            <template #options>
-              <KButtonGroup>
-                <!-- Margins to and bottom adds space when buttons are vertically stacked -->
-                <KButton
-                  v-if="channelsAreInstalled"
-                  hasDropdown
-                  appearance="raised-button"
-                  :text="coreString('optionsLabel')"
-                  :style="{ margin: '16px 8px -16px 0' }"
-                >
-                  <template #menu>
-                    <KDropdownMenu
-                      position="bottom left"
-                      :options="dropdownOptions"
-                      @select="handleSelect"
-                    />
-                  </template>
-                </KButton>
-                <KButton
-                  :text="$tr('import')"
-                  style="margin-top: 16px; margin-bottom: -16px;"
-                  :primary="true"
-                  @click="startImportWorkflow()"
-                />
-              </KButtonGroup>
-            </template>
-          </HeaderWithOptions>
-
-          <TasksBar
-            v-if="managedTasks.length > 0"
-            :tasks="managedTasks"
-            :taskManagerLink="{ name: 'MANAGE_TASKS' }"
-            @clearall="handleClickClearAll"
-          />
-
-          <p v-if="!channelsAreInstalled && !channelListLoading">
-            {{ $tr('emptyChannelListMessage') }}
-          </p>
-
-          <div class="channels-list">
-            <KCircularLoader v-if="channelListLoading" />
-            <div v-else>
-              <ChannelPanel
-                v-for="channel in sortedChannels"
-                :key="channel.id"
-                :channel="channel"
-                :disabled="channelIsBeingDeleted(channel.id)"
-                :showNewLabel="showNewLabel(channel.id)"
-                @select_delete="deleteChannelId = channel.id"
-                @select_manage="handleSelectManage(channel.id)"
+      <div>
+        <HeaderWithOptions :headerText="coreString('channelsLabel')">
+          <template #options>
+            <KButtonGroup>
+              <!-- Margins to and bottom adds space when buttons are vertically stacked -->
+              <KButton
+                v-if="channelsAreInstalled"
+                hasDropdown
+                appearance="raised-button"
+                :text="coreString('optionsLabel')"
+                :style="{ margin: '16px 8px -16px 0' }"
+              >
+                <template #menu>
+                  <KDropdownMenu
+                    position="bottom left"
+                    :options="dropdownOptions"
+                    @select="handleSelect"
+                  />
+                </template>
+              </KButton>
+              <KButton
+                :text="$tr('import')"
+                style="margin-top: 16px; margin-bottom: -16px;"
+                :primary="true"
+                @click="startImportWorkflow()"
               />
-            </div>
+            </KButtonGroup>
+          </template>
+        </HeaderWithOptions>
+
+        <TasksBar
+          v-if="managedTasks.length > 0"
+          :tasks="managedTasks"
+          :taskManagerLink="{ name: 'MANAGE_TASKS' }"
+          @clearall="handleClickClearAll"
+        />
+
+        <p v-if="!channelsAreInstalled && !channelListLoading">
+          {{ $tr('emptyChannelListMessage') }}
+        </p>
+
+        <div class="channels-list">
+          <KCircularLoader v-if="!welcomeModalVisible && channelListLoading" />
+          <div v-else>
+            <ChannelPanel
+              v-for="channel in sortedChannels"
+              :key="channel.id"
+              :channel="channel"
+              :disabled="channelIsBeingDeleted(channel.id)"
+              :showNewLabel="showNewLabel(channel.id)"
+              @select_delete="deleteChannelId = channel.id"
+              @select_manage="handleSelectManage(channel.id)"
+            />
           </div>
-
-          <SelectTransferSourceModal :pageName="pageName" />
-
-          <DeleteChannelModal
-            v-if="deleteChannelId"
-            :channelTitle="selectedChannelTitle"
-            @submit="handleDeleteChannel"
-            @cancel="deleteChannelId = null"
-          />
-
         </div>
 
-      </KPageContainer>
+        <SelectTransferSourceModal :pageName="pageName" />
 
-    </DeviceAppBarPage>
-  </div>
+        <DeleteChannelModal
+          v-if="deleteChannelId"
+          :channelTitle="selectedChannelTitle"
+          @submit="handleDeleteChannel"
+          @cancel="deleteChannelId = null"
+        />
+
+      </div>
+
+    </KPageContainer>
+
+  </DeviceAppBarPage>
 
 </template>
 
@@ -189,8 +186,6 @@
         );
       },
       areChannelsImported() {
-        console.log('debugggggggggg');
-        console.log(this.installedChannelsWithResources);
         return this.installedChannelsWithResources.length > 0;
       },
     },

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -52,7 +52,7 @@
         </p>
 
         <div class="channels-list">
-          <KCircularLoader v-if="!welcomeModalVisible && channelListLoading" />
+          <KCircularLoader v-if="channelListLoading" />
           <div v-else>
             <ChannelPanel
               v-for="channel in sortedChannels"

--- a/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
+++ b/kolibri/plugins/learn/assets/src/views/LearnIndex.vue
@@ -4,13 +4,6 @@
     :authorized="userIsAuthorized"
     authorizedRole="registeredUser"
   >
-    <transition name="delay-entry">
-      <PostSetupModalGroup
-        v-if="welcomeModalVisible"
-        isOnMyOwnUser
-        @cancel="hideWelcomeModal"
-      />
-    </transition>
     <router-view :loading="loading" />
   </NotificationsRoot>
 
@@ -23,30 +16,18 @@
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import plugin_data from 'plugin_data';
   import { PageNames } from '../constants';
-  import PostSetupModalGroup from '../../../../device/assets/src/views/PostSetupModalGroup.vue';
-
-  const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
 
   export default {
     name: 'LearnIndex',
     components: {
       NotificationsRoot,
-      PostSetupModalGroup,
     },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
       ...mapState({
-        welcomeModalVisibleState: 'welcomeModalVisible',
-      }),
-      ...mapState({
         loading: state => state.core.loading,
       }),
-      welcomeModalVisible() {
-        return (
-          this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
-        );
-      },
+
       userIsAuthorized() {
         if (this.pageName === PageNames.BOOKMARKS) {
           return this.isUserLoggedIn;
@@ -56,12 +37,7 @@
         );
       },
     },
-    methods: {
-      hideWelcomeModal() {
-        window.localStorage.setItem(welcomeDismissalKey, true);
-        this.$store.commit('SET_WELCOME_MODAL_VISIBLE', false);
-      },
-    },
+    methods: {},
   };
 
 </script>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -3,7 +3,7 @@
   <div>
     <transition name="delay-entry">
       <PostSetupModalGroup
-        v-if="welcomeModalVisible"
+        v-if="welcomeModalVisible && !areChannelsImported"
         isOnMyOwnUser
         @cancel="hideWelcomeModal"
       />
@@ -450,6 +450,11 @@
       },
       studioId() {
         return KolibriStudioId;
+      },
+      areChannelsImported() {
+        console.log('debugggggggggg');
+        console.log(this.rootNodes.length);
+        return this.rootNodes.length > 0;
       },
     },
     watch: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -36,7 +36,7 @@
           - Otherwise, show search results.
         -->
         <KCircularLoader
-          v-if="!welcomeModalVisible && (rootNodesLoading || searchLoading)"
+          v-if="rootNodesLoading || searchLoading"
           class="loader"
           type="indeterminate"
           :delay="false"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -3,7 +3,7 @@
   <div>
     <transition name="delay-entry">
       <PostSetupModalGroup
-        v-if="welcomeModalVisible && !areChannelsImported"
+        v-if="!(rootNodesLoading || searchLoading) && welcomeModalVisible && !areChannelsImported"
         isOnMyOwnUser
         @cancel="hideWelcomeModal"
       />
@@ -36,7 +36,7 @@
           - Otherwise, show search results.
         -->
         <KCircularLoader
-          v-if="rootNodesLoading || searchLoading"
+          v-if="!welcomeModalVisible && (rootNodesLoading || searchLoading)"
           class="loader"
           type="indeterminate"
           :delay="false"
@@ -452,8 +452,6 @@
         return KolibriStudioId;
       },
       areChannelsImported() {
-        console.log('debugggggggggg');
-        console.log(this.rootNodes.length);
         return this.rootNodes.length > 0;
       },
     },


### PR DESCRIPTION
## Summary
- Fixes the bug with display of Welcome Modal w.r.t multiple browser sessions.
- Move PostSetup Modal to index level.
- Use getter function along with localStorage to decide display of Welcome Modal.

## References
closes #11456 

## ScreenShot
![image](https://github.com/learningequality/kolibri/assets/51698593/cb189572-e1ed-4fa5-9cab-a61919303784)
(welcome modal does not get displayed after clearing the DEVICE_WELCOME_MODAL_DISMISSED key from cookies)

## Reviewer guidance
1. Sign in and go to the Library page and/or Device > Channels - observe the welcome modal.
2. Import channels
3. Clear all the browser cookies and sign in again, or sign in using a different browser, Welcome Modal is not displayed now!
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
