### PR TITLE
Resolve webpack loaders and dependencies relative to kolibri-tools

### DIFF
--- a/packages/kolibri-tools/lib/alias_import_resolver.js
+++ b/packages/kolibri-tools/lib/alias_import_resolver.js
@@ -1,4 +1,4 @@
-var path = require('path');
+var path = require('node:path');
 var resolve = require('resolve');
 var coreAliases = require('./apiSpecExportTools').coreAliases();
 var coreExternals = require('./apiSpecExportTools').coreExternals();

--- a/packages/kolibri-tools/lib/apiSpecExportTools.js
+++ b/packages/kolibri-tools/lib/apiSpecExportTools.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const resolve = require('resolve');
 const espree = require('espree');
 const escodegen = require('escodegen');

--- a/packages/kolibri-tools/lib/clean.js
+++ b/packages/kolibri-tools/lib/clean.js
@@ -1,5 +1,5 @@
-var path = require('path');
-var fs = require('fs');
+var path = require('node:path');
+var fs = require('node:fs');
 var logging = require('./logging');
 
 var deleteRecursive = function(p) {

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const program = require('commander');
 const checkVersion = require('check-node-version');
 const ini = require('ini');

--- a/packages/kolibri-tools/lib/compress.js
+++ b/packages/kolibri-tools/lib/compress.js
@@ -1,5 +1,5 @@
-const { constants, createGzip } = require('zlib');
-const { pipeline } = require('stream');
+const { constants, createGzip } = require('node:zlib');
+const { pipeline } = require('node:stream');
 const { createReadStream, createWriteStream } = require('fs');
 const logger = require('./logging');
 

--- a/packages/kolibri-tools/lib/ensureDist.js
+++ b/packages/kolibri-tools/lib/ensureDist.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 function ensureDist() {
   fs.mkdirSync(path.resolve(__dirname, '../dist'), { recursive: true });

--- a/packages/kolibri-tools/lib/lint.js
+++ b/packages/kolibri-tools/lib/lint.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const prettier = require('prettier');
 const compiler = require('vue-template-compiler');
 const ESLintCLIEngine = require('eslint').CLIEngine;

--- a/packages/kolibri-tools/lib/read_webpack_json.js
+++ b/packages/kolibri-tools/lib/read_webpack_json.js
@@ -1,6 +1,6 @@
-const fs = require('fs');
-const execSync = require('child_process').execSync;
-const path = require('path');
+const fs = require('node:fs');
+const execSync = require('node:child_process').execSync;
+const path = require('node:path');
 const temp = require('temp').track();
 
 const webpack_json = path.resolve(path.dirname(__filename), './webpack_json.py');

--- a/packages/kolibri-tools/lib/version.js
+++ b/packages/kolibri-tools/lib/version.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const execSync = require('child_process').execSync;
+const fs = require('node:fs');
+const execSync = require('node:child_process').execSync;
 const temp = require('temp').track();
 const readlineSync = require('readline-sync');
 const semver = require('semver');

--- a/packages/kolibri-tools/lib/webpack.config.base.js
+++ b/packages/kolibri-tools/lib/webpack.config.base.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const { VueLoaderPlugin } = require('vue-loader');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
@@ -17,28 +17,33 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
   const base_dir = path.join(__dirname, '..');
 
   const postCSSLoader = {
-    loader: 'postcss-loader',
+    loader: require.resolve('postcss-loader'),
     options: {
       postcssOptions: {
-        plugins: [['autoprefixer']],
+        plugins: [[require.resolve('autoprefixer')]],
       },
       sourceMap: !production,
     },
   };
 
   const cssLoader = {
-    loader: 'css-loader',
+    loader: require.resolve('css-loader'),
     options: { sourceMap: !production },
   };
 
   // for scss blocks
-  const sassLoaders = [cssInsertionLoader, cssLoader, postCSSLoader, 'sass-loader'];
+  const sassLoaders = [
+    cssInsertionLoader,
+    cssLoader,
+    postCSSLoader,
+    require.resolve('sass-loader'),
+  ];
 
   const rules = [
     // Transpilation and code loading rules
     {
       test: /\.vue$/,
-      loader: 'vue-loader',
+      loader: require.resolve('vue-loader'),
       options: {
         compilerOptions: {
           preserveWhitespace: false,
@@ -70,7 +75,7 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
   if (transpile) {
     rules.push({
       test: /\.(js|mjs)$/,
-      loader: 'babel-loader',
+      loader: require.resolve('babel-loader'),
       exclude: [
         // From: https://webpack.js.org/loaders/babel-loader/#exclude-libraries-that-should-not-be-transpiled
         // \\ for Windows, / for macOS and Linux
@@ -143,7 +148,7 @@ module.exports = ({ mode = 'development', hot = false, cache = false, transpile 
         'process.server': JSON.stringify(false),
       }),
       new webpack.ProvidePlugin({
-        process: 'process/browser',
+        process: require.resolve('process/browser'),
       }),
     ],
     devtool: production ? 'source-map' : 'cheap-module-source-map',

--- a/packages/kolibri-tools/lib/webpack.config.plugin.js
+++ b/packages/kolibri-tools/lib/webpack.config.plugin.js
@@ -7,7 +7,7 @@
  * to add test specific features.
  */
 
-const path = require('path');
+const path = require('node:path');
 const webpack = require('webpack');
 const { merge } = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');

--- a/packages/kolibri-tools/lib/webpackBundleTracker.js
+++ b/packages/kolibri-tools/lib/webpackBundleTracker.js
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-const path = require('path');
-const fs = require('fs');
-const crypto = require('crypto');
+const path = require('node:path');
+const fs = require('node:fs');
+const crypto = require('node:crypto');
 
 const defaults = require('lodash/defaults');
 const assign = require('lodash/assign');

--- a/packages/kolibri-tools/lib/webpackRtlPlugin.js
+++ b/packages/kolibri-tools/lib/webpackRtlPlugin.js
@@ -13,7 +13,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // Vendored and simplified from https://github.com/romainberger/webpack-rtl-plugin/blob/master/src/index.js
-const path = require('path');
+const path = require('node:path');
 const rtlcss = require('rtlcss');
 const webpack = require('webpack');
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Where you can find the dependencies for each of a project's dependencies depends on that project's package manager. With Studio using `pnpm`, the webpack config becomes relative to the Studio context, and Studio does not declare these dependencies, because it relies on `kolibri-tools` as a toolbox for all of them.

This PR updates the webpack config to use `require.resolve` on any Webpack loader or plugin that is passed by its string package name. It also updates `kolibri-tools` to import all node-specific dependencies using the `node:` protocol

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Required by: https://github.com/learningequality/studio/pull/4462

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Does anything break?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
