### PR TITLE
Add .git to aphrodite fork in perseus viewer's package json

### DIFF
--- a/kolibri/plugins/perseus_viewer/package.json
+++ b/kolibri/plugins/perseus_viewer/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "version": "0.0.1",
   "dependencies": {
-    "aphrodite": "https://github.com/learningequality/aphrodite/",
+    "aphrodite": "https://github.com/learningequality/aphrodite.git",
     "btoa": "1.2.1",
     "classnames": "^2.2.5",
     "draft-js": "^0.10.1",


### PR DESCRIPTION

## Summary
While setting up Kolibri, a common issue regarding the inability of yarn package manager to install the aphorodite fork from github occurs
I encountered this while setting up the `release` branch when trying to address #11879 
@marsian83 helped out by [referencing his pr in `studio`](https://github.com/learningequality/kolibri/issues/11879#issuecomment-2001960579)

I have made those changes, and I open this PR to help out future contributors who might face this issue while contributing!


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
