### PR TITLE
Linting rule to check formatting of translation strings

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExploreLibrariesPage/index.vue
@@ -173,7 +173,7 @@
       },
       showingLibraries: {
         message: 'Showing libraries on other devices around you',
-        continue: 'Description of the kind of devices displayed',
+        context: 'Description of the kind of devices displayed',
       },
       // The strings below are not used currently used in the code.
       // This is to aid the translation of the string

--- a/packages/eslint-plugin-kolibri/lib/rules/vue-string-objects-formatting.js
+++ b/packages/eslint-plugin-kolibri/lib/rules/vue-string-objects-formatting.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Disallow improper formatting of translation strings.
+ */
+
+'use strict';
+
+const eslintPluginVueUtils = require('eslint-plugin-vue/lib/utils');
+
+const get = require('lodash/get');
+const utils = require('../utils');
+
+const create = context => {
+  let hasTemplate;
+  const normalDefinitionNodes = [];
+
+  const initialize = {
+    Program(node) {
+      if (!utils.checkVueEslintParser(context)) {
+        return;
+      }
+      hasTemplate = Boolean(node.templateBody);
+    },
+  };
+
+  const scriptVisitor = Object.assign(
+    {},
+    {
+      'CallExpression[callee.type="Identifier"]'(node) {
+        if (node.callee.name == 'createTranslator' && node.arguments.length) {
+          node.arguments.forEach(arg => {
+            if (arg.type === 'ObjectExpression') {
+              arg.properties.forEach(prop => {
+                if (prop.value.type !== 'ObjectExpression') {
+                  if (typeof prop.value.value !== 'string') {
+                    context.report({
+                      node: prop,
+                      message: `Invalid translation string format detected within createTranslator(): "${prop.key.name}". Ensure proper formatting for translation strings.
+                      `,
+                    });
+                  }
+                } else {
+                  const messageProperty = prop.value.properties.find(p => p.key.name === 'message');
+                  const contextProperty = prop.value.properties.find(p => p.key.name === 'context');
+                  if (
+                    !messageProperty ||
+                    prop.value.properties.find(
+                      p => p.key.name !== 'message' && p.key.name !== 'context'
+                    ) ||
+                    (contextProperty && typeof contextProperty.value.value !== 'string')
+                  ) {
+                    context.report({
+                      node: prop,
+                      message: `Invalid translation string format detected within createTranslator(): "${prop.key.name}". Ensure proper formatting for translation strings.
+                      `,
+                    });
+                  }
+                }
+              });
+            }
+          });
+        }
+      },
+    },
+
+    {
+      ObjectExpression(node) {
+        if (get(node, 'parent.key.name') === '$trs') {
+          node.properties.forEach(prop => {
+            if (prop.value.type !== 'ObjectExpression') {
+              if (typeof prop.value.value !== 'string') {
+                normalDefinitionNodes.push({ name: prop });
+              }
+            } else {
+              const messageProperty = prop.value.properties.find(p => p.key.name === 'message');
+              const contextProperty = prop.value.properties.find(p => p.key.name === 'context');
+              if (
+                !messageProperty ||
+                prop.value.properties.find(
+                  p => p.key.name !== 'message' && p.key.name !== 'context'
+                ) ||
+                (contextProperty && typeof contextProperty.value.value !== 'string')
+              ) {
+                normalDefinitionNodes.push({ name: prop });
+              }
+            }
+          });
+        }
+      },
+    },
+
+    eslintPluginVueUtils.executeOnVue(context, () => {
+      if (!hasTemplate) {
+        utils.reportImproperTranslationString(context, normalDefinitionNodes);
+      }
+    })
+  );
+  const templateVisitor = Object.assign(
+    {},
+    utils.executeOnRootTemplateEnd(() => {
+      utils.reportImproperTranslationString(context, normalDefinitionNodes);
+    })
+  );
+
+  return Object.assign(
+    {},
+    initialize,
+    eslintPluginVueUtils.defineTemplateBodyVisitor(context, templateVisitor, scriptVisitor)
+  );
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow improper formatting of translation strings.',
+    },
+    fixable: null,
+  },
+  create,
+};

--- a/packages/eslint-plugin-kolibri/lib/utils.js
+++ b/packages/eslint-plugin-kolibri/lib/utils.js
@@ -240,4 +240,19 @@ module.exports = {
       });
     });
   },
+
+  /**
+   * Report improper translation string definitions
+   */
+  reportImproperTranslationString(context, normalDefinitionNodes) {
+    const trsNodes = normalDefinitionNodes.map(prop => prop.name);
+
+    trsNodes.forEach(node => {
+      context.report({
+        node,
+        message: `Invalid translation string format detected in $trs: "${node.key.name}". Ensure proper formatting for translation strings.
+        `,
+      });
+    });
+  },
 };

--- a/packages/kolibri-tools/.eslintrc.js
+++ b/packages/kolibri-tools/.eslintrc.js
@@ -218,6 +218,7 @@ module.exports = {
     'kolibri/vue-watch-no-string': ERROR,
     'kolibri/vue-no-unused-translations': ERROR,
     'kolibri/vue-no-undefined-string-uses': ERROR,
+    'kolibri/vue-string-objects-formatting': ERROR,
 
     'prefer-const': [ERROR, {
       destructuring: 'any',

--- a/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context01.vue
+++ b/packages/kolibri-tools/test/fixtures/i18nSyncContext/Context01.vue
@@ -8,6 +8,7 @@
 <script>
 
   /* eslint-disable kolibri/vue-no-unused-translations */
+  /* eslint-disable kolibri/vue-string-objects-formatting */
   /**
    * This file is a basic definition file and can be used for testing several
    * functions.


### PR DESCRIPTION
## Summary
This PR introduces a new linting rule to check if the translation strings defined in `$trs` and `createTranslator` functions are properly formatted, i.e, they have a specific shape and their properties are of a specific datatype.

## Sample error

![errorlog](https://github.com/learningequality/kolibri/assets/116485536/f97787b8-9100-4e26-9435-ea891d740f85)

## References
Closes #11301 

## Reviewer guidance
To test these changes:

1. Modify any translation string defined in a Vue or JS file so that it has an improper format.
2. Run the linting command: `yarn run lint-frontend`.
3. You'll see the particular translation string's name logged in the terminal.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
