### PR TITLE
Set markdown to None in module cache to prevent it being imported by DRF.

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -103,6 +103,17 @@ def check_python_versions():
         warn(warning_text, DeprecationWarning)
 
 
+def monkey_patch_markdown():
+    """
+    Monkey patch markdown module into module cache to set to None.
+    This is to avoid a bug caused by newer versions of markdown that causes
+    a crash during the attempted optional import of markdown in DRF.
+    """
+    # TODO: rtibbles remove this once we upgrade to a newer version of Django REST Framework
+    # that doesn't have this issue.
+    sys.modules["markdown"] = None
+
+
 def set_env():
     """
     Sets the Kolibri environment for the CLI or other application worker
@@ -113,6 +124,8 @@ def set_env():
     else.
     """
     check_python_versions()
+
+    monkey_patch_markdown()
 
     from kolibri import dist as kolibri_dist  # noqa
 


### PR DESCRIPTION
## Summary
Django REST Framework automatically attempts to import the markdown module if available.
The version we use checks the `version` attribute, however the latest versions of the markdown module use __version__ instead of version, and an error happens at runtime.
Fix this by setting markdown to None in module cache.
This means that when DRF tries to import markdown, it will raise an ImportError and DRF will carry on, rather than trying to check the version.

## References
Fixes #11895

## Reviewer guidance
This is best tested in a fresh virtual environment using Python 3.11.
First download the whl file from this PR and install it into the virtual environment `pip install <path to whl file`.
Then install markdown: `pip install markdown`
Confirm that running Kolibri does not immediately give an error (as it does in the issue referenced).

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
