### PR TITLE
Prevent learner only devices from being shown as an import source when creating one.

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -10,9 +10,9 @@
     @cancel="$emit('cancel')"
   >
     <template>
-      <p v-if="filterLODAvailable">
+      <!-- <p v-if="filterLODAvailable">
         {{ $tr('lodSubHeader') }}
-      </p>
+      </p> -->
       <p v-if="hasFetched && !devices.length">
         {{ $tr('noDeviceText') }}
       </p>
@@ -387,6 +387,9 @@
         context:
           'Error message that displays when an admin attempts to find a device, but the device is not found.',
       },
+      // TODO Update this string to be more specific that it is 0.15 or greater
+      // once this is done, reinstate the $tr('lodSubHeader') in the template
+      // eslint-disable-next-line kolibri/vue-no-unused-translations
       lodSubHeader: {
         message: 'Select a device with Kolibri version 0.15 to import learner user accounts',
         context:

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -19,6 +19,7 @@
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
+      :filterLODAvailable="true"
       :filterByFacilityCanSignUp="selected === Options.JOIN ? true : null"
       @cancel="showSelectAddressModal = false"
       @submit="handleContinueImport"


### PR DESCRIPTION
## Summary
Prevents us from showing subset of user devices when importing learner(s) to create a subset of user device

## References
Fixes #11749

## Reviewer guidance
Startup an already provisioned learner only device
Startup a fresh Kolibri env with this fix
Go through the learner only device flow
See that the already provisioned learner only device does not show up in the device selection modal

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
