### PR TITLE
Add "Update resources" option to Options dropdown

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -573,7 +573,9 @@
       handleActiveSectionAction(opt) {
         const section_id = this.activeSection.section_id;
         const editRoute = this.$router.getRoute(PageNames.QUIZ_SECTION_EDITOR, { section_id });
-        const resourcesRoute = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES);
+        const resourcesRoute = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES, {
+          section_id,
+        });
         switch (opt.label) {
           case this.editSectionLabel$():
             this.$router.push(editRoute);

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -389,6 +389,7 @@
         questionList$,
         sectionDeletedNotification$,
         deleteConfirmation$,
+        updateResources$,
       } = enhancedQuizManagementStrings;
 
       const {
@@ -461,6 +462,7 @@
         updateQuiz,
         addQuestionToSelection,
         removeQuestionFromSelection,
+        updateResources$,
 
         // Computed
         channels,
@@ -532,6 +534,11 @@
             icon: 'delete',
             id: 'delete',
           },
+          {
+            label: this.updateResources$(),
+            icon: 'plus',
+            id: 'plus',
+          },
         ];
       },
     },
@@ -566,12 +573,16 @@
       handleActiveSectionAction(opt) {
         const section_id = this.activeSection.section_id;
         const editRoute = this.$router.getRoute(PageNames.QUIZ_SECTION_EDITOR, { section_id });
+        const resourcesRoute = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES);
         switch (opt.label) {
           case this.editSectionLabel$():
             this.$router.push(editRoute);
             break;
           case this.deleteSectionLabel$():
             this.handleShowConfirmation(section_id);
+            break;
+          case this.updateResources$():
+            this.$router.push(resourcesRoute);
             break;
         }
       },

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -182,4 +182,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message: "Section '{ section_title }' deleted",
     context: 'A snackbar message that appears when the user deletes a section',
   },
+  updateResources: {
+    message: 'Update resources',
+  },
 });


### PR DESCRIPTION


## Summary
This pull request  adds  "Update resources" option  to the Options menu to enhance user flow
## References
[#12095](https://github.com/learningequality/kolibri/issues/12095)
## Reviewer guidance
 go to "Options -> Edit Section" to open the side panel, then click "update resources' verify if everything works perfectly 
## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
