### PR TITLE
Add --manifest-only option to exportcontent command

### DIFF
--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -119,19 +119,13 @@ class Command(AsyncCommand):
         logger.info(
             "Exporting content for channel id {} to {}".format(channel_id, data_dir)
         )
-        exported_files = []
         with self.start_progress(
             total=total_bytes_to_transfer
         ) as overall_progress_update:
             for f in files:
                 if self.is_cancelled():
                     break
-
-                dest = self.export_file(f, data_dir, overall_progress_update)
-                if dest:
-                    exported_files.append(dest)
-
-        return exported_files
+                self.export_file(f, data_dir, overall_progress_update)
 
     def export_file(self, f, data_dir, overall_progress_update):
         filename = get_content_file_name(f)

--- a/kolibri/core/content/management/commands/exportcontent.py
+++ b/kolibri/core/content/management/commands/exportcontent.py
@@ -96,21 +96,9 @@ class Command(AsyncCommand):
 
         # dont copy files if we are only exporting the manifest
         if not options["manifest_only"]:
-            logger.info(
-                "Exporting content for channel id {} to {}".format(channel_id, data_dir)
+            self.copy_content_files(
+                channel_id, data_dir, files, total_bytes_to_transfer
             )
-            exported_files = []
-            with self.start_progress(
-                total=total_bytes_to_transfer
-            ) as overall_progress_update:
-                for f in files:
-
-                    if self.is_cancelled():
-                        break
-
-                    dest = self.export_file(f, data_dir, overall_progress_update)
-                    if dest:
-                        exported_files.append(dest)
 
         # Reraise any cancellation
         self.check_for_cancel()
@@ -126,6 +114,24 @@ class Command(AsyncCommand):
             channel_id, channel_metadata.version, nodes_queries_list
         )
         content_manifest.write(manifest_path)
+
+    def copy_content_files(self, channel_id, data_dir, files, total_bytes_to_transfer):
+        logger.info(
+            "Exporting content for channel id {} to {}".format(channel_id, data_dir)
+        )
+        exported_files = []
+        with self.start_progress(
+            total=total_bytes_to_transfer
+        ) as overall_progress_update:
+            for f in files:
+                if self.is_cancelled():
+                    break
+
+                dest = self.export_file(f, data_dir, overall_progress_update)
+                if dest:
+                    exported_files.append(dest)
+
+        return exported_files
 
     def export_file(self, f, data_dir, overall_progress_update):
         filename = get_content_file_name(f)

--- a/kolibri/core/content/test/test_import_export.py
+++ b/kolibri/core/content/test/test_import_export.py
@@ -2254,6 +2254,33 @@ class ExportContentTestCase(TestCase):
         )
         cancel_mock.assert_called_with()
 
+    @patch(
+        "kolibri.core.content.management.commands.exportcontent.Command.copy_content_files"
+    )
+    def test_manifest_only(
+        self,
+        copy_content_files_mock,
+        ContentManifestMock,
+        get_content_nodes_data_mock,
+        get_import_export_nodes_mock,
+    ):
+        get_content_nodes_data_mock.return_value = (
+            1,
+            [LocalFile.objects.values("id", "file_size", "extension").first()],
+            10,
+        )
+
+        # run with manifest-only option
+        call_command(
+            "exportcontent", self.the_channel_id, tempfile.mkdtemp(), manifest_only=True
+        )
+
+        copy_content_files_mock.assert_not_called()
+
+        ContentManifestMock.return_value.write.assert_called_once()
+
+        # Shall be enough mock assertions for now ?
+
 
 class TestFilesToTransfer(TestCase):
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Adds a new `--manifest-only` option to just export the manifest.json file instead of entire content data in the `exportcontent` command

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #10384 


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Run the below command:
```
kolibri manage exportcontent 0e173fca6e9052f8a474a2fb84055faf <path-to-export> --manifest-only
```
Observe only manifest.json getting generated, contrary to above command being used without `--manifest-only` which will also generate content

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
