### PR TITLE
Add a meaningful error warning when KDS path is not provided when running yarn run devserver-with-kds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "app-devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:app-python-devserver yarn:hashi-dev --",
     "devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
     "devserver-hot": "concurrently --passthrough-arguments --kill-others \"yarn:watch-hot --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
-    "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly --kds --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
+    "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly={2} --require-kds-path --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt --transpile",
     "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
     "preinstall": "node ./packages/kolibri-tools/lib/npm_deprecation_warning.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "app-devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:app-python-devserver yarn:hashi-dev --",
     "devserver": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
     "devserver-hot": "concurrently --passthrough-arguments --kill-others \"yarn:watch-hot --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
-    "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
+    "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly --kds --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt --transpile",
     "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
     "preinstall": "node ./packages/kolibri-tools/lib/npm_deprecation_warning.js",

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -81,7 +81,7 @@ function runWebpackBuild(mode, bundleData, devServer, options, cb = null) {
     cache: options.cache,
     transpile: options.transpile,
     devServer,
-    kds: options.kds,
+    requireKdsPath: options.requireKdsPath,
     kdsPath: options.kdsPath,
   };
 
@@ -227,12 +227,18 @@ program
     list,
     []
   )
-  .option('--kds', 'Flag to use local kds', false)
+  .option(
+    '--require-kds-path',
+    'Flag to check if yarn command is run using devserver-with-kds',
+    false
+  )
   .option('--kds-path <kdsPath>', 'Full path to local kds directory', String, '')
   .action(function(mode, options) {
-    if (options.kds) {
+    if (options.requireKdsPath) {
       if (!options.kdsPath) {
-        cliLogging.error('Path to the local KDS directory not specified.');
+        cliLogging.error(
+          'The --require-kds-path flag was specified, but no --kds-path value was provided. Please include the path to the local KDS directory.'
+        );
         process.exit(1);
       }
     }

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -81,6 +81,7 @@ function runWebpackBuild(mode, bundleData, devServer, options, cb = null) {
     cache: options.cache,
     transpile: options.transpile,
     devServer,
+    kds: options.kds,
     kdsPath: options.kdsPath,
   };
 
@@ -226,8 +227,15 @@ program
     list,
     []
   )
+  .option('--kds', 'Flag to use local kds', false)
   .option('--kds-path <kdsPath>', 'Full path to local kds directory', String, '')
   .action(function(mode, options) {
+    if (options.kds) {
+      if (!options.kdsPath) {
+        cliLogging.error('Path to the local KDS directory not specified.');
+        process.exit(1);
+      }
+    }
     if (typeof mode !== 'string') {
       cliLogging.error('Build mode must be specified');
       process.exit(1);


### PR DESCRIPTION
## Summary

This PR aims to make the `yarn run devserver-with-kds` command throw an error warning when KDS path is not provided while running it in the cli.

## References
#11632 

## Reviewer guidance

1.  Run the `yarn run devserver-with-kds` command in the cli without specifying the path to the local kds.
2. You'll see an error message and the command will terminate with `exit code 1`.

## Screenshot

![Errorproof](https://github.com/learningequality/kolibri/assets/116485536/596ebfc6-eb74-4f4c-897d-c8551836b63c)

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
