### PR TITLE
fix: content_id access from wrong object

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -160,7 +160,10 @@
        * source of truth for referencing progress of content nodes.
        */
       cacheProgress() {
-        setContentNodeProgress({ content_id: this.contentNode.content_id, progress: this.progress });
+        setContentNodeProgress({
+          content_id: this.contentNode.content_id,
+          progress: this.progress,
+        });
       },
       updateInteraction({ progress, interaction }) {
         this.updateContentSession({

--- a/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
+++ b/kolibri/plugins/learn/assets/src/views/ChannelRenderer/ContentItem.vue
@@ -160,7 +160,7 @@
        * source of truth for referencing progress of content nodes.
        */
       cacheProgress() {
-        setContentNodeProgress({ content_id: this.content.content_id, progress: this.progress });
+        setContentNodeProgress({ content_id: this.contentNode.content_id, progress: this.progress });
       },
       updateInteraction({ progress, interaction }) {
         this.updateContentSession({


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Remove wrongful access of property resulting in silent console error.
Root issue being `content_id` being accessed from `content` rather than `contentNode`. It would be better to have consistent prop naming and replacing `content` with `contentNode` or visa versa so as to avoid such errors in future. 

…

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

References #9074 

Before:
![151972657-a545f8f1-2d1e-4a12-80df-b48e60dbb370](https://github.com/learningequality/kolibri/assets/19166045/b43fa61d-690f-4105-876a-3d0e5608eaba)

After:
![Screenshot from 2024-03-15 22-29-45](https://github.com/learningequality/kolibri/assets/19166045/506cb46c-90ba-471e-9945-a90f2a4c083f)



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
