### PR TITLE
Fix Vue Tesing Library routes bug

### DIFF
--- a/kolibri/core/assets/src/views/ContentRenderer/__tests__/ContentRendererError.spec.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/__tests__/ContentRendererError.spec.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import userEvent from '@testing-library/user-event';
 import ContentRendererError from '../ContentRendererError.vue';
 
@@ -7,7 +6,6 @@ import ContentRendererError from '../ContentRendererError.vue';
 const renderComponent = props => {
   return render(ContentRendererError, {
     props,
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/ContentRenderer/__tests__/ContentRendererLoading.spec.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/__tests__/ContentRendererLoading.spec.js
@@ -1,12 +1,9 @@
 import { render, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import ContentRendererLoading from '../ContentRendererLoading.vue';
 
 describe('ContentRendererLoading', () => {
   test('the component should render correctly', () => {
-    render(ContentRendererLoading, {
-      routes: new VueRouter(),
-    });
+    render(ContentRendererLoading);
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });

--- a/kolibri/core/assets/src/views/ContentRenderer/__tests__/DownloadButton.spec.js
+++ b/kolibri/core/assets/src/views/ContentRenderer/__tests__/DownloadButton.spec.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { render, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import useUser, { useUserMock } from 'kolibri.coreVue.composables.useUser';
 import DownloadButton from '../DownloadButton.vue';
 import { RENDERER_SUFFIX } from '../constants';
@@ -35,7 +34,6 @@ const renderComponent = props => {
   );
 
   return render(DownloadButton, {
-    routes: new VueRouter(),
     props: {
       files: [],
       nodeTitle: '',

--- a/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuDivider.spec.js
+++ b/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuDivider.spec.js
@@ -1,12 +1,9 @@
 import { render, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import CoreMenuDivider from '../CoreMenuDivider.vue';
 
 describe('CoreMenuDivider', () => {
   test('renders the component', () => {
-    render(CoreMenuDivider, {
-      routes: new VueRouter(),
-    });
+    render(CoreMenuDivider);
 
     expect(screen.getByRole('listitem')).toBeInTheDocument();
   });

--- a/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuOption.spec.js
+++ b/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuOption.spec.js
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import VueRouter from 'vue-router';
 import CoreMenuOption from '../CoreMenuOption.vue';
 
 const sampleSubRoutes = [
@@ -17,7 +16,6 @@ const renderComponent = props => {
       subRoutes: [],
       ...props,
     },
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuOption.spec.js
+++ b/kolibri/core/assets/src/views/CoreMenu/__tests__/CoreMenuOption.spec.js
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import VueRouter from 'vue-router';
 import CoreMenuOption from '../CoreMenuOption.vue';
 
 const sampleSubRoutes = [
@@ -16,6 +17,7 @@ const renderComponent = props => {
       subRoutes: [],
       ...props,
     },
+    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptIconDiff.spec.js
+++ b/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptIconDiff.spec.js
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import VueRouter from 'vue-router';
 import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
 import AttemptIconDiff from '../AttemptIconDiff.vue';
 
@@ -14,7 +13,6 @@ const renderComponent = props => {
       diff: 1,
       ...props,
     },
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptTextDiff.spec.js
+++ b/kolibri/core/assets/src/views/ExamReport/__tests__/AttemptTextDiff.spec.js
@@ -1,11 +1,9 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import VueRouter from 'vue-router';
 import AttemptTextDiff from '../AttemptTextDiff.vue';
 
 const renderComponent = props => {
   return render(AttemptTextDiff, {
-    routes: new VueRouter(),
     props,
     store: {
       getters: {

--- a/kolibri/core/assets/src/views/ExamReport/__tests__/TriesOverview.spec.js
+++ b/kolibri/core/assets/src/views/ExamReport/__tests__/TriesOverview.spec.js
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/vue';
 import '@testing-library/jest-dom';
-import VueRouter from 'vue-router';
 import TriesOverview from '../TriesOverview.vue';
 import * as tryValidatorModule from '../utils';
 
@@ -33,7 +32,6 @@ const renderComponent = props => {
       ...defaultProps,
       ...props,
     },
-    routes: new VueRouter(),
     mixins: [commonCoreStrings],
   });
 };

--- a/kolibri/core/assets/src/views/InteractionList/__tests__/InteractionItem.spec.js
+++ b/kolibri/core/assets/src/views/InteractionList/__tests__/InteractionItem.spec.js
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import { themeTokens } from 'kolibri-design-system/lib/styles/theme';
 import InteractionItem from '../InteractionItem.vue';
 
@@ -11,7 +10,6 @@ const renderComponent = props => {
 
   return render(InteractionItem, {
     props: { ...defaultProps, ...props },
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/InteractionList/__tests__/index.spec.js
+++ b/kolibri/core/assets/src/views/InteractionList/__tests__/index.spec.js
@@ -1,5 +1,4 @@
 import { render, fireEvent, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import InteractionList from '../';
 
 const renderComponent = props => {
@@ -13,7 +12,6 @@ const renderComponent = props => {
       ...defaultProps,
       ...props,
     },
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
+++ b/kolibri/core/assets/src/views/__tests__/TotalPoints.spec.js
@@ -1,4 +1,3 @@
-import VueRouter from 'vue-router';
 import { render, screen, fireEvent } from '@testing-library/vue';
 import TotalPoints from '../TotalPoints.vue';
 import '@testing-library/jest-dom';
@@ -24,7 +23,6 @@ const getMockStore = () => {
 const renderComponent = store => {
   return render(TotalPoints, {
     store,
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/sync/__tests__/ConfirmationRegisterModal.spec.js
+++ b/kolibri/core/assets/src/views/sync/__tests__/ConfirmationRegisterModal.spec.js
@@ -1,5 +1,4 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import { PortalResource, FacilityDatasetResource } from 'kolibri.resources';
 import { ERROR_CONSTANTS } from 'kolibri.coreVue.vuex.constants';
 import ConfirmationRegisterModal from '../ConfirmationRegisterModal.vue';
@@ -20,7 +19,6 @@ const renderComponent = props => {
       token: sampleToken,
       ...props,
     },
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/sync/__tests__/SelectSourceModal.spec.js
+++ b/kolibri/core/assets/src/views/sync/__tests__/SelectSourceModal.spec.js
@@ -1,11 +1,9 @@
 import { render, fireEvent, screen } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import SelectSourceModal from '../SelectSourceModal.vue';
 
 const renderComponent = props => {
   return render(SelectSourceModal, {
     props,
-    routes: new VueRouter(),
   });
 };
 

--- a/kolibri/core/assets/src/views/userAccounts/__tests__/GenderDisplayText.spec.js
+++ b/kolibri/core/assets/src/views/userAccounts/__tests__/GenderDisplayText.spec.js
@@ -1,4 +1,3 @@
-import VueRouter from 'vue-router';
 import { render, screen } from '@testing-library/vue';
 import { FacilityUserGender } from 'kolibri.coreVue.vuex.constants';
 import GenderDisplayText from '../GenderDisplayText.vue';
@@ -6,7 +5,6 @@ import '@testing-library/jest-dom';
 
 const renderComponent = gender => {
   return render(GenderDisplayText, {
-    routes: new VueRouter(),
     props: {
       gender,
     },

--- a/kolibri/core/assets/src/views/userAccounts/__tests__/GenderSelect.spec.js
+++ b/kolibri/core/assets/src/views/userAccounts/__tests__/GenderSelect.spec.js
@@ -1,12 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/vue';
-import VueRouter from 'vue-router';
 import GenderSelect from '../GenderSelect.vue';
 import '@testing-library/jest-dom';
 
 const renderComponent = () => {
-  return render(GenderSelect, {
-    routes: new VueRouter(),
-  });
+  return render(GenderSelect);
 };
 
 describe('GenderSelect', () => {

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -36,10 +36,10 @@ logging.setLevel('silent');
 // Register Vue plugins and components
 Vue.use(Vuex);
 Vue.mixin({
-  beforeCreate: function () {
+  beforeCreate: function() {
     // This fix some problems between the VueRouter plugin, and Vue-testing-library.
-    this.$options.router ||= undefined;
-  }
+    this.$options.router = this.$options.router || undefined;
+  },
 });
 Vue.use(VueRouter);
 Vue.use(VueMeta);

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -35,6 +35,12 @@ logging.setLevel('silent');
 
 // Register Vue plugins and components
 Vue.use(Vuex);
+Vue.mixin({
+  beforeCreate: function () {
+    // This fix some problems between the VueRouter plugin, and Vue-testing-library.
+    this.$options.router ||= undefined;
+  }
+});
 Vue.use(VueRouter);
 Vue.use(VueMeta);
 Vue.use(KThemePlugin);

--- a/packages/kolibri-tools/jest.conf/setup.js
+++ b/packages/kolibri-tools/jest.conf/setup.js
@@ -14,6 +14,8 @@ import logging from 'kolibri.lib.logging';
 import { i18nSetup } from 'kolibri.utils.i18n';
 import KThemePlugin from 'kolibri-design-system/lib/KThemePlugin';
 
+/* eslint-disable vue/one-component-per-file */
+
 global.beforeEach(() => {
   return new Promise(resolve => {
     Aphrodite.StyleSheetTestUtils.suppressStyleInjection();
@@ -75,3 +77,4 @@ global.flushPromises = function flushPromises() {
     scheduler(resolve);
   });
 };
+/* eslint-enable vue/one-component-per-file */


### PR DESCRIPTION
## Summary

For now there is a bug when we use the render function of Vue testing library without passing a `routes` prop, this has forced us to import VueRouter, and pass a `routes: new VueRouter()` prop just to avoid this error, although we don't use it. This means that we have more boilerplate code even for the simplest tests.

This error raises because for some reason vue router in its inner implementation checks if the `$option.router` object is defined, but just checking for `undefined` values, so when this value is null, it gives a null pointer exception.  

## Reviewer guidance

Check that VTL tests run successfully even if we dont pass the `routes` prop.


## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
