### PR TITLE
Quiz creation: Snackbar improvements

### DIFF
--- a/kolibri/plugins/coach/assets/src/app.js
+++ b/kolibri/plugins/coach/assets/src/app.js
@@ -42,11 +42,13 @@ class CoachToolsModule extends KolibriApp {
         this.store.dispatch('loading');
       }
       const promises = [];
+
       // Clear the snackbar at every navigation to prevent it from re-appearing
       // when the next page component mounts.
-      if (this.store.state.core.snackbar.isVisible) {
+      if (this.store.state.core.snackbar.isVisible && !skipLoading.includes(to.name)) {
         this.store.dispatch('clearSnackbar');
       }
+
       this.store.commit('SET_PAGE_NAME', to.name);
       if (
         to.name &&

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -225,7 +225,7 @@
               :tooltip="coreString('deleteAction')"
               :aria-label="coreString('deleteAction')"
               :disabled="selectedActiveQuestions.length === 0"
-              @click="deleteActiveSelectedQuestions()"
+              @click="() => deleteQuestions()"
             />
           </template>
           <template #default="{ toggleItemState, isItemExpanded }">
@@ -396,6 +396,8 @@
         sectionDeletedNotification$,
         deleteConfirmation$,
         updateResources$,
+        changesSavedSuccessfully$,
+        questionsDeletedNotification$,
       } = enhancedQuizManagementStrings;
 
       const {
@@ -452,6 +454,8 @@
         questionList$,
         sectionDeletedNotification$,
         deleteConfirmation$,
+        changesSavedSuccessfully$,
+        questionsDeletedNotification$,
 
         toggleQuestionInSelection,
         selectAllQuestions,
@@ -633,6 +637,7 @@
           questions: newArray,
         };
         this.updateSection(payload);
+        this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
         this.dragActive = false;
       },
       handleAddSection() {
@@ -647,6 +652,16 @@
       openSelectResources(section_id) {
         const route = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES, { section_id });
         this.$router.push(route);
+      },
+      deleteQuestions() {
+        const count = this.selectedActiveQuestions.length;
+        this.deleteActiveSelectedQuestions();
+        this.$store.dispatch(
+          'createSnackbar',
+          this.questionsDeletedNotification$({
+            count,
+          })
+        );
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -212,10 +212,8 @@
         const count = replacements.value.length;
         router.replace({
           name: PageNames.EXAM_CREATION_ROOT,
-          query: {
-            snackbar: numberOfQuestionsReplaced$({ count }),
-          },
         });
+        this.$store.dispatch('createSnackbar', numberOfQuestionsReplaced$({ count }));
       }
 
       function confirmReplacement() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -595,8 +595,8 @@
 
         this.$router.replace({
           ...this.prevRoute,
-          ...{ query: { snackbar: this.changesSavedSuccessfully$() } },
         });
+        this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
       },
       selectionMetadata(content) {
         if (content.kind === ContentNodeKinds.TOPIC) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -336,8 +336,8 @@
         removeSection(showDeleteConfirmation.value);
         router.replace({
           name: PageNames.EXAM_CREATION_ROOT,
-          query: { snackbar: sectionDeletedNotification$({ section_title }) },
         });
+        this.$store.dispatch('createSnackbar', sectionDeletedNotification$({ section_title }));
       }
 
       function handleDeleteSection(section_id) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -350,7 +350,7 @@
       const description = ref(activeSection.value.description);
       const section_title = ref(activeSection.value.section_title);
 
-      const formDataHasChanged = computed(() => {
+      const activeSectionChanged = computed(() => {
         return !isEqual(
           {
             learners_see_fixed_order: learners_see_fixed_order.value,
@@ -367,6 +367,19 @@
         );
       });
 
+      const sectionOrderList = ref(allSections.value);
+
+      const sectionOrderChanged = computed(() => {
+        return !isEqual(
+          allSections.value.map(section => section.section_id),
+          sectionOrderList.value.map(section => section.section_id)
+        );
+      });
+
+      const formDataHasChanged = computed(() => {
+        return activeSectionChanged.value || sectionOrderChanged.value;
+      });
+
       const { windowIsLarge, windowIsSmall } = useKResponsiveWindow();
 
       const resourceButtonLabel = computed(() => {
@@ -379,6 +392,7 @@
 
       return {
         formDataHasChanged,
+        sectionOrderChanged,
         showCloseConfirmation,
         showDeleteConfirmation,
         handleCancelClose,
@@ -389,7 +403,7 @@
         channels,
         activeSection,
         activeResourcePool,
-        allSections,
+        sectionOrderList,
         updateSection,
         updateQuiz,
         handleDeleteSection,
@@ -440,12 +454,6 @@
       dividerStyle() {
         return `color : ${this.$themeTokens.fineLine}`;
       },
-      /**
-       * @returns { QuizSection[] }
-       */
-      sectionOrderList() {
-        return this.allSections;
-      },
       draggableStyle() {
         return {
           backgroundColor: this.$themeTokens.surface,
@@ -473,7 +481,7 @@
     },
     methods: {
       handleSectionSort(e) {
-        this.updateQuiz({ question_sources: e.newArray });
+        this.sectionOrderList = e.newArray;
       },
       applySettings() {
         this.updateSection({
@@ -483,6 +491,11 @@
           question_count: this.question_count,
           learners_see_fixed_order: this.learners_see_fixed_order,
         });
+        if (this.sectionOrderChanged) {
+          this.updateQuiz({
+            question_sources: this.sectionOrderList,
+          });
+        }
         this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -98,17 +98,6 @@
         });
       },
     },
-    beforeRouteUpdate(to, from, next) {
-      // Handle snackbar query param and show message - particularly for when closing the side panel
-      // and saying "Action Succeeded"
-      if (to.query.snackbar) {
-        this.$store.dispatch('createSnackbar', to.query.snackbar).then(() => {
-          delete to.query.snackbar;
-          next(to);
-        });
-      }
-      next();
-    },
     mounted() {
       this.$store.dispatch('notLoading');
     },

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -190,6 +190,10 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message: "Section '{ section_title }' deleted",
     context: 'A snackbar message that appears when the user deletes a section',
   },
+  questionsDeletedNotification: {
+    message: '{ count, number } { count, plural, one { question } other { questions }} deleted',
+    context: 'A snackbar message that appears when the user deletes questions',
+  },
   updateResources: {
     message: 'Update resources',
   },


### PR DESCRIPTION
## Summary
Replace snackbar support in route.query with direct calls to the `createSnackbar` action. And ensures that these are not deleted when entering any of the `skipLoading` routes

## References
Closes #12038.

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Play around with the Quiz Editor saving sections, replacing questions, removing sections, go back from the Side Panel, and snackbar should behave consistently.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
