### PR TITLE
Fix facility sync elapsed time

### DIFF
--- a/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
+++ b/kolibri/core/assets/src/views/sync/FacilityNameAndSyncStatus/index.vue
@@ -76,13 +76,17 @@
 
 <script>
 
-  import { now } from 'kolibri.utils.serverClock';
+  import useNow from 'kolibri.coreVue.composables.useNow';
   import taskStrings from 'kolibri.coreVue.mixins.commonTaskStrings';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
 
   export default {
     name: 'FacilityNameAndSyncStatus',
     mixins: [taskStrings, commonCoreStrings],
+    setup() {
+      const { now } = useNow();
+      return { now };
+    },
     props: {
       facility: {
         type: Object,
@@ -104,11 +108,6 @@
         type: Object,
         required: true,
       },
-    },
-    data() {
-      return {
-        now: now(),
-      };
     },
     computed: {
       syncFailed() {

--- a/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
+++ b/kolibri/plugins/facility/assets/src/views/DataPage/SyncInterface/index.vue
@@ -232,8 +232,8 @@
         TaskResource.get(this.syncTaskId).then(task => {
           if (task.clearable) {
             this.isSyncing = false;
-            this.syncTaskId = '';
             TaskResource.clear(this.syncTaskId);
+            this.syncTaskId = '';
             if (task.status === TaskStatuses.FAILED) {
               this.syncHasFailed = true;
             } else if (task.status === TaskStatuses.COMPLETED) {


### PR DESCRIPTION
## Summary

Refresh elapsed time since last sync in the Facility sync status

## References

Closes #10759

## Reviewer guidance

Reproduce #10759

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
