### PR TITLE
Notify our slack on contributors' issue comments

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -1,0 +1,27 @@
+name: Send a slack notification when a contributor comments on issue
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  contributor_issue_comment:
+    name: Contributor issue comment
+
+    if: >-
+      ${{
+        !github.event.issue.pull_request &&
+        github.event.comment.author_association != 'MEMBER' &&
+        github.event.comment.author_association != 'OWNER'
+      }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send message to Slack channel
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data \
+          '{"text": "New comment on issue: '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}' by '${GITHUB_ACTOR}'"}' \
+          $SLACK_WEBHOOK_URL

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -21,7 +21,11 @@ jobs:
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          ISSUE_TITLE="${{ github.event.issue.title }} by ${GITHUB_ACTOR}"
+          ISSUE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}"
+          ISSUE_COMMENT_URL="${ISSUE_URL}#issuecomment-${{ github.event.comment.id }}"
+          JSON_TEXT="{\"text\": \"*New comment on issue: <${ISSUE_COMMENT_URL}|${ISSUE_TITLE}>*\"}"
+
           curl -X POST -H 'Content-type: application/json' \
-          --data \
-          '{"text": "New comment on issue: '${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/issues/${{ github.event.issue.number }}' by '${GITHUB_ACTOR}'"}' \
+          --data "$JSON_TEXT" \
           $SLACK_WEBHOOK_URL


### PR DESCRIPTION
## Summary
This adds a github action that will notify our slack #dev-community channel when any contributor comments on a issue. 

ToDo -- 
- [x]  Activate slack's webhook, already requested, need to be approved by one of our slack admins.
- [x] Add `SLACK_WEBHOOK_URL` as a GitHub secret.
- [x] Merge this PR and then test the action.

## References
Closes https://github.com/learningequality/kolibri/issues/9521.

## Reviewer guidance
I don't know how best to test this :man_shrugging: 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
