### PR TITLE
Truncate long lesson title

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
+++ b/kolibri/plugins/coach/assets/src/views/home/HomePage/ItemProgressDisplay.vue
@@ -9,7 +9,9 @@
     <KFixedGrid numCols="4" class="wrapper">
       <KFixedGridItem span="3">
         <h3 class="title">
-          {{ name }}
+          <TextTruncatorCss
+            :text="name"
+          />
         </h3>
       </KFixedGridItem>
       <KFixedGridItem span="1" alignment="right">
@@ -35,6 +37,7 @@
 <script>
 
   import { validateLinkObject } from 'kolibri.utils.validators';
+  import TextTruncatorCss from 'kolibri.coreVue.components.TextTruncatorCss';
   import commonCoach from '../../common';
   import ProgressSummaryBar from '../../common/status/ProgressSummaryBar';
 
@@ -42,6 +45,7 @@
     name: 'ItemProgressDisplay',
     components: {
       ProgressSummaryBar,
+      TextTruncatorCss,
     },
     mixins: [commonCoach],
     props: {


### PR DESCRIPTION
## Summary
I have added the TextTruncateCss component from the design library to truncate the lesson title that were overlapping with other text.
![image](https://github.com/learningequality/kolibri/assets/77184239/ec258fb9-a15b-485d-bbae-3ac27242adab)

…

## References
Issue: #7579 
…

## Reviewer guidance
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
