### PR TITLE
Issue 10254: Improve coach tabs accessibility of Reports Lesson Tab

### DIFF
--- a/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
@@ -31,3 +31,8 @@ export const QuizzesTabs = {
   REPORT: 'tabReport',
   DIFFICULT_QUESTIONS: 'tabDifficultQuestions',
 };
+export const REPORTS_LESSON_TABS_ID = 'coachReportsLesson';
+export const ReportsLessonTabs = {
+  REPORTS: 'tabReports',
+  LEARNERS: 'tabLearners',
+};

--- a/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
+++ b/kolibri/plugins/coach/assets/src/constants/tabsConstants.js
@@ -20,8 +20,8 @@ export const ReportsGroupTabs = {
   ACTIVITY: 'tabActivity',
 };
 
-export const LEARNERS_TABS_ID = 'reportLearners';
-export const LearnersTabs = {
+export const REPORTS_LEARNERS_TABS_ID = 'coachReportsLearners';
+export const ReportsLearnersTabs = {
   REPORTS: 'tabReports',
   ACTIVITY: 'tabActivity',
 };

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -603,6 +603,10 @@ const coachStrings = createTranslator('CommonCoachStrings', {
     context:
       'Indicates to the coach how many questions the learner answered correctly compared to the previous attempt',
   },
+  coachReportsLesson: {
+    message: 'Report lesson',
+    context: 'Labels the Reports > Lesson tab for screen reader users',
+  },
 });
 
 // Strings for the Missing Content modals, tooltips, alerts, etc.

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -8,10 +8,10 @@
 
     <KPageContainer>
 
-      <ReportsLearnerHeader :enablePrint="true" :activeTabId="LearnersTabs.ACTIVITY" />
+      <ReportsLearnerHeader :enablePrint="true" :activeTabId="ReportsLearnersTabs.ACTIVITY" />
       <KTabsPanel
-        :tabsId="LEARNERS_TABS_ID"
-        :activeTabId="LearnersTabs.ACTIVITY"
+        :tabsId="REPORTS_LEARNERS_TABS_ID"
+        :activeTabId="ReportsLearnersTabs.ACTIVITY"
       >
         <ActivityList
           embeddedPageName="ReportsLearnerActivityPage"
@@ -29,7 +29,7 @@
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import ActivityList from '../common/notifications/ActivityList';
-  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
+  import { REPORTS_LEARNERS_TABS_ID, ReportsLearnersTabs } from '../../constants/tabsConstants';
   import ReportsLearnerHeader from './ReportsLearnerHeader';
 
   export default {
@@ -42,8 +42,8 @@
     mixins: [commonCoach],
     data() {
       return {
-        LEARNERS_TABS_ID,
-        LearnersTabs,
+        REPORTS_LEARNERS_TABS_ID,
+        ReportsLearnersTabs,
       };
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerHeader.vue
@@ -55,11 +55,11 @@
     <HeaderTabs :enablePrint="enablePrint">
       <KTabsList
         ref="tabList"
-        :tabsId="LEARNERS_TABS_ID"
+        :tabsId="REPORTS_LEARNERS_TABS_ID"
         :ariaLabel="$tr('reportLearners')"
         :activeTabId="activeTabId"
         :tabs="tabs"
-        @click="() => saveTabsClick(LEARNERS_TABS_ID)"
+        @click="() => saveTabsClick(REPORTS_LEARNERS_TABS_ID)"
       />
     </HeaderTabs>
   </div>
@@ -71,7 +71,7 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
-  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
+  import { REPORTS_LEARNERS_TABS_ID, ReportsLearnersTabs } from '../../constants/tabsConstants';
   import { useCoachTabs } from '../../composables/useCoachTabs';
 
   export default {
@@ -97,7 +97,7 @@
     },
     data() {
       return {
-        LEARNERS_TABS_ID,
+        REPORTS_LEARNERS_TABS_ID,
       };
     },
     computed: {
@@ -136,12 +136,12 @@
       tabs() {
         return [
           {
-            id: LearnersTabs.REPORTS,
+            id: ReportsLearnersTabs.REPORTS,
             label: this.coachString('reportsLabel'),
             to: this.classRoute('ReportsLearnerReportPage', {}),
           },
           {
-            id: LearnersTabs.ACTIVITY,
+            id: ReportsLearnersTabs.ACTIVITY,
             label: this.coachString('activityLabel'),
             to: this.classRoute('ReportsLearnerActivityPage', {}),
           },
@@ -153,8 +153,8 @@
       // that this header was re-mounted as a result
       // of navigation after clicking a tab (focus shouldn't
       // be manipulated programatically in other cases, e.g.
-      // when visiting the Plan page for the first time)
-      if (this.wereTabsClickedRecently(this.LEARNERS_TABS_ID)) {
+      // when visiting the page for the first time)
+      if (this.wereTabsClickedRecently(this.REPORTS_LEARNERS_TABS_ID)) {
         this.$nextTick(() => {
           this.$refs.tabList.focusActiveTab();
         });
@@ -168,7 +168,7 @@
       },
       reportLearners: {
         message: 'Report learners',
-        context: 'Labels the Reports > Learners tab for screen reander users',
+        context: 'Labels the Reports > Learners tab for screen reader users',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -8,10 +8,10 @@
 
     <KPageContainer>
 
-      <ReportsLearnerHeader :activeTabId="LearnersTabs.REPORTS" />
+      <ReportsLearnerHeader :activeTabId="ReportsLearnersTabs.REPORTS" />
       <KTabsPanel
-        :tabsId="LEARNERS_TABS_ID"
-        :activeTabId="LearnersTabs.REPORTS"
+        :tabsId="REPORTS_LEARNERS_TABS_ID"
+        :activeTabId="ReportsLearnersTabs.REPORTS"
       >
         <ReportsControls :disableExport="true" />
 
@@ -102,7 +102,7 @@
   import commonCoach from '../common';
   import CoachAppBarPage from '../CoachAppBarPage';
   import { PageNames } from '../../constants';
-  import { LEARNERS_TABS_ID, LearnersTabs } from '../../constants/tabsConstants';
+  import { REPORTS_LEARNERS_TABS_ID, ReportsLearnersTabs } from '../../constants/tabsConstants';
   import ReportsLearnerHeader from './ReportsLearnerHeader';
   import ReportsControls from './ReportsControls';
 
@@ -116,8 +116,8 @@
     mixins: [commonCoach, commonCoreStrings],
     data() {
       return {
-        LEARNERS_TABS_ID,
-        LearnersTabs,
+        REPORTS_LEARNERS_TABS_ID,
+        ReportsLearnersTabs,
       };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -93,7 +93,7 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const { coachReportsLesson$ } = coachStrings();
+      const { coachReportsLesson$ } = coachStrings;
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
       return {
         saveTabsClick,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -43,7 +43,7 @@
             <KTabsList
               ref="tabList"
               :tabsId="REPORTS_LESSON_TABS_ID"
-              :ariaLabel="$tr('coachReportsLesson')"
+              :ariaLabel="coachReportsLesson$()"
               :activeTabId="activeTabId"
               :tabs="tabs"
               @click="() => saveTabsClick(REPORTS_LESSON_TABS_ID)"
@@ -71,6 +71,7 @@
   import sortBy from 'lodash/sortBy';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonCoach from '../common';
+  import { coachStrings } from '../common/commonCoachStrings';
   import CoachAppBarPage from '../CoachAppBarPage';
   import CSVExporter from '../../csv/exporter';
   import * as csvFields from '../../csv/fields';
@@ -92,10 +93,12 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
+      const {coachReportsLesson$} = coachStrings();
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
       return {
         saveTabsClick,
         wereTabsClickedRecently,
+        coachReportsLesson$,
       };
     },
     props: {
@@ -269,12 +272,6 @@
             );
           }
         }
-      },
-    },
-    $trs: {
-      coachReportsLesson: {
-        message: 'Report lesson',
-        context: 'Labels the Reports > Lesson tab for screen reader users',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -93,7 +93,7 @@
     },
     mixins: [commonCoach, commonCoreStrings],
     setup() {
-      const {coachReportsLesson$} = coachStrings();
+      const { coachReportsLesson$ } = coachStrings();
       const { saveTabsClick, wereTabsClickedRecently } = useCoachTabs();
       return {
         saveTabsClick,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerListPage.vue
@@ -1,18 +1,27 @@
 <template>
 
-  <ReportsLessonBase :showLearners="true" />
+  <ReportsLessonBase :showLearners="true" :activeTabId="ReportsLessonTabs.LEARNERS">
+    <KTabPanel :tabsId="REPORTS_LESSON_TABS_ID" :activeTabId="ReportsLessonTabs.LEARNERS" />
+  </ReportsLessonBase>
 
 </template>
 
 
 <script>
 
+  import { REPORTS_LESSON_TABS_ID, ReportsLessonTabs } from '../../constants/tabsConstants';
   import ReportsLessonBase from './ReportsLessonBase';
 
   export default {
     name: 'ReportsLessonLearnerListPage',
     components: {
       ReportsLessonBase,
+    },
+    data() {
+      return {
+        REPORTS_LESSON_TABS_ID,
+        ReportsLessonTabs,
+      };
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -1,18 +1,26 @@
 <template>
 
-  <ReportsLessonBase :showResources="true" />
+  <ReportsLessonBase :showResources="true" :activeTabId="ReportsLessonTabs.REPORTS">
+    <KTabPanel :tabsId="REPORTS_LESSON_TABS_ID" :activeTabId="ReportsLessonTabs.REPORTS" />
+  </ReportsLessonBase>
 
 </template>
 
 
 <script>
-
+  import { REPORTS_LESSON_TABS_ID, ReportsLessonTabs } from '../../constants/tabsConstants';
   import ReportsLessonBase from './ReportsLessonBase';
 
   export default {
     name: 'ReportsLessonReportPage',
     components: {
       ReportsLessonBase,
+    },
+    data() {
+      return {
+        REPORTS_LESSON_TABS_ID,
+        ReportsLessonTabs,
+      };
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonReportPage.vue
@@ -8,6 +8,7 @@
 
 
 <script>
+
   import { REPORTS_LESSON_TABS_ID, ReportsLessonTabs } from '../../constants/tabsConstants';
   import ReportsLessonBase from './ReportsLessonBase';
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Use KTabs to improve the accessibility of the Reports Lesson Tabs.

![Peek 2023-12-09 17-21](https://github.com/learningequality/kolibri/assets/74391865/80d8c20b-0964-4f48-bc59-344f2c411960)



## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #10254

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->



To review, Go to Coach -->Select a Class --> Reports --> Lesson --> Select a lesson. Then test the tabs with keyboard tabs key.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
