### PR TITLE
Fix failing csv report generation api test in different timezones

### DIFF
--- a/kolibri/plugins/facility/test/test_api.py
+++ b/kolibri/plugins/facility/test/test_api.py
@@ -22,7 +22,7 @@ from kolibri.core.logger.test.factory_logger import ContentSummaryLogFactory
 from kolibri.core.logger.test.factory_logger import FacilityUserFactory
 from kolibri.plugins.facility.views import CSV_EXPORT_FILENAMES
 from kolibri.utils import conf
-from kolibri.utils.time_utils import local_now
+from kolibri.utils.time_utils import utc_now
 
 
 def output_filename(log_type, facility, **kwargs):
@@ -67,7 +67,7 @@ class ContentSummaryLogCSVExportTestCase(APITestCase):
         ]
         cls.facility.add_admin(cls.admin)
         cls.start_date = datetime.datetime(2020, 10, 21, tzinfo=pytz.UTC).isoformat()
-        cls.end_date = local_now().isoformat()
+        cls.end_date = utc_now().isoformat()
 
     @mock.patch.object(log_exports_cleanup, "enqueue", return_value=None)
     def test_csv_download_anonymous_permissions(self, mock_enqueue):
@@ -170,7 +170,7 @@ class ContentSessionLogCSVExportTestCase(APITestCase):
         ]
         cls.facility.add_admin(cls.admin)
         cls.start_date = datetime.datetime(2020, 10, 21, tzinfo=pytz.UTC).isoformat()
-        cls.end_date = local_now().isoformat()
+        cls.end_date = utc_now().isoformat()
 
     @mock.patch.object(log_exports_cleanup, "enqueue", return_value=None)
     def test_csv_download_anonymous_permissions(self, mock_enqueue):

--- a/kolibri/utils/time_utils.py
+++ b/kolibri/utils/time_utils.py
@@ -2,7 +2,17 @@ from django.utils import timezone
 
 
 def local_now():
+    """
+    Returns the current time in the local timezone.
+    """
     return timezone.localtime(timezone.now())
+
+
+def utc_now():
+    """
+    Returns the current time in the UTC timezone.
+    """
+    return timezone.now()
 
 
 def naive_utc_datetime(dt):


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
The problem was because `start_data` was in UTC and `end_date` was in LOCAL timezone

- Introduced a new time_util `utc_now` to return current datatime in UTC
- used `utc_now` for calculating `end_date`
- Tested with all edge cases in the issue #11932 
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11932 
…



----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
