### PR TITLE
Standardize ContentCardList Component and Introduce ViewMoreButtonStates

### DIFF
--- a/kolibri/plugins/coach/assets/src/constants/index.js
+++ b/kolibri/plugins/coach/assets/src/constants/index.js
@@ -53,6 +53,13 @@ export const GroupModals = {
   DELETE_GROUP: 'DELETE_GROUP',
 };
 
+export const ViewMoreButtonStates = {
+  LOADING: 'LOADING',
+  HAS_MORE: 'HAS_MORE',
+  NO_MORE: 'NO_MORE',
+  ERROR: 'ERROR',
+};
+
 export const pageNameToModuleMap = {
   [PageNames.EXAMS]: 'examsRoot',
   [PageNames.EXAM_REPORT]: 'examReport',

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreatePracticeQuizPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreatePracticeQuizPage.vue
@@ -43,7 +43,7 @@
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import ResourceSelectionBreadcrumbs from '../../plan/LessonResourceSelectionPage/SearchTools/ResourceSelectionBreadcrumbs';
-  import { PageNames } from '../../../constants';
+  import { PageNames, ViewMoreButtonStates } from '../../../constants/index';
   import ContentCardList from '../../plan/LessonResourceSelectionPage/ContentCardList';
   import commonCoach from '../../common';
   import CoachImmersivePage from '../../CoachImmersivePage';
@@ -58,7 +58,7 @@
     mixins: [commonCoreStrings, commonCoach],
     data() {
       return {
-        viewMoreButtonState: 'no_more_results',
+        viewMoreButtonState: ViewMoreButtonStates.NO_MORE,
         contentHasCheckbox: () => false,
         contentIsSelected: () => '',
       };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -41,7 +41,6 @@
         :channelsLink="channelsLink"
         :topicsLink="topicsLink"
       />
-
       <ContentCardList
         :contentList="contentList"
         :showSelectAll="true"
@@ -97,7 +96,7 @@
   import { ContentNodeResource, ChannelResource } from 'kolibri.resources';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import useKResponsiveWindow from 'kolibri-design-system/lib/useKResponsiveWindow';
-  import { PageNames } from '../../../constants';
+  import { PageNames, ViewMoreButtonStates } from '../../../constants/index';
   import BookmarkIcon from '../LessonResourceSelectionPage/LessonContentCard/BookmarkIcon.vue';
   import useQuizResources from '../../../composables/useQuizResources';
   import { injectQuizCreation } from '../../../composables/useQuizCreation';
@@ -135,9 +134,9 @@
       // TODO let's not use text for this
       const viewMoreButtonState = computed(() => {
         if (hasMore.value) {
-          return 'yes';
+          return ViewMoreButtonStates.HAS_MORE;
         } else {
-          return 'no_more_results';
+          return ViewMoreButtonStates.NO_MORE;
         }
       });
 

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
@@ -45,11 +45,11 @@
         @click="$emit('moreresults')"
       />
       <KCircularLoader
-        v-if="viewMoreButtonState === 'waiting'"
+        v-if="viewMoreButtonState === ViewMoreButtonStates.LOADING"
         :delay="false"
       />
       <!-- TODO introduce messages in next version -->
-      <p v-else-if="viewMoreButtonState === 'error'">
+      <p v-else-if="viewMoreButtonState === ViewMoreButtonStates.ERROR">
         <KIcon icon="error" />
         <!-- {{ $tr('moreResultsError') }} -->
       </p>
@@ -65,6 +65,8 @@
 <script>
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { ViewMoreButtonStates } from '../../../constants/index';
+
   import LessonContentCard from './LessonContentCard';
 
   export default {
@@ -73,6 +75,12 @@
       LessonContentCard,
     },
     mixins: [commonCoreStrings],
+
+    setup() {
+      return {
+        ViewMoreButtonStates,
+      };
+    },
     props: {
       showSelectAll: {
         type: Boolean,
@@ -121,11 +129,10 @@
         required: true,
       },
     },
+
     computed: {
       showButton() {
-        return (
-          this.viewMoreButtonState !== 'waiting' && this.viewMoreButtonState !== 'no_more_results'
-        );
+        return this.viewMoreButtonState === this.ViewMoreButtonStates.HAS_MORE;
       },
       needCheckboxes() {
         return this.contentList.some(c => this.contentHasCheckbox(c));

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -122,6 +122,7 @@
   import CoachAppBarPage from '../../CoachAppBarPage';
   import CoachImmersivePage from '../../CoachImmersivePage';
   import { LessonsPageNames } from '../../../constants/lessonsConstants';
+  import { ViewMoreButtonStates } from '../../../constants/index';
   import LessonsSearchBox from './SearchTools/LessonsSearchBox';
   import LessonsSearchFilters from './SearchTools/LessonsSearchFilters';
   import ResourceSelectionBreadcrumbs from './SearchTools/ResourceSelectionBreadcrumbs';
@@ -252,13 +253,16 @@
         );
       },
       viewMoreButtonState() {
-        if (this.moreResultsState === 'waiting' || this.moreResultsState === 'error') {
+        if (
+          this.moreResultsState === ViewMoreButtonStates.LOADING ||
+          this.moreResultsState === ViewMoreButtonStates.ERROR
+        ) {
           return this.moreResultsState;
         }
         if (!this.inSearchMode || this.numRemainingSearchResults === 0) {
-          return 'no_more_results';
+          return ViewMoreButtonStates.NO_MORE;
         }
-        return 'visible';
+        return ViewMoreButtonStates.HAS_MORE;
       },
       contentIsInLesson() {
         return ({ id }) =>
@@ -519,7 +523,7 @@
         });
       },
       handleMoreResults() {
-        this.moreResultsState = 'waiting';
+        this.moreResultsState = ViewMoreButtonStates.LOADING;
         this.fetchAdditionalSearchResults({
           searchTerm: this.searchTerm,
           kind: this.filters.kind,
@@ -530,7 +534,7 @@
             this.moreResultsState = null;
           })
           .catch(() => {
-            this.moreResultsState = 'error';
+            this.moreResultsState = ViewMoreButtonStates.ERROR;
           });
       },
       topicsLink(topicId) {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->
Fixes #11771 
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
In the process of content creation, we drew inspiration from previous Lesson resource selection components, specifically the ContentCardList component. However, considering the component's last update was three years ago, there are noticeable inconsistencies that we aim to address for a more unified developer interface.

The `viewMoreButtonState` prop in the ContentCardList component currently relies on a string input. To enhance consistency and maintainability, we propose the transition to a constant-based approach.

**Acceptance Criteria:**
**View More Button State**
- Created and exported a new object named `ViewMoreButtonStates` in the `coach/.../constants/index.js` file, structured similarly to existing constants.
- The new object manages the following states:
  - Loading (previously denoted as waiting)
  - Has more (previously determined by not passing specific strings for loading or not having more)
  - No more
  - Error
- ContentCardList has been updated to validate the `viewMoreButtonStates` prop against these constants, ensuring only valid constants are accepted.
- ContentCardList no longer relies on the absence of errors to display the button; instead, it checks for the `ViewMoreButtonStates.hasMore` state.
- Components using the ContentCardList have been updated to incorporate the new constants when passing the prop. Specifically, adjustments have been made in LessonResourceSelectionPage/index.vue, CreateExamPage/index.vue, and CreateExamPage/CreatePracticeQuiz.vue.

These changes aim to standardize the ContentCardList component and introduce a clear set of constants for the viewMoreButtonState prop. This not only improves code consistency but also facilitates easier maintenance and future development.

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
