### PR TITLE
Raise errors with expected format

### DIFF
--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -48,13 +48,14 @@ def get_remote_users_info(baseurl, facility_id, username, password):
         )
         response.raise_for_status()
     except (CommandError, HTTPError, ConnectionError) as e:
-        detail = []
         if password == NOT_SPECIFIED or not password:
-            detail = [{"id": error_constants.MISSING_PASSWORD}]
-            raise AuthenticationFailed(detail)
+            raise AuthenticationFailed(
+                detail="Password is required", code=error_constants.MISSING_PASSWORD
+            )
         else:
-            detail = [{"id": error_constants.AUTHENTICATION_FAILED, "message": e}]
-            raise AuthenticationFailed(detail)
+            raise AuthenticationFailed(
+                detail=str(e), code=error_constants.AUTHENTICATION_FAILED
+            )
     auth_info = response.json()
     if len(auth_info) > 1:
         user_info = [u for u in response.json() if u["username"] == username][0]


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Updates `get_remote_users_info` to raise errors with expected format to avoid 500 errors

![Screenshot from 2023-11-17 07-46-36](https://github.com/learningequality/kolibri/assets/819838/295d3153-3fe0-430c-8176-b08f4f3557ec)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://github.com/learningequality/kolibri/issues/11540 - does not entirely fix, as there is no error handling (?)

Prior error
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/kolibri/dist/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/kolibri/core/tasks/api.py", line 198, in create
    validated_data = self.validate_create_req_data(request)
  File "/usr/lib/python3/dist-packages/kolibri/core/tasks/api.py", line 68, in validate_create_req_data
    job, enqueue_args = registered_task.validate_job_data(
  File "/usr/lib/python3/dist-packages/kolibri/core/tasks/registry.py", line 272, in validate_job_data
    validator.is_valid(raise_exception=True)
  File "/usr/lib/python3/dist-packages/kolibri/dist/rest_framework/serializers.py", line 236, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/usr/lib/python3/dist-packages/kolibri/core/tasks/validation.py", line 123, in run_validation
    value = self.validate(value)
  File "/usr/lib/python3/dist-packages/kolibri/core/auth/tasks.py", line 535, in validate
    facility_info = get_remote_users_info(baseurl, facility_id, username, password)
  File "/usr/lib/python3/dist-packages/kolibri/core/auth/utils/users.py", line 57, in get_remote_users_info
    raise AuthenticationFailed(detail)
rest_framework.exceptions.AuthenticationFailed: [{'id': ErrorDetail(string='AUTHENTICATION_FAILED', code='authentication_failed'), 'message': ErrorDetail(string='401 Client Error: Unauthorized for url: http://192.168.100.49:8080/api/public/facilityuser/?facility_id=13785e243c00fb2b8b0a70b0f2ce0ffe', code='authentication_failed')}]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/kolibri/dist/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/lib/python3/dist-packages/kolibri/dist/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/lib/python3/dist-packages/kolibri/dist/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3/dist-packages/kolibri/dist/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/kolibri/dist/rest_framework/viewsets.py", line 116, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/kolibri/dist/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/usr/lib/python3/dist-packages/kolibri/dist/rest_framework/views.py", line 452, in handle_exception
    response = exception_handler(exc, context)
  File "/usr/lib/python3/dist-packages/kolibri/core/utils/exception_handler.py", line 21, in custom_exception_handler
    response.data = _handle_403_format(response, context)
  File "/usr/lib/python3/dist-packages/kolibri/core/utils/exception_handler.py", line 60, in _handle_403_format
    "id": response.data["detail"].code.upper(),
TypeError: list indices must be integers or slices, not str
```

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Provide incorrect credentials when attempting to import a single learner in the setup wizard

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
