### PR TITLE
Resource selection UX- Improvement 

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
@@ -8,7 +8,7 @@ import useFetchTree from './useFetchTree';
 import { QuizExercise } from './quizCreationSpecs.js';
 
 const logger = logging.getLogger(__filename);
-
+const _loadingMore = ref(false);
 /**
  * @typedef {Object} QuizResourcesConfig
  * @property { computed <string|null|undefined> } topicId - The id of the root node to fetch the
@@ -115,11 +115,16 @@ export default function useQuizResources({ topicId } = {}) {
    */
   async function fetchMoreQuizResources() {
     set(_loading, true);
+    set(_loadingMore, true);
     return fetchMore().then(async results => {
       set(_resources, [...get(_resources), ...results]);
       return annotateTopicsWithDescendantCounts(
         results.filter(({ kind }) => kind === ContentNodeKinds.TOPIC).map(topic => topic.id)
-      ).then(() => set(_loading, false));
+      ).then(() =>{
+        set(_loading, false);
+        set(_loadingMore, false);
+      }
+      );
     });
   }
 
@@ -139,6 +144,7 @@ export default function useQuizResources({ topicId } = {}) {
     setResources,
     resources: computed(() => get(_resources)),
     loading: computed(() => get(_loading) || get(treeLoading)),
+    loadingMore: computed(() => get(_loadingMore)),
     fetchQuizResources,
     fetchMoreQuizResources,
     hasCheckbox,

--- a/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
@@ -120,11 +120,10 @@ export default function useQuizResources({ topicId } = {}) {
       set(_resources, [...get(_resources), ...results]);
       return annotateTopicsWithDescendantCounts(
         results.filter(({ kind }) => kind === ContentNodeKinds.TOPIC).map(topic => topic.id)
-      ).then(() =>{
+      ).then(() => {
         set(_loading, false);
         set(_loadingMore, false);
-      }
-      );
+      });
     });
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -65,6 +65,7 @@
         :contentCardMessage="selectionMetadata"
         :contentCardLink="contentLink"
         :selectAllIndeterminate="selectAllIndeterminate"
+        :loadingMoreState="loadingMore"
         @changeselectall="toggleTopicInWorkingResources"
         @change_content_card="toggleSelected"
         @moreresults="fetchMoreQuizResources"
@@ -204,6 +205,7 @@
         hasMore,
         annotateTopicsWithDescendantCounts,
         setResources,
+        loadingMore,
       } = useQuizResources({ topicId });
 
       const _loading = ref(true);
@@ -288,6 +290,7 @@
         hasCheckbox,
         loading,
         hasMore,
+        loadingMore,
         fetchMoreQuizResources,
         resetWorkingResourcePool,
         contentPresentInWorkingResourcePool,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -5,11 +5,24 @@
       <KCircularLoader />
     </div>
     <div v-else>
-      <h5
-        class="title-style"
-      >
-        {{ /* selectFoldersOrExercises$() */ }}
-      </h5>
+      <KGrid class="align-select-folder-style">
+        <KGridItem
+          :layout12="{ span: 1 }"
+          :layout8="{ span: 1 }"
+        >
+          <KIconButton
+            icon="back"
+            @click="goBack()"
+          />
+        </KGridItem>
+
+        <KGridItem
+          :layout12="{ span: 11 }"
+          :layout8="{ span: 7 }"
+        >
+          <h5 class="select-folder-style"> {{ selectFoldersOrExercises$() }} </h5>
+        </KGridItem>
+      </KGrid>
 
       <div v-if="!isTopicIdSet && bookmarks.length && !showBookmarks">
 
@@ -126,7 +139,7 @@
         sectionSettings$,
         selectFromBookmarks$,
         numberOfSelectedBookmarks$,
-        //selectFoldersOrExercises$,
+        selectFoldersOrExercises$,
         numberOfSelectedResources$,
         numberOfResources$,
         selectedResourcesInformation$,
@@ -282,7 +295,7 @@
         sectionSettings$,
         selectFromBookmarks$,
         numberOfSelectedBookmarks$,
-        //selectFoldersOrExercises$,
+        selectFoldersOrExercises$,
         numberOfSelectedResources$,
         numberOfResources$,
         windowIsSmall,
@@ -505,6 +518,14 @@
     span {
       line-height: 2.5em;
     }
+  }
+
+  .select-folder-style{
+    font-size: 18px;
+    margin-top:0.5em;
+  }
+  .align-select-folder-style{
+    margin-top:2em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -54,7 +54,7 @@
         :channelsLink="channelsLink"
         :topicsLink="topicsLink"
       />
-
+      {{ scrollable }}
       <ContentCardList
         :contentList="contentList"
         :showSelectAll="true"
@@ -320,6 +320,11 @@
         required: true,
       },
     },
+    data() {
+      return {
+        scrollable: 0,
+      };
+    },
     computed: {
       isTopicIdSet() {
         return this.$route.params.topic_id;
@@ -363,6 +368,13 @@
       bookmarks(newVal) {
         this.bookmarksCount = newVal.length;
       },
+      storedScrollPosition(newValue, oldValue) {
+        // Handle the scroll position change here
+        this.addScrollListener();
+      },
+    },
+    mounted() {
+      this.addScrollListener();
     },
     methods: {
       /** @public */

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -20,7 +20,9 @@
           :layout12="{ span: 11 }"
           :layout8="{ span: 7 }"
         >
-          <h5 class="select-folder-style"> {{ selectFoldersOrExercises$() }} </h5>
+          <h5 class="select-folder-style">
+            {{ selectFoldersOrExercises$() }}
+          </h5>
         </KGridItem>
       </KGrid>
 
@@ -54,7 +56,6 @@
         :channelsLink="channelsLink"
         :topicsLink="topicsLink"
       />
-      {{ scrollable }}
       <ContentCardList
         :contentList="contentList"
         :showSelectAll="true"
@@ -320,11 +321,6 @@
         required: true,
       },
     },
-    data() {
-      return {
-        scrollable: 0,
-      };
-    },
     computed: {
       isTopicIdSet() {
         return this.$route.params.topic_id;
@@ -368,13 +364,6 @@
       bookmarks(newVal) {
         this.bookmarksCount = newVal.length;
       },
-      storedScrollPosition(newValue, oldValue) {
-        // Handle the scroll position change here
-        this.addScrollListener();
-      },
-    },
-    mounted() {
-      this.addScrollListener();
     },
     methods: {
       /** @public */
@@ -535,12 +524,13 @@
     }
   }
 
-  .select-folder-style{
+  .select-folder-style {
+    margin-top: 0.5em;
     font-size: 18px;
-    margin-top:0.5em;
   }
-  .align-select-folder-style{
-    margin-top:2em;
+
+  .align-select-folder-style {
+    margin-top: 2em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -1,7 +1,7 @@
 <template>
 
   <div class="select-resource">
-    <div v-if="loading">
+    <div v-if="loading && !loadingMore">
       <KCircularLoader />
     </div>
     <div v-else>
@@ -369,6 +369,9 @@
       /** @public */
       focusFirstEl() {
         this.$refs.textbox.focus();
+      },
+      goBack() {
+        return this.$router.go(-1);
       },
       contentLink(content) {
         if (this.showBookmarks) {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
@@ -39,13 +39,13 @@
 
     <template>
       <KButton
-        v-if="showButton"
+        v-if="showButton && !loadingMoreState"
         :text="coreString('viewMoreAction')"
         :primary="false"
         @click="$emit('moreresults')"
       />
       <KCircularLoader
-        v-if="viewMoreButtonState === 'waiting'"
+        v-if="viewMoreButtonState === 'waiting' & loadingMoreState"
         :delay="false"
       />
       <!-- TODO introduce messages in next version -->
@@ -120,6 +120,10 @@
         type: Function, // ContentNode => Route
         required: true,
       },
+      loadingMoreState:{
+        type: Boolean,
+        default: false,
+      }
     },
     computed: {
       showButton() {

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
@@ -120,10 +120,10 @@
         type: Function, // ContentNode => Route
         required: true,
       },
-      loadingMoreState:{
+      loadingMoreState: {
         type: Boolean,
         default: false,
-      }
+      },
     },
     computed: {
       showButton() {


### PR DESCRIPTION

## Summary
Replaced the `View more` button with a KCircularLoader when clicked and things are loading.

Added  `loading ref ` in the useQuizResources 

 `The View more` button fetches the same amount of resources that the initial fetch

 The` back arrow` is now only visible when there is somewhere within the panel to go back to.
The `back arrow` also serves as clicking the browser "Back" button
closes #11733

## References
#11733

## Reviewer guidance

- Confirm that the "View more" button is effectively replaced with a KCircularLoader when clicked and during the loading state
- Review the implementation of a separate "loading" ref,  loadingMore, to manage the loading state  for the "View more"
- Confirm that the back arrow icon is only visible when there is a valid context within the panel to go back to.
- Clarify that the back arrow does not close the panel; rather, it navigates back within the panel

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
