### PR TITLE
Add conditional check to ensure resource exists before rendering report page

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsResourceHeader.vue
@@ -23,7 +23,7 @@
           />
         </template>
       </HeaderWithOptions>
-      <MissingResourceAlert v-if="!$isPrint && !resource.available" :multiple="false" />
+      <MissingResourceAlert v-if="resourceMissing" :multiple="false" />
       <h1>
         <KLabeledIcon :icon="resource.kind" :label="resource.title" />
       </h1>
@@ -180,6 +180,12 @@
           this.resource.license_name,
           this.resource.license_description
         );
+      },
+      resourceMissing() {
+        if (Object.keys(this.resource).length !== 0) {
+          return !this.$isPrint && !this.resource.available;
+        }
+        return false;
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
Adds a check to ensure that `resource` which is necessary to render the page fully, exists in the state before it renders. This prevents the "missing resource" from appearing when the resource does exist.

## References
Fixes #11824

| | Screenshot |
|---|---|
| Before | ![coach-report-before](https://github.com/learningequality/kolibri/assets/17235236/a60d43f6-297c-4501-ab8e-2ecdf1d05352) | 
| After | ![updated-coach-report](https://github.com/learningequality/kolibri/assets/17235236/a98b778f-4d61-4c90-9006-2574befe80ff) |


## Reviewer guidance
Do I need to do some other sort of more robust error handling here in case the resource does not in fact exist on the device and missing resource alert is more appropriate @rtibbles ?  (`coreLoading` does not work as a condition)
----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
