### PR TITLE
Fix version parsing for release candidates.

### DIFF
--- a/kolibri/utils/tests/test_version.py
+++ b/kolibri/utils/tests/test_version.py
@@ -108,6 +108,18 @@ class TestKolibriVersion(unittest.TestCase):
         v = get_version((0, 7, 1))
         self.assertIn("0.7.1b1.dev0+git.2.gfd48a7a", v)
 
+    @mock.patch(
+        "kolibri.utils.version.get_version_file",
+        return_value="0.7.1rc1.dev0+git.2.gfd48a7a",
+    )
+    @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)
+    def test_version_file_local_git_version_rc(self, describe_mock, file_mock):
+        """
+        Test that a version file with git describe output is correctly parsed
+        """
+        v = get_version((0, 7, 1))
+        self.assertIn("0.7.1rc1.dev0+git.2.gfd48a7a", v)
+
     @mock.patch("kolibri.utils.version.get_version_file", return_value="0.1.0a1\n")
     @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)
     @mock.patch("kolibri.utils.version.get_git_changeset", return_value=None)
@@ -173,6 +185,16 @@ class TestKolibriVersion(unittest.TestCase):
         Test that the VERSION file is used when git data is available
         """
         assert get_version((0, 1, 0)) == "0.1.0b1"
+
+    @mock.patch("kolibri.utils.version.get_version_file", return_value="0.1.0rc1")
+    @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)
+    @mock.patch("kolibri.utils.version.get_git_changeset", return_value=None)
+    def test_version_file_rc(self, get_git_changeset_mock, describe_mock, file_mock):
+        """
+        Test that a VERSION specifying a final version will work when the
+        kolibri.VERSION tuple is consistent.
+        """
+        assert get_version((0, 1, 0)) == "0.1.0rc1"
 
     @mock.patch("kolibri.utils.version.get_version_file", return_value="0.1.0")
     @mock.patch("kolibri.utils.version.get_git_describe", return_value=None)

--- a/kolibri/utils/version.py
+++ b/kolibri/utils/version.py
@@ -406,7 +406,7 @@ def normalize_version_to_semver(version):
     after = (after or "").strip("-").strip("+").strip(".").split("+")[0]
 
     # split up the alpha/beta letters from the numbers, to sort numerically not alphabetically
-    after_pieces = re.match(r"([a-z])(\d+)", after)
+    after_pieces = re.match(r"([a-z]{1,2})(\d+)", after)
     if after_pieces:
         after = ".".join([piece for piece in after_pieces.group() if piece])
 


### PR DESCRIPTION
## Summary
Fixes a version parsing bug for post-release candidate dev versions.

## References
Fixes bug seen in https://github.com/learningequality/kolibri/pull/11871

## Reviewer guidance
Write the version to your development environment like this:
`python -c "import kolibri; print(kolibri.__version__)" > kolibri/VERSION`
then start kolibri and ensure it doesn't break.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
