### PR TITLE
Update condition to display new label for content imports

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/ChannelPanel/WithSizeAndOptions.vue
@@ -20,7 +20,7 @@
           />
           <NewBadge
             v-if="showNewLabel"
-            :label="deviceString('newChannelLabel')"
+            :label="$tr('updatedResourcesLabel')"
             class="new-label"
           />
         </div>
@@ -100,6 +100,10 @@
         message: 'Manage',
         context: "Operation that can be performed on a channel. Refers to the 'Manage' button.",
       },
+      updatedResourcesLabel: {
+        message: 'Resources recently updated',
+        context: 'Label for channels that contain recently updated resources.',
+      },
     },
   };
 
@@ -162,12 +166,13 @@
   }
 
   .new-label {
-    position: absolute;
-    top: 2px;
-    margin-left: 8px;
+    position: relative;
+    top: 5px;
+    display: inline-block;
 
     .panel-sm & {
-      top: -2px;
+      top: 2px;
+      margin-left: 0;
     }
   }
 

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -229,13 +229,13 @@
         }[value];
         this.$router.push(this.$router.getRoute(nextRoute));
       },
-      showNewLabel(channelId, channelVersion) {
+      showNewLabel(channelId, remoteChannelVersion) {
         const match = find(this.installedChannelsWithResources, { id: channelId });
         // Check if channel match exists and is a newer version or has resources
         return (
           match &&
-          (match.version > channelVersion ||
-            (match.version === channelVersion && match.taskIndex > -1))
+          (match.version < remoteChannelVersion ||
+            (match.version === remoteChannelVersion && match.taskIndex > -1))
         );
       },
       handleDeleteChannel() {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -59,7 +59,7 @@
               :key="channel.id"
               :channel="channel"
               :disabled="channelIsBeingDeleted(channel.id)"
-              :showNewLabel="showNewLabel(channel.id)"
+              :showNewLabel="showNewLabel(channel.id, channel.version)"
               @select_delete="deleteChannelId = channel.id"
               @select_manage="handleSelectManage(channel.id)"
             />
@@ -229,9 +229,14 @@
         }[value];
         this.$router.push(this.$router.getRoute(nextRoute));
       },
-      showNewLabel(channelId) {
+      showNewLabel(channelId, channelVersion) {
         const match = find(this.installedChannelsWithResources, { id: channelId });
-        return match && match.taskIndex > -1;
+        // Check if channel match exists and is a newer version or has resources
+        return (
+          match &&
+          (match.version > channelVersion ||
+            (match.version === channelVersion && match.taskIndex > -1))
+        );
       },
       handleDeleteChannel() {
         if (this.deleteChannelId) {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -59,7 +59,7 @@
               :key="channel.id"
               :channel="channel"
               :disabled="channelIsBeingDeleted(channel.id)"
-              :showNewLabel="showNewLabel(channel.id, channel.version)"
+              :showNewLabel="showNewLabel(channel.id)"
               @select_delete="deleteChannelId = channel.id"
               @select_manage="handleSelectManage(channel.id)"
             />
@@ -229,14 +229,9 @@
         }[value];
         this.$router.push(this.$router.getRoute(nextRoute));
       },
-      showNewLabel(channelId, remoteChannelVersion) {
+      showNewLabel(channelId) {
         const match = find(this.installedChannelsWithResources, { id: channelId });
-        // Check if channel match exists and is a newer version or has resources
-        return (
-          match &&
-          (match.version < remoteChannelVersion ||
-            (match.version === remoteChannelVersion && match.taskIndex > -1))
-        );
+        return match && match.taskIndex > -1;
       },
       handleDeleteChannel() {
         if (this.deleteChannelId) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request includes a modification where the string "Resources recently updated" is used instead of the label "New" when importing channel resources on the device to resolve any confusion surrounding to recently imported resources that are considered "new" on the device, but could be imported from older versioned channels.

Before:
![labelbefore](https://github.com/learningequality/kolibri/assets/46411498/a809c72b-2b9d-4ce5-887f-8963eeb4697a)

After:


![afterlabel](https://github.com/learningequality/kolibri/assets/46411498/1cb3f732-9012-4553-80b5-81287d70b6cb)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #9415 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Import from someone over the network, making sure that the person you are importing from has an older version of the channel compared to the one currently installed on your device. The label 'Resources recently updated' should be displayed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
