### PR TITLE
Hardcode user model to avoid conflict with other kolibri usages

### DIFF
--- a/kolibri/core/device/migrations/0019_syncqueue_and_status.py
+++ b/kolibri/core/device/migrations/0019_syncqueue_and_status.py
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
             name="user",
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.CASCADE,
-                to=settings.AUTH_USER_MODEL,
+                to="kolibriauth.FacilityUser",
                 unique=True,
             ),
         ),


### PR DESCRIPTION
## Summary
Migration `kolibri/core/device/migrations/0019_syncqueue_and_status.py` is using a setting variable  `settings.AUTH_USER_MODEL` to refer to `kolibri.core.auth.models.FacilityUser`.
This is causing problem in other usages where `settings.AUTH_USER_MODEL` is a different model

This PR uses the real model name to avoid problems


## Reviewer guidance
Tested in KDP where `settings.AUTH_USER_MODEL`=`kolibri_data_portal.PortalUser`
do migrations run correctly?

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
