### PR TITLE
Remove AssessmentMetadataState mapper and update to direct API access…

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -1,7 +1,6 @@
 import every from 'lodash/every';
 import uniq from 'lodash/uniq';
 import { v4 as uuidv4 } from 'uuid';
-import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { ExamResource, ContentNodeResource } from 'kolibri.resources';
 
 /*
@@ -144,7 +143,9 @@ export function convertExamQuestionSources(exam, extraArgs = {}) {
     const { contentNodes } = extraArgs;
     const questionIds = {};
     contentNodes.forEach(node => {
-      questionIds[node.id] = assessmentMetaDataState(node).assessmentIds;
+      questionIds[node.id] = node.assessmentmetadata
+        ? node.assessmentmetadata.assessment_item_ids
+        : [];
     });
     return annotateQuestionsWithItem(
       convertExamQuestionSourcesV0V2(exam.question_sources, exam.seed, questionIds)

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/actions.js
@@ -3,7 +3,6 @@ import uniq from 'lodash/uniq';
 import unionBy from 'lodash/unionBy';
 import union from 'lodash/union';
 import shuffled from 'kolibri.utils.shuffled';
-import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { ContentNodeResource, ContentNodeSearchResource } from 'kolibri.resources';
 import { getContentNodeThumbnail } from 'kolibri.utils.contentNode';
 import router from 'kolibri.coreVue.router';
@@ -220,8 +219,8 @@ export function updateSelectedQuestions(store) {
       const doNothing = () => null;
       const availableExercises = exerciseIds.filter(id => exercises[id]);
       const exerciseTitles = availableExercises.map(id => exercises[id].title);
-      const questionIdArrays = availableExercises.map(
-        id => assessmentMetaDataState(exercises[id]).assessmentIds
+      const questionIdArrays = availableExercises.map(id =>
+        exercises[id].assessmentmetadata ? exercises[id].assessmentmetadata.assessment_item_ids : []
       );
       store.commit(
         'SET_SELECTED_QUESTIONS',

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -236,12 +236,12 @@ export function showPracticeQuizCreationPreviewPage(store, params) {
 function _prepPracticeQuizContentPreview(store, classId, contentId) {
   return ContentNodeResource.fetchModel({ id: contentId }).then(
     contentNode => {
-      const contentMetadata = contentNode.assessmentmetadata || {};
+      const assessmentMetadata = contentNode.assessmentmetadata || {};
       store.commit('SET_TOOLBAR_ROUTE', {});
       store.commit('examCreation/SET_CURRENT_CONTENT_NODE', { ...contentNode });
       store.commit('examCreation/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessment_item_ids,
-        completionData: contentMetadata.mastery_model,
+        questions: assessmentMetadata.assessment_item_ids,
+        completionData: assessmentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', PageNames.EXAM_CREATION_PRACTICE_QUIZ_PREVIEW);
       return contentNode;
@@ -254,12 +254,12 @@ function _prepPracticeQuizContentPreview(store, classId, contentId) {
 function _prepExamContentPreview(store, classId, contentId) {
   return ContentNodeResource.fetchModel({ id: contentId }).then(
     contentNode => {
-      const contentMetadata = contentNode.assessmentmetadata || {};
+      const assessmentMetadata = contentNode.assessmentmetadata || {};
       store.commit('SET_TOOLBAR_ROUTE', {});
       store.commit('examCreation/SET_CURRENT_CONTENT_NODE', { ...contentNode });
       store.commit('examCreation/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessment_item_ids,
-        completionData: contentMetadata.mastery_model,
+        questions: assessmentMetadata.assessment_item_ids,
+        completionData: assessmentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', PageNames.EXAM_CREATION_PREVIEW);
       return contentNode;

--- a/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/examCreation/handlers.js
@@ -7,7 +7,6 @@ import {
   ContentNodeSearchResource,
   ChannelResource,
 } from 'kolibri.resources';
-import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import router from 'kolibri.coreVue.router';
 import chunk from 'lodash/chunk';
 import { PageNames } from '../../constants';
@@ -237,12 +236,12 @@ export function showPracticeQuizCreationPreviewPage(store, params) {
 function _prepPracticeQuizContentPreview(store, classId, contentId) {
   return ContentNodeResource.fetchModel({ id: contentId }).then(
     contentNode => {
-      const contentMetadata = assessmentMetaDataState(contentNode);
+      const contentMetadata = contentNode.assessmentmetadata || {};
       store.commit('SET_TOOLBAR_ROUTE', {});
       store.commit('examCreation/SET_CURRENT_CONTENT_NODE', { ...contentNode });
       store.commit('examCreation/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessmentIds,
-        completionData: contentMetadata.masteryModel,
+        questions: contentMetadata.assessment_item_ids,
+        completionData: contentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', PageNames.EXAM_CREATION_PRACTICE_QUIZ_PREVIEW);
       return contentNode;
@@ -255,12 +254,12 @@ function _prepPracticeQuizContentPreview(store, classId, contentId) {
 function _prepExamContentPreview(store, classId, contentId) {
   return ContentNodeResource.fetchModel({ id: contentId }).then(
     contentNode => {
-      const contentMetadata = assessmentMetaDataState(contentNode);
+      const contentMetadata = contentNode.assessmentmetadata || {};
       store.commit('SET_TOOLBAR_ROUTE', {});
       store.commit('examCreation/SET_CURRENT_CONTENT_NODE', { ...contentNode });
       store.commit('examCreation/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessmentIds,
-        completionData: contentMetadata.masteryModel,
+        questions: contentMetadata.assessment_item_ids,
+        completionData: contentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', PageNames.EXAM_CREATION_PREVIEW);
       return contentNode;

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -267,7 +267,7 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
     getParams: { no_available_filtering: true },
   }).then(
     contentNode => {
-      const contentMetadata = contentNode.assessmentmetadata;
+      const assessmentMetadata = contentNode.assessmentmetadata;
       store.commit('lessonSummary/SET_STATE', {
         toolbarRoute: {},
         // only exist if exercises
@@ -276,8 +276,8 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
       });
       store.commit('lessonSummary/resources/SET_CURRENT_CONTENT_NODE', contentNode);
       store.commit('lessonSummary/resources/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessment_item_ids,
-        completionData: contentMetadata.mastery_model,
+        questions: assessmentMetadata.assessment_item_ids,
+        completionData: assessmentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', LessonsPageNames.CONTENT_PREVIEW);
       return contentNode;

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -1,5 +1,4 @@
 import pickBy from 'lodash/pickBy';
-import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import {
   BookmarksResource,
   ContentNodeResource,
@@ -268,7 +267,7 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
     getParams: { no_available_filtering: true },
   }).then(
     contentNode => {
-      const contentMetadata = assessmentMetaDataState(contentNode);
+      const contentMetadata = contentNode.assessmentmetadata;
       store.commit('lessonSummary/SET_STATE', {
         toolbarRoute: {},
         // only exist if exercises
@@ -277,8 +276,8 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
       });
       store.commit('lessonSummary/resources/SET_CURRENT_CONTENT_NODE', contentNode);
       store.commit('lessonSummary/resources/SET_PREVIEW_STATE', {
-        questions: contentMetadata.assessmentIds,
-        completionData: contentMetadata.masteryModel,
+        questions: contentMetadata.assessment_item_ids,
+        completionData: contentMetadata.mastery_model,
       });
       store.commit('SET_PAGE_NAME', LessonsPageNames.CONTENT_PREVIEW);
       return contentNode;

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -1,6 +1,5 @@
 import { ContentNodeResource } from 'kolibri.resources';
 import store from 'kolibri.coreVue.vuex.store';
-import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
 import { fetchNodeDataAndConvertExam } from 'kolibri.utils.exams';
 import { coachStrings } from '../../views/common/commonCoachStrings';
 
@@ -55,7 +54,7 @@ function showQuestionDetailView(params) {
   return promise
     .then(exam => {
       return ContentNodeResource.fetchModel({ id: exerciseNodeId }).then(exercise => {
-        exercise.assessmentmetadata = assessmentMetaDataState(exercise);
+        exercise.assessmentmetadata = exercise.assessmentmetadata || {};
         let title;
         if (exam) {
           const question = exam.question_sources.find(source => source.item === questionId);
@@ -66,7 +65,7 @@ function showQuestionDetailView(params) {
         } else {
           const questionNumber = Math.max(
             1,
-            exercise.assessmentmetadata.assessmentIds.indexOf(questionId)
+            exercise.assessmentmetadata.assessment_item_ids.indexOf(questionId)
           );
           title = coachStrings.$tr('nthExerciseName', {
             name: exercise.title,

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -26,7 +26,6 @@
 <script>
 
   import { mapState, mapGetters } from 'vuex';
-  import { assessmentMetaDataState } from 'kolibri.coreVue.vuex.mappers';
   import { ContentNodeKinds } from 'kolibri.coreVue.vuex.constants';
   import { setContentNodeProgress } from '../../composables/useContentNodeProgress';
   import useProgressTracking from '../../composables/useProgressTracking';
@@ -114,14 +113,14 @@
         if (!this.contentIsExercise) {
           return {};
         }
-        const assessment = assessmentMetaDataState(this.contentNode);
+        const assessment = this.contentNode.assessmentmetadata || {};
         return {
           kind: this.contentNode.kind,
           files: this.contentNode.files,
           lang: this.contentNode.lang,
           randomize: this.contentNode.randomize,
-          masteryModel: assessment.masteryModel,
-          assessmentIds: assessment.assessmentIds,
+          masteryModel: assessment.mastery_model,
+          assessmentIds: assessment.assessment_item_ids,
           available: this.contentNode.available,
           extraFields: this.extra_fields,
           progress: this.progress,
@@ -137,7 +136,7 @@
         if (this.contentNode.kind !== ContentNodeKinds.EXERCISE) {
           return null;
         } else {
-          return assessmentMetaDataState(this.contentNode);
+          return this.contentNode.assessmentmetadata || {};
         }
       },
     },


### PR DESCRIPTION
… (#11724)



## Summary
Removing the usage of the AssessmentMetadataState mapper and updating references to assessment metadata as per the new API endpoint return shape. 


## References
Closes Issue: [ #11724]
ContentNode API JSDoc: https://github.com/learningequality/kolibri/blob/release-v0.16.x/kolibri/core/assets/src/api-resources/contentNode.js#L64


## Reviewer guidance

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
