### PR TITLE
Fix welcome modal appearing after deleting channels

### DIFF
--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -3,7 +3,7 @@
   <DeviceAppBarPage :title="pageTitle">
     <transition name="delay<-entry">
       <PostSetupModalGroup
-        v-if="!channelListLoading && welcomeModalVisible && !areChannelsImported"
+        v-if="!channelListLoading && welcomeModalVisible"
         @cancel="hideWelcomeModal"
       />
     </transition>
@@ -182,11 +182,9 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
+          window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
+          !this.installedChannelsWithResources.length > 0
         );
-      },
-      areChannelsImported() {
-        return this.installedChannelsWithResources.length > 0;
       },
     },
     watch: {

--- a/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/ManageContentPage/index.vue
@@ -140,6 +140,7 @@
         'channelIsBeingDeleted',
         'managedTasks',
       ]),
+      ...mapGetters(['isLearnerOnlyImport']),
       ...mapState('manageContent/wizard', ['pageName']),
       ...mapState('manageContent', ['channelListLoading']),
       ...mapState({
@@ -183,7 +184,7 @@
         return (
           this.welcomeModalVisibleState &&
           window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
-          !this.installedChannelsWithResources.length > 0
+          (!this.installedChannelsWithResources.length > 0) & !this.isLearnerOnlyImport
         );
       },
     },

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -4,9 +4,7 @@
     <transition name="delay-entry">
       <PostSetupModalGroup
         v-if="!(rootNodesLoading || searchLoading)
-          && welcomeModalVisible
-          && !areChannelsImported
-          && !isLearnerOnlyImport"
+          && welcomeModalVisible"
         isOnMyOwnUser
         @cancel="hideWelcomeModal"
       />
@@ -416,7 +414,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isLearnerOnlyImport']),
+      ...mapGetters(['isLearner']),
       ...mapState({
         welcomeModalVisibleState: 'welcomeModalVisible',
       }),
@@ -429,7 +427,9 @@
       welcomeModalVisible() {
         return (
           this.welcomeModalVisibleState &&
-          window.localStorage.getItem(welcomeDismissalKey) !== 'true'
+          window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
+          !(this.rootNodes.length > 0) &&
+          !this.isLearner
         );
       },
       showOtherLibraries() {
@@ -478,9 +478,6 @@
       },
       studioId() {
         return KolibriStudioId;
-      },
-      areChannelsImported() {
-        return this.rootNodes.length > 0;
       },
     },
     watch: {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -414,7 +414,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isLearner']),
+      ...mapGetters(['isLearnerOnlyImport', 'canManageContent']),
       ...mapState({
         welcomeModalVisibleState: 'welcomeModalVisible',
       }),
@@ -429,7 +429,8 @@
           this.welcomeModalVisibleState &&
           window.localStorage.getItem(welcomeDismissalKey) !== 'true' &&
           !(this.rootNodes.length > 0) &&
-          !this.isLearner
+          this.canManageContent &&
+          !this.isLearnerOnlyImport
         );
       },
       showOtherLibraries() {


### PR DESCRIPTION
## Summary
- Consolidated welcomeModalVisible logic with number of channels present.

## References
closes #11644

## Reviewer guidance
- Remove the local storage key "welcomeDismissalKey".
- Welcome modal appears initially.
- Add channels.
- Remove them.
- The Welcome Modal does not appear again.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
