### PR TITLE
Tweak navbar overflow logic to catch selected items

### DIFF
--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -49,6 +49,7 @@
 
 <script>
 
+  import isUndefined from 'lodash/isUndefined';
   import Navbar from 'kolibri.coreVue.components.Navbar';
   import NavbarLink from 'kolibri.coreVue.components.NavbarLink';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
@@ -91,22 +92,22 @@
         return this.$themeTokens.textInverted;
       },
       overflowMenuLinks() {
-        return (this.mounted && this.windowWidth
-          ? this.allLinks.filter((link, index) => {
-              const navLink = this.$refs.navLinks[index].$el;
-              const navLinkTop = navLink.offsetTop;
-
-              const containerTop = this.$refs.navContainer.offsetTop;
-              const containerBottom = containerTop + this.$refs.navContainer.clientHeight;
-              // Accounts for changes in container height that is not matched by height of buttons
-              // as mobile styles are applied to the nav bar
-              const heightDifference = Math.abs(
-                this.$refs.navContainer.clientHeight - navLink.clientHeight
-              );
-              return navLinkTop + heightDifference >= containerBottom;
-            })
-          : []
-        ).map(l => ({ label: l.title, value: l.link, icon: l.icon }));
+        if (!this.mounted || isUndefined(this.windowWidth)) {
+          return [];
+        }
+        const containerTop = this.$refs.navContainer.offsetTop;
+        const containerHeight = this.$refs.navContainer.clientHeight;
+        return this.allLinks
+          .filter((link, index) => {
+            const navLink = this.$refs.navLinks[index].$el;
+            // Calculate navLinkTop relative to the navContainer by subtracting the container's top
+            const navLinkTop = navLink.offsetTop - containerTop;
+            const navLinkHeight = navLink.clientHeight;
+            const navLinkBottom = navLinkTop + navLinkHeight;
+            // Check if the navLink is _not_ completely bounded the container, top and bottom.
+            return !(navLinkTop >= 0 && navLinkBottom <= containerHeight);
+          })
+          .map(l => ({ label: l.title, value: l.link, icon: l.icon }));
       },
     },
     mounted() {

--- a/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
+++ b/kolibri/core/assets/src/views/HorizontalNavBarWithOverflowMenu.vue
@@ -115,6 +115,10 @@
     },
     methods: {
       handleSelect(option) {
+        // Prevent redundant navigation
+        if (this.$route.name === option.value.name) {
+          return;
+        }
         this.$router.push(this.$router.getRoute(option.value.name));
       },
     },


### PR DESCRIPTION
## Summary
* Updates nav link in navbar check to ensure the link is completely bounded by the navbar
* If not, it is included in the dropdown menu
* Also skips attempting to navigate if we are already on the selected page from the dropdown menu

## References
Fixes #11776

## Reviewer guidance
Test on a 375 pixel wide screen, click into the info page on the device tab.
Ensure that the navigation overflow is still visible.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
