### PR TITLE
Better setup wizard errors

### DIFF
--- a/kolibri/core/assets/src/views/userAccounts/UsernameTextbox.vue
+++ b/kolibri/core/assets/src/views/userAccounts/UsernameTextbox.vue
@@ -9,6 +9,7 @@
     :maxlength="30"
     :invalid="Boolean(shownInvalidText)"
     :invalidText="shownInvalidText"
+    autocomplete="username"
     @blur="blurred = true"
     @input="handleInput"
   />

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div class="full-page">
-    <AppError :hideParagraphs="true">
+    <AppError v-if="coreError" :hideParagraphs="true">
       <template #buttons>
         <KButton
           :text="coreString('startOverAction')"
@@ -15,7 +15,7 @@
       </template>
     </AppError>
     <main
-      v-if="!coreError"
+      v-else
       class="content"
     >
       <KolibriLoadingSnippet />

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/UserCredentialsForm.vue
@@ -12,11 +12,10 @@
   >
     <slot name="aboveform"></slot>
 
-    <!-- HACK in Import mode, this slot will be replaced by Password-only form -->
     <!-- VUE3-COMPAT: linter doesn't like that we are injecting "footer" slot from
          inside a slot default
     -->
-    <slot name="form">
+    <form>
       <!-- Hiding the fullname and username textboxes, but their values are filled in and presumed
            valid if we're given the user that we're taking credentials for (ie, just entering
            password for admin)
@@ -57,7 +56,7 @@
 
       <PrivacyLinkAndModal v-if="!hidePrivacyLink" />
 
-    </slot>
+    </form>
 
     <slot name="footer">
       <div class="reminder">
@@ -109,15 +108,15 @@
       },
       step: {
         type: Number,
-        required: true,
+        default: null,
       },
       steps: {
         type: Number,
-        required: true,
+        default: null,
       },
       footerMessageType: {
         type: String,
-        required: true,
+        default: null,
       },
       // A passthrough to the onboarding step base to hide "GO BACK" when needed
       noBackAction: {

--- a/packages/kolibri-common/components/AppError/index.vue
+++ b/packages/kolibri-common/components/AppError/index.vue
@@ -8,27 +8,26 @@
       {{ headerText }}
     </h1>
 
-    <template v-if="!hideParagraphs">
-      <p v-for="(paragraph, idx) in paragraphTexts" :key="idx">
-        {{ paragraph }}
-      </p>
-    </template>
+    <p v-for="paragraph in paragraphTexts" :key="paragraph">
+      {{ paragraph }}
+    </p>
 
     <p>
-      <slot name="buttons"></slot>
-      <KButtonGroup v-if="!$slots.buttons">
-        <KButton
-          v-if="!isPageNotFound"
-          :text="coreString('refresh')"
-          :primary="true"
-          @click="reloadPage"
-        />
-        <KButton
-          :primary="isPageNotFound"
-          appearance="raised-button"
-          :text="exitButtonLabel"
-          @click="handleClickBackToHome"
-        />
+      <KButtonGroup>
+        <slot name="buttons">
+          <KButton
+            v-if="!isPageNotFound"
+            :text="coreString('refresh')"
+            :primary="true"
+            @click="reloadPage"
+          />
+          <KButton
+            :primary="isPageNotFound"
+            appearance="raised-button"
+            :text="exitButtonLabel"
+            @click="handleClickBackToHome"
+          />
+        </slot>
       </KButtonGroup>
     </p>
 
@@ -89,6 +88,9 @@
         return this.$tr('defaultErrorHeader');
       },
       paragraphTexts() {
+        if (this.hideParagraphs) {
+          return [];
+        }
         if (this.isPageNotFound) {
           return [this.$tr('resourceNotFoundMessage')];
         }


### PR DESCRIPTION
## Summary
* Does some cleanup of vue prop warnings
* Cleans up some form warnings
* Reverts my previous suggestion to @akolson to use UIAlert, as it causes a big old mess without additional strings, and reverts to the AppError component
* Always displays a retry and a restart button if there is an error on the provisioning page to ensure that people can start over if needed.

## References
Fixes https://github.com/learningequality/kolibri/issues/11574

![image](https://github.com/learningequality/kolibri/assets/1680573/de95d3e9-0762-4686-91f5-24e50ce2c99b)


## Reviewer guidance
I tested this by adding `raise Exception` here: https://github.com/learningequality/kolibri/blob/release-v0.16.x/kolibri/core/device/api.py#L101

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
