### PR TITLE
fix: os_user unnecessary password field

### DIFF
--- a/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/SignInPage/index.vue
@@ -339,6 +339,7 @@
         // and forth
         this.usernameBlurred = false;
         this.passwordBlurred = false;
+        this.usernameSubmittedWithoutPassword = false;
         this.loginError = null;
       },
       // Sets the selected list user and/or logs them in


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Resets `usernameSubmittedWithoutPassword` back to `false` on `clearUser` (executed when user goes back using "Change User")

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #11777 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Running Kolibri locally [not in app_mode], create a user with a password (let's call this "pw_user")
2. Stop your Kolibri server, but maintain the same KOLIBRI_HOME folder
    Run Kolibri locally using (https://kolibri-dev.readthedocs.io/en/develop/getting_started.html#running-in-app-mode). (let's call this "os_user")
2. Sign out. You should now see both "pw_user" and "os_user" available to select in the sign in page
    Select "pw_user". You should be directed to the next step, where you enter your password. Do not sign in. Go back via "Change User"
3. Select "os_user". **You should not see any password field show up and sign-in should happen automatically.**
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
