### PR TITLE
Removes uncleaned up reference to isAndroidWebview.

### DIFF
--- a/kolibri/core/assets/src/views/CoreFullscreen.vue
+++ b/kolibri/core/assets/src/views/CoreFullscreen.vue
@@ -14,9 +14,6 @@
 <script>
 
   import ScreenFull from 'screenfull';
-  import { isAndroidWebView } from 'kolibri.utils.browserInfo';
-
-  const fullscreenApiIsSupported = ScreenFull.isEnabled && !isAndroidWebView;
 
   const NORMALIZE_FULLSCREEN_CLASS = 'normalize-fullscreen';
   const MIMIC_FULLSCREEN_CLASS = 'mimic-fullscreen';
@@ -32,7 +29,7 @@
     computed: {
       fullscreenClass() {
         if (this.isInFullscreen) {
-          return fullscreenApiIsSupported ? NORMALIZE_FULLSCREEN_CLASS : MIMIC_FULLSCREEN_CLASS;
+          return ScreenFull.isEnabled ? NORMALIZE_FULLSCREEN_CLASS : MIMIC_FULLSCREEN_CLASS;
         }
         return null;
       },
@@ -46,7 +43,7 @@
     },
     mounted() {
       // Catch the use of the esc key to exit fullscreen
-      if (fullscreenApiIsSupported) {
+      if (ScreenFull.isEnabled) {
         ScreenFull.onchange(() => {
           this.isInFullscreen = ScreenFull.isFullscreen;
         });
@@ -60,13 +57,13 @@
         if (!this.toggling) {
           let fullScreenPromise;
           this.toggling = true;
-          if (fullscreenApiIsSupported) {
+          if (ScreenFull.isEnabled) {
             fullScreenPromise = ScreenFull.toggle(this.$refs.fullscreen);
           } else {
             fullScreenPromise = Promise.resolve();
           }
           fullScreenPromise.then(() => {
-            this.isInFullscreen = fullscreenApiIsSupported
+            this.isInFullscreen = ScreenFull.isEnabled
               ? ScreenFull.isFullscreen
               : !this.isInFullscreen;
             this.toggling = false;


### PR DESCRIPTION
## Summary
* isAndroidWebview is used by our CoreFullscreen implementation to block activation of full screen because of historic issues with full screen on Android web view
* These have since been fixed.
* The isAndroidWebview export was removed in this PR https://github.com/learningequality/kolibri/pull/11740 leaving the export undefined
* This removes this lingering, unnecessary reference to it

## References
Fixes oversight from https://github.com/learningequality/kolibri/pull/11740

## Reviewer guidance
Do uses of CoreFullscreen still work as expected? Fullscreen a video, an EPUB, or an HTML5 app.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
