### PR TITLE
move MeteredConnectionNotificationModal to Library Page & conditionally render "Other Libraries"

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -45,8 +45,6 @@
       @cancel="languageModalShown = false"
     />
 
-    <MeteredConnectionNotificationModal />
-
   </div>
 
 </template>
@@ -61,7 +59,6 @@
   import SideNav from 'kolibri.coreVue.components.SideNav';
   import { LearnerDeviceStatus } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import MeteredConnectionNotificationModal from 'kolibri-common/components/MeteredConnectionNotificationModal';
   import AppBar from '../AppBar';
   import StorageNotification from '../StorageNotification';
   import useUserSyncStatus from '../../composables/useUserSyncStatus';
@@ -70,7 +67,6 @@
     name: 'AppBarPage',
     components: {
       AppBar,
-      MeteredConnectionNotificationModal,
       LanguageSwitcherModal,
       ScrollingHeader,
       SideNav,

--- a/kolibri/plugins/learn/assets/src/composables/useDeviceSettings.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDeviceSettings.js
@@ -1,5 +1,8 @@
-import { computed } from 'kolibri.lib.vueCompositionApi';
+import { computed, ref } from 'kolibri.lib.vueCompositionApi';
 import store from 'kolibri.coreVue.vuex.store';
+import plugin_data from 'plugin_data';
+
+const allowDownloadOnMeteredConnection = ref(plugin_data.allowDownloadOnMeteredConnection);
 
 export default function useDeviceSettings() {
   const allowGuestAccess = computed(() => store.getters.allowGuestAccess);
@@ -8,5 +11,6 @@ export default function useDeviceSettings() {
   return {
     allowGuestAccess,
     canAccessUnassignedContent,
+    allowDownloadOnMeteredConnection,
   };
 }

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -16,6 +16,7 @@ export default {
       welcomeModalVisible: false,
       canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
       allowGuestAccess: plugin_data.allowGuestAccess,
+      allowDownloadOnMeteredConnection: plugin_data.allowDownloadOnMeteredConnection,
       /**
        * Used as a Learn-global state to allow communication about whether this modal is shown
        * or not at any time. It should be set as `false` whenever the content page is loaded.

--- a/kolibri/plugins/learn/assets/src/modules/pluginModule.js
+++ b/kolibri/plugins/learn/assets/src/modules/pluginModule.js
@@ -16,7 +16,6 @@ export default {
       welcomeModalVisible: false,
       canAccessUnassignedContentSetting: plugin_data.allowLearnerUnassignedResourceAccess,
       allowGuestAccess: plugin_data.allowGuestAccess,
-      allowDownloadOnMeteredConnection: plugin_data.allowDownloadOnMeteredConnection,
       /**
        * Used as a Learn-global state to allow communication about whether this modal is shown
        * or not at any time. It should be set as `false` whenever the content page is loaded.

--- a/kolibri/plugins/learn/kolibri_plugin.py
+++ b/kolibri/plugins/learn/kolibri_plugin.py
@@ -64,6 +64,9 @@ class LearnAsset(webpack_hooks.WebpackBundleHook):
         from kolibri.core.discovery.well_known import CENTRAL_CONTENT_BASE_INSTANCE_ID
 
         return {
+            "allowDownloadOnMeteredConnection": get_device_setting(
+                "allow_download_on_metered_connection"
+            ),
             "allowGuestAccess": get_device_setting("allow_guest_access"),
             "allowLearnerDownloads": get_device_setting(
                 "allow_learner_download_resources"

--- a/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
+++ b/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
@@ -87,8 +87,6 @@
           // if we only include one of the keys for the extra_settings object
           client({ method: 'GET', url: this.settingsUrl })
             .then(({ data }) => {
-              console.log('mounted', isMetered);
-              console.log(data);
               this.extra_settings = data.extra_settings;
               this.selected = this.extra_settings.allow_download_on_metered_connection
                 ? Options.USE_METERED
@@ -116,6 +114,7 @@
           data: { extra_settings },
         })
           .then(() => {
+            this.$emit('update', allow_download_on_metered_connection);
             window.sessionStorage.setItem(meteredNetworkModalDismissedKey, true);
             this.dismissed = true;
 


### PR DESCRIPTION
### *This PR is based off of `release-v0.16.x` and is intended for the planned patch 1 release*

## Summary

This PR relocates the `MeteredConnectionNotificationModal` [that was previously added to the codebase](https://github.com/learningequality/kolibri/pull/10624) and adjusts the logic for rendering the "Other Libraries" component in `Learn > Library`. 

With these changes, "Other Libraries" will not render for a user on a metered connection unless they choose "Allow download on metered connection" on the `MeteredConnectionNotificationModal` that now appears on the `Learn > Library` page. If the user chooses "Do not allow download..." the `OtherLibraries` component should not render unless  & until the user on a metered connection later changes this choice in their device settings. After dismissing the modal, it should not pop up for users again.

This PR represents a departure from the initial issue spec, as it was determined that prior plans to have the `MeteredConnectionNotificationModal` appear at point of download would not actually save users any data, as the content had already been loaded on their device for viewing. The solution presented here appeared to be the swiftest way to avoid unnecessarily expending a user's data without their explicit agreement.

## References

- Closes https://github.com/learningequality/kolibri/issues/10662
- Extends functionality of https://github.com/learningequality/kolibri/pull/10624

## Reviewer guidance
There are several conditions to explore once the testing setup steps are followed: 
- user is on metered connection
    - has not yet dismissed `MeteredConnectionNotificationModal`:
         - chooses `"Allow download on metered connection"`:
              - upon dismissal of the modal, `OtherLibraries` component renders & is navigable
         - chooses `"Do not allow download on metered connection"`:
              - upon dismissal of the modal, `OtherLibraries` component does not render 
     - has already dismissed `MeteredConnectionNotificationModal`:
        - `OtherLibraries` only visible if `"Allow download on metered connection"` previously selected
        - user does not encounter modal again after dismissing 
- user is not on metered connection  
    - `MeteredConnectionNotificationModal` does not render
    - `OtherLibraries` renders (when applicable/available to user)

### Testing as a dev -- instructions borrowed from https://github.com/learningequality/kolibri/pull/10624

Run `yarn app-devserver` to run Kolibri in the app mode. Be sure to click the `initialize/` url that will come up in your console. If you want to test with the connection not being metered, update the `run_kolibri_app_mode.py` file's `check_is_metered` function to return `False` and restart the `yarn app-devserver`.

Log in as a superuser and you should see the modal the first time and never again after. The key is stored in session storage, clear it and you'll see it again if you selected to not allow connections. As is, if you click "Allow..." then you'll never see the modal again no matter what per the expected logic of the modal not showing whenever they've already said it was allowed. Until the Device Settings page is updated you won't be able to change this directly without going into the Kolibri shell and running:

```python
from kolibri.core.device.models import DeviceSettings
settings = DeviceSettings.objects.first()
ex = settings.extra_settings
ex["allow_download_on_metered_connection"] = False
settings.extra_settings = ex
settings.save()
```

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
