### PR TITLE
Remove redundant mastery label masking exercise card thumbnail

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
+++ b/kolibri/plugins/learn/assets/src/views/HybridLearningContentCard/CardThumbnail.vue
@@ -5,7 +5,7 @@
   >
     <template #labels>
       <LearningActivityDuration
-        v-if="checkIfExercise || displayDurationChip"
+        v-if="displayDurationChip"
         :contentNode="contentNode"
         appearance="chip"
         class="duration"
@@ -47,18 +47,8 @@
     },
     computed: {
       displayDurationChip() {
-        if (this.hideDuration) {
-          return false;
-        } else if (this.isMobile) {
-          return false;
-        }
-        return true;
-      },
-      checkIfExercise() {
-        if (this.contentNode.kind === 'exercise') {
-          return true;
-        }
-        return false;
+        // Hide if hideDuration or isMobile is true, display if contentNode kind is exercise
+        return this.hideDuration || this.isMobile ? false : this.contentNode.kind === 'exercise';
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr modifies the conditional `displayDurationChip` for `HybridLearningContentCard/CardThumbnail`. This tag previously 
covered the thumbnail on exercise cards listed on `LessonPlaylistPage`.

| BEFORE  | AFTER  |
|---|---|
 |  ![LessonPlaylistPageBefore](https://github.com/learningequality/kolibri/assets/46411498/357dda56-521c-41f8-ab10-af7858a7d9e0) |  ![LessonPlaylistPageAfter](https://github.com/learningequality/kolibri/assets/46411498/26973f3d-afc6-4ad7-ba92-52de750c0b82)  |
 | ![LessonPlaylistPageMobileBefore](https://github.com/learningequality/kolibri/assets/46411498/ebd7ee03-b0c2-4147-871a-988716f5fc24) | ![LessonPlaylistPageMobileAfter](https://github.com/learningequality/kolibri/assets/46411498/7c105999-ffcb-440b-96ee-9a3ca288c54b) |

The duration chip is still displayed on `TopicsPage` and is hidden on smaller screen sizes.
| TOPICS PAGE NORMAL VIEW  | TOPICS PAGE MOBILE VIEW |
|---|---|
 | ![TopicsPage](https://github.com/learningequality/kolibri/assets/46411498/8743f931-9cb1-42f0-8d71-2ff2a73125fa) |  ![TopicsPageMobile](https://github.com/learningequality/kolibri/assets/46411498/f334b32c-2574-43ff-bddd-7550b82a96f1) |


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #11804 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Open a lesson that has an exercise resource on a Learn Only Device

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
