### PR TITLE
Support content renderable_only option in tasks API

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -100,6 +100,7 @@ class ChannelResourcesValidator(ChannelValidator):
 
 class ChannelResourcesImportValidator(ChannelResourcesValidator):
     update = serializers.BooleanField(default=False)
+    renderable_only = serializers.BooleanField(default=True)
     fail_on_error = serializers.BooleanField(default=False)
     new_version = serializers.IntegerField(required=False)
     all_thumbnails = serializers.BooleanField(default=False)
@@ -109,6 +110,7 @@ class ChannelResourcesImportValidator(ChannelResourcesValidator):
         job_data["kwargs"].update(
             {
                 "update": data.get("update"),
+                "renderable_only": data.get("renderable_only"),
                 "fail_on_error": data.get("fail_on_error"),
                 "all_thumbnails": data.get("all_thumbnails"),
             }
@@ -158,6 +160,7 @@ def diskcontentimport(
     update=False,
     node_ids=None,
     exclude_node_ids=None,
+    renderable_only=True,
     fail_on_error=False,
     all_thumbnails=False,
 ):
@@ -171,6 +174,7 @@ def diskcontentimport(
         drive_id=drive_id,
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
+        renderable_only=renderable_only,
         fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,
     )
@@ -247,6 +251,7 @@ def remotecontentimport(
     node_ids=None,
     exclude_node_ids=None,
     update=False,
+    renderable_only=True,
     fail_on_error=False,
     all_thumbnails=False,
 ):
@@ -259,6 +264,7 @@ def remotecontentimport(
         peer_id=peer_id,
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
+        renderable_only=renderable_only,
         fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,
     )
@@ -525,6 +531,7 @@ def remoteimport(
     node_ids=None,
     exclude_node_ids=None,
     update=False,
+    renderable_only=True,
     fail_on_error=False,
     all_thumbnails=False,
 ):
@@ -549,6 +556,7 @@ def remoteimport(
         peer_id=peer_id,
         node_ids=node_ids,
         exclude_node_ids=exclude_node_ids,
+        renderable_only=renderable_only,
         fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,
     )
@@ -570,6 +578,7 @@ def diskimport(
     update=False,
     node_ids=None,
     exclude_node_ids=None,
+    renderable_only=True,
     fail_on_error=False,
     all_thumbnails=False,
 ):
@@ -596,6 +605,7 @@ def diskimport(
         path=drive.datafolder,
         drive_id=drive_id,
         node_ids=node_ids,
+        renderable_only=renderable_only,
         exclude_node_ids=exclude_node_ids,
         fail_on_error=fail_on_error,
         all_thumbnails=all_thumbnails,


### PR DESCRIPTION
This is the last non-backend specific option to allow the tasks API to have the same interface as the CLI.

<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I wanted to make an API request to import content with `renderable_only=False` (equivalent to `--include-unrenderable-content`), but that's not in the API.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Similar to #10229.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Create a homedir and provision the facility with a superuser. Then run the server with `--settings kolibri.deployment.default.settings.dev` so it accepts HTTP Basic authentication. Then you can trigger a content import like:

```
curl -u "$user:$password" -H 'Content-Type: application/json' -d '{"type": "kolibri.core.content.tasks.remotecontentimport", "channel_id": "$some_channel_id", "channel_name": "something", "renderable_only": false}' http://127.0.0.1:8080/api/tasks/tasks/
```

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
