### PR TITLE
Prevent unique constraint saving errors.

### DIFF
--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -884,16 +884,17 @@ def process_user_downloads_for_removal():
     largest_user_download = user_downloads.order_by("-total_size").first()
 
     # adding this opposite of the user download request allows us to detect this situation
-    user_download_removal = ContentRemovalRequest(
-        facility_id=largest_user_download.facility_id,
+    # this removal request will be processed on the next loop
+    ContentRemovalRequest.objects.update_or_create(
         source_model=largest_user_download.source_model,
         source_id=largest_user_download.source_id,
-        reason=ContentRequestReason.SyncInitiated,
-        status=ContentRequestStatus.Pending,
         contentnode_id=largest_user_download.contentnode_id,
+        defaults=dict(
+            facility_id=largest_user_download.facility_id,
+            reason=ContentRequestReason.SyncInitiated,
+            status=ContentRequestStatus.Pending,
+        ),
     )
-    # this removal request will be processed on the next loop
-    user_download_removal.save()
     logger.info(
         "Added removal request for user download of {}".format(
             largest_user_download.contentnode_id


### PR DESCRIPTION
## Summary
While doing some local testing to attempt to resolve https://github.com/learningequality/kolibri/issues/11895#issuecomment-1953287471 I noticed an unrelated error, where content download removal request processing was causing breakage.

## References
Traceback:
```
ERROR    2024-02-19 16:32:28,147 Job 78af46f9c4724ad7a926a96cc829cac4 raised an exception: Traceback (most recent call last):
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return Database.Cursor.execute(self, query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.IntegrityError: UNIQUE constraint failed: content_contentrequest.type, content_contentrequest.source_model, content_contentrequest.source_id, content_contentrequest.contentnode_id

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/richard/github/kolibri/kolibri/core/tasks/job.py", line 329, in execute
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/github/kolibri/kolibri/core/tasks/registry.py", line 238, in __call__
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/github/kolibri/kolibri/core/content/tasks.py", line 403, in automatic_resource_import
    process_content_requests()
  File "/home/richard/github/kolibri/kolibri/core/content/utils/content_request.py", line 505, in process_content_requests
    _process_content_requests(incomplete_downloads)
  File "/home/richard/github/kolibri/kolibri/core/content/utils/content_request.py", line 733, in _process_content_requests
    process_user_downloads_for_removal()
  File "/home/richard/github/kolibri/kolibri/core/content/utils/content_request.py", line 896, in process_user_downloads_for_removal
    user_download_removal.save()
  File "/home/richard/github/kolibri/kolibri/core/content/models.py", line 505, in save
    return super(ContentRequest, self).save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/base.py", line 807, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/base.py", line 838, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/base.py", line 924, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/base.py", line 962, in _do_insert
    return manager._insert([self], fields=fields, return_id=update_pk,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/query.py", line 1079, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1112, in execute_sql
    cursor.execute(sql, params)
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/backends/utils.py", line 60, in execute
    with self.db.wrap_database_errors:
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/utils/six.py", line 685, in reraise
    raise value.with_traceback(tb)
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/richard/.virtualenvs/kolibripy3.11/lib/python3.11/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return Database.Cursor.execute(self, query, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.IntegrityError: UNIQUE constraint failed: content_contentrequest.type, content_contentrequest.source_model, content_contentrequest.source_id, content_contentrequest.contentnode_id
```

## Reviewer guidance
Prevents the above error by doing an update_or_create call instead.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
