### PR TITLE
Hide modal when a token has multiple channels

### DIFF
--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -331,6 +331,7 @@
         return this.$router.push({ query: newQuery });
       },
       handleSubmitToken({ token, channels }) {
+        this.showTokenModal = false;
         if (channels.length > 1) {
           if (this.$route.query.token !== token) {
             this.disableModal = true;
@@ -341,8 +342,6 @@
                 token,
               },
             });
-          } else {
-            this.showTokenModal = false;
           }
         } else {
           this.goToSelectContentPageForChannel(channels[0]);

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -285,7 +285,11 @@
         return !this.channelsAreLoading && this.availableChannels.length > 0;
       },
       showUnlistedChannels() {
-        return this.channelsAreAvailable && (this.inRemoteImportMode || this.isStudioApplication);
+        return (
+          this.channelsAreAvailable &&
+          (this.inRemoteImportMode || this.isStudioApplication) &&
+          this.$route.query.token === undefined
+        );
       },
       notEnoughFreeSpace() {
         // if the REMOTE_CONTENT option is true, we should not be submitting disk space issues
@@ -334,7 +338,6 @@
         this.showTokenModal = false;
         if (channels.length > 1) {
           if (this.$route.query.token !== token) {
-            this.disableModal = true;
             this.$router.push({
               ...this.$route,
               query: {

--- a/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/AvailableChannelsPage/index.vue
@@ -285,11 +285,7 @@
         return !this.channelsAreLoading && this.availableChannels.length > 0;
       },
       showUnlistedChannels() {
-        return (
-          this.channelsAreAvailable &&
-          (this.inRemoteImportMode || this.isStudioApplication) &&
-          this.$route.query.token === undefined
-        );
+        return this.channelsAreAvailable && (this.inRemoteImportMode || this.isStudioApplication);
       },
       notEnoughFreeSpace() {
         // if the REMOTE_CONTENT option is true, we should not be submitting disk space issues


### PR DESCRIPTION
## Summary
When a token results in more than one channel, modal to insert the token didn't dissappear. This PR fixes it.


## References
Closes: #11647 
Refers to : #9729

## Reviewer guidance
Using the procedure described in #11647 :
- Test it with a token that only has one channel as Kolibri QA Channel
- Test it with a token that provides more than one channel as `latuk-noriz`


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
