### PR TITLE
Fix learning facility setup window's Continue button action

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -66,24 +66,25 @@
         Presets,
       };
     },
-    mounted() {
-      this.focusOnTextbox();
-    },
     computed: {
       facilityNameInvalid() {
         return !this.facilityName || this.facilityName.trim() === '';
       },
+    },
+    mounted() {
+      this.focusOnTextbox();
     },
     inject: ['wizardService'],
     methods: {
       handleContinue() {
         if (this.facilityNameInvalid) {
           return this.focusOnTextbox();
-        }else{
-        this.wizardService.send({
-          type: 'CONTINUE', 
-          value: { selected: this.selected, facilityName: this.facilityName },
-        });}
+        } else {
+          this.wizardService.send({
+            type: 'CONTINUE',
+            value: { selected: this.selected, facilityName: this.facilityName },
+          });
+        }
       },
       focusOnTextbox() {
         if (this.$refs && this.$refs['facility-name']) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FacilityPermissionsForm.vue
@@ -69,13 +69,21 @@
     mounted() {
       this.focusOnTextbox();
     },
+    computed: {
+      facilityNameInvalid() {
+        return !this.facilityName || this.facilityName.trim() === '';
+      },
+    },
     inject: ['wizardService'],
     methods: {
       handleContinue() {
+        if (this.facilityNameInvalid) {
+          return this.focusOnTextbox();
+        }else{
         this.wizardService.send({
-          type: 'CONTINUE',
+          type: 'CONTINUE', 
           value: { selected: this.selected, facilityName: this.facilityName },
-        });
+        });}
       },
       focusOnTextbox() {
         if (this.$refs && this.$refs['facility-name']) {


### PR DESCRIPTION
## Summary

This PR aims to fix the bug in the learning facility form of the setup wizard (the continue button moving to next form even if a user has not filled the facility name).

The changes introduced have been fully tested in the local environment and work without any errors. The updated behavior is as show in the video:

https://github.com/learningequality/kolibri/assets/116485536/4e535dd1-8cb0-4765-b42d-ad8a77902e0e

## References

Closes #11486 

## Reviewer guidance

To test these changes, head over to `create_facility/1`  page of the setup wizard. Clicking continue will now prompt the user to fill the textbox, if left empty, instead of skipping that particular step.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
