### PR TITLE
Prevent errors for exact duplicate usernames

### DIFF
--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1180,9 +1180,34 @@ class LoginLogoutTestCase(APITestCase):
         # Assert the expected behavior for the second user
         self.assertEqual(response_user2.status_code, 200)
 
-        # Cleanup: Delete the created users
-        self.user1.delete()
-        self.user2.delete()
+    def test_case_sensitive_matching_usernames(self):
+        FacilityUserFactory.create(username="shared_username", facility=self.facility)
+
+        response_user2 = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "username": "shared_username",
+                "password": DUMMY_PASSWORD,
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+
+        # Assert the expected behavior for the second user
+        self.assertEqual(response_user2.status_code, 200)
+
+        # Test no error when authentication fails
+        response_user3 = self.client.post(
+            reverse("kolibri:core:session-list"),
+            data={
+                "username": "shared_username",
+                "password": "wrong_password",
+                "facility": self.facility.id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response_user3.status_code, 401)
 
 
 class SignUpBase(object):


### PR DESCRIPTION
## Summary
* #11716 fixed errors caused by case insensitively matching usernames, but a possible error remained if usernames were exact duplicates (this is possible by the same username being created on different devices, but the same facility and then being synced)
* This adds a regression test and fixes this issue
* Also moves querying of the unauthenticated user until after we have failed to login, to avoid an unnecessary premature query.

## References
Depends on #11754, as that involved some updates to the authentication logic, and so avoids a merge conflict.

## Reviewer guidance
Check that the newly added test makes sense. Check that it passes.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
