### PR TITLE
Hides app bars on scroll down and show on scroll up

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -215,30 +215,6 @@
 
   @import '~kolibri-design-system/lib/styles/definitions';
 
-  .v-leave {
-    opacity: 1;
-  }
-
-  .v-leave-active {
-    transition: opacity 0.5s;
-  }
-
-  .v-leave-to {
-    opacity: 0;
-  }
-
-  .v-enter {
-    opacity: 0;
-  }
-
-  .v-enter-active {
-    transition: opacity 0.5s;
-  }
-
-  .v-enter-to {
-    opacity: 1;
-  }
-
   .app-bar {
     @extend %dropshadow-8dp;
 

--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -183,13 +183,6 @@
           window.addEventListener('scroll', this.throttledHandleScroll);
         }
       },
-      removeScrollListener() {
-        if (this.isAppContextAndTouchDevice) {
-          window.removeEventListener('scroll', this.throttledHandleScroll);
-          this.throttledHandleScroll.cancel();
-          this.throttledHandleScroll = null;
-        }
-      },
       findFirstEl() {
         this.$nextTick(() => {
           this.$refs.sideNav.focusFirstEl();
@@ -204,6 +197,13 @@
           this.hideAppBars = true;
         }
         this.lastScrollTop = scrollTop;
+      },
+      removeScrollListener() {
+        if (this.isAppContextAndTouchDevice) {
+          window.removeEventListener('scroll', this.throttledHandleScroll);
+          this.throttledHandleScroll.cancel();
+          this.throttledHandleScroll = null;
+        }
       },
     },
   };

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -210,7 +210,8 @@
             />
             <div
               v-show="setLimitForAutodownload"
-              class="left-margin"
+              class="left-margin limit-for-autodownload"
+              :class="$computedClass(limitForAutodownloadStyle)"
               :disabled="isRemoteContent"
             >
               <KTextbox
@@ -227,7 +228,10 @@
                 :floatingLabel="false"
                 @input="updateLimitForAutodownload"
               />
-              <div class="slider-section">
+              <div class="slider-section" :class="$computedClass(sliderSectionStyle)">
+                <p class="slider-min-max">
+                  0
+                </p>
                 <input
                   id="slider"
                   v-model="limitForAutodownload"
@@ -239,14 +243,9 @@
                   step="1"
                   @input="updateLimitForAutodownloadInput"
                 >
-                <div class="slider-constraints">
-                  <p class="slider-min-max">
-                    0
-                  </p>
-                  <p class="slider-min-max">
-                    {{ toGigabytes(freeSpace) }}
-                  </p>
-                </div>
+                <p class="slider-min-max">
+                  {{ toGigabytes(freeSpace) }}
+                </p>
               </div>
             </div>
           </div>
@@ -361,6 +360,7 @@
   import { availableLanguages, currentLanguage } from 'kolibri.utils.i18n';
   import sortLanguages from 'kolibri.utils.sortLanguages';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
+  import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import { checkCapability } from 'kolibri.utils.appCapabilities';
   import commonDeviceStrings from '../commonDeviceStrings';
   import DeviceAppBarPage from '../DeviceAppBarPage';
@@ -400,6 +400,7 @@
     setup() {
       const { canRestart, restart, restarting } = useDeviceRestart();
       const { plugins, fetchPlugins, togglePlugin } = usePlugins();
+      const { windowIsSmall } = useKResponsiveWindow();
       const dataPlugins = ref(null);
 
       fetchPlugins.then(() => {
@@ -433,6 +434,7 @@
         dataPlugins,
         checkPluginChanges,
         checkAndTogglePlugins,
+        windowIsSmall,
       };
     },
     data() {
@@ -517,7 +519,22 @@
         });
         return this.readOnlyPaths >= 1;
       },
+      limitForAutodownloadStyle() {
+        const alignItems = this.windowIsSmall ? 'start' : 'center';
+        const flexDirection = this.windowIsSmall ? 'column' : 'row';
+        return {
+          alignItems,
+          flexDirection,
+        };
+      },
+      sliderSectionStyle() {
+        const paddingLeft = this.windowIsSmall ? '0px' : '20px';
+        return {
+          paddingLeft,
+        };
+      },
       sliderStyle() {
+        const width = this.windowIsSmall ? '35vw' : '12vw';
         if (this.notEnoughFreeSpace) {
           return {
             background: `linear-gradient(to right, ${this.$themeTokens.primary} 0%, ${
@@ -528,6 +545,7 @@
             '::-webkit-slider-thumb': {
               background: this.$themeTokens.fineLine,
             },
+            width,
           };
         } else {
           return {
@@ -541,6 +559,7 @@
             '::-webkit-slider-thumb': {
               background: this.$themeTokens.primary,
             },
+            width,
           };
         }
       },
@@ -1169,12 +1188,18 @@
     margin-left: 32px;
   }
 
+  .limit-for-autodownload {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
   .info-description {
     color: #616161;
   }
 
   input[type='range'] {
-    width: 264px;
+    width: 12vw;
     height: 2px;
     margin-left: 10px;
     appearance: none;
@@ -1190,24 +1215,17 @@
   }
 
   .download-limit-textbox {
-    display: inline-block;
     width: 70px;
   }
 
   .slider-section {
-    position: absolute;
-    display: inline-block;
-    padding-top: 10px;
-  }
-
-  .slider-constraints {
     display: flex;
+    flex-direction: row;
     justify-content: space-between;
-    margin-left: 10px;
+    padding-left: 20px;
   }
 
   .slider-min-max {
-    display: inline-block;
     margin-top: 5px;
     font-size: 14px;
     font-weight: 400;


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr implements the hide/show behavior of the top bar and the bottom navigation when a user scrolls down, and show again as they scroll up.

_**Note:** The `useScroll` from `vueUse` seems like a more cleaner way to implement the behavior in place of the scroll event handler(as recommended by @MisRob), but it seems it only works for predetermined widths and heights. I am happy to hear any thoughts on possible ways it could still be used. Also happy to hear from @jtamiace @tomiwaoLE about the behavior(hide/show) from a UI/UX perspective._
- Touch device

https://github.com/learningequality/kolibri/assets/5203639/71a5db5a-4208-4fbf-9343-3d62342dafe4

- Non touch device

https://github.com/learningequality/kolibri/assets/5203639/36e40104-7229-4f14-b917-c0ca66faf41e

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes https://github.com/learningequality/kolibri/issues/11471

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Run the the apk artifact on this pr.
- Try so scroll up and down in any scrollable screen;
  - on scroll down, the top bar and the bottom navigation are hidden
  - on scroll up, the top bar and the bottom navigation are shown
- This behavior should not be present on any of the web based artifacts(.dmg, .pex, etc) but only on touch devices(apk artifact)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
