### PR TITLE
Fixes the broken slack contributor notification gh action

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -17,18 +17,14 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Escape title double quotes
-        id: escape_title
-        run: |
-          echo "ISSUE_TITLE=${{ toJSON(github.event.issue.title) }}" >> "$GITHUB_OUTPUT"
-
       - name: Send message to Slack channel
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+            ISSUE_TITLE: ${{ toJSON(github.event.issue.title) }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {
-              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
+              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|$ISSUE_TITLE by ${{ github.event.comment.user.login }}>*"
             }


### PR DESCRIPTION
This PR attempts to fix the broken GitHub action for sending slack notification on contributor issue comments -- https://github.com/learningequality/kolibri/actions/runs/8035102518/job/21947381220.

My intuition is, the `echo` is using double quotes which is messing the bash syntax. In this PR, I have removed the `echo >> GITHUB_OUTPUT` step and using env var instead. 

I feel this PR should definitely fix the action. Let's merge it and test it out. @rtibbles @micahscopes.