### PR TITLE
Update Mac tests to run on Python 3.10

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
The Mac App is built against Python 3.10, but currently our Mac tests run on Python 3.6
Updates the Python version for Mac tests to Python 3.10 instead.

## References
https://github.com/learningequality/kolibri-app/blob/main/.github/workflows/build_mac.yml#L55

## Reviewer guidance
Do the Python tests still pass?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
