### PR TITLE
Use responsive composable instead of mixin to fix errors from the mixin.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/cards/CardGrid.vue
+++ b/kolibri/plugins/learn/assets/src/views/cards/CardGrid.vue
@@ -9,14 +9,17 @@
 
 <script>
 
-  import responsiveWindowMixin from 'kolibri-design-system/lib/KResponsiveWindowMixin';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
 
   const GRID_TYPE_1 = 1;
   const GRID_TYPE_2 = 2;
 
   export default {
     name: 'CardGrid',
-    mixins: [responsiveWindowMixin],
+    setup() {
+      const { windowBreakpoint } = useKResponsiveWindow();
+      return { windowBreakpoint };
+    },
     props: {
       /**
        * `1` or `2`


### PR DESCRIPTION
## Summary
* Fixes bug in responsive layout of card grids caused by incorrect reporting of window breakpoint by the responsive window mixin

## Reviewer guidance
Before:
![image](https://github.com/learningequality/kolibri/assets/1680573/5ac4145b-fed7-4124-9ac2-a63d157a9454)

After:
![Screenshot from 2024-01-25 11-49-22](https://github.com/learningequality/kolibri/assets/1680573/0036da23-7e0d-4710-ac9f-8e328b049809)

Tested on Breakpoint 0 - Pixel 7 in chrome dev tools.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
