### PR TITLE
Fix issue where device connection check is not memoized

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useConnectionChecker.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useConnectionChecker.js
@@ -10,7 +10,7 @@ function useMemoizeWithExpiry(asyncFunction, options = {}) {
   return async (...args) => {
     let result = null;
     try {
-      result = await asyncFunction(...args);
+      result = await memoizedFunc(...args);
       setTimeout(() => memoizedFunc.cache.delete(getKey(args)), options.expiry || 10000);
     } catch (e) {
       // clear immediately


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
I just happened to notice that a [bit of code](https://github.com/learningequality/kolibri/blob/bad3d07cf2f411726ba1890525c6cfa0d6988685/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useConnectionChecker.js#L13) was incorrect, within the device connection checker logic. It should be using a memoized function to ensure the frontend doesn't query for connection testing too often for a device.

![Screenshot from 2024-01-23 11-08-11](https://github.com/learningequality/kolibri/assets/819838/58bccb1d-ed39-4905-ad75-a30067f3bdae)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
https://learningequality.slack.com/archives/CB37UM23A/p1705105053832879?thread_ts=1705100642.965639&cid=CB37UM23A

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I ran Kolibri and tested that the device selection modal still worked and tested connections appropriately.

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [X] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
