### PR TITLE
Release upload fixes

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -34,10 +34,10 @@ jobs:
   dmg:
     name: Build DMG file
     needs: whl
-    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@main
+    uses: learningequality/kolibri-app/.github/workflows/build_mac.yml@v0.4.0
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: main
+      ref: v0.4.0
   deb:
     name: Build DEB file
     needs: whl
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.0
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.1
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.0
+      ref: v1.6.1
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -184,13 +184,13 @@ jobs:
     - name: Upload files to Google Cloud Storage
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: 'dist/${{ matrix.filename }}'
+        path: 'dist/${{ matrix.filename }}/${{ matrix.filename }}'
         destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}/${{ matrix.filename }}'
     - name: Upload to BCK bucket
       if: ${{ github.event.release.name == 'latest' }} && ${{ endsWith(matrix.filename, '.whl') }}
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: 'dist/${{ matrix.filename }}'
+        path: 'dist/${{ matrix.filename }}/${{ matrix.filename }}'
         destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}/${{ matrix.filename }}'
   android_release:
     name: Release Android App

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -69,11 +69,11 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.0
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.1
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.0
+      ref: v1.6.1
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}
@@ -86,10 +86,10 @@ jobs:
   zip:
     name: Build Raspberry Pi Image
     needs: deb
-    uses: learningequality/pi-gen/.github/workflows/build_zip.yml@v0.16.0
+    uses: learningequality/pi-gen/.github/workflows/build_zip.yml@v0.16.1
     with:
       deb-file-name: ${{ needs.deb.outputs.deb-file-name }}
-      ref: v0.16.0
+      ref: v0.16.1
   upload_zip:
     uses: ./.github/workflows/upload_github_release_asset.yml
     needs: zip


### PR DESCRIPTION
## Summary
* Updates the path specification for upload to GCS to include the extra folder that the Github download artifacts action adds when multiple artifacts are uploaded from different action steps.
* Updates the Raspberry Pi image generator and Windows installer actions to versions that name the outputted files in accordance with the expectations for our release assets.
* Fixes oversight where the Mac App generation was not pinned in the PR build

## References
Fixes #11908

## Reviewer guidance
Because of how the action works, we'll have to wait for release to truly test it - but a quick eyeball of the changes (making sure that the @ tags on the actions match up with the `ref` inputs) would be helpful. Also, we can check the names of the built asset for the Windows installer in this PR.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
