### PR TITLE
Don't fail when a lesson or exam is assigned through multiple ways.

### DIFF
--- a/kolibri/core/exams/single_user_assignment_utils.py
+++ b/kolibri/core/exams/single_user_assignment_utils.py
@@ -32,7 +32,7 @@ def update_individual_syncable_exams_from_assignments(user_id):
 
     # update existing syncable exam objects for all active assignments
     for syncableexam in to_update:
-        assignment = assignments.get(exam_id=syncableexam.exam_id)
+        assignment = assignments.filter(exam_id=syncableexam.exam_id).first()
         updated_serialization = IndividualSyncableExam.serialize_exam(assignment.exam)
         if (
             syncableexam.serialized_exam != updated_serialization

--- a/kolibri/core/lessons/single_user_assignment_utils.py
+++ b/kolibri/core/lessons/single_user_assignment_utils.py
@@ -40,7 +40,7 @@ def update_individual_syncable_lessons_from_assignments(user_id):
 
     # update existing syncable lesson objects for all active assignments
     for syncablelesson in to_update:
-        assignment = assignments.get(lesson_id=syncablelesson.lesson_id)
+        assignment = assignments.filter(lesson_id=syncablelesson.lesson_id).first()
         updated_serialization = IndividualSyncableLesson.serialize_lesson(
             assignment.lesson
         )


### PR DESCRIPTION
## Summary
* Fixes bug where an exam or lesson assigned via a class _and_ a group (for example) would cause an error during the post sync hooks because of multiple objects being returned

## References
Unreported bug, but could have been the cause of syncing errors.

## Reviewer guidance
This just takes the first assignment, any issues with this?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
