### PR TITLE
Update useUser mocks for updated API.

### DIFF
--- a/kolibri/core/assets/src/composables/__mocks__/useUser.js
+++ b/kolibri/core/assets/src/composables/__mocks__/useUser.js
@@ -30,6 +30,20 @@
  * useUser.mockImplementation(() => useUserMock())
  * ```
  */
+import { computed } from 'kolibri.lib.vueCompositionApi';
+import { UserKinds } from '../../constants';
+
+const session = {
+  app_context: false,
+  can_manage_content: false,
+  facility_id: undefined,
+  full_name: '',
+  id: undefined,
+  kind: [UserKinds.ANONYMOUS],
+  user_id: undefined,
+  username: '',
+  full_facility_import: true,
+};
 
 const MOCK_DEFAULTS = {
   isLearnerOnlyImport: false,
@@ -39,13 +53,31 @@ const MOCK_DEFAULTS = {
   isAdmin: false,
   isSuperuser: false,
   canManageContent: false,
+  isAppContext: false,
+  isClassCoach: false,
+  isFacilityCoach: false,
+  isLearner: true,
+  isFacilityAdmin: false,
+  userIsMultipleFacility: false,
+  getUserPermissions: {},
+  userFacilityId: undefined,
+  getUserKind: UserKinds.ANONYMOUS,
+  userHasPermissions: false,
+  session,
+  //state
+  ...session,
 };
 
 export function useUserMock(overrides = {}) {
-  return {
+  const mocks = {
     ...MOCK_DEFAULTS,
     ...overrides,
   };
+  const computedMocks = {};
+  for (const key in mocks) {
+    computedMocks[key] = computed(() => mocks[key]);
+  }
+  return computedMocks;
 }
 
 export default jest.fn(() => useUserMock());


### PR DESCRIPTION
## Summary
Follow up to #12027 that adds mocks for each new exported property

## References
#12027

## Reviewer guidance
Is every property mocked?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
