### PR TITLE
With 2.7 dropped, use shutil disk_usage function universally.

### DIFF
--- a/kolibri/core/discovery/utils/filesystem/posix.py
+++ b/kolibri/core/discovery/utils/filesystem/posix.py
@@ -72,7 +72,7 @@ PATH_PREFIX_BLACKLIST = ["/proc", "/sys", "/tmp", "/var", "/boot", "/dev"]
 def get_drive_list():
     """
     Gets a list of drives and metadata by parsing the output of `mount`, and adding additional info from various commands.
-    Disk size/usage comes from shutil.disk_usage or os.statvfs, and name/type info from dbus (Linux) or diskutil (OSX).
+    Disk size/usage comes from shutil.disk_usage, and name/type info from dbus (Linux) or diskutil (OSX).
     """
 
     if sys.platform == "darwin":

--- a/kolibri/utils/system.py
+++ b/kolibri/utils/system.py
@@ -14,13 +14,13 @@ etc..
 """
 import logging
 import os
+import shutil
 import sys
 
 from django.db import connections
 
 from .conf import KOLIBRI_HOME
 from .conf import OPTIONS
-from kolibri.utils.android import on_android
 
 logger = logging.getLogger(__name__)
 
@@ -127,44 +127,13 @@ class _WindowsNullDevice:
 
 def get_free_space(path=KOLIBRI_HOME):
 
-    while path and not os.path.exists(path):
-        path = os.path.dirname(path)  # look to parent if it doesn't exist
-    if not path:
-        raise Exception("Could not calculate free space")
+    path = os.path.realpath(path)
 
-    if sys.platform.startswith("win"):
-        import ctypes
-
-        free = ctypes.c_ulonglong(0)
-        check = ctypes.windll.kernel32.GetDiskFreeSpaceExW(
-            ctypes.c_wchar_p(path), None, None, ctypes.pointer(free)
-        )
-        if check == 0:
-            raise ctypes.winError()
-        result = free.value
-    elif on_android():
-        # This is meant for android, which needs to interact with android API to understand free
-        # space. If we're somehow getting here on non-android, we've got a problem.
-        try:
-            from jnius import autoclass
-
-            StatFs = autoclass("android.os.StatFs")
-            AndroidString = autoclass("java.lang.String")
-
-            st = StatFs(AndroidString(path))
-
-            try:
-                # for api version 18+
-                result = st.getFreeBlocksLong() * st.getBlockSizeLong()
-            except Exception:
-                # for api versions < 18
-                result = st.getFreeBlocks() * st.getBlockSize()
-
-        except Exception as e:
-            raise e
-    else:
-        st = os.statvfs(os.path.realpath(path))
-        result = st.f_bavail * st.f_frsize
+    while path and not os.path.exists(path) and not os.path.isdir(path):
+        path = os.path.dirname(
+            path
+        )  # look to parent if it doesn't exist or isn't a directory
+    result = shutil.disk_usage(path).free
 
     return max(result - OPTIONS["Deployment"]["MINIMUM_DISK_SPACE"], 0)
 


### PR DESCRIPTION
## Summary
Removes platform specific behaviour.
Uses shutil disk_usage which has support on Unix systems and Windows.
This may well break Android, as it removes the Android specific code, but this will be rectified in the Android installer with this issue: https://github.com/learningequality/kolibri-installer-android/issues/211

## References
Fixes the Kolibri side of https://github.com/learningequality/kolibri-installer-android/issues/211

## Reviewer guidance
Windows and Unix systems should show free space appropriately for content imports.

Opening as a draft to first confirm the impact on the Android installer.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
