### PR TITLE
Solve the out of frame bug of quiz images

### DIFF
--- a/kolibri/plugins/perseus_viewer/assets/dist/perseus.js
+++ b/kolibri/plugins/perseus_viewer/assets/dist/perseus.js
@@ -102254,7 +102254,7 @@ var Card = React.createClass({
             left: this.props.startOffset.left,
             top: this.props.startOffset.top
         });
-        this.props.width && (style.width = this.props.width);
+        this.props.width && (style.minWidth = this.props.width);
         var className = [ "card" ];
         this.props.stack && className.push("stack");
         if (this.props.floating && !this.props.animating) {


### PR DESCRIPTION
## Summary
The dynamic sizing of images was causing overflow issues as it relied on the 'width' attribute, leading to images getting out of frame.

https://github.com/learningequality/kolibri/assets/77184239/3932231d-3a52-48bd-ba7c-18f9f4b1676d

I addressed this by updating the code to use the 'min-width' attribute, ensuring the image size adapts dynamically while preventing overflow. This resolves the framing issues.

https://github.com/learningequality/kolibri/assets/77184239/f3a1f0e7-9cd1-49b9-8d51-cabafa8ab15a

…

## References
#9211 
…

## Reviewer guidance

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
