### PR TITLE
Sanitize inputs to handle NULL characters when parsing a string literal

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -20,7 +20,7 @@ from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
-from django.db.models import TextField
+from django.db.models import TextField, CharField
 from django.db.models import Value
 from django.db.models.functions import Cast
 from django.http import Http404
@@ -42,6 +42,7 @@ from morango.models import TransferSession
 from rest_framework import decorators
 from rest_framework import filters
 from rest_framework import permissions
+from rest_framework import serializers
 from rest_framework import status
 from rest_framework import views
 from rest_framework import viewsets
@@ -80,6 +81,7 @@ from kolibri.core.device.utils import valid_app_key_on_request
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.mixins import BulkCreateMixin
 from kolibri.core.mixins import BulkDeleteMixin
+from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.query import annotate_array_aggregate
 from kolibri.core.query import SQCount
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
@@ -429,12 +431,18 @@ class FacilityUserViewSet(ValuesViewset):
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
 
+class SanitizeInputsSerializer(serializers.Serializer):
+    username= serializers.CharField()
+    facility= HexOnlyUUIDField()
 
 class UsernameAvailableView(views.APIView):
     def post(self, request):
-        username = request.data.get("username")
-        facility_id = request.data.get("facility")
-
+        serializer = SanitizeInputsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        username = serializer.validated_data["username"]
+        facility_id = serializer.validated_data["facility"]
         if not username or not facility_id:
             return Response(
                 "Must specify username, and facility",

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -20,7 +20,7 @@ from django.db.models import Func
 from django.db.models import OuterRef
 from django.db.models import Q
 from django.db.models import Subquery
-from django.db.models import TextField, CharField
+from django.db.models import TextField
 from django.db.models import Value
 from django.db.models.functions import Cast
 from django.http import Http404
@@ -81,9 +81,9 @@ from kolibri.core.device.utils import valid_app_key_on_request
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.mixins import BulkCreateMixin
 from kolibri.core.mixins import BulkDeleteMixin
-from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.query import annotate_array_aggregate
 from kolibri.core.query import SQCount
+from kolibri.core.serializers import HexOnlyUUIDField
 from kolibri.core.utils.pagination import ValuesViewsetPageNumberPagination
 from kolibri.plugins.app.utils import interface
 
@@ -431,9 +431,11 @@ class FacilityUserViewSet(ValuesViewset):
         if self.request.user == instance:
             update_session_auth_hash(self.request, instance)
 
+
 class SanitizeInputsSerializer(serializers.Serializer):
-    username= serializers.CharField()
-    facility= HexOnlyUUIDField()
+    username = serializers.CharField()
+    facility = HexOnlyUUIDField()
+
 
 class UsernameAvailableView(views.APIView):
     def post(self, request):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -441,8 +441,6 @@ class UsernameAvailableView(views.APIView):
     def post(self, request):
         serializer = SanitizeInputsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         username = serializer.validated_data["username"]
         facility_id = serializer.validated_data["facility"]
         if not username or not facility_id:


### PR DESCRIPTION
## Summary
This PR aims to sanitize the username and facility inputs from `Create Account` page by passing them through a serializer so as to avoid NULL characters and use the validated data from the serializer.

## References
#10505

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
