### PR TITLE
Align Windows Python versions for tox tests and c extensions to 3.8.

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -156,7 +156,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v4

--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -185,7 +185,7 @@ def parse_package_page(files, pk_version, index_url, cache_path):
             continue
         if "macosx" in platform:
             continue
-        if "win_amd64" in platform and python_version != "39":
+        if "win_amd64" in platform and python_version != "38":
             continue
 
         # Cryptography builds for Linux target Python 3.4+ but the only existing


### PR DESCRIPTION
## Summary
To ensure backwards compatibility with Windows 7, our Windows installer currently bundles Python 3.8
This fixes our Python tests on Windows to the same, and also bundles Python 3.8 C extensions for Windows also.

## References
May ameliorate #9908

## Reviewer guidance
Test the Windows installer asset, check if it produces such high CPU usage.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
