### PR TITLE
LOD Syncing: create canonical set of assignments when learner is assigned multiple ways

### DIFF
--- a/kolibri/core/auth/test/test_sync_utils.py
+++ b/kolibri/core/auth/test/test_sync_utils.py
@@ -2,7 +2,15 @@ from django.test import TestCase
 from mock import Mock
 from morango.sync.utils import SyncSignalGroup
 
+from .helpers import create_dummy_facility_data
+from .helpers import provision_device
 from kolibri.core.auth.management.utils import MorangoSyncCommand
+from kolibri.core.auth.models import AdHocGroup
+from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
+from kolibri.core.exams.models import Exam
+from kolibri.core.exams.models import ExamAssignment
+from kolibri.core.lessons.models import Lesson
+from kolibri.core.lessons.models import LessonAssignment
 
 
 class TestProgressTracking(TestCase):
@@ -67,3 +75,113 @@ class TestProgressTracking(TestCase):
 
         # Check that start_progress has now been called
         instance.start_progress.assert_called()
+
+
+class CanonicalizeAssignmentsTestCase(TestCase):
+    def setUp(self):
+        super(CanonicalizeAssignmentsTestCase, self).setUp()
+        provision_device()
+        self.test_data = create_dummy_facility_data()
+        self.ad_hoc_group = AdHocGroup.objects.create(
+            name="An ad hoc group",
+            parent=self.test_data["classrooms"][0],
+        )
+        self.ad_hoc_group.add_learner(self.test_data["learner_all_groups"])
+
+    def _create_lesson_assignment(self, lesson, collection):
+        return LessonAssignment.objects.create(
+            lesson=lesson,
+            collection=collection,
+            assigned_by=self.test_data["facility_admin"],
+        )
+
+    def _create_exam_assignment(self, exam, collection):
+        return ExamAssignment.objects.create(
+            exam=exam,
+            collection=collection,
+            assigned_by=self.test_data["facility_admin"],
+        )
+
+    def _assert_assignments(self, resource_name, all_assignments, expected):
+        self.assertEqual(len(all_assignments), 2)
+        assignments = learner_canonicalized_assignments(resource_name, all_assignments)
+        self.assertEqual(len(assignments), 1)
+        assignment = assignments[0]
+        self.assertEqual(assignment.id, expected.id)
+
+    def test_canonicalize_assignments__lesson(self):
+        lesson = Lesson.objects.create(
+            title="A lesson",
+            created_by=self.test_data["facility_admin"],
+            collection=self.test_data["classrooms"][0],
+            is_active=True,
+        )
+        expected = self._create_lesson_assignment(
+            lesson, self.test_data["classrooms"][0]
+        )
+        self._create_lesson_assignment(lesson, self.test_data["learnergroups"][0][0])
+
+        assignments = LessonAssignment.objects.filter(
+            collection__membership__user_id=self.test_data["learner_all_groups"].id,
+            lesson__is_active=True,
+        ).distinct()
+
+        self._assert_assignments("lesson", assignments, expected)
+
+    def test_canonicalize_assignments__lesson__no_classroom(self):
+        lesson = Lesson.objects.create(
+            title="A lesson",
+            created_by=self.test_data["facility_admin"],
+            collection=self.test_data["classrooms"][0],
+            is_active=True,
+        )
+
+        expected = self._create_lesson_assignment(
+            lesson, self.test_data["learnergroups"][0][0]
+        )
+        self._create_lesson_assignment(lesson, self.ad_hoc_group)
+
+        assignments = LessonAssignment.objects.filter(
+            collection__membership__user_id=self.test_data["learner_all_groups"].id,
+            lesson__is_active=True,
+        ).distinct()
+
+        self._assert_assignments("lesson", assignments, expected)
+
+    def test_canonicalize_assignments__exam(self):
+        exam = Exam.objects.create(
+            title="An exam",
+            question_count=10,
+            active=True,
+            creator=self.test_data["facility_admin"],
+            collection=self.test_data["classrooms"][0],
+        )
+        expected = self._create_exam_assignment(exam, self.test_data["classrooms"][0])
+        self._create_exam_assignment(exam, self.test_data["learnergroups"][0][0])
+
+        assignments = ExamAssignment.objects.filter(
+            collection__membership__user_id=self.test_data["learner_all_groups"].id,
+            exam__active=True,
+        ).distinct()
+
+        self._assert_assignments("exam", assignments, expected)
+
+    def test_canonicalize_assignments__exam__no_classroom(self):
+        exam = Exam.objects.create(
+            title="An exam",
+            question_count=10,
+            active=True,
+            creator=self.test_data["facility_admin"],
+            collection=self.test_data["classrooms"][0],
+        )
+        expected = self._create_exam_assignment(
+            exam, self.test_data["learnergroups"][0][0]
+        )
+        self._create_exam_assignment(exam, self.ad_hoc_group)
+
+        assignments = ExamAssignment.objects.filter(
+            collection__membership__user_id=self.test_data["learner_all_groups"].id,
+            exam__active=True,
+        ).distinct()
+
+        self._assert_assignments("exam", assignments, expected)

--- a/kolibri/core/exams/single_user_assignment_utils.py
+++ b/kolibri/core/exams/single_user_assignment_utils.py
@@ -1,6 +1,7 @@
 from .models import ExamAssignment
 from .models import IndividualSyncableExam
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
+from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
 
 
 def update_individual_syncable_exams_from_assignments(user_id):
@@ -8,9 +9,12 @@ def update_individual_syncable_exams_from_assignments(user_id):
     Updates the set of IndividualSyncableExam objects for the user.
     """
     syncableexams = IndividualSyncableExam.objects.filter(user_id=user_id)
-    assignments = ExamAssignment.objects.filter(
-        collection__membership__user_id=user_id, exam__active=True
-    ).distinct()
+    assignments = learner_canonicalized_assignments(
+        "exam",
+        ExamAssignment.objects.filter(
+            collection__membership__user_id=user_id, exam__active=True
+        ).distinct(),
+    )
 
     # get a list of all active assignments that don't have a syncable exam
     to_create = assignments.exclude(exam_id__in=syncableexams.values_list("exam_id"))

--- a/kolibri/core/lessons/single_user_assignment_utils.py
+++ b/kolibri/core/lessons/single_user_assignment_utils.py
@@ -1,6 +1,7 @@
 from .models import IndividualSyncableLesson
 from .models import LessonAssignment
 from kolibri.core.auth.utils.delete import DisablePostDeleteSignal
+from kolibri.core.auth.utils.sync import learner_canonicalized_assignments
 
 
 def update_individual_syncable_lessons_from_assignments(user_id):
@@ -8,9 +9,12 @@ def update_individual_syncable_lessons_from_assignments(user_id):
     Updates the set of IndividualSyncableLesson objects for the user.
     """
     syncablelessons = IndividualSyncableLesson.objects.filter(user_id=user_id)
-    assignments = LessonAssignment.objects.filter(
-        collection__membership__user_id=user_id, lesson__is_active=True
-    ).distinct()
+    assignments = learner_canonicalized_assignments(
+        "lesson",
+        LessonAssignment.objects.filter(
+            collection__membership__user_id=user_id, lesson__is_active=True
+        ).distinct(),
+    )
 
     # get a list of all active assignments that don't have a syncable lesson
     to_create = assignments.exclude(


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Creates helper function that generates accepts a queryset and returns another queryset that selects only the canonical assignments when a lesson or exam is assigned to the learner through multiple ways, i.e. classroom, group or individual
- Adds to existing morango integration tests to add coverage on this scenario
- Adds unit tests for the helper

Note:
I was unable to get the SQLite version to be performed in pure SQL due to issues with Django forcing the `CASE` expression used in the `ORDER BY` into the `SELECT` expression

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes undocumented issue referenced in https://github.com/learningequality/kolibri/pull/11845

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
- Does it make sense?
- Does the postgres version work?
- Running morango integration tests help, which I ran both for SQLite and Postgres


----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [X] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [X] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
