### PR TITLE
Add regression testing for channel update deletion behaviour

### DIFF
--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -960,3 +960,78 @@ class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
     @classmethod
     def setUpClass(cls):
         super(NoVersionv040ImportTestCase, cls).setUpClass()
+
+
+class ChannelImportTestCase(TestCase):
+    def setUp(self):
+        self.channel_id = "6199dde695db4ee4ab392222d5af1e5c"
+        self.channel_version = 2
+        self.current_channel = None
+
+    @patch("kolibri.core.content.utils.channel_import.logger")
+    @patch("kolibri.core.content.utils.channel_import.select")
+    def test_channel_already_exists(self, select_mock, logger_mock):
+        self.current_channel = ChannelMetadata.objects.create(
+            id=self.channel_id,
+            name="existing_channel",
+            min_schema_version="1",
+            root_id=self.channel_id,
+        )
+        self.current_channel.version = self.channel_version
+        self.channel_import = ChannelImport(self.channel_id, self.channel_version)
+        result = self.channel_import.check_and_delete_existing_channel()
+        self.assertFalse(result)
+
+    @patch("kolibri.core.content.utils.channel_import.logger")
+    @patch("kolibri.core.content.utils.channel_import.select")
+    def test_partial_import_no_deletion(self, select_mock, logger_mock):
+        self.current_channel = ChannelMetadata.objects.create(
+            id=self.channel_id,
+            name="test",
+            min_schema_version="1",
+            root_id=self.channel_id,
+        )
+        self.channel_import = ChannelImport(self.channel_id, self.channel_version)
+        self.channel_import.partial = True
+
+        result = self.channel_import.check_and_delete_existing_channel()
+        self.assertTrue(result)
+
+    @patch("kolibri.core.content.utils.channel_import.logger")
+    @patch("kolibri.core.content.utils.channel_import.select")
+    def test_partial_import_with_deletion(self, select_mock, logger_mock):
+        # Simulate partial import with the same version
+        self.current_channel = ChannelMetadata.objects.create(
+            id=self.channel_id,
+            name="existing_channel",
+            min_schema_version="1",
+            root_id=self.channel_id,
+        )
+        self.current_channel.version = self.channel_version - 1
+        self.channel_import = ChannelImport(self.channel_id, self.channel_version)
+        self.channel_import.partial = True
+        result = self.channel_import.check_and_delete_existing_channel()
+        self.assertFalse(result)
+
+    @patch("kolibri.core.content.utils.channel_import.logger")
+    @patch("kolibri.core.content.utils.channel_import.select")
+    def test_full_import_with_newer_version(self, select_mock, logger_mock):
+        # Simulate full import with a newer version
+        self.current_channel = ChannelMetadata.objects.create(
+            id=self.channel_id,
+            name="existing_channel",
+            min_schema_version="1",
+            root_id=self.channel_id,
+        )
+        self.current_channel.version = self.channel_version + 1
+        self.channel_import = ChannelImport(self.channel_id, self.channel_version)
+        result = self.channel_import.check_and_delete_existing_channel()
+        self.assertFalse(result)
+
+    @patch("kolibri.core.content.utils.channel_import.logger")
+    @patch("kolibri.core.content.utils.channel_import.select")
+    def test_channel_not_exists(self, select_mock, logger_mock):
+        # Simulate channel not existing in the database
+        self.channel_import = ChannelImport(self.channel_id, self.channel_version)
+        result = self.channel_import.check_and_delete_existing_channel()
+        self.assertTrue(result)

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -965,36 +965,37 @@ class NoVersionv040ImportTestCase(NoVersionv020ImportTestCase):
 @patch("kolibri.core.content.utils.channel_import.Bridge")
 @patch("kolibri.core.content.utils.channel_import.logger")
 @patch("kolibri.core.content.utils.channel_import.select")
-class ChannelImportTestCase(TestCase):
+@patch("kolibri.core.content.utils.channel_import.apps")
+class ChannelImportTestCase(ContentImportTestBase, TransactionTestCase):
+    name = CONTENT_SCHEMA_VERSION
+    legacy_schema = None
+
     def setUp(self):
+        super(ChannelImportTestCase, self).setUp()
         self.channel_id = "6199dde695db4ee4ab392222d5af1e5c"
         self.channel_version = 2
         self.current_channel = None
 
-    def test_channel_already_exists(self, select_mock, logger_mock, BridgeMock):
-        self.current_channel = ChannelMetadata.objects.create(
-            id=self.channel_id,
-            name="existing_channel",
-            min_schema_version="1",
-            root_id=self.channel_id,
-        )
+    def tearDown(self):
+        return super().tearDown()
+
+    def test_channel_already_exists(
+        self, select_mock, logger_mock, apps_mock, BridgeMock
+    ):
+        self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
         self.current_channel.version = self.channel_version
-        ChannelMetadata.save(self.current_channel)
+        self.current_channel.save()
         self.channel_import = ChannelImport(self.channel_id, "")
         self.channel_import.channel_version = self.channel_version
         result = self.channel_import.check_and_delete_existing_channel()
         self.assertFalse(result)
 
-    def test_partial_import_no_deletion(self, select_mock, logger_mock, BridgeMock):
-        self.current_channel = ChannelMetadata.objects.create(
-            id=self.channel_id,
-            name="test",
-            min_schema_version="1",
-            root_id=self.channel_id,
-        )
+    def test_partial_import_no_deletion(
+        self, select_mock, logger_mock, apps_mock, BridgeMock
+    ):
+        self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
         self.current_channel.version = self.channel_version
-        ChannelMetadata.save(self.current_channel)
-        print("from", self.current_channel.version)
+        self.current_channel.save()
         self.channel_import = ChannelImport(self.channel_id, "")
         self.channel_import.channel_version = self.channel_version
         self.channel_import.partial = True
@@ -1002,38 +1003,32 @@ class ChannelImportTestCase(TestCase):
         result = self.channel_import.check_and_delete_existing_channel()
         self.assertTrue(result)
 
-    def test_partial_import_with_deletion(self, select_mock, logger_mock, BridgeMock):
+    def test_partial_import_with_deletion(
+        self, select_mock, logger_mock, apps_mock, BridgeMock
+    ):
         # Simulate partial import with the same version
-        self.current_channel = ChannelMetadata.objects.create(
-            id=self.channel_id,
-            name="existing_channel",
-            min_schema_version="1",
-            root_id=self.channel_id,
-        )
+        self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
         self.current_channel.version = self.channel_version
-        ChannelMetadata.save(self.current_channel)
+        self.current_channel.save()
         self.channel_import = ChannelImport(self.channel_id, "")
         self.channel_import.channel_version = self.channel_version - 1
         self.channel_import.partial = True
         result = self.channel_import.check_and_delete_existing_channel()
         self.assertFalse(result)
 
-    def test_full_import_with_newer_version(self, select_mock, logger_mock, BridgeMock):
+    def test_full_import_with_newer_version(
+        self, select_mock, logger_mock, apps_mock, BridgeMock
+    ):
         # Simulate full import with a newer version
-        self.current_channel = ChannelMetadata.objects.create(
-            id=self.channel_id,
-            name="existing_channel",
-            min_schema_version="1",
-            root_id=self.channel_id,
-        )
+        self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
         self.current_channel.version = self.channel_version
-        ChannelMetadata.save(self.current_channel)
+        self.current_channel.save()
         self.channel_import = ChannelImport(self.channel_id, "")
         self.channel_import.channel_version = self.channel_version + 1
         result = self.channel_import.check_and_delete_existing_channel()
-        self.assertFalse(result)
+        self.assertTrue(result)
 
-    def test_channel_not_exists(self, select_mock, logger_mock, BridgeMock):
+    def test_channel_not_exists(self, select_mock, logger_mock, apps_mock, BridgeMock):
         # Simulate channel not existing in the database
         self.channel_import = ChannelImport(self.channel_id, "")
         self.channel_import.channel_version = self.channel_version

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -741,7 +741,7 @@ class ChannelImport(object):
                     )
                     return False
                 return True
-            elif current_version and (
+            elif current_version is not None and (
                 current_version < self.channel_version or current_partial
             ):
                 # We have an older version of this channel, so let's clean out the old stuff first

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -241,9 +241,7 @@ class ChannelImport(object):
         self.channel_version = channel_version
         try:
             self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
-            print(self.current_channel)
         except ChannelMetadata.DoesNotExist:
-            print("Not Possible")
             self.current_channel = None
 
         self.cancel_check = cancel_check
@@ -724,6 +722,7 @@ class ChannelImport(object):
         return result
 
     def check_and_delete_existing_channel(self):
+
         if self.current_channel:
             current_version = self.current_channel.version
             current_partial = self.current_channel.partial
@@ -782,6 +781,7 @@ class ChannelImport(object):
                     )
                 )
                 return False
+
         return True
 
     def _can_use_optimized_pre_deletion(self, model):

--- a/kolibri/core/content/utils/channel_import.py
+++ b/kolibri/core/content/utils/channel_import.py
@@ -241,7 +241,9 @@ class ChannelImport(object):
         self.channel_version = channel_version
         try:
             self.current_channel = ChannelMetadata.objects.get(id=self.channel_id)
+            print(self.current_channel)
         except ChannelMetadata.DoesNotExist:
+            print("Not Possible")
             self.current_channel = None
 
         self.cancel_check = cancel_check
@@ -722,7 +724,6 @@ class ChannelImport(object):
         return result
 
     def check_and_delete_existing_channel(self):
-
         if self.current_channel:
             current_version = self.current_channel.version
             current_partial = self.current_channel.partial
@@ -741,7 +742,9 @@ class ChannelImport(object):
                     )
                     return False
                 return True
-            elif current_version < self.channel_version or current_partial:
+            elif current_version and (
+                current_version < self.channel_version or current_partial
+            ):
                 # We have an older version of this channel, so let's clean out the old stuff first
                 # Or we only have a partial import of this channel.
                 logger.info(
@@ -779,7 +782,6 @@ class ChannelImport(object):
                     )
                 )
                 return False
-
         return True
 
     def _can_use_optimized_pre_deletion(self, model):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Add test cases as mentioned in https://github.com/learningequality/kolibri/issues/5960#issuecomment-1937101674
Also handle the case when `current_version` or `current_partial` is None, preventing the TypeError from occurring.
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #5960 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I am not sure about my `test_full_import_with_newer_version` which apparently is failing
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
