### PR TITLE
Fix URL handling regression

### DIFF
--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -53,7 +53,7 @@ class RemoteFacilityUserViewset(APIView):
 
 class RemoteFacilityUserAuthenticatedViewset(APIView):
     def post(self, request, *args, **kwargs):
-        baseurl = request.query_params.get("baseurl", "")
+        baseurl = request.data.get("baseurl", "")
         try:
             validator(baseurl)
         except DjangoValidationError as e:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11552,7 +11552,7 @@ vue2-teleport@^1.0.1:
   resolved "https://registry.yarnpkg.com/vue2-teleport/-/vue2-teleport-1.0.1.tgz#1b7f9f69c1223f522cf6cd81c39b8d6019e1cf66"
   integrity sha512-hbY/Q0x8qXGFxo6h4KU4YYesUcN+uUjliqqC0PoNSgpcbS2QRb3qXi+7XMTgLYs0a8i7o1H6Mu43UV4Vbgkhgw==
 
-vue@2.6.14, vue@^2.6.14:
+vue@2.6.14:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==


### PR DESCRIPTION
## Summary
#12028 introduced a regression due to a copy paste error by me, that tried to use query_params inside a POST request.
Reverts back to data.

## References
Fixes #12048

## Reviewer guidance
Start with a fresh KOLIBRI_HOME
Use the On My Own workflow
Create a user whose username already exists on a remote facility
Complete setup
Go to user profile
Change Learning Facility
Go through the steps to merge your user with the existing user
Rejoice when it works.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
