### PR TITLE
Upgrade KDS to the latest on the develop branch

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#0ed2f274b1bc3808218a4d3f526c181b96b32c6d",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e0bd6f3aa3b2696a6e1b9dc42e69e94c183c931",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.0",
-    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#v2.0.0-beta1",
+    "kolibri-design-system": "https://github.com/learningequality/kolibri-design-system#2e0bd6f3aa3b2696a6e1b9dc42e69e94c183c931",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,7 +4315,7 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-date-fns@^1.28.2:
+date-fns@^1.28.2, date-fns@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -7647,13 +7647,15 @@ kolibri-constants@0.2.0:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.0.tgz#47c9d773894e23251ba5ac4db420822e45603142"
   integrity sha512-WYDMGDzB9gNxRbpX1O2cGe1HrJvLvSZGwMuAv6dqrxJgPf7iO+Hi40/1CXjHM7nk5CRt+hn5bqnMzCBmj1omPA==
 
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#0ed2f274b1bc3808218a4d3f526c181b96b32c6d":
+"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#2e0bd6f3aa3b2696a6e1b9dc42e69e94c183c931":
   version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#0ed2f274b1bc3808218a4d3f526c181b96b32c6d"
+  resolved "https://github.com/learningequality/kolibri-design-system#2e0bd6f3aa3b2696a6e1b9dc42e69e94c183c931"
   dependencies:
+    "@vue/composition-api" "^1.7.2"
     aphrodite "https://github.com/learningequality/aphrodite/"
     autosize "^3.0.21"
     css-element-queries "^1.2.0"
+    date-fns "^1.30.1"
     frame-throttle "^3.0.0"
     fuzzysearch "^1.0.3"
     keen-ui "^1.3.0"
@@ -7662,22 +7664,7 @@ kolibri-constants@0.2.0:
     purecss "^0.6.2"
     tippy.js "^4.2.1"
     vue-intl "^3.1.0"
-
-"kolibri-design-system@https://github.com/learningequality/kolibri-design-system#v2.0.0-beta1":
-  version "1.3.0"
-  resolved "https://github.com/learningequality/kolibri-design-system#13e539592fd87508cd32f60e4ad22c1ec320559b"
-  dependencies:
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "^3.0.21"
-    css-element-queries "^1.2.0"
-    frame-throttle "^3.0.0"
-    fuzzysearch "^1.0.3"
-    keen-ui "^1.3.0"
-    lodash "^4.17.15"
-    popper.js "^1.14.6"
-    purecss "^0.6.2"
-    tippy.js "^4.2.1"
-    vue-intl "^3.1.0"
+    xstate "^4.38.3"
 
 launch-editor-middleware@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
## Summary

We forgot to keep `develop` up to date with the latest KDS for some time so this PR updates KDS version to the latest KDS commit. No changes are breaking and I haven't noticed any updates needed in Kolibri.

The relevant portion of the KDS changelog:

```markdown
- [#522]
  - **Description:** Upgrades github-actions/cache dependency
  - **Products impact:** Dev dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#522]: https://github.com/learningequality/kolibri-design-system/pull/522

- [#518]
  - **Description:** Add testing for KImg component
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/512
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no  - 
  - **Guidance:** -

[#518]: https://github.com/learningequality/kolibri-design-system/pull/518

- [#521]
  - **Description:** Move date-fns dependency to depencies rather than dev-dependencies.
  - **Products impact:** bugfix
  - **Addresses:** N/A
  - **Components:** KDateRange/KDateInput
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** ~

[#521]: [https://github.com/learningequality/kolibri-design-system/pull/521]

- [#509]
  - **Description:** Introduces `appearanceOverrides` prop for the `KImg` component
  - **Products impact:** new API 
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/371
  - **Components:** KImg
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** -

[#509]: https://github.com/learningequality/kolibri-design-system/pull/509

- [#516]
  - **Description:** Upgrades follow-redirects dependency
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#516]: https://github.com/learningequality/kolibri-design-system/pull/516

- [#508]
  - **Description:** Update Github maintained github actions to latest versions
  - **Products impact:** -
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no  
  - **Guidance:** -

[#508]: https://github.com/learningequality/kolibri-design-system/pull/508

- [#502]
  - **Description:** Add dispatching of 'error' event when failed to load image for 'KImg'
  - **Products impact:** new API
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/372
  - **Components:** KImg
  - **Breaking:** no
  - **Impacts a11y:** yes  
  - **Guidance:** Allows the consumer to hook into the lifecycle of 'KImg' and handle the cases when the image fails to load

[#502]: https://github.com/learningequality/kolibri-design-system/pull/502

- [#505]
  - **Description:**  Added custom implementation of GH action that checks that changelog is updated in each pull request
  - **Products impact:** none
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/481
  - **Components:** -
  - **Breaking:** 
  - **Impacts a11y:** 
  - **Guidance:** -

[#505]: https://github.com/learningequality/kolibri-design-system/pull/505

- [#493]
  - **Description:** Changed the value of z-index of KDropdownMenu to 99.
  - **Products impact:** Bugfix
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/486
  - **Components:** KDropdownMenu
  - **Breaking:** No
  - **Impacts a11y:** No
  - **Guidance:** -

[#493]: https://github.com/learningequality/kolibri-design-system/pull/493

- [#500]
  - **Description:** Upgrades vue-router dependency
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#500]: https://github.com/learningequality/kolibri-design-system/pull/500

- [#421]
  - **Description:** Upgrades kolibri-tools dependency and removes KDS' circular dependency on itself
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#421]: https://github.com/learningequality/kolibri-design-system/pull/421

- [#499]
  - **Description:** Upgrades @babel/traverse dependency to address security vulnerability
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#499]: https://github.com/learningequality/kolibri-design-system/pull/499

- [#467]
  - **Description:** Upgrades word-wrap dependency to address security vulnerability
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#467]: https://github.com/learningequality/kolibri-design-system/pull/467

- [#483]
  - **Description:** Upgrades browserify-sign dependency to address security vulnerability
  - **Products impact:** Dependency upgrade
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** no
  - **Impacts a11y:** no
  - **Guidance:** -

[#483]: https://github.com/learningequality/kolibri-design-system/pull/483

- [#494]
  - **Description:** Update contributing guidelines
  - **Products impact:** none
  - **Addresses:** -
  - **Components:** -
  - **Breaking:** -
  - **Impacts a11y:** -
  - **Guidance:** -

[#494]: [https://github.com/learningequality/kolibri-design-system/pull/494]

- [#492]
  - **Description:** Add autofocus directive on KRadioButton to fix autofocus behavior on dynamic rendering.
  - **Products impact:** bugfix
  - **Addresses:** https://github.com/learningequality/kolibri-design-system/issues/489
  - **Components:** KRadioButton
  - **Breaking:** no
  - **Impacts a11y:** yes
  - **Guidance:** Add "autofocus" prop on KRadioButton. This change improves keyboard navigation on forms where a KRadioButton jumps into the DOM.

[#492]: https://github.com/learningequality/kolibri-design-system/pull/492

- [#497]
  - **Description:** KDropdownMenu now emits a @tab event when the user hits the [Tab] key and a @close event when the menu is closed programmatically. Additionally, a new icon for Expand All was added and can be used just like any other icon with the "expandAll" name.
  - **Products impact:** updated API
  - **Addresses:** -
  - **Components:** KDropdownMenu
  - **Breaking:** No
  - **Impacts a11y:** yes
  - **Guidance:**  The @tab event can be used for more precise focus management as the popover by default could end up sending focus to the root HTML element by default. Note that the browser event is passed to the handler function, so you may need/want to call `preventDefault()` on that event depending on your use case.

  [#497]: https://github.com/learningequality/kolibri-design-system/pull/497
```

## Reviewer guidance

You could preview the changelog section pasted above and run Kolibri.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
