### PR TITLE
Add a meaningful error warning when KDS path is not provided when running yarn run devserver-with-kds

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -228,6 +228,10 @@ program
   )
   .option('--kds-path <kdsPath>', 'Full path to local kds directory', String, '')
   .action(function(mode, options) {
+    if (!options.kdsPath) {
+      cliLogging.error('Path to the local KDS directory not specified.');
+      process.exit(1);
+    }
     if (typeof mode !== 'string') {
       cliLogging.error('Build mode must be specified');
       process.exit(1);


### PR DESCRIPTION
## Summary

This PR aims to make the `yarn run devserver-with-kds` command throw an error warning when KDS path is not provided along while running it in the cli.

## References


## Reviewer guidance

1.  Run the `yarn run devserver-with-kds` command in the cli without specifying the path to the local kds.
2. You'll see an error message and the command will terminate with `exit code 1`.

## Screenshot

![Errorproof](https://github.com/learningequality/kolibri/assets/116485536/feb73743-009b-43e2-82e3-c83dc15eaa2a)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
