### PR TITLE
Try to fix Slack notifications actions failing when " character is in the issue title

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -20,8 +20,7 @@ jobs:
       - name: Escape title double quotes
         id: escape_title
         run: |
-          title=${{ github.event.issue.title }}
-          echo "ISSUE_TITLE=${title//\"/\\\"}" >> "$GITHUB_OUTPUT"
+          echo "ISSUE_TITLE=${{ toJSON(github.event.issue.title) }}" >> "$GITHUB_OUTPUT"
 
       - name: Send message to Slack channel
         env:

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           payload: |
             {
-              "text": "*Kolibri: New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
+              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
             }

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - name: Escape title double quotes
         id: escape_title
-        run: echo "ISSUE_TITLE=${${{ github.event.issue.title }}//\"/\\\"}" >> "$GITHUB_OUTPUT"
+        run: |
+          title=${{ github.event.issue.title }}
+          echo "ISSUE_TITLE=${title//\"/\\\"}" >> "$GITHUB_OUTPUT"
 
       - name: Send message to Slack channel
         env:

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -17,6 +17,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Escape title double quotes
+        id: escape_title
+        run: echo "ISSUE_TITLE=${${{ github.event.issue.title }}//\"/\\\"}" >> "$GITHUB_OUTPUT"
+
       - name: Send message to Slack channel
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -25,5 +29,5 @@ jobs:
         with:
           payload: |
             {
-              "text": "*New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ github.event.issue.title }} by ${{ github.event.comment.user.login }}>*"
+              "text": "*New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
             }

--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           payload: |
             {
-              "text": "*New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
+              "text": "*Kolibri: New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
             }


### PR DESCRIPTION
## Summary

I noticed that the action that sends notifications to Slack about comments on issues from external developers fails when there's the double-quote character " in the issue title. Example: https://github.com/learningequality/kolibri/actions/runs/7845520071/job/21410131371. This seems to be caused by the unescaped " causing invalid string value in the payload we send to Slack API that subsequently returns "Error: Need to provide valid JSON payload".

![Screenshot from 2024-02-19 16-15-39](https://github.com/learningequality/kolibri/assets/13509191/b1cd18c7-e357-45f3-86ec-951dcb7a5dd0)

Here, I attempt to fix it by escaping double quotes.

## Reviewer guidance

Does code make sense? If yes, I guess we can try to merge and see if it works?

At least, I tried escaping logic  in bash:

![Screenshot from 2024-02-19 16-07-36](https://github.com/learningequality/kolibri/assets/13509191/560b71e8-233f-483e-b131-b8c1a2da8b4b)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
