### PR TITLE
trying to make all of the card layouts be in sync with one another

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useCardLayoutSpan.js
+++ b/kolibri/plugins/learn/assets/src/composables/useCardLayoutSpan.js
@@ -8,10 +8,10 @@ export default function useCardLayoutSpan() {
     if (get(windowIsSmall)) {
       return 1;
     }
-    if (get(windowBreakpoint) < 5) {
+    if (get(windowBreakpoint) < 3) {
       return 2;
     }
-    if (get(windowBreakpoint) < 6) {
+    if (get(windowBreakpoint) < 7) {
       return 3;
     }
     return 4;

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -68,7 +68,7 @@
 <style lang="scss" scoped>
 
   .grid {
-    padding: 8px;
+    padding-top: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelCardGroupGrid.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <KGrid>
+  <KGrid gutter="16">
     <KGridItem
       v-for="content in contents"
       :key="content.id"
@@ -65,4 +65,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .grid {
+    padding: 8px;
+  }
+
+</style>

--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/LibraryItem.vue
@@ -175,6 +175,8 @@
   .device-description {
     padding: 0;
     margin: 0 0 15px;
+    margin-right: -12px;
+    margin-left: -12px;
   }
 
   .library-header-sm {

--- a/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryAndChannelBrowserMainContent.vue
@@ -5,6 +5,7 @@
       :is="!windowIsSmall && currentCardViewStyle === 'list' ? 'div' : 'CardGrid'"
       :data-test="`${windowIsSmall ? '' : 'non-'}mobile-card-grid`"
       :style="{ maxWidth: '1700px' }"
+      :gridType="gridType"
     >
       <component
         :is="componentType"
@@ -82,6 +83,10 @@
       allowDownloads: {
         type: Boolean,
         default: false,
+      },
+      gridType: {
+        type: Number,
+        default: 1,
       },
     },
     computed: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div>
-    <KGrid gutter="12">
+    <KGrid gutter="16" class="grid">
       <KGridItem
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
@@ -240,6 +240,10 @@
   .wifi-svg {
     top: 0;
     transform: scale(1.5);
+  }
+
+  .grid {
+    margin: 8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/OtherLibraries.vue
@@ -1,13 +1,13 @@
 <template>
 
   <div>
-    <KGrid gutter="16" class="grid">
+    <KGrid gutter="0" class="grid">
       <KGridItem
         :layout12="{ span: 6 }"
         :layout8="{ span: 4 }"
         :layout4="{ span: 4 }"
       >
-        <h1>
+        <h1 :style="{ marginLeft: '-8px' }">
           {{ injectedtr('otherLibraries') }}
         </h1>
       </KGridItem>
@@ -69,10 +69,11 @@
     <h2
       v-if="!threeLibrariesOrFewer && pinnedDevicesExist && unpinnedDevicesExist"
       data-test="pinned-label"
+      :style="{ marginLeft: '-8px' }"
     >
       {{ injectedtr('pinned') }}
     </h2>
-    <FadeInTransitionGroup>
+    <FadeInTransitionGroup class="other-libraries-grid">
       <LibraryItem
         v-for="device in fullLibrariesToDisplay"
         :key="device['instance_id']"
@@ -87,7 +88,7 @@
 
     <!-- More  -->
 
-    <KGrid v-if="!threeLibrariesOrFewer && unpinnedDevicesExist">
+    <KGrid v-if="!threeLibrariesOrFewer && unpinnedDevicesExist" class="other-libraries-grid">
       <KGridItem
         :layout12="{ span: 10 }"
         :layout8="{ span: 6 }"
@@ -96,7 +97,7 @@
         <h2
           v-if="pinnedDevicesExist"
           data-test="more-label"
-          :style="{ marginTop: '0px' }"
+          :style="{ marginTop: '0px', marginLeft: '-8px' }"
         >
           {{ injectedtr('moreLibraries') }}
         </h2>
@@ -244,6 +245,10 @@
 
   .grid {
     margin: 8px;
+  }
+
+  .other-libraries-grid {
+    margin-left: 0.75em;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -30,6 +30,7 @@
       <LibraryAndChannelBrowserMainContent
         :contents="contentCardsToDisplay"
         data-test="resumable-content-card-grid"
+        class="resumable-content-card-grid"
         :currentCardViewStyle="currentCardViewStyle"
         :gridType="gridType"
         @openCopiesModal="copies => displayedCopies = copies"
@@ -175,6 +176,11 @@
 
   .toggle-view-buttons {
     float: right;
+  }
+
+  .resumable-content-card-grid {
+    margin-right: -8px;
+    margin-left: -8px;
   }
 
 </style>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/ResumableContentGrid.vue
@@ -31,7 +31,7 @@
         :contents="contentCardsToDisplay"
         data-test="resumable-content-card-grid"
         :currentCardViewStyle="currentCardViewStyle"
-        :gridType="1"
+        :gridType="gridType"
         @openCopiesModal="copies => displayedCopies = copies"
         @toggleInfoPanel="$emit('setSidePanelMetadataContent', $event)"
       />
@@ -127,7 +127,7 @@
     },
     computed: {
       numContentCardsToDisplay() {
-        return this.windowBreakpoint === 2 ? 4 : 3;
+        return this.windowBreakpoint === 2 || this.windowBreakpoint > 6 ? 4 : 3;
       },
       contentCardsToDisplay() {
         if (this.showMoreContentCards) {
@@ -138,6 +138,9 @@
       },
       moreContentCards() {
         return this.resumableContentNodes.length > this.numContentCardsToDisplay;
+      },
+      gridType() {
+        return this.windowBreakpoint > 6 ? 2 : 1;
       },
     },
     methods: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -76,6 +76,7 @@
             v-if="!deviceId && isUserLoggedIn"
             data-test="other-libraries"
             :injectedtr="injecttr"
+            class="other-libraries"
           />
 
         </div>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -76,7 +76,6 @@
             v-if="!deviceId && isUserLoggedIn"
             data-test="other-libraries"
             :injectedtr="injecttr"
-            class="other-libraries"
           />
 
         </div>

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -442,7 +442,7 @@
           (this.isLocalLibraryEmpty && !this.deviceId)
         ) {
           return 0;
-        } else if (this.windowBreakpoint < 4) {
+        } else if (this.windowBreakpoint < 5) {
           return 234;
         } else {
           return 346;

--- a/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/SearchResultsGrid.vue
@@ -42,7 +42,7 @@
       :allowDownloads="allowDownloads"
       data-test="search-results-card-grid"
       :currentCardViewStyle="currentCardViewStyle"
-      :gridType="1"
+      :gridType="gridType"
       @openCopiesModal="copies => displayedCopies = copies"
       @toggleInfoPanel="$emit('setSidePanelMetadataContent', $event)"
     />
@@ -143,6 +143,11 @@
       return {
         displayedCopies: [],
       };
+    },
+    computed: {
+      gridType() {
+        return this.windowBreakpoint > 6 ? 2 : 1;
+      },
     },
     methods: {
       toggleCardView(value) {

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/TopicSubsection.vue
@@ -33,6 +33,7 @@
       v-if="topic.children && topic.children.length"
       data-test="children-cards-grid"
       :contents="topic.children"
+      :gridType="gridType"
       :allowDownloads="allowDownloads"
       currentCardViewStyle="card"
       :keepCurrentBackLink="true"
@@ -92,6 +93,10 @@
         type: Boolean,
         default: false,
         required: false,
+      },
+      gridType: {
+        type: Number,
+        default: 1,
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -110,6 +110,7 @@
                   :key="t.id"
                   :topic="t"
                   :subTopicLoading="t.id === subTopicLoading"
+                  :gridType="gridType"
                   :allowDownloads="allowDownloads"
                   @showMore="handleShowMore"
                   @loadMoreInSubtopic="handleLoadMoreInSubtopic"
@@ -124,7 +125,7 @@
                 :allowDownloads="allowDownloads"
                 data-test="search-results"
                 :contents="resourcesDisplayed"
-                :numCols="numCols"
+                :gridType="gridType"
                 currentCardViewStyle="card"
                 @toggleInfoPanel="toggleInfoPanel"
               />
@@ -570,9 +571,6 @@
           ? this.learnString('exploreLibraries')
           : (this.topic && this.topic.title) || '';
       },
-      childrenToDisplay() {
-        return Math.max(this.numCols, 3);
-      },
       breadcrumbs() {
         if (!this.topic || !this.topic.ancestors) {
           return [];
@@ -601,6 +599,12 @@
       },
       resources() {
         return this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
+      },
+      childrenToDisplay() {
+        return this.windowBreakpoint === 2 || this.windowBreakpoint > 6 ? 4 : 3;
+      },
+      gridType() {
+        return this.windowBreakpoint > 6 ? 2 : 1;
       },
       resourcesDisplayed() {
         // if no folders are shown at this level, show more resources to fill the space
@@ -696,7 +700,7 @@
       sidePanelWidth() {
         if (!this.windowIsLarge) {
           return 0;
-        } else if (this.windowBreakpoint < 4) {
+        } else if (this.windowBreakpoint < 5) {
           return 234;
         } else {
           return 346;
@@ -728,15 +732,6 @@
           style.marginLeft = `${this.sidePanelWidth + 24}px`;
         }
         return style;
-      },
-      numCols() {
-        if (this.windowBreakpoint > 1 && this.windowBreakpoint < 2) {
-          return 2;
-        } else if (this.windowBreakpoint >= 2 && this.windowBreakpoint <= 4) {
-          return 3;
-        } else if (this.windowBreakpoint > 4) {
-          return 4;
-        } else return null;
       },
       throttledStickyCalculation() {
         return throttle(this.stickyCalculation);

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -601,10 +601,10 @@
         return this.contents.filter(content => content.kind !== ContentNodeKinds.TOPIC);
       },
       childrenToDisplay() {
-        return this.windowBreakpoint === 2 || this.windowBreakpoint > 6 ? 4 : 3;
+        return this.windowBreakpoint === 2 || this.windowBreakpoint > 4 ? 4 : 3;
       },
       gridType() {
-        return this.windowBreakpoint > 6 ? 2 : 1;
+        return this.windowBreakpoint > 4 ? 2 : 1;
       },
       resourcesDisplayed() {
         // if no folders are shown at this level, show more resources to fill the space

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -656,6 +656,7 @@
             // showMore is whether we should show more inline
             const showMore =
               !this.subTopicId &&
+              this.topics.length != 1 &&
               topicChildren.length > this.childrenToDisplay &&
               !this.expandedTopics[t.id];
 


### PR DESCRIPTION
## Summary
Following up on some regressions @thanksameeelian noticed with her work in #11515 and expanding on that work just a tiny bit for uniformity

## References
| Description | Screenshot |
|---|---|
| **"Mobile" or narrow screen**: single card wide in all sections; "recent" has 3 cards per "show more" | <img width="517" alt="Screenshot 2023-12-01 at 11 09 15 AM" src="https://github.com/learningequality/kolibri/assets/17235236/728a32e2-e5f5-4849-9d55-8f566fb47b73"> |
| **"Tablet" sized screen**: 2 cards wide in all sections; "recent" has 4 cards (2x2 grid) and then adds an even number more in a 2x2 grid with "show more"  | <img width="803" alt="Screenshot 2023-12-01 at 11 09 02 AM" src="https://github.com/learningequality/kolibri/assets/17235236/f8464d21-e6a8-4c63-9c67-7c7a8baf3004"> |
| **"Normal"** browser screen: 3 cards wide in all sections, "recent" increments rows by multiples of 3 | <img width="1437" alt="Screenshot 2023-12-01 at 11 08 37 AM" src="https://github.com/learningequality/kolibri/assets/17235236/82c3ff64-f274-4aa2-808f-7075533ad553">  |
|  **"Narrow"** browser screen: reduced side panel width (_slightly different than the spec_) at a higher breakpoint, such that the cards are less narrow |  <img width="1029" alt="Screenshot 2023-12-01 at 11 08 49 AM" src="https://github.com/learningequality/kolibri/assets/17235236/cec9c927-1ea2-4859-865e-bf26733916d7"> |
|  **"Wide"** browser screen:  Up to 4 cards, with a max grid width of 1700px | ![Screenshot 2023-12-01 at 11 08 23 AM](https://github.com/learningequality/kolibri/assets/17235236/ec6b650c-2f06-4b04-b31a-310266dea773) |
| **Topics Page**: Defaults to 4 cards/4 columns, with a max grid width of 170px | <img width="1429" alt="Screenshot 2023-12-14 at 10 38 08 AM" src="https://github.com/learningequality/kolibri/assets/17235236/94d3d220-58f8-4f70-aeb1-f0581d646374">
 |


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
