### PR TITLE
Misc fixes for LOD syncing and upgrade Morango

### DIFF
--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -27,7 +27,9 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
         """
         :type context: morango.sync.context.LocalSessionContext
         """
-        if context.is_receiver:
+        from kolibri.core.device.utils import device_provisioned
+
+        if context.is_receiver and device_provisioned():
             is_pull = context.is_pull
             is_push = context.is_push
             sync_filter = str(context.filter)

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -466,7 +466,8 @@ def enqueue_soud_sync_processing(force=False):
                 )
                 return
             # Otherwise, cancel the existing job, and re-enqueue
-            job_storage.cancel_if_exists(SOUD_SYNC_PROCESSING_JOB_ID)
+            logger.info("Would be canceling SoUD sync processing job")
+            # job_storage.cancel_if_exists(SOUD_SYNC_PROCESSING_JOB_ID)
         except JobNotFound:
             pass
 

--- a/kolibri/core/auth/test/test_hooks.py
+++ b/kolibri/core/auth/test/test_hooks.py
@@ -4,6 +4,7 @@ import mock
 from django.test import TestCase
 from morango.sync.context import LocalSessionContext
 
+from .helpers import provision_device
 from kolibri.core.auth.kolibri_plugin import AuthSyncHook
 from kolibri.core.auth.kolibri_plugin import CleanUpTaskOperation
 
@@ -11,6 +12,7 @@ from kolibri.core.auth.kolibri_plugin import CleanUpTaskOperation
 @mock.patch("kolibri.core.auth.kolibri_plugin.cleanupsync")
 class CleanUpTaskOperationTestCase(TestCase):
     def setUp(self):
+        provision_device()
         self.context = mock.MagicMock(
             spec=LocalSessionContext(),
             filter=uuid.uuid4().hex,

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -318,7 +318,7 @@ def get_time_to_next_attempt():
     )
     if attempt_at is None:
         return None
-    return datetime.timedelta(seconds=attempt_at - time.time())
+    return datetime.timedelta(seconds=max(attempt_at - time.time(), 0))
 
 
 def attempt_execute_window():
@@ -376,6 +376,9 @@ def execute_sync(context):
     sync_queue.save()
 
     try:
+        if not context.network_location:
+            raise NetworkLocation.DoesNotExist
+
         call_command(
             command,
             user=context.user_id,

--- a/kolibri/core/device/soud.py
+++ b/kolibri/core/device/soud.py
@@ -390,6 +390,7 @@ def execute_sync(context):
         cleanup = True
         logger.debug("{} Network location unavailable".format(context))
         sync_queue.status = SyncQueueStatus.Pending
+        sync_queue.increment_and_backoff_next_attempt()
     except Exception as e:
         cleanup = True
         if isinstance(e, MorangoResumeSyncError):

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -6,8 +6,10 @@ import uuid
 from functools import partial
 
 import mock
+from django.db.models.signals import post_save
 from django.test import TestCase
 from morango.errors import MorangoResumeSyncError
+from morango.sync.utils import mute_signals
 
 from ..soud import Context
 from ..soud import execute_sync
@@ -167,6 +169,7 @@ class SoudRequestSyncHookHandlerTestCase(TestCase):
         self.assertEqual(queue.updated, updated)
 
 
+@mute_signals(post_save)
 class SoudExecuteSyncsTestCase(TestCase):
     multi_db = True
 
@@ -368,6 +371,7 @@ class SoudExecuteSyncsTestCase(TestCase):
             )
 
 
+@mute_signals(post_save)
 class SoudExecuteSyncTestCase(TestCase):
     multi_db = True
 

--- a/kolibri/core/device/test/test_soud.py
+++ b/kolibri/core/device/test/test_soud.py
@@ -3,12 +3,17 @@ Subset of Users Device (SOUD) tests
 """
 import time
 import uuid
+from functools import partial
 
 import mock
 from django.test import TestCase
+from morango.errors import MorangoResumeSyncError
 
 from ..soud import Context
+from ..soud import execute_sync
+from ..soud import execute_syncs
 from ..soud import request_sync_hook
+from ..soud import WINDOW_SEC
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import SyncQueue
@@ -160,3 +165,358 @@ class SoudRequestSyncHookHandlerTestCase(TestCase):
         queue.refresh_from_db()
         self.assertEqual(queue.status, SyncQueueStatus.Syncing)
         self.assertEqual(queue.updated, updated)
+
+
+class SoudExecuteSyncsTestCase(TestCase):
+    multi_db = True
+
+    def setUp(self):
+        super(SoudExecuteSyncsTestCase, self).setUp()
+        self.user_id = uuid.uuid4().hex
+        self.instance_id = uuid.uuid4().hex
+
+        execute_sync = mock.patch("kolibri.core.device.soud.execute_sync")
+        self.mock_execute_sync = execute_sync.start()
+        self.mock_execute_sync.side_effect = partial(
+            self._mock_side_effect, self.mock_execute_sync
+        )
+        self.addCleanup(execute_sync.stop)
+
+        request_sync = mock.patch("kolibri.core.device.soud.request_sync")
+        self.mock_request_sync = request_sync.start()
+        self.mock_request_sync.side_effect = partial(
+            self._mock_side_effect, self.mock_request_sync
+        )
+        self.addCleanup(request_sync.stop)
+
+        self.time = time.time()
+        self.queue_index = 0
+        self.side_effects = {
+            id(self.mock_execute_sync): {},
+            id(self.mock_request_sync): {},
+        }
+
+    def _mock_side_effect(self, mock_func, context):
+        updates = self.side_effects[id(mock_func)].get(
+            "{}:{}".format(context.user_id, context.instance_id)
+        )
+        if updates:
+            SyncQueue.objects.filter(
+                user_id=context.user_id, instance_id=context.instance_id
+            ).update(**updates.pop(0))
+
+    def _add_side_effect(self, mock_func, queue, **updates):
+        self.side_effects[id(mock_func)][
+            "{}:{}".format(queue.user_id, queue.instance_id)
+        ].append(updates)
+
+    def _create_queue(
+        self, status=SyncQueueStatus.Pending, user_id=None, instance_id=None
+    ):
+        user_id = user_id or self.user_id
+        instance_id = instance_id or self.instance_id
+        self.queue_index += 1
+
+        for mock_func in (self.mock_execute_sync, self.mock_request_sync):
+            self.side_effects[id(mock_func)]["{}:{}".format(user_id, instance_id)] = []
+
+        return SyncQueue.objects.create(
+            user_id=user_id,
+            instance_id=instance_id,
+            status=status,
+            updated=self.time,
+            keep_alive=self.queue_index,
+        )
+
+    def assertCalledWithContext(
+        self, mock_func, user_id=None, instance_id=None, call_index=0
+    ):
+        user_id = user_id or self.user_id
+        instance_id = instance_id or self.instance_id
+        calls = mock_func.mock_calls
+        _, args, kwargs = calls[call_index]
+        self.assertIsInstance(args[0], Context)
+        self.assertEqual(args[0].user_id, user_id)
+        self.assertEqual(args[0].instance_id, instance_id)
+
+    def assertNotCalledWithContext(self, mock_func, user_id=None, instance_id=None):
+        user_id = user_id or self.user_id
+        instance_id = instance_id or self.instance_id
+        calls = mock_func.mock_calls
+        for _, args, kwargs in calls:
+            self.assertIsInstance(args[0], Context)
+            self.assertFalse(
+                args[0].user_id == user_id and args[0].instance_id == instance_id,
+                "Unexpected call with context: {}".format(args[0]),
+            )
+
+    def test_none(self):
+        execute_syncs()
+        self.mock_execute_sync.assert_not_called()
+        self.mock_request_sync.assert_not_called()
+
+    def test_syncing(self):
+        queue = self._create_queue(status=SyncQueueStatus.Syncing)
+        self._add_side_effect(
+            self.mock_request_sync, queue, status=SyncQueueStatus.Ineligible
+        )
+        execute_syncs()
+        self.mock_execute_sync.assert_not_called()
+        self.assertCalledWithContext(self.mock_request_sync)
+
+    def test_ready(self):
+        queue = self._create_queue(status=SyncQueueStatus.Ready)
+        self._add_side_effect(
+            self.mock_execute_sync,
+            queue,
+            status=SyncQueueStatus.Pending,
+            keep_alive=60,
+        )
+        execute_syncs()
+        self.assertCalledWithContext(self.mock_execute_sync)
+        self.mock_request_sync.assert_not_called()
+
+    def test_pending(self):
+        queue = self._create_queue(status=SyncQueueStatus.Pending)
+        self._add_side_effect(
+            self.mock_request_sync,
+            queue,
+            status=SyncQueueStatus.Queued,
+            keep_alive=60,
+        )
+        execute_syncs()
+        self.mock_execute_sync.assert_not_called()
+        self.assertCalledWithContext(self.mock_request_sync)
+
+    def test_queued(self):
+        queue = self._create_queue(status=SyncQueueStatus.Queued)
+        self._add_side_effect(
+            self.mock_request_sync,
+            queue,
+            status=SyncQueueStatus.Queued,
+            keep_alive=10,
+        )
+        execute_syncs()
+        self.mock_execute_sync.assert_not_called()
+        self.assertCalledWithContext(self.mock_request_sync)
+
+    def test_queued__then_ready(self):
+        queue = self._create_queue(status=SyncQueueStatus.Queued)
+        self._add_side_effect(
+            self.mock_request_sync,
+            queue,
+            status=SyncQueueStatus.Ready,
+            keep_alive=0,
+        )
+        self._add_side_effect(
+            self.mock_execute_sync,
+            queue,
+            status=SyncQueueStatus.Pending,
+            keep_alive=60,
+        )
+        execute_syncs()
+        self.assertCalledWithContext(self.mock_request_sync)
+        self.assertCalledWithContext(self.mock_execute_sync)
+        self.mock_execute_sync.assert_called_once()
+        self.mock_request_sync.assert_called_once()
+
+    def test_ready__then_pending(self):
+        queue = self._create_queue(status=SyncQueueStatus.Ready)
+        self._add_side_effect(
+            self.mock_execute_sync,
+            queue,
+            status=SyncQueueStatus.Pending,
+            keep_alive=0,
+        )
+        self._add_side_effect(
+            self.mock_request_sync,
+            queue,
+            status=SyncQueueStatus.Queued,
+            keep_alive=60,
+        )
+        execute_syncs()
+        self.assertCalledWithContext(self.mock_request_sync)
+        self.assertCalledWithContext(self.mock_execute_sync)
+        self.mock_execute_sync.assert_called_once()
+        self.mock_request_sync.assert_called_once()
+
+    def test_ordering(self):
+        queues = []
+        for i in range(WINDOW_SEC + 2):
+            queue = self._create_queue(
+                instance_id=uuid.uuid4().hex, status=SyncQueueStatus.Pending
+            )
+            queues.append(queue)
+            self._add_side_effect(
+                self.mock_request_sync,
+                queue,
+                status=SyncQueueStatus.Queued,
+                keep_alive=60,
+            )
+
+        execute_syncs()
+        self.mock_execute_sync.assert_not_called()
+
+        for i, queue in enumerate(queues[:WINDOW_SEC]):
+            self.assertCalledWithContext(
+                self.mock_request_sync, instance_id=queue.instance_id, call_index=i
+            )
+
+        for i, queue in enumerate(queues[WINDOW_SEC:]):
+            self.assertNotCalledWithContext(
+                self.mock_request_sync, instance_id=queue.instance_id
+            )
+
+
+class SoudExecuteSyncTestCase(TestCase):
+    multi_db = True
+
+    def setUp(self):
+        super(SoudExecuteSyncTestCase, self).setUp()
+        self.user_id = uuid.uuid4().hex
+        self.instance_id = uuid.uuid4().hex
+
+        self.facility = Facility.objects.create(name="Test")
+        self.user = FacilityUser.objects.get_or_create(
+            id=self.user_id,
+            defaults=dict(
+                username=self.user_id,
+                facility=self.facility,
+            ),
+        )
+
+        self.network_location = StaticNetworkLocation.objects.create(
+            base_url="https://kolibrihappyurl.qqq/",
+            connection_status=ConnectionStatus.Okay,
+            application="kolibri",
+            instance_id=self.instance_id,
+        )
+        self.context = Context(self.user_id, self.instance_id)
+
+        self.sync = mock.patch("kolibri.core.device.soud.call_command")
+        self.mock_sync = self.sync.start()
+        self.addCleanup(self.sync.stop)
+
+        self.sync_queue = SyncQueue.objects.create(
+            user_id=self.user_id,
+            instance_id=self.instance_id,
+            status=SyncQueueStatus.Ready,
+            updated=time.time(),
+            keep_alive=0,
+        )
+
+    def test_success(self):
+        queue_updated = self.sync_queue.updated
+
+        def _side_effect(*args, **kwargs):
+            """ Assert the sync queue is updated to Syncing when calling the sync command."""
+            self.sync_queue.refresh_from_db()
+            self.assertEqual(self.sync_queue.status, SyncQueueStatus.Syncing)
+
+        self.mock_sync.side_effect = _side_effect
+
+        execute_sync(self.context)
+
+        self.mock_sync.assert_called_once_with(
+            "sync",
+            user=self.user_id,
+            facility=self.facility.id,
+            baseurl=self.network_location.base_url,
+            keep_alive=True,
+            noninteractive=True,
+        )
+        self.sync_queue.refresh_from_db()
+        self.assertEqual(self.sync_queue.status, SyncQueueStatus.Pending)
+        self.assertGreaterEqual(self.sync_queue.updated, queue_updated)
+        self.assertEqual(self.sync_queue.keep_alive, 60)
+
+    def test_resume(self):
+        queue_updated = self.sync_queue.updated
+        self.sync_queue.sync_session_id = uuid.uuid4().hex
+        self.sync_queue.save()
+
+        def _side_effect(*args, **kwargs):
+            """ Assert the sync queue is updated to Syncing when calling the sync command."""
+            self.sync_queue.refresh_from_db()
+            self.assertEqual(self.sync_queue.status, SyncQueueStatus.Syncing)
+
+        self.mock_sync.side_effect = _side_effect
+
+        execute_sync(self.context)
+
+        self.mock_sync.assert_called_once_with(
+            "resumesync",
+            user=self.user_id,
+            facility=self.facility.id,
+            baseurl=self.network_location.base_url,
+            keep_alive=True,
+            noninteractive=True,
+            id=self.sync_queue.sync_session_id,
+        )
+
+        self.sync_queue.refresh_from_db()
+        self.assertEqual(self.sync_queue.status, SyncQueueStatus.Pending)
+        self.assertGreaterEqual(self.sync_queue.updated, queue_updated)
+        self.assertEqual(self.sync_queue.keep_alive, 60)
+
+    def test_no_network_location(self):
+        queue_updated = self.sync_queue.updated
+        self.network_location.delete()
+
+        execute_sync(self.context)
+
+        self.mock_sync.assert_not_called()
+
+        self.sync_queue.refresh_from_db()
+        self.assertEqual(self.sync_queue.status, SyncQueueStatus.Pending)
+        self.assertGreaterEqual(self.sync_queue.updated, queue_updated)
+        self.assertEqual(self.sync_queue.attempts, 1)
+        self.assertEqual(self.sync_queue.keep_alive, 30)
+
+    def test_resume_failure(self):
+        queue_updated = self.sync_queue.updated
+        self.sync_queue.sync_session_id = uuid.uuid4().hex
+        self.sync_queue.save()
+
+        self.mock_sync.side_effect = MorangoResumeSyncError("Some error")
+
+        execute_sync(self.context)
+
+        self.mock_sync.assert_called_once_with(
+            "resumesync",
+            user=self.user_id,
+            facility=self.facility.id,
+            baseurl=self.network_location.base_url,
+            keep_alive=True,
+            noninteractive=True,
+            id=self.sync_queue.sync_session_id,
+        )
+
+        self.sync_queue.refresh_from_db()
+        self.assertEqual(self.sync_queue.status, SyncQueueStatus.Ready)
+        self.assertGreaterEqual(self.sync_queue.updated, queue_updated)
+        self.assertEqual(self.sync_queue.attempts, 0)
+        self.assertEqual(self.sync_queue.keep_alive, 0)
+        self.assertIsNone(self.sync_queue.sync_session_id)
+
+    def test_failure(self):
+        queue_updated = self.sync_queue.updated
+
+        self.mock_sync.side_effect = RuntimeError("Some error")
+
+        execute_sync(self.context)
+
+        self.mock_sync.assert_called_once_with(
+            "sync",
+            user=self.user_id,
+            facility=self.facility.id,
+            baseurl=self.network_location.base_url,
+            keep_alive=True,
+            noninteractive=True,
+        )
+
+        self.sync_queue.refresh_from_db()
+        self.assertEqual(self.sync_queue.status, SyncQueueStatus.Pending)
+        self.assertGreaterEqual(self.sync_queue.updated, queue_updated)
+        self.assertEqual(self.sync_queue.attempts, 1)
+        self.assertEqual(self.sync_queue.keep_alive, 30)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ more-itertools==5.0.0  # Last Python 2.7 friendly release # pyup: <6.0
 le-utils==0.2.2
 jsonfield==2.0.2
 requests-toolbelt==0.9.1
-morango==0.6.18
+morango==0.6.19
 tzlocal==2.1
 pytz==2022.1
 python-dateutil==2.8.2


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates LOD sync processing to never cancel the task but just enqueue and catch `JobRunning`
- Updates LOD sync processing to reset any queue records that are marked as `Syncing` since there should only ever be one job running that code at a time, and records with that status indicate it was terminated unexpectedly
- Adds check in cleanup hook that enqueues sync garbage collection to only occur if Kolibri is provisioned
- Adds defensive check to LOD syncing for unavailable network locations and backs off syncing in that scenario
- Upgrades morango to 0.6.19, fixing issue with premature cleanup of LOD sync sessions interfering with resumption
- Adds more unit tests for LOD syncing code

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Resolves https://github.com/learningequality/kolibri/issues/11524
Includes https://github.com/learningequality/morango/pull/205

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Sync

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
