### PR TITLE
Capture more errors from the backend and show error messages for them

### DIFF
--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -1,6 +1,7 @@
 import requests
 from django.urls import reverse
 from rest_framework import decorators
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
@@ -154,7 +155,12 @@ class FacilityImportViewSet(ViewSet):
         baseurl = request.data.get("baseurl")
         password = request.data.get("password")
         username = request.data.get("username")
-        facility_info = get_remote_users_info(baseurl, facility_id, username, password)
+        try:
+            facility_info = get_remote_users_info(
+                baseurl, facility_id, username, password
+            )
+        except AuthenticationFailed:
+            raise PermissionDenied()
         user_info = facility_info["user"]
         roles = user_info["roles"]
         admin_roles = (user_kinds.ADMIN, user_kinds.SUPERUSER)

--- a/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/ImportIndividualUserForm.vue
@@ -252,10 +252,12 @@
         });
       },
       handleSubmit() {
-        this.shouldValidate = true;
-        if (this.invalidText) {
-          this.$refs.usernameTextbox.focus();
-          return;
+        if (this.wizardService.state.context.importedUsers.length === 0) {
+          this.shouldValidate = true;
+          if (this.invalidText) {
+            this.$refs.usernameTextbox.focus();
+            return;
+          }
         }
         this.formSubmitted = true;
         const task_name = 'kolibri.core.auth.tasks.peeruserimport';


### PR DESCRIPTION
## Summary

In the wizard setup, when importing users from a remote facility
- Force validation in some cases that were not covered
- Better capture of the error messages provided by the backend
- Clean previous errors when the modal to use admin credentials is shown


## References
Closes #11711

In reference to #11711 , the last point of the description:
> when we have both the Username and Password fields displayed and I enter the username of a learner who was originally created without a password then it's not accepted as valid credentials and I have to import that learner signed in as an admin

has not being changed as it seems a correct behaviour of the application. When facility settings are changed, previous user not requiring a password to login can't login until they have a password. Importing them remotely should not be different. In any case, if @jtamiace has a better solution, perfect.


## Reviewer guidance
Follow the steps @pcenov described in #11711

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
