### PR TITLE
Improved route handlers architecture in Coach - planRoutes

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -10,6 +10,9 @@ import routes from './routes';
 import pluginModule from './modules/pluginModule';
 import { LessonsPageNames } from './constants/lessonsConstants';
 import LessonEditDetailsPage from './views/plan/LessonEditDetailsPage';
+import GroupsPage from './views/plan/GroupsPage';
+import GroupMembersPage from './views/plan/GroupMembersPage';
+import GroupEnrollPage from './views/plan/GroupEnrollPage';
 
 class CoachToolsModule extends KolibriApp {
   get stateSetters() {
@@ -74,6 +77,9 @@ class CoachToolsModule extends KolibriApp {
           LessonsPageNames.LESSON_SELECTION_BOOKMARKS_MAIN,
           LessonsPageNames.SELECTION_CONTENT_PREVIEW,
           LessonsPageNames.RESOURCE_CONTENT_PREVIEW,
+          GroupsPage.name,
+          GroupMembersPage.name,
+          GroupEnrollPage.name,
         ].includes(to.name)
       ) {
         next();

--- a/kolibri/plugins/coach/assets/src/composables/useGroups.js
+++ b/kolibri/plugins/coach/assets/src/composables/useGroups.js
@@ -10,9 +10,14 @@ export function useGroups() {
     groupsAreLoading.value = loading;
   }
 
-  function showGroupsPage(store, classId) {
-    // On this page, handle loading state locally
-    // TODO: Open follow-up so that we don't need to do this
+  async function showGroupsPage(store, classId) {
+    const initClassInfoPromise = store.dispatch('initClassInfo', classId);
+    const getFacilitiesPromise =
+      store.getters.isSuperuser && store.state.core.facilities.length === 0
+        ? store.dispatch('getFacilities').catch(() => {})
+        : Promise.resolve();
+
+    await Promise.all([initClassInfoPromise, getFacilitiesPromise]);
     store.dispatch('notLoading');
 
     setGroupsLoading(true);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This is the continuation of the refactoring process for the coach page, transitioning from a global route handler to local route handlers for planRoutes. https://github.com/learningequality/kolibri/issues/11219

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->


### List of all `planRoutes`:
| Route name | Handler/component to refactor | Refactor done? | How to test the page |
| ------- | ---------------- | ------------------------------ | ------ |
| PageNames.PLAN_PAGE | Doesn't need refactoring | - | Coach -> Plan |
| GroupsPage.name | showGroupsPage | yes | Coach -> Plan -> groups |
| GroupMembersPage.name | showGroupsPage | yes | Coach -> Plan -> Groups -> Select any group |
| GroupEnrollPage.name | showGroupsPage | yes | Coach -> Plan -> Groups -> Select any group -> Click Enroll Learners |

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please Follow the table for reviewing the refactored routes.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
