### PR TITLE
Fix to new badge being shown on channel delete

### DIFF
--- a/kolibri/plugins/device/assets/src/modules/manageContent/index.js
+++ b/kolibri/plugins/device/assets/src/modules/manageContent/index.js
@@ -49,12 +49,24 @@ export default {
 
       return channels.map(channel => {
         const taskIndex = findLastIndex(getters.managedTasks, task => {
+          const isLatest = task => {
+            const tasksWithSameChannelId = getters.managedTasks.filter(
+              t => t.extra_metadata.channel_id === channel.id && t.status === TaskStatuses.COMPLETED
+            );
+            const maxScheduledDatetime = tasksWithSameChannelId.reduce(
+              (max, current) =>
+                current.scheduled_datetime > max ? current.scheduled_datetime : max,
+              tasksWithSameChannelId[0].scheduled_datetime
+            );
+            return task.scheduled_datetime === maxScheduledDatetime;
+          };
           return (
             ![TaskTypes.DISKCONTENTEXPORT, TaskTypes.DISKEXPORT, TaskTypes.DELETECHANNEL].includes(
               task.type
             ) &&
             task.extra_metadata.channel_id === channel.id &&
-            task.status === TaskStatuses.COMPLETED
+            task.status === TaskStatuses.COMPLETED &&
+            isLatest(task) // corresponds to latest changes on channel
           );
         });
         return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The cause of the bug is well addressed in https://github.com/learningequality/kolibri/issues/6730#issuecomment-1870973735

For handling that we will show `new` badge based on the latest task which will be the task with highest scheduled_datetime(among the tasks with same channel_id)
**Screencast**
Here I delete resource initially(shows no `new` badge)
Then install more resource(shows `new` badge as it should)
Then remove a resource(shows no `new` badge, as it shouldn't)
[Screencast from 28-12-23 04:11:18 PM IST.webm](https://github.com/learningequality/kolibri/assets/120925871/717af862-dcde-4d15-a3b9-935450f90a0c)



…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #6730 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
