### PR TITLE
Do a correct check to know if the facility has been imported

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -163,12 +163,17 @@
         deviceFilters.push(useDeviceChannelFilter({ id: props.filterByChannelId }));
       }
 
-      if (props.filterByFacilityId !== null || props.filterByFacilityCanSignUp !== null) {
+      if (
+        props.filterByFacilityId !== null ||
+        props.filterByFacilityCanSignUp !== null ||
+        props.filterByOnMyOwnFacility !== null
+      ) {
         apiParams.subset_of_users_device = false;
         deviceFilters.push(
           useDeviceFacilityFilter({
             id: props.filterByFacilityId,
             learner_can_sign_up: props.filterByFacilityCanSignUp,
+            on_my_own_setup: props.filterByOnMyOwnFacility,
           })
         );
       }
@@ -240,6 +245,12 @@
       // When looking for devices for which a learner can sign up
       // eslint-disable-next-line kolibri/vue-no-unused-properties
       filterByFacilityCanSignUp: {
+        type: Boolean,
+        default: null,
+      },
+      // In the setup wizard, to exclude importiing facilities that are "On My Own"
+      // eslint-disable-next-line kolibri/vue-no-unused-properties
+      filterByOnMyOwnFacility: {
         type: Boolean,
         default: null,
       },

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
@@ -12,6 +12,7 @@
       :filterByFacilityId="filterByFacilityId"
       :filterLODAvailable="filterLODAvailable"
       :filterByFacilityCanSignUp="filterByFacilityCanSignUp"
+      :filterByOnMyOwnFacility="filterByOnMyOwnFacility"
       :selectedId="addedAddressId"
       :formDisabled="$attrs.selectAddressDisabled"
       @click_add_address="goToAddAddress"
@@ -52,6 +53,11 @@
       },
       // When looking for devices for which a learner can sign up
       filterByFacilityCanSignUp: {
+        type: Boolean,
+        default: null,
+      },
+      // When looking for facilities to import in the setup wizard
+      filterByOnMyOwnFacility: {
         type: Boolean,
         default: null,
       },

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -172,9 +172,14 @@ function useAsyncDeviceFilter(filterFunction) {
  * Produces a function that resolves with a boolean for a device that has the specified facility
  * @param {string|null} [id]
  * @param {bool|null} [learner_can_sign_up]
+ * @param {bool|null} [on_my_own_setup]
  * @return {function(NetworkLocation): Promise<boolean>}
  */
-export function useDeviceFacilityFilter({ id = null, learner_can_sign_up = null }) {
+export function useDeviceFacilityFilter({
+  id = null,
+  learner_can_sign_up = null,
+  on_my_own_setup = null,
+}) {
   const filters = {};
 
   // If `id` is an empty string, we don't want to filter by that
@@ -184,6 +189,10 @@ export function useDeviceFacilityFilter({ id = null, learner_can_sign_up = null 
 
   if (learner_can_sign_up !== null) {
     filters.learner_can_sign_up = learner_can_sign_up;
+  }
+
+  if (on_my_own_setup !== null) {
+    filters.on_my_own_setup = on_my_own_setup;
   }
 
   if (Object.keys(filters).length === 0) {

--- a/kolibri/core/auth/serializers.py
+++ b/kolibri/core/auth/serializers.py
@@ -170,12 +170,18 @@ class FacilitySerializer(serializers.ModelSerializer):
 class PublicFacilitySerializer(serializers.ModelSerializer):
     learner_can_login_with_no_password = serializers.SerializerMethodField()
     learner_can_sign_up = serializers.SerializerMethodField()
+    on_my_own_setup = serializers.SerializerMethodField()
 
     def get_learner_can_login_with_no_password(self, instance):
         return instance.dataset.learner_can_login_with_no_password
 
     def get_learner_can_sign_up(self, instance):
         return instance.dataset.learner_can_sign_up
+
+    def get_on_my_own_setup(self, instance):
+        if instance.dataset.extra_fields is not None:
+            return instance.dataset.extra_fields.get("on_my_own_setup", False)
+        return False
 
     class Meta:
         model = Facility
@@ -185,6 +191,7 @@ class PublicFacilitySerializer(serializers.ModelSerializer):
             "name",
             "learner_can_login_with_no_password",
             "learner_can_sign_up",
+            "on_my_own_setup",
         )
 
 

--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -41,6 +41,8 @@
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
 
+  const facilityImported = 'FACILITY_IS_IMPORTED';
+
   const Steps = Object.freeze({
     WELCOME: 'WELCOME',
     PERMISSIONS_CHANGE: 'PERMISSIONS_CHANGE',
@@ -70,12 +72,9 @@
     },
     computed: {
       ...mapGetters(['isUserLoggedIn']),
-      // Assume that if first facility has non-null 'last_successful_sync'
-      // field, then it was imported in Setup Wizard.
-      // This used to determine Select Source workflow to enter into
       importedFacility() {
         const [facility] = this.$store.state.core.facilities;
-        if (facility && facility.last_successful_sync !== null) {
+        if (facility && window.sessionStorage.getItem(facilityImported) === 'true') {
           return facility;
         }
         return null;

--- a/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
+++ b/kolibri/plugins/setup_wizard/assets/src/machines/wizardMachine.js
@@ -74,6 +74,7 @@ const initialContext = {
   importedUsers: [],
   firstImportedLodUser: null,
   facilitiesOnDeviceCount: null,
+  isImportedFacility: false,
 };
 
 export const wizardMachine = createMachine(
@@ -307,6 +308,7 @@ export const wizardMachine = createMachine(
             on: {
               BACK: 'selectSuperAdminAccountForm',
             },
+            exit: 'setImportedFacility',
           },
         },
         // Listener on the importFacility state; typically this would be above `states` but
@@ -537,6 +539,11 @@ export const wizardMachine = createMachine(
        * This effectively resets the machine's state
        */
       resetContext: assign(initialContext),
+      setImportedFacility: assign({
+        isImportedFacility: () => {
+          return true;
+        },
+      }),
     },
     guards: {
       // Functions used to return a true/false value. When the functions are called, they are passed

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectSuperAdminAccountForm.vue
@@ -152,17 +152,17 @@
       },
       resetFormAndRefocus() {
         this.shouldValidate = false;
-        if (this.$refs.password) {
+        if (this.$refs.passwordTextbox) {
           // If password was set to the facility.password in handler
           if (this.selected.label !== this.facility.username) {
-            this.$refs.password.resetAndFocus();
+            this.$refs.passwordTextbox.resetAndFocus();
           }
         }
       },
       handleClickNextImportedUser() {
         this.error = false;
-        if (!this.passwordValid) {
-          this.$refs.password.focus();
+        if (!this.passwordValid && 'passwordTextbox' in this.$refs) {
+          this.$refs.passwordTextbox.focus();
           return;
         }
         return FacilityImportResource.grantsuperuserpermissions({

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -19,7 +19,6 @@
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
-      :filterByFacilityCanSignUp="true"
       :filterByOnMyOwnFacility="false"
       @cancel="showSelectAddressModal = false"
       @submit="handleContinueImport"

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SetUpLearningFacilityForm.vue
@@ -19,6 +19,8 @@
     />
     <SelectDeviceModalGroup
       v-if="showSelectAddressModal"
+      :filterByFacilityCanSignUp="true"
+      :filterByOnMyOwnFacility="false"
       @cancel="showSelectAddressModal = false"
       @submit="handleContinueImport"
     />

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/SettingUpKolibri.vue
@@ -194,7 +194,12 @@
         })
           .then(() => {
             const welcomeDismissalKey = 'DEVICE_WELCOME_MODAL_DISMISSED';
+            const facilityImported = 'FACILITY_IS_IMPORTED';
             window.sessionStorage.setItem(welcomeDismissalKey, false);
+            window.sessionStorage.setItem(
+              facilityImported,
+              this.wizardContext('isImportedFacility')
+            );
 
             Lockr.rm('savedState'); // Clear out saved state machine
             redirectBrowser();


### PR DESCRIPTION
## Summary
Using the FacilityViewset api to check if a facility has been imported after the setup wizard finishes does not work because in https://github.com/learningequality/kolibri/blob/develop/kolibri/core/auth/api.py#L617-L629 it checks PUSH transfers, that don't happen when importing a facility.

This PR changes the setup wizard behavior to solve it.
It also fixes an error observed while testing the wizard due to a incorrect ref name.


## References
Closes: #10959
Closes: #11769

## Reviewer guidance

- do tests pass?
- After running the setup wizard and importing a facility, does a modal to select a source to install resources appear?

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
