### PR TITLE
Add command line deprecation warning for Python 2.7

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import sys
+from warnings import warn
 
 from kolibri.utils.compat import monkey_patch_collections
 from kolibri.utils.compat import monkey_patch_translation
@@ -92,6 +93,16 @@ def prepend_cext_path(dist_path):
         logger.debug("No C extensions are available for this platform")
 
 
+def check_python_versions():
+    if sys.version_info.major == 2:
+        logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
+        logging.StreamHandler(sys.stdout)
+        logger = logging.getLogger("env")
+        warning_text = "Python 2.7 support will be dropped in Kolibri 0.17, please upgrade your Python version"
+        logger.warn(warning_text)
+        warn(warning_text, DeprecationWarning)
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -101,6 +112,8 @@ def set_env():
     from the distributed version in case it exists before importing anything
     else.
     """
+    check_python_versions()
+
     from kolibri import dist as kolibri_dist  # noqa
 
     monkey_patch_collections()


### PR DESCRIPTION
## Summary
* Adds a command line deprecation warning for Python 2.7

## References
Follows the same pattern used previously for 3.4 and 3.5 deprecation: https://github.com/learningequality/kolibri/blob/release-v0.15.x/kolibri/utils/env.py#L106

## Reviewer guidance
If you run using Python 2.7 do you see a deprecation warning?

e.g.

```
WARNING: Python 2.7 support will be dropped in Kolibri 0.17, please upgrade your Python version
INFO     2024-01-04 15:19:00,126 Option DEBUG_LOG_DATABASE in section [Server] being overridden by environment variable KOLIBRI_DEBUG_LOG_DATABASE
INFO     2024-01-04 15:19:00,128 Option DEBUG in section [Server] being overridden by environment variable KOLIBRI_DEBUG
INFO     2024-01-04 15:19:00,128 Option RUN_MODE in section [Deployment] being overridden by environment variable KOLIBRI_RUN_MODE
```

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
