### PR TITLE
Fix issues with Logging module ('kolibri.lib.logging')

### DIFF
--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -11,7 +11,6 @@ class Logger {
   constructor(loggerName) {
     this.loggerName = loggerName;
     this.logger = loglevel.getLogger(loggerName);
-    loglevel.levels['log'] = 1;
     Object.keys(loglevel.levels).forEach(methodName => {
       const name = methodName.toLowerCase();
       const logFunction = this.logger[name];

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -11,11 +11,14 @@ class Logger {
   constructor(loggerName) {
     this.loggerName = loggerName;
     this.logger = loglevel.getLogger(loggerName);
+    loglevel.levels["log"] = 1
     Object.keys(loglevel.levels).forEach(methodName => {
       const name = methodName.toLowerCase();
       const logFunction = this.logger[name];
       if (logFunction) {
-        this[name] = logFunction.bind(console, this.messagePrefix(name));
+        this[name] = (param) => {
+          return this.logger[name].bind(console, this.messagePrefix(name))(param);
+        }
       }
     });
   }

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -5,25 +5,31 @@
 
 import loglevel from 'loglevel';
 
-const console = global.console;
-
 class Logger {
   constructor(loggerName) {
     this.loggerName = loggerName;
     this.logger = loglevel.getLogger(loggerName);
+    this.setMessagePrefix();
     Object.keys(loglevel.levels).forEach(methodName => {
       const name = methodName.toLowerCase();
       const logFunction = this.logger[name];
       if (logFunction) {
         this[name] = param => {
-          return this.logger[name].bind(console, this.messagePrefix(name))(param);
+          return this.logger[name](param);
         };
       }
     });
   }
 
-  messagePrefix(type) {
-    return `[${type.toUpperCase()}: ${this.loggerName}]`;
+  setMessagePrefix() {
+    var originalFactory = this.logger.methodFactory;
+    this.logger.methodFactory = function(methodName, logLevel, loggerName) {
+      var rawMethod = originalFactory(methodName, logLevel, loggerName);
+      return function(message) {
+        rawMethod(`[${methodName}: ${loggerName}] ` + message);
+      };
+    };
+    this.logger.setLevel(this.logger.getLevel());
   }
 
   setLevel(level, persist) {

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -26,7 +26,7 @@ class Logger {
     this.logger.methodFactory = function(methodName, logLevel, loggerName) {
       var rawMethod = originalFactory(methodName, logLevel, loggerName);
       return function(message) {
-        rawMethod(`[${methodName}: ${loggerName}] ` + message);
+        rawMethod(`[${methodName.toUpperCase()}: ${loggerName}] ` + message);
       };
     };
     this.logger.setLevel(this.logger.getLevel());

--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -11,14 +11,14 @@ class Logger {
   constructor(loggerName) {
     this.loggerName = loggerName;
     this.logger = loglevel.getLogger(loggerName);
-    loglevel.levels["log"] = 1
+    loglevel.levels['log'] = 1;
     Object.keys(loglevel.levels).forEach(methodName => {
       const name = methodName.toLowerCase();
       const logFunction = this.logger[name];
       if (logFunction) {
-        this[name] = (param) => {
+        this[name] = param => {
           return this.logger[name].bind(console, this.messagePrefix(name))(param);
-        }
+        };
       }
     });
   }

--- a/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
+++ b/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
@@ -90,8 +90,8 @@
           // if we only include one of the keys for the extra_settings object
           client({ method: 'GET', url: this.settingsUrl })
             .then(({ data }) => {
-              logging.log('mounted', isMetered);
-              logging.log(data);
+              logging.info('mounted', isMetered);
+              logging.info(data);
               this.extra_settings = data.extra_settings;
               this.selected = this.extra_settings.allow_download_on_metered_connection
                 ? Options.USE_METERED


### PR DESCRIPTION
This PR fixes both the issues mentioned in #11819  and also it fixes #11821 (the reason why the modal is not closing  is because the logging module's .log method was not working in the below mentioned lines in the code base  

https://github.com/learningequality/kolibri/blob/11233954b3ef17b56d3c23645fbd82540a6ef9c7/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue#L93-L94

)

I hope this changes solves the issue.

Fixes #11819, fixes #11821 

###  Results: 
**Image (after making .log function work)**
![image](https://github.com/learningequality/kolibri/assets/143542192/e790342b-40f4-4064-ac5e-03e266986afe)
**Image (after making .setLevel function work)**
![image](https://github.com/learningequality/kolibri/assets/143542192/a36aaeeb-ea8e-4c57-a58d-55fc4699312b)
