### PR TITLE
Issue 10255 improve coach tabs accessibility

### DIFF
--- a/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
@@ -20,7 +20,7 @@ export const ReportsGroupTabs = {
   ACTIVITY: 'tabActivity',
 };
 
-export const LEARNERS_TABS_ID = 'coachLearners';
+export const LEARNERS_TABS_ID = 'reportLearners';
 export const LearnersTabs = {
   REPORTS: 'tabReports',
   ACTIVITY: 'tabActivity',

--- a/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
@@ -19,3 +19,9 @@ export const ReportsGroupTabs = {
   MEMBERS: 'tabMembers',
   ACTIVITY: 'tabActivity',
 };
+
+export const LEARNERS_TABS_ID = 'coachLearners';
+export const LearnersTabs = {
+  REPORTS: 'tabReports',
+  ACTIVITY: 'tabActivity',
+};

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -8,13 +8,16 @@
 
     <KPageContainer>
 
-      <ReportsLearnerHeader :enablePrint="true" />
-
-      <ActivityList
-        embeddedPageName="ReportsLearnerActivityPage"
-        :noActivityString="coachString('activityListEmptyState')"
-      />
-
+      <ReportsLearnerHeader :enablePrint="true" :activeTabId="LearnersTabs.ACTIVITY" />
+      <KTabsPanel
+        :tabsId="LEARNERS_TABS_ID"
+        :activeTabId="LearnersTabs.ACTIVITY"
+      >
+        <ActivityList
+          embeddedPageName="ReportsLearnerActivityPage"
+          :noActivityString="coachString('activityListEmptyState')"
+        />
+      </KTabsPanel>
     </KPageContainer>
   </CoachAppBarPage>
 
@@ -26,6 +29,7 @@
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import ActivityList from '../common/notifications/ActivityList';
+  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
   import ReportsLearnerHeader from './ReportsLearnerHeader';
 
   export default {
@@ -36,6 +40,12 @@
       ReportsLearnerHeader,
     },
     mixins: [commonCoach],
+    data() {
+      return {
+        LEARNERS_TABS_ID,
+        LearnersTabs,
+      };
+    },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -78,7 +78,7 @@
     name: 'ReportsLearnerHeader',
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const {saveTabsClick, wereTabsClickedRecently} = useCoachTabs();
+      const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
       return {
         saveTabsClick,
         wereTabsClickedRecently,
@@ -157,7 +157,7 @@
       if (this.wereTabsClickedRecently(this.LEARNERS_TABS_ID)) {
         this.$nextTick(() => {
           this.$refs.tabList.focusActiveTab();
-        })
+        });
       }
     },
     $trs: {
@@ -168,7 +168,7 @@
       },
       reportLearners: {
         message: 'Report learners',
-        context: "Labels the Reports > Learners tab for screen reander users",
+        context: 'Labels the Reports > Learners tab for screen reander users',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -53,13 +53,11 @@
       </HeaderTableRow>
     </HeaderTable>
     <HeaderTabs :enablePrint="enablePrint">
-      <HeaderTab
-        :text="coachString('reportsLabel')"
-        :to="classRoute('ReportsLearnerReportPage', {})"
-      />
-      <HeaderTab
-        :text="coachString('activityLabel')"
-        :to="classRoute('ReportsLearnerActivityPage', {})"
+      <KTabsList
+        :tabsId="LEARNERS_TABS_ID"
+        :activeTabId="activeTabId"
+        ariaLabel="Coach learners"
+        :tabs="tabs"
       />
     </HeaderTabs>
   </div>
@@ -71,6 +69,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
+  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
 
   export default {
     name: 'ReportsLearnerHeader',
@@ -81,6 +80,15 @@
         required: false,
         default: false,
       },
+      activeTabId: {
+        type: String,
+        required: true,
+      },
+    },
+    data() {
+      return {
+        LEARNERS_TABS_ID,
+      };
     },
     computed: {
       learner() {
@@ -114,6 +122,20 @@
             status.status !== this.STATUSES.notStarted
         );
         return statuses.length;
+      },
+      tabs() {
+        return [
+          {
+            id: LearnersTabs.REPORTS,
+            label: this.coachString('reportsLabel'),
+            to: this.classRoute('ReportsLearnerReportPage', {}),
+          },
+          {
+            id: LearnersTabs.ACTIVITY,
+            label: this.coachString('activityLabel'),
+            to: this.classRoute('ReportsLearnerActivityPage', {}),
+          },
+        ];
       },
     },
     $trs: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -54,10 +54,12 @@
     </HeaderTable>
     <HeaderTabs :enablePrint="enablePrint">
       <KTabsList
+        ref="tabList"
         :tabsId="LEARNERS_TABS_ID"
         :activeTabId="activeTabId"
         ariaLabel="Coach learners"
         :tabs="tabs"
+        @click="() => saveTabsClick(LEARNERS_TABS_ID)"
       />
     </HeaderTabs>
   </div>
@@ -70,10 +72,18 @@
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
   import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
+  import { useCoachTabs } from '../../composables/useCoachTabs';
 
   export default {
     name: 'ReportsLearnerHeader',
     mixins: [commonCoach, commonCoreStrings],
+    setup() {
+      const {saveTabsClick, wereTabsClickedRecently} = useCoachTabs();
+      return {
+        saveTabsClick,
+        wereTabsClickedRecently,
+      };
+    },
     props: {
       enablePrint: {
         type: Boolean,
@@ -137,6 +147,18 @@
           },
         ];
       },
+    },
+    mounted() {
+      // focus the active tab but only when it's likely
+      // that this header was re-mounted as a result
+      // of navigation after clicking a tab (focus shouldn't
+      // be manipulated programatically in other cases, e.g.
+      // when visiting the Plan page for the first time)
+      if (this.wereTabsClickedRecently(this.LEARNERS_TABS_ID)) {
+        this.$nextTick(() => {
+          this.$refs.tabList.focusActiveTab();
+        })
+      }
     },
     $trs: {
       back: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -56,8 +56,8 @@
       <KTabsList
         ref="tabList"
         :tabsId="LEARNERS_TABS_ID"
+        :ariaLabel="$tr('reportLearners')"
         :activeTabId="activeTabId"
-        ariaLabel="Coach learners"
         :tabs="tabs"
         @click="() => saveTabsClick(LEARNERS_TABS_ID)"
       />
@@ -165,6 +165,10 @@
         message: 'All learners',
         context:
           "Link that takes user back to the list of learners on the 'Reports' tab, from the individual learner's information page.",
+      },
+      reportLearners: {
+        message: 'Report learners',
+        context: "Labels the Reports > Learners tab for screen reander users",
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -8,84 +8,88 @@
 
     <KPageContainer>
 
-      <ReportsLearnerHeader />
+      <ReportsLearnerHeader :activeTabId="LearnersTabs.REPORTS" />
+      <KTabsPanel
+        :tabsId="LEARNERS_TABS_ID"
+        :activeTabId="LearnersTabs.REPORTS"
+      >
+        <ReportsControls :disableExport="true" />
 
-      <ReportsControls :disableExport="true" />
-
-      <KGrid>
-        <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
-          <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
-          <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
-            <template #headers>
-              <th>{{ coachString('titleLabel') }}</th>
-              <th>{{ coreString('progressLabel') }}</th>
-            </template>
-            <template #tbody>
-              <transition-group
-                tag="tbody"
-                name="list"
-              >
-                <tr
-                  v-for="tableRow in lessonsTable"
-                  :key="tableRow.id"
+        <KGrid>
+          <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
+            <h2>{{ coachString('lessonsAssignedLabel') }}</h2>
+            <CoreTable :emptyMessage="coachString('lessonListEmptyState')">
+              <template #headers>
+                <th>{{ coachString('titleLabel') }}</th>
+                <th>{{ coreString('progressLabel') }}</th>
+              </template>
+              <template #tbody>
+                <transition-group
+                  tag="tbody"
+                  name="list"
                 >
-                  <td>
-                    <KRouterLink
-                      :to="classRoute('ReportsLearnerReportLessonPage', {
-                        lessonId: tableRow.id
-                      })"
-                      :text="tableRow.title"
-                      icon="lesson"
-                    />
-                  </td>
-                  <td>
-                    <StatusSimple :status="tableRow.status" />
-                  </td>
-                </tr>
-              </transition-group>
-            </template>
-          </CoreTable>
-        </KGridItem>
-        <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
-          <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
-          <CoreTable
-            :class="{ print: $isPrint }"
-            :emptyMessage="coachString('quizListEmptyState')"
-          >
-            <template #headers>
-              <th>{{ coachString('titleLabel') }}</th>
-              <th>{{ coreString('progressLabel') }}</th>
-              <th>{{ coreString('scoreLabel') }}</th>
-            </template>
-            <template #tbody>
-              <transition-group
-                tag="tbody"
-                name="list"
-              >
-                <tr
-                  v-for="tableRow in examsTable"
-                  :key="tableRow.id"
+                  <tr
+                    v-for="tableRow in lessonsTable"
+                    :key="tableRow.id"
+                  >
+                    <td>
+                      <KRouterLink
+                        :to="classRoute('ReportsLearnerReportLessonPage', {
+                          lessonId: tableRow.id
+                        })"
+                        :text="tableRow.title"
+                        icon="lesson"
+                      />
+                    </td>
+                    <td>
+                      <StatusSimple :status="tableRow.status" />
+                    </td>
+                  </tr>
+                </transition-group>
+              </template>
+            </CoreTable>
+          </KGridItem>
+          <KGridItem :layout12="{ span: $isPrint ? 12 : 6 }">
+            <h2>{{ coachString('quizzesAssignedLabel') }}</h2>
+            <CoreTable
+              :class="{ print: $isPrint }"
+              :emptyMessage="coachString('quizListEmptyState')"
+            >
+              <template #headers>
+                <th>{{ coachString('titleLabel') }}</th>
+                <th>{{ coreString('progressLabel') }}</th>
+                <th>{{ coreString('scoreLabel') }}</th>
+              </template>
+              <template #tbody>
+                <transition-group
+                  tag="tbody"
+                  name="list"
                 >
-                  <td>
-                    <KRouterLink
-                      :to="quizLink(tableRow.id)"
-                      :text="tableRow.title"
-                      icon="quiz"
-                    />
-                  </td>
-                  <td>
-                    <StatusSimple :status="tableRow.statusObj.status" />
-                  </td>
-                  <td>
-                    <Score :value="tableRow.statusObj.score" />
-                  </td>
-                </tr>
-              </transition-group>
-            </template>
-          </CoreTable>
-        </KGridItem>
-      </KGrid>
+                  <tr
+                    v-for="tableRow in examsTable"
+                    :key="tableRow.id"
+                  >
+                    <td>
+                      <KRouterLink
+                        :to="quizLink(tableRow.id)"
+                        :text="tableRow.title"
+                        icon="quiz"
+                      />
+                    </td>
+                    <td>
+                      <StatusSimple :status="tableRow.statusObj.status" />
+                    </td>
+                    <td>
+                      <Score :value="tableRow.statusObj.score" />
+                    </td>
+                  </tr>
+                </transition-group>
+              </template>
+            </CoreTable>
+          </KGridItem>
+        </KGrid>
 
+      </KTabsPanel>
     </KPageContainer>
   </CoachAppBarPage>
 
@@ -98,6 +102,7 @@
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import { PageNames } from '../../constants';
+  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
   import ReportsLearnerHeader from './ReportsLearnerHeader';
   import ReportsControls from './ReportsControls';
 
@@ -109,6 +114,12 @@
       ReportsControls,
     },
     mixins: [commonCoach, commonCoreStrings],
+    data() {
+      return {
+        LEARNERS_TABS_ID,
+        LearnersTabs,
+      };
+    },
     computed: {
       learner() {
         return this.learnerMap[this.$route.params.learnerId];


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Use KDS tabs (KTabsList and KTabsPanel) in the Learners tab which is inside Coach->Reports->Learners->Select a learner.
Add new constants for the Learners tab inside `tabsConstants.js`

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

#10255

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

To review

Go to Coach->Reports-Learners-Select a learner
For accessibility, use the keyboard and go to the **Reports tab** and then press the **right arrow** to move focus to the **Activity tab**. Press enter to open the focused tab.
For normal, use the mouse to click the respective tab to open.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
