### PR TITLE
Fix to Env Var and Config persisting in options.ini in KOLIBRI_HOME

### DIFF
--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -827,7 +827,6 @@ def _set_from_envvars(conf):
                                 optname=optname, section=section
                             )
                         )
-                    conf[section][optname] = os.environ[envvar]
                     using_env_vars[optname] = envvar
                     break
     return using_env_vars
@@ -1007,10 +1006,5 @@ def generate_empty_options_file(ini_filename="options.ini"):
                 comments.append("{} = {}".format(optname, attrs.get("default", "")))
                 comments.append("")
     conf.final_comment = comments
-    for section, opts in option_spec.items():
-        for optname, attrs in opts.items():
-            for envvar in attrs.get("envvars", []):
-                if envvar in os.environ:
-                    conf[section][optname]='False'
 
     conf.write()

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -1007,5 +1007,10 @@ def generate_empty_options_file(ini_filename="options.ini"):
                 comments.append("{} = {}".format(optname, attrs.get("default", "")))
                 comments.append("")
     conf.final_comment = comments
+    for section, opts in option_spec.items():
+        for optname, attrs in opts.items():
+            for envvar in attrs.get("envvars", []):
+                if envvar in os.environ:
+                    conf[section][optname]='False'
 
     conf.write()

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -827,6 +827,7 @@ def _set_from_envvars(conf):
                                 optname=optname, section=section
                             )
                         )
+                    conf[section][optname] = os.environ[envvar]
                     using_env_vars[optname] = envvar
                     break
     return using_env_vars
@@ -990,6 +991,12 @@ def generate_empty_options_file(ini_filename="options.ini"):
     # Generate an options.ini file inside the KOLIBRI_HOME as default placeholder config
 
     conf = read_options_file(ini_filename=ini_filename)
+
+    for section, opts in option_spec.items():
+        for optname, attrs in opts.items():
+            for envvar in attrs.get("envvars", []):
+                if envvar in os.environ:
+                    conf[section].pop(optname, None)
 
     comments = None
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This Solution Aims to override the default config of environment variables in `_set_from_envvars`
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #9551 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
