### PR TITLE
There can be more than one network location for an instance ID

### DIFF
--- a/kolibri/core/content/test/utils/test_content_request.py
+++ b/kolibri/core/content/test/utils/test_content_request.py
@@ -44,6 +44,8 @@ def _facility(dataset_id=None):
 
 
 class BaseTestCase(TestCase):
+    multi_db = True
+
     def _create_sync_and_network_location(
         self, sync_overrides=None, location_overrides=None
     ):
@@ -641,6 +643,25 @@ class PreferredDevicesTestCase(BaseTestCase):
         self.assertEqual(len(peers), 2)
         self.assertEqual(peers[0].id, network_location1.id)
         self.assertEqual(peers[1].id, network_location2.id)
+
+    def test_multiple_locations__same_instance_id(self):
+        dynamic_location = self._create_network_location(
+            connection_status=ConnectionStatus.Unknown,
+        )
+        static_location = self._create_network_location(
+            location_type="static",
+            instance_id=dynamic_location.instance_id,
+        )
+        self.assertEqual(dynamic_location.instance_id, static_location.instance_id)
+
+        instance = PreferredDevices(
+            instance_ids=[
+                dynamic_location.instance_id,
+            ],
+        )
+        peers = list(instance)
+        self.assertEqual(len(peers), 1)
+        self.assertEqual(peers[0].id, static_location.id)
 
 
 class PreferredDevicesWithClientTestCase(BaseTestCase):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Fixes issue where filtering by `instance_id` could encounter an error if there are multiple `NetworkLocation`s with the same ID, which I forgot about when I wrote the original code

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
In logs from @marcellamaki 
```
ERROR 2023-11-17 12:01:17,019 kolibri.core.content.utils.content_request get() returned more than one NetworkLocation -- it returned 2!
Traceback (most recent call last):
  File "/Users/marcellamaki/Documents/learning-equality/kolibri/kolibri/core/content/utils/content_request.py", line 769, in process_download_request
    for peer in chain(*peer_sets):
  File "/Users/marcellamaki/Documents/learning-equality/kolibri/kolibri/core/content/utils/content_request.py", line 286, in __iter__
    peer = self._get_and_validate_peer(instance_id)
  File "/Users/marcellamaki/Documents/learning-equality/kolibri/kolibri/core/content/utils/content_request.py", line 250, in _get_and_validate_peer
    peer = NetworkLocation.objects.get(
  File "/Users/marcellamaki/.pyenv/versions/3.9.9/envs/kolibri-develop/lib/python3.9/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/marcellamaki/.pyenv/versions/3.9.9/envs/kolibri-develop/lib/python3.9/site-packages/django/db/models/query.py", line 382, in get
    raise self.model.MultipleObjectsReturned(
kolibri.core.discovery.models.MultipleObjectsReturned: get() returned more than one NetworkLocation -- it returned 2!
```

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I wrote a regression test for it, which failed, then fixed the issue and the test passed, as well as all others.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
