### PR TITLE
Use FacilityUser instead of AUTH_USER_MODEL in migrations

### DIFF
--- a/kolibri/core/bookmarks/migrations/0001_initial.py
+++ b/kolibri/core/bookmarks/migrations/0001_initial.py
@@ -15,7 +15,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("kolibriauth", "0019_collection_no_mptt"),
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
     ]
 
     operations = [

--- a/kolibri/core/device/migrations/0012_syncqueue.py
+++ b/kolibri/core/device/migrations/0012_syncqueue.py
@@ -15,7 +15,7 @@ from django.db import models
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
+        ("kolibriauth", "0001_initial"),
         ("device", "0011_devicesettings_subset_of_users_device"),
     ]
 

--- a/kolibri/core/device/migrations/0013_usersyncstatus.py
+++ b/kolibri/core/device/migrations/0013_usersyncstatus.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("morango", "0016_store_deserialization_error"),
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
+        ("kolibriauth", "0001_initial"),
         ("device", "0012_syncqueue"),
     ]
 

--- a/kolibri/core/device/migrations/0016_osuser.py
+++ b/kolibri/core/device/migrations/0016_osuser.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
                         primary_key=True,
                         related_name="os_user",
                         serialize=False,
-                        to=settings.AUTH_USER_MODEL,
+                        to="kolibriauth.FacilityUser",
                     ),
                 ),
                 ("os_username", models.CharField(db_index=True, max_length=64)),

--- a/kolibri/core/device/migrations/0018_add_learner_device_status.py
+++ b/kolibri/core/device/migrations/0018_add_learner_device_status.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("kolibriauth", "0020_facilitydataset_extra_fields"),
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("device", "0017_extra_settings"),
     ]
 
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
                     models.OneToOneField(
                         on_delete=django.db.models.deletion.CASCADE,
                         related_name="learner_device_status",
-                        to=settings.AUTH_USER_MODEL,
+                        to="kolibriauth.FacilityUser",
                     ),
                 ),
             ],

--- a/kolibri/core/device/migrations/0018_add_learner_device_status.py
+++ b/kolibri/core/device/migrations/0018_add_learner_device_status.py
@@ -13,7 +13,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("kolibriauth", "0020_facilitydataset_extra_fields"),
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("device", "0017_extra_settings"),
     ]
 

--- a/kolibri/core/discovery/migrations/0007_device_pinning.py
+++ b/kolibri/core/discovery/migrations/0007_device_pinning.py
@@ -14,7 +14,7 @@ import kolibri.core.discovery.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
+        ("kolibriauth", "0001_initial"),
         ("discovery", "0006_networklocation_min_content_schema_version"),
     ]
 

--- a/kolibri/core/discovery/migrations/0007_device_pinning.py
+++ b/kolibri/core/discovery/migrations/0007_device_pinning.py
@@ -14,7 +14,7 @@ import kolibri.core.discovery.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("discovery", "0006_networklocation_min_content_schema_version"),
     ]
 
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
                     "user",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        to=settings.AUTH_USER_MODEL,
+                        to="kolibriauth.FacilityUser",
                     ),
                 ),
             ],

--- a/kolibri/core/discovery/migrations/0013_recreate_pinned_device.py
+++ b/kolibri/core/discovery/migrations/0013_recreate_pinned_device.py
@@ -13,7 +13,7 @@ from django.db import models
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
+        ("kolibriauth", "0001_initial"),
         ("discovery", "0012_remove_pinned_device"),
     ]
 

--- a/kolibri/core/discovery/migrations/0013_recreate_pinned_device.py
+++ b/kolibri/core/discovery/migrations/0013_recreate_pinned_device.py
@@ -13,7 +13,7 @@ from django.db import models
 class Migration(migrations.Migration):
 
     dependencies = [
-        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("discovery", "0012_remove_pinned_device"),
     ]
 
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
                     "user",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        to=settings.AUTH_USER_MODEL,
+                        to="kolibriauth.FacilityUser",
                     ),
                 ),
             ],

--- a/kolibri/core/exams/migrations/0005_individualsyncableexam.py
+++ b/kolibri/core/exams/migrations/0005_individualsyncableexam.py
@@ -15,7 +15,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("kolibriauth", "0019_collection_no_mptt"),
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("exams", "0004_exam_add_dates_opened_created_and_archived"),
     ]
 

--- a/kolibri/core/lessons/migrations/0003_individualsyncablelesson.py
+++ b/kolibri/core/lessons/migrations/0003_individualsyncablelesson.py
@@ -15,7 +15,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("kolibriauth", "0019_collection_no_mptt"),
-        migrations.swappable_dependency("kolibriauth.FacilityUser"),
         ("lessons", "0002_auto_20180221_1115"),
     ]
 


### PR DESCRIPTION
## Summary

Using settings.AUTH_USER_MODEL breaks migrations when using kolibri in context where this model points to something different than FacilityUser. For example, PortalUser in KDP


## References

For the future, any time migrations are created that relate to the user model, we should ensure that they point to FacilityUser. When changing AUTH_USER_MODEL, we may not want the kolibri models to be used for this new user type.



## Reviewer guidance

Migrations should continue working fine

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
