### PR TITLE
Replace requests with NetworkClient

### DIFF
--- a/kolibri/core/analytics/tasks.py
+++ b/kolibri/core/analytics/tasks.py
@@ -1,12 +1,12 @@
 import logging
 
 from django.db import connection
-from requests.exceptions import ConnectionError
-from requests.exceptions import RequestException
-from requests.exceptions import Timeout
 
 from kolibri.core.analytics.utils import DEFAULT_SERVER_URL
 from kolibri.core.analytics.utils import ping_once
+from kolibri.core.discovery.utils.network.errors import NetworkLocationConnectionFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseTimeout
 from kolibri.core.tasks.decorators import register_task
 from kolibri.core.tasks.exceptions import JobRunning
 from kolibri.core.tasks.main import job_storage
@@ -25,21 +25,21 @@ DEFAULT_PING_INTERVAL = 24 * 60
 def _ping(started, server, checkrate):
     try:
         ping_once(started, server=server)
-    except ConnectionError:
+    except NetworkLocationConnectionFailure:
         logger.warning(
             "Ping failed (could not connect). Trying again in {} minutes.".format(
                 checkrate
             )
         )
         raise
-    except Timeout:
+    except NetworkLocationResponseTimeout:
         logger.warning(
             "Ping failed (connection timed out). Trying again in {} minutes.".format(
                 checkrate
             )
         )
         raise
-    except RequestException as e:
+    except NetworkLocationResponseFailure as e:
         logger.warning(
             "Ping failed ({})! Trying again in {} minutes.".format(e, checkrate)
         )

--- a/kolibri/core/analytics/test/test_ping.py
+++ b/kolibri/core/analytics/test/test_ping.py
@@ -18,8 +18,8 @@ def load_zipped_json(data):
     return json.loads(data)
 
 
-def mocked_requests_post_wrapper(json_data, status_code):
-    def mocked_requests_post(*args, **kwargs):
+def mocked_network_client_post_wrapper(json_data, status_code):
+    def mocked_network_client_post(*args, **kwargs):
         class MockResponse(Response):
             def __init__(self):
                 self.json_data = json_data
@@ -27,19 +27,21 @@ def mocked_requests_post_wrapper(json_data, status_code):
                 self._content = json.dumps(json_data).encode()
                 self.reason = ""
                 self.url = args[0]
+                if 400 <= self.status_code < 600:
+                    self.raise_for_status()
 
             def json(self):
                 return self.json_data
 
         return MockResponse()
 
-    return mocked_requests_post
+    return mocked_network_client_post
 
 
 class PingCommandTestCase(BaseDeviceSetupMixin, TransactionTestCase):
     @mock.patch(
-        "kolibri.core.analytics.utils.requests.post",
-        side_effect=mocked_requests_post_wrapper({"id": 17}, 200),
+        "kolibri.core.discovery.utils.network.client.NetworkClient.post",
+        side_effect=mocked_network_client_post_wrapper({"id": 17}, 200),
     )
     def test_ping_succeeds(self, post_mock):
         call_command("ping", once=True)
@@ -49,8 +51,8 @@ class PingCommandTestCase(BaseDeviceSetupMixin, TransactionTestCase):
         assert load_zipped_json(post_mock.call_args_list[1][1]["data"])["pi"] == 17
 
     @mock.patch(
-        "kolibri.core.analytics.utils.requests.post",
-        side_effect=mocked_requests_post_wrapper({}, 400),
+        "kolibri.core.discovery.utils.network.client.NetworkClient.post",
+        side_effect=mocked_network_client_post_wrapper({}, 400),
     )
     def test_ping_fails(self, post_mock):
         with self.assertRaises(CommandError):

--- a/kolibri/core/auth/management/commands/fullfacilitysync.py
+++ b/kolibri/core/auth/management/commands/fullfacilitysync.py
@@ -1,6 +1,5 @@
 import getpass
 
-import requests
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -18,8 +17,9 @@ from kolibri.core.auth.models import FacilityUser
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import provision_device
+from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.tasks.management.commands.base import AsyncCommand
-from kolibri.core.utils.urls import reverse_remote
+from kolibri.core.utils.urls import reverse_path
 
 
 class Command(AsyncCommand):
@@ -34,9 +34,9 @@ class Command(AsyncCommand):
 
     def get_dataset_id(self, base_url, dataset_id):
         # get list of facilities and if more than 1, display all choices to user
-        facility_url = reverse_remote(base_url, "kolibri:core:publicfacility-list")
-        facility_resp = requests.get(facility_url)
-        facility_resp.raise_for_status()
+        client = NetworkClient.build_for_address(base_url)
+        facility_url = reverse_path("kolibri:core:publicfacility-list")
+        facility_resp = client.get(facility_url)
         facilities = facility_resp.json()
         if len(facilities) > 1 and not dataset_id:
             message = "Please choose a facility to sync with:\n"

--- a/kolibri/core/auth/management/commands/registerfacility.py
+++ b/kolibri/core/auth/management/commands/registerfacility.py
@@ -2,11 +2,12 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
 from morango.models import Certificate
-from requests import exceptions
 
 from kolibri.core import error_constants
 from kolibri.core.auth.management.utils import confirm_or_exit
 from kolibri.core.auth.management.utils import get_facility
+from kolibri.core.discovery.utils.network.errors import NetworkClientError
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 from kolibri.core.utils.portal import registerfacility
 
 
@@ -42,7 +43,7 @@ class Command(BaseCommand):
                 )
             )
         # an invalid nonce/register response
-        except exceptions.HTTPError as e:
+        except NetworkLocationResponseFailure as e:
             error = e.response.json()[0]
             message = error["metadata"].get("message") or e.response.text
             # handle facility not existing response from portal server
@@ -71,5 +72,5 @@ class Command(BaseCommand):
                 )
             )
         # handle any other invalid response
-        except exceptions.RequestException as e:
+        except NetworkClientError as e:
             raise CommandError(e)

--- a/kolibri/core/auth/management/utils.py
+++ b/kolibri/core/auth/management/utils.py
@@ -9,7 +9,6 @@ import sys
 from contextlib import contextmanager
 from functools import wraps
 
-import requests
 from django.core.management.base import CommandError
 from morango.models import Certificate
 from morango.models import InstanceIDModel
@@ -37,7 +36,7 @@ from kolibri.core.discovery.utils.network.errors import URLParseError
 from kolibri.core.tasks.exceptions import UserCancelledError
 from kolibri.core.tasks.management.commands.base import AsyncCommand
 from kolibri.core.utils.lock import db_lock_sqlite_only
-from kolibri.core.utils.urls import reverse_remote
+from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.data import bytes_for_humans
 
 
@@ -125,9 +124,9 @@ def get_facility(facility_id=None, noninteractive=False):
 
 def get_facility_dataset_id(baseurl, identifier=None, noninteractive=False):
     # get list of facilities and if more than 1, display all choices to user
-    facility_url = reverse_remote(baseurl, "kolibri:core:publicfacility-list")
-    response = requests.get(facility_url)
-    response.raise_for_status()
+    client = NetworkClient.build_for_address(baseurl)
+    facility_url = reverse_path("kolibri:core:publicfacility-list")
+    response = client.get(facility_url)
     facilities = response.json()
     if not facilities:
         raise CommandError("There are no facilities available at: {}".format(baseurl))

--- a/kolibri/core/auth/test/sync_utils.py
+++ b/kolibri/core/auth/test/sync_utils.py
@@ -9,16 +9,16 @@ import tempfile
 import time
 import uuid
 
-import requests
 from django.conf import settings
 from django.db import connection
 from django.db import connections
 from django.utils.functional import wraps
 from morango.models.core import DatabaseIDModel
-from requests.exceptions import RequestException
 
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
+from kolibri.core.discovery.utils.network.client import NetworkClient
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 
 # custom Morango instance info used in tests
 CUSTOM_INSTANCE_INFO = {"kolibri": "0.14.7"}
@@ -119,12 +119,13 @@ class KolibriServer(object):
         )
 
     def _wait_for_server_start(self, timeout=20):
+        client = NetworkClient.build_for_address(self.baseurl, timeout=3)
         for i in range(timeout * 2):
             try:
-                resp = requests.get(self.baseurl + "api/public/info/", timeout=3)
+                resp = client.get("api/public/info/")
                 if resp.status_code > 0:
                     return
-            except RequestException:
+            except NetworkLocationResponseFailure:
                 pass
             time.sleep(0.5)
 

--- a/kolibri/core/auth/test/test_register_facility.py
+++ b/kolibri/core/auth/test/test_register_facility.py
@@ -18,7 +18,7 @@ class RegisterFacilityTestCase(TestCase):
         self.token = "token"
         FacilityFactory()
 
-    @mock.patch("requests.post")
+    @mock.patch("kolibri.core.discovery.utils.network.client.NetworkClient.post")
     def test_no_owned_certificates(self, post_mock):
         post_mock.json.return_value = {"id": uuid.uuid4().hex}
         cert = Certificate.objects.first()

--- a/kolibri/core/auth/utils/sync.py
+++ b/kolibri/core/auth/utils/sync.py
@@ -9,7 +9,6 @@ from django.db.models.expressions import When
 from morango.models import ScopeDefinition
 from morango.models import SyncSession
 from morango.sync.controller import MorangoProfileController
-from requests.exceptions import HTTPError
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import PermissionDenied
 
@@ -20,6 +19,7 @@ from kolibri.core.auth.constants.morango_sync import PROFILE_FACILITY_DATA
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
 from kolibri.core.auth.management.utils import get_client_and_server_certs
 from kolibri.core.auth.management.utils import get_facility_dataset_id
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
 
 
 def find_soud_sync_sessions(using=None, **filters):
@@ -102,7 +102,7 @@ def validate_and_create_sync_credentials(
             facility_id=facility_id,
             noninteractive=True,
         )
-    except (CommandError, HTTPError) as e:
+    except (CommandError, NetworkLocationResponseFailure) as e:
         if not username and not password:
             raise PermissionDenied(
                 "Username and password required to validate sync credentials, and were not supplied"

--- a/kolibri/core/content/test/test_file_availability.py
+++ b/kolibri/core/content/test/test_file_availability.py
@@ -140,20 +140,24 @@ class LocalFileRemote(TransactionTestCase):
         process_cache.clear()
         self.location = NetworkLocation.objects.create(base_url="test")
 
-    @patch("kolibri.core.content.utils.file_availability.requests")
-    def test_set_one_file(self, requests_mock):
-        requests_mock.post.return_value.status_code = 200
-        requests_mock.post.return_value.content = "1"
+    @patch("kolibri.core.content.utils.file_availability.NetworkClient")
+    def test_set_one_file(self, networkclient_mock):
+        network_client = networkclient_mock.build_for_address.return_value
+        network_client.base_url = "test"
+        network_client.post.return_value.status_code = 200
+        network_client.post.return_value.content = "1"
         checksums = get_available_checksums_from_remote(
             test_channel_id, self.location.id
         )
         self.assertEqual(len(checksums), 1)
         self.assertTrue(local_file_qs.filter(id=list(checksums)[0]).exists())
 
-    @patch("kolibri.core.content.utils.file_availability.requests")
-    def test_set_two_files_in_channel(self, requests_mock):
-        requests_mock.post.return_value.status_code = 200
-        requests_mock.post.return_value.content = "3"
+    @patch("kolibri.core.content.utils.file_availability.NetworkClient")
+    def test_set_two_files_in_channel(self, networkclient_mock):
+        network_client = networkclient_mock.build_for_address.return_value
+        network_client.base_url = "test"
+        network_client.post.return_value.status_code = 200
+        network_client.post.return_value.content = "3"
         checksums = get_available_checksums_from_remote(
             test_channel_id, self.location.id
         )
@@ -161,27 +165,33 @@ class LocalFileRemote(TransactionTestCase):
         self.assertTrue(local_file_qs.filter(id=list(checksums)[0]).exists())
         self.assertTrue(local_file_qs.filter(id=list(checksums)[1]).exists())
 
-    @patch("kolibri.core.content.utils.file_availability.requests")
-    def test_set_two_files_none_in_channel(self, requests_mock):
-        requests_mock.post.return_value.status_code = 200
-        requests_mock.post.return_value.content = "0"
+    @patch("kolibri.core.content.utils.file_availability.NetworkClient")
+    def test_set_two_files_none_in_channel(self, networkclient_mock):
+        network_client = networkclient_mock.build_for_address.return_value
+        network_client.base_url = "test"
+        network_client.post.return_value.status_code = 200
+        network_client.post.return_value.content = "0"
         checksums = get_available_checksums_from_remote(
             test_channel_id, self.location.id
         )
         self.assertEqual(checksums, set())
 
-    @patch("kolibri.core.content.utils.file_availability.requests")
-    def test_404_remote_checksum_response(self, requests_mock):
-        requests_mock.post.return_value.status_code = 404
+    @patch("kolibri.core.content.utils.file_availability.NetworkClient")
+    def test_404_remote_checksum_response(self, networkclient_mock):
+        network_client = networkclient_mock.build_for_address.return_value
+        network_client.base_url = "test"
+        network_client.post.return_value.status_code = 404
         checksums = get_available_checksums_from_remote(
             test_channel_id, self.location.id
         )
         self.assertIsNone(checksums)
 
-    @patch("kolibri.core.content.utils.file_availability.requests")
-    def test_invalid_integer_remote_checksum_response(self, requests_mock):
-        requests_mock.post.return_value.status_code = 200
-        requests_mock.post.return_value.content = "I am not a json, I am a free man!"
+    @patch("kolibri.core.content.utils.file_availability.NetworkClient")
+    def test_invalid_integer_remote_checksum_response(self, networkclient_mock):
+        network_client = networkclient_mock.build_for_address.return_value
+        network_client.base_url = "test"
+        network_client.post.return_value.status_code = 200
+        network_client.post.return_value.content = "I am not a json, I am a free man!"
         checksums = get_available_checksums_from_remote(
             test_channel_id, self.location.id
         )

--- a/kolibri/core/content/utils/resource_import.py
+++ b/kolibri/core/content/utils/resource_import.py
@@ -43,20 +43,20 @@ def lookup_channel_listing_status(channel_id, baseurl=None):
     Look up the listing status of the channel from the remote, this is surfaced as a
     `public` boolean field.
     """
-    resp = requests.get(get_channel_lookup_url(identifier=channel_id, baseurl=baseurl))
-
-    # Raise here to prevent trying to fetch a channel from a remote that it is not
-    # available from.
+    client = NetworkClient.build_for_address(baseurl)
     try:
-        resp.raise_for_status()
-    except requests.exceptions.RequestException:
+        # prevent trying to fetch a channel from a remote that it is not
+        # available from.
+        resp = client.get(
+            get_channel_lookup_url(identifier=channel_id, baseurl=baseurl)
+        )
+
+    except NetworkLocationResponseFailure as e:
+        if e.response.status_code == 404:
+            return None
         raise LocationError(
             "Channel {} not found on remote {}".format(channel_id, baseurl)
         )
-
-    if resp.status_code != 200:
-        return None
-
     (channel_info,) = resp.json()
     return channel_info.get("public", None)
 

--- a/kolibri/core/discovery/utils/network/urls.py
+++ b/kolibri/core/discovery/utils/network/urls.py
@@ -187,5 +187,4 @@ def get_normalized_url_variations(address):
                         path=path,
                     )
                 )
-
     return urls

--- a/kolibri/core/utils/portal.py
+++ b/kolibri/core/utils/portal.py
@@ -1,12 +1,11 @@
 import json
 
-import requests
 from morango.api.serializers import CertificateSerializer
 from morango.constants.api_urls import NONCE
 from morango.models import Certificate
 
 from kolibri.core.auth.constants.morango_sync import ScopeDefinitions
-from kolibri.core.utils.urls import join_url
+from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.utils import conf
 
 
@@ -14,8 +13,8 @@ def registerfacility(token, facility):
 
     # request the server for a one-time-use nonce
     PORTAL_URL = conf.OPTIONS["Urls"]["DATA_PORTAL_SYNCING_BASE_URL"]
-    response = requests.post(join_url(PORTAL_URL, NONCE))
-    response.raise_for_status()
+    client = NetworkClient(PORTAL_URL)
+    response = client.post(NONCE)
     server_nonce = response.json()["id"]
 
     # get owned certificate for this facility
@@ -46,8 +45,5 @@ def registerfacility(token, facility):
     data["signature"] = client_cert.sign(message)
 
     # attempt to claim the facility
-    response = requests.post(
-        join_url(PORTAL_URL, "portal/api/public/v1/registerfacility/"), data=data
-    )
-    response.raise_for_status()
+    response = client.post("portal/api/public/v1/registerfacility/", data=data)
     return response

--- a/kolibri/plugins/user_profile/viewsets.py
+++ b/kolibri/plugins/user_profile/viewsets.py
@@ -7,7 +7,9 @@ from rest_framework.views import APIView
 
 from .utils import TokenGenerator
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.utils.urls import reverse_remote
+from kolibri.core.discovery.utils.network.client import NetworkClient
+from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
+from kolibri.core.utils.urls import reverse_path
 from kolibri.utils.urls import validator
 
 
@@ -38,15 +40,15 @@ class RemoteFacilityUserViewset(APIView):
         facility = request.query_params.get("facility", None)
         if username is None or facility is None:
             raise ValidationError(detail="Both username and facility are required")
-        url = reverse_remote(baseurl, "kolibri:core:publicsearchuser-list")
+        client = NetworkClient.build_for_address(baseurl)
+        url = reverse_path("kolibri:core:publicsearchuser-list")
         try:
-            response = requests.get(
+            response = client.get(
                 url, params={"facility": facility, "search": username}
             )
-            if response.status_code == 200:
-                return Response(response.json())
-            else:
-                return Response({})
+            return Response(response.json())
+        except NetworkLocationResponseFailure:
+            return Response({})
         except Exception as e:
             raise ValidationError(detail=str(e))
 
@@ -63,7 +65,8 @@ class RemoteFacilityUserAuthenticatedViewset(APIView):
         password = request.data.get("password", None)
         if username is None or facility is None:
             raise ValidationError(detail="Both username and facility are required")
-        url = reverse_remote(baseurl, "kolibri:core:publicuser-list")
+        client = NetworkClient.build_for_address(baseurl)
+        url = reverse_path("kolibri:core:publicuser-list")
         params = {"facility": facility, "search": username}
 
         # adding facility so auth works when learners can login without password:
@@ -71,11 +74,11 @@ class RemoteFacilityUserAuthenticatedViewset(APIView):
 
         auth = requests.auth.HTTPBasicAuth(username, password)
         try:
-            response = requests.get(url, params=params, verify=False, auth=auth)
-            if response.status_code == 200:
-                return Response(response.json())
-            else:
-                return Response({"error": response.json()["detail"]})
+            response = client.get(url, params=params, verify=False, auth=auth)
+            return Response(response.json())
+        except NetworkLocationResponseFailure as e:
+            response = e.response
+            return Response({"error": response.json()["detail"]})
         except Exception as e:
             raise ValidationError(detail=str(e))
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Use NetworkClient to make HTTP requests instead of requests.
- Use the NetworkClient errors in place of regular requests exception, as the NetworkClient Errors are wrapper around them
- Update the mocks of requests with NetworkClient in tests


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes #11018 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

I did a manual test thoroughly, and mostly followed TDD.
The only place I am not sure is core.api.KolibriDataPortalViewSet as testing it required a token and no tests are written for this. Maybe we can have a issue to do this?

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [x] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
