### PR TITLE
Fix title validation error bug in quizSection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -23,7 +23,7 @@
           :label="quizTitle$()"
           :autofocus="true"
           :maxlength="100"
-          @blur="e => updateQuiz({ title: e.target })"
+          @blur="e => updateQuiz({ title: e.target.value })"
           @change="title => updateQuiz({ title })"
         />
       </KGridItem>


### PR DESCRIPTION
## Summary
- Fix the incorrect value of title being passed down in the KTextbox.


## References

## Reviewer guidance
- Go to the quiz section.
- Try adding a section, the validation error popping earlier in the console is fixed!


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
