### PR TITLE
Catch badly formed UUIDs passed to facility parameter

### DIFF
--- a/kolibri/core/public/api.py
+++ b/kolibri/core/public/api.py
@@ -353,7 +353,7 @@ class FacilitySearchUsernameViewSet(BaseValuesViewset):
             return Response(content, status=status.HTTP_412_PRECONDITION_FAILED)
         try:
             facility = Facility.objects.get(id=facility_id)
-        except (AttributeError, Facility.DoesNotExist):
+        except (AttributeError, Facility.DoesNotExist, ValueError):
             content = "The facility does not exist in this device"
             return Response(content, status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
## Summary
* Public username API endpoint could return a 500 if sent a non-UUID parseable parameter

## Reviewer guidance
Thanks to Django's input sanitization, this should be all that we need to do to protect against dubious API requests, but good to catch the 500, rather than have it flood sentry after release.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
