### PR TITLE
useUser can now get all states and getters

### DIFF
--- a/kolibri/core/assets/src/composables/useUser.js
+++ b/kolibri/core/assets/src/composables/useUser.js
@@ -2,6 +2,7 @@ import { computed } from 'kolibri.lib.vueCompositionApi';
 import store from 'kolibri.coreVue.vuex.store';
 
 export default function useUser() {
+  //getters
   const isUserLoggedIn = computed(() => store.getters.isUserLoggedIn);
   const currentUserId = computed(() => store.getters.currentUserId);
   const isLearnerOnlyImport = computed(() => store.getters.isLearnerOnlyImport);
@@ -10,6 +11,27 @@ export default function useUser() {
   const isSuperuser = computed(() => store.getters.isSuperuser);
   const canManageContent = computed(() => store.getters.canManageContent);
   const isAppContext = computed(() => store.getters.isAppContext);
+  const isClassCoach = computed(() => store.getters.isClassCoach);
+  const isFacilityCoach = computed(() => store.getters.isFacilityCoach);
+  const isLearner = computed(() => store.getters.isLearner);
+  const isFacilityAdmin = computed(() => store.getters.isFacilityAdmin);
+  const userIsMultipleFacility = computed(() => store.getters.userIsMultipleFacility);
+  const getUserPermissions = computed(() => store.getters.getUserPermissions);
+  const userFacilityId = computed(() => store.getters.userFacilityId);
+  const getUserKind = computed(() => store.getters.getUserKind);
+  const userHasPermissions = computed(() => store.getters.userHasPermissions);
+  const session = computed(() => store.getters.session);
+
+  //state
+  const app_context = computed(() => store.getters.session.app_context);
+  const can_manage_content = computed(() => store.getters.session.can_manage_content);
+  const facility_id = computed(() => store.getters.session.facility_id);
+  const full_name = computed(() => store.getters.session.full_name);
+  const id = computed(() => store.getters.session.id);
+  const kind = computed(() => store.getters.session.kind);
+  const user_id = computed(() => store.getters.session.user_id);
+  const full_facility_import = computed(() => store.getters.session.full_facility_import);
+  const username = computed(() => store.getters.session.username);
 
   return {
     isLearnerOnlyImport,
@@ -20,5 +42,25 @@ export default function useUser() {
     isSuperuser,
     canManageContent,
     isAppContext,
+    isClassCoach,
+    isFacilityCoach,
+    isLearner,
+    isFacilityAdmin,
+    userIsMultipleFacility,
+    getUserPermissions,
+    userFacilityId,
+    getUserKind,
+    userHasPermissions,
+    session,
+    //state
+    app_context,
+    can_manage_content,
+    facility_id,
+    full_name,
+    id,
+    kind,
+    user_id,
+    username,
+    full_facility_import,
   };
 }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

useUser can be used to get getters and state of sessions

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #11723 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I have tested that all these works by console logging them in learn plugin. I have used the computed property because when I tried to use store.state.core.session.state_specified_in_sessionjs, it would not give the right states and would give undefined for some states.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
