### PR TITLE
Attempt to fix GH notification action

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -17,14 +17,19 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+      - name: Escape title double quotes
+        id: escape_title
+        run: |
+          title=${{ github.event.issue.title }}
+          echo "ISSUE_TITLE=${title//\"/\\\"}" >> "$GITHUB_OUTPUT"
+
       - name: Send message to Slack channel
         env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-            ISSUE_TITLE: ${{ toJSON(github.event.issue.title) }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {
-              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|$ISSUE_TITLE by ${{ github.event.comment.user.login }}>*"
+              "text": "*[Kolibri] New comment on issue: <${{ github.event.issue.html_url }}#issuecomment-${{ github.event.comment.id }}|${{ steps.escape_title.outputs.ISSUE_TITLE }} by ${{ github.event.comment.user.login }}>*"
             }


### PR DESCRIPTION
## Summary

The action is still broken, see https://learningequality.slack.com/archives/CB37UM23A/p1709043421448809?thread_ts=1708938068.560799&cid=CB37UM23A

## References

Follow-up to

- https://github.com/learningequality/kolibri/pull/11902
- https://github.com/learningequality/kolibri/pull/11922

## Reviewer guidance

This has been reviewed in https://github.com/learningequality/kolibri/pull/11902 already before we experimented with `toJSON`, so I think we can merge and see if it works.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
