### PR TITLE
Quiz creation DEBUG data improvements

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
+++ b/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
@@ -42,19 +42,6 @@ export const QuizResource = {
     type: String,
     default: '',
   },
-};
-
-/**
- * @typedef   {Object}  ExerciseResource        A particular exercise that can be selected within a
- *                                              quiz. An ExerciseResource here is a QuizResource
- *                                              with assessment metadata attached.
- * @extends   {QuizResource}
- * @property  {Array}   assessment_ids  A list of assessment item IDs that are associated with
- *                                      this exercise
- * @property  {string}  contentnode     The contentnode ID for the Assessment
- */
-export const ExerciseResource = {
-  ...QuizResource,
   assessment_ids: {
     type: Array,
     default: () => [],
@@ -67,7 +54,7 @@ export const ExerciseResource = {
 
 /**
  * @typedef  {Object} QuizQuestion         A particular question in a Quiz - aka an assessment item
- *                                         from an ExerciseResource.
+ *                                         from an QuizResource.
  * @property {string} exercise_id          The ID of the resource from which the question originates
  * @property {string} question_id          A *unique* identifier of this particular question within
  *                                         the quiz -- same as the `assessment_item_id`
@@ -110,7 +97,9 @@ export const QuizQuestion = {
  * @property {boolean}            learners_see_fixed_order   A bool flag indicating whether this
  *                                                           section is shown in the same order, or
  *                                                           randomized, to the learners
- * @property {ExerciseResource[]} resource_pool              An array of contentnode ids indicat
+ * @property {QuizResource[]}     resource_pool              An array of QuizResource objects from
+ *                                                           which the questions in this section_id
+ *                                                           will be drawn
  */
 export const QuizSection = {
   section_id: {
@@ -141,7 +130,7 @@ export const QuizSection = {
   resource_pool: {
     type: Array,
     default: () => [],
-    spec: ExerciseResource,
+    spec: QuizResource,
   },
 };
 

--- a/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
+++ b/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
@@ -100,6 +100,8 @@ export const QuizQuestion = {
  * @property {QuizExercise[]}     resource_pool              An array of QuizExercise objects from
  *                                                           which the questions in this section_id
  *                                                           will be drawn
+ * @property {QuizQuestion[]}    question_pool              An array of QuizQuestion objects
+ *                                                          derived from the resource_pool
  */
 export const QuizSection = {
   section_id: {
@@ -131,6 +133,11 @@ export const QuizSection = {
     type: Array,
     default: () => [],
     spec: QuizExercise,
+  },
+  question_pool: {
+    type: Array,
+    default: () => [],
+    spec: QuizQuestion,
   },
 };
 

--- a/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
+++ b/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * @typedef   {Object}  QuizResource    An object referencing an exercise or topic to be used
+ * @typedef   {Object}  QuizExercise    An object referencing an exercise or topic to be used
  *                                      within the `QuizSeciton.resource_pool` property.
  * @property  {string}  title           The resource title
  * @property  {string}  ancestor_id     The ID of the parent contentnode
@@ -17,7 +17,7 @@
  * @property  {string}  kind            Exercise or Topic in our case - see: `ContentNodeKinds`
  */
 
-export const QuizResource = {
+export const QuizExercise = {
   title: {
     type: String,
     default: '',
@@ -54,7 +54,7 @@ export const QuizResource = {
 
 /**
  * @typedef  {Object} QuizQuestion         A particular question in a Quiz - aka an assessment item
- *                                         from an QuizResource.
+ *                                         from an QuizExercise.
  * @property {string} exercise_id          The ID of the resource from which the question originates
  * @property {string} question_id          A *unique* identifier of this particular question within
  *                                         the quiz -- same as the `assessment_item_id`
@@ -97,7 +97,7 @@ export const QuizQuestion = {
  * @property {boolean}            learners_see_fixed_order   A bool flag indicating whether this
  *                                                           section is shown in the same order, or
  *                                                           randomized, to the learners
- * @property {QuizResource[]}     resource_pool              An array of QuizResource objects from
+ * @property {QuizExercise[]}     resource_pool              An array of QuizExercise objects from
  *                                                           which the questions in this section_id
  *                                                           will be drawn
  */
@@ -130,7 +130,7 @@ export const QuizSection = {
   resource_pool: {
     type: Array,
     default: () => [],
-    spec: QuizResource,
+    spec: QuizExercise,
   },
 };
 

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -11,7 +11,7 @@ import { get, set } from '@vueuse/core';
 import { computed, ref, provide, inject } from 'kolibri.lib.vueCompositionApi';
 // TODO: Probably move this to this file's local dir
 import selectQuestions from '../modules/examCreation/selectQuestions.js';
-import { Quiz, QuizSection, QuizQuestion, QuizResource } from './quizCreationSpecs.js';
+import { Quiz, QuizSection, QuizQuestion, QuizExercise } from './quizCreationSpecs.js';
 
 /** Validators **/
 /* objectSpecs expects every property to be available -- but we don't want to have to make an
@@ -23,8 +23,8 @@ function validateQuiz(quiz) {
 }
 
 /**
- * @param {QuizResource} o - The resource to check
- * @returns {boolean} - True if the resource is a valid QuizResource
+ * @param {QuizExercise} o - The resource to check
+ * @returns {boolean} - True if the resource is a valid QuizExercise
  */
 function isExercise(o) {
   return o.kind === ContentNodeKinds.EXERCISE;
@@ -59,7 +59,7 @@ export default function useQuizCreation(DEBUG = false) {
   /**
    * DEBUG Data
    *
-   * Generates a test quiz with multiple sections. It generates properly shaped QuizResource type
+   * Generates a test quiz with multiple sections. It generates properly shaped QuizExercise type
    * and QuizQuestion type objects, but the content is not real.
    *
    * This should be suitable for all UI testing purposes EXCEPT for resource selection.
@@ -70,7 +70,7 @@ export default function useQuizCreation(DEBUG = false) {
       console.error("You're trying to generate test data in production. Please set DEBUG = false.");
     }
     // First let's make some QuizQuestion objects so we have them to initialize resources with
-    // Typically this data would be fetched and usable from the useQuizResources module
+    // Typically this data would be fetched and usable from the useExerciseResources module
     const dummyQuestions = range(1, 100).map(i => {
       const questionOverrides = {
         exercise_id: uuidv4(),
@@ -95,13 +95,13 @@ export default function useQuizCreation(DEBUG = false) {
         assessment_ids: sliceOfQuestions.map(q => q.question_id),
         contentnode: uuidv4(),
       };
-      return objectWithDefaults(resourceOverrides, QuizResource);
+      return objectWithDefaults(resourceOverrides, QuizExercise);
     });
 
     const sections = range(1, 5).map(i => {
       const resource_pool = shuffle(resources).slice(0, 3);
       const questions = resource_pool.reduce((acc, resource) => {
-        // Typically this would be generated in the useQuizResources module but we're doing it here
+        // Typically this would be generated in the useExerciseResources module but we're doing it here
         // with our dummy data
         acc = [
           ...acc,
@@ -364,7 +364,7 @@ export default function useQuizCreation(DEBUG = false) {
   const inactiveSections = computed(() =>
     get(allSections).filter(s => s.section_id !== get(_activeSectionId))
   );
-  /** @type {ComputedRef<QuizResource[]>}   The active section's `resource_pool` */
+  /** @type {ComputedRef<QuizExercise[]>}   The active section's `resource_pool` */
   const activeResourcePool = computed(() => get(activeSection).resource_pool);
   /** @type {ComputedRef<ExerciseResource[]>} The active section's `resource_pool` - that is,
    *                                          Exercises from which we will enumerate all

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -66,6 +66,9 @@ export default function useQuizCreation(DEBUG = false) {
    * DO NOT use this if you're testing resource selection or want to use real resources.
    */
   function _generateTestData() {
+    if (process.env.NODE_ENV === 'production') {
+      console.error("You're trying to generate test data in production. Please set DEBUG = false.");
+    }
     // First let's make some QuizQuestion objects so we have them to initialize resources with
     // Typically this data would be fetched and usable from the useQuizResources module
     const dummyQuestions = range(1, 100).map(i => {
@@ -445,6 +448,7 @@ export default function useQuizCreation(DEBUG = false) {
   provide('replacementQuestionPool', replacementQuestionPool);
   provide('selectAllQuestions', selectAllQuestions);
   provide('deleteActiveSelectedQuestions', deleteActiveSelectedQuestions);
+  provide('toggleQuestionInSelection', toggleQuestionInSelection);
 
   return {
     // Methods
@@ -458,7 +462,6 @@ export default function useQuizCreation(DEBUG = false) {
     updateQuiz,
     addQuestionToSelection,
     removeQuestionFromSelection,
-    toggleQuestionInSelection,
 
     // Computed
     channels,
@@ -510,6 +513,7 @@ export function injectQuizCreation() {
   const replacementQuestionPool = inject('replacementQuestionPool');
   const selectAllQuestions = inject('selectAllQuestions');
   const deleteActiveSelectedQuestions = inject('deleteActiveSelectedQuestions');
+  const toggleQuestionInSelection = inject('toggleQuestionInSelection');
 
   return {
     // Methods
@@ -525,6 +529,7 @@ export function injectQuizCreation() {
     updateQuiz,
     addQuestionToSelection,
     removeQuestionFromSelection,
+    toggleQuestionInSelection,
 
     // Computed
     channels,

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -443,6 +443,9 @@ export default function useQuizCreation(DEBUG = false) {
   provide('activeQuestions', activeQuestions);
   provide('selectedActiveQuestions', selectedActiveQuestions);
   provide('replacementQuestionPool', replacementQuestionPool);
+  provide('selectAllQuestions', selectAllQuestions);
+  provide('deleteActiveSelectedQuestions', deleteActiveSelectedQuestions);
+
   return {
     // Methods
     saveQuiz,
@@ -453,11 +456,9 @@ export default function useQuizCreation(DEBUG = false) {
     setActiveSection,
     initializeQuiz,
     updateQuiz,
-    deleteActiveSelectedQuestions,
     addQuestionToSelection,
     removeQuestionFromSelection,
     toggleQuestionInSelection,
-    selectAllQuestions,
 
     // Computed
     channels,
@@ -507,10 +508,14 @@ export function injectQuizCreation() {
   const activeQuestions = inject('activeQuestions');
   const selectedActiveQuestions = inject('selectedActiveQuestions');
   const replacementQuestionPool = inject('replacementQuestionPool');
+  const selectAllQuestions = inject('selectAllQuestions');
+  const deleteActiveSelectedQuestions = inject('deleteActiveSelectedQuestions');
 
   return {
     // Methods
     saveQuiz,
+    deleteActiveSelectedQuestions,
+    selectAllQuestions,
     updateSection,
     replaceSelectedQuestions,
     addSection,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -368,6 +368,7 @@
         updateQuiz,
         addQuestionToSelection,
         removeQuestionFromSelection,
+        selectAllQuestions,
 
         // Computed
         channels,
@@ -403,6 +404,7 @@
         replaceAction$,
         questionList$,
 
+        selectAllQuestions,
         saveQuiz,
         updateSection,
         allQuestionsSelected,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -17,7 +17,7 @@
     </UiAlert>
 
     <KPageContainer
-      :style="{ ...maxContainerHeight, maxWidth: '1000px', margin: '0 auto' }"
+      :style="{ maxWidth: '1000px', margin: '0 auto 2em' }"
     >
 
       <CreateQuizSection v-if="quizInitialized" />
@@ -84,9 +84,6 @@
       };
     },
     computed: {
-      maxContainerHeight() {
-        return { maxHeight: '1000px' };
-      },
       backRoute() {
         return { name: PageNames.EXAMS };
       },

--- a/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
+++ b/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
@@ -1,7 +1,7 @@
 import { get } from '@vueuse/core';
 import { ChannelResource, ExamResource } from 'kolibri.resources';
 import { objectWithDefaults } from 'kolibri.utils.objectSpecs';
-import { ExerciseResource, QuizQuestion } from '../src/composables/quizCreationSpecs.js';
+import { QuizResource, QuizQuestion } from '../src/composables/quizCreationSpecs.js';
 import useQuizCreation from '../src/composables/useQuizCreation.js';
 
 const {
@@ -50,7 +50,7 @@ function generateQuestions(num = 0) {
  *  A helper function to mock an exercise with a given number of questions (for `resource_pool`)
  */
 function generateExercise(numQuestions) {
-  const exercise = objectWithDefaults({ resource_id: 'exercise_1' }, ExerciseResource);
+  const exercise = objectWithDefaults({ resource_id: 'exercise_1' }, QuizResource);
   exercise.questions = generateQuestions(numQuestions);
   return exercise;
 }

--- a/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
+++ b/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
@@ -1,7 +1,7 @@
 import { get } from '@vueuse/core';
 import { ChannelResource, ExamResource } from 'kolibri.resources';
 import { objectWithDefaults } from 'kolibri.utils.objectSpecs';
-import { QuizResource, QuizQuestion } from '../src/composables/quizCreationSpecs.js';
+import { QuizExercise, QuizQuestion } from '../src/composables/quizCreationSpecs.js';
 import useQuizCreation from '../src/composables/useQuizCreation.js';
 
 const {
@@ -50,7 +50,7 @@ function generateQuestions(num = 0) {
  *  A helper function to mock an exercise with a given number of questions (for `resource_pool`)
  */
 function generateExercise(numQuestions) {
-  const exercise = objectWithDefaults({ resource_id: 'exercise_1' }, QuizResource);
+  const exercise = objectWithDefaults({ resource_id: 'exercise_1' }, QuizExercise);
   exercise.questions = generateQuestions(numQuestions);
   return exercise;
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

### DEBUG data

Improves the DEBUG data generation when the `DEBUG` flag is set to `true` in the `useQuizCreation` module.

This relies heavily on the `quizCreationSpecs.js` module which defines a set of "types" which are referenced throughout the greater quiz creation module.

We generate a bunch of questions (`QuizQuestion`) and then we create a bunch of resources (`QuizResource` - representing a `ContentNode` object suitable for our uses (aka, it has `assessmentids` which map to the `QuizQuestion.question_id`).

Those resources are then used to generate the `resource_pool` properties for some sections (`QuizSection`) and then sets that sections `questions` (`QuizQuestion[]`) array to the items in our dummy questions that match the section's `resource_pool` resources.

IRL a separate module will be handling the business of fetching and storing the `QuizQuestion` data which we can read from based on the data in a quiz section. For example -- when a user "selects resources" the section's `resource_pool` will list the resources selected. This gives us a list of `assessment_ids` which we can use to fetch and display actual questions from within each resource.

### Removing `ExerciseResource`

I previously envisioned that the module would work in a way where the `resource_pool` could house _either_ a Topic OR an Exercise and then we'd be able to answer the question "should the checkbox for this **Topic** here be checked, indeterminate (ie, we have some but not all children of the topic), or unchecked?" by reducing the `resource_pool` to list of all of the exercises within selected topics and so forth. 

However, after chatting w/ @rtibbles we're going to lean on the `fetchTree` API method which will allow us to basically get 2 generations of a tree at any time so we will only give the topic a checkbox if we can get all of its children using this. We'll calculate this by comparing the "total resources in this topic" with the "total resources among this topics children and grandchildren" -- if they're different, then we cannot access all of the Exercises in the Topic and won't show the checkbox at all. 

The point is -- we only now are concerned with one "type", the `QuizResource` which will be an Exercise and have the assessment_ids we need to get the actual questions.

### Bonus fixes

- Provide/Inject the handlers for the accordion actions
- Visual bug where having a lot of questions would give us a second scrollbar on the questions list

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### Code Review

- Does the code make sense? 
- Do the comments help explain what is going on and why?
