### PR TITLE
Ensure facility id is properly sent to public signup viewset.

### DIFF
--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -51,7 +51,9 @@ class SetupWizardResource(ViewSet):
         url = "{}{}".format(baseurl, api_url)
 
         payload = {
-            "facility_id": facility_id,
+            # N.B. facility is keyed by facility not facility_id on the signup
+            # viewset serializer.
+            "facility": facility_id,
             "username": username,
             "password": password,
             "full_name": full_name,

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants import user_kinds
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
@@ -53,7 +54,7 @@ class SetupWizardResource(ViewSet):
         payload = {
             # N.B. facility is keyed by facility not facility_id on the signup
             # viewset serializer.
-            "facility": facility_id,
+            FACILITY_CREDENTIAL_KEY: facility_id,
             "username": username,
             "password": password,
             "full_name": full_name,


### PR DESCRIPTION
## Summary
* The remote user sign up viewset was sending the facility id as `facility_id` instead of the expected `facility`
* This caused things to go wrong when signing up to a device with more than one facility

## References
Fixes #11832

## Reviewer guidance
Use the database from the linked issue for a server device, and then attempt to create a new user account for `jerrym` username on the second facility (imported from Win11).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
