### PR TITLE
Migrate quizForge object references to composition API standard

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -31,7 +31,7 @@ function isExercise(o) {
 /**
  * Composable function presenting primary interface for Quiz Creation
  */
-export default function useQuizCreation(DEBUG = false) {
+export default function useQuizCreation(DEBUG = true) {
   // -----------
   // Local state
   // -----------

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -31,7 +31,7 @@ function isExercise(o) {
 /**
  * Composable function presenting primary interface for Quiz Creation
  */
-export default function useQuizCreation(DEBUG = true) {
+export default function useQuizCreation(DEBUG = false) {
   // -----------
   // Local state
   // -----------

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -448,7 +448,7 @@ export function injectQuizCreation() {
   const updateSection = inject('updateSection');
   const replaceSelectedQuestions = inject('replaceSelectedQuestions');
   const addSection = inject('addSection');
-  const removeSection = inject('removeSection,');
+  const removeSection = inject('removeSection');
   const setActiveSection = inject('setActiveSection');
   const initializeQuiz = inject('initializeQuiz');
   const updateQuiz = inject('updateQuiz');

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -6,7 +6,7 @@ import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
 import { ChannelResource, ExamResource } from 'kolibri.resources';
 import { validateObject, objectWithDefaults } from 'kolibri.utils.objectSpecs';
 import { get, set } from '@vueuse/core';
-import { computed, ref } from 'kolibri.lib.vueCompositionApi';
+import { computed, ref, provide, inject } from 'kolibri.lib.vueCompositionApi';
 // TODO: Probably move this to this file's local dir
 import selectQuestions from '../modules/examCreation/selectQuestions.js';
 import { Quiz, QuizSection, QuizQuestion } from './quizCreationSpecs.js';
@@ -31,7 +31,7 @@ function isExercise(o) {
 /**
  * Composable function presenting primary interface for Quiz Creation
  */
-export default (DEBUG = false) => {
+export default function useQuizCreation(DEBUG = false) {
   // -----------
   // Local state
   // -----------
@@ -380,6 +380,26 @@ export default (DEBUG = false) => {
     return !get(allQuestionsSelected) && !get(noQuestionsSelected);
   });
 
+  provide('saveQuiz', saveQuiz);
+  provide('updateSection', updateSection);
+  provide('replaceSelectedQuestions', replaceSelectedQuestions);
+  provide('addSection', addSection);
+  provide('removeSection', removeSection);
+  provide('setActiveSection', setActiveSection);
+  provide('initializeQuiz', initializeQuiz);
+  provide('updateQuiz', updateQuiz);
+  provide('addQuestionToSelection', addQuestionToSelection);
+  provide('removeQuestionFromSelection', removeQuestionFromSelection);
+  provide('channels', channels);
+  provide('quiz', quiz);
+  provide('allSections', allSections);
+  provide('activeSection', activeSection);
+  provide('inactiveSections', inactiveSections);
+  provide('activeExercisePool', activeExercisePool);
+  provide('activeQuestionsPool', activeQuestionsPool);
+  provide('activeQuestions', activeQuestions);
+  provide('selectedActiveQuestions', selectedActiveQuestions);
+  provide('replacementQuestionPool', replacementQuestionPool);
   return {
     // Methods
     saveQuiz,
@@ -412,4 +432,62 @@ export default (DEBUG = false) => {
     allQuestionsSelected,
     noQuestionsSelected,
   };
-};
+
+  /*
+  return {
+    // Only what is needed where we want the rest of the module to be
+    // provided
+    saveQuiz,
+    initializeQuiz,
+  };
+  */
+}
+
+export function injectQuizCreation() {
+  const saveQuiz = inject('saveQuiz');
+  const updateSection = inject('updateSection');
+  const replaceSelectedQuestions = inject('replaceSelectedQuestions');
+  const addSection = inject('addSection');
+  const removeSection = inject('removeSection,');
+  const setActiveSection = inject('setActiveSection');
+  const initializeQuiz = inject('initializeQuiz');
+  const updateQuiz = inject('updateQuiz');
+  const addQuestionToSelection = inject('addQuestionToSelection');
+  const removeQuestionFromSelection = inject('removeQuestionFromSelection');
+  const channels = inject('channels');
+  const quiz = inject('quiz');
+  const allSections = inject('allSections');
+  const activeSection = inject('activeSection');
+  const inactiveSections = inject('inactiveSections');
+  const activeExercisePool = inject('activeExercisePool');
+  const activeQuestionsPool = inject('activeQuestionsPool');
+  const activeQuestions = inject('activeQuestions');
+  const selectedActiveQuestions = inject('selectedActiveQuestions');
+  const replacementQuestionPool = inject('replacementQuestionPool');
+
+  return {
+    // Methods
+    saveQuiz,
+    updateSection,
+    replaceSelectedQuestions,
+    addSection,
+    removeSection,
+    setActiveSection,
+    initializeQuiz,
+    updateQuiz,
+    addQuestionToSelection,
+    removeQuestionFromSelection,
+
+    // Computed
+    channels,
+    quiz,
+    allSections,
+    activeSection,
+    inactiveSections,
+    activeExercisePool,
+    activeQuestionsPool,
+    activeQuestions,
+    selectedActiveQuestions,
+    replacementQuestionPool,
+  };
+}

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -78,37 +78,7 @@
                   :hasIcons="true"
                   :options="overflowTabs"
                   @select="opt => setActiveSection(opt.id)"
-                >
-                  <template #option="{ option }">
-                    <!-- TODO Clean this up by moving it to another component -->
-                    <!-- Maybe not so easy since they're styled differently -->
-                    <KButton
-                      appearance="flat-button"
-                      :primary="activeSection.section_id === option.id"
-                      :appearanceOverrides="tabStyles"
-                      class="menu-button"
-                      @click="() => setActiveSection(option.id)"
-                    >
-                      {{ option.label }}
-                    </KButton>
-                    <KIconButton
-                      icon="optionsVertical"
-                      style="position: absolute; right: 0; border-radius: 0!important;"
-                      @click="() => null"
-                    >
-                      <template #menu>
-                        <KDropdownMenu
-                          :primary="false"
-                          :disabled="false"
-                          :hasIcons="true"
-                          :containFocus="false"
-                          :options="sectionOptions"
-                          @select="opt => handleSectionOptionSelect(opt, option.id)"
-                        />
-                      </template>
-                    </KIconButton>
-                  </template>
-                </KDropdownMenu>
+                />
               </template>
             </KIconButton>
           </template>
@@ -135,7 +105,6 @@
 
     <KTabsPanel
       v-if="activeSection"
-      class="no-question-layout"
       tabsId="quizSectionTabs"
       :activeTabId="activeSection ? activeSection.section_id : ''"
     >
@@ -571,19 +540,6 @@
       },
       handleDragStart() {
         set(this.dragActive, true);
-      },
-      handleSectionOptionSelect({ label }, section_id) {
-        // Always set the active section to the one that is having its side panel opened
-        this.setActiveSection(section_id);
-
-        switch (label) {
-          case this.editSectionLabel$():
-            this.$router.replace({ path: 'new/' + section_id + '/edit' });
-            break;
-          case this.deleteSectionLabel$():
-            this.removeSection(section_id);
-            break;
-        }
       },
       openSelectResources(section_id) {
         this.$router.replace({ path: 'new/' + section_id + '/select-resources' });

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -23,7 +23,7 @@
           :label="quizTitle$()"
           :autofocus="true"
           :maxlength="100"
-          @blur="e => updateQuiz({ title: e.target.value })"
+          @blur="e => updateQuiz({ title: e.target })"
           @change="title => updateQuiz({ title })"
         />
       </KGridItem>
@@ -44,8 +44,8 @@
           class="section-tabs"
           :tabs="tabs"
           :appearanceOverrides="{ padding: '0px', overflow: 'hidden' }"
-          :activeTabId="activeSection.value ?
-            activeSection.value.section_id :
+          :activeTabId="activeSection ?
+            activeSection.section_id :
             '' "
           backgroundColor="transparent"
           hoverBackgroundColor="transparent"
@@ -84,7 +84,7 @@
                     <!-- Maybe not so easy since they're styled differently -->
                     <KButton
                       appearance="flat-button"
-                      :primary="activeSection.value.section_id === option.id"
+                      :primary="activeSection.section_id === option.id"
                       :appearanceOverrides="tabStyles"
                       class="menu-button"
                       @click="() => setActiveSection(option.id)"
@@ -134,14 +134,14 @@
     </KGrid>
 
     <KTabsPanel
-      v-if="activeSection.value"
+      v-if="activeSection"
       class="no-question-layout"
       tabsId="quizSectionTabs"
-      :activeTabId="activeSection.value ? activeSection.value.section_id : ''"
+      :activeTabId="activeSection ? activeSection.section_id : ''"
     >
-      <p>{{ activeSection.value.section_id }}</p>
+      <p>{{ activeSection.section_id }}</p>
       <!-- TODO This should be a separate component like "empty section container" or something -->
-      <div v-if="!activeQuestions.value.length" class="no-question-style">
+      <div v-if="!activeQuestions.length" class="no-question-style">
         <KGrid class="questions-list-label-row">
           <KGridItem
             class="right-side-heading"
@@ -177,7 +177,7 @@
         <KButton
           primary
           icon="plus"
-          @click="openSelectResources(activeSection.value.section_id)"
+          @click="openSelectResources(activeSection.section_id)"
         >
           {{ addQuestionsLabel$() }}
         </KButton>
@@ -248,7 +248,7 @@
           <template #default="{ toggleItemState, isItemExpanded }">
             <DragContainer
               key="drag-container"
-              :items="activeQuestions.value"
+              :items="activeQuestions"
               @sort="handleQuestionOrderChange"
               @dragStart="handleDragStart"
             >
@@ -258,7 +258,7 @@
                 class="wrapper"
               >
                 <Draggable
-                  v-for="(question, index) in activeQuestions.value"
+                  v-for="(question, index) in activeQuestions"
                   :key="`drag-${question.question_id}`"
                   tabindex="-1"
                   style="background: white"
@@ -276,7 +276,7 @@
                               moveDownText="down"
                               :noDrag="true"
                               :isFirst="index === 0"
-                              :isLast="index === activeQuestions.value.length - 1"
+                              :isLast="index === activeQuestions.length - 1"
                               @moveUp="shiftOne(index, -1)"
                               @moveDown="shiftOne(index, +1)"
                             />
@@ -284,7 +284,7 @@
                         </DragHandle>
                         <KCheckbox
                           style="padding-left: 0.5em"
-                          :checked="selectedActiveQuestions.value.includes(
+                          :checked="selectedActiveQuestions.includes(
                             question.question_id
                           )"
                           @change="() => toggleQuestionInSelection(question.question_id)"
@@ -311,10 +311,10 @@
                       <div
                         :id="`question-panel-${question.question_id}`"
                         :ref="`question-panel-${question.question_id}`"
-                        :style="{ userSelect: dragActive.value ? 'none!important' : 'text' }"
+                        :style="{ userSelect: dragActive ? 'none!important' : 'text' }"
                       >
                         <p
-                          v-if="isItemExpanded(question.question_id) && !dragActive.value"
+                          v-if="isItemExpanded(question.question_id) && !dragActive"
                           class="question-content-panel"
                         >
                           CONTENT OF {{ question.title }}
@@ -513,13 +513,13 @@
         this.$router.replace({ path: 'new/' + section_id + '/replace-questions' });
       },
       handleActiveSectionAction(opt) {
-        const section_id = this.activeSection.value.section_id;
+        const section_id = this.activeSection.section_id;
         switch (opt.label) {
           case this.editSectionLabel$():
             this.$router.replace({ path: 'new/' + section_id + '/edit' });
             break;
           case this.deleteSectionLabel$():
-            this.removeSection(this.activeSection.value.section_id);
+            this.removeSection(this.activeSection.section_id);
             this.focusActiveSectionTab();
             break;
         }
@@ -528,7 +528,7 @@
         return `section-tab-${section_id}`;
       },
       focusActiveSectionTab() {
-        const label = this.tabRefLabel(this.activeSection.value.section_id);
+        const label = this.tabRefLabel(this.activeSection.section_id);
         const tabRef = this.$refs[label];
         // TODO Consider the "Delete section" button on the side panel; maybe we need to await
         // nextTick if we're getting the error

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -248,7 +248,7 @@
           <template #default="{ toggleItemState, isItemExpanded }">
             <DragContainer
               key="drag-container"
-              :items="quizForge.activeQuestions.value"
+              :items="activeQuestions.value"
               @sort="handleQuestionOrderChange"
               @dragStart="handleDragStart"
             >
@@ -258,7 +258,7 @@
                 class="wrapper"
               >
                 <Draggable
-                  v-for="(question, index) in quizForge.activeQuestions.value"
+                  v-for="(question, index) in activeQuestions.value"
                   :key="`drag-${question.question_id}`"
                   tabindex="-1"
                   style="background: white"
@@ -276,7 +276,7 @@
                               moveDownText="down"
                               :noDrag="true"
                               :isFirst="index === 0"
-                              :isLast="index === quizForge.activeQuestions.value.length - 1"
+                              :isLast="index === activeQuestions.value.length - 1"
                               @moveUp="shiftOne(index, -1)"
                               @moveDown="shiftOne(index, +1)"
                             />
@@ -284,10 +284,10 @@
                         </DragHandle>
                         <KCheckbox
                           style="padding-left: 0.5em"
-                          :checked="quizForge.selectedActiveQuestions.value.includes(
+                          :checked="selectedActiveQuestions.value.includes(
                             question.question_id
                           )"
-                          @change="() => quizForge.toggleQuestionInSelection(question.question_id)"
+                          @change="() => toggleQuestionInSelection(question.question_id)"
                         />
                         <KButton
                           tabindex="0"
@@ -509,17 +509,17 @@
     },
     methods: {
       handleReplaceSelection() {
-        const section_id = get(this.quizForge.activeSection).section_id;
+        const section_id = get(this.activeSection).section_id;
         this.$router.replace({ path: 'new/' + section_id + '/replace-questions' });
       },
       handleActiveSectionAction(opt) {
-        const section_id = this.quizForge.activeSection.value.section_id;
+        const section_id = this.activeSection.value.section_id;
         switch (opt.label) {
           case this.editSectionLabel$():
             this.$router.replace({ path: 'new/' + section_id + '/edit' });
             break;
           case this.deleteSectionLabel$():
-            this.quizForge.removeSection(this.quizForge.activeSection.value.section_id);
+            this.removeSection(this.activeSection.value.section_id);
             this.focusActiveSectionTab();
             break;
         }
@@ -559,10 +559,10 @@
       handleQuestionOrderChange({ newArray }) {
         set(this.dragActive, false);
         const payload = {
-          section_id: get(this.quizForge.activeSection).section_id,
+          section_id: get(this.activeSection).section_id,
           questions: newArray,
         };
-        this.quizForge.updateSection(payload);
+        this.updateSection(payload);
       },
       handleAddSection() {
         const newSection = this.addSection();

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -2,7 +2,7 @@
 
   <div>
     <h1>Replace questions</h1>
-    <p v-for="(question,index) in quizForge.selectedActiveQuestions.value" :key="`${index}q`">
+    <p v-for="(question, index) in selectedActiveQuestions.value" :key="`${index}q`">
       {{ JSON.stringify(question) }}
     </p>
     <h2>
@@ -17,9 +17,19 @@
 
 <script>
 
+  import { injectQuizCreation } from '../../../composables/useQuizCreation';
+
   export default {
     name: 'ReplaceQuestions',
-    inject: ['quizForge'],
+    setup() {
+      const {
+        // Computed
+        selectedActiveQuestions,
+      } = injectQuizCreation();
+      return {
+        selectedActiveQuestions,
+      };
+    },
   };
 
 </script>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -145,7 +145,7 @@
         >
           <DragHandle>
             <div
-              :style="section.isActive ? activeSection : borderStyle "
+              :style="section.isActive ? activeSectionStyles : borderStyle "
               class="section-order-list"
             >
               <KGrid>
@@ -175,7 +175,7 @@
                   :style="{ color: $themePalette.grey.v_700 }"
                 >
                   <p
-                    v-if="quizForge.activeSection.value.section_id === section.section_id"
+                    v-if="activeSection.value.section_id === section.section_id"
                     class="current-section-text space-content"
                   >
                     {{ currentSection$() }}
@@ -197,7 +197,7 @@
         >
           <KButton
             :text="deleteSectionLabel$()"
-            @click="quizForge.deleteSection(quizForge.activeSection.value.section_id)"
+            @click="deleteSection(activeSection.value.section_id)"
           />
         </KGridItem>
         <KGridItem
@@ -227,6 +227,7 @@
   import Draggable from 'kolibri.coreVue.components.Draggable';
   import DragContainer from 'kolibri.coreVue.components.DragContainer';
   import DragHandle from 'kolibri.coreVue.components.DragHandle';
+  import { injectQuizCreation } from '../../../composables/useQuizCreation';
 
   export default {
     name: 'SectionEditor',
@@ -235,7 +236,6 @@
       DragContainer,
       DragHandle,
     },
-    inject: ['quizForge'],
     setup() {
       const {
         sectionSettings$,
@@ -255,8 +255,22 @@
         fixedLabel$,
         fixedOptionDescription$,
       } = enhancedQuizManagementStrings;
+
+      const {
+        activeSection,
+        allSections,
+        updateSection,
+        updateQuiz,
+        deleteSection,
+      } = injectQuizCreation();
+
       const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       return {
+        activeSection,
+        allSections,
+        updateSection,
+        updateQuiz,
+        deleteSection,
         windowIsLarge,
         windowIsSmall,
         sectionSettings$,
@@ -279,17 +293,17 @@
     },
     data() {
       return {
-        selectedQuestionOrder: this.quizForge.activeSection.value.learners_see_fixed_order,
-        numberOfQuestions: this.quizForge.activeSection.value.question_count,
-        descriptionText: this.quizForge.activeSection.value.description,
-        sectionTitle: this.quizForge.activeSection.value.section_title,
+        selectedQuestionOrder: this.activeSection.value.learners_see_fixed_order,
+        numberOfQuestions: this.activeSection.value.question_count,
+        descriptionText: this.activeSection.value.description,
+        sectionTitle: this.activeSection.value.section_title,
       };
     },
     computed: {
       borderStyle() {
         return `border: 1px solid ${this.$themeTokens.fineLine}`;
       },
-      activeSection() {
+      activeSectionStyles() {
         return {
           backgroundColor: this.$themePalette.grey.v_50,
           border: `1px solid ${this.$themeTokens.fineLine}`,
@@ -302,7 +316,7 @@
        * @returns { QuizSection[] }
        */
       sectionOrderList() {
-        return this.quizForge.allSections.value;
+        return this.allSections.value;
       },
       draggableStyle() {
         return {
@@ -312,11 +326,11 @@
     },
     methods: {
       handleSectionSort(e) {
-        this.quizForge.updateQuiz({ question_sources: e.newArray });
+        this.updateQuiz({ question_sources: e.newArray });
       },
       applySettings() {
-        this.quizForge.updateSection({
-          section_id: this.quizForge.activeSection.value.section_id,
+        this.updateSection({
+          section_id: this.activeSection.value.section_id,
           section_title: this.sectionTitle,
           description: this.descriptionText,
           question_count: this.numberOfQuestions,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -32,7 +32,6 @@
   export default {
     name: 'SectionSidePanel',
     components: { SidePanelModal, SectionEditor, ReplaceQuestions, ResourceSelection },
-    inject: ['quizForge'],
     data() {
       return {
         prevRoute: { name: PageNames.EXAM_CREATION_ROOT },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -27,7 +27,7 @@
           <KButton
             :text="coreString('saveAction')"
             primary
-            @click="() => quizForge.saveQuiz()"
+            @click="() => saveQuiz()"
           />
         </KButtonGroup>
       </BottomAppBar>
@@ -61,24 +61,12 @@
     },
     mixins: [commonCoreStrings, commonCoach, responsiveWindowMixin],
     setup() {
-      const quizForge = useQuizCreation();
+      const { saveQuiz, initializeQuiz } = useQuizCreation();
       const quizInitialized = ref(false);
-
-      return {
-        quizInitialized,
-        quizForge,
-      };
+      return { saveQuiz, initializeQuiz, quizInitialized };
     },
-    /**
-     * @returns {object}
-     * @property {object} quizForge - see useQuizCreation for details; this is a reflection of
-     *                                the object returned by that function which is initialized
-     *                                within this component
-     * add `inject: ['quizForge']` to any descendant component to access this
-     */
     provide() {
       return {
-        quizForge: this.quizForge,
         showError: false,
         moreResultsState: null,
         // null corresponds to 'All' filter value
@@ -113,12 +101,12 @@
         });
       },
     },
-    created() {
-      this.quizForge.initializeQuiz();
-      this.quizInitialized = true;
-    },
     mounted() {
       this.$store.dispatch('notLoading');
+    },
+    created() {
+      this.initializeQuiz();
+      this.quizInitialized = true;
     },
     $trs: {
       createNewExamLabel: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -62,12 +62,13 @@
     mixins: [commonCoreStrings, commonCoach, responsiveWindowMixin],
     setup() {
       const { saveQuiz, initializeQuiz } = useQuizCreation();
+      const showError = ref(false);
       const quizInitialized = ref(false);
-      return { saveQuiz, initializeQuiz, quizInitialized };
+      return { showError, saveQuiz, initializeQuiz, quizInitialized };
     },
     provide() {
       return {
-        showError: false,
+        showError: this.showError,
         moreResultsState: null,
         // null corresponds to 'All' filter value
         filters: {


### PR DESCRIPTION
## Summary
- Migrate to using the composition API's way of using provide/inject.
- Remove all instances of quizForge references and rather return the functions as necessary.

## References
Closes #11546

## Reviewer guidance
 

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
