### PR TITLE
test: Add complete test suite for `InteractionItem`

### DIFF
--- a/kolibri/core/assets/src/views/InteractionList/InteractionItem.vue
+++ b/kolibri/core/assets/src/views/InteractionList/InteractionItem.vue
@@ -6,6 +6,7 @@
       border: `2px solid ${selected ? $themeTokens.text : $themeTokens.textDisabled }`,
       cursor: selected ? 'auto' : 'pointer',
     }"
+    data-testid="attemptBox"
   >
     <template v-if="isAnswer">
       <KIcon
@@ -13,12 +14,14 @@
         class="svg-item"
         icon="correct"
         :style="[svgItemBorder, { fill: $themeTokens.correct }]"
+        data-testid="correctAnswerIcon"
       />
       <KIcon
         v-if="!interaction.correct"
         class="svg-item"
         icon="incorrect"
         :style="[svgItemBorder, { fill: $themeTokens.incorrect }]"
+        data-testid="incorrectAnswerIcon"
       />
     </template>
     <KIcon
@@ -26,12 +29,14 @@
       class="svg-item"
       icon="hint"
       :style="[svgItemBorder, { fill: $themeTokens.annotation } ]"
+      data-testid="hintIcon"
     />
     <KIcon
       v-else-if="isError"
       class="svg-item"
       icon="helpNeeded"
       :style="[svgItemBorder, { fill: $themeTokens.annotation } ]"
+      data-testid="helpNeededIcon"
     />
   </div>
 
@@ -46,6 +51,17 @@
       interaction: {
         type: Object,
         required: true,
+        validator: function(value) {
+          // The object must have a 'type' property
+          if (!value['type']) {
+            return false;
+          }
+          // If the type is 'correct', then it additionally must have a 'correct' property
+          if (value.type === 'correct' && (value.correct === undefined || value.correct === null)) {
+            return false;
+          }
+          return true;
+        },
       },
       selected: {
         type: Boolean,

--- a/kolibri/core/assets/src/views/InteractionList/__tests__/InteractionItem.spec.js
+++ b/kolibri/core/assets/src/views/InteractionList/__tests__/InteractionItem.spec.js
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
+import InteractionItem from '../InteractionItem.vue';
+
+const renderComponent = props => {
+  const defaultProps = {
+    interaction: { type: 'answer', correct: true },
+    selected: true,
+  };
+
+  return render(InteractionItem, {
+    props: { ...defaultProps, ...props },
+    routes: new VueRouter(),
+  });
+};
+
+const allIcons = ['correctAnswerIcon', 'incorrectAnswerIcon', 'hintIcon', 'helpNeededIcon'];
+const testCases = [
+  {
+    name: 'renders interaction item with correct answer',
+    interaction: { type: 'answer', correct: true },
+    expectedIcon: 'correctAnswerIcon',
+    expectedFill: themeTokens().correct,
+  },
+  {
+    name: 'renders interaction item with incorrect answer',
+    interaction: { type: 'answer', correct: false },
+    expectedIcon: 'incorrectAnswerIcon',
+    expectedFill: themeTokens().incorrect,
+  },
+  {
+    name: 'renders interaction item with hint',
+    interaction: { type: 'hint' },
+    expectedIcon: 'hintIcon',
+    expectedFill: themeTokens().annotation,
+  },
+  {
+    name: 'renders interaction item with error',
+    interaction: { type: 'error' },
+    expectedIcon: 'helpNeededIcon',
+    expectedFill: themeTokens().annotation,
+  },
+];
+
+describe('InteractionItem', () => {
+  // Test cases to ensure that only the correct icons are rendered
+  testCases.forEach(({ name, interaction, expectedIcon, expectedFill }) => {
+    test(name, () => {
+      renderComponent({ interaction });
+
+      const icon = screen.getByTestId(expectedIcon);
+      expect(icon).toBeInTheDocument();
+      expect(icon).toHaveStyle({ fill: expectedFill });
+
+      allIcons
+        .filter(iconName => iconName !== expectedIcon)
+        .forEach(iconName => expect(screen.queryByTestId(iconName)).not.toBeInTheDocument());
+    });
+  });
+
+  test('renders the attempt box correctly when it is selected', () => {
+    renderComponent({ selected: true });
+
+    expect(screen.getByTestId('attemptBox')).toHaveStyle({
+      border: `2px solid ${themeTokens().text}`,
+      cursor: 'auto',
+    });
+  });
+
+  test('renders the attempt box correctly when it is not selected', () => {
+    renderComponent({ selected: false });
+
+    expect(screen.getByTestId('attemptBox')).toHaveStyle({
+      border: `2px solid ${themeTokens().textDisabled}`,
+      cursor: 'pointer',
+    });
+  });
+});

--- a/kolibri/core/assets/src/views/InteractionList/__tests__/index.spec.js
+++ b/kolibri/core/assets/src/views/InteractionList/__tests__/index.spec.js
@@ -1,0 +1,42 @@
+import { render, fireEvent, screen } from '@testing-library/vue';
+import VueRouter from 'vue-router';
+import InteractionList from '../';
+
+const renderComponent = props => {
+  const defaultProps = {
+    interactions: [{ type: 'answer', correct: true }, { type: 'hint' }, { type: 'error' }],
+    selectedInteractionIndex: 0,
+  };
+
+  return render(InteractionList, {
+    props: {
+      ...defaultProps,
+      ...props,
+    },
+    routes: new VueRouter(),
+  });
+};
+
+const checkSelectedStatus = (interactionItems, selectedIndex) => {
+  // Check if the selected interaction has the correct cursor
+  // Auto cursor means that the interaction is selected, and pointer cursor means that it is not
+  const isSelected = iteractionItem => iteractionItem.style.cursor === 'auto';
+
+  interactionItems.forEach((interactionItem, index) =>
+    expect(isSelected(interactionItem)).toBe(index === selectedIndex)
+  );
+};
+
+describe('InteractionList', () => {
+  test('the item renders correctly and the selected iteraction changes correctly on user clicks', async () => {
+    renderComponent();
+
+    const interactionItems = screen.getAllByTestId('attemptBox');
+    expect(interactionItems).toHaveLength(3);
+    checkSelectedStatus(interactionItems, 0);
+
+    // Click the second interaction
+    await fireEvent.click(interactionItems[1]);
+    checkSelectedStatus(interactionItems, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Added the tests for the `Interaction Item` component. 
- Added Test IDs to some of the divisions of the base component as there isn't a real accessible (`role` based) query parameter to capture them as they are mostly icons and can be visually distinguished by the users.

## Reviewer guidance
- I have tested all the changes by running the test suite locally

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [X] Critical user journeys are covered by Gherkin stories
- [X] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
