### PR TITLE
Upgrade KDS to v2.0.0 on the release branch

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v2.0.0-beta1",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v2.0.0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v2.0.0-beta1",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v2.0.0",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7637,7 +7637,7 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v2.0.0-beta1":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v2.0.0":
   version "1.3.0"
   resolved "https://github.com/learningequality/kolibri-design-system#13e539592fd87508cd32f60e4ad22c1ec320559b"
   dependencies:


### PR DESCRIPTION
## Summary

It doesn't introduce any changes since v2.0.0 is identical to the previously installed v2.0.0-beta1

KDS v2.0.0 Release Notes: https://github.com/learningequality/kolibri-design-system/releases/tag/v2.0.0

## Reviewer guidance

I think it should be safe to merge.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~

## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
