### PR TITLE
Turn on learner resource download by default for on my own setup.

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -143,6 +143,8 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
 
             custom_settings = validated_data.pop("settings")
 
+            allow_learner_download_resources = False
+
             if facility_created:
                 # We only want to update things about the facility or the facility dataset in the case
                 # that we are creating the facility during this provisioning process.
@@ -154,6 +156,10 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
 
                 if "on_my_own_setup" in custom_settings:
                     facility.on_my_own_setup = custom_settings.pop("on_my_own_setup")
+                    # If we are in on my own setup, then we want to allow learners to download resources
+                    # to give them a seamless onboarding experience, without the need to use the device
+                    # plugin to download resources en masse.
+                    allow_learner_download_resources = True
 
                 # overwrite the settings in dataset_data with validated_data.settings
                 for key, value in custom_settings.items():
@@ -227,6 +233,7 @@ class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
                 "language_id": language_id,
                 "default_facility": facility,
                 "allow_guest_access": allow_guest_access,
+                "allow_learner_download_resources": allow_learner_download_resources,
             }
 
             if is_soud:


### PR DESCRIPTION
## Summary
* The original motivation for remote resource browsing and learner initiated download was to let standalone app users seamlessly manage their local library mostly through the learn interface.
* However, currently, by default, this capability is off.
* This PR changes this to turn this on by default for 'on my own' users

## Reviewer guidance
Setup a device using the 'on my own' workflow.
See the ability to download individual resources when browsing remotely.
Rejoice.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
