### PR TITLE
Fix 500 errors when using django redis cache for response caching

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -117,7 +117,7 @@ def metadata_cache(view_func, cache_key_func=get_cache_key):
         # Prevent the Django caching middleware from caching
         # this response, as we want to cache it ourselves
         request._cache_update_cache = False
-        key_prefix = get_cache_key(request)
+        key_prefix = cache_key_func(request)
         url_key = hashlib.md5(
             force_bytes(iri_to_uri(request.build_absolute_uri()))
         ).hexdigest()
@@ -129,7 +129,7 @@ def metadata_cache(view_func, cache_key_func=get_cache_key):
             response = view_func(*args, **kwargs)
             if response.status_code == 200:
                 if key_prefix is None:
-                    key_prefix = get_cache_key(request)
+                    key_prefix = cache_key_func(request)
                 if (
                     key_prefix is not None
                     and hasattr(response, "render")

--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -3,6 +3,7 @@ import logging
 from django.core.cache import caches
 from django.core.cache import InvalidCacheBackendError
 from django.utils.functional import SimpleLazyObject
+from redis_cache import RedisCache as BaseRedisCache
 
 
 logger = logging.getLogger(__name__)
@@ -61,3 +62,15 @@ class RedisSettingsHelper(object):
             logger.info("Overwriting Redis config")
             self.client.config_rewrite()
             self.changed = False
+
+
+class RedisCache(BaseRedisCache):
+    def set(self, *args, **kwargs):
+        """
+        Overwrite the set method to not return a value, in line with the Django cache interface
+        This causes particular issues for Django's caching middleware, which expects the set method to return None
+        as it invokes it directly in a lambda in the response.add_post_render_callback method
+        We use a similar pattern in our own caching decorator in kolibri/core/content/api.py and saw errors
+        due to the fact if the lambda returns a value, it is interpreted as a replacement for the response object.
+        """
+        super(RedisCache, self).set(*args, **kwargs)

--- a/kolibri/deployment/default/cache.py
+++ b/kolibri/deployment/default/cache.py
@@ -38,7 +38,7 @@ process_cache = {
 
 if cache_options["CACHE_BACKEND"] == "redis":
     base_cache = {
-        "BACKEND": "redis_cache.RedisCache",
+        "BACKEND": "kolibri.core.utils.cache.RedisCache",
         "LOCATION": cache_options["CACHE_LOCATION"],
         # Default time out of each cache key
         "TIMEOUT": cache_options["CACHE_TIMEOUT"],


### PR DESCRIPTION
## Summary
* Fixes a small oversight whereby the passed in caching key generation function is not used consistently in the function decorator (not directly related to this fix, but important cleanup)
* Django Redis Cache does not implement an idiomatic cache backend for Django, inasmuch as it always returns a value for each of its cache methods.
* This causes particular issues both in our code and in the code used by the default [Django cache middleware](https://github.com/django/django/blob/stable/1.11.x/django/middleware/cache.py#L102), whereby a response is cached in its post render callback, with the implementation using a lambda to invoke the cache setting, with the expectation that cache.set returns None.
* Due to the fact that the django-redis-cache implementation returns the response from the Redis client as the return of the set function (in the case of a successful set ' `True`) this is returned from the lambda and assumed by Django to be a replacement response object to be returned instead of the original. Hilarity ensues.
* This is fixed by subclassing the django-redis-cache RedisCache class and simply not returning anything from the set function while invoking the super method.

## References
Fixes https://github.com/learningequality/kolibri/issues/11848

## Reviewer guidance
Load an uncached contentnode API endpoint and confirm it does not return a 500.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
