### PR TITLE
Fix issue with duplicate lesson from join.

### DIFF
--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1537,7 +1537,8 @@ class UserContentNodeFilter(ContentNodeFilter):
             lesson = Lesson.objects.filter(
                 lesson_assignments__collection__membership__user=self.request.user,
                 is_active=True,
-            ).get(pk=value)
+                pk=value,
+            ).first()
             node_ids = list(map(lambda x: x["contentnode_id"], lesson.resources))
             return queryset.filter(pk__in=node_ids)
         except Lesson.DoesNotExist:

--- a/kolibri/core/content/api.py
+++ b/kolibri/core/content/api.py
@@ -1533,16 +1533,15 @@ class UserContentNodeFilter(ContentNodeFilter):
     popular = BooleanFilter(method="filter_by_popular")
 
     def filter_by_lesson(self, queryset, name, value):
-        try:
-            lesson = Lesson.objects.filter(
-                lesson_assignments__collection__membership__user=self.request.user,
-                is_active=True,
-                pk=value,
-            ).first()
-            node_ids = list(map(lambda x: x["contentnode_id"], lesson.resources))
-            return queryset.filter(pk__in=node_ids)
-        except Lesson.DoesNotExist:
+        lesson = Lesson.objects.filter(
+            lesson_assignments__collection__membership__user=self.request.user,
+            is_active=True,
+            pk=value,
+        ).first()
+        if lesson is None:
             return queryset.none()
+        node_ids = list(map(lambda x: x["contentnode_id"], lesson.resources))
+        return queryset.filter(pk__in=node_ids)
 
     def filter_by_resume(self, queryset, name, value):
         user = self.request.user


### PR DESCRIPTION
## Summary
* If a lesson is assigned through multiple collections to a learner, then a get call with a PK can fail with MultipleObjectsReturned
* Instead, after filtering with the pk here, call first to only return one instance
* Adds basic tests for lesson filtering, covering a simple filter, filtering by a lesson that a user does not have permissions for, and filtering by a lesson that has multiple assignment

## References
Unreported

## Reviewer guidance
Create a lesson, assign it to a learner individually and also to a group the learner is a member of.
Navigate to view the lesson in the learn page, confirm that it does not error.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
