### PR TITLE
Remove any order_by to ensure values_list is properly unique.

### DIFF
--- a/kolibri/core/content/utils/content_request.py
+++ b/kolibri/core/content/utils/content_request.py
@@ -584,7 +584,9 @@ def process_metadata_import(incomplete_downloads_without_metadata):
     preferred_instance_ids = list(
         incomplete_downloads_without_metadata.values_list(
             "source_instance_id", flat=True
-        ).distinct()
+        )
+        # Remove any ordering to ensure the distinct makes the list properly unique.
+        .order_by().distinct()
     )
     version_filter = ">=0.16.0"
     preferred_peers = PreferredDevicesWithClient(


### PR DESCRIPTION
## Summary
* Prevents duplicate instance_ids when getting preferred instance ids for metadata import

## Reviewer guidance
Do a full facility import from a facility with a lot of quizzes and lessons - see that it doesn't do a lot of unnecessary calls to clients during metadata import

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
