### PR TITLE
Fix 'missing resource' alert not showing on Home page for missing quiz resources

### DIFF
--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -224,7 +224,9 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                 }
             missing_resource = False
             for question_source in exam["question_sources"]:
-                missing_resource = not question_source["exercise_id"] in contentnode_map
+                if question_source["exercise_id"] not in contentnode_map:
+                    missing_resource = True
+                    break
             exam["missing_resource"] = missing_resource
         out_items = []
         for item in items:

--- a/kolibri/plugins/learn/viewsets.py
+++ b/kolibri/plugins/learn/viewsets.py
@@ -54,6 +54,16 @@ class LearnStateView(APIView):
         )
 
 
+def _map_contentnodes(request, content_ids):
+    contentnodes = (
+        contentnode_viewset.serialize_list(request, {"ids": content_ids})
+        if content_ids
+        else []
+    )
+    contentnode_map = {c["id"]: c for c in contentnodes}
+    return contentnode_map
+
+
 def _consolidate_lessons_data(request, lessons):
     lesson_contentnode_ids = set()
     for lesson in lessons:
@@ -69,15 +79,9 @@ def _consolidate_lessons_data(request, lessons):
         else []
     )
 
-    contentnodes = (
-        contentnode_viewset.serialize_list(request, {"ids": lesson_contentnode_ids})
-        if lesson_contentnode_ids
-        else []
-    )
+    contentnode_map = _map_contentnodes(request, lesson_contentnode_ids)
 
     progress_map = {l["content_id"]: l["progress"] for l in contentnode_progress}
-
-    contentnode_map = {c["id"]: c for c in contentnodes}
 
     for lesson in lessons:
         lesson["progress"] = {
@@ -198,6 +202,8 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
             )
         )
 
+        contentnode_map = _map_contentnodes(self.request, available_exam_ids)
+
         for exam in exams:
             closed = exam.pop("closed")
             score = exam.pop("score")
@@ -216,10 +222,10 @@ class LearnerClassroomViewset(ReadOnlyValuesViewset):
                     "closed": None,
                     "started": False,
                 }
-            exam["missing_resource"] = any(
-                question["exercise_id"] not in available_exam_ids
-                for question in exam.get("question_sources")
-            )
+            missing_resource = False
+            for question_source in exam["question_sources"]:
+                missing_resource = not question_source["exercise_id"] in contentnode_map
+            exam["missing_resource"] = missing_resource
         out_items = []
         for item in items:
             item["assignments"] = {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pr fixes the 'missing resource' alert not displaying on the Homepage if quiz resources have been removed from the device.
- Adds function `_map_contentnodes()` to map exam and lesson node ids using the same approach
- Updates how missing resources for exams are checked within `LearnerClassroomViewset`

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11453 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Set up a full facility and a learn-only device.
2. Assign a quiz to the learner on the LOD.
3. Sign in as the learner and delete some of the quiz resources by going to Device > Channel.
4. Go to the learner's home page and confirm the alert 'Some resources are missing or not supported..' is shown.

https://github.com/learningequality/kolibri/assets/46411498/9b9eaa46-7d9a-4d2d-b5ff-adb35dc1d818

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
