### PR TITLE
Overflowfix

### DIFF
--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -1,6 +1,8 @@
 <template>
 
-  <Navbar>
+  <Navbar
+    class="navbar-positioning"
+  >
     <div
       ref="navContainer"
       class="navcontainer"
@@ -27,6 +29,7 @@
         appearance="flat-button"
         :color="color"
         :primary="false"
+        class="kiconbutton-style"
       >
         <template #menu>
           <KDropdownMenu
@@ -122,8 +125,17 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .kiconbutton-style {
+    position: absolute;
+    margin-left: 1em;
+  }
+
+  .navbar-positioning {
+    position: relative;
+    padding-right: 3.5em;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -23,6 +23,7 @@
     <span v-if="overflowMenuLinks && overflowMenuLinks.length > 0">
       <KIconButton
         :tooltip="coreString('moreOptions')"
+        :style="{ left: computedWidth }"
         tooltipPosition="top"
         :ariaLabel="coreString('moreOptions')"
         icon="optionsHorizontal"
@@ -90,6 +91,13 @@
       color() {
         return this.$themeTokens.textInverted;
       },
+      computedWidth() {
+        const childrenWidth = this.$refs.navContainer.children
+          .slice(this.overflowMenuLinks.length)
+          .reduce((totalWidth, child) => totalWidth + child.offsetWidth, 0);
+        
+        return `${childrenWidth + 16}px`;
+      },
       overflowMenuLinks() {
         return (this.mounted && this.windowWidth
           ? this.allLinks.filter((link, index) => {
@@ -98,7 +106,11 @@
 
               const containerTop = this.$refs.navContainer.offsetTop;
               const containerBottom = containerTop + this.$refs.navContainer.clientHeight;
-              return navLinkTop >= containerBottom;
+              // Accounts for changes in container height that is not matched by height of buttons
+              // as mobile styles are applied to the nav bar
+              const heightDifference = Math.abs
+                (this.$refs.navContainer.clientHeight - navLink.clientHeight);
+              return (navLinkTop + heightDifference) >= containerBottom;
             })
           : []
         ).map(l => ({ label: l.title, value: l.link, icon: l.icon }));
@@ -125,12 +137,11 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    text-overflow: ellipsis;
   }
 
   .kiconbutton-style {
     position: absolute;
-    margin-left: 1em;
+    right: 1em;
   }
 
   .navbar-positioning {

--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -23,7 +23,6 @@
     <span v-if="overflowMenuLinks && overflowMenuLinks.length > 0">
       <KIconButton
         :tooltip="coreString('moreOptions')"
-        :style="{ left: computedWidth }"
         tooltipPosition="top"
         :ariaLabel="coreString('moreOptions')"
         icon="optionsHorizontal"
@@ -91,13 +90,6 @@
       color() {
         return this.$themeTokens.textInverted;
       },
-      computedWidth() {
-        const childrenWidth = this.$refs.navContainer.children
-          .slice(this.overflowMenuLinks.length)
-          .reduce((totalWidth, child) => totalWidth + child.offsetWidth, 0);
-        
-        return `${childrenWidth + 16}px`;
-      },
       overflowMenuLinks() {
         return (this.mounted && this.windowWidth
           ? this.allLinks.filter((link, index) => {
@@ -108,9 +100,10 @@
               const containerBottom = containerTop + this.$refs.navContainer.clientHeight;
               // Accounts for changes in container height that is not matched by height of buttons
               // as mobile styles are applied to the nav bar
-              const heightDifference = Math.abs
-                (this.$refs.navContainer.clientHeight - navLink.clientHeight);
-              return (navLinkTop + heightDifference) >= containerBottom;
+              const heightDifference = Math.abs(
+                this.$refs.navContainer.clientHeight - navLink.clientHeight
+              );
+              return navLinkTop + heightDifference >= containerBottom;
             })
           : []
         ).map(l => ({ label: l.title, value: l.link, icon: l.icon }));
@@ -137,6 +130,7 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    overflow: hidden;
   }
 
   .kiconbutton-style {

--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -123,6 +123,7 @@
     flex-direction: row;
     flex-wrap: wrap;
     overflow: hidden;
+    text-overflow: ellipsis;
   }
 
 </style>

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -60,7 +60,6 @@
     margin-left: 16px;
     overflow-x: hidden;
     overflow-y: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
   }
 

--- a/kolibri/core/assets/src/views/Navbar/index.vue
+++ b/kolibri/core/assets/src/views/Navbar/index.vue
@@ -60,6 +60,7 @@
     margin-left: 16px;
     overflow-x: hidden;
     overflow-y: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
   }
 

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -539,7 +539,7 @@
   }
 
   .mobile-button {
-    margin-top: 0;
+    margin-top:0px;
   }
 
   .facility-loader {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -539,7 +539,7 @@
   }
 
   .mobile-button {
-    margin-top:0px;
+    margin-top: 0;
   }
 
   .facility-loader {

--- a/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/FacilityConfigPage/index.vue
@@ -186,23 +186,36 @@
         v-if="!isAppContext"
         style="margin-top: 8px;"
       >
-        <KButton
-          :primary="false"
-          appearance="flat-button"
-          :text="$tr('resetToDefaultSettings')"
-          name="reset-settings"
-          @click="showModal = true"
-        />
-
-        <KButton
-          :primary="true"
-          :class="windowIsSmall ? 'mobile-button' : ''"
-          appearance="raised-button"
-          :text="coreString('saveChangesAction')"
-          name="save-settings"
-          :disabled="!settingsHaveChanged"
-          @click="saveConfig()"
-        />
+        <KGrid>
+          <KGridItem
+            :layout12="{ span: 6 }"
+            :layout8="{ span: 4 }"
+            :layout4="{ span: 2 }"
+          >
+            <KButton
+              :primary="false"
+              appearance="flat-button"
+              :text="$tr('resetToDefaultSettings')"
+              name="reset-settings"
+              @click="showModal = true"
+            />
+          </KGridItem>
+          <KGridItem
+            :layout12="{ span: 6 }"
+            :layout8="{ span: 4 }"
+            :layout4="{ span: 2 }"
+          >
+            <KButton
+              :primary="true"
+              :class="windowIsSmall ? 'mobile-button' : ''"
+              appearance="raised-button"
+              :text="coreString('saveChangesAction')"
+              name="save-settings"
+              :disabled="!settingsHaveChanged"
+              @click="saveConfig()"
+            />
+          </KGridItem>
+        </KGrid>
       </KButtonGroup>
     </BottomAppBar>
   </FacilityAppBarPage>
@@ -526,7 +539,7 @@
   }
 
   .mobile-button {
-    margin-top: 16px;
+    margin-top: 0;
   }
 
   .facility-loader {


### PR DESCRIPTION
## Summary
Fixes the navigation menu to overflow correctly. There was also another unnecessary scrollbar that could hide the BottomAppBar buttons on smaller screens on the facility plugin, it is also fixed by this PR.
Closes #11423

### Before

https://github.com/learningequality/kolibri/assets/103313919/805039b8-1ed4-4041-9585-666f6b224cb6
###  Button being hidden

https://github.com/learningequality/kolibri/assets/103313919/31de03e7-d6b3-498e-99bf-b0df220e98a5



### After the fix

https://github.com/learningequality/kolibri/assets/103313919/d7ceb243-7e8d-4b1d-b698-9d61299d99c2



## References
 #11423

## Reviewer guidance
 

- Test if the navlinks are still getting hidden on the device plugins with different screen sizes.
- Test whether scroll bar is still appearing on the BottomAppBar on the facility plugin
-  And from the code perspective, does it make sense?

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
