### PR TITLE
Increase number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       interval: "weekly"
       day: "wednesday"
       time: "00:00"
+    open-pull-requests-limit: 10
     groups:
       babel:
         patterns:


### PR DESCRIPTION
## Summary
Allows ten dependabot NPM PRs to be simultaneously open.