### PR TITLE
[re-open] Fix #11881 Side navigation scrolling

### DIFF
--- a/kolibri/core/assets/src/views/SideNav.vue
+++ b/kolibri/core/assets/src/views/SideNav.vue
@@ -565,6 +565,7 @@
     padding-top: 4px;
     overflow: auto;
     overflow-x: hidden;
+    overscroll-behavior: contain;
   }
 
   .bottom-nav-scrollable-area {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Fixes #11881
When the side nav was scrolled to its top or bottom limit, further scrolling attempts would unexpectedly propagate to the main content area, causing it to scroll instead. To resolve this issue, I've added the CSS property `overscroll-behavior: contain;` to the `.side-nav-scrollable-area` class, containing the scroll within the side nav and preventing it from affecting the main content area.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Run the Kolibri Mac app on the browser
2. Open the main side navigation
3. Scroll, and observe the main page content does not also scrolling

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md

https://github.com/learningequality/kolibri/assets/81625625/d2d5dc51-8d97-4c4e-979b-a15c2effe0fd

https://github.com/learningequality/kolibri/assets/81625625/7579574e-6d32-49dd-bf8c-59264729c9de