### PR TITLE
Ensure noarch dir is added to path when abi3 c extensions are used.

### DIFF
--- a/kolibri/utils/env.py
+++ b/kolibri/utils/env.py
@@ -77,15 +77,20 @@ def prepend_cext_path(dist_path):
         else:
             dirname = os.path.join(dirname, python_version + "mu")
 
-    dirname = os.path.join(dirname, machine_name)
+    arch_dirname = os.path.join(dirname, machine_name)
     noarch_dir = os.path.join(dist_path, "cext")
-    if sys.version_info >= (3, 6) and os.path.exists(abi3_dirname):
-        sys.path = [str(abi3_dirname)] + sys.path
+    abi3_dir_exists = sys.version_info >= (3, 6) and os.path.exists(abi3_dirname)
+    arch_dir_exists = os.path.exists(arch_dirname)
+    # If either the abi3 or arch directory exists, add the noarch directory to sys.path
+    if abi3_dir_exists or arch_dir_exists:
+        # Add the noarch (OpenSSL) modules to sys.path
+        sys.path = [str(noarch_dir)] + sys.path
 
-    if os.path.exists(dirname):
+    if abi3_dir_exists:
+        sys.path = [str(abi3_dirname)] + sys.path
+    if arch_dir_exists:
         # If the directory of platform-specific cextensions (cryptography) exists,
-        # add it + the matching noarch (OpenSSL) modules to sys.path
-        sys.path = [str(dirname), str(noarch_dir)] + sys.path
+        sys.path = [str(arch_dirname)] + sys.path
     else:
         logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
         logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
## Summary
* Ensures we use bundled Kolibri packages when C extension are active to prevent version conflicts

## References
Fixes error reported in https://github.com/learningequality/kolibri/issues/11895#issuecomment-1953287471

## Reviewer guidance
Set up a Python 2.7 virtualenv.
Run `make staticdeps` and `make staticdeps-cext`.

Set up a Python 3.11 virtualenv. Install kolibri and all dependencies into the virtualenv. Install PyOpenSSL version 23.0.0 into the virtual env.

Run kolibri, ensure that it does not give the error reported above (or any errors, hopefully!).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
