### PR TITLE
Update now value in SyncStatusDisplay

### DIFF
--- a/kolibri/core/assets/src/composables/useNow.js
+++ b/kolibri/core/assets/src/composables/useNow.js
@@ -1,0 +1,21 @@
+import { now as getNow } from 'kolibri.utils.serverClock';
+
+import { ref, onMounted, onUnmounted } from 'kolibri.lib.vueCompositionApi';
+
+export default function useNow(interval = 10000) {
+  const now = ref(getNow());
+
+  let timer;
+
+  onMounted(() => {
+    timer = setInterval(() => {
+      now.value = getNow();
+    }, interval);
+  });
+
+  onUnmounted(() => {
+    clearInterval(timer);
+  });
+
+  return { now };
+}

--- a/kolibri/core/assets/src/core-app/apiSpec.js
+++ b/kolibri/core/assets/src/core-app/apiSpec.js
@@ -106,6 +106,7 @@ import NotificationsRoot from '../views/NotificationsRoot';
 import useMinimumKolibriVersion from '../composables/useMinimumKolibriVersion';
 import useUserSyncStatus from '../composables/useUserSyncStatus';
 import useUser from '../composables/useUser';
+import useNow from '../composables/useNow';
 
 // webpack optimization
 import CoreInfoIcon from '../views/CoreInfoIcon';
@@ -230,6 +231,7 @@ export default {
       useKResponsiveWindow,
       useKShow,
       useMinimumKolibriVersion,
+      useNow,
       useUser,
       useUserSyncStatus,
     },

--- a/kolibri/core/assets/src/views/SyncStatusDisplay.vue
+++ b/kolibri/core/assets/src/views/SyncStatusDisplay.vue
@@ -21,11 +21,15 @@
 
 <script>
 
-  import { now } from 'kolibri.utils.serverClock';
+  import useNow from 'kolibri.coreVue.composables.useNow';
   import { SyncStatus } from 'kolibri.coreVue.vuex.constants';
 
   export default {
     name: 'SyncStatusDisplay',
+    setup() {
+      const { now } = useNow();
+      return { now };
+    },
     props: {
       syncStatus: {
         type: String,
@@ -42,11 +46,6 @@
           return ['small', 'large', 'large-bold'].includes(val);
         },
       },
-    },
-    data() {
-      return {
-        now: now(),
-      };
     },
     computed: {
       syncTextDisplayMap() {


### PR DESCRIPTION
## Summary

Update now value in SyncStatusDisplay component.


https://github.com/learningequality/kolibri/assets/51239030/24946819-30e2-4209-bf46-cb0431036cbf




## References

Closes #11880.

## Reviewer guidance

1. Set up two Kolibris - one as a Learn Only Device (LOD) and one as a full facility. The LOD should be set up to sync back the main facility
2. Assign some resources to the Learner
3. Observe the accuracy of sync status and the calculation of relative time
4. Repeat if necessary

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
