### PR TITLE
Quiz rebase regression fixes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -107,36 +107,39 @@
       tabsId="quizSectionTabs"
       :activeTabId="activeSection ? activeSection.section_id : ''"
     >
-      <p>{{ activeSection.section_id }}</p>
-      <!-- TODO This should be a separate component like "empty section container" or something -->
-      <div v-if="!activeQuestions.length" class="no-question-style">
-        <KGrid class="questions-list-label-row">
-          <KGridItem
-            class="right-side-heading"
-            style="padding: 0.7em 0.75em;"
+      <KGrid v-if="!activeQuestions.length" class="questions-list-label-row">
+        <KGridItem
+          class="right-side-heading"
+          style="padding: 0.7em 0.75em;"
+        >
+          <KButton
+            primary
+            :text="coreString('optionsLabel')"
           >
-            <KButton
-              primary
-              :text="coreString('optionsLabel')"
-            >
-              <template #menu>
-                <KDropdownMenu
-                  :primary="false"
-                  :disabled="false"
-                  :hasIcons="true"
-                  :options="activeSectionActions"
-                  @tab="e => (e.preventDefault() || $refs.selectAllCheckbox.focus())"
-                  @select="handleActiveSectionAction"
-                />
-              </template>
-            </KButton>
-          </KGridItem>
-        </KGrid>
+            <template #menu>
+              <KDropdownMenu
+                :primary="false"
+                :disabled="false"
+                :hasIcons="true"
+                :options="activeSectionActions"
+                @tab="e => (e.preventDefault() || $refs.selectAllCheckbox.focus())"
+                @select="handleActiveSectionAction"
+              />
+            </template>
+          </KButton>
+        </KGridItem>
+      </KGrid>
+      <!-- TODO This should be a separate component like "empty section container" or something -->
+      <div
+        v-if="!activeQuestions.length"
+        style="text-align: center; padding: 0 0 1em 0; max-width: 350px; margin: 0 auto;"
+      >
+        <!-- TODO This question mark thing should probably be an SVG for improved a11y -->
         <div class="question-mark-layout">
           <span class="help-icon-style">?</span>
         </div>
 
-        <p class="no-question-style">
+        <p style="margin-top: 1em; font-weight: bold;">
           {{ noQuestionsInSection$() }}
         </p>
 
@@ -145,6 +148,7 @@
         <KButton
           primary
           icon="plus"
+          style="margin-top: 1em;"
           @click="openSelectResources(activeSection.section_id)"
         >
           {{ addQuestionsLabel$() }}
@@ -586,10 +590,11 @@
   }
 
   .question-mark-layout {
-    align-items: center;
     width: 2.5em;
     height: 2.5em;
     margin: auto;
+    line-height: 1.7;
+    text-align: center;
     background-color: #dbc3d4;
   }
 
@@ -597,10 +602,6 @@
     font-size: 1.5em;
     font-weight: 700;
     color: #996189;
-  }
-
-  .no-question-style {
-    font-weight: bold;
   }
 
   .kgrid-alignment-style {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -43,7 +43,6 @@
           tabsId="quizSectionTabs"
           class="section-tabs"
           :tabs="tabs"
-          :appearanceOverrides="{ padding: '0px', overflow: 'hidden' }"
           :activeTabId="activeSection ?
             activeSection.section_id :
             '' "

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -139,8 +139,8 @@
     >
       <transition-group>
         <Draggable
-          v-for="(section,index) in sectionOrderList"
-          :key="index"
+          v-for="(section) in sectionOrderList"
+          :key="section.section_id"
           :style="draggableStyle"
         >
           <DragHandle>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -175,7 +175,7 @@
                   :style="{ color: $themePalette.grey.v_700 }"
                 >
                   <p
-                    v-if="activeSection.value.section_id === section.section_id"
+                    v-if="activeSection.section_id === section.section_id"
                     class="current-section-text space-content"
                   >
                     {{ currentSection$() }}
@@ -197,7 +197,7 @@
         >
           <KButton
             :text="deleteSectionLabel$()"
-            @click="deleteSection(activeSection.value.section_id)"
+            @click="deleteSection(activeSection.section_id)"
           />
         </KGridItem>
         <KGridItem
@@ -222,6 +222,8 @@
 
 <script>
 
+  import { ref } from 'kolibri.lib.vueCompositionApi';
+  import { get } from '@vueuse/core';
   import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import Draggable from 'kolibri.coreVue.components.Draggable';
@@ -264,15 +266,28 @@
         deleteSection,
       } = injectQuizCreation();
 
+      const selectedQuestionOrder = ref(get(activeSection).learners_see_fixed_order);
+      const numberOfQuestions = ref(get(activeSection).question_count);
+      const descriptionText = ref(get(activeSection).description);
+      const sectionTitle = ref(get(activeSection).section_title);
+
       const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
       return {
+        // useQuizCreation
         activeSection,
         allSections,
         updateSection,
         updateQuiz,
         deleteSection,
+        // Form models
+        selectedQuestionOrder,
+        numberOfQuestions,
+        descriptionText,
+        sectionTitle,
+        // Responsiveness
         windowIsLarge,
         windowIsSmall,
+        // i18n
         sectionSettings$,
         sectionTitle$,
         numberOfQuestionsLabel$,
@@ -289,14 +304,6 @@
         randomizedOptionDescription$,
         fixedLabel$,
         fixedOptionDescription$,
-      };
-    },
-    data() {
-      return {
-        selectedQuestionOrder: this.activeSection.value.learners_see_fixed_order,
-        numberOfQuestions: this.activeSection.value.question_count,
-        descriptionText: this.activeSection.value.description,
-        sectionTitle: this.activeSection.value.section_title,
       };
     },
     computed: {
@@ -316,7 +323,7 @@
        * @returns { QuizSection[] }
        */
       sectionOrderList() {
-        return this.allSections.value;
+        return this.allSections;
       },
       draggableStyle() {
         return {
@@ -330,7 +337,7 @@
       },
       applySettings() {
         this.updateSection({
-          section_id: this.activeSection.value.section_id,
+          section_id: this.activeSection.section_id,
           section_title: this.sectionTitle,
           description: this.descriptionText,
           question_count: this.numberOfQuestions,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "extends browserslist-config-kolibri"
   ],
   "volta": {
-    "node": "16.18.0"
+    "node": "16.18.0",
+    "yarn": "1.12.3"
   }
 }
-


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

### Fixes the "SectionEditor" side panel not displaying

Some issues w/ .value removal seem to have been the culprit here. I've also reworked some of the local state management for the form.

##  Fixes section tab styles

Artifact of mistaken conflict resolution.

| Before | ![image](https://github.com/learningequality/kolibri/assets/6356129/13509437-d5a2-4ca2-b423-606ce41bf81e) |
|--------|--------|
| After | ![image](https://github.com/learningequality/kolibri/assets/6356129/0a1ffb72-07d2-43c5-a75d-9fe68f4b0d4b) |

### Re-applies styles from @AllanOXDi 's previous work styling the "No questions" view

Another artifact of mistakes in conflict resolution / rebasing.

| Before | ![image](https://github.com/learningequality/kolibri/assets/6356129/5f2b464d-36b7-4cb3-80a0-276e90c9b476) |
|--------|--------|
| After | ![image](https://github.com/learningequality/kolibri/assets/6356129/0ae9f174-ac6d-4f18-8c0e-03abab3b39e9) | 



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### QA @radinamatic 

- Tabs a11y still works as expected including:
    - Tab navigation
    - Add section button accessible
- Post-tabs navigation 
    - Options dropdown menu accessible, buttons open "Section Editor" and delete the section per their labels
    -  When no questions present: The information is read out / focused appropriately
    -  When no questions present: Add questions button opens a _currently non-functional_ side panel

NOTE: The alternative "when questions _are_ present" is not necessary to be tested here for two reasons: 1) there is no way to add questions w/out altering the code and 2) it has been tested locally and works as it did previously so it can wait for more robust testing

### Code Review

Does everything make sense?

---

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
