### PR TITLE
Introduce flake8-print as pre-commit hook with migration of print to logger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
     hooks:
     -   id: trailing-whitespace
     -   id: flake8
+        additional_dependencies: [
+            'flake8-print==3.1.4'
+        ]
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: debug-statements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     -   id: trailing-whitespace
     -   id: flake8
         additional_dependencies: [
-            'flake8-print==3.1.4'
+            'flake8-print==5.0.0'
         ]
     -   id: check-yaml
     -   id: check-added-large-files

--- a/build_tools/customize_build.py
+++ b/build_tools/customize_build.py
@@ -5,6 +5,7 @@ the DJANGO_SETTINGS_MODULE environment variable.
 
 For more detail see the documentation in __init__.py
 """
+import logging
 import os
 import sys
 import tempfile
@@ -13,6 +14,7 @@ import requests
 
 sys.path.append(os.path.realpath(os.path.join(os.path.dirname(__file__), "..")))
 
+logger = logging.getLogger(__name__)
 plugins_cache = {}
 
 
@@ -21,7 +23,7 @@ def load_plugins_from_file(file_path):
     if file_path not in plugins_cache:
         # We have been passed a URL, not a local file path
         if file_path.startswith("http"):
-            print(
+            logger.info(
                 "Downloading plugins manifest from {file_path}".format(
                     file_path=file_path
                 )
@@ -53,7 +55,7 @@ def set_default_settings_module():
         default_settings_path = os.environ["DEFAULT_SETTINGS_MODULE"]
         with open(os.path.join(build_config_path, "default_settings.py"), "w") as f:
             # Just write out settings_path = '<settings_path>'
-            print(
+            logger.info(
                 "Setting default settings module to {path}".format(
                     path=default_settings_path
                 )
@@ -69,10 +71,10 @@ def set_run_time_plugins():
         runtime_plugins = load_plugins_from_file(os.environ["RUN_TIME_PLUGINS"])
         with open(os.path.join(build_config_path, "default_plugins.py"), "w") as f:
             # Just write out 'plugins = [...]' <-- list of plugins
-            print("Setting run time plugins to:")
+            logger.info("Setting run time plugins to:")
             for runtime_plugin in runtime_plugins:
-                print(runtime_plugin)
-            print("### End run time plugins ###")
+                logger.info(runtime_plugin)
+            logger.info("### End run time plugins ###")
             f.write(run_time_plugin_template.format(plugins=runtime_plugins.__str__()))
 
 

--- a/build_tools/customize_docker_envlist.py
+++ b/build_tools/customize_docker_envlist.py
@@ -4,12 +4,15 @@ at Kolibri build time to pass into the docker build environment.
 
 For more detail see the documentation in __init__.py
 """
+import logging
 import os
 
 BUILD_ENV_PREFIX = "KOLIBRI_BUILD_"
 ENVLIST_FILE = os.path.abspath(
     os.path.join(os.path.dirname(os.path.dirname(__file__)), "docker", "env.list")
 )
+
+logger = logging.getLogger(__name__)
 
 
 def add_env_var_to_docker():
@@ -23,7 +26,7 @@ def add_env_var_to_docker():
             if env.startswith(BUILD_ENV_PREFIX):
                 key = env.replace(BUILD_ENV_PREFIX, "")
                 f.write("\n{key}={value}".format(key=key, value=envs[env]))
-                print(
+                logger.info(
                     "Writing value of environment variable {} to Docker env.list\n".format(
                         key
                     )

--- a/build_tools/customize_requirements.py
+++ b/build_tools/customize_requirements.py
@@ -4,10 +4,13 @@ and hence bundled into the dist folder.
 
 For more detail see the documentation in __init__.py
 """
+import logging
 import os
 import tempfile
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 
 def add_requirements_to_base():
@@ -15,7 +18,7 @@ def add_requirements_to_base():
         file_path = os.environ["EXTRA_REQUIREMENTS"]
         # We have been passed a URL, not a local file path
         if file_path.startswith("http"):
-            print(
+            logger.info(
                 "Downloading extra requirements from {file_path}".format(
                     file_path=file_path
                 )

--- a/build_tools/install_cexts.py
+++ b/build_tools/install_cexts.py
@@ -24,6 +24,7 @@ passed into the function is not writable, a folder named `cext_cache` will be
 created under the directory where the script runs to store the cache data.
 """
 import argparse
+import logging
 import os
 import shutil
 import subprocess
@@ -40,6 +41,8 @@ DIST_CEXT = os.path.join(
 )
 PYPI_DOWNLOAD = "https://pypi.python.org/simple/"
 PIWHEEL_DOWNLOAD = "https://www.piwheels.org/simple/"
+
+logger = logging.getLogger(__name__)
 
 
 def get_path_with_arch(platform, path, abi, implementation, python_version):
@@ -135,7 +138,7 @@ def install_package(package_name, package_version, index_url, info, cache_path):
             platform, version_path, abi, implementation, python_version
         )
 
-        print("Installing package {}...".format(filename))
+        logger.info("Installing package {}...".format(filename))
         # Install the package using pip with cache_path as the cache directory
         install_return = run_pip_install(
             package_path,
@@ -218,13 +221,13 @@ def parse_pypi_and_piwheels(name, pk_version, cache_path, session):
                 r = session.get(url)
                 r.raise_for_status()
             except Exception as e:
-                print("Error retrieving {}: {}".format(url, e))
+                logger.info("Error retrieving {}: {}".format(url, e))
             else:
                 if r.status_code == 200:
                     # Got a valid response
                     break
 
-                print(
+                logger.info(
                     "Unexpected response from {}: {} {}".format(
                         url, r.status_code, r.reason
                     )
@@ -253,7 +256,7 @@ def check_cache_path_writable(cache_path):
         return cache_path
     except (OSError, IOError):
         new_path = os.path.realpath("cext_cache")
-        print(
+        logger.info(
             "The cache directory {old_path} is not writable. Changing to directory {new_path}.".format(
                 old_path=cache_path, new_path=new_path
             )

--- a/build_tools/preseed_home.py
+++ b/build_tools/preseed_home.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import shutil
 import tempfile
 
 temphome = tempfile.mkdtemp()
 os.environ["KOLIBRI_HOME"] = temphome
+
+logger = logging.getLogger(__name__)
 
 from kolibri.main import initialize  # noqa E402
 from kolibri.deployment.default.sqlite_db_names import (  # noqa E402
@@ -16,7 +19,7 @@ move_to = os.path.join(os.path.dirname(__file__), "..", "kolibri", "dist", "home
 shutil.rmtree(move_to, ignore_errors=True)
 os.mkdir(move_to)
 
-print("Generating preseeded home data in {}".format(temphome))
+logger.info("Generating preseeded home data in {}".format(temphome))
 
 initialize()
 call_command(
@@ -27,6 +30,6 @@ for db_config in settings.DATABASES.values():
     if db_config["ENGINE"] == "django.db.backends.sqlite3":
         shutil.move(os.path.join(temphome, db_config["NAME"]), move_to)
 
-print("Moved all preseeded home data to {}".format(move_to))
+logger.info("Moved all preseeded home data to {}".format(move_to))
 
 shutil.rmtree(temphome)

--- a/build_tools/read_whl_version.py
+++ b/build_tools/read_whl_version.py
@@ -1,14 +1,16 @@
+import logging
 import sys
 
 from pkginfo import Wheel
 
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: read_whl_version.py <whl_file>")
+        logger.error("Usage: read_whl_version.py <whl_file>")
         sys.exit(1)
 
     whl_file = sys.argv[1]
     whl = Wheel(whl_file)
-    print(whl.version)
+    logger.info(whl.version)
     sys.exit(0)

--- a/integration_testing/scripts/run_kolibri_app_mode.py
+++ b/integration_testing/scripts/run_kolibri_app_mode.py
@@ -24,7 +24,7 @@ class AppPlugin(SimplePlugin):
         start_url = "http://127.0.0.1:{port}".format(
             port=self.port
         ) + interface.get_initialize_url(auth_token="1234")
-        print("Kolibri running at: {start_url}".format(start_url=start_url))
+        logging.info("Kolibri running at: {start_url}".format(start_url=start_url))
 
 
 logging.info("Initializing Kolibri and running any upgrade routines")

--- a/kolibri/core/analytics/management/commands/benchmark.py
+++ b/kolibri/core/analytics/management/commands/benchmark.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 from django.conf import settings
@@ -16,6 +17,8 @@ from kolibri.utils.server import installation_type
 from kolibri.utils.server import NotRunning
 from kolibri.utils.system import get_free_space
 from kolibri.utils.time_utils import local_now
+
+logger = logging.getLogger(__name__)
 
 
 def format_line(parameter, value, indented=False):
@@ -75,7 +78,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if not SUPPORTED_OS:
-            print("This OS is not yet supported")
+            logger.error("This OS is not yet supported")
             sys.exit(1)
 
         try:
@@ -146,7 +149,7 @@ class Command(BaseCommand):
         self.messages.append(format_line("Server timezone", settings.TIME_ZONE))
 
         self.messages.append("")
-        print("\n".join(self.messages))
+        logger.info("\n".join(self.messages))
 
     def add_header(self, header):
         self.messages.append("")

--- a/kolibri/core/analytics/management/commands/profile.py
+++ b/kolibri/core/analytics/management/commands/profile.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 import os.path
 import sys
 import time
@@ -15,6 +16,8 @@ from kolibri.utils import conf
 from kolibri.utils.server import NotRunning
 from kolibri.utils.server import PROFILE_LOCK
 from kolibri.utils.system import pid_exists
+
+logger = logging.getLogger(__name__)
 
 
 def remove_lock():
@@ -54,11 +57,11 @@ class Command(BaseCommand):
 
     def check_start_conditions(self):
         if not SUPPORTED_OS:
-            print("This OS is not yet supported")
+            logger.error("This OS is not yet supported")
             sys.exit(1)
 
         if not conf.OPTIONS["Server"]["PROFILE"]:
-            print(
+            logger.error(
                 "Kolibri has not enabled profiling of its requests."
                 "To enable it, edit the Kolibri options.ini file and "
                 "add `PROFILE = true` in the [Server] section"
@@ -73,7 +76,7 @@ class Command(BaseCommand):
                 remove_lock()
             if command_pid:
                 if pid_exists(command_pid):
-                    print("Profile command is already running")
+                    logger.error("Profile command is already running")
                     sys.exit(1)
                 else:
                     remove_lock()
@@ -89,7 +92,7 @@ class Command(BaseCommand):
                 f.write("%d" % this_pid)
                 f.write("\n{}".format(file_timestamp))
         except (IOError, OSError):
-            print(
+            logger.error(
                 "Impossible to create profile lock file. Kolibri won't profile its requests"
             )
         samples = 1
@@ -102,7 +105,7 @@ class Command(BaseCommand):
             try:
                 os.mkdir(performance_dir)
             except OSError:
-                print("Not enough permissions to write performance logs")
+                logger.error("Not enough permissions to write performance logs")
                 sys.exit(1)
         with open(self.performance_file, mode="w") as profile_file:
             profile_writer = csv.writer(

--- a/kolibri/core/analytics/measurements.py
+++ b/kolibri/core/analytics/measurements.py
@@ -1,3 +1,4 @@
+import logging
 from collections import namedtuple
 from datetime import timedelta
 
@@ -15,6 +16,8 @@ from kolibri.core.logger.models import ContentSessionLog
 from kolibri.core.logger.models import UserSessionLog
 from kolibri.utils.server import NotRunning
 from kolibri.utils.server import PID_FILE
+
+logger = logging.getLogger(__name__)
 
 try:
     import kolibri.utils.pskolibri as psutil
@@ -53,7 +56,9 @@ def get_db_info():
             ).count()
         )
     except OperationalError:
-        print("Database unavailable, impossible to retrieve users and sessions info")
+        logger.info(
+            "Database unavailable, impossible to retrieve users and sessions info"
+        )
 
     return (active_sessions, active_users, active_users_minute)
 
@@ -94,7 +99,7 @@ def get_channels_usage_info():
                     )
                 )
     except OperationalError:
-        print("Database unavailable, impossible to retrieve channels usage info")
+        logger.info("Database unavailable, impossible to retrieve channels usage info")
     return channels_info
 
 

--- a/kolibri/core/auth/management/commands/deleteuser.py
+++ b/kolibri/core/auth/management/commands/deleteuser.py
@@ -1,8 +1,12 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 
 from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.models import FacilityUser
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -51,10 +55,10 @@ class Command(BaseCommand):
             "ARE YOU SURE? If you do this, there is no way to recover the user data on this device."
         )
 
-        print(
+        logger.info(
             "Proceeding with user deletion. Deleting all data for user <{}>".format(
                 options["username"]
             )
         )
         user.delete(hard_delete=True)
-        print("Deletion complete. All data for this user has been deleted.")
+        logger.info("Deletion complete. All data for this user has been deleted.")

--- a/kolibri/core/auth/management/commands/deprovision.py
+++ b/kolibri/core/auth/management/commands/deprovision.py
@@ -88,6 +88,6 @@ class Command(AsyncCommand):
                 "ARE YOU SURE? If you do this, there is no way to recover the user data on this device."
             )
 
-        print("Proceeding with deprovisioning. Deleting all user data.")
+        logger.info("Proceeding with deprovisioning. Deleting all user data.")
         self.deprovision()
-        print("Deprovisioning complete. All user data has been deleted.")
+        logger.info("Deprovisioning complete. All user data has been deleted.")

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -49,7 +49,7 @@ def confirm_or_exit(message):
     while answer not in ["yes", "n", "no"]:
         answer = input("{} [Type 'yes' or 'no'.] ".format(message)).lower()
     if answer != "yes":
-        print("Canceled! Exiting without touching the database.")
+        logger.info("Canceled! Exiting without touching the database.")
         sys.exit(1)
 
 
@@ -308,7 +308,7 @@ def create_superuser_and_provision_device(username, dataset_id, noninteractive=F
                 DevicePermissions.objects.create(
                     user=superuser, is_superuser=True, can_manage_content=True
                 )
-                print(
+                logger.info(
                     "Temporary superuser with username: `superuser` and password: `password` created"
                 )
                 return
@@ -316,7 +316,7 @@ def create_superuser_and_provision_device(username, dataset_id, noninteractive=F
                 "Please enter username of account that will become the superuser on this device: "
             )
         if not FacilityUser.objects.filter(username=username).exists():
-            print(
+            logger.error(
                 "User with username `{}` does not exist on this device".format(username)
             )
             username = None

--- a/kolibri/core/content/test/test_channel_import.py
+++ b/kolibri/core/content/test/test_channel_import.py
@@ -1,5 +1,6 @@
 import io
 import json
+import logging
 import os
 import tempfile
 import uuid
@@ -44,6 +45,8 @@ from kolibri.core.content.utils.channel_import import import_channel_from_local_
 from kolibri.core.content.utils.channel_import import topological_sort
 from kolibri.core.content.utils.sqlalchemybridge import get_default_db_string
 from kolibri.core.content.utils.sqlalchemybridge import load_metadata
+
+logger = logging.getLogger(__name__)
 
 
 class UtilityTestCase(TestCase):
@@ -399,7 +402,7 @@ class ContentImportTestBase(TransactionTestCase):
         try:
             self.set_content_fixture()
         except (IOError, EOFError):
-            print(
+            logger.error(
                 "No content schema and/or data for {name}".format(name=self.schema_name)
             )
 

--- a/kolibri/core/content/test/test_channel_upgrade.py
+++ b/kolibri/core/content/test/test_channel_upgrade.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import random
 import tempfile
 import uuid
@@ -28,6 +29,8 @@ from kolibri.core.content.utils.sqlalchemybridge import load_metadata
 from kolibri.core.content.utils.upgrade import count_removed_resources
 from kolibri.core.content.utils.upgrade import get_automatically_updated_resources
 from kolibri.core.content.utils.upgrade import get_new_resources_available_for_import
+
+logger = logging.getLogger(__name__)
 
 
 def to_dict(instance):
@@ -103,7 +106,7 @@ class ChannelBuilder(object):
             for key in self.tree_keys:
                 setattr(self, key, data[key])
         except KeyError:
-            print(
+            logger.error(
                 "No tree cache found for {} levels and {} children per level".format(
                     self.levels, self.num_children
                 )

--- a/kolibri/core/device/management/commands/devicesettings.py
+++ b/kolibri/core/device/management/commands/devicesettings.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         ]
 
         if options["json"]:
-            print(json.dumps(dict(data), indent=2))
+            logger.info(json.dumps(dict(data), indent=2))
         else:
             header = ("Device setting", "Value")
             self._tabulate(header, data)
@@ -143,11 +143,11 @@ class Command(BaseCommand):
             for i, col in enumerate(row):
                 col_length[i] = max(col_length[i], len(str(col)))
 
-        print(
+        logger.info(
             " | ".join([str(col).ljust(col_length[i]) for i, col in enumerate(header)])
         )
-        print("-+-".join(["-" * col_length[i] for i, col in enumerate(header)]))
+        logger.info("-+-".join(["-" * col_length[i] for i, col in enumerate(header)]))
         for row in data:
-            print(
+            logger.info(
                 " | ".join([str(col).ljust(col_length[i]) for i, col in enumerate(row)])
             )

--- a/kolibri/core/logger/utils/user_data.py
+++ b/kolibri/core/logger/utils/user_data.py
@@ -47,7 +47,7 @@ def logger_info(message, verbosity=1):
         # print("====> verbosity %s" % verbosity)
         if verbosity > 0:
             # REF: [Python, Unicode, and the Windows console](https://stackoverflow.com/a/32176732/845481)
-            print(message)  # noqa: T001
+            print(message)  # noqa: T201
     except Exception:
         # TODO(cpauya): Don't just pass on everything, capture only specific ones.
         pass

--- a/kolibri/core/logger/utils/user_data.py
+++ b/kolibri/core/logger/utils/user_data.py
@@ -47,7 +47,7 @@ def logger_info(message, verbosity=1):
         # print("====> verbosity %s" % verbosity)
         if verbosity > 0:
             # REF: [Python, Unicode, and the Windows console](https://stackoverflow.com/a/32176732/845481)
-            print(message)
+            print(message)  # noqa: T001
     except Exception:
         # TODO(cpauya): Don't just pass on everything, capture only specific ones.
         pass

--- a/kolibri/deployment/default/wsgi.py
+++ b/kolibri/deployment/default/wsgi.py
@@ -6,6 +6,7 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.11/howto/deployment/wsgi/
 """
+import logging
 import os
 import time
 
@@ -16,6 +17,8 @@ from django.db.utils import OperationalError
 from kolibri.core.content.utils import paths
 from kolibri.utils import conf
 from kolibri.utils.kolibri_whitenoise import DynamicWhiteNoise
+
+logger = logging.getLogger(__name__)
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE", "kolibri.deployment.default.settings.base"
@@ -49,7 +52,7 @@ while not application and tries_remaining:
     except OperationalError:
         # An OperationalError happens when sqlite vacuum is being
         # executed. the db is locked
-        print(
+        logger.error(
             "Database assumed to be undergoing a VACUUM, retrying again in {} seconds...".format(
                 interval
             )
@@ -58,7 +61,7 @@ while not application and tries_remaining:
         time.sleep(interval)
 
 if not application:
-    print(
+    logger.error(
         "Could not start Kolibri with {} retries. Trying one last time".format(
             tries_remaining
         )

--- a/packages/kolibri-tools/lib/i18n/crowdin.py
+++ b/packages/kolibri-tools/lib/i18n/crowdin.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import time
 import zipfile
+from builtins import FileNotFoundError
 from contextlib import contextmanager
 
 from utils import available_languages

--- a/packages/kolibri-tools/lib/i18n/crowdin.py
+++ b/packages/kolibri-tools/lib/i18n/crowdin.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 import time
 import zipfile
-from builtins import FileNotFoundError
 from contextlib import contextmanager
 
 from utils import available_languages

--- a/packages/kolibri-tools/lib/i18n/nutritionfacts_i18n.py
+++ b/packages/kolibri-tools/lib/i18n/nutritionfacts_i18n.py
@@ -85,7 +85,7 @@ def main(title, message, link_text):
         output[lang_object[utils.KEY_INTL_CODE]] = i18n
 
     # output JSON
-    print(
+    logging.info(
         json.dumps(
             output, sort_keys=True, indent=2, separators=(",", ": "), ensure_ascii=False
         )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,7 @@
 -r base.txt
 ipdb==0.13.2
 flake8==3.8.3
+flake8-print==5.0.0
 pre-commit==1.15.1
 tox==3.1.3
 django-debug-panel==0.8.3

--- a/test/coverage_blame.py
+++ b/test/coverage_blame.py
@@ -3,10 +3,6 @@
 # Derived from http://scottlobdell.me/2015/04/gamifying-test-coverage-project/
 # Before running this script, first run tests with coverage using:
 #  tox -e py3.9
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
 from collections import Counter
 from subprocess import PIPE

--- a/test/coverage_blame.py
+++ b/test/coverage_blame.py
@@ -3,10 +3,16 @@
 # Derived from http://scottlobdell.me/2015/04/gamifying-test-coverage-project/
 # Before running this script, first run tests with coverage using:
 #  tox -e py3.9
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
 from collections import Counter
 from subprocess import PIPE
 from subprocess import Popen
 
+logger = logging.getLogger(__name__)
 
 LINE_COUNT_THRESH = 50
 
@@ -53,7 +59,7 @@ class ExcludeLineParser(object):
             try:
                 line_number = int(exclude_line_string)
             except ValueError:
-                print("Error for values ({})".format(exclude_line_string))
+                logger.error("Error for values ({})".format(exclude_line_string))
                 return []
             return [line_number]
 
@@ -172,7 +178,7 @@ if __name__ == "__main__":
     for author, cov in sorted(
         author_to_test_coverage.items(), key=lambda t: t[1], reverse=True
     ):
-        print(
+        logger.info(
             "#%s. %s: %.2d%% coverage (%d out of %d lines)"
             % (
                 rank,

--- a/test/do_mock_provisioning.py
+++ b/test/do_mock_provisioning.py
@@ -35,7 +35,7 @@ status_code = None
 timeout = 30  # wait for kolibri to start
 now = time()
 
-print("mock provisioning...")
+logger.info("mock provisioning...")
 while time() < now + timeout and status_code != 201:
     sleep(1)
     try:
@@ -45,8 +45,8 @@ while time() < now + timeout and status_code != 201:
         pass
 
 if status_code == 201:
-    print("success!")
+    logger.info("success!")
     exit(0)
 else:
-    print("failed with status %i" % status_code)
+    logger.error("failed with status %i" % status_code)
     exit(1)

--- a/test/patch_pytest.py
+++ b/test/patch_pytest.py
@@ -2,11 +2,14 @@
 This script backports this Python 3.10 compatibility fix https://github.com/pytest-dev/pytest/pull/8540
 in order to allow pytest to run in Python 3.10 without upgrading to version 6.2.5 which does not support 2.7
 """
+import logging
 import os
 import subprocess
 import sys
 
 import pytest
+
+logger = logging.getLogger(__name__)
 
 
 def patch():
@@ -14,7 +17,7 @@ def patch():
 
     patch_file = os.path.join(os.path.dirname(__file__), "pytest_3.10.patch")
 
-    print("Applying patch: " + str(patch_file))
+    logger.info("Applying patch: " + str(patch_file))
 
     # -N: insist this is FORWARD patch, don't reverse apply
     # -p1: strip first path component
@@ -29,7 +32,7 @@ def patch():
         "-i",
         patch_file,
     ]
-    print(" ".join(patch_command))
+    logger.info(" ".join(patch_command))
     try:
         # Use a dry run to establish whether the patch is already applied.
         # If we don't check this, the patch may be partially applied (which is bad!)
@@ -38,8 +41,8 @@ def patch():
         if e.returncode == 1:
             # Return code 1 means not all hunks could be applied, this usually
             # means the patch is already applied.
-            print(
-                "Warning: failed to apply patch (exit code 1), "
+            logger.warning(
+                "Failed to apply patch (exit code 1), "
                 "assuming it is already applied: ",
                 str(patch_file),
             )


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Add `flake8-print:3.1.4` which is back-compatible with py2.7
- Removes use of `print` with `logger`

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #11990 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- I was getting `packages/kolibri-tools/lib/i18n/crowdin.py:158:12: F821 undefined name 'FileNotFoundError'`, so i imported it from builtins

- Wasn't sure about https://github.com/learningequality/kolibri/blob/develop/kolibri/core/logger/utils/user_data.py#L50 so used noqa. I know logger can be used here, but was not sure to remove print or not


----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
