### PR TITLE
Handle suspicious file operations and return a 404.

### DIFF
--- a/kolibri/utils/tests/test_kolibri_whitenoise.py
+++ b/kolibri/utils/tests/test_kolibri_whitenoise.py
@@ -5,6 +5,7 @@ from mock import MagicMock
 
 from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
 from kolibri.utils.kolibri_whitenoise import FileFinder
+from kolibri.utils.kolibri_whitenoise import NOT_FOUND
 
 
 def test_file_finder():
@@ -84,5 +85,26 @@ def test_dynamic_whitenoise():
     os.remove(tempdir21tempfilepath)
     os.close(tempdir22tempfile)
     os.remove(tempdir22tempfilepath)
+    os.removedirs(tempdir11)
+    os.removedirs(tempdir12)
+
+
+def test_dynamic_whitenoise_suspicious_file():
+    tempdir11 = tempfile.mkdtemp()
+    tempdir12 = tempfile.mkdtemp()
+    prefix1 = "/test"
+    dynamic_whitenoise = DynamicWhiteNoise(
+        MagicMock(),
+        dynamic_locations=[
+            (prefix1, tempdir11),
+            (prefix1, tempdir12),
+        ],
+    )
+    assert (
+        dynamic_whitenoise.find_and_cache_dynamic_file(
+            prefix1 + "/" + tempdir11 + "../../../leet_haxx0r.js", None
+        )
+        is not NOT_FOUND
+    )
     os.removedirs(tempdir11)
     os.removedirs(tempdir12)


### PR DESCRIPTION
## Summary
* Django already smartly handles attempts to traverse the file system with URL paths
* We now catch these errors and return a 404
* Adds a regression test for this behaviour

## References
Fixes #11595 

## Reviewer guidance
Do the changes make sense? Does the test make sense?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
