### PR TITLE
Replaced isEmbeddedWebView with isAppContext

### DIFF
--- a/kolibri/core/assets/src/composables/useUser.js
+++ b/kolibri/core/assets/src/composables/useUser.js
@@ -9,6 +9,7 @@ export default function useUser() {
   const isAdmin = computed(() => store.getters.isAdmin);
   const isSuperuser = computed(() => store.getters.isSuperuser);
   const canManageContent = computed(() => store.getters.canManageContent);
+  const isAppContext = computed(() => store.getters.isAppContext);
 
   return {
     isLearnerOnlyImport,
@@ -18,5 +19,6 @@ export default function useUser() {
     isAdmin,
     isSuperuser,
     canManageContent,
+    isAppContext,
   };
 }

--- a/kolibri/core/assets/src/utils/browserInfo.js
+++ b/kolibri/core/assets/src/utils/browserInfo.js
@@ -86,7 +86,7 @@ export const isMacWebView =
 /**
  * All web views
  */
-export const isEmbeddedWebView = isAndroidWebView || isMacWebView;
+export const isAppContext = isAndroidWebView || isMacWebView;
 
 // Check for presence of the touch event in DOM or multi-touch capabilities
 export const isTouchDevice =

--- a/kolibri/core/assets/src/utils/browserInfo.js
+++ b/kolibri/core/assets/src/utils/browserInfo.js
@@ -64,30 +64,6 @@ export const os = {
   patch: osVersion[2],
 };
 
-/**
- * Detection of whether an Android device is using WebView based on
- * https://developer.chrome.com/multidevice/user-agent#webview_user_agent
- * First checks for 'wv' (Lolipop+), then for 'Version/x.x'
- */
-const isAndroid = os.name === 'Android';
-export const isAndroidWebView =
-  isAndroid &&
-  (browser.name === 'Chrome Webview' ||
-    (browser.name === 'Chrome' && /Version\/\d+\.\d+/.test(userAgent)));
-
-/**
- * Embedded WebViews on Mac have no app identifier, while all the major browsers do, so check
- * for browser app strings and mark as embedded if none are found.
- */
-const isMac = os.name === 'Mac OS';
-export const isMacWebView =
-  isMac && !(/Safari/.test(userAgent) || /Chrome/.test(userAgent) || /Firefox/.test(userAgent));
-
-/**
- * All web views
- */
-export const isAppContext = isAndroidWebView || isMacWebView;
-
 // Check for presence of the touch event in DOM or multi-touch capabilities
 export const isTouchDevice =
   'ontouchstart' in window ||

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -20,12 +20,19 @@
 
 <script>
 
-  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import { getFilePresetString } from './filePresetStrings';
   import { getRenderableFiles } from './utils';
 
   export default {
     name: 'DownloadButton',
+    setup() {
+      const { isAppContext } = useUser();
+
+      return {
+        isAppContext,
+      };
+    },
     props: {
       files: {
         type: Array,
@@ -41,7 +48,7 @@
         return getRenderableFiles(this.files).filter(file => file.preset !== 'exercise');
       },
       canDownload() {
-        return !isEmbeddedWebView && this.downloadableFiles.length;
+        return this.isAppContext && this.downloadableFiles.length;
       },
       fileOptions() {
         const options = this.files.map(file => {

--- a/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
+++ b/kolibri/core/assets/src/views/ContentRenderer/DownloadButton.vue
@@ -48,7 +48,7 @@
         return getRenderableFiles(this.files).filter(file => file.preset !== 'exercise');
       },
       canDownload() {
-        return this.isAppContext && this.downloadableFiles.length;
+        return !this.isAppContext && this.downloadableFiles.length;
       },
       fileOptions() {
         const options = this.files.map(file => {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -68,7 +68,7 @@
     computed: {
       exportDisabled() {
         // Always disable in app mode until we add the ability to download files.
-        return !this.isAppContext || this.disableExport;
+        return this.isAppContext || this.disableExport;
       },
       isMainReport() {
         return (

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsControls.vue
@@ -43,8 +43,8 @@
 
 <script>
 
-  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
   import pickBy from 'lodash/pickBy';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import commonCoach from '../common';
   import { ClassesPageNames } from '../../../../../learn/assets/src/constants';
   import { LastPages } from '../../constants/lastPagesConstants';
@@ -52,6 +52,13 @@
   export default {
     name: 'ReportsControls',
     mixins: [commonCoach],
+    setup() {
+      const { isAppContext } = useUser();
+
+      return {
+        isAppContext,
+      };
+    },
     props: {
       disableExport: {
         type: Boolean,
@@ -61,7 +68,7 @@
     computed: {
       exportDisabled() {
         // Always disable in app mode until we add the ability to download files.
-        return isEmbeddedWebView || this.disableExport;
+        return !this.isAppContext || this.disableExport;
       },
       isMainReport() {
         return (

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -2,7 +2,7 @@ import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
-import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
+import store from 'kolibri.coreVue.vuex.store';
 
 /* Function to fetch device info from the backend
  * and resolve validated data
@@ -22,7 +22,7 @@ export function getDeviceInfo() {
     const { server } = infoResponse.headers;
 
     if (server.includes('0.0.0.0')) {
-      if (isEmbeddedWebView) {
+      if (store.getters.isAppContext) {
         data.server_type = 'Kolibri app server';
       } else {
         data.server_type = 'Kolibri internal server';

--- a/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
+++ b/kolibri/plugins/device/assets/src/modules/deviceInfo/handlers.js
@@ -2,7 +2,8 @@ import client from 'kolibri.client';
 import urls from 'kolibri.urls';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
 import bytesForHumans from 'kolibri.utils.bytesForHumans';
-import store from 'kolibri.coreVue.vuex.store';
+import { get } from '@vueuse/core';
+import useUser from 'kolibri.coreVue.composables.useUser';
 
 /* Function to fetch device info from the backend
  * and resolve validated data
@@ -20,9 +21,10 @@ export function getDeviceInfo() {
     data.device_name = nameResponse.data.name;
 
     const { server } = infoResponse.headers;
+    const { isAppContext } = useUser();
 
     if (server.includes('0.0.0.0')) {
-      if (store.getters.isAppContext) {
+      if (get(isAppContext)) {
         data.server_type = 'Kolibri app server';
       } else {
         data.server_type = 'Kolibri internal server';

--- a/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/index.vue
@@ -184,7 +184,7 @@
 <script>
 
   import { mapState, mapGetters, mapActions } from 'vuex';
-  import { isEmbeddedWebView } from 'kolibri.utils.browserInfo';
+  import useUser from 'kolibri.coreVue.composables.useUser';
   import urls from 'kolibri.urls';
   import { FacilityResource } from 'kolibri.resources';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -221,7 +221,8 @@
     mixins: [commonCoreStrings],
     setup() {
       const { windowIsMedium, windowIsSmall } = useKResponsiveWindow();
-      return { windowIsMedium, windowIsSmall };
+      const { isAppContext } = useUser();
+      return { windowIsMedium, windowIsSmall, isAppContext };
     },
     data() {
       return {
@@ -247,7 +248,7 @@
       // NOTE: We disable CSV file upload/download on embedded web views like the Mac
       // and Android apps
       canUploadDownloadFiles() {
-        return !isEmbeddedWebView;
+        return !this.isAppContext;
       },
       pollForTasks() {
         return this.$route.name === PageNames.DATA_EXPORT_PAGE;


### PR DESCRIPTION

## Summary
This Pr replaces the use of isEmbeddedWebView with isAppContext

  - Added an isAppContext computed property to the core useUser composable
  - Replaced every instance of isEmbeddedWebView with the isAppContext computed prop
  - Deleted unused isEmbeddedWebView and the constituent values from browserInfo.js

## References
 #11689

…

## Reviewer guidance
Do these changes make sense ?

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
