### PR TITLE
limit number of cards visible in "Recent"

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -4,6 +4,7 @@
     <component
       :is="!windowIsSmall && currentCardViewStyle === 'list' ? 'div' : 'CardGrid'"
       :data-test="`${windowIsSmall ? '' : 'non-'}mobile-card-grid`"
+      :style="{ maxWidth: '1700px' }"
     >
       <component
         :is="componentType"

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -40,6 +40,7 @@
     <!-- if all items in initial backend response are not already being shown -->
     <KButton
       v-if="moreContentCards && !showMoreContentCards"
+      data-test="show-more-resumable-nodes-button"
       appearance="basic-link"
       @click="handleShowMoreContentCards"
     >
@@ -49,7 +50,7 @@
     <!-- if there are 13+ recent items & the first 12 are currently visible -->
     <KButton
       v-if="moreResumableContentNodes && showMoreContentCards"
-      data-test="more-resumable-nodes-button"
+      data-test="view-more-resumable-nodes-button"
       appearance="basic-link"
       @click="fetchMoreResumableContentNodes"
     >

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -28,7 +28,7 @@
         {{ $tr('recent') }}
       </h2>
       <LibraryAndChannelBrowserMainContent
-        :contents="resumableContentNodes"
+        :contents="contentCardsToDisplay"
         data-test="resumable-content-card-grid"
         :currentCardViewStyle="currentCardViewStyle"
         :gridType="1"
@@ -36,8 +36,19 @@
         @toggleInfoPanel="$emit('setSidePanelMetadataContent', $event)"
       />
     </div>
+
+    <!-- if all items in initial backend response are not already being shown -->
     <KButton
-      v-if="moreResumableContentNodes"
+      v-if="moreContentCards && !showMoreContentCards"
+      appearance="basic-link"
+      @click="handleShowMoreContentCards"
+    >
+      {{ coreString('showMoreAction') }}
+    </KButton>
+
+    <!-- if there are 13+ recent items & the first 12 are currently visible -->
+    <KButton
+      v-if="moreResumableContentNodes && showMoreContentCards"
       data-test="more-resumable-nodes-button"
       appearance="basic-link"
       @click="fetchMoreResumableContentNodes"
@@ -109,12 +120,31 @@
     },
     data() {
       return {
+        showMoreContentCards: false,
         displayedCopies: [],
       };
+    },
+    computed: {
+      numContentCardsToDisplay() {
+        return this.windowBreakpoint === 2 ? 4 : 3;
+      },
+      contentCardsToDisplay() {
+        if (this.showMoreContentCards) {
+          return this.resumableContentNodes;
+        } else {
+          return this.resumableContentNodes.slice(0, this.numContentCardsToDisplay);
+        }
+      },
+      moreContentCards() {
+        return this.resumableContentNodes.length > this.numContentCardsToDisplay;
+      },
     },
     methods: {
       toggleCardView(value) {
         this.$emit('setCardStyle', value);
+      },
+      handleShowMoreContentCards() {
+        this.showMoreContentCards = true;
       },
     },
     $trs: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -37,7 +37,7 @@
       />
     </div>
     <KButton
-      v-if="(moreResumableContentNodes || []).length"
+      v-if="moreResumableContentNodes"
       data-test="more-resumable-nodes-button"
       appearance="basic-link"
       @click="fetchMoreResumableContentNodes"

--- a/kolibri/plugins/learn/assets/test/views/resumable-content-grid.spec.js
+++ b/kolibri/plugins/learn/assets/test/views/resumable-content-grid.spec.js
@@ -13,12 +13,25 @@ describe('when there are nodes with progress that can be resumed', () => {
     useLearnerResources.mockImplementation(() =>
       useLearnerResourcesMock({
         /*
-         * moreResumableContentNodes having length would realistically mean
-         * that there are a significant number of resumableContentNodes but we
+         * moreResumableContentNodes existing would realistically mean
+         * that there are 13+ resumableContentNodes but we
          * rely on useSearch to handle the details of that implementation
          */
-        resumableContentNodes: [{ node: 1 }],
-        moreResumableContentNodes: [{ node: 2 }],
+        resumableContentNodes: [
+          { node: 1 },
+          { node: 2 },
+          { node: 3 },
+          { node: 4 },
+          { node: 5 },
+          { node: 6 },
+          { node: 7 },
+          { node: 8 },
+          { node: 9 },
+          { node: 10 },
+          { node: 11 },
+          { node: 12 },
+        ],
+        moreResumableContentNodes: { cursor: 'rogkor2', resume: true },
       })
     )
   );
@@ -47,20 +60,53 @@ describe('when there are nodes with progress that can be resumed', () => {
     expect(wrapper.find('[data-test="resumable-content-card-grid"').element).toBeTruthy();
   });
 
-  it('displays button to show more resumableContentNodes when there are moreResumableContentNodes', () => {
-    const wrapper = shallowMount(ResumableContentGrid, {});
-    expect(wrapper.find('[data-test="more-resumable-nodes-button"').element).toBeTruthy();
+  it('displays button to "show more" when more items exist than currently shown', () => {
+    const wrapper = shallowMount(ResumableContentGrid, {
+      data: function() {
+        return { showMoreContentCards: false };
+      },
+      computed: { moreContentCards: () => true },
+    });
+    expect(wrapper.find('[data-test="show-more-resumable-nodes-button"').element).toBeTruthy();
   });
 
-  it('does not show a button to show more resumableContentNodes when there are no moreResumableContentNodes', () => {
-    jest.clearAllMocks();
-    useLearnerResources.mockImplementation(() =>
-      useLearnerResourcesMock({
-        resumableContentNodes: [{ node: 1 }],
-        moreResumableContentNodes: [],
-      })
-    );
-    const wrapper = shallowMount(ResumableContentGrid, {});
-    expect(wrapper.find('[data-test="more-resumable-nodes-button"').element).toBeFalsy();
+  it('does not show a button to "show more" if button already pressed', () => {
+    const wrapper = shallowMount(ResumableContentGrid, {
+      data: function() {
+        return { showMoreContentCards: true };
+      },
+      computed: { moreContentCards: () => false },
+    });
+    expect(wrapper.find('[data-test="show-more-resumable-nodes-button"').element).toBeFalsy();
+  });
+
+  it('does not show a button to "show more" if number of items does not exceed that displayed', () => {
+    const wrapper = shallowMount(ResumableContentGrid, {
+      data: function() {
+        return { showMoreContentCards: true };
+      },
+      computed: { moreContentCards: () => false },
+    });
+    expect(wrapper.find('[data-test="show-more-resumable-nodes-button"').element).toBeFalsy();
+  });
+
+  it('displays button to view more resumableContentNodes when there are 13+ recent items & 12 are currently displayed', () => {
+    const wrapper = shallowMount(ResumableContentGrid, {
+      data: function() {
+        return { showMoreContentCards: true };
+      },
+      computed: { moreContentCards: () => true },
+    });
+    expect(wrapper.find('[data-test="view-more-resumable-nodes-button"').element).toBeTruthy();
+  });
+
+  it('does not show a button to view more resumableContentNodes if "show more" has not been exhausted', () => {
+    const wrapper = shallowMount(ResumableContentGrid, {
+      data: function() {
+        return { showMoreContentCards: false };
+      },
+      computed: { moreContentCards: () => true },
+    });
+    expect(wrapper.find('[data-test="view-more-resumable-nodes-button"').element).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary
the "Recent" section in `Learn` > `Library` was initially displaying up to 12 recent items, and never displaying "View more" if there were 13+ items (due to a small, additional bug). 

this PR changes the "Recent" section to almost always initially display 3 cards (4 at a specific window size), rendering a "Show more" button if there are additional items. Once all 12 items in the initial BE response are shown, if there are still more recent items, a "View more" button will now render and allow the option to display those as well. 

### Before
#### User with 13 recent items - 12 shown with no option to see the 13th
(sidenav weirdness due to screenshot app)
![image](https://github.com/learningequality/kolibri/assets/43046460/e582a30f-9abb-4ed6-a3f7-66740f2c6810)


### After
#### Window larger than breakpoint 2
![image](https://github.com/learningequality/kolibri/assets/43046460/1ebb616e-8f0a-4e47-a8e4-7d3884efd2a4)

#### Window at breakpoint 2
![image](https://github.com/learningequality/kolibri/assets/43046460/136bf43e-da2d-4d99-bd34-e56c5dc648db)

#### Window smaller than breakpoint 2
![image](https://github.com/learningequality/kolibri/assets/43046460/3a3030b6-5150-47f6-97e2-f065d24ffd73)

#### User with 13 recent items, with "Show more" clicked
![image](https://github.com/learningequality/kolibri/assets/43046460/1e2f587f-27b4-4b80-aa71-534383bbf19e)

#### User with 13 recent items with "Show more" & "View more" clicked
![image](https://github.com/learningequality/kolibri/assets/43046460/6cab9e3b-e8a7-45ca-a86d-f108b2ae5842)



## References
Resolves #11438 

## Reviewer guidance
- all changes have taken place in `Learn` > `Library` > "Recent" section
- note behavior & appearance of cards in "Recent" section as a user with:
    - 3-4 recently viewed items ==> if window size is at anything but window breakpoint 2 (narrow-medium size), user should see 3 cards displayed in section, with no "Show more" or "View more" buttons. if at breakpoint 2, the same applies but for 4 cards. 
    - 5-12 recently viewed items ===> 3-4 cards should be displayed based on window size as described above, with a "Show more" button rendered that, when clicked, displays all items, up to and including the 12th.
    - 13+ recently viewed items ===> same expected behavior as above, but once "Show more" is pressed and 12 cards are visible, "View more" button should render and display the 13th item and beyond once clicked. 


## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
