### PR TITLE
Reuse URL validator for remote URL access.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1770,7 +1770,11 @@ class RemoteChannelViewSet(viewsets.ViewSet):
     def _make_channel_endpoint_request(
         self, identifier=None, baseurl=None, keyword=None, language=None
     ):
-
+        if baseurl is not None:
+            try:
+                validator(baseurl)
+            except ValidationError:
+                baseurl = None
         url = get_channel_lookup_url(
             identifier=identifier, baseurl=baseurl, keyword=keyword, language=language
         )

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -1,5 +1,6 @@
 import requests
 from django.contrib.auth import login
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -7,6 +8,7 @@ from rest_framework.views import APIView
 from .utils import TokenGenerator
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.utils.urls import reverse_remote
+from kolibri.utils.urls import validator
 
 
 class OnMyOwnSetupViewset(APIView):
@@ -27,7 +29,11 @@ class OnMyOwnSetupViewset(APIView):
 
 class RemoteFacilityUserViewset(APIView):
     def get(self, request):
-        baseurl = request.query_params.get("baseurl", request.build_absolute_uri("/"))
+        baseurl = request.query_params.get("baseurl", "")
+        try:
+            validator(baseurl)
+        except DjangoValidationError as e:
+            raise ValidationError(detail=str(e))
         username = request.query_params.get("username", None)
         facility = request.query_params.get("facility", None)
         if username is None or facility is None:
@@ -47,7 +53,11 @@ class RemoteFacilityUserViewset(APIView):
 
 class RemoteFacilityUserAuthenticatedViewset(APIView):
     def post(self, request, *args, **kwargs):
-        baseurl = request.data.get("baseurl", request.build_absolute_uri("/"))
+        baseurl = request.query_params.get("baseurl", "")
+        try:
+            validator(baseurl)
+        except DjangoValidationError as e:
+            raise ValidationError(detail=str(e))
         username = request.data.get("username", None)
         facility = request.data.get("facility", None)
         password = request.data.get("password", None)


### PR DESCRIPTION
## Summary
* Reuses the existing remote URL validation used in the remote content API endpoints for other endpoints that take a baseurl GET parameter

## Reviewer guidance
Double check the setup wizard import and creation workflows
Double check channel import from peers

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
