### PR TITLE
Remove stray references to quizForge

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -185,7 +185,7 @@
         </KGrid>
 
         <AccordionContainer
-          :items="quizForge.activeQuestions.value.map(i => ({
+          :items="activeQuestions.map(i => ({
             id: i.question_id,
           }))"
         >
@@ -193,25 +193,25 @@
             <KCheckbox
               ref="selectAllCheckbox"
               class="select-all-box"
-              :label="quizForge.selectAllLabel.value"
-              :checked="quizForge.allQuestionsSelected.value"
-              :indeterminate="quizForge.selectAllIsIndeterminate.value"
-              @change="() => quizForge.selectAllQuestions()"
+              :label="selectAllLabel$()"
+              :checked="allQuestionsSelected"
+              :indeterminate="selectAllIsIndeterminate"
+              @change="() => selectAllQuestions()"
             />
           </template>
           <template #right-actions>
             <KIconButton
               icon="refresh"
               :tooltip="replaceAction$()"
-              :disabled="quizForge.selectedActiveQuestions.value.length === 0"
-              @click="handleReplaceSelection"
+              :disabled="selectedActiveQuestions.length === 0"
+              @click="handleReplaceSelection()"
             />
             <KIconButton
               icon="trash"
               :tooltip="coreString('deleteAction')"
               :aria-label="coreString('deleteAction')"
-              :disabled="quizForge.selectedActiveQuestions.value.length === 0"
-              @click="quizForge.deleteActiveSelectedQuestions"
+              :disabled="selectedActiveQuestions.length === 0"
+              @click="deleteActiveSelectedQuestions()"
             />
           </template>
           <template #default="{ toggleItemState, isItemExpanded }">
@@ -339,6 +339,7 @@
     setup() {
       const {
         sectionLabel$,
+        selectAllLabel$,
         addQuizSections$,
         addSectionLabel$,
         quizTitle$,
@@ -356,6 +357,9 @@
         // Methods
         saveQuiz,
         updateSection,
+        allQuestionsSelected,
+        selectAllIsIndeterminate,
+        deleteActiveSelectedQuestions,
         replaceSelectedQuestions,
         addSection,
         removeSection,
@@ -386,6 +390,7 @@
         dragActive,
         sectionCreationCount,
         sectionLabel$,
+        selectAllLabel$,
         addQuizSections$,
         quizSectionsLabel$,
         addSectionLabel$,
@@ -400,6 +405,9 @@
 
         saveQuiz,
         updateSection,
+        allQuestionsSelected,
+        selectAllIsIndeterminate,
+        deleteActiveSelectedQuestions,
         replaceSelectedQuestions,
         addSection,
         removeSection,


### PR DESCRIPTION
## Summary
This PR does some small follow-up tidying of quizForge references, and ensures that as we moved to provide/inject, everything is imported.

## Reviewer guidance
- are all references to quizForge and .value in the template now removed? 
- are all method/computed referenced accurately, particularly when referenced during render (this is something I am actually the least sure about)?
- does the page render properly?
- are all strings available?


I am still getting some console errors about the quiz data structure in debug mode

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
