### PR TITLE
Fix #9067: Redirect signed-out users to resource URL without lessonId or classId

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -164,6 +164,7 @@
   import { AddDeviceForm } from 'kolibri.coreVue.componentSets.sync';
   import { ContentNodeKinds, ContentErrorConstants } from 'kolibri.coreVue.vuex.constants';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
@@ -425,6 +426,9 @@
       lessonId() {
         return lodashGet(this.back, 'params.lessonId', null);
       },
+      classId() {
+        return lodashGet(this.back, 'params.classId', null);
+      },
       viewResourcesTitle() {
         /* eslint-disable kolibri/vue-no-undefined-string-uses */
         return this.lessonContext
@@ -515,6 +519,9 @@
         this.resourcesSidePanelLoading = false;
         if (this.content) {
           const id = this.content.id;
+          if (!this.isUserLoggedIn && (this.lessonId || this.classId)) {
+            redirectBrowser(window.location.href.split('?')[0]);
+          }
           client({
             method: 'get',
             url: urls['kolibri:core:bookmarks-list'](),


### PR DESCRIPTION
## Summary

When the "Allow users to explore resources without signing in" setting is enabled, if a signed-out user accesses a resource page with the `lessonId` or `classId` query parameters, it auto-redirects to the same page of the topic that does not contain these parameters.

Therefore, an check was added onto the `initializeState` method of the `TopicsContentPage.vue` file to verify if the user is not logged in. If so, it also checks for the existence of the parameters mentioned before in the URL. If at least one of these parameters exist, the user is redirected, using the `redirectBrowser` function, to the same page, but with the identifiers removed.

This change prevents problems regarding lesson and topic contexts from happening.

## References

Fixes #9067 

## Reviewer guidance

In order to reproduce this issue, login as a student and navigate to a resource from one lesson. The URL of the content should contain the `classId` and `lessonId` keywords in its parameters. Copy the URL, then log out.

When signed out, if the URL is pasted onto the search bar, the app should redirect to an URL that does not contain these keywords.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests

## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
