### PR TITLE
Don't require channel name in content tasks API

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -67,7 +67,7 @@ def get_status(job):
 
 class ChannelValidator(JobValidator):
     channel_id = HexOnlyUUIDField()
-    channel_name = serializers.CharField()
+    channel_name = serializers.CharField(default="", allow_blank=True)
 
     def validate(self, data):
         job_data = super(ChannelValidator, self).validate(data)

--- a/kolibri/core/content/test/test_tasks.py
+++ b/kolibri/core/content/test/test_tasks.py
@@ -52,14 +52,16 @@ class ValidateContentTaskTestCase(TestCase):
                 }
             ).is_valid(raise_exception=True)
 
-    def test_missing_channel_name(self):
-        with self.assertRaises(serializers.ValidationError):
-            ChannelValidator(
-                data={
-                    "type": "kolibri.core.content.tasks.remotechannelimport",
-                    "channel_id": self.channel_id,
-                }
-            ).is_valid(raise_exception=True)
+    def test_default_channel_name(self):
+        validator = ChannelValidator(
+            data={
+                "type": "kolibri.core.content.tasks.remotechannelimport",
+                "channel_id": self.channel_id,
+            }
+        )
+        validator.is_valid(raise_exception=True)
+
+        self.assertEqual(validator.validated_data["extra_metadata"]["channel_name"], "")
 
     def test_wrong_node_ids_type(self):
         with self.assertRaises(serializers.ValidationError):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

It's nice to include the channel name in the tasks extra metadata so that it can be shown in the frontend, but often the caller only has the channel ID and is required to supply a bogus name. Instead, default to the empty string and let anyone inspecting the task decide how they want to deal with a missing name.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

None, although we often have to make use bogus names in kolibri-explore-plugin during data import since we only have a content manifest, and that only contains channel IDs.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Start a server in dev mode
2. Create a superuser
3. Make a post request to `/api/tasks/tasks/` to import a channel with data like `{"type": "kolibri.core.content.tasks.remotechannelimport", "channel_id": "<channel_id>"}`

Currently that will error as invalid tasks data. After the change, it will be inspected and the generated job will have an empty `channel_name` in the `extra_metadata` field.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
