### PR TITLE
Quiz creation resource selection: Topic selection & "Select all" 

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
@@ -128,11 +128,17 @@ export default function useQuizResources({ topicId } = {}) {
   }
 
   /** @returns {Boolean} Whether the given node should be displayed with a checkbox
-   * @description Returns whether the given node is an exercise or not -- although, could be
-   * extended in the future to permit topic-level selection if desired
+   *  @description Returns true for exercises and for topics that have no topic children and no
+   *  more children to load
    */
   function hasCheckbox(node) {
-    return node.kind === ContentNodeKinds.EXERCISE;
+    return (
+      node.kind === ContentNodeKinds.EXERCISE ||
+      // Has children, no more to load, and no children are topics
+      (node.children &&
+        !node.children.more &&
+        !node.children.results.some(c => c.kind === ContentNodeKinds.TOPIC))
+    );
   }
 
   function setResources(r) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -70,6 +70,7 @@
         @clear="clearSearchTerm"
         @searchterm="handleSearchTermChange"
       />
+
       <ContentCardList
         :contentList="contentList"
         :showSelectAll="showSelectAll"
@@ -83,15 +84,8 @@
         :loadingMoreState="loadingMore"
         @changeselectall="handleSelectAll"
         @change_content_card="toggleSelected"
-        @moreresults="fetchMoreQuizResources"
-      >
-        <template #notice="{ content }">
-          <div v-if="showTopicSizeWarningCard(content)" style="position: absolute; bottom: 1em;">
-            <KIcon icon="warning" :color="$themePalette.orange.v_400" />
-            <span>&nbsp;&nbsp;{{ cannotSelectTopicCard$() }}</span>
-          </div>
-        </template>
-      </ContentCardList>
+        @moreresults="fetchMoreResources"
+      />
 
       <div class="bottom-navigation">
         <KGrid>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -53,7 +53,7 @@
       <div
         v-if="showTopicSizeWarning()"
         class="shadow"
-        :style=" { padding: '1em', backgroundColor: $themePalette.grey.v_100 }"
+        :style=" { padding: '1em', marginBottom: '1em', backgroundColor: $themePalette.grey.v_100 }"
       >
         {{ cannotSelectSomeTopicWarning$() }}
       </div>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -50,6 +50,14 @@
         </div>
       </div>
 
+      <div
+        v-if="showTopicSizeWarning()"
+        class="shadow"
+        :style=" { padding: '1em', backgroundColor: $themePalette.grey.v_100 }"
+      >
+        {{ cannotSelectSomeTopicWarning$() }}
+      </div>
+
       <ResourceSelectionBreadcrumbs
         v-if="isTopicIdSet"
         :ancestors="topic.ancestors"
@@ -75,8 +83,15 @@
         :loadingMoreState="loadingMore"
         @changeselectall="handleSelectAll"
         @change_content_card="toggleSelected"
-        @moreresults="fetchMoreResources"
-      />
+        @moreresults="fetchMoreQuizResources"
+      >
+        <template #notice="{ content }">
+          <div v-if="showTopicSizeWarningCard(content)" style="position: absolute; bottom: 1em;">
+            <KIcon icon="warning" :color="$themePalette.orange.v_400" />
+            <span>&nbsp;&nbsp;{{ cannotSelectTopicCard$() }}</span>
+          </div>
+        </template>
+      </ContentCardList>
 
       <div class="bottom-navigation">
         <KGrid>
@@ -154,6 +169,8 @@
         numberOfSelectedResources$,
         numberOfResources$,
         selectedResourcesInformation$,
+        cannotSelectTopicCard$,
+        cannotSelectSomeTopicWarning$,
       } = enhancedQuizManagementStrings;
 
       // TODO let's not use text for this
@@ -440,6 +457,8 @@
         resetWorkingResourcePool,
         contentPresentInWorkingResourcePool,
         //contentList,
+        cannotSelectTopicCard$,
+        cannotSelectSomeTopicWarning$,
         sectionSettings$,
         selectFromBookmarks$,
         numberOfSelectedBookmarks$,
@@ -496,6 +515,12 @@
       },
     },
     methods: {
+      showTopicSizeWarningCard(content) {
+        return !this.hasCheckbox(content) && content.kind === ContentNodeKinds.TOPIC;
+      },
+      showTopicSizeWarning() {
+        return this.contentList.some(this.showTopicSizeWarningCard);
+      },
       /** @public */
       focusFirstEl() {
         this.$refs.textbox.focus();
@@ -662,6 +687,11 @@
 
   .align-select-folder-style {
     margin-top: 2em;
+  }
+
+  .shadow {
+    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),
+      0 2px 1px -1px rgba(0, 0, 0, 0.12);
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -163,7 +163,6 @@
         numberOfSelectedResources$,
         numberOfResources$,
         selectedResourcesInformation$,
-        cannotSelectTopicCard$,
         cannotSelectSomeTopicWarning$,
       } = enhancedQuizManagementStrings;
 
@@ -451,7 +450,6 @@
         resetWorkingResourcePool,
         contentPresentInWorkingResourcePool,
         //contentList,
-        cannotSelectTopicCard$,
         cannotSelectSomeTopicWarning$,
         sectionSettings$,
         selectFromBookmarks$,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -283,7 +283,7 @@
 
       function handleSelectAll(isChecked) {
         if (isChecked) {
-          this.addToWorkingResourcePool(this.contentList);
+          this.addToWorkingResourcePool(selectableContentList());
         } else {
           this.contentList.forEach(content => {
             var contentToRemove = [];

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
@@ -33,7 +33,11 @@
           :link="contentCardLink(content)"
           :numCoachContents="content.num_coach_contents"
           :isLeaf="content.is_leaf"
-        />
+        >
+          <template #notice>
+            <slot name="notice" :content="content"></slot>
+          </template>
+        </LessonContentCard>
       </li>
     </ul>
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/LessonContentCard/index.vue
@@ -52,6 +52,7 @@
           :isTopic="isTopic"
         />
       </div>
+      <slot name="notice"></slot>
     </div>
 
   </router-link>

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -154,11 +154,8 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:
       '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
   },
-  cannotSelectTopicCard: {
-    message: 'Folder exceeds 12 exercises',
-  },
   cannotSelectSomeTopicWarning: {
     message:
-      'Select only folders with 12 or fewer exercises and no subfolders to avoid oversized quizzes. Proceed to choose a smaller folder.',
+      'You can only select folders with 12 or less exercises and no subfolders to avoid oversized quizzes.',
   },
 });

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -154,4 +154,11 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:
       '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
   },
+  cannotSelectTopicCard: {
+    message: 'Folder exceeds 12 exercises',
+  },
+  cannotSelectSomeTopicWarning: {
+    message:
+      'Select only folders with 12 or fewer exercises and no subfolders to avoid oversized quizzes. Proceed to choose a smaller folder.',
+  },
 });


### PR DESCRIPTION
## Summary

- Implements topic selection logic (can select topic when all children are fetched and are exercises)
- [De]select all accounts for possibility of topics, using new `hasCheckbox` logic
- Only shows "Select all" when every child `hasCheckbox` based on the new logic
- Generally begins moving logic into relevant blocks within setup()
- Show warning icon & message on topic cards which cannot be selected
- Show message above cards list when any topic is listed that cannot be selected  

![image](https://github.com/learningequality/kolibri/assets/6356129/301496b3-ffd1-45b4-beaf-58718c92fe0c)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #11790 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

#### Messaging

- Go to create a quiz and use a channel like the QA channel to get a mix of folders which meet the messaging criteria
- Navigate and see that when you cannot select a folder, it has the warning on the card
- Note that if any topic has the warning, then the message appears at the top as shown in the screenshot above
- No non-folder should ever have the warning message
- The message at the top should not be visible if there are no folders which have the warning

#### Select all logic

- When a folder has a checkbox and you click it, you should see all of it's child exercises have been selected

