### PR TITLE
Handle weird edge case where the extra_settings key does not exist yet.

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -192,7 +192,10 @@ class DeviceSettings(models.Model):
         :param name: A str name of the `extra_settings` field
         :return: mixed
         """
-        return self.extra_settings.get(name, extra_settings_default_values[name])
+        try:
+            return self.extra_settings.get(name, extra_settings_default_values[name])
+        except KeyError:
+            return extra_settings_default_values[name]
 
     @property
     def allow_download_on_metered_connection(self):


### PR DESCRIPTION
## Summary
* When upgrading, it appears it is possible for this key to be unavailable on the model object
* Adds a defensive check when trying to access this value

## References
Fixes #11518

## Reviewer guidance
I am not entirely sure how this even happens - but this defensive check seemed the simplest way to handle it.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
