### PR TITLE
Enque_lifo_job

### DIFF
--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -67,7 +67,7 @@ def get_remote_users_info(baseurl, facility_id, username, password):
                         "id": error_constants.AUTHENTICATION_FAILED,
                         "metadata": {
                             "field": "username_password",
-                            "message": "Incorrect username or password.",
+                            "message": str(e),
                         },
                     }
                 ],

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -47,7 +47,7 @@ def get_remote_users_info(baseurl, facility_id, username, password):
             ),
         )
         response.raise_for_status()
-        except (CommandError, HTTPError, ConnectionError) as e:
+    except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
                 [

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -50,7 +50,13 @@ def get_remote_users_info(baseurl, facility_id, username, password):
     except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
-                detail="Password is required", code=error_constants.MISSING_PASSWORD
+                    {
+                        "id": error_constants.AUTHENTICATION_FAILED,
+                        "metadata": {
+                            "field": "password",
+                            "message": "Password is required",
+                        },
+                    }
             )
         else:
             raise AuthenticationFailed(

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -47,7 +47,6 @@ def get_remote_users_info(baseurl, facility_id, username, password):
             ),
         )
         response.raise_for_status()
-    except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
                 [

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -54,7 +54,15 @@ def get_remote_users_info(baseurl, facility_id, username, password):
             )
         else:
             raise AuthenticationFailed(
-                detail=str(e), code=error_constants.AUTHENTICATION_FAILED
+                [
+                    {
+                        "id": error_constants.AUTHENTICATION_FAILED,
+                        "metadata": {
+                            "field": "username_password",
+                            "message": "Incorrect username or password.",
+                        },
+                    }
+                ],
             )
     auth_info = response.json()
     if len(auth_info) > 1:

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -50,13 +50,15 @@ def get_remote_users_info(baseurl, facility_id, username, password):
     except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
+                [
                     {
-                        "id": error_constants.AUTHENTICATION_FAILED,
+                        "id": error_constants.MISSING_PASSWORD,
                         "metadata": {
                             "field": "password",
                             "message": "Password is required",
                         },
                     }
+                ]
             )
         else:
             raise AuthenticationFailed(

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -50,27 +50,11 @@ def get_remote_users_info(baseurl, facility_id, username, password):
     except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
-                [
-                    {
-                        "id": error_constants.MISSING_PASSWORD,
-                        "metadata": {
-                            "field": "password",
-                            "message": "Password is required",
-                        },
-                    }
-                ]
+                detail="Password is required", code=error_constants.MISSING_PASSWORD
             )
         else:
             raise AuthenticationFailed(
-                [
-                    {
-                        "id": error_constants.AUTHENTICATION_FAILED,
-                        "metadata": {
-                            "field": "username_password",
-                            "message": str(e),
-                        },
-                    }
-                ],
+                detail=str(e), code=error_constants.AUTHENTICATION_FAILED
             )
     auth_info = response.json()
     if len(auth_info) > 1:

--- a/kolibri/core/auth/utils/users.py
+++ b/kolibri/core/auth/utils/users.py
@@ -47,6 +47,7 @@ def get_remote_users_info(baseurl, facility_id, username, password):
             ),
         )
         response.raise_for_status()
+        except (CommandError, HTTPError, ConnectionError) as e:
         if password == NOT_SPECIFIED or not password:
             raise AuthenticationFailed(
                 [

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -298,6 +298,19 @@ class RegisteredTask(object):
             retry_interval=retry_interval,
         )
 
+    def enqueue_lifo_job(self, job=None, retry_interval=None, priority=None, **job_kwargs):
+        """
+        Enqueue the function with arguments passed to this method using LIFO order.
+
+        :return: enqueued job's id.
+        """
+        return job_storage.enqueue_lifo(
+            job or self._ready_job(**job_kwargs),
+            queue=self.queue,
+            priority=priority or self.priority,
+            retry_interval=retry_interval,
+        )
+        
     def enqueue_if_not(
         self, job=None, retry_interval=None, priority=None, **job_kwargs
     ):

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -310,7 +310,7 @@ class RegisteredTask(object):
             priority=priority or self.priority,
             retry_interval=retry_interval,
         )
-        
+
     def enqueue_if_not(
         self, job=None, retry_interval=None, priority=None, **job_kwargs
     ):

--- a/kolibri/core/tasks/registry.py
+++ b/kolibri/core/tasks/registry.py
@@ -298,7 +298,7 @@ class RegisteredTask(object):
             retry_interval=retry_interval,
         )
 
-    def enqueue_lifo_job(self, job=None, retry_interval=None, priority=None, **job_kwargs):
+    def enqueue_lifo(self, job=None, retry_interval=None, priority=None, **job_kwargs):
         """
         Enqueue the function with arguments passed to this method using LIFO order.
 

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -2,8 +2,8 @@ import logging
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import timedelta
-import pytz
 
+import pytz
 from sqlalchemy import Column
 from sqlalchemy import DateTime
 from sqlalchemy import func as sql_func
@@ -199,6 +199,7 @@ class Storage(object):
                 )
             )
             return job.job_id
+
     def enqueue_lifo(
         self, job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
     ):
@@ -211,7 +212,12 @@ class Storage(object):
                 .order_by(ORMJob.scheduled_time)
                 .first()
             )
-            dt = pytz.timezone('UTC').localize(soonest_job.scheduled_time) - timedelta(microseconds=1) if soonest_job else self._now()
+            dt = (
+                pytz.timezone("UTC").localize(soonest_job.scheduled_time)
+                - timedelta(microseconds=1)
+                if soonest_job
+                else self._now()
+            )
         try:
             return self.schedule(
                 dt,
@@ -229,6 +235,7 @@ class Storage(object):
                 )
             )
             return job.job_id
+
     def enqueue_job_if_not_enqueued(
         self, job, queue=DEFAULT_QUEUE, priority=Priority.REGULAR, retry_interval=None
     ):

--- a/kolibri/core/tasks/storage.py
+++ b/kolibri/core/tasks/storage.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import pytz
 
 from sqlalchemy import Column
-from sqlalchemy.orm import Session
 from sqlalchemy import DateTime
 from sqlalchemy import func as sql_func
 from sqlalchemy import Index

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -211,20 +211,22 @@ class TestBackend:
         assert len(defaultbackend.get_running_jobs(queues=[DEFAULT_QUEUE])) == 2
         assert len(defaultbackend.get_running_jobs(queues=[QUEUE])) == 1
         assert len(defaultbackend.get_running_jobs(queues=[DEFAULT_QUEUE, QUEUE])) == 3
+
     def test_lifo_behavior_with_scheduled_time(self, defaultbackend, simplejob):
         # Enqueue multiple jobs as LIFO
         job1 = Job(open)
         job2 = Job(open)
         job3 = Job(open)
-        job1_id = defaultbackend.enqueue_lifo(job1, QUEUE)
-        job2_id = defaultbackend.enqueue_lifo(job2, QUEUE)
+        defaultbackend.enqueue_lifo(job1, QUEUE)
+        defaultbackend.enqueue_lifo(job2, QUEUE)
         job3_id = defaultbackend.enqueue_lifo(job3, QUEUE)
-   
+
         # Ensure that the last queued job is returned by get_next_queued_job
         last_queued_job_id = defaultbackend.get_next_queued_job().job_id
-    
+
         # Assert that the last queued job matches the expected job
         assert last_queued_job_id == job3_id
+
     def test_get_canceling_jobs(self, defaultbackend):
         # Schedule jobs
         schedule_time = local_now() + datetime.timedelta(hours=1)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -74,7 +74,7 @@ class TestBackend:
         job2 = Job(open)
 
         job1_id = defaultbackend.enqueue_job(job1, QUEUE)
- 
+
         # Sleep to prevent same time_created timestamp.
         time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -74,7 +74,7 @@ class TestBackend:
         job2 = Job(open)
 
         job1_id = defaultbackend.enqueue_job(job1, QUEUE)
-        
+ 
         # Sleep to prevent same time_created timestamp.
         time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -74,7 +74,8 @@ class TestBackend:
         job2 = Job(open)
 
         job1_id = defaultbackend.enqueue_job(job1, QUEUE)
-
+        job2_id = defaultbackend.enqueue_job(job2, QUEUE)
+       
         # Sleep to prevent same time_created timestamp.
         time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)
@@ -198,7 +199,7 @@ class TestBackend:
         job1 = defaultbackend.schedule(schedule_time, Job(id))
         job2 = defaultbackend.schedule(schedule_time, Job(id))
         job3 = defaultbackend.schedule(schedule_time, Job(id), QUEUE)
-
+     
         # mark jobs as running
         defaultbackend.mark_job_as_running(job1)
         defaultbackend.mark_job_as_running(job2)
@@ -211,7 +212,21 @@ class TestBackend:
         assert len(defaultbackend.get_running_jobs(queues=[DEFAULT_QUEUE])) == 2
         assert len(defaultbackend.get_running_jobs(queues=[QUEUE])) == 1
         assert len(defaultbackend.get_running_jobs(queues=[DEFAULT_QUEUE, QUEUE])) == 3
+    def test_lifo_behavior_with_scheduled_time(self, defaultbackend, simplejob):
+        # Enqueue multiple jobs as LIFO
+        
+        job1 = Job(open)
+        job2 = Job(open)
+        job3 = Job(open)
+        job1_id = defaultbackend.enqueue_lifo(job1, QUEUE)
+        job2_id = defaultbackend.enqueue_lifo(job2, QUEUE)
+        job3_id = defaultbackend.enqueue_lifo(job3, QUEUE)
+        # Ensure that the last queued job is returned by get_next_queued_job
 
+        last_queued_job_id = defaultbackend.get_next_queued_job().job_id
+
+        # Assert that the last queued job matches the expected job
+        assert last_queued_job_id == job3_id
     def test_get_canceling_jobs(self, defaultbackend):
         # Schedule jobs
         schedule_time = local_now() + datetime.timedelta(hours=1)

--- a/kolibri/core/tasks/test/taskrunner/test_storage.py
+++ b/kolibri/core/tasks/test/taskrunner/test_storage.py
@@ -74,8 +74,7 @@ class TestBackend:
         job2 = Job(open)
 
         job1_id = defaultbackend.enqueue_job(job1, QUEUE)
-        job2_id = defaultbackend.enqueue_job(job2, QUEUE)
-       
+        
         # Sleep to prevent same time_created timestamp.
         time.sleep(2)
         defaultbackend.enqueue_job(job2, QUEUE)
@@ -199,7 +198,7 @@ class TestBackend:
         job1 = defaultbackend.schedule(schedule_time, Job(id))
         job2 = defaultbackend.schedule(schedule_time, Job(id))
         job3 = defaultbackend.schedule(schedule_time, Job(id), QUEUE)
-     
+
         # mark jobs as running
         defaultbackend.mark_job_as_running(job1)
         defaultbackend.mark_job_as_running(job2)
@@ -214,17 +213,16 @@ class TestBackend:
         assert len(defaultbackend.get_running_jobs(queues=[DEFAULT_QUEUE, QUEUE])) == 3
     def test_lifo_behavior_with_scheduled_time(self, defaultbackend, simplejob):
         # Enqueue multiple jobs as LIFO
-        
         job1 = Job(open)
         job2 = Job(open)
         job3 = Job(open)
         job1_id = defaultbackend.enqueue_lifo(job1, QUEUE)
         job2_id = defaultbackend.enqueue_lifo(job2, QUEUE)
         job3_id = defaultbackend.enqueue_lifo(job3, QUEUE)
+   
         # Ensure that the last queued job is returned by get_next_queued_job
-
         last_queued_job_id = defaultbackend.get_next_queued_job().job_id
-
+    
         # Assert that the last queued job matches the expected job
         assert last_queued_job_id == job3_id
     def test_get_canceling_jobs(self, defaultbackend):

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -372,7 +372,7 @@ class TestRegisteredTask(TestCase):
 
         _ready_job_mock.return_value = "lifo_job"
 
-        self.registered_task.enqueue_lifo_job(args=args, kwargs=kwargs)
+        self.registered_task.enqueue_lifo(args=args, kwargs=kwargs)
 
         _ready_job_mock.assert_called_once_with(args=args, kwargs=kwargs)
         job_storage_mock.enqueue_lifo.assert_called_once_with(

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -364,7 +364,24 @@ class TestRegisteredTask(TestCase):
             priority=self.registered_task.priority,
             retry_interval=None,
         )
+    @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
+    @mock.patch("kolibri.core.tasks.registry.job_storage")
+    def test_enqueue_lifo_job(self, job_storage_mock, _ready_job_mock):
+        args = ("10",)
+        kwargs = dict(base=10)
 
+        _ready_job_mock.return_value = "lifo_job"
+
+        self.registered_task.enqueue_lifo_job(args=args, kwargs=kwargs)
+
+        _ready_job_mock.assert_called_once_with(args=args, kwargs=kwargs)
+        job_storage_mock.enqueue_lifo.assert_called_once_with(
+            "lifo_job",
+            queue=self.registered_task.queue,
+            priority=self.registered_task.priority,
+            retry_interval=None,
+        )
+        
     @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
     @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue__override_priority(self, job_storage_mock, _ready_job_mock):

--- a/kolibri/core/tasks/test/test_job.py
+++ b/kolibri/core/tasks/test/test_job.py
@@ -364,6 +364,7 @@ class TestRegisteredTask(TestCase):
             priority=self.registered_task.priority,
             retry_interval=None,
         )
+
     @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
     @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue_lifo_job(self, job_storage_mock, _ready_job_mock):
@@ -381,7 +382,7 @@ class TestRegisteredTask(TestCase):
             priority=self.registered_task.priority,
             retry_interval=None,
         )
-        
+
     @mock.patch("kolibri.core.tasks.registry.RegisteredTask._ready_job")
     @mock.patch("kolibri.core.tasks.registry.job_storage")
     def test_enqueue__override_priority(self, job_storage_mock, _ready_job_mock):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
This pull request introduces the option for Last-In-First-Out (LIFO) job queueing

## Changes Made
- Added a new method, `enqueue_lifo_job`, for explicitly enqueuing LIFO jobs.
- Updated relevant tests to cover the new LIFO functionality.
…

## Testing
- Added unit tests for the new LIFO functionality.
- Conducted manual testing .
…

## Related Issues
Closes [#11506](https://github.com/learningequality/kolibri/issues/11506)


…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
