### PR TITLE
 Improve messaging around question replacement requirements

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -308,19 +308,19 @@
         );
       },
       replaceSelectedQuestionsString(){
-        const x = this.selectedActiveQuestions.length - this.replacements.length;
-        if(x === 0){
+        const unreplacedCount = this.selectedActiveQuestions.length - this.replacements.length;
+        if(unreplacedCount === 0){
           return this.numberOfSelectedReplacements$({
             count: this.replacements.length,
             total: this.selectedActiveQuestions.length
           });
-        }else if(x > 0 ){
+        }else if(unreplacedCount > 0 ){
           return this.selectMoreQuestion$({
-            count: x
+            count: unreplacedCount
           });
         }else{
           return this.selectFewerQuestion$({
-            count: Math.abs(x)
+            count: Math.abs(unreplacedCount)
           });
         }
       }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -105,11 +105,7 @@
           :layout8="{ span: 6 }"
           :layout4="{ span: 3 }"
         >
-          {{ numberOfSelectedReplacements$({
-            count: replacements.length,
-            total: selectedActiveQuestions.length }
-          )
-          }}
+          {{ replaceSelectedQuestionsString }}
         </KGridItem>
         <KGridItem
           style="text-align: right;"
@@ -185,6 +181,8 @@
         numberOfSelectedReplacements$,
         numberOfQuestionsReplaced$,
         noUndoWarning$,
+        selectMoreQuestion$,
+        selectFewerQuestion$,
       } = enhancedQuizManagementStrings;
       const {
         // Computed
@@ -285,6 +283,8 @@
         closeConfirmationTitle$,
         noUndoWarning$,
         replaceQuestionsExplaination$,
+        selectMoreQuestion$,
+        selectFewerQuestion$,
       };
     },
     computed: {
@@ -307,6 +307,23 @@
           this.replacements.length === this.selectedActiveQuestions.length
         );
       },
+      replaceSelectedQuestionsString(){
+        const x = this.selectedActiveQuestions.length - this.replacements.length;
+        if(x === 0){
+          return this.numberOfSelectedReplacements$({
+            count: this.replacements.length,
+            total: this.selectedActiveQuestions.length
+          });
+        }else if(x > 0 ){
+          return this.selectMoreQuestion$({
+            count: x
+          });
+        }else{
+          return this.selectFewerQuestion$({
+            count: Math.abs(x)
+          });
+        }
+      }
     },
     beforeRouteLeave(_, __, next) {
       if (

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -307,23 +307,23 @@
           this.replacements.length === this.selectedActiveQuestions.length
         );
       },
-      replaceSelectedQuestionsString(){
+      replaceSelectedQuestionsString() {
         const unreplacedCount = this.selectedActiveQuestions.length - this.replacements.length;
-        if(unreplacedCount === 0){
+        if (unreplacedCount === 0) {
           return this.numberOfSelectedReplacements$({
             count: this.replacements.length,
-            total: this.selectedActiveQuestions.length
+            total: this.selectedActiveQuestions.length,
           });
-        }else if(unreplacedCount > 0 ){
+        } else if (unreplacedCount > 0) {
           return this.selectMoreQuestion$({
-            count: unreplacedCount
+            count: unreplacedCount,
           });
-        }else{
+        } else {
           return this.selectFewerQuestion$({
-            count: Math.abs(unreplacedCount)
+            count: Math.abs(unreplacedCount),
           });
         }
-      }
+      },
     },
     beforeRouteLeave(_, __, next) {
       if (

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -168,7 +168,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   },
   selectedResourcesInformation: {
     message:
-      '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
+      '{count, number, integer} of {total, number, integer} {total, plural, one {question selected} other {questions selected}}',
   },
   selectMoreQuestion:{
     message:'select { count } more { count, plural , one { question } other { questions }} to continue',

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -174,7 +174,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:'select { count } more { count, plural , one { question } other { questions }} to continue',
   },
   selectFewerQuestion:{
-    message:'select { count } fewer { count, plural ,one { question } other { questions }} to continue',
+    message:'Select { count } fewer { count, plural ,one { question } other { questions }} to continue',
   },
   cannotSelectSomeTopicWarning: {
     message:

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -170,6 +170,12 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:
       '{count, number, integer} of {total, number, integer} {total, plural, one {resource selected} other {resources selected}}',
   },
+  selectMoreQuestion:{
+    message:'select { count } more { count, plural , one { question } other { questions }} to continue',
+  },
+  selectFewerQuestion:{
+    message:'select { count } fewer { count, plural ,one { question } other { questions }} to continue',
+  },
   cannotSelectSomeTopicWarning: {
     message:
       'You can only select folders with 12 or less exercises and no subfolders to avoid oversized quizzes.',

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -170,11 +170,13 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:
       '{count, number, integer} of {total, number, integer} {total, plural, one {question selected} other {questions selected}}',
   },
-  selectMoreQuestion:{
-    message:'select { count } more { count, plural , one { question } other { questions }} to continue',
+  selectMoreQuestion: {
+    message:
+      'select { count } more { count, plural , one { question } other { questions }} to continue',
   },
-  selectFewerQuestion:{
-    message:'Select { count } fewer { count, plural ,one { question } other { questions }} to continue',
+  selectFewerQuestion: {
+    message:
+      'Select { count } fewer { count, plural ,one { question } other { questions }} to continue',
   },
   cannotSelectSomeTopicWarning: {
     message:

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -172,7 +172,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   },
   selectMoreQuestion: {
     message:
-      'select { count } more { count, plural , one { question } other { questions }} to continue',
+      'Select { count } more { count, plural , one { question } other { questions }} to continue',
   },
   selectFewerQuestion: {
     message:


### PR DESCRIPTION

## Summary
This pull request enhances user guidance regarding the absence of a "Replace" action button. A new string  is added to provide clear instructions to users regarding the selection or deselection of questions so that the message indicates how many questions the user needs to select or deselect.

closes #12093


## References
#12093

## Reviewer guidance

1.  Navigate to the coach plugin
2.  In the plan tab , go to create a quiz 
3.  Select some resources and save changes and close the side panel
4.  Select the questions you want to replace from the question list and click on the replace icon which will open up the replace question side panel
5.  Select the question(s) you want to replace as you observe the string below on the side panel.


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
