### PR TITLE
Consolidate browser compatibility data, drop IE11 support

### DIFF
--- a/kolibri/core/assets/src/mixins/commonCoreStrings.js
+++ b/kolibri/core/assets/src/mixins/commonCoreStrings.js
@@ -1289,19 +1289,14 @@ export const coreStrings = createTranslator('CommonCoreStrings', {
   },
 
   // Device upgrades recommended
-  currentDeviceUsingIE11: {
-    message: 'You seem to be using Internet Explorer 11.',
-    context:
-      'Displayed on a device that is using Internet Explorer 11, as part of a message encouraging the user to upgrade.',
-  },
   userDevicesUsingIE11: {
-    message: 'Some users seem to be accessing Kolibri via Internet Explorer 11',
+    message: 'Some users seem to have accessed Kolibri via Internet Explorer 11',
     context:
       'Displayed to an admin, where devices on their network are using Internet Explorer 11, as part of a message encouraging the user to upgrade.',
   },
-  browserSupportWillBeDroppedIE11: {
+  browserSupportDroppedIE11: {
     message:
-      'Please note that support for this browser will be dropped in the upcoming version, 0.17.  We recommend installing other browsers, such as Mozilla Firefox or Google Chrome, in order to continue working with Kolibri.',
+      'Please note that support for this browser has been dropped.  We recommend installing other browsers, such as Mozilla Firefox or Google Chrome, in order to continue working with Kolibri.',
     context:
       'Displayed to users of kolibri where one or more devices on the network are using Internet Explorer 11, as part of a message encouraging the user to upgrade.',
   },

--- a/kolibri/core/assets/src/utils/minimumBrowserRequirements.js
+++ b/kolibri/core/assets/src/utils/minimumBrowserRequirements.js
@@ -1,16 +1,30 @@
+import isUndefined from 'lodash/isUndefined';
+import browsers from 'browserslist-config-kolibri';
 import { browser, passesRequirements } from './browserInfo';
 import plugin_data from 'plugin_data';
 
-const minimumBrowserRequirements = {
-  IE: {
-    major: 11,
-  },
-  Android: {
-    major: 4,
-    minor: 0,
-    patch: 2,
-  },
-};
+const minimumBrowserRequirements = {};
+
+const browserRegex = /^([a-zA-Z]+) ([><=]+) (\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
+
+for (const browser of browsers) {
+  const [name, sign, major, minor, patch] = browserRegex.exec(browser).slice(1);
+  // This only supports > and >=, but that's all we need.
+  const addOne = sign === '>' ? 1 : 0;
+  const entry = {
+    major: isUndefined(minor) && isUndefined(patch) ? Number(major) + addOne : Number(major),
+  };
+  if (!isUndefined(minor)) {
+    entry.minor = Number(minor);
+    if (isUndefined(patch)) {
+      entry.minor += addOne;
+    }
+  }
+  if (!isUndefined(patch)) {
+    entry.patch = Number(patch) + addOne;
+  }
+  minimumBrowserRequirements[name] = entry;
+}
 
 if (!passesRequirements(browser, minimumBrowserRequirements)) {
   window.location.href = plugin_data.unsupportedUrl;

--- a/kolibri/core/assets/src/utils/minimumBrowserRequirements.js
+++ b/kolibri/core/assets/src/utils/minimumBrowserRequirements.js
@@ -9,19 +9,30 @@ const browserRegex = /^([a-zA-Z]+) ([><=]+) (\d+)(?:\.(\d+))?(?:\.(\d+))?$/;
 
 for (const browser of browsers) {
   const [name, sign, major, minor, patch] = browserRegex.exec(browser).slice(1);
+  if (sign !== '>' && sign !== '>=') {
+    throw new Error('Unsupported browser requirement');
+  }
+
   // This only supports > and >=, but that's all we need.
-  const addOne = sign === '>' ? 1 : 0;
+  // In the case that it is > then we will need to add one to the version number
+  // we will add one to the smallest defined version number out of major, minor, patch
+  const addOne = sign === '>';
   const entry = {
-    major: isUndefined(minor) && isUndefined(patch) ? Number(major) + addOne : Number(major),
+    major: Number(major),
   };
+  let valueToIncrement = 'major';
   if (!isUndefined(minor)) {
     entry.minor = Number(minor);
-    if (isUndefined(patch)) {
-      entry.minor += addOne;
+    valueToIncrement = 'minor';
+    // We only check for patch if we have a minor version number
+    // as it is not possible to be defined without a minor version number
+    if (!isUndefined(patch)) {
+      entry.patch = Number(patch);
+      valueToIncrement = 'patch';
     }
   }
-  if (!isUndefined(patch)) {
-    entry.patch = Number(patch) + addOne;
+  if (addOne) {
+    entry[valueToIncrement] += 1;
   }
   minimumBrowserRequirements[name] = entry;
 }

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div
-    v-show="showBanner"
+    v-show="userDevicesUsingIE11"
     class="alert"
     :style="{ backgroundColor: $themePalette.yellow.v_100 }"
   >
@@ -15,14 +15,11 @@
       </div>
 
       <div class="error-message">
-        <p v-if="currentUserOnIE11">
-          {{ coreString('currentDeviceUsingIE11') }}
-        </p>
-        <p v-if="userDevicesUsingIE11">
+        <p>
           {{ coreString('userDevicesUsingIE11') }}
         </p>
-        <p v-if="currentUserOnIE11 || userDevicesUsingIE11">
-          {{ coreString('browserSupportWillBeDroppedIE11') }}
+        <p>
+          {{ coreString('browserSupportDroppedIE11') }}
         </p>
       </div>
     </div>
@@ -34,21 +31,14 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { browser } from 'kolibri.utils.browserInfo';
   import plugin_data from 'plugin_data';
 
   export default {
     name: 'DeprecationWarningBanner',
     mixins: [commonCoreStrings],
     computed: {
-      showBanner() {
-        return this.currentUserOnIE11 || this.userDevicesUsingIE11;
-      },
       userDevicesUsingIE11() {
         return plugin_data.deprecationWarnings.ie11;
-      },
-      currentUserOnIE11() {
-        return browser.name === 'IE';
       },
     },
   };

--- a/packages/browserslist-config-kolibri/index.js
+++ b/packages/browserslist-config-kolibri/index.js
@@ -9,7 +9,6 @@ module.exports = [
   'Chrome >= 49',
   'ChromeAndroid >= 49',
   'Edge >= 18',
-  'IE >= 11',
   'Firefox >= 52',
   'FirefoxAndroid >= 68',
   'iOS >= 9.3',


### PR DESCRIPTION
## Summary
* Consolidates browser compatibility data so that we use the same source of truth for browserslist and checking supported browsers in the frontend
* Drops IE11 support
* Updates deprecation warnings about IE11 for browsing users to give upgrade warning instead

## References
Fixes https://github.com/learningequality/kolibri/issues/5336

## Reviewer guidance
The only other place I could find IE11 specific code was in the TextTruncatorCSS component, but I was not entirely sure how to remove the IE11 specific code. Advice from @MisRob would be appreciated, or we can file a follow up issue for this cleanup.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
