### PR TITLE
Exam report: Avoid loading on question change

### DIFF
--- a/kolibri/plugins/learn/assets/src/modules/examReportViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examReportViewer/handlers.js
@@ -2,11 +2,49 @@ import { getExamReport } from 'kolibri.utils.exams';
 import router from 'kolibri.coreVue.router';
 import { ClassesPageNames } from '../../constants';
 
+function getExamReportFromState(state, params) {
+  const {
+    examReportViewer: {
+      exam: { id: stateExamId } = {},
+      questions = [],
+      exerciseContentNodes = [],
+    } = {},
+  } = state;
+
+  const { examId, questionNumber, tryIndex, questionInteraction } = params;
+
+  if (stateExamId !== examId) {
+    return null;
+  }
+
+  const exercise = exerciseContentNodes.find(
+    node => node.id === questions[questionNumber].exercise_id
+  );
+  if (!exercise) {
+    return null;
+  }
+
+  return {
+    ...state.examReportViewer,
+    exercise,
+    tryIndex: Number(tryIndex),
+    questionNumber: Number(questionNumber),
+    interactionIndex: Number(questionInteraction),
+  };
+}
+
 export function showExamReport(store, params) {
   const { classId, examId, tryIndex, questionNumber, questionInteraction } = params;
-  store.commit('CORE_SET_PAGE_LOADING', true);
   store.commit('SET_PAGE_NAME', ClassesPageNames.EXAM_REPORT_VIEWER);
 
+  const examReportFromState = getExamReportFromState(store.state, params);
+  if (examReportFromState) {
+    store.commit('examReportViewer/SET_STATE', examReportFromState);
+    store.commit('CORE_SET_ERROR', null);
+    return;
+  }
+
+  store.commit('CORE_SET_PAGE_LOADING', true);
   const examReportPromise = getExamReport(examId, tryIndex, questionNumber, questionInteraction);
   Promise.all([examReportPromise]).then(
     ([examReport]) => {


### PR DESCRIPTION
## Summary
Avoid fetching exam resources again if they are already loaded.

## References
Closes #12062

## Screenshots


https://github.com/learningequality/kolibri/assets/51239030/954b6fe8-de64-4dec-b425-2f3589e9fe6b



## Reviewer guidance

1. Take an exam as a learner.
2. Review different exam reports and check that everything is loading correctly.
3. Switch between questions, attempts and question interactions and the loading state should not appear


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
