### PR TITLE
Remove inaccessible language switcher modal.

### DIFF
--- a/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
+++ b/kolibri/core/assets/src/views/CorePage/AppBarPage.vue
@@ -11,7 +11,6 @@
           class="app-bar"
           :title="title"
           @toggleSideNav="navShown = !navShown"
-          @showLanguageModal="languageModalShown = true"
         >
           <template #sub-nav>
             <slot name="subNav"></slot>
@@ -44,12 +43,6 @@
         @shouldFocusFirstEl="findFirstEl()"
       />
     </transition>
-    <LanguageSwitcherModal
-      v-if="languageModalShown"
-      ref="languageSwitcherModal"
-      :style="{ color: $themeTokens.text }"
-      @cancel="languageModalShown = false"
-    />
 
   </div>
 
@@ -60,7 +53,6 @@
 
   import { mapGetters } from 'vuex';
   import { throttle } from 'frame-throttle';
-  import LanguageSwitcherModal from 'kolibri.coreVue.components.LanguageSwitcherModal';
   import ScrollingHeader from 'kolibri.coreVue.components.ScrollingHeader';
   import useKResponsiveWindow from 'kolibri.coreVue.composables.useKResponsiveWindow';
   import SideNav from 'kolibri.coreVue.components.SideNav';
@@ -75,7 +67,6 @@
     name: 'AppBarPage',
     components: {
       AppBar,
-      LanguageSwitcherModal,
       ScrollingHeader,
       SideNav,
       StorageNotification,
@@ -110,7 +101,6 @@
     data() {
       return {
         appBarHeight: 0,
-        languageModalShown: false,
         navShown: false,
         lastScrollTop: 0,
         hideAppBars: true,

--- a/kolibri/core/assets/test/views/app-bar-core-page.spec.js
+++ b/kolibri/core/assets/test/views/app-bar-core-page.spec.js
@@ -64,20 +64,4 @@ describe('AppBarPage', () => {
       expect(wrapper.findComponent({ name: 'SideNav' }).vm.navShown).toBe(false);
     });
   });
-
-  describe('Toggling the language switcher modal', () => {
-    it('should show the side nav when the AppBar.showLanguageModal event is emitted', async () => {
-      const wrapper = createWrapper();
-      expect(wrapper.findComponent({ name: 'LanguageSwitcherModal' }).exists()).toBe(false);
-      await wrapper.vm.$refs.appBar.$emit('showLanguageModal');
-      expect(wrapper.findComponent({ name: 'LanguageSwitcherModal' }).exists()).toBe(true);
-    });
-    it('should hide the language switcher modal when LanguageSwitcherModal.cancel is emitted', async () => {
-      const wrapper = createWrapper();
-      await wrapper.setData({ languageModalShown: true });
-      expect(wrapper.findComponent({ name: 'LanguageSwitcherModal' }).exists()).toBe(true);
-      await wrapper.vm.$refs.languageSwitcherModal.$emit('cancel');
-      expect(wrapper.findComponent({ name: 'LanguageSwitcherModal' }).exists()).toBe(false);
-    });
-  });
 });


### PR DESCRIPTION
## Summary
* Removes the LanguageSwitcherModal from the AppBarPage as it is no longer accessible (the submenu in the AppBar that used to trigger it has been removed)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
