### PR TITLE
Use router.replace for redirect.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -164,7 +164,6 @@
   import { AddDeviceForm } from 'kolibri.coreVue.componentSets.sync';
   import { ContentNodeKinds, ContentErrorConstants } from 'kolibri.coreVue.vuex.constants';
   import { crossComponentTranslator } from 'kolibri.utils.i18n';
-  import redirectBrowser from 'kolibri.utils.redirectBrowser';
   import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
   import client from 'kolibri.client';
   import urls from 'kolibri.urls';
@@ -520,7 +519,7 @@
         if (this.content) {
           const id = this.content.id;
           if (!this.isUserLoggedIn && (this.lessonId || this.classId)) {
-            redirectBrowser(window.location.href.split('?')[0]);
+            this.$router.replace({ ...this.$route, query: null });
           }
           client({
             method: 'get',


### PR DESCRIPTION
## Summary
Uses router.replace instead of redirect

## References
Follow up to #12039 to avoid unnecessary page loads

## Reviewer guidance
Ensure your device is setup to allow anonymous resource browsing.
Go to a resource in a lesson as a logged in user.
Copy the URL.
Logout.
Go to the URL you copied.
See that it redirects without a page reload, and without the pasted URL appearing in the browser history.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
