### PR TITLE
Fixes hitherto unnoticed bug that meant time_updated was never set.

### DIFF
--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -66,7 +66,7 @@ class ORMJob(Base):
     saved_job = Column(String)
 
     time_created = Column(DateTime(timezone=True), server_default=sql_func.now())
-    time_updated = Column(DateTime(timezone=True), server_onupdate=sql_func.now())
+    time_updated = Column(DateTime(timezone=True), onupdate=sql_func.now())
 
     # Repeat interval in seconds.
     interval = Column(Integer, default=0)


### PR DESCRIPTION
## Summary
* Uses the appropriate Column kwarg to ensure that the time_updated column is properly updated on update

## References
None, but may be useful for detecting stale or stalled tasks in future.

See here for motivation behind the diff: https://stackoverflow.com/a/33532154 the current code doesn't actually issue an update at all!

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
