### PR TITLE
Move handleReplacement logic from ReplaceQuestions.vue to useQuizCreation.js

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -51,6 +51,9 @@ export default function useQuizCreation() {
   /** @type {ref<Number>} A counter for use in naming new sections */
   const _sectionLabelCounter = ref(1);
 
+  /** @type {ref<Array>} A list of all Question objects selected for replacement */
+  const replacements = ref([]);
+
   // ------------------
   // Section Management
   // ------------------
@@ -160,6 +163,16 @@ export default function useQuizCreation() {
         }
         return section;
       }),
+    });
+  }
+
+  function handleReplacement() {
+    const questionsNotSelectedToBeReplaced = activeQuestions.value.filter(
+      question => !selectedActiveQuestions.value.includes(question.id)
+    );
+    updateSection({
+      section_id: activeSection.value.section_id,
+      questions: [...questionsNotSelectedToBeReplaced, ...replacements.value],
     });
   }
 
@@ -481,6 +494,7 @@ export default function useQuizCreation() {
 
   provide('saveQuiz', saveQuiz);
   provide('updateSection', updateSection);
+  provide('handleReplacement', handleReplacement);
   provide('replaceSelectedQuestions', replaceSelectedQuestions);
   provide('addSection', addSection);
   provide('removeSection', removeSection);
@@ -491,6 +505,7 @@ export default function useQuizCreation() {
   provide('removeQuestionFromSelection', removeQuestionFromSelection);
   provide('clearSelectedQuestions', clearSelectedQuestions);
   provide('channels', channels);
+  provide('replacements', replacements);
   provide('quiz', quiz);
   provide('allSections', allSections);
   provide('activeSection', activeSection);
@@ -511,6 +526,7 @@ export default function useQuizCreation() {
     // Methods
     saveQuiz,
     updateSection,
+    handleReplacement,
     replaceSelectedQuestions,
     addSection,
     removeSection,
@@ -523,6 +539,7 @@ export default function useQuizCreation() {
 
     // Computed
     channels,
+    replacements,
     quiz,
     allSections,
     activeSection,
@@ -552,6 +569,7 @@ export default function useQuizCreation() {
 export function injectQuizCreation() {
   const saveQuiz = inject('saveQuiz');
   const updateSection = inject('updateSection');
+  const handleReplacement = inject('handleReplacement');
   const replaceSelectedQuestions = inject('replaceSelectedQuestions');
   const addSection = inject('addSection');
   const removeSection = inject('removeSection');
@@ -562,6 +580,7 @@ export function injectQuizCreation() {
   const removeQuestionFromSelection = inject('removeQuestionFromSelection');
   const clearSelectedQuestions = inject('clearSelectedQuestions');
   const channels = inject('channels');
+  const replacements = inject('replacements');
   const quiz = inject('quiz');
   const allSections = inject('allSections');
   const activeSection = inject('activeSection');
@@ -584,6 +603,7 @@ export function injectQuizCreation() {
     deleteActiveSelectedQuestions,
     selectAllQuestions,
     updateSection,
+    handleReplacement,
     replaceSelectedQuestions,
     addSection,
     removeSection,
@@ -599,6 +619,7 @@ export function injectQuizCreation() {
     allQuestionsSelected,
     selectAllIsIndeterminate,
     channels,
+    replacements,
     quiz,
     allSections,
     activeSection,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -132,7 +132,7 @@
       :cancelText="coreString('cancelAction')"
       :title="replaceQuestions$()"
       @cancel="showReplacementConfirmation = false"
-      @submit="handleReplacement"
+      @submit="submitReplacement"
     >
       <div> {{ replaceQuestionsExplaination$() }} </div>
       <div style="font-weight: bold;">
@@ -188,7 +188,6 @@
       } = enhancedQuizManagementStrings;
       const {
         // Computed
-        activeQuestions,
         activeSection,
         selectedActiveQuestions,
         activeResourceMap,
@@ -199,6 +198,8 @@
         replaceSelectedQuestions,
         toggleQuestionInSelection,
         updateSection,
+        handleReplacement,
+        replacements,
       } = injectQuizCreation();
 
       const showCloseConfirmation = ref(false);
@@ -208,17 +209,9 @@
         context.emit('closePanel');
       }
 
-      const replacements = ref([]);
-
-      function handleReplacement() {
+      function submitReplacement() {
+        handleReplacement();
         const count = replacements.value.length;
-        const questionsNotSelectedToBeReplaced = activeQuestions.value.filter(
-          question => !selectedActiveQuestions.value.includes(question.id)
-        );
-        updateSection({
-          section_id: activeSection.value.section_id,
-          questions: [...questionsNotSelectedToBeReplaced, ...replacements.value],
-        });
         router.replace({
           name: PageNames.EXAM_CREATION_ROOT,
           query: {
@@ -263,8 +256,6 @@
 
       return {
         toggleInReplacements,
-        handleReplacement,
-        replacements,
         activeSection,
         selectAllReplacementQuestions,
         selectedActiveQuestions,
@@ -283,6 +274,8 @@
         isItemExpanded,
         toggleQuestionInSelection,
         updateSection,
+        submitReplacement,
+        replacements,
         replaceQuestions$,
         deleteSectionLabel$,
         replaceAction$,


### PR DESCRIPTION
## Summary
This PR aims to move the handleReplacements logic from the file `ReplaceQuestions.vue` to `useQuizCreation.js` as it was identified as a tech-debt and is better placed in `useQuizCreation`. The changes are introduced keeping in mind the requirements of the issue and the discussion in PR #11937.

## References
Closes #12012 

## Reviewer guidance
To verify the working of the changes introduced:
1. Login as an admin/coach.
2. Create a new quiz.
3. After importing the questions, try to replace them using the replace option.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
