### PR TITLE
Remove mostly useless warning against using npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly={2} --require-kds-path --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt --transpile",
     "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
-    "preinstall": "node ./packages/kolibri-tools/lib/npm_deprecation_warning.js",
     "lint-frontend": "kolibri-tools lint --pattern '{kolibri*/**/assets,packages,build_tools}/**/*.{js,vue,scss,less,css}' --ignore '**/dist/**,**/node_modules/**,**/static/**,**/kolibri-core-for-export/**'",
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",

--- a/packages/kolibri-tools/lib/npm_deprecation_warning.js
+++ b/packages/kolibri-tools/lib/npm_deprecation_warning.js
@@ -1,8 +1,0 @@
-if (!process.env.npm_execpath.endsWith('yarn.js')) {
-  /* eslint-disable no-console */
-  console.error(
-    'ERROR: Please use yarn to manage frontend dependencies, see Kolibri documentation for details'
-  );
-  /* eslint-enable no-console */
-  process.exit(1);
-}


### PR DESCRIPTION
## Summary
* A long, long time ago, in a galaxy far, far away, we added a preinstall script to prevent people using npm to install dependencies.
* Due to a bug in NPM from v7 onwards that devs show no inclination to fix https://github.com/npm/cli/issues/2660 this now only runs after all dependencies have been installed. It's possible that this could still be useful, but after we saw a false positive for the check, where someone running yarn was prevented from installing dependencies, it seems better to just remove it as it is _mostly_ useless.


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
