### PR TITLE
Handle metadata import failure.

### DIFF
--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -527,7 +527,7 @@ def _get_import_metadata(client, contentnode_id):
         return response.json()
     except NetworkLocationResponseFailure as e:
         # 400 level errors, like 404, are ignored
-        if e.response and 400 <= e.response.status_code < 500:
+        if e.response is not None and 400 <= e.response.status_code < 500:
             logger.debug(
                 "Metadata request failure: GET {} {}".format(
                     url_path, e.response.status_code


### PR DESCRIPTION
## Summary
* Fixes bug where failure to load metadata for resource import would break automatic content import

## Reviewer guidance
Seems to be an issue whereby failed requests responses are Falsey.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
