### PR TITLE
Prevent display of welcome modal in LOD's

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -3,7 +3,10 @@
   <div>
     <transition name="delay-entry">
       <PostSetupModalGroup
-        v-if="!(rootNodesLoading || searchLoading) && welcomeModalVisible && !areChannelsImported"
+        v-if="!(rootNodesLoading || searchLoading)
+          && welcomeModalVisible
+          && !areChannelsImported
+          && !isLearnerOnlyImport"
         isOnMyOwnUser
         @cancel="hideWelcomeModal"
       />
@@ -162,7 +165,7 @@
   import useUser from 'kolibri.coreVue.composables.useUser';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import { ContentNodeResource } from 'kolibri.resources';
-  import { mapState } from 'vuex';
+  import { mapState, mapGetters } from 'vuex';
   import SidePanelModal from '../SidePanelModal';
   import SearchFiltersPanel from '../SearchFiltersPanel';
   import { KolibriStudioId, PageNames } from '../../constants';
@@ -402,6 +405,7 @@
       };
     },
     computed: {
+      ...mapGetters(['isLearnerOnlyImport']),
       ...mapState({
         welcomeModalVisibleState: 'welcomeModalVisible',
       }),


### PR DESCRIPTION
## Summary
Use the existing getter function "isLearnerOnlyImport" to prevent display of welcome modal in the LOD's

…

## References
closes #11456 

…

## Reviewer guidance
- Open the library section.
- The Welcome Modal does not appear any more.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
