### PR TITLE
Prevent user sign up on LOD imports

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -775,7 +775,11 @@ class SignUpViewSet(viewsets.GenericViewSet, CreateModelMixin):
     serializer_class = FacilityUserSerializer
 
     def check_can_signup(self, serializer):
-        if not serializer.validated_data["facility"].dataset.learner_can_sign_up:
+        facility = serializer.validated_data["facility"]
+        if (
+            not facility.dataset.learner_can_sign_up
+            or not facility.dataset.full_facility_import
+        ):
             raise PermissionDenied("Cannot sign up to this facility")
 
     def perform_create(self, serializer):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -80,6 +80,7 @@ from kolibri.core.auth.permissions.general import DenyAll
 from kolibri.core.device.utils import allow_guest_access
 from kolibri.core.device.utils import allow_other_browsers_to_connect
 from kolibri.core.device.utils import APP_AUTH_TOKEN_COOKIE_NAME
+from kolibri.core.device.utils import is_full_facility_import
 from kolibri.core.device.utils import valid_app_key_on_request
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.core.mixins import BulkCreateMixin
@@ -182,6 +183,10 @@ class FacilityDatasetFilter(FilterSet):
         fields = ["facility_id"]
 
 
+def _is_full_facility_import(dataset):
+    return is_full_facility_import(dataset["id"])
+
+
 class FacilityDatasetViewSet(ValuesViewset):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (
@@ -207,7 +212,10 @@ class FacilityDatasetViewSet(ValuesViewset):
         "preset",
     )
 
-    field_map = {"allow_guest_access": lambda x: allow_guest_access()}
+    field_map = {
+        "allow_guest_access": lambda x: allow_guest_access(),
+        "is_full_facility_import": _is_full_facility_import,
+    }
 
     def get_queryset(self):
         return FacilityDataset.objects.filter(

--- a/kolibri/core/auth/models.py
+++ b/kolibri/core/auth/models.py
@@ -249,6 +249,13 @@ class FacilityDataset(FacilityDataSyncableModel):
             setattr(self, key, value)
         self.save()
 
+    @cached_property
+    def full_facility_import(self):
+        """
+        Returns True if this user is a member of a facility that has been fully imported.
+        """
+        return is_full_facility_import(self.id)
+
 
 class AbstractFacilityDataModel(FacilityDataSyncableModel):
     """

--- a/kolibri/core/device/utils.py
+++ b/kolibri/core/device/utils.py
@@ -19,6 +19,7 @@ from kolibri.core.auth.constants.facility_presets import mappings
 from kolibri.core.content.constants.schema_versions import MIN_CONTENT_SCHEMA_VERSION
 from kolibri.utils.android import ANDROID_PLATFORM_SYSTEM_VALUE
 from kolibri.utils.android import on_android
+from kolibri.utils.lru_cache import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -486,6 +487,7 @@ def get_device_info(version=DEVICE_INFO_VERSION):
     return info
 
 
+@lru_cache()
 def is_full_facility_import(dataset_id):
     """
     Returns True if this the dataset_id holds a facility that has been fully imported.

--- a/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
+++ b/kolibri/plugins/user_auth/assets/src/views/AuthBase.vue
@@ -212,7 +212,9 @@
         return urls['kolibri:core:guest']();
       },
       canSignUp() {
-        return !this.isLearnerOnlyImport && this.facilityConfig.learner_can_sign_up;
+        return (
+          this.facilityConfig.is_full_facility_import && this.facilityConfig.learner_can_sign_up
+        );
       },
       nextParam() {
         // query is after hash


### PR DESCRIPTION
## Summary
* Adds full facility import flag on dataset API response
* Use that to determine if we should allow signup
* Adds a permission check in the SignupViewset to prevent signups under the same condition at the API level

## References
Fixes #11817

## Reviewer guidance
Do a learner only import from a facility that allows learners to sign up.
Ensure that you cannot create an account.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
