### PR TITLE
Pass the correct kwargs to the cleanupsyncs management command.

### DIFF
--- a/kolibri/core/auth/kolibri_plugin.py
+++ b/kolibri/core/auth/kolibri_plugin.py
@@ -30,8 +30,8 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
         from kolibri.core.device.utils import device_provisioned
 
         if context.is_receiver and device_provisioned():
-            is_pull = context.is_pull
-            is_push = context.is_push
+            pull = context.is_pull
+            push = context.is_push
             sync_filter = str(context.filter)
 
             instance_kwargs = {}
@@ -51,10 +51,7 @@ class CleanUpTaskOperation(KolibriSyncOperationMixin, LocalOperation):
 
             cleanupsync.enqueue(
                 kwargs=dict(
-                    is_pull=is_pull,
-                    is_push=is_push,
-                    sync_filter=sync_filter,
-                    **instance_kwargs
+                    pull=pull, push=push, sync_filter=sync_filter, **instance_kwargs
                 )
             )
 

--- a/kolibri/core/auth/tasks.py
+++ b/kolibri/core/auth/tasks.py
@@ -613,20 +613,18 @@ def deletefacility(facility):
 
 
 class CleanUpSyncsValidator(JobValidator):
-    is_pull = serializers.BooleanField(required=False)
-    is_push = serializers.BooleanField(required=False)
+    pull = serializers.BooleanField(required=False)
+    push = serializers.BooleanField(required=False)
     sync_filter = serializers.CharField(required=True)
     client_instance_id = HexOnlyUUIDField(required=False)
     server_instance_id = HexOnlyUUIDField(required=False)
 
     def validate(self, data):
-        if data.get("is_pull") is None and data.get("is_push") is None:
+        if data.get("pull") is None and data.get("push") is None:
+            raise serializers.ValidationError("Either pull or push must be specified")
+        elif data.get("pull") is data.get("push"):
             raise serializers.ValidationError(
-                "Either is_pull or is_push must be specified"
-            )
-        elif data.get("is_pull") is data.get("is_push"):
-            raise serializers.ValidationError(
-                "Only one of is_pull or is_push needs to be specified"
+                "Only one of pull or push needs to be specified"
             )
 
         if (

--- a/kolibri/core/auth/test/test_auth_tasks.py
+++ b/kolibri/core/auth/test/test_auth_tasks.py
@@ -802,26 +802,24 @@ class CleanUpSyncsTaskValidatorTestCase(TestCase):
     def setUp(self):
         self.kwargs = dict(
             type=cleanupsync.__name__,
-            is_push=True,
-            is_pull=False,
+            push=True,
+            pull=False,
             sync_filter=uuid4().hex,
             client_instance_id=uuid4().hex,
         )
 
     def test_validator__no_push_no_pull(self):
-        self.kwargs.pop("is_push")
-        self.kwargs.pop("is_pull")
+        self.kwargs.pop("push")
+        self.kwargs.pop("pull")
         validator = CleanUpSyncsValidator(data=self.kwargs)
-        with self.assertRaisesRegex(
-            serializers.ValidationError, "Either is_pull or is_push"
-        ):
+        with self.assertRaisesRegex(serializers.ValidationError, "Either pull or push"):
             validator.is_valid(raise_exception=True)
 
     def test_validator__both_push_and_pull(self):
-        self.kwargs.update(is_pull=True)
+        self.kwargs.update(pull=True)
         validator = CleanUpSyncsValidator(data=self.kwargs)
         with self.assertRaisesRegex(
-            serializers.ValidationError, "Only one of is_pull or is_push"
+            serializers.ValidationError, "Only one of pull or push"
         ):
             validator.is_valid(raise_exception=True)
 
@@ -853,8 +851,8 @@ class CleanUpSyncsTaskValidatorTestCase(TestCase):
 class CleanUpSyncsTaskTestCase(TestCase):
     def setUp(self):
         self.kwargs = dict(
-            is_push=True,
-            is_pull=False,
+            push=True,
+            pull=False,
             sync_filter=uuid4().hex,
             client_instance_id=uuid4().hex,
         )
@@ -876,8 +874,8 @@ class CleanUpSyncsTaskTestCase(TestCase):
         mock_call_command.assert_called_with(
             "cleanupsyncs",
             expiration=1,
-            is_push=self.kwargs["is_push"],
-            is_pull=self.kwargs["is_pull"],
+            push=self.kwargs["push"],
+            pull=self.kwargs["pull"],
             sync_filter=self.kwargs["sync_filter"],
             client_instance_id=self.kwargs["client_instance_id"],
         )
@@ -903,7 +901,7 @@ class CleanUpSyncsTaskTestCase(TestCase):
             id=uuid4().hex,
             active=True,
             sync_session=sync_session,
-            push=self.kwargs["is_push"],
+            push=self.kwargs["push"],
             filter=self.kwargs["sync_filter"],
             last_activity_timestamp=last_activity_timestamp,
         )

--- a/kolibri/core/auth/test/test_hooks.py
+++ b/kolibri/core/auth/test/test_hooks.py
@@ -39,8 +39,8 @@ class CleanUpTaskOperationTestCase(TestCase):
         self.assertFalse(result)
         mock_task.enqueue.assert_called_once_with(
             kwargs=dict(
-                is_pull=self.context.is_pull,
-                is_push=self.context.is_push,
+                pull=self.context.is_pull,
+                push=self.context.is_push,
                 sync_filter=str(self.context.filter),
                 client_instance_id=self.context.sync_session.client_instance_id.hex,
             )
@@ -53,8 +53,8 @@ class CleanUpTaskOperationTestCase(TestCase):
         self.assertFalse(result)
         mock_task.enqueue.assert_called_once_with(
             kwargs=dict(
-                is_pull=self.context.is_pull,
-                is_push=self.context.is_push,
+                pull=self.context.is_pull,
+                push=self.context.is_push,
                 sync_filter=str(self.context.filter),
                 server_instance_id=self.context.sync_session.server_instance_id.hex,
             )


### PR DESCRIPTION
## Summary
* The [morango cleanupsyncs command](https://github.com/learningequality/morango/blob/release-v0.7.x/morango/management/commands/cleanupsyncs.py#L52) takes `push` and `pull` kwargs to specify push and pull cleanups, but our task wrapper is currently passing `is_push` and `is_pull`
* Rectifies this by correcting the kwargs after the validation has happened
* Updates the relevant test

## References
No extant issue - noticed while doing some testing on Django 3.2 upgrading, where Django now complains if you pass non-existent kwargs to a management command!

## Reviewer guidance
I ran the tests, with the tweak they passed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
