### PR TITLE
Allow preset to be optional

### DIFF
--- a/kolibri/core/device/serializers.py
+++ b/kolibri/core/device/serializers.py
@@ -52,7 +52,7 @@ class DeviceSerializerMixin(object):
 class DeviceProvisionSerializer(DeviceSerializerMixin, serializers.Serializer):
     facility = FacilitySerializer(required=False, allow_null=True)
     facility_id = serializers.CharField(max_length=50, required=False, allow_null=True)
-    preset = serializers.ChoiceField(choices=choices)
+    preset = serializers.ChoiceField(choices=choices, required=False, allow_null=True)
     superuser = NoFacilityFacilityUserSerializer(required=False)
     language_id = serializers.CharField(max_length=15)
     device_name = serializers.CharField(max_length=50, allow_null=True)


### PR DESCRIPTION
## Summary
* If we are provisioning a device to which we have already imported a facility, the preset argument to the provision endpoint is a no op
* A bug that previously sent the preset to the backend anyway was addressed in the course of preventing issues with the on my own workflow
* This follows that up by making the preset argument optional for the provisioning serializer, and instead deferring enforcement of the preset parameter to the pre-existing check in the `validate` method that makes sure if a facility is being created, the preset is required

## References
Fixes #11763

Follow up to #11514

…

## Reviewer guidance
Is there any other possibility here not covered by the validate and create methods?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
