### PR TITLE
Ensure Enter key works as continue button click on Setup Wizard

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -100,3 +100,5 @@ If you have contributed to Kolibri, feel free to add your name and Github accoun
 | Kris Katkus | katkuskris |
 | Garvit Singhal | GarvitSinghal47 |
 | Adars T S | a6ar55 |
+| Alex Vélez | AlexVelezLl |
+

--- a/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/PasswordTextbox.vue
@@ -49,6 +49,10 @@
       shouldValidate: {
         type: Boolean,
       },
+      shouldValidateOnEnter: {
+        type: Boolean,
+        default: true,
+      },
       // Set to false if you just want one password field
       showConfirmationInput: {
         type: Boolean,
@@ -122,6 +126,9 @@
         this.$refs.password.focus();
       },
       checkErrorsAndSubmit(e) {
+        if (!this.shouldValidateOnEnter) {
+          return;
+        }
         if (this.valid) {
           this.$emit('submitNewPassword');
         } else {

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -10,12 +10,14 @@
       :label="$tr('joinFacilityLabel')"
       :value="Options.JOIN"
       class="radio-button"
+      :autofocus="isJoinSetup"
     />
     <KRadioButton
       v-model="selected"
       :label="$tr('importFromFacilityLabel')"
       :value="Options.IMPORT"
       class="radio-button"
+      :autofocus="isImportSetup"
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
@@ -46,6 +48,14 @@
         selected: Options.JOIN,
         showSelectAddressModal: false,
       };
+    },
+    computed: {
+      isJoinSetup() {
+        return this.selected === Options.JOIN;
+      },
+      isImportSetup() {
+        return this.selected === Options.IMPORT;
+      },
     },
     methods: {
       handleContinueImport(address) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/CreateLearnerAccountForm.vue
@@ -15,6 +15,7 @@
       class="radio-button"
       :label="$tr('yesOptionLabel')"
       :value="true"
+      :autofocus="setting"
     />
     <KRadioButton
       ref="noRadio"
@@ -22,6 +23,7 @@
       class="radio-button"
       :label="$tr('noOptionLabel')"
       :value="false"
+      :autofocus="!setting"
     />
     <p class="description">
       {{ getCommonSyncString('changeLater') }}

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -9,12 +9,14 @@
       :label="$tr('fullDeviceLabel')"
       :value="Options.FULL"
       :description="$tr('fullDeviceDescription')"
+      :autofocus="isFullSetup"
     />
     <KRadioButton
       v-model="selected"
       :label="$tr('learnOnlyDeviceLabel')"
       :value="Options.LOD"
       :description="$tr('learnOnlyDeviceDescription')"
+      :autofocus="isLODSetup"
     />
   </OnboardingStepBase>
 
@@ -42,6 +44,14 @@
         Options,
         selected,
       };
+    },
+    computed: {
+      isFullSetup() {
+        return this.selected === Options.FULL;
+      },
+      isLODSetup() {
+        return this.selected === Options.LOD; 
+      },
     },
     methods: {
       handleContinue() {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -50,7 +50,7 @@
         return this.selected === Options.FULL;
       },
       isLODSetup() {
-        return this.selected === Options.LOD; 
+        return this.selected === Options.LOD;
       },
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/GuestAccessForm.vue
@@ -15,12 +15,14 @@
       v-model="setting"
       :label="$tr('yesOptionLabel')"
       :value="true"
+      :autofocus="setting"
     />
     <KRadioButton
       ref="noRadio"
       v-model="setting"
       :label="$tr('noOptionLabel')"
       :value="false"
+      :autofocus="!setting"
     />
     <p class="form">
       {{ $tr('changeLater') }}

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -49,7 +49,7 @@
         return this.selected === UsePresets.ON_MY_OWN;
       },
       isGroupSetup() {
-        return this.selected === UsePresets.GROUP; 
+        return this.selected === UsePresets.GROUP;
       },
       UsePresets() {
         return UsePresets;

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/HowAreYouUsingKolibri.vue
@@ -12,12 +12,14 @@
       :value="UsePresets.ON_MY_OWN"
       :label="$tr('onMyOwnLabel')"
       :description="getCommonSyncString('onMyOwn')"
+      :autofocus="isOnMyOwnSetup"
     />
     <KRadioButton
       v-model="selected"
       :value="UsePresets.GROUP"
       :label="$tr('groupLearningLabel')"
       :description="$tr('groupLearningDescription')"
+      :autofocus="isGroupSetup"
     />
   </OnboardingStepBase>
 
@@ -45,6 +47,9 @@
     computed: {
       isOnMyOwnSetup() {
         return this.selected === UsePresets.ON_MY_OWN;
+      },
+      isGroupSetup() {
+        return this.selected === UsePresets.GROUP; 
       },
       UsePresets() {
         return UsePresets;

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/RequirePasswordForLearnersForm.vue
@@ -14,6 +14,7 @@
       class="radio-button"
       :label="$tr('yesOptionLabel')"
       :value="true"
+      :autofocus="setting"
     />
     <KRadioButton
       ref="noRadio"
@@ -21,6 +22,7 @@
       class="radio-button"
       :label="$tr('noOptionLabel')"
       :value="false"
+      :autofocus="!setting"
     />
     <p class="description">
       {{ getCommonSyncString('changeLater') }}

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -55,7 +55,7 @@
         return this.selected === Options.NEW;
       },
       isImportFacilitySetup() {
-        return this.selected === Options.IMPORT; 
+        return this.selected === Options.IMPORT;
       },
     },
     methods: {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -10,12 +10,14 @@
       :label="$tr('createFacilityLabel')"
       :value="Options.NEW"
       class="radio-button"
+      :autofocus="isNewFacilitySetup"
     />
     <KRadioButton
       v-model="selected"
       :label="$tr('importFacilityLabel')"
       :value="Options.IMPORT"
       class="radio-button"
+      :autofocus="isImportFacilitySetup"
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
@@ -47,6 +49,14 @@
         selected,
         showSelectAddressModal: false,
       };
+    },
+    computed: {
+      isNewFacilitySetup() {
+        return this.selected === Options.NEW;
+      },
+      isImportFacilitySetup() {
+        return this.selected === Options.IMPORT; 
+      },
     },
     methods: {
       handleContinueImport(address) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -50,6 +50,7 @@
         :isValid.sync="passwordValid"
         :shouldValidate="formSubmitted"
         :showConfirmationInput="!selectedUser"
+        :shouldValidateOnEnter="false"
         autocomplete="new-password"
       />
 


### PR DESCRIPTION
## Summary

This PR makes the use of the enter key consistent in all forms steps of the setup wizard and is the same as the behavior that would occur if the user clicks on the "Continue" button, including the form validations. This works with the steps with text inputs for now, but with the steps with radio button inputs, the issue [KDS#489](https://github.com/learningequality/kolibri-design-system/issues/489) must be resolved first, which prevents KRadioButtons from getting focus when rendered dynamically.

**Before**

https://github.com/learningequality/kolibri/assets/51239030/af363f1d-53cd-4189-9f37-4b6851e2ccf6

**After**


https://github.com/learningequality/kolibri/assets/51239030/b2fa3d9d-6e24-482d-a2a0-0a102c84551d



## References
#11458

## Reviewer guidance

Go to the setup wizard and check that in forms with text inputs, the enter key works as if you clicked the enter button, including the form validations.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
