### PR TITLE
Fix some missed updates in theming

### DIFF
--- a/kolibri/core/assets/src/styles/themeSpec.js
+++ b/kolibri/core/assets/src/styles/themeSpec.js
@@ -3,23 +3,12 @@ import isObject from 'lodash/isObject';
 
 const logging = logger.getLogger(__filename);
 
-function _colorScaleValidator(value) {
+function _brandColorScaleValidator(value) {
   if (!isObject(value)) {
     logging.error(`Expected object but got '${value}'`);
     return false;
   }
-  const COLOR_NAMES = [
-    'v_50',
-    'v_100',
-    'v_200',
-    'v_300',
-    'v_400',
-    'v_500',
-    'v_600',
-    'v_700',
-    'v_800',
-    'v_900',
-  ];
+  const COLOR_NAMES = ['v_200', 'v_400', 'v_600', 'v_800', 'v_1000', 'v_1100'];
   for (const colorName of COLOR_NAMES) {
     if (!value[colorName]) {
       logging.error(`${colorName} '${name}' not defined by theme`);
@@ -60,12 +49,12 @@ export default {
       primary: {
         type: Object,
         required: true,
-        validator: _colorScaleValidator,
+        validator: _brandColorScaleValidator,
       },
       secondary: {
         type: Object,
         required: true,
-        validator: _colorScaleValidator,
+        validator: _brandColorScaleValidator,
       },
     },
   },

--- a/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
+++ b/kolibri/plugins/device/assets/src/views/DeprecationWarningBanner.vue
@@ -3,7 +3,7 @@
   <div
     v-show="showBanner"
     class="alert"
-    :style="{ backgroundColor: $themePalette.yellow.v_100 }"
+    :style="{ backgroundColor: $themePalette.yellow.v_200 }"
   >
     <div style="display:flex">
       <div>

--- a/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/DeviceSettingsPage/index.vue
@@ -481,7 +481,7 @@
       ...mapGetters('deviceInfo', ['isRemoteContent']),
       InfoDescriptionColor() {
         return {
-          color: this.$themePalette.grey.v_700,
+          color: this.$themePalette.grey.v_600,
         };
       },
       pageTitle() {

--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/UnPinnedDevices.vue
@@ -111,7 +111,7 @@
         }
       },
       channelColor() {
-        return this.$themePalette.grey.v_700;
+        return this.$themePalette.grey.v_600;
       },
     },
     $trs: {


### PR DESCRIPTION
## Summary
* Updates the custom brand color validation to match the new [expected color names](https://github.com/learningequality/kolibri-design-system/blob/release-v4/lib/styles/colorsDefault.js#L50)
* Fixes three color token references that no longer exist (see https://github.com/learningequality/kolibri-design-system/blob/release-v4/lib/styles/colorsMaterial.js for reference)

## References
Unreported regressions.

## Reviewer guidance
Example of one place this makes a difference:
Before
![Screenshot from 2024-05-09 16-46-56](https://github.com/learningequality/kolibri/assets/1680573/0c5dfba2-fd39-421e-b0c6-d9ffb763afac)

After
![Screenshot from 2024-05-09 16-48-26](https://github.com/learningequality/kolibri/assets/1680573/8e4ca28d-ad96-45a2-b550-3d769a948cd8)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e239cbeac7075adfb476e9c851a55d5d59be4bc5  | 
|--------|

### Summary:
This PR updates color validation and references across multiple components to align with new color naming conventions in the design system.

**Key points**:
- Updated color validation in `themeSpec.js` to new color names.
- Changed color references in `DeprecationWarningBanner.vue`, `DeviceSettingsPage/index.vue`, and `UnPinnedDevices.vue` to align with updated color names.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
