### PR TITLE
Swap on-my-own const for using the existing Personal const

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/constants.js
+++ b/kolibri/plugins/setup_wizard/assets/src/constants.js
@@ -11,7 +11,6 @@ const Presets = Object.freeze({
  * enum identifying whether the user has gone to the on my own flow or not
  */
 const UsePresets = Object.freeze({
-  ON_MY_OWN: 'on my own',
   GROUP: 'group',
 });
 

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -1,6 +1,12 @@
 import uniq from 'lodash/uniq';
 import { checkCapability } from 'kolibri.utils.appCapabilities';
-import { DeviceTypePresets, FacilityTypePresets, LodTypePresets, UsePresets } from '../constants';
+import {
+  DeviceTypePresets,
+  FacilityTypePresets,
+  LodTypePresets,
+  UsePresets,
+  Presets,
+} from '../constants';
 
 /**
  * __ Setting up the XState Visualizer __
@@ -536,7 +542,7 @@ export const wizardMachine = createMachine(
       // Functions used to return a true/false value. When the functions are called, they are passed
       // the current value of the machine's context as the only parameter
       isOnMyOwnOrGroup: context => {
-        return context.onMyOwnOrGroup === UsePresets.ON_MY_OWN;
+        return context.onMyOwnOrGroup === Presets.PERSONAL;
       },
       isGroupSetup: context => {
         return context.onMyOwnOrGroup === UsePresets.GROUP;

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -42,9 +42,6 @@
       };
     },
     computed: {
-      isOnMyOwnSetup() {
-        return this.selected === Presets.PERSONAL;
-      },
       UsePresets() {
         return UsePresets;
       },
@@ -54,14 +51,6 @@
     },
     methods: {
       handleContinue() {
-        if (this.isOnMyOwnSetup) {
-          // If the user is on their own, set the preset to personal here
-          // If not then the user will set it using a form later on
-          this.$store.commit('SET_FACILITY_PRESET', Presets.PERSONAL);
-        }
-        this.goToNextStep();
-      },
-      goToNextStep() {
         this.wizardService.send({ type: 'CONTINUE', value: this.selected });
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -9,7 +9,7 @@
     <KRadioButton
       v-model="selected"
       style="margin-bottom: 1em"
-      :value="UsePresets.ON_MY_OWN"
+      :value="Presets.PERSONAL"
       :label="$tr('onMyOwnLabel')"
       :description="getCommonSyncString('onMyOwn')"
     />
@@ -36,17 +36,20 @@
     mixins: [commonSyncElements],
     inject: ['wizardService'],
     data() {
-      const selected = this.wizardService.state.context['onMyOwnOrGroup'] || UsePresets.ON_MY_OWN;
+      const selected = this.wizardService.state.context['onMyOwnOrGroup'] || Presets.PERSONAL;
       return {
         selected,
       };
     },
     computed: {
       isOnMyOwnSetup() {
-        return this.selected === UsePresets.ON_MY_OWN;
+        return this.selected === Presets.PERSONAL;
       },
       UsePresets() {
         return UsePresets;
+      },
+      Presets() {
+        return Presets;
       },
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -44,7 +44,7 @@
   import urls from 'kolibri.urls';
   import client from 'kolibri.client';
   import Lockr from 'lockr';
-  import { DeviceTypePresets, UsePresets } from '../../constants';
+  import { DeviceTypePresets, Presets } from '../../constants';
 
   export default {
     name: 'SettingUpKolibri',
@@ -160,7 +160,7 @@
 
       /** Introspecting the machine via it's `state.context` properties */
       isOnMyOwnSetup() {
-        return this.wizardContext('onMyOwnOrGroup') == UsePresets.ON_MY_OWN;
+        return this.wizardContext('onMyOwnOrGroup') == Presets.PERSONAL;
       },
     },
     created() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -143,7 +143,7 @@
           ...this.facilityData,
           superuser,
           settings: omitBy(settings, v => v === null),
-          preset: this.wizardContext('formalOrNonformal') || 'nonformal',
+          preset: this.presetValue,
           language_id: currentLanguage,
           device_name:
             this.wizardContext('deviceName') ||
@@ -161,6 +161,16 @@
       /** Introspecting the machine via it's `state.context` properties */
       isOnMyOwnSetup() {
         return this.wizardContext('onMyOwnOrGroup') == Presets.PERSONAL;
+      },
+      presetValue() {
+        // this computed prop was to guard against a strange edge case where a mismatched
+        // preset was inadvertently being sent to the backend, where the values
+        // were not valid, including an incorrect fallback, and 'on my own' being sent as a value
+        if (this.isOnMyOwnSetup) {
+          return Presets.PERSONAL;
+        } else {
+          return this.wizardContext('formalOrNonformal');
+        }
       },
     },
     created() {


### PR DESCRIPTION
prevent state management snafus

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
