### PR TITLE
Update development documentation

### DIFF
--- a/docs/howtos/development_with_kds.md
+++ b/docs/howtos/development_with_kds.md
@@ -1,0 +1,15 @@
+## Running Kolibri with local Kolibri Design System
+
+Kolibri uses components from [Kolibri Design System](https://github.com/learningequality/kolibri-design-system) (KDS). KDS is installed in Kolibri as a usual npm dependency.
+
+It is sometimes useful to run Kolibri development server linked to local KDS repository, for example to confirm that a KDS update fixes bug observed in Kolibri, when developing new KDS feature in support of Kolibri feature, etc.
+
+For this purpose, Kolibri provides `devserver-with-kds` command that will run the development server with Kolibri using local KDS:
+
+```bash
+yarn run devserver-with-kds <kds-path>
+```
+
+where `<kds-path>` is the path of the local `kolibri-design-system` repository.
+
+It is recommended to use an absolute KDS path as some developers observed problems when running the command with a relative path.

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -12,5 +12,6 @@ These guides are step by step guides for common tasks in getting started and wor
   installing_pyenv
   pyenv_virtualenv
   nodeenv
-  another_kolibri_instance
   rebasing_a_pull_request
+  another_kolibri_instance
+  development_with_kds

--- a/docs/howtos/rebasing_a_pull_request.md
+++ b/docs/howtos/rebasing_a_pull_request.md
@@ -1,3 +1,5 @@
+## Rebasing a Pull Request
+
 On certain occasions, it might be necessary to redirect a pull request from the develop branch to the latest release branch, such as `release-v*` (e.g., `release-v0.16.x` when working on version 0.16), or vice versa. This guide outlines the steps for rebasing a feature branch related to your pull request while maintaining a clean commit history.
 
 The demonstration centers on the process of rebasing a feature branch that is directed towards the `develop` branch in your pull request, transitioning it to the most recent release branch, identified as `release-v*`. If the need arises to rebase your pull request in the opposite direction—from `release-v*` to `develop` you can follow the same steps, just adjusting the branch names as indicated in the guide below.

--- a/docs/howtos/rebasing_a_pull_request.rst
+++ b/docs/howtos/rebasing_a_pull_request.rst
@@ -1,6 +1,0 @@
-.. _rebasing_a_pull_request:
-
-Rebasing a Pull Request
-=======================
-
-.. mdinclude:: ./rebasing_a_pull_request.md


### PR DESCRIPTION
## Summary

- Fixes ["Running another Kolibri instance alongside the development server" ](https://kolibri-dev--11917.org.readthedocs.build/en/11917/howtos/another_kolibri_instance.html) guide not being displayed (cc @rtibbles)
- Adds [a new guide for running Kolibri with local KDS](https://kolibri-dev--11917.org.readthedocs.build/en/11917/howtos/development_with_kds.html)

Also see related https://github.com/learningequality/kolibri-design-system/pull/557

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
