### PR TITLE
Add write to disk options for build command

### DIFF
--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -326,14 +326,9 @@ program
       cliLogging.warn(
         'Enabling write-to-disk mode may fill up your developer machine with lots of different built files if frequent changes are made.'
       );
-      runWebpackBuild(mode, bundleData, false, {
-        ...options,
-        cache: false,
-        hot: false,
-      });
-    } else {
-      runWebpackBuild(mode, bundleData, mode === modes.DEV, options);
     }
+
+    runWebpackBuild(mode, bundleData, !options.writeToDisk && mode === modes.DEV, options);
   });
 
 const ignoreDefaults = ['**/node_modules/**', '**/static/**'];

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -235,6 +235,7 @@ program
     false
   )
   .option('--kds-path <kdsPath>', 'Full path to local kds directory', String, '')
+  .option('--write-to-disk', 'Write files to disk instead of using webpack devserver', false)
   .action(function(mode, options) {
     if (options.requireKdsPath) {
       if (!options.kdsPath) {
@@ -320,7 +321,19 @@ program
         });
       }
     }
-    runWebpackBuild(mode, bundleData, mode === modes.DEV, options);
+
+    if (options.writeToDisk && mode === modes.DEV) {
+      cliLogging.warn(
+        'Enabling write-to-disk mode may fill up your developer machine with lots of different built files if frequent changes are made.'
+      );
+      runWebpackBuild(mode, bundleData, false, {
+        ...options,
+        cache: false,
+        hot: false,
+      });
+    } else {
+      runWebpackBuild(mode, bundleData, mode === modes.DEV, options);
+    }
   });
 
 const ignoreDefaults = ['**/node_modules/**', '**/static/**'];


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

This exposes `--write-to-disk` flag in build that writes file to disk instead of webpack

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #4826 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

In https://github.com/learningequality/kolibri/blob/develop/package.json#L15 Should there be a `prod` argument?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
