### PR TITLE
Add form to add address after device import

### DIFF
--- a/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
+++ b/kolibri/plugins/device/assets/src/views/PostSetupModalGroup.vue
@@ -12,11 +12,16 @@
       v-if="step === Steps.PERMISSIONS_CHANGE"
       newRole="superadmin"
     />
-
+    <AddDeviceForm
+      v-if="addingAddress"
+      @cancel="addingAddress = false"
+      @added_address="handleAddedAddress"
+    />
     <SelectDeviceForm
       v-else-if="step === Steps.SELECT_SOURCE_FACILITY_PEER"
       :title="getCommonSyncString('selectSourceTitle')"
       @submit="handleSubmit"
+      @click_add_address="goToAddAddress"
       @cancel="$emit('cancel')"
     >
       <template #underbuttons>
@@ -36,7 +41,7 @@
 
   import { mapGetters } from 'vuex';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
-  import { SelectDeviceForm } from 'kolibri.coreVue.componentSets.sync';
+  import { SelectDeviceForm, AddDeviceForm } from 'kolibri.coreVue.componentSets.sync';
   import { availableChannelsPageLink } from './ManageContentPage/manageContentLinks';
   import WelcomeModal from './WelcomeModal';
   import PermissionsChangeModal from './PermissionsChangeModal';
@@ -53,6 +58,7 @@
   export default {
     name: 'PostSetupModalGroup',
     components: {
+      AddDeviceForm,
       PermissionsChangeModal,
       WelcomeModal,
       SelectDeviceForm,
@@ -68,6 +74,8 @@
       return {
         step: Steps.WELCOME,
         Steps,
+        addingAddress: false,
+        addedAddressId: '',
       };
     },
     computed: {
@@ -81,9 +89,24 @@
       },
     },
     methods: {
+      createSnackbar(args) {
+        this.$store.dispatch('createSnackbar', args);
+      },
       startNormalImportWorkflow() {
         this.$emit('cancel');
         this.$store.dispatch('manageContent/startImportWorkflow');
+      },
+      goToSelectAddress() {
+        this.addingAddress = false;
+      },
+      goToAddAddress() {
+        this.addedAddressId = '';
+        this.addingAddress = true;
+      },
+      handleAddedAddress(addressId) {
+        this.addedAddressId = addressId;
+        this.createSnackbar(this.$tr('addDeviceSnackbarText'));
+        this.goToSelectAddress();
       },
       handleSubmit(data) {
         if (this.step === Steps.WELCOME) {
@@ -105,6 +128,10 @@
         message: 'Choose another source',
         context:
           'Button that opens the modal to choose source for content import workflow from Kolibri Studio or an attached local drive',
+      },
+      addDeviceSnackbarText: {
+        message: 'Successfully added device',
+        context: 'This message appears if a device has been added correctly.',
       },
     },
   };


### PR DESCRIPTION
## Summary
Adding a device to import content after the setup finishes was not implemented

## References
Closes: #12085

## Reviewer guidance
Following the steps described by @pcenov  in the referenced issue you must be able to add a new device to import content after the setup wizard finishes

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
