### PR TITLE
Handle updated exception signature from super validate method.

### DIFF
--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -2,10 +2,11 @@ import requests
 from django.core.management import call_command
 from morango.errors import MorangoError
 from rest_framework import serializers
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import ValidationError
 from rest_framework.status import HTTP_201_CREATED
 
 from .utils import TokenGenerator
+from kolibri.core import error_constants
 from kolibri.core.auth.constants import role_kinds
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.tasks import PeerImportSingleSyncJobValidator
@@ -40,9 +41,12 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
     def validate(self, data):
         try:
             job_data = super(MergeUserValidator, self).validate(data)
-        except AuthenticationFailed:
-            self.create_remote_user(data)
-            job_data = super(MergeUserValidator, self).validate(data)
+        except ValidationError as e:
+            if e.detail.code == error_constants.AUTHENTICATION_FAILED:
+                self.create_remote_user(data)
+                job_data = super(MergeUserValidator, self).validate(data)
+            else:
+                raise
 
         job_data["kwargs"]["local_user_id"] = data["local_user_id"].id
         job_data["extra_metadata"].update(user_fullname=data["local_user_id"].full_name)


### PR DESCRIPTION
## Summary
* A recent change to the handling of authentication errors in the `PeerImportSingleSyncValidator` changed the kind of error thrown by the validate function: https://github.com/learningequality/kolibri/pull/11704
* This was not accounted for in the `MergeUserValidator` which inherits from and extends this validate method
* Updates the method to handle the ValidationError instead

## References
Fixes https://github.com/learningequality/kolibri/issues/11768

## Reviewer guidance
Follow the steps outlined in the issue - attempt to merge a user into a facility, when that user does not yet exist in that facility.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
