### PR TITLE
Fixes #11985 Can't set 'use mobile data'

### DIFF
--- a/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
+++ b/packages/kolibri-common/components/MeteredConnectionNotificationModal.vue
@@ -90,8 +90,8 @@
           // if we only include one of the keys for the extra_settings object
           client({ method: 'GET', url: this.settingsUrl })
             .then(({ data }) => {
-              logging.log('mounted', isMetered);
-              logging.log(data);
+              logging.info('mounted', isMetered);
+              logging.info(data);
               this.extra_settings = data.extra_settings;
               this.selected = this.extra_settings.allow_download_on_metered_connection
                 ? Options.USE_METERED


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

#11985. After some digging, I found the root of this issue is the frontend didn't correctly fetch devicesettings data.
```js
          client({ method: 'GET', url: this.settingsUrl })
            .then(({ data }) => {
              logging.log('mounted', isMetered);  // 'logging.log' doesn't exist, should be 'logging.info'
              logging.log(data); // Same as above
              this.extra_settings = data.extra_settings;
              this.selected = this.extra_settings.allow_download_on_metered_connection
                ? Options.USE_METERED
                : Options.DO_NOT_USE_METERED;
            })
            .catch(e => {
              logging.error(e);
            })
            .finally(() => (this.loading = false));
```
After fixing the that. frontend correctly fetch the data and the issue is resolved.
## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

N/A

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Follow the steps to reproduce in the original issue.
2. Observe the issue is resolved.
----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
