### PR TITLE
Quiz creation bookmark selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -11,7 +11,7 @@
         {{ /* selectFoldersOrExercises$() */ }}
       </h5>
 
-      <div v-if="!isTopicIdSet && bookmarks.length && !bookMarksFlag">
+      <div v-if="!isTopicIdSet && bookmarks.length && !showBookmarks">
 
         <p>{{ selectFromBookmarks$() }}</p>
 
@@ -74,7 +74,7 @@
             <KButton
               :text="coreString('saveChangesAction')"
               :primary="true"
-              :disabled="!hasTopicId() && !bookMarksFlag"
+              :disabled="!hasTopicId() && !showBookmarks"
               @click="saveSelectedResource"
             />
           </KGridItem>
@@ -113,7 +113,10 @@
       const store = getCurrentInstance().proxy.$store;
       const route = computed(() => store.state.route);
       const topicId = computed(() => route.value.params.topic_id);
-      const bookMarksFlag = computed(() => route.value.query.bookmarks);
+      // We use this query parameter to decide if we want to show the Bookmarks Card
+      // or the actual exercises that are bookmarked and can be selected
+      // to be added to Quiz Section.
+      const showBookmarks = computed(() => route.value.query.showBookmarks);
       const {
         updateSection,
         activeSection,
@@ -218,7 +221,7 @@
           return channels.value;
         }
         */
-        if (bookMarksFlag.value) {
+        if (showBookmarks.value) {
           return bookmarks.value
             .filter(item => item.kind === 'exercise')
             .map(item => ({ ...item, is_leaf: true }));
@@ -263,7 +266,7 @@
         workingResourcePool,
         addToWorkingResourcePool,
         removeFromWorkingResourcePool,
-        bookMarksFlag,
+        showBookmarks,
       };
     },
     props: {
@@ -314,9 +317,12 @@
         // };
       },
       getBookmarksLink() {
+        // Inject the showBookmarks parameter so that
+        // the resourceSelection component now renderes only the
+        // the exercises that are bookmarked for the Quiz selection.
         return {
           name: PageNames.QUIZ_SELECT_RESOURCES,
-          query: { bookmarks: true },
+          query: { showBookmarks: true },
         };
       },
       channelsLink() {
@@ -341,7 +347,7 @@
         this.$refs.textbox.focus();
       },
       contentLink(content) {
-        if (this.bookMarksFlag) {
+        if (this.showBookmarks) {
           return this.$route;
         } else if (!content.is_leaf) {
           return {


### PR DESCRIPTION
## Summary
- Explored various other path ways to implement the Bookmarks support with sidePanel for quiz selection. 
- Added Query parameter in the route to support conditional rendering of Bookmarks.
- Render Bookmarks card and exercises Bookmarked according to the boolean value of the query parameter. 

## References
closes #11818

## Reviewer guidance
- Bookmark some of the exercises from the existing channels.
- Go to Quiz Section.
- When you open the sidepanel to add questions, you will also see an option to add bookmarked exercises.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
