### PR TITLE
Include nodes for import that are missing supplementary files

### DIFF
--- a/kolibri/core/content/utils/import_export_content.py
+++ b/kolibri/core/content/utils/import_export_content.py
@@ -162,8 +162,13 @@ def get_import_export_nodes(  # noqa: C901
         kind=content_kinds.TOPIC
     )
 
-    if available is not None:
-        nodes_to_include = nodes_to_include.filter(available=available)
+    # When exporting, only include available nodes. When importing, include any
+    # nodes that are missing files in case they have missing supplementary
+    # files and would be considered available.
+    if available is True:
+        nodes_to_include = nodes_to_include.filter(available=True)
+    elif available is False:
+        nodes_to_include = nodes_to_include.filter(files__local_file__available=False)
 
     if check_file_availability:
         nodes_to_include = filter_by_file_availability(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

When calculating nodes to import, only nodes that aren't available are included. However, a node is considered available if it's only missing supplementary files, so only nodes that aren't missing files should be filtered out of the import data.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Discussed on Slack with @rtibbles. What we're trying to do is mirror channels from Studio so that we can use it as a local cache when building OS images that contain preloaded Kolibri content. However, sometimes our channels have missing files despite repeatedly trying to import them from Studio. We tracked this down to supplementary files (thumbnails) that aren't being pulled from Studio when a channel is already present on the cache server.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Import a channel and content, delete a thumbnail file, scan the content so it gets marked as unavailable, then import the channel content again. The thumbnail won't be downloaded again.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
