### PR TITLE
Fix dev docs typo

### DIFF
--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -102,7 +102,7 @@ Common strings modules should typically have a translator created using the ``cr
   export default {
     name: 'someComponent',
     setup() {
-      const { myCoolString$, stringWithArgument$ } = commonStringsModule();
+      const { myCoolString$, stringWithArgument$ } = commonStringsModule;
       return {
         myCoolString$, stringWithArgument$
       };


### PR DESCRIPTION
## Summary

Fixes a tiny typo in the documentation for new strings syntax (discovered [here](https://github.com/learningequality/kolibri/pull/11606#issuecomment-1946024115)).

![Screenshot from 2024-02-15 13-46-15](https://github.com/learningequality/kolibri/assets/13509191/610847c9-c3ef-4417-b865-0e2f49578f55)

I think the intention was rather:

```js
const { myCoolString$, stringWithArgument$ } = commonStringsModule;
```
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] ~If there are any front-end changes, before/after screenshots are included~
- [ ] ~Critical user journeys are covered by Gherkin stories~
- [ ] ~Critical and brittle code paths are covered by unit tests~


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] ~If this is an important user-facing change, PR or related issue has a 'changelog' label~
- [ ] ~If this includes an internal dependency change, a link to the diff is provided~

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
