### PR TITLE
Update windows installer for another naming fix. This time for signed assets.

### DIFF
--- a/.github/workflows/pr_build_kolibri.yml
+++ b/.github/workflows/pr_build_kolibri.yml
@@ -48,10 +48,10 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.2
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.3
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      ref: v1.6.2
+      ref: v1.6.3
   apk:
     name: Build APK file
     needs: whl

--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -69,11 +69,11 @@ jobs:
   exe:
     name: Build EXE file
     needs: whl
-    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.2
+    uses: learningequality/kolibri-installer-windows/.github/workflows/build_exe.yml@v1.6.3
     with:
       whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
       release: true
-      ref: v1.6.2
+      ref: v1.6.3
     secrets:
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE }}
       KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.KOLIBRI_WINDOWS_INSTALLER_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
## Summary
Updates for latest update from https://github.com/learningequality/kolibri-installer-windows/pull/223 to fix signed windows asset naming