### PR TITLE
Add check to call render on the response if it has a render method

### DIFF
--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -339,7 +339,8 @@ def cache_no_user_data(view_func):
     _response = local()
 
     def render_and_cache(response, cache_key):
-        response.render()
+        if hasattr(response, "render"):
+            response.render()
         etag = hashlib.md5(
             kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")
         ).hexdigest()

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -339,7 +339,7 @@ def cache_no_user_data(view_func):
     _response = local()
 
     def render_and_cache(response, cache_key):
-        if hasattr(response, "render"):
+        if hasattr(response, "render") and callable(response.render):
             response.render()
         etag = hashlib.md5(
             kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")

--- a/kolibri/core/decorators.py
+++ b/kolibri/core/decorators.py
@@ -341,11 +341,14 @@ def cache_no_user_data(view_func):
     def render_and_cache(response, cache_key):
         if hasattr(response, "render") and callable(response.render):
             response.render()
-        etag = hashlib.md5(
-            kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")
-        ).hexdigest()
-        cache.set(cache_key, etag, CACHE_TIMEOUT)
-        return etag
+        if response.content:
+            etag = hashlib.md5(
+                kolibri_version.encode("utf-8") + str(response.content).encode("utf-8")
+            ).hexdigest()
+            cache.set(cache_key, etag, CACHE_TIMEOUT)
+            return etag
+        else:
+            return None
 
     def calculate_spa_etag(*args, **kwargs):
         # Clear the local thread 'response' property


### PR DESCRIPTION
## Summary
This PR fixes the error : `'HttpResponseNotAllowed' object has no attribute 'render'` when render method is called on response without checking if render attribute exists or is callable.

## References
Closes #10506 

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
