### PR TITLE
Always show the background for the Kolibri logo.

### DIFF
--- a/kolibri/core/assets/src/views/CoreLogo/index.vue
+++ b/kolibri/core/assets/src/views/CoreLogo/index.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <component :is="component" altText="" :src="image" />
+  <component :is="component" altText="" :src="image" :showBackground="true" />
 
 </template>
 


### PR DESCRIPTION
## Summary
* Fixes oversight from #12124 to ensure that the logo is shown with the background blob
