### PR TITLE
number of resources updates on selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -414,9 +414,18 @@
       },
       selectionMetadata(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {
-          const count = this.workingResourcePool.length;
           const total = content.num_exercises;
-          return this.selectedResourcesInformation$({ count, total });
+          const numberOfresourcesSelected = this.workingResourcePool.reduce((acc, wr) => {
+            if (wr.ancestors.map(ancestor => ancestor.id).includes(content.id)) {
+              return acc + 1;
+            }
+            return acc;
+          }, 0);
+
+          return this.selectedResourcesInformation$({
+            count: numberOfresourcesSelected,
+            total: total,
+          });
         }
         return '';
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -332,31 +332,6 @@
           this.contentList.some(content => workingResourceIds.includes(content.id))
         );
       },
-      // selectionMetadata(content) {
-      //   console.log(content);
-      //   return ()=>{};
-      // TODO This should return a function that returns a string telling us how many of this
-      // topic's descendants are selected out of its total descendants -- basically answering
-      // "How many resources in the working resource_pool are from this topic?"
-      // Tracked in https://github.com/learningequality/kolibri/issues/11741
-      // return () => { this.workingResourcePool.length };
-      // let count = 0;
-      // let total = 0;
-      // if (this.ancestorCounts[content.id]) {
-      //   count = this.ancestorCounts[content.id].count;
-      //   total = this.ancestorCounts[content.id].total;
-      // }
-      // if (count) {
-      //   return this.$tr('selectionInformation', {
-      //     '32',
-      //     '45',
-      //   });
-      // }
-      // return '';
-      // return function() {
-      //   console.log('Dynamic function called');
-      // };
-      // },
 
       getBookmarksLink() {
         // Inject the showBookmarks parameter so that

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -371,7 +371,7 @@
       },
       toggleSelected({ content, checked }) {
         if (checked) {
-          this.addToSelectedResources(content);
+          this.addToWorkingResourcePool([content]);
         } else {
           this.removeFromWorkingResourcePool(content);
         }
@@ -381,9 +381,7 @@
           this.addToWorkingResourcePool(this.contentList);
         } else {
           this.contentList.forEach(content => {
-            if (content.kind === ContentNodeKinds.TOPIC) {
-              this.removeFromWorkingResourcePool(content);
-            }
+            this.removeFromWorkingResourcePool(content);
           });
         }
       },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -311,13 +311,7 @@
       isSelectAllChecked() {
         // Returns true if all the resources in the topic are in the working resource pool
         const workingResourceIds = this.workingResourcePool.map(wr => wr.id);
-
-        if (this.contentList.every(content => workingResourceIds.includes(content.id))) {
-          this.addToWorkingResourcePoolForTopics(this.contentList);
-          return true;
-        } else {
-          return false;
-        }
+        return this.contentList.every(content => workingResourceIds.includes(content.id));
       },
       selectAllIndeterminate() {
         // Returns true if some, but not all, of the resources in the topic are in the working
@@ -382,22 +376,16 @@
           this.removeFromWorkingResourcePool(content);
         }
       },
-      // addToSelectedResources(content) {
-      //   this.addToWorkingResourcePool([content]);
-      // },
       toggleTopicInWorkingResources(isChecked) {
         if (isChecked) {
           this.addToWorkingResourcePool(this.contentList);
         } else {
-          this.resetWorkingResourcePool();
+          this.contentList.forEach(content => {
+            if (content.kind === ContentNodeKinds.TOPIC) {
+              this.removeFromWorkingResourcePool(content);
+            }
+          });
         }
-      },
-      addToWorkingResourcePoolForTopics(topics) {
-        topics.forEach(topic => {
-          if (topic.kind === ContentNodeKinds.TOPIC) {
-            this.addToWorkingResourcePool(topic.children.results);
-          }
-        });
       },
       topicListingLink({ topicId }) {
         return this.$router.getRoute(

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -129,6 +129,7 @@
         //selectFoldersOrExercises$,
         numberOfSelectedResources$,
         numberOfResources$,
+        selectedResourcesInformation$,
       } = enhancedQuizManagementStrings;
 
       // TODO let's not use text for this
@@ -294,6 +295,7 @@
         addToWorkingResourcePool,
         removeFromWorkingResourcePool,
         showBookmarks,
+        selectedResourcesInformation$
       };
     },
     props: {
@@ -320,12 +322,14 @@
           this.contentList.some(content => workingResourceIds.includes(content.id))
         );
       },
-      selectionMetadata(/*content*/) {
+      // selectionMetadata(content) {
+      //   console.log(content);
+      //   return ()=>{};
         // TODO This should return a function that returns a string telling us how many of this
         // topic's descendants are selected out of its total descendants -- basically answering
         // "How many resources in the working resource_pool are from this topic?"
         // Tracked in https://github.com/learningequality/kolibri/issues/11741
-        return () => { this.workingResourcePool.length };
+        // return () => { this.workingResourcePool.length };
         // let count = 0;
         // let total = 0;
         // if (this.ancestorCounts[content.id]) {
@@ -334,15 +338,16 @@
         // }
         // if (count) {
         //   return this.$tr('selectionInformation', {
-        //     count,
-        //     total,
+        //     '32',
+        //     '45',
         //   });
         // }
         // return '';
         // return function() {
         //   console.log('Dynamic function called');
         // };
-      },
+      // },
+
       getBookmarksLink() {
         // Inject the showBookmarks parameter so that
         // the resourceSelection component now renderes only the
@@ -431,19 +436,16 @@
 
         this.$router.replace(this.closePanelRoute);
       },
-      // selectionMetadata(content) {
-      //   if (content.kind === ContentNodeKinds.TOPIC) {
-      //     const count = content.exercises.filter(exercise =>
-      //       Boolean(this.selectedExercises[exercise.id])
-      //     ).length;
-      //     if (count === 0) {
-      //       return '';
-      //     }
-      //     const total = content.exercises.length;
-      //     return this.$tr('total_number', { count, total });
-      //   }
-      //   return '';
-      // },
+      selectionMetadata(content) {
+        if (content.kind === ContentNodeKinds.TOPIC) {
+          const count = this.workingResourcePool.length;
+          const total = content.children.results.length;
+          console.log(content);
+          console.log(this.workingResourcePool);
+          return this.selectedResourcesInformation$({ count, total });
+        }
+        return '';
+      },
     },
   };
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -311,7 +311,16 @@
       isSelectAllChecked() {
         // Returns true if all the resources in the topic are in the working resource pool
         const workingResourceIds = this.workingResourcePool.map(wr => wr.id);
-        return this.contentList.every(content => workingResourceIds.includes(content.id));
+        if(this.contentList.every(content => workingResourceIds.includes(content.id))){
+          this.contentList.forEach(resource => {
+            if(resource.kind === ContentNodeKinds.TOPIC){
+              this.addToWorkingResourcePool(resource.children.results);
+            }
+          });
+          return true;
+        }else{
+          return false;
+        }
       },
       selectAllIndeterminate() {
         // Returns true if some, but not all, of the resources in the topic are in the working
@@ -439,9 +448,7 @@
       selectionMetadata(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {
           const count = this.workingResourcePool.length;
-          const total = content.children.results.length;
-          console.log(content);
-          console.log(this.workingResourcePool);
+          const total = content.num_exercises;
           return this.selectedResourcesInformation$({ count, total });
         }
         return '';

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -228,7 +228,7 @@
           // to the value of the channels (treating those channels as the topics) -- we then
           // call this annotateTopicsWithDescendantCounts method to ensure that the channels are
           // annotated with their num_assessments and those without assessments are filtered out
-          annotateTopicsWithDescendantCounts(channels.value.map(c => c.id)).then(() => {
+          annotateTopicsWithDescendantCounts(resources.value.map(c => c.id)).then(() => {
             _loading.value = false;
           });
         });

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -313,11 +313,7 @@
         const workingResourceIds = this.workingResourcePool.map(wr => wr.id);
 
         if (this.contentList.every(content => workingResourceIds.includes(content.id))) {
-          this.contentList.forEach(resource => {
-            if (resource.kind === ContentNodeKinds.TOPIC) {
-              this.addToWorkingResourcePool(resource.children.results);
-            }
-          });
+          this.addToWorkingResourcePoolForTopics(this.contentList);
           return true;
         } else {
           return false;
@@ -386,15 +382,22 @@
           this.removeFromWorkingResourcePool(content);
         }
       },
-      addToSelectedResources(content) {
-        this.addToWorkingResourcePool([content]);
-      },
+      // addToSelectedResources(content) {
+      //   this.addToWorkingResourcePool([content]);
+      // },
       toggleTopicInWorkingResources(isChecked) {
         if (isChecked) {
           this.addToWorkingResourcePool(this.contentList);
         } else {
           this.resetWorkingResourcePool();
         }
+      },
+      addToWorkingResourcePoolForTopics(topics) {
+        topics.forEach(topic => {
+          if (topic.kind === ContentNodeKinds.TOPIC) {
+            this.addToWorkingResourcePool(topic.children.results);
+          }
+        });
       },
       topicListingLink({ topicId }) {
         return this.$router.getRoute(

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -295,7 +295,7 @@
         addToWorkingResourcePool,
         removeFromWorkingResourcePool,
         showBookmarks,
-        selectedResourcesInformation$
+        selectedResourcesInformation$,
       };
     },
     props: {
@@ -311,14 +311,15 @@
       isSelectAllChecked() {
         // Returns true if all the resources in the topic are in the working resource pool
         const workingResourceIds = this.workingResourcePool.map(wr => wr.id);
-        if(this.contentList.every(content => workingResourceIds.includes(content.id))){
+
+        if (this.contentList.every(content => workingResourceIds.includes(content.id))) {
           this.contentList.forEach(resource => {
-            if(resource.kind === ContentNodeKinds.TOPIC){
+            if (resource.kind === ContentNodeKinds.TOPIC) {
               this.addToWorkingResourcePool(resource.children.results);
             }
           });
           return true;
-        }else{
+        } else {
           return false;
         }
       },
@@ -334,27 +335,27 @@
       // selectionMetadata(content) {
       //   console.log(content);
       //   return ()=>{};
-        // TODO This should return a function that returns a string telling us how many of this
-        // topic's descendants are selected out of its total descendants -- basically answering
-        // "How many resources in the working resource_pool are from this topic?"
-        // Tracked in https://github.com/learningequality/kolibri/issues/11741
-        // return () => { this.workingResourcePool.length };
-        // let count = 0;
-        // let total = 0;
-        // if (this.ancestorCounts[content.id]) {
-        //   count = this.ancestorCounts[content.id].count;
-        //   total = this.ancestorCounts[content.id].total;
-        // }
-        // if (count) {
-        //   return this.$tr('selectionInformation', {
-        //     '32',
-        //     '45',
-        //   });
-        // }
-        // return '';
-        // return function() {
-        //   console.log('Dynamic function called');
-        // };
+      // TODO This should return a function that returns a string telling us how many of this
+      // topic's descendants are selected out of its total descendants -- basically answering
+      // "How many resources in the working resource_pool are from this topic?"
+      // Tracked in https://github.com/learningequality/kolibri/issues/11741
+      // return () => { this.workingResourcePool.length };
+      // let count = 0;
+      // let total = 0;
+      // if (this.ancestorCounts[content.id]) {
+      //   count = this.ancestorCounts[content.id].count;
+      //   total = this.ancestorCounts[content.id].total;
+      // }
+      // if (count) {
+      //   return this.$tr('selectionInformation', {
+      //     '32',
+      //     '45',
+      //   });
+      // }
+      // return '';
+      // return function() {
+      //   console.log('Dynamic function called');
+      // };
       // },
 
       getBookmarksLink() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -325,7 +325,7 @@
         // topic's descendants are selected out of its total descendants -- basically answering
         // "How many resources in the working resource_pool are from this topic?"
         // Tracked in https://github.com/learningequality/kolibri/issues/11741
-        return () => '';
+        return () => { this.workingResourcePool.length };
         // let count = 0;
         // let total = 0;
         // if (this.ancestorCounts[content.id]) {
@@ -401,10 +401,8 @@
       },
       toggleTopicInWorkingResources(isChecked) {
         if (isChecked) {
-          this.isSelectAllChecked = true;
           this.addToWorkingResourcePool(this.contentList);
         } else {
-          this.isSelectAllChecked = false;
           this.resetWorkingResourcePool();
         }
       },

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -150,4 +150,8 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   numberOfResources: {
     message: '{count, number} {count, plural, one {resource selected} other {resources selected}}',
   },
+  selectedResourcesInformation: {
+    message:
+      '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
+  },
 });


### PR DESCRIPTION


## Summary

- Ensures the proper count and ancestor counts are dynamically populated based on the selected topic.
- Select all Checkbox counts the total number of resources in the working resources pool in the topic tree.
-  updates the count of individual resources selected within the pool.
closes #11784

## References
#11784

## Reviewer guidance

- Verify that the ancestor counts are correctly updated within the selected topic.
- Confirm that the "Select All" Checkbox counts the total number of resources within the topic tree.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
