### PR TITLE
Fix card widths on ultra wide screen

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div>
+  <div :style="{ maxWidth: '1700px' }">
     <transition name="delay-entry">
       <PostSetupModalGroup
         v-if="!(rootNodesLoading || searchLoading)


### PR DESCRIPTION
This PR is a fix to https://github.com/learningequality/kolibri/issues/11653

This fix is made assuming that the explorer button/text above should also be displayed within the max width of 1700px. 
![image](https://github.com/learningequality/kolibri/assets/143542192/96ae47f1-1247-4e40-8183-5b10353ca96b)

This PR only fixes Library page, because Topic/Channel View & Explore Libraries main view are already behaving as expected.

Before:
![image](https://github.com/learningequality/kolibri/assets/143542192/53cfb4ab-84bf-498e-b32b-8319d978ec3f)  
After:
![image](https://github.com/learningequality/kolibri/assets/143542192/ae23e1a4-a3be-4f2d-9202-4b1a8a7f4128)