### PR TITLE
Ensure that Kolibri can start regardless of whether redis and redis cache is installed.

### DIFF
--- a/kolibri/core/utils/cache.py
+++ b/kolibri/core/utils/cache.py
@@ -78,5 +78,5 @@ try:
             super(RedisCache, self).set(*args, **kwargs)
 
 
-except ImportError:
+except (ImportError, InvalidCacheBackendError):
     pass

--- a/kolibri/utils/options.py
+++ b/kolibri/utils/options.py
@@ -19,6 +19,7 @@ from django.utils.six import string_types
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.parse import urlunparse
 from validate import is_boolean
+from validate import is_option
 from validate import Validator
 from validate import VdtTypeError
 from validate import VdtValueError
@@ -271,6 +272,28 @@ def multiprocess_bool(value):
         return False
 
 
+def cache_option(value):
+    """
+    Validate the cache options.
+    Do this by checking it's an allowed option, and also that redis cache
+    can be imported properly on this platform.
+    """
+    value = is_option(value, "memory", "redis")
+    try:
+        if value == "redis":
+            # Check that we can properly import our RedisCache
+            # implementation, to ensure that we can use it.
+            # Also ensure that the redis package is installed.
+            from kolibri.core.utils.cache import RedisCache  # noqa
+            import redis  # noqa
+        return value
+    except ImportError:
+        logger.error(
+            "Redis cache backend is not available, are Redis packages installed?"
+        )
+        raise VdtValueError(value)
+
+
 class LazyImportFunction(object):
     """
     A function wrapper that will import a module when called.
@@ -339,8 +362,7 @@ def lazy_import_callback_list(value):
 base_option_spec = {
     "Cache": {
         "CACHE_BACKEND": {
-            "type": "option",
-            "options": ("memory", "redis"),
+            "type": "cache_option",
             "default": "memory",
             "description": """
                 Which backend to use for the main cache - if 'memory' is selected, then for most cache operations,
@@ -716,6 +738,7 @@ def _get_validator():
             "url_prefix": url_prefix,
             "bytes": validate_bytes,
             "multiprocess_bool": multiprocess_bool,
+            "cache_option": cache_option,
             "lazy_import_callback_list": lazy_import_callback_list,
         }
     )


### PR DESCRIPTION
## Summary
* Fixes issue reported here: https://github.com/learningequality/kolibri/pull/11853#issuecomment-1941520530
* This was caused by the Android App not being able to import Redis packages
* Makes the redis packages optional and handle when they cannot be imported

## Reviewer guidance
Easiest way to test this is from source, install all requirements, then do:
`pip uninstall redis`
Ensure that Kolibri still starts.
`pip install redis`
`pip uninstall django-redis-cache`
Ensure that Kolibri still starts.

Finally reinstall both packages, and set the following settings in options.ini:
```
[Cache]
CACHE_BACKEND = redis
CACHE_REDIS_MAXMEMORY_POLICY = allkeys-lru
CACHE_REDIS_MAXMEMORY = 1660575744
```

Make sure you have Redis setup locally, and ensure that Kolibri still starts properly.

Finally, install the APK and ensure that it now starts properly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
