### PR TITLE
Adds modal before delete section

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -329,7 +329,7 @@
       :title="deleteSectionLabel$()"
       :submitText="coreString('deleteAction')"
       :cancelText="coreString('cancelAction')"
-      @cancel="handleCancelDelete"
+      @cancel="handleShowConfirmation"
       @submit="handleConfirmDelete"
     >
       {{ deleteConfirmation$({ section_title: activeSection.section_title }) }}
@@ -543,9 +543,6 @@
       }
     },
     methods: {
-      handleCancelDelete() {
-        this.showDeleteConfirmation = false;
-      },
       handleConfirmDelete() {
         const { section_id, section_title } = this.activeSection;
         this.removeSection(section_id);
@@ -556,9 +553,9 @@
           );
           this.focusActiveSectionTab();
         });
-        this.handleDeleteSection(null);
+        this.handleShowConfirmation();
       },
-      handleDeleteSection(section_id) {
+      handleShowConfirmation(section_id = null) {
         this.showDeleteConfirmation = section_id;
       },
       handleReplaceSelection() {
@@ -574,7 +571,7 @@
             this.$router.push(editRoute);
             break;
           case this.deleteSectionLabel$():
-            this.handleDeleteSection(section_id);
+            this.handleShowConfirmation(section_id);
             break;
         }
       },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This PR updates the the "Options > Delete" action in "Create new quiz" to display a delete confirmation modal prior to deleting the section

https://github.com/learningequality/kolibri/assets/5203639/e7cf4183-edcb-4b50-b7c2-f4ffaa741599

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Fixes https://github.com/learningequality/kolibri/issues/12064

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

1. Create a new quiz
2. Add a new section
3. Delete the section using "Options > Delete"

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
