### PR TITLE
Remove coach page specific sub nav toggling.

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/CoachAppBarPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/CoachAppBarPage.vue
@@ -5,10 +5,7 @@
     :authorizedRole="authorizedRole"
   >
     <AppBarPage :title="appBarTitle || defaultAppBarTitle">
-      <template
-        v-if="showSubNav && !isAppContext"
-        #subNav
-      >
+      <template #subNav>
         <TopNavbar />
       </template>
       <div class="coach-main">
@@ -24,7 +21,7 @@
 
 <script>
 
-  import { mapState, mapGetters } from 'vuex';
+  import { mapState } from 'vuex';
   import AppBarPage from 'kolibri.coreVue.components.AppBarPage';
   import NotificationsRoot from 'kolibri.coreVue.components.NotificationsRoot';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -78,17 +75,11 @@
         type: String,
         default: null,
       },
-      showSubNav: {
-        type: Boolean,
-        required: false,
-        default: false,
-      },
     },
     computed: {
       ...mapState({
         error: state => state.core.error,
       }),
-      ...mapGetters(['isAppContext']),
     },
     $trs: {
       kolibriTitleMessage: {

--- a/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomeActivityPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
     <KPageContainer>
       <p>

--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KGrid gutter="16">

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupMembersPage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
     <KPageContainer>
       <p>

--- a/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/GroupsPage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
     <KPageContainer>
       <PlanHeader :activeTabId="PlanTabs.GROUPS" />

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonSummaryPage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KGrid v-if="!loading">

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="$store.getters.userIsAuthorizedForCoach"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KGrid gutter="16">

--- a/kolibri/plugins/coach/assets/src/views/reports/ExerciseQuestionListPageBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ExerciseQuestionListPageBase.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupActivityPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonExerciseLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportLessonResourceLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerActivityPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportLessonPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLearnerReportPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonBase.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KGrid gutter="16">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonExerciseLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerBase.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonLearnerBase.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonManagerPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonManagerPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsLessonResourceLearnerListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KGrid gutter="16">

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -3,7 +3,6 @@
   <CoachAppBarPage
     :authorized="userIsAuthorized"
     authorizedRole="adminOrCoach"
-    :showSubNav="true"
   >
 
     <KPageContainer :class="{ 'print': $isPrint }">


### PR DESCRIPTION
## Summary
* Before we finalized the updates to the AppBar for conditional display in certain app contexts, we had added it individually in the Coach plugin
* This caused the coach top nav to not display in non-touch device contexts in app mode
* Cleans this up and removes unused prop

## Reviewer guidance
Run the Mac App or run the local development app server command
Go to the coach plugin
Ensure that once you have selected a facility and a class the top nav displays

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
