### PR TITLE
Fix NO_FILE_BASED_LOGGING environment variable behavior

### DIFF
--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -44,9 +44,8 @@ if not os.path.exists(KOLIBRI_HOME):
 
 # Create a folder named logs inside KOLIBRI_HOME to store all the log files.
 LOG_ROOT = os.path.join(KOLIBRI_HOME, "logs")
-if not os.path.exists(LOG_ROOT):
-    if not (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true"):
-        os.mkdir(LOG_ROOT)
+if not os.path.exists(LOG_ROOT) and not NO_FILE_BASED_LOGGING:
+    os.mkdir(LOG_ROOT)
 
 
 def __initialize_options():

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -45,7 +45,7 @@ if not os.path.exists(KOLIBRI_HOME):
 # Create a folder named logs inside KOLIBRI_HOME to store all the log files.
 LOG_ROOT = os.path.join(KOLIBRI_HOME, "logs")
 if not os.path.exists(LOG_ROOT):
-    if not (NO_FILE_BASED_LOGGING.lower() == "true"):
+    if not (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true"):
         os.mkdir(LOG_ROOT)
 
 

--- a/kolibri/utils/conf.py
+++ b/kolibri/utils/conf.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 #: Absolute path of the main user data directory.
 #: Will be created automatically if it doesn't exist.
 KOLIBRI_HOME = os.path.abspath(os.path.expanduser(os.environ["KOLIBRI_HOME"]))
+NO_FILE_BASED_LOGGING = os.environ.get("KOLIBRI_NO_FILE_BASED_LOGGING", False)
 
 # Creating KOLIBRI_HOME atm. has to happen here as for instance utils.cli is not
 # called through py.test. This file is the first basic entry point of
@@ -44,7 +45,8 @@ if not os.path.exists(KOLIBRI_HOME):
 # Create a folder named logs inside KOLIBRI_HOME to store all the log files.
 LOG_ROOT = os.path.join(KOLIBRI_HOME, "logs")
 if not os.path.exists(LOG_ROOT):
-    os.mkdir(LOG_ROOT)
+    if not (NO_FILE_BASED_LOGGING.lower() == "true"):
+        os.mkdir(LOG_ROOT)
 
 
 def __initialize_options():

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -197,7 +197,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
 
     DEFAULT_HANDLERS = (
         ["console", "console-error"]
-        if NO_FILE_BASED_LOGGING
+        if (NO_FILE_BASED_LOGGING.lower() == "true")
         else ["file", "console", "console-error", "file_debug"]
     )
 
@@ -237,24 +237,30 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "formatter": "color",
                 "stream": "ext://sys.stdout",
             },
-            "file": {
-                "level": "INFO",
-                "filters": [],
-                "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
-                "filename": os.path.join(LOG_ROOT, "kolibri.txt"),
-                "formatter": "simple_date",
-                "when": "midnight",
-                "backupCount": 30,
-                "encoding": "utf-8",
-            },
-            "file_debug": {
-                "level": "DEBUG",
-                "filters": ["require_debug_true"],
-                "class": "logging.FileHandler",
-                "filename": os.path.join(LOG_ROOT, "debug.txt"),
-                "formatter": "simple_date",
-                "encoding": "utf-8",
-            },
+            **(
+                {
+                    "file": {
+                        "level": "INFO",
+                        "filters": [],
+                        "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
+                        "filename": os.path.join(LOG_ROOT, "kolibri.txt"),
+                        "formatter": "simple_date",
+                        "when": "midnight",
+                        "backupCount": 30,
+                        "encoding": "utf-8",
+                    },
+                    "file_debug": {
+                        "level": "DEBUG",
+                        "filters": ["require_debug_true"],
+                        "class": "logging.FileHandler",
+                        "filename": os.path.join(LOG_ROOT, "debug.txt"),
+                        "formatter": "simple_date",
+                        "encoding": "utf-8",
+                    },
+                }
+                if not (NO_FILE_BASED_LOGGING.lower() == "true")
+                else {}
+            ),
         },
         "loggers": {
             "": {

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -197,7 +197,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
 
     DEFAULT_HANDLERS = (
         ["console", "console-error"]
-        if (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true")
+        if NO_FILE_BASED_LOGGING
         else ["file", "console", "console-error", "file_debug"]
     )
 
@@ -221,7 +221,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
         },
     }
 
-    if not (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true"):
+    if not NO_FILE_BASED_LOGGING:
         handlers["file"] = {
             "level": "INFO",
             "filters": [],

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -197,7 +197,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
 
     DEFAULT_HANDLERS = (
         ["console", "console-error"]
-        if (NO_FILE_BASED_LOGGING.lower() == "true")
+        if (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true")
         else ["file", "console", "console-error", "file_debug"]
     )
 
@@ -258,7 +258,10 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                         "encoding": "utf-8",
                     },
                 }
-                if not (NO_FILE_BASED_LOGGING.lower() == "true")
+                if not (
+                    NO_FILE_BASED_LOGGING
+                    and str(NO_FILE_BASED_LOGGING).lower() == "true"
+                )
                 else {}
             ),
         },

--- a/kolibri/utils/logger.py
+++ b/kolibri/utils/logger.py
@@ -205,6 +205,43 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
     DEFAULT_LEVEL = "INFO" if not debug else "DEBUG"
     DATABASE_LEVEL = "INFO" if not debug_database else "DEBUG"
 
+    handlers = {
+        "console-error": {
+            "level": "ERROR",
+            "class": "kolibri.utils.logger.EncodingStreamHandler",
+            "formatter": "color",
+            "stream": "ext://sys.stderr",
+        },
+        "console": {
+            "level": DEFAULT_LEVEL,
+            "filters": ["no_exceptions"],
+            "class": "kolibri.utils.logger.EncodingStreamHandler",
+            "formatter": "color",
+            "stream": "ext://sys.stdout",
+        },
+    }
+
+    if not (NO_FILE_BASED_LOGGING and str(NO_FILE_BASED_LOGGING).lower() == "true"):
+        handlers["file"] = {
+            "level": "INFO",
+            "filters": [],
+            "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
+            "filename": os.path.join(LOG_ROOT, "kolibri.txt"),
+            "formatter": "simple_date",
+            "when": "midnight",
+            "backupCount": 30,
+            "encoding": "utf-8",
+        }
+
+        handlers["file_debug"] = {
+            "level": "DEBUG",
+            "filters": ["require_debug_true"],
+            "class": "logging.FileHandler",
+            "filename": os.path.join(LOG_ROOT, "debug.txt"),
+            "formatter": "simple_date",
+            "encoding": "utf-8",
+        }
+
     return {
         "version": 1,
         "disable_existing_loggers": False,
@@ -223,48 +260,7 @@ def get_default_logging_config(LOG_ROOT, debug=False, debug_database=False):
                 "log_colors": LOG_COLORS,
             },
         },
-        "handlers": {
-            "console-error": {
-                "level": "ERROR",
-                "class": "kolibri.utils.logger.EncodingStreamHandler",
-                "formatter": "color",
-                "stream": "ext://sys.stderr",
-            },
-            "console": {
-                "level": DEFAULT_LEVEL,
-                "filters": ["no_exceptions"],
-                "class": "kolibri.utils.logger.EncodingStreamHandler",
-                "formatter": "color",
-                "stream": "ext://sys.stdout",
-            },
-            **(
-                {
-                    "file": {
-                        "level": "INFO",
-                        "filters": [],
-                        "class": "kolibri.utils.logger.KolibriTimedRotatingFileHandler",
-                        "filename": os.path.join(LOG_ROOT, "kolibri.txt"),
-                        "formatter": "simple_date",
-                        "when": "midnight",
-                        "backupCount": 30,
-                        "encoding": "utf-8",
-                    },
-                    "file_debug": {
-                        "level": "DEBUG",
-                        "filters": ["require_debug_true"],
-                        "class": "logging.FileHandler",
-                        "filename": os.path.join(LOG_ROOT, "debug.txt"),
-                        "formatter": "simple_date",
-                        "encoding": "utf-8",
-                    },
-                }
-                if not (
-                    NO_FILE_BASED_LOGGING
-                    and str(NO_FILE_BASED_LOGGING).lower() == "true"
-                )
-                else {}
-            ),
-        },
+        "handlers": handlers,
         "loggers": {
             "": {
                 "handlers": DEFAULT_HANDLERS,


### PR DESCRIPTION
## Summary
This PR aims to fix the behavior of `NO_FILE_BASED_LOGGING` environment variable.

## References
Closes #9161 

## Reviewer guidance
To test these changes:

1. Set the `KOLIBRI_NO_FILE_BASED_LOGGING` env variable to true.
2. Run any command that triggers upgrade, for example- `kolibri manage migrate`.
3. You'll see that _"kolibri.txt"_ file (or _"debug.txt"_ file) in the _"logs"_ folder doesn't reflect the update logs generated.
4. If the _"logs"_ folder doesn't already exist and the env variable is set to true, there will be no attempt made to create it automatically.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
