### PR TITLE
Close the import modal after the import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -341,6 +341,8 @@
                 token,
               },
             });
+            this.disableModal = false;
+            this.showTokenModal = false;
           } else {
             this.showTokenModal = false;
           }


### PR DESCRIPTION
The following PR fixes https://github.com/learningequality/kolibri/issues/11647
i.e the import modal closes after the import is done 

I hope this fixes the issue