### PR TITLE
Update facility settings link display for Learn Only Device users

### DIFF
--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -22,7 +22,7 @@
         <p>
           {{ $tr('pageDescription') }}
           <KExternalLink
-            v-if="!isMultiFacilitySuperuser && getFacilitySettingsPath()"
+            v-if="!isLearnerOnlyImport && !isMultiFacilitySuperuser && getFacilitySettingsPath()"
             :text="$tr('facilitySettings')"
             :href="getFacilitySettingsPath()"
           />
@@ -477,7 +477,7 @@
       };
     },
     computed: {
-      ...mapGetters(['isAppContext', 'isPageLoading', 'snackbarIsVisible']),
+      ...mapGetters(['isAppContext', 'isPageLoading', 'snackbarIsVisible', 'isLearnerOnlyImport']),
       ...mapGetters('deviceInfo', ['isRemoteContent']),
       InfoDescriptionColor() {
         return {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
Previously admin users on a learn-only device could see "You can also configure Facility settings” link in Device settings, but users on a LOD cannot access the facility settings page. This pull request modifies the Device Settings page to display the link if the user is not on a Learn Only Device.

- Updates vuex `mapGetters` with `isLearnerOnlyImport` on the `DeviceSettingsPage` and modifies the conditional to display the `KExternalLink` that leads to `FacilityConfigPage`.

View of a super admin on a full device:

![devicesettingspage](https://github.com/learningequality/kolibri/assets/46411498/17dbf1e7-a170-44d2-be93-2a43b92d98d0)

Updated view for admins on a learn only device:

![Screenshot 2024-05-01 at 9 57 26 AM](https://github.com/learningequality/kolibri/assets/46411498/f94f55ce-187e-45c8-840b-c768fe8c439f)

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #11877 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Follow the group learning setup and select Learn-Only device -> import or create a user account with an existing facility -> go to the Device settings page -> Verify that the message `The changes you make here will affect this device only.` is displayed.
2. Follow the On My Own setup -> go to Device settings page -> Verify that the message and link `The changes you make here will affect this device only. You can also configure device settings` are displayed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
