### PR TITLE
Fix collection on lessons assigned to subsets of users

### DIFF
--- a/kolibri/core/lessons/models.py
+++ b/kolibri/core/lessons/models.py
@@ -241,12 +241,15 @@ class IndividualSyncableLesson(AbstractFacilityDataModel):
     @classmethod
     def serialize_lesson(cls, lesson):
         serialized = lesson.serialize()
-        for key in ["is_active", "created_by_id", "date_created", "collection_id"]:
+        for key in ["is_active", "created_by_id", "date_created"]:
             serialized.pop(key, None)
         return serialized
 
-    @classmethod
-    def deserialize_lesson(cls, serialized_lesson):
-        lesson = Lesson.deserialize(serialized_lesson)
+    def deserialize_lesson(self):
+        lesson = Lesson.deserialize(self.serialized_lesson)
         lesson.is_active = True
+        # a lesson's collection should be the classroom, but previously the serialized lesson
+        # did not include the collection_id, so we need to set it here to ensure it isn't null
+        if not lesson.collection_id:
+            lesson.collection_id = self.collection_id
         return lesson

--- a/kolibri/core/lessons/single_user_assignment_utils.py
+++ b/kolibri/core/lessons/single_user_assignment_utils.py
@@ -84,10 +84,7 @@ def update_assignments_from_individual_syncable_lessons(user_id):
     # create new assignments and lessons for all new syncable lesson objects
     for syncablelesson in to_create:
 
-        lesson = IndividualSyncableLesson.deserialize_lesson(
-            syncablelesson.serialized_lesson
-        )
-        lesson.collection_id = syncablelesson.collection_id
+        lesson = syncablelesson.deserialize_lesson()
         # shouldn't need to set this field (as it's nullable, according to the model definition, but got errors)
         lesson.created_by_id = user_id
         lesson.save(update_dirty_bit_to=False)
@@ -115,10 +112,7 @@ def update_assignments_from_individual_syncable_lessons(user_id):
             syncablelesson.serialized_lesson != updated_serialization
             or syncablelesson.collection_id != assignment.collection_id
         ):
-            lesson = IndividualSyncableLesson.deserialize_lesson(
-                syncablelesson.serialized_lesson
-            )
-            lesson.collection_id = syncablelesson.collection_id
+            lesson = syncablelesson.deserialize_lesson()
             lesson.created_by_id = user_id
             lesson.save(update_dirty_bit_to=False)
             assignment.lesson = lesson


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- The logic for handling lessons in LOD syncing set the lessons collection to the same collection as the assignment, which if the assignment collection wasn't the classroom meant the lesson wouldn't be returned by the learn API
- This updates the serialization of lessons for LOD syncing to include its `collection_id` and to avoid overwriting it

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes: https://github.com/learningequality/kolibri/issues/11495

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I ran the morango integration tests, which have coverage over the modified code.

or
1. Create a full server and LOD 
2. Assign a lesson to just the learner, not the full class, as coach on the full device
3. Ensure the lesson is visible on the LOD after syncing

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
