### PR TITLE
Added another condition for TOPICS_TOPIC_SEARCH redirection

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -401,7 +401,7 @@
         if (children.every(c => c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
           // if all children are leaf nodes (i.e. they have no children themselves)
           // then redirect to search results
-          if (children.every(c => c.title == "")) {
+          if (children.every(c => c.title == '')) {
             router.replace({
               name: PageNames.TOPICS_TOPIC_SEARCH,
               params: { ...route.params, id },

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -414,6 +414,8 @@
           // If we have skipped down the topic tree, replace to the new top level topic
           router.replace({ name: route.name, params: { ...route.params, id }, query: route.query });
           return true;
+        } else {
+          sidePanelIsOpen.value = false;
         }
       }
 

--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -370,6 +370,7 @@
       const channel = ref(null);
       const contents = ref([]);
       const loading = ref(true);
+      const sidePanelIsOpen = ref(false);
 
       const _getAllDescendantChildren = topic => {
         const contentnode_id__in = [];
@@ -397,14 +398,18 @@
       };
 
       function _handleTopicRedirect(route, children, id, skipped) {
-        if (!children.some(c => !c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
-          // if there are no children which are not leaf nodes (i.e. they have children themselves)
+        if (children.every(c => c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
+          // if all children are leaf nodes (i.e. they have no children themselves)
           // then redirect to search results
-          router.replace({
-            name: PageNames.TOPICS_TOPIC_SEARCH,
-            params: { ...route.params, id },
-            query: route.query,
-          });
+          if (children.every(c => c.title == "")) {
+            router.replace({
+              name: PageNames.TOPICS_TOPIC_SEARCH,
+              params: { ...route.params, id },
+              query: route.query,
+            });
+          } else {
+            sidePanelIsOpen.value = false;
+          }
         } else if (skipped) {
           // If we have skipped down the topic tree, replace to the new top level topic
           router.replace({ name: route.name, params: { ...route.params, id }, query: route.query });
@@ -532,6 +537,7 @@
         isUserLoggedIn,
         fetchContentNodeTreeProgress,
         loading,
+        sidePanelIsOpen,
       };
     },
     props: {
@@ -554,7 +560,6 @@
       return {
         sidePanelStyleOverrides: {},
         showMoreResources: false,
-        sidePanelIsOpen: false,
         metadataSidePanelContent: null,
         expandedTopics: {},
         subTopicLoading: null,


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->


User can now see content instead of search bar. Also, I changed the **not some not condition** logic to **every condition** logic(they are equivalent to each other) because it is easier to read.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #11842 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I have tested this with nested empty folders as well and this works on them too. However, I haven't tested them on completely empty folders with no content as I couldn't find such channel(or make one).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
