### PR TITLE
Add fields for tracking where jobs are executed

### DIFF
--- a/kolibri/core/tasks/job.py
+++ b/kolibri/core/tasks/job.py
@@ -262,6 +262,15 @@ class Job(object):
             self.extra_metadata[key] = value
         self.save_meta()
 
+    def update_worker_info(self, host=None, process=None, thread=None, extra=None):
+        self.storage.save_worker_info(
+            self.job_id,
+            host=host,
+            process=process,
+            thread=thread,
+            extra=extra,
+        )
+
     def check_for_cancel(self):
         if self.cancellable:
             if self.storage.check_job_canceled(self.job_id):

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -42,6 +42,7 @@ def execute_job_with_python_worker(job_id):
     directly from python internals.
     """
     import os
+    import socket
     import sys
     import threading
 
@@ -53,7 +54,7 @@ def execute_job_with_python_worker(job_id):
 
     execute_job(
         job_id,
-        worker_host=os.uname()[1],
+        worker_host=socket.gethostname(),
         worker_process=str(os.getpid()),
         worker_thread=str(thread_ident),
     )

--- a/kolibri/core/tasks/worker.py
+++ b/kolibri/core/tasks/worker.py
@@ -42,13 +42,20 @@ def execute_job_with_python_worker(job_id):
     directly from python internals.
     """
     import os
+    import sys
     import threading
+
+    # get_ident was added in Python 3.3 and never backported to 2.7
+    if sys.version_info[0] < 3:
+        thread_ident = threading.current_thread().ident
+    else:
+        thread_ident = threading.get_ident()
 
     execute_job(
         job_id,
         worker_host=os.uname()[1],
         worker_process=str(os.getpid()),
-        worker_thread=str(threading.get_ident()),
+        worker_thread=str(thread_ident),
     )
 
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Adds new fields to the `jobs` table which allow us to better reconcile the jobs with their status if worker execution is interrupted for some reason. These fields track:
- the hostname of the worker
- the process ID of the worker
- the thread ID of the worker
- any extra data the worker wants to track

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes https://github.com/learningequality/kolibri/issues/9710

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
There should be no perceptible change. The extra fields can be observed in the database, e.g.:
```
$ sqlite3 job_storage.sqlite3 
SQLite version 3.37.2 2022-01-06 13:25:41
Enter ".help" for usage hints.

sqlite> select id, func, state, worker_host, worker_process, worker_thread from jobs;
id                                func                                                          state      worker_host  worker_process  worker_thread  
--------------------------------  ------------------------------------------------------------  ---------  -----------  --------------  ---------------
d10e8b82fc8340a09dc886b53a841a46  kolibri.core.content.tasks.automatic_resource_import          COMPLETED  phlack       51781           140127435208256
1                                 kolibri.core.deviceadmin.tasks.perform_vacuum                 QUEUED     NULL         NULL            NULL           
streamed_cache_cleanup            kolibri.core.deviceadmin.tasks.streamed_cache_cleanup         QUEUED     NULL         NULL            NULL           
1000                              kolibri.core.discovery.tasks.reset_connection_states          QUEUED     phlack       51781           140127435208256
935d0c9cbb2ed6d2b971b26c6a3a2314  kolibri.core.discovery.tasks.add_dynamic_network_location     COMPLETED  phlack       51781           140127435208256
178d445f96e4ef5c8239edffc7e3472c  kolibri.core.discovery.tasks.perform_network_location_update  COMPLETED  phlack       51781           140127435208256
50                                kolibri.core.auth.tasks.soud_sync_processing                  QUEUED     phlack       51781           140127435208256
f870bab4a1884593bfc918f8d421ec1b  kolibri.core.auth.tasks.cleanupsync                           COMPLETED  phlack       51781           140120455886400
d660db3c63b846eebaad9bfd71bdc175  kolibri.core.content.tasks.automatic_resource_import          FAILED     phlack       51781           140120455886400
2dc8e34f08234f3bbdba42a6bd4bd48c  kolibri.core.auth.tasks.cleanupsync                           COMPLETED  phlack       51781           140127435208256
e38dd2e4c1f2456cb9aa94b7476dbb7d  kolibri.core.content.tasks.automatic_resource_import          FAILED     phlack       51781           140127435208256
0740f4d6436348a382a2dd5048b3c678  kolibri.core.auth.tasks.cleanupsync                           COMPLETED  phlack       51781           140120455886400
191b720c94c3410d980970d26eb85726  kolibri.core.content.tasks.automatic_resource_import          FAILED     phlack       51781           140120455886400

```
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
