### PR TITLE
Next attempt at fixing GCS upload

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -128,36 +128,10 @@ jobs:
       GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-  block_release_step:
-  # This step ties to the release environment which requires manual approval
-  # before it can execute. Once manual approval has been granted, the release is
-  # unblocked and all the subsequent steps in this workflow will happen.
-    name: Job to block publish of a release until it has been manually approved
-    if: ${{ !github.event.release.prerelease }}
-    needs: [whl, pex, dmg, deb, exe, test_pypi_upload]
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - run: echo "Release now publishing!"
-  pypi_upload:
-    name: Upload to PyPi
-    if: ${{ !github.event.release.prerelease }}
-    needs: [whl, block_release_step]
-    uses: ./.github/workflows/pypi_upload.yml
-    with:
-      whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
-      tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
-      test: false
-    secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
   gcs_upload:
-    name: Upload to Google Cloud Storage
-    if: ${{ !github.event.release.prerelease }}
+    name: Upload to Google Cloud Storage for LE Downloads
     runs-on: ubuntu-latest
-    needs: [block_release_step, whl, pex, dmg, deb, exe, zip, apk]
+    needs: [whl, pex, dmg, deb, exe, zip, apk]
     strategy:
       matrix:
         filename: [
@@ -184,14 +158,54 @@ jobs:
     - name: Upload files to Google Cloud Storage
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: 'dist/${{ matrix.filename }}/${{ matrix.filename }}'
-        destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}/${{ matrix.filename }}'
+        path: 'dist/${{ matrix.filename }}'
+        destination: '${{ secrets.KOLIBRI_PUBLIC_RELEASE_GCS_BUCKET }}/downloads/kolibri/${{ github.event.release.name }}'
+  block_release_step:
+  # This step ties to the release environment which requires manual approval
+  # before it can execute. Once manual approval has been granted, the release is
+  # unblocked and all the subsequent steps in this workflow will happen.
+    name: Job to block publish of a release until it has been manually approved
+    if: ${{ !github.event.release.prerelease }}
+    needs: [whl, pex, dmg, deb, exe, test_pypi_upload]
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - run: echo "Release now publishing!"
+  pypi_upload:
+    name: Upload to PyPi
+    if: ${{ !github.event.release.prerelease }}
+    needs: [whl, block_release_step]
+    uses: ./.github/workflows/pypi_upload.yml
+    with:
+      whl-file-name: ${{ needs.whl.outputs.whl-file-name }}
+      tar-file-name: ${{ needs.whl.outputs.tar-file-name }}
+      test: false
+    secrets:
+      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+  bck_gcs_upload:
+    name: Upload WHL file to Google Cloud Storage for BCK
+    if: ${{ !github.event.release.prerelease && github.event.release.name == 'latest'}}
+    runs-on: ubuntu-latest
+    needs: [block_release_step, whl]
+    steps:
+    - name: Download WHL artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ needs.whl.outputs.whl-file-name }}
+        path: dist
+    - uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GH_UPLOADER_GCP_SA_CREDENTIALS }}'
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v2'
     - name: Upload to BCK bucket
-      if: ${{ github.event.release.name == 'latest' }} && ${{ endsWith(matrix.filename, '.whl') }}
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: 'dist/${{ matrix.filename }}/${{ matrix.filename }}'
-        destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}/${{ matrix.filename }}'
+        path: 'dist/${{ needs.whl.outputs.whl-file-name }}'
+        destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}'
   android_release:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}


### PR DESCRIPTION
## Summary
* My previous attempt to fix this was misguided - I assumed the issue was caused by the way the download artifact action was handling artifacts, but that was not the case.
* Separate out BCK and other artifact upload.
* Upload artifacts to LE downloads for all releases including prereleases, so we can test this sooner, and also get ready to create redirect links for prereleases.
* Attempt to fix artifact upload by reverting previous change and changing destination argument for the google cloud upload seems promising due to this similar report https://github.com/google-github-actions/upload-cloud-storage/issues/353

## References
Fixes #11908


## Reviewer guidance
Clearly I was wrong last time - a quick read through and then we test this on prereleases is probably best!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
