### PR TITLE
Removes inconsistently applied and mostly no-op double click blocking.

### DIFF
--- a/kolibri/core/assets/src/state/modules/core/actions.js
+++ b/kolibri/core/assets/src/state/modules/core/actions.js
@@ -92,22 +92,6 @@ export function handleApiError(store, { error, reloadOnReconnect = false } = {})
   throw error;
 }
 
-/**
- * Used to prevent inadvertent actions if a user double-clicks to navigate
- *
- * Something of a hack. A better strategy would be to create a new
- * `setLoading` action which handles both `state.core.loading` and
- * `state.core.blockDoubleClicks` with a single function.
- */
-export function blockDoubleClicks(store) {
-  if (!store.state.blockDoubleClicks) {
-    store.commit('CORE_BLOCK_CLICKS', true);
-    setTimeout(() => {
-      store.commit('CORE_BLOCK_CLICKS', false);
-    }, 500);
-  }
-}
-
 export function setSession(store, { session, clientNow }) {
   const serverTime = session.server_time;
   if (clientNow) {

--- a/kolibri/core/assets/src/state/modules/core/index.js
+++ b/kolibri/core/assets/src/state/modules/core/index.js
@@ -10,7 +10,6 @@ export default {
   state() {
     return {
       error: '',
-      blockDoubleClicks: false,
       loading: true,
       pageSessionId: 0,
       totalProgress: null,

--- a/kolibri/core/assets/src/state/modules/core/mutations.js
+++ b/kolibri/core/assets/src/state/modules/core/mutations.js
@@ -15,9 +15,6 @@ export default {
   CORE_SET_ERROR(state, error) {
     state.error = error;
   },
-  CORE_BLOCK_CLICKS(state, blocked) {
-    state.blockDoubleClicks = blocked;
-  },
   SET_TOTAL_PROGRESS(state, progress) {
     state.totalProgress = progress;
   },

--- a/kolibri/plugins/learn/assets/src/app.js
+++ b/kolibri/plugins/learn/assets/src/app.js
@@ -43,7 +43,6 @@ class LearnModule extends KolibriApp {
 
     // after every navigation, block double-clicks
     router.afterEach((toRoute, fromRoute) => {
-      this.store.dispatch('blockDoubleClicks');
       this.store.dispatch('resetModuleState', { toRoute, fromRoute });
     });
     super.ready();

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -5,8 +5,6 @@
     class="main-wrapper"
   >
 
-    <div v-if="blockDoubleClicks" class="click-mask"></div>
-
     <SkipNavigationLink />
     <LearningActivityBar
       ref="activityBar"
@@ -381,7 +379,6 @@
     computed: {
       ...mapState({
         error: state => state.core.error,
-        blockDoubleClicks: state => state.core.blockDoubleClicks,
       }),
       isCoachContent() {
         return this.content && this.content.coach_content ? 1 : 0;
@@ -733,15 +730,6 @@
   // When focused by SkipNavigationLink, don't outline non-buttons/links
   /deep/ [tabindex='-1'] {
     outline-style: none !important;
-  }
-
-  .click-mask {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 24;
-    width: 100%;
-    height: 100%;
   }
 
   .loader {

--- a/kolibri/plugins/user_auth/assets/src/views/UserAuthLayout.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/UserAuthLayout.vue
@@ -6,8 +6,6 @@
     :style="mainWrapperStyles"
   >
 
-    <div v-if="blockDoubleClicks" class="click-mask"></div>
-
     <div
       v-if="!loading"
       class="scrolling-pane"
@@ -89,7 +87,6 @@
       ...mapState({
         error: state => state.core.error,
         loading: state => state.core.loading,
-        blockDoubleClicks: state => state.core.blockDoubleClicks,
       }),
       isAuthorized() {
         return !(
@@ -166,15 +163,6 @@
     margin-top: 0;
     margin-bottom: 0;
     overflow-x: auto;
-  }
-
-  .click-mask {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 24;
-    width: 100%;
-    height: 100%;
   }
 
   .debug {


### PR DESCRIPTION
## Summary
Double click blocking was originally introduced to prevent a problem seen in user navigation through the topic tree, where users would double click, resulting in a double navigation. This click blocking is no longer applied on topic navigation (there is no click mask) and yet the issue does not still seem to be prevalent.

Cleans up the click blocking logic which appears to do nothing at this juncture.

## References
See original implementing PR for reference: https://github.com/learningequality/kolibri/pull/3915
Also fixes #7444

## Reviewer guidance
I am targeting this for Planned Patch 1, as it is useful cleanup, but doesn't need to block release, and could do with a little bit of QA to ensure it doesn't introduce a regression.

The only places that might be affected is when viewing a resource in Learn, and when moving between different pages during user login/signup.
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
