### PR TITLE
Fix setup wizard selection of network devices for sign up or import

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -38,10 +38,10 @@
             :key="idx"
             v-model="selectedDeviceId"
             class="radio-button"
-            :value="canLearnerSignUp(d.id) ? d.id : false"
+            :value="d.id"
             :label="d.nickname"
             :description="d.base_url"
-            :disabled="!canLearnerSignUp(d.id) || formDisabled || !isDeviceAvailable(d.id)"
+            :disabled="formDisabled || !isDeviceAvailable(d.id)"
           />
           <KButton
             :key="`forget-${idx}`"
@@ -65,13 +65,10 @@
             :key="d.id"
             v-model="selectedDeviceId"
             class="radio-button"
-            :value="canLearnerSignUp(d.id) ? d.instance_id : false"
+            :value="d.instance_id"
             :label="formatNameAndId(d.device_name, d.id)"
             :description="formatBaseDevice(d)"
-            :disabled="!canLearnerSignUp(d.id)
-              || formDisabled
-              || fetchFailed
-              || !isDeviceAvailable(d.id)"
+            :disabled="formDisabled || fetchFailed || !isDeviceAvailable(d.id)"
           />
         </div>
       </template>
@@ -136,8 +133,8 @@
 
 <script>
 
-  import { computed, ref } from 'kolibri.lib.vueCompositionApi';
-  import { useLocalStorage, get, computedAsync } from '@vueuse/core';
+  import { computed } from 'kolibri.lib.vueCompositionApi';
+  import { useLocalStorage, get } from '@vueuse/core';
   import find from 'lodash/find';
   import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -150,7 +147,6 @@
     useDevicesForLearnOnlyDevice,
   } from './useDevices.js';
   import useConnectionChecker from './useConnectionChecker.js';
-  import { deviceFacilityCanSignUp } from './api.js';
 
   export default {
     name: 'SelectDeviceForm',
@@ -200,24 +196,6 @@
       const discoveredDevices = computed(() => get(devices).filter(d => d.dynamic));
       const savedDevices = computed(() => get(devices).filter(d => !d.dynamic));
 
-      const isLoading = ref(false);
-
-      const lodsWithSignupFacility = computedAsync(
-        async () => {
-          const devicesAvailable = get(devices);
-          const allDevices = {};
-          for (const i of devicesAvailable) {
-            const canSignUp = await deviceFacilityCanSignUp(i.id);
-            if (canSignUp) {
-              allDevices[i.id] = true;
-            }
-          }
-          return allDevices;
-        },
-        {},
-        isLoading
-      );
-
       return {
         // useDevices
         devices,
@@ -237,7 +215,6 @@
         discoveredDevices,
         savedDevices,
         storageDeviceId,
-        lodsWithSignupFacility,
       };
     },
     props: {
@@ -390,9 +367,6 @@
         return this.doDelete(id).then(() => {
           this.$emit('removed_address');
         });
-      },
-      canLearnerSignUp(id) {
-        return this.lodsWithSignupFacility && id in this.lodsWithSignupFacility;
       },
     },
     $trs: {

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
@@ -61,6 +61,7 @@ describe('SelectDeviceForm', () => {
     const { els, wrapper } = makeWrapper();
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
     expect(wrapper.vm.hasFetched).toBe(true);
     expect(els.radioButtons()).toHaveLength(6);
     const server1 = els.radioButtons().at(0);
@@ -72,6 +73,7 @@ describe('SelectDeviceForm', () => {
   it('if there are no devices, it shows an empty message', async () => {
     fetchDevices.mockResolvedValue([]);
     const { els, wrapper } = makeWrapper();
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(els.radioButtons()).toHaveLength(0);
@@ -87,6 +89,7 @@ describe('SelectDeviceForm', () => {
         .at(n)
         .props().disabled;
     }
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(radioButtonNIsDisabled(0)).toEqual(false);
@@ -106,6 +109,7 @@ describe('SelectDeviceForm', () => {
     await wrapper.vm.$nextTick();
     updateConnectionStatus.mockResolvedValue(staticDevices[0]);
     els.KModal().vm.$emit('submit');
+    await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().submit[0][0].id).toEqual('1');

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
@@ -1,6 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import SelectDeviceForm from '../SelectDeviceForm';
 import { fetchDevices, updateConnectionStatus } from '../api';
+import { ConnectionStatus } from '../constants';
 
 jest.mock('../api.js', () => ({
   fetchDevices: jest.fn(),
@@ -13,25 +14,40 @@ const devices = [
     id: '1',
     instance_id: '1',
     nickname: 'Available Server',
+    device_name: 'Available Server',
     base_url: 'http://localhost:8000',
     application: 'kolibri',
     available: true,
+    is_local: true,
+    since_last_accessed: 0,
+    subset_of_users_device: false,
+    kolibri_version: '0.16.0',
   },
   {
     id: '2',
     instance_id: '2',
     nickname: 'Unavailable Server',
+    device_name: 'Unavailable Server',
     base_url: 'http://localhost:8001',
     application: 'kolibri',
     available: false,
+    is_local: true,
+    since_last_accessed: 0,
+    subset_of_users_device: false,
+    kolibri_version: '0.16.0',
   },
   {
     id: '3',
     instance_id: '3',
     nickname: 'Content-less Server',
+    device_name: 'Content-less Server',
     base_url: 'http://localhost:8001',
     application: 'kolibri',
     available: true,
+    is_local: true,
+    since_last_accessed: 0,
+    subset_of_users_device: false,
+    kolibri_version: '0.16.0',
   },
 ];
 
@@ -52,9 +68,22 @@ function makeWrapper() {
 }
 
 describe('SelectDeviceForm', () => {
+  let devices = [];
   beforeEach(() => {
+    devices = staticDevices.concat(dynamicDevices);
     fetchDevices.mockReset();
-    fetchDevices.mockResolvedValue(staticDevices.concat(dynamicDevices));
+    fetchDevices.mockResolvedValue(devices);
+    updateConnectionStatus.mockImplementation(device => {
+      const updatedDevice = devices.find(d => d.id === device.id);
+      if (!updatedDevice) {
+        return Promise.resolve({
+          ...device,
+          available: false,
+          connection_status: ConnectionStatus.Unknown,
+        });
+      }
+      return Promise.resolve(device);
+    });
   });
 
   it('shows one device for each one fetched', async () => {
@@ -89,6 +118,7 @@ describe('SelectDeviceForm', () => {
         .at(n)
         .props().disabled;
     }
+
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();
     await wrapper.vm.$nextTick();

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/__test__/SelectDeviceForm.spec.js
@@ -6,7 +6,6 @@ jest.mock('../api.js', () => ({
   fetchDevices: jest.fn(),
   deleteDevice: jest.fn().mockResolvedValue(),
   updateConnectionStatus: jest.fn(),
-  deviceFacilityCanSignUp: jest.fn().mockResolvedValue(true),
 }));
 
 const devices = [
@@ -40,13 +39,7 @@ const staticDevices = devices.map(a => ({ ...a, dynamic: false }));
 const dynamicDevices = devices.map(a => ({ ...a, dynamic: true }));
 
 function makeWrapper() {
-  const deviceIdMap = devices.reduce((acc, device) => {
-    acc[device.id] = device;
-    return acc;
-  }, {});
-  const wrapper = shallowMount(SelectDeviceForm, {
-    mocks: { lodsWithSignupFacility: deviceIdMap },
-  });
+  const wrapper = shallowMount(SelectDeviceForm);
   // prettier-ignore
   const els = {
     KModal: () => wrapper.findComponent({ name: 'KModal' }),

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
@@ -1,3 +1,4 @@
+import matches from 'lodash/matches';
 import {
   NetworkLocationResource,
   RemoteChannelResource,
@@ -24,13 +25,20 @@ export function fetchDevices(params = {}) {
 }
 
 /**
- * @param {string} facilityId
+ * @typedef {Object} FacilityFilter
+ * @property {string} [id]
+ * @property {boolean} [learner_can_sign_up]
+ */
+
+/**
  * @param {NetworkLocation} device
+ * @param {FacilityFilter} facility
  * @return {Promise<boolean>}
  */
-export function facilityIsAvailableAtDevice(facilityId, device) {
+export function deviceHasMatchingFacility(device, facility) {
+  // TODO: ideally we could pass along the filters directly to the API
   return NetworkLocationResource.fetchFacilities(device.id).then(({ facilities }) => {
-    return Boolean(facilities.find(({ id }) => id === facilityId));
+    return Boolean(facilities.find(matches(facility)));
   });
 }
 

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
@@ -58,20 +58,3 @@ export function channelIsAvailableAtDevice(channelId, device) {
 export function updateConnectionStatus(device) {
   return NetworkLocationResource.updateConnectionStatus(device.id);
 }
-
-/**
- * @param {string} deviceId
- * @return {Promise<boolean>}
- */
-export function deviceFacilityCanSignUp(deviceId) {
-  return NetworkLocationResource.fetchFacilities(deviceId).then(({ device_id, facilities }) => {
-    if (deviceId === device_id) {
-      for (const facility of facilities) {
-        if (facility.learner_can_sign_up) {
-          return true;
-        }
-      }
-    }
-    return false;
-  });
-}

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
@@ -11,6 +11,7 @@
       :filterByChannelId="filterByChannelId"
       :filterByFacilityId="filterByFacilityId"
       :filterLODAvailable="filterLODAvailable"
+      :filterByFacilityCanSignUp="filterByFacilityCanSignUp"
       :selectedId="addedAddressId"
       :formDisabled="$attrs.selectAddressDisabled"
       @click_add_address="goToAddAddress"
@@ -48,6 +49,11 @@
       filterLODAvailable: {
         type: Boolean,
         default: false,
+      },
+      // When looking for devices for which a learner can sign up
+      filterByFacilityCanSignUp: {
+        type: Boolean,
+        default: null,
       },
     },
     data() {

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -88,7 +88,7 @@ export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
           // result is memoized once successful
           let isAvailable = true;
           for (const filterFunction of filterFunctions) {
-            if (!(await filterFunction(device))) {
+            if (filterFunction && !(await filterFunction(device))) {
               isAvailable = false;
               break;
             }
@@ -96,11 +96,11 @@ export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
 
           // Put into refs to trigger reactive behavior in computed devices
           if (isAvailable) {
-            if (get(availableIds).indexOf(device.id) < 0) {
+            if (!get(availableIds).includes(device.id)) {
               get(availableIds).push(device.id);
             }
           } else {
-            if (get(unavailableIds).indexOf(device.id) < 0) {
+            if (!get(unavailableIds).includes(device.id)) {
               get(unavailableIds).push(device.id);
             }
           }
@@ -119,10 +119,12 @@ export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
     // use computed array that depends on availableIds/unavailableIds
     devices: computed(() => {
       return get(devices)
-        .filter(d => get(unavailableIds).indexOf(d.id) < 0)
+        .filter(d => !get(unavailableIds).includes(d.id))
         .map(d => {
           // set unavailable if we haven't determined if it should be filtered out yet
-          d.available = get(availableIds).indexOf(d.id) >= 0;
+          if (!get(availableIds).includes(d.id)) {
+            d.available = false;
+          }
           return d;
         });
     }),

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -1,4 +1,5 @@
 import logger from 'kolibri.lib.logging';
+import _get from 'lodash/get';
 import isArray from 'lodash/isArray';
 import { ref, reactive, computed, onBeforeUnmount, watch } from 'kolibri.lib.vueCompositionApi';
 import { get, set, useMemoize, useTimeoutPoll } from '@vueuse/core';
@@ -157,7 +158,7 @@ function useAsyncDeviceFilter(filterFunction) {
       return await memoized(device);
     } catch (e) {
       // If not 404 clear cache to try again on next poll
-      if (e?.response?.status !== 404) {
+      if (_get(e, 'response.status') !== 404) {
         memoized.cache.delete(device.id);
         throw e;
       }

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -1,8 +1,9 @@
+import isArray from 'lodash/isArray';
 import { ref, reactive, computed, onBeforeUnmount, watch } from 'kolibri.lib.vueCompositionApi';
 import { get, set, useMemoize, useTimeoutPoll } from '@vueuse/core';
 
 import useMinimumKolibriVersion from 'kolibri.coreVue.composables.useMinimumKolibriVersion';
-import { fetchDevices, channelIsAvailableAtDevice, facilityIsAvailableAtDevice } from './api';
+import { fetchDevices, channelIsAvailableAtDevice, deviceHasMatchingFacility } from './api';
 
 /**
  * @param {{}} apiParams
@@ -55,13 +56,15 @@ export default function useDevices(apiParams = {}) {
 /**
  *
  * @param {{}} apiParams
- * @param {function(NetworkLocation): Promise<bool>} filterFunction
+ * @param {
+ *  function(NetworkLocation): Promise<bool>|[function(NetworkLocation): Promise<bool>]
+ * } filterFunctionOrFunctions
  * @return {{
  *  devices: Ref<NetworkLocation[]>, hasFetched: Ref<bool>, isFetching: Ref<bool>,
  *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
  * }}
  */
-function useDevicesWithFilter(apiParams, filterFunction) {
+export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
   const isFiltering = ref(false);
   const filteringFailed = ref(false);
   const hasFiltered = ref(false);
@@ -69,7 +72,9 @@ function useDevicesWithFilter(apiParams, filterFunction) {
   const unavailableIds = ref([]);
   const { devices, isFetching, fetchFailed, hasFetched, forceFetch } = useDevices(apiParams);
 
-  const getIsAvailable = useMemoize(filterFunction, { getKey: device => device.id });
+  const filterFunctions = isArray(filterFunctionOrFunctions)
+    ? filterFunctionOrFunctions
+    : [filterFunctionOrFunctions];
 
   // await for changes in devices array
   watch(devices, async devices => {
@@ -81,7 +86,13 @@ function useDevicesWithFilter(apiParams, filterFunction) {
       get(devices).map(async device => {
         try {
           // result is memoized once successful
-          const isAvailable = await getIsAvailable(device);
+          let isAvailable = true;
+          for (const filterFunction of filterFunctions) {
+            if (!(await filterFunction(device))) {
+              isAvailable = false;
+              break;
+            }
+          }
 
           // Put into refs to trigger reactive behavior in computed devices
           if (isAvailable) {
@@ -94,13 +105,7 @@ function useDevicesWithFilter(apiParams, filterFunction) {
             }
           }
         } catch (e) {
-          // clear cache to try again on next poll
-          getIsAvailable.cache.delete(device.id);
-
-          // If 404, don't mark as failed
-          if (e.response.status !== 404) {
-            failed = true;
-          }
+          failed = true;
         }
       })
     );
@@ -129,51 +134,83 @@ function useDevicesWithFilter(apiParams, filterFunction) {
 }
 
 /**
- * Filters devices to those that also have the specified channel
- * @param channelId
- * @return {{
- *  devices: Ref<NetworkLocation[]>, hasFetched: Ref<bool>, isFetching: Ref<bool>,
- *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
- * }}
+ * Produces a memoized function that returns a Promise resolving with a boolean for filtering
+ * devices, and automatically clears memoized result if it fails, unless it is a 404
+ *
+ * @param {function(NetworkLocation): Promise<boolean>} filterFunction
+ * @return {(function(NetworkLocation): Promise<boolean>)}
  */
-export function useDevicesWithChannel(channelId = '') {
-  // If channelId is not provided, then we are at top-level import workflow and do not
-  // disable any devices unless it is unavailable
-  const filterDevices =
-    channelId === '' ? () => Promise.resolve(true) : channelIsAvailableAtDevice.bind({}, channelId);
+function useAsyncDeviceFilter(filterFunction) {
+  const memoized = useMemoize(filterFunction, { getKey: device => device.id });
 
-  return useDevicesWithFilter({}, filterDevices);
+  return async function deviceFilter(device) {
+    try {
+      return await memoized(device);
+    } catch (e) {
+      // If not 404 clear cache to try again on next poll
+      if (e?.response?.status !== 404) {
+        memoized.cache.delete(device.id);
+        throw e;
+      }
+
+      return false;
+    }
+  };
 }
 
 /**
- * Filters devices to those that also have the specified facility
- * @param facilityId
- * @return {{
- *  devices: Ref<NetworkLocation[]>, hasFetched: Ref<bool>, isFetching: Ref<bool>,
- *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
- * }}
+ * Produces a function that resolves with a boolean for a device that has the specified facility
+ * @param {string|null} [id]
+ * @param {bool|null} [learner_can_sign_up]
+ * @return {function(NetworkLocation): Promise<boolean>}
  */
-export function useDevicesWithFacility({ facilityId = '', soud = false } = {}) {
-  // If facilityId is not provided, then we are at the initial Facility Import workflow
-  // disable any devices unless it is unavailable/offline
-  const filterDevices =
-    facilityId === ''
-      ? () => Promise.resolve(true)
-      : facilityIsAvailableAtDevice.bind({}, facilityId);
+export function useDeviceFacilityFilter({ id = null, learner_can_sign_up = null }) {
+  const filters = {};
 
-  return useDevicesWithFilter({ subset_of_users_device: soud }, filterDevices);
-}
+  // If `id` is an empty string, we don't want to filter by that
+  if (id) {
+    filters.id = id;
+  }
 
-/**
- * Filters devices to those that are not SoUDs/LOD, since SoUD/LOD sync to full-facility devices
- * @return {{
- *  devices: Ref<NetworkLocation[]>, hasFetched: Ref<bool>, isFetching: Ref<bool>,
- *  filterFailed: Ref<bool>, forceFetch: (function(): Promise<void>)
- * }}
- */
-export function useDevicesForLearnOnlyDevice() {
-  const { isMinimumKolibriVersion } = useMinimumKolibriVersion(0, 15, 0);
-  return useDevicesWithFilter({ subset_of_users_device: false }, async device => {
-    return isMinimumKolibriVersion(device.kolibri_version);
+  if (learner_can_sign_up !== null) {
+    filters.learner_can_sign_up = learner_can_sign_up;
+  }
+
+  if (Object.keys(filters).length === 0) {
+    return () => Promise.resolve(true);
+  }
+
+  return useAsyncDeviceFilter(function deviceFacilityFilter(device) {
+    return deviceHasMatchingFacility(device, filters);
   });
+}
+
+/**
+ * Produces a function that resolves with a boolean for a device that has the specified channel
+ * @param {string|null} id
+ * @return {function(NetworkLocation): Promise<boolean>}
+ */
+export function useDeviceChannelFilter({ id = null }) {
+  if (!id) {
+    return () => Promise.resolve(true);
+  }
+
+  return useAsyncDeviceFilter(function deviceChannelFilter(device) {
+    return channelIsAvailableAtDevice(id, device);
+  });
+}
+
+/**
+ * Produces a function that resolves with a boolean if Kolibri version is at least the specified
+ * @param {number} major
+ * @param {number} minor
+ * @param {number} patch
+ * @return {function(NetworkLocation): Promise<boolean>}
+ */
+export function useDeviceMinimumVersionFilter(major, minor, patch) {
+  const { isMinimumKolibriVersion } = useMinimumKolibriVersion(major, minor, patch);
+
+  return async function deviceMinimumVersionFilter(device) {
+    return isMinimumKolibriVersion(device.kolibri_version);
+  };
 }

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -1,9 +1,12 @@
+import logger from 'kolibri.lib.logging';
 import isArray from 'lodash/isArray';
 import { ref, reactive, computed, onBeforeUnmount, watch } from 'kolibri.lib.vueCompositionApi';
 import { get, set, useMemoize, useTimeoutPoll } from '@vueuse/core';
 
 import useMinimumKolibriVersion from 'kolibri.coreVue.composables.useMinimumKolibriVersion';
 import { fetchDevices, channelIsAvailableAtDevice, deviceHasMatchingFacility } from './api';
+
+const logging = logger.getLogger(__filename);
 
 /**
  * @param {{}} apiParams
@@ -105,6 +108,7 @@ export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
             }
           }
         } catch (e) {
+          logging.error(e);
           failed = true;
         }
       })
@@ -123,7 +127,10 @@ export function useDevicesWithFilter(apiParams, filterFunctionOrFunctions) {
         .map(d => {
           // set unavailable if we haven't determined if it should be filtered out yet
           if (!get(availableIds).includes(d.id)) {
-            d.available = false;
+            return {
+              ...d,
+              available: false,
+            };
           }
           return d;
         });

--- a/kolibri/core/assets/src/views/sync/syncComponentSet.js
+++ b/kolibri/core/assets/src/views/sync/syncComponentSet.js
@@ -11,9 +11,10 @@ export { default as SelectSourceModal } from './SelectSourceModal';
 export { default as SyncFacilityModalGroup } from './SyncFacilityModalGroup';
 export {
   default as useDevices,
-  useDevicesForLearnOnlyDevice,
-  useDevicesWithFacility,
-  useDevicesWithChannel,
+  useDevicesWithFilter,
+  useDeviceChannelFilter,
+  useDeviceFacilityFilter,
+  useDeviceMinimumVersionFilter,
 } from './SelectDeviceModalGroup/useDevices';
 export { default as useDeviceDeletion } from './SelectDeviceModalGroup/useDeviceDeletion';
 export { default as useConnectionChecker } from './SelectDeviceModalGroup/useConnectionChecker';

--- a/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
+++ b/kolibri/plugins/learn/assets/src/views/HomePage/__tests__/HomePage.spec.js
@@ -2,7 +2,7 @@ import { mount, createLocalVue } from '@vue/test-utils';
 import VueRouter from 'vue-router';
 import Vuex from 'vuex';
 
-import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+import { useDevicesWithFilter } from 'kolibri.coreVue.componentSets.sync';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 import { ClassesPageNames, PageNames } from '../../../constants';
@@ -112,7 +112,7 @@ describe(`HomePage`, () => {
     useUser.mockImplementation(() => useUserMock());
     useDeviceSettings.mockImplementation(() => useDeviceSettingsMock());
     useLearnerResources.mockImplementation(() => useLearnerResourcesMock());
-    useDevicesWithFacility.mockReturnValue({
+    useDevicesWithFilter.mockReturnValue({
       devices: [
         {
           id: '1',

--- a/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/learning-activity-bar.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount, mount } from '@vue/test-utils';
-import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+import { useDevicesWithFilter } from 'kolibri.coreVue.componentSets.sync';
 import { LearningActivities } from 'kolibri.coreVue.vuex.constants';
 import LearningActivityBar from '../../src/views/LearningActivityBar';
 
@@ -12,7 +12,7 @@ function makeWrapper({ propsData } = {}) {
 
 describe('LearningActivityBar', () => {
   beforeEach(() => {
-    useDevicesWithFacility.mockReturnValue({
+    useDevicesWithFilter.mockReturnValue({
       devices: [
         {
           id: '1',

--- a/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/topics-page.spec.js
@@ -4,7 +4,7 @@ import { createLocalVue, shallowMount, mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import KBreadcrumbs from 'kolibri-design-system/lib/KBreadcrumbs';
 import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
-import { useDevicesWithFacility } from 'kolibri.coreVue.componentSets.sync';
+import { useDevicesWithFilter } from 'kolibri.coreVue.componentSets.sync';
 import { ContentNodeResource } from 'kolibri.resources';
 import plugin_data from 'plugin_data';
 import makeStore from '../makeStore';
@@ -139,7 +139,7 @@ describe('TopicsPage', () => {
       ...store.state.core,
       loading: false,
     };
-    useDevicesWithFacility.mockReturnValue({
+    useDevicesWithFilter.mockReturnValue({
       devices: [
         {
           id: '1',

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -19,6 +19,7 @@
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
+      :filterByFacilityCanSignUp="selected === Options.JOIN ? true : null"
       @cancel="showSelectAddressModal = false"
       @submit="handleContinueImport"
     />

--- a/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
+++ b/packages/kolibri-common/components/SyncSchedule/ManageSyncSchedule.vue
@@ -126,7 +126,8 @@
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
   import {
     SyncFacilityModalGroup,
-    useDevicesWithFacility,
+    useDeviceFacilityFilter,
+    useDevicesWithFilter,
   } from 'kolibri.coreVue.componentSets.sync';
   import { TaskTypes } from 'kolibri.utils.syncTaskUtils';
   import { KDP_ID, oneHour, oneDay, oneWeek, twoWeeks, oneMonth } from './constants';
@@ -142,7 +143,13 @@
     extends: ImmersivePage,
     mixins: [commonCoreStrings, commonSyncElements],
     setup(props) {
-      const { devices } = useDevicesWithFacility({ facilityId: props.facilityId });
+      const deviceFilter = useDeviceFacilityFilter({ id: props.facilityId });
+      const { devices } = useDevicesWithFilter(
+        {
+          subset_of_users_device: false,
+        },
+        deviceFilter
+      );
       const devicesById = computed(() => {
         return devices.value.reduce(
           (acc, device) => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Reverts prior change that implemented filtering on whether a learner can signup
- Implements, through refactoring, method for flexible filtering of facilities which is now supported through the selection form

### With learner sign up disabled
| Join | Import |
| --- | --- |
| ![Screenshot from 2023-11-08 12-23-04](https://github.com/learningequality/kolibri/assets/819838/2b03fab9-6797-423c-931f-2248393e4e93) | ![Screenshot from 2023-11-08 12-22-53](https://github.com/learningequality/kolibri/assets/819838/ab14ab7e-847f-4003-987b-30f456716c1d) | 

### With learner signup enabled
| Join | Import |
| --- | --- |
| ![Screenshot from 2023-11-08 12-41-28](https://github.com/learningequality/kolibri/assets/819838/cbdc7dc0-bcaa-4beb-8e51-4483a2975c6f) |  ![Screenshot from 2023-11-08 12-41-39](https://github.com/learningequality/kolibri/assets/819838/00255b0f-08e0-4f70-90b3-e08d70e21ac6) |


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes: https://github.com/learningequality/kolibri/issues/11496

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Tested the signup flow and channel import

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
