### PR TITLE
Exams: Create them, take them, view reports

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -1,4 +1,5 @@
 import uniq from 'lodash/uniq';
+import some from 'lodash/some';
 import { v4 as uuidv4 } from 'uuid';
 import { ExamResource, ContentNodeResource } from 'kolibri.resources';
 
@@ -61,15 +62,17 @@ function convertExamQuestionSourcesV0V2(questionSources, seed, questionIds) {
 }
 
 function convertExamQuestionSourcesV1V2(questionSources) {
+  if (some(questionSources, 'counterInExercise')) {
+    for (const question of questionSources) {
+      if (!question.counterInExercise) {
+        continue;
+      }
+      question.counter_in_exercise = question.counterInExercise;
+      delete question.counterInExercise;
+    }
+  }
   // In case a V1 quiz already has this with the old name, rename it
-  return annotateQuestionSourcesWithCounter(
-    questionSources.map(question => {
-      const copy = question;
-      copy.counter_in_exercise = copy.counter_in_exercise || copy.counterInExercise;
-      delete copy.counterInExercise;
-      return copy;
-    })
-  );
+  return annotateQuestionSourcesWithCounter(questionSources);
 }
 
 /**

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -159,9 +159,6 @@ export async function convertExamQuestionSources(exam) {
     exam.data_model_version = 3;
   }
 
-  // TODO This avoids updating older code that used `item` to refer to the unique question id
-  // we've started calling `id` (ie, in useQuizCreation.js) but we should update this to use `id`
-  // everywhere and remove this line
   // Now we know we have the latest V3 structure
   exam.question_sources = exam.question_sources.map(section => {
     section.questions = annotateQuestionsWithItem(section.questions);

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -264,7 +264,8 @@ export default function useQuizCreation() {
    * use */
 
   function initializeQuiz(collection) {
-    set(_quiz, objectWithDefaults({ collection }, Quiz));
+    const assignments = [collection];
+    set(_quiz, objectWithDefaults({ collection, assignments }, Quiz));
     const newSection = addSection();
     setActiveSection(newSection.section_id);
     _fetchChannels();

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -188,7 +188,7 @@ export default function useQuizCreation() {
    */
   function selectRandomQuestionsFromResources(numQuestions, pool = [], excludedIds = []) {
     pool = pool.length ? pool : get(activeResourcePool);
-    const exerciseIds = pool.map(r => r.content_id);
+    const exerciseIds = pool.map(r => r.id);
     const exerciseTitles = pool.map(r => r.title);
     const questionIdArrays = pool.map(r => r.unique_question_ids);
     return selectQuestions(
@@ -400,7 +400,7 @@ export default function useQuizCreation() {
   /** @type {ComputedRef<QuizExercise[]>}   The active section's `resource_pool` */
   const activeResourceMap = computed(() =>
     get(activeResourcePool).reduce((acc, resource) => {
-      acc[resource.content_id] = resource;
+      acc[resource.id] = resource;
       return acc;
     }, {})
   );

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -277,7 +277,7 @@ export default function useQuizCreation() {
    */
   function saveQuiz() {
     const totalQuestions = get(allSections).reduce((acc, section) => {
-      acc += section.question_count;
+      acc += parseInt(section.question_count);
       return acc;
     }, 0);
 

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -411,7 +411,7 @@ export default function useQuizCreation() {
       (count, r) => count + r.assessmentmetadata.assessment_item_ids.length,
       0
     );
-    const exerciseIds = pool.map(r => r.content_id);
+    const exerciseIds = pool.map(r => r.exercise_id);
     const exerciseTitles = pool.map(r => r.title);
     const questionIdArrays = pool.map(r => r.unique_question_ids);
     return selectQuestions(

--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -1,6 +1,6 @@
 import { ContentNodeResource } from 'kolibri.resources';
 import store from 'kolibri.coreVue.vuex.store';
-import { fetchNodeDataAndConvertExam } from 'kolibri.utils.exams';
+import { fetchExamWithContent } from 'kolibri.utils.exams';
 import { coachStrings } from '../../views/common/commonCoachStrings';
 
 export function questionRootRedirectHandler(params, name, next) {
@@ -41,7 +41,7 @@ function showQuestionDetailView(params) {
     // Additionally the questionId is actually the unique item value, made
     // of a combination of 'question_id:exercise_id'
     const baseExam = store.state.classSummary.examMap[quizId];
-    promise = fetchNodeDataAndConvertExam(baseExam).then(exam => {
+    promise = fetchExamWithContent(baseExam).then(({ exam }) => {
       exerciseNodeId = exam.question_sources.find(source => source.item === questionId).exercise_id;
       return exam;
     });

--- a/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
+++ b/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
@@ -76,6 +76,7 @@ export default function selectQuestions(
           counter_in_exercise: questionIdArrays[ri].indexOf(uId) + 1,
           exercise_id: uId.includes(':') ? uId.split(':')[0] : uId,
           question_id: uId.split(':')[1],
+          // TODO See #12127 re: replacing all `id` with `item`
           id: uId,
           title: exerciseTitles[ri],
         });

--- a/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
+++ b/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
@@ -74,7 +74,7 @@ export default function selectQuestions(
       if (!find(output, { id: uId })) {
         output.push({
           counter_in_exercise: questionIdArrays[ri].indexOf(uId) + 1,
-          exercise_id: exerciseIds[ri],
+          exercise_id: uId.includes(':') ? uId.split(':')[0] : uId,
           question_id: uId.split(':')[1],
           id: uId,
           title: exerciseTitles[ri],

--- a/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
+++ b/kolibri/plugins/coach/assets/src/utils/selectQuestions.js
@@ -17,8 +17,8 @@ const getTotalOfQuestions = sumBy(qArray => qArray.length);
  * @param {Number} numQuestions - target number of questions
  * @param {String[]} exerciseIds - QuizExercise IDs
  * @param {String[]} exerciseTitle - QuizExercise titles
- * @param {Array[String[]]} questionIdArrays - QuizQuestion (assessment) ID arrays corresponding
- *  to each exercise by index (ie, questionIdArrays[i] corresponds to exerciseIds[i])
+ * @param {Array[String[]]} questionIdArrays - QuizQuestion (assessmentitem) unique IDs in the
+ *                                             composite format `exercise_id:question_id`
  * @param {number} seed - value to seed the random shuffle with
  *
  * @return {QuizQuestion[]}

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -137,8 +137,14 @@
         style="text-align: center; padding: 0 0 1em 0; max-width: 350px; margin: 0 auto;"
       >
         <!-- TODO This question mark thing should probably be an SVG for improved a11y -->
-        <div class="question-mark-layout">
-          <span class="help-icon-style">?</span>
+        <div
+          class="question-mark-layout"
+          :style="{ backgroundColor: $themeBrand.secondary.v_200 }"
+        >
+          <span
+            class="help-icon-style"
+            :style="{ color: $themeTokens.secondaryDark }"
+          >?</span>
         </div>
 
         <p style="margin-top: 1em; font-weight: bold;">
@@ -669,7 +675,6 @@
     margin: auto;
     line-height: 1.7;
     text-align: center;
-    background-color: #dbc3d4;
   }
 
   .help-icon-style {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -501,6 +501,10 @@
     margin-right: 0.5em;
   }
 
+  .section-settings-content {
+    margin-bottom: 7em;
+  }
+
   .section-settings-heading {
     margin-bottom: 0.5em;
     font-size: 1em;
@@ -557,6 +561,7 @@
     left: 0;
     padding: 1em;
     margin-top: 1em;
+    background-color: #ffffff;
     border-top: 1px solid black;
 
     > div {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -27,7 +27,7 @@
           <KButton
             :text="coreString('saveAction')"
             primary
-            @click="() => saveQuiz()"
+            @click="() => saveQuizAndRedirect()"
           />
         </KButtonGroup>
       </BottomAppBar>
@@ -115,6 +115,13 @@
     created() {
       this.initializeQuiz(this.$route.params.classId);
       this.quizInitialized = true;
+    },
+    methods: {
+      saveQuizAndRedirect() {
+        this.saveQuiz().then(() => {
+          this.$router.replace({ name: PageNames.EXAMS });
+        });
+      },
     },
     $trs: {
       createNewExamLabel: {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -119,7 +119,10 @@
     methods: {
       saveQuizAndRedirect() {
         this.saveQuiz().then(() => {
-          this.$router.replace({ name: PageNames.EXAMS });
+          this.$router.replace({
+            name: PageNames.EXAMS,
+            classId: this.$route.params.classId,
+          });
         });
       },
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/api.js
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/api.js
@@ -1,28 +1,16 @@
-import map from 'lodash/map';
-import { fetchNodeDataAndConvertExam } from 'kolibri.utils.exams';
-import { ExamResource, ContentNodeResource } from 'kolibri.resources';
+import { fetchExamWithContent } from 'kolibri.utils.exams';
+import { ExamResource } from 'kolibri.resources';
 
 export function fetchQuizSummaryPageData(examId) {
-  const payload = {
-    // To display the title, status, etc. of the Quiz
-    exam: {},
-    // To render the exercises in QuestionListPreview > ContentRenderer
-    exerciseContentNodes: {},
-  };
   return ExamResource.fetchModel({ id: examId })
     .then(exam => {
-      return fetchNodeDataAndConvertExam(exam);
+      return fetchExamWithContent(exam);
     })
-    .then(exam => {
-      payload.exam = exam;
-      return ContentNodeResource.fetchCollection({
-        getParams: {
-          ids: map(exam.question_sources, 'exercise_id'),
-        },
-      }).then(contentNodes => {
-        payload.exerciseContentNodes = contentNodes;
-        return payload;
-      });
+    .then(({ exam, exercises }) => {
+      return {
+        exerciseContentNodes: exercises,
+        exam,
+      };
     });
 }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -118,7 +118,10 @@
       /* eslint-disable-next-line kolibri/vue-no-unused-vuex-properties */
       ...mapState('classSummary', ['groupMap', 'learnerMap']),
       selectedQuestions() {
-        return this.quiz.question_sources;
+        return this.quiz.question_sources.reduce((acc, section) => {
+          acc = [...acc, ...section.questions];
+          return acc;
+        }, []);
       },
       quizIsRandomized() {
         return !this.quiz.learners_see_fixed_order;

--- a/kolibri/plugins/coach/assets/test/selectRandomExamQuestions.spec.js
+++ b/kolibri/plugins/coach/assets/test/selectRandomExamQuestions.spec.js
@@ -5,9 +5,9 @@ jest.mock('kolibri.lib.logging');
 const EXERCISES_IDS = ['A', 'B', 'C'];
 const EXERCISES_TITLES = ['title_x', 'title_y', 'title_z'];
 const QUESTION_IDS = [
-  ['A1', 'A2', 'A3'],
-  ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8'],
-  ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7', 'C8', 'C9'],
+  ['A:A1', 'A:A2', 'A:A3'],
+  ['B:B1', 'B:B2', 'B:B3', 'B:B4', 'B:B5', 'B:B6', 'B:B7', 'B:B8'],
+  ['C:C1', 'C:C2', 'C:C3', 'C:C4', 'C:C5', 'C:C6', 'C:C7', 'C:C8', 'C:C9'],
 ];
 
 function countQuestions(exerciseId, questionList) {

--- a/kolibri/plugins/coach/assets/test/selectRandomExamQuestions.spec.js
+++ b/kolibri/plugins/coach/assets/test/selectRandomExamQuestions.spec.js
@@ -4,7 +4,7 @@ jest.mock('kolibri.lib.logging');
 
 const EXERCISES_IDS = ['A', 'B', 'C'];
 const EXERCISES_TITLES = ['title_x', 'title_y', 'title_z'];
-const QUESTION_IDS = [
+const UNIQUE_QUESTION_IDS = [
   ['A:A1', 'A:A2', 'A:A3'],
   ['B:B1', 'B:B2', 'B:B3', 'B:B4', 'B:B5', 'B:B6', 'B:B7', 'B:B8'],
   ['C:C1', 'C:C2', 'C:C3', 'C:C4', 'C:C5', 'C:C6', 'C:C7', 'C:C8', 'C:C9'],
@@ -30,7 +30,7 @@ expect.extend({
 describe('selectQuestions function', () => {
   it('will choose even distributions across multiple exercises', () => {
     const numQs = 8;
-    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
+    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
     expect(output.length).toEqual(numQs);
     expect(countQuestions('A', output)).toBeOneOf(2, 3);
     expect(countQuestions('B', output)).toBeOneOf(2, 3);
@@ -43,7 +43,7 @@ describe('selectQuestions function', () => {
       numQs,
       EXERCISES_IDS.slice(2),
       EXERCISES_TITLES.slice(2),
-      QUESTION_IDS.slice(2),
+      UNIQUE_QUESTION_IDS.slice(2),
       1
     );
     expect(output.length).toEqual(numQs);
@@ -54,7 +54,7 @@ describe('selectQuestions function', () => {
 
   it('handles a small number of questions from a few exercises', () => {
     const numQs = 2;
-    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
+    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
     expect(output.length).toEqual(numQs);
     expect(countQuestions('A', output)).toBeOneOf(0, 1);
     expect(countQuestions('B', output)).toBeOneOf(0, 1);
@@ -63,7 +63,7 @@ describe('selectQuestions function', () => {
 
   it('will handle exercises with smaller numbers of questions', () => {
     const numQs = 18;
-    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
+    const output = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
     expect(output.length).toEqual(numQs);
     expect(countQuestions('A', output)).toBe(3);
     expect(countQuestions('B', output)).toBeOneOf(7, 8);
@@ -72,15 +72,15 @@ describe('selectQuestions function', () => {
 
   it('will choose the same questions for the same seed', () => {
     const numQs = 5;
-    const output1 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
-    const output2 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
+    const output1 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
+    const output2 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
     expect(output1).toEqual(output2);
   });
 
   it('will choose different questions for different seeds', () => {
     const numQs = 5;
-    const output1 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 1);
-    const output2 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, QUESTION_IDS, 2);
+    const output1 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 1);
+    const output2 = selectQuestions(numQs, EXERCISES_IDS, EXERCISES_TITLES, UNIQUE_QUESTION_IDS, 2);
     expect(output1).not.toEqual(output2);
   });
 });

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -1,7 +1,6 @@
-import { ContentNodeResource, ExamResource } from 'kolibri.resources';
-import uniq from 'lodash/uniq';
+import { ExamResource } from 'kolibri.resources';
 import samePageCheckGenerator from 'kolibri.utils.samePageCheckGenerator';
-import { convertExamQuestionSources } from 'kolibri.utils.exams';
+import { fetchExamWithContent } from 'kolibri.utils.exams';
 import shuffled from 'kolibri.utils.shuffled';
 import { ClassesPageNames } from '../../constants';
 import { LearnerClassroomResource } from '../../apiResources';
@@ -29,97 +28,67 @@ export function showExam(store, params, alreadyOnQuiz) {
       ([classroom, exam]) => {
         if (shouldResolve()) {
           store.commit('classAssignments/SET_CURRENT_CLASSROOM', classroom);
+          fetchExamWithContent(exam).then(({ exam: converted, exercises: contentNodes }) => {
+            if (shouldResolve()) {
+              const { question_sources } = converted;
 
-          let contentPromise;
-          let allExerciseIds = [];
-          if (exam.data_model_version == 3) {
-            allExerciseIds = uniq(
-              exam.question_sources.reduce((acc, section) => {
-                acc = [...acc, ...section.questions.map(q => q.exercise_id)];
+              // When necessary, randomize the questions for the learner.
+              // Seed based on the user ID so they see a consistent order each time.
+              question_sources.forEach(section => {
+                if (!section.learners_see_fixed_order) {
+                  section.questions = shuffled(section.questions, store.state.core.session.user_id);
+                }
+              });
+              // If necessary, convert the question source info
+              const allQuestions = question_sources.reduce((acc, section) => {
+                acc = [...acc, ...section.questions];
                 return acc;
-              }, [])
-            );
-          } else {
-            allExerciseIds = exam.question_sources.map(q => q.exercise_id);
-          }
-          if (allExerciseIds.length) {
-            contentPromise = ContentNodeResource.fetchCollection({
-              getParams: {
-                ids: allExerciseIds,
-              },
-            });
-          } else {
-            contentPromise = Promise.resolve([]);
-          }
-          contentPromise.then(
-            contentNodes => {
-              if (shouldResolve()) {
-                // If necessary, convert the question source info
-                convertExamQuestionSources(exam).then(converted => {
-                  const { question_sources } = converted;
+              }, []);
 
-                  // When necessary, randomize the questions for the learner.
-                  // Seed based on the user ID so they see a consistent order each time.
-                  question_sources.forEach(section => {
-                    if (!section.learners_see_fixed_order) {
-                      section.questions = shuffled(
-                        section.questions,
-                        store.state.core.session.user_id
-                      );
-                    }
-                  });
-
-                  const allQuestions = question_sources.reduce((acc, section) => {
-                    acc = [...acc, ...section.questions];
-                    return acc;
-                  }, []);
-
-                  // Exam is drawing solely on malformed exercise data, best to quit now
-                  if (allQuestions.some(question => !question.question_id)) {
-                    store.dispatch(
-                      'handleError',
-                      `This quiz cannot be displayed:\nQuestion sources: ${JSON.stringify(
-                        allQuestions
-                      )}\nExam: ${JSON.stringify(exam)}`
-                    );
-                    return;
-                  }
-                  // Illegal question number!
-                  else if (questionNumber >= allQuestions.length) {
-                    store.dispatch(
-                      'handleError',
-                      `Question number ${questionNumber} is not valid for this quiz`
-                    );
-                    return;
-                  }
-
-                  const contentNodeMap = {};
-
-                  for (const node of contentNodes) {
-                    contentNodeMap[node.id] = node;
-                  }
-
-                  for (const question of allQuestions) {
-                    question.missing = !contentNodeMap[question.exercise_id];
-                  }
-                  exam.question_sources = question_sources;
-                  store.commit('examViewer/SET_STATE', {
-                    contentNodeMap,
-                    exam,
-                    questionNumber,
-                    questions: allQuestions,
-                  });
-                  store.commit('CORE_SET_PAGE_LOADING', false);
-                  store.commit('CORE_SET_ERROR', null);
-                });
+              // Exam is drawing solely on malformed exercise data, best to quit now
+              if (allQuestions.some(question => !question.question_id)) {
+                store.dispatch(
+                  'handleError',
+                  `This quiz cannot be displayed:\nQuestion sources: ${JSON.stringify(
+                    allQuestions
+                  )}\nExam: ${JSON.stringify(exam)}`
+                );
+                return;
               }
-            },
+              // Illegal question number!
+              else if (questionNumber >= allQuestions.length) {
+                store.dispatch(
+                  'handleError',
+                  `Question number ${questionNumber} is not valid for this quiz`
+                );
+                return;
+              }
+
+              const contentNodeMap = {};
+
+              for (const node of contentNodes) {
+                contentNodeMap[node.id] = node;
+              }
+
+              for (const question of allQuestions) {
+                question.missing = !contentNodeMap[question.exercise_id];
+              }
+              exam.question_sources = question_sources;
+              store.commit('examViewer/SET_STATE', {
+                contentNodeMap,
+                exam,
+                questionNumber,
+                questions: allQuestions,
+              });
+              store.commit('CORE_SET_PAGE_LOADING', false);
+              store.commit('CORE_SET_ERROR', null);
+            }
+          }),
             error => {
               shouldResolve()
                 ? store.dispatch('handleApiError', { error, reloadOnReconnect: true })
                 : null;
-            }
-          );
+            };
         }
       },
       error => {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

I've tried my best to sort of fold together the existing data architecture code for Coach quiz reports and Learner quiz reports with the updated data structures.

I've kept front-end architecture shaped the same, but updated the shape of the data, basically testing out the reports and such, finding bugs, then fixing them. The changes were in relatively self-contained / purpose-built modules -- that is to say that I've tried to be sure that there are no chances of regressions.

The `exam.utils` module has been significantly updated. Now there are functions going from each `data_model_version` to the next (ie, v0-v1, v1-v2, etc). 

There appear to be two things needed from this module at this time:

- Convert an exam to the latest version
- Fetch all of the exercises for the exam

Now there is a general function for the first part and the second function does the conversion and fetches the nodes. 

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #12097

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

### Backward compatibility

A big part of this change involves ensuring backward compatibility. There are automated tests that do this, but I've not tested with any "data model version" below 2. 

Seems like to get an exam < v2 you will need to create a quiz using Kolibri <=0.11 as V2 seems to have [been added into 0.12](https://github.com/learningequality/kolibri/pull/5431).

- Create like 5 quizzes in Kolibri <= 0.11
- Take a few of the quizzes with multiple learners (but also leave at least one untouched) -- _also, be sure to get some wrong for a couple users_
- Start this PR's assets on the same KOLIBRI_HOME (stopping the old one first)

Here you should be able to do the following:

- View exam reports for all exams that have been taken, for all users
- View specific questions' reports in Coach
- View "difficult questions" list in Coach reports
- View quiz report as the learner
- Take the quiz if it has not been taken previously by a user