### PR TITLE
ENFORCE CSRF verification in API to be accessed by a browser strictly

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -874,7 +874,6 @@ class SetNonSpecifiedPasswordView(views.APIView):
 class SessionViewSet(viewsets.ViewSet):
     def _check_os_user(self, request, username):
         auth_token = request.COOKIES.get(APP_AUTH_TOKEN_COOKIE_NAME)
-        print("Auth", auth_token)
         if auth_token:
             try:
                 user = FacilityUser.objects.get_or_create_os_user(auth_token)
@@ -884,8 +883,6 @@ class SessionViewSet(viewsets.ViewSet):
                 logger.error(e)
 
     def create(self, request):
-        auth_token = request.COOKIES.get(APP_AUTH_TOKEN_COOKIE_NAME)
-        print("Auth", auth_token)
         username = request.data.get("username", "")
         password = request.data.get("password", "")
         facility_id = request.data.get("facility", None)

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -574,7 +574,6 @@ def _map_dataset(facility):
     return dataset
 
 
-@method_decorator(csrf_protect, name="dispatch")
 class FacilityViewSet(ValuesViewset):
     permission_classes = (KolibriAuthPermissions,)
     filter_backends = (KolibriAuthPermissionsFilter,)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1919,7 +1919,7 @@ class DuplicateUsernameTestCase(APITestCase):
         self.assertEqual(response.data, True)
 
 
-class CSRFProtectedTestCase(APITestCase):
+class CSRFProtectedAuthTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         provision_device()

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -22,7 +22,6 @@ from django.utils.encoding import iri_to_uri
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_page
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import etag
 from django_filters.rest_framework import BaseInFilter
 from django_filters.rest_framework import BooleanFilter
@@ -1388,7 +1387,6 @@ class ContentRequestFilter(FilterSet):
         fields = ("contentnode_id", "contentnode_id__in")
 
 
-@method_decorator(csrf_protect, name="dispatch")
 class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
     serializer_class = serializers.ContentDownloadRequestSerializer
     filter_backends = (DjangoFilterBackend,)

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -22,6 +22,7 @@ from django.utils.encoding import iri_to_uri
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_page
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import etag
 from django_filters.rest_framework import BaseInFilter
 from django_filters.rest_framework import BooleanFilter
@@ -1387,6 +1388,7 @@ class ContentRequestFilter(FilterSet):
         fields = ("contentnode_id", "contentnode_id__in")
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class ContentRequestViewset(ReadOnlyValuesViewset, CreateModelMixin):
     serializer_class = serializers.ContentDownloadRequestSerializer
     filter_backends = (DjangoFilterBackend,)

--- a/kolibri/core/device/api.py
+++ b/kolibri/core/device/api.py
@@ -13,7 +13,9 @@ from django.db.models.query import Q
 from django.http import Http404
 from django.http.response import HttpResponseBadRequest
 from django.utils import timezone
+from django.utils.decorators import method_decorator
 from django.utils.translation import get_language
+from django.views.decorators.csrf import csrf_protect
 from django_filters.rest_framework import DjangoFilterBackend
 from django_filters.rest_framework import FilterSet
 from django_filters.rest_framework import ModelChoiceFilter
@@ -93,6 +95,7 @@ class DevicePermissionsViewSet(viewsets.ModelViewSet):
     filter_backends = (KolibriAuthPermissionsFilter,)
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class DeviceProvisionView(viewsets.GenericViewSet):
     permission_classes = (NotProvisionedCanPost,)
     serializer_class = DeviceProvisionSerializer

--- a/kolibri/core/logger/api.py
+++ b/kolibri/core/logger/api.py
@@ -14,6 +14,8 @@ from django.db.models import Value
 from django.db.models import When
 from django.db.models.functions import Coalesce
 from django.http import Http404
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 from django_filters.rest_framework import BooleanFilter
 from django_filters.rest_framework import CharFilter
 from django_filters.rest_framework import ChoiceFilter
@@ -226,6 +228,7 @@ class LogContext(object):
         return output
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class ProgressTrackingViewSet(viewsets.GenericViewSet):
     def _precache_dataset_id(self, user):
         if user is None or user.is_anonymous:

--- a/kolibri/core/logger/test/test_integrated_api.py
+++ b/kolibri/core/logger/test/test_integrated_api.py
@@ -12,6 +12,7 @@ from le_utils.constants import content_kinds
 from le_utils.constants import exercises
 from le_utils.constants import modalities
 from mock import patch
+from rest_framework import status
 from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
@@ -2902,4 +2903,4 @@ class CSRFProtectedLoggerTestCase(APITestCase):
         }
         url = reverse("kolibri:core:trackprogress-list")
         response = self.client_csrf.post(url, post_data, format="json")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -1,7 +1,9 @@
 import logging
 
 from django.http.response import Http404
+from django.utils.decorators import method_decorator
 from django.utils.timezone import make_aware
+from django.views.decorators.csrf import csrf_protect
 from pytz import utc
 from rest_framework import decorators
 from rest_framework import serializers
@@ -40,6 +42,7 @@ class TasksSerializer(serializers.Serializer):
         return fields
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class TasksViewSet(viewsets.GenericViewSet):
     serializer_class = TasksSerializer
 
@@ -195,7 +198,7 @@ class TasksViewSet(viewsets.GenericViewSet):
             object, including args, kwargs, and extra_metadata.
         """
         validated_data = self.validate_create_req_data(request)
-
+        print("HI")
         enqueued_jobs_response = []
 
         # Once we have validated all the tasks, we are good to go!

--- a/kolibri/core/tasks/api.py
+++ b/kolibri/core/tasks/api.py
@@ -198,7 +198,6 @@ class TasksViewSet(viewsets.GenericViewSet):
             object, including args, kwargs, and extra_metadata.
         """
         validated_data = self.validate_create_req_data(request)
-        print("HI")
         enqueued_jobs_response = []
 
         # Once we have validated all the tasks, we are good to go!

--- a/kolibri/core/tasks/test/test_api.py
+++ b/kolibri/core/tasks/test/test_api.py
@@ -8,6 +8,8 @@ from mock import Mock
 from mock import patch
 from pytz import utc
 from rest_framework import serializers
+from rest_framework import status
+from rest_framework.test import APIClient
 from rest_framework.test import APITestCase
 
 from kolibri.core.auth.models import Facility
@@ -1482,3 +1484,14 @@ class TaskAPIPermissionsTestCase(APITestCase):
     def test_list_permissions(self, job_storage_mock):
         response = self.client.get(reverse("kolibri:core:task-list"), format="json")
         self.assertEqual(response.status_code, 200)
+
+
+class CSRFProtectedTaskTestCase(APITestCase):
+    def setUp(self):
+        self.client_csrf = APIClient(enforce_csrf_checks=True)
+
+    def test_csrf_protected_task(self):
+        response = self.client_csrf.post(
+            reverse("kolibri:core:task-list"), {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -67,6 +67,7 @@ class SetupWizardResource(ViewSet):
         return Response({"status": r.status_code, "data": r.content})
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class FacilityImportViewSet(ViewSet):
     """
     A group of endpoints that are used by the SetupWizard to import a facility

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -1,5 +1,7 @@
 import requests
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_protect
 from rest_framework import decorators
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import NotFound
@@ -32,6 +34,7 @@ class HasPermissionDuringLODSetup(BasePermission):
         return get_device_setting("subset_of_users_device")
 
 
+@method_decorator(csrf_protect, name="dispatch")
 class SetupWizardResource(ViewSet):
     """
     Generic endpoints for use during various setup wizard onboarding flows

--- a/kolibri/plugins/setup_wizard/test/test_api.py
+++ b/kolibri/plugins/setup_wizard/test/test_api.py
@@ -120,7 +120,7 @@ class CreateSuperuserTest(APITestCase):
         self.assertTrue(superuser.is_superuser)
 
 
-class CSRFProtectedTestCase(APITestCase):
+class CSRFProtectedSetupTestCase(APITestCase):
     def setUp(self):
         provision_device()
         clear_process_cache()
@@ -142,7 +142,7 @@ class CSRFProtectedTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_csrf_protected_setupwizard(self):
-        # passing and empty dictionary as data as i don't know what will be in baseurl
+        # passing and empty dictionary as data as i don't know what is baseurl
         response = self.client_csrf.post(
             reverse(
                 "kolibri:kolibri.plugins.setup_wizard:setupwizard-createuseronremote"


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Enforces CSRF Verification more strongly in post api endpoints which are supposed to be accessed only by browser
…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #7389 
…

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
I performed Manual QA on the following API's:(except for setupwizard, i was confused with the actual api of that)

1. `api/auth/session/`
2. `api/auth/facility/`
3. `api/content/contentrequest/`
4. `api/auth/signup/`
5. `api/tasks/tasks/ `
6. `api/device/deviceprovision/ `


I ran curl commands like: 
```
curl -X POST "http://localhost:8000/api/auth/facility/" -H  "accept: application/json" -H  "authorization: Basic c3VqYWk6c3VqYWk=" -H  "Content-Type: application/json"  -d "{  \"name\": \"string\"}"
 ```
I did the above for all API's i have changed here, without my changes i was in the API but with it i wasn't able to access it
…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
