### PR TITLE
fixes user selection getting lost on closing the sidepanel

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -174,6 +174,7 @@ export default function useQuizCreation() {
       section_id: activeSection.value.section_id,
       questions: [...questionsNotSelectedToBeReplaced, ...replacements.value],
     });
+    set(replacements, []);
   }
 
   /**

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -209,6 +209,7 @@
 
       function submitReplacement() {
         handleReplacement();
+        this.clearSelectedQuestions();
         const count = replacements.value.length;
         router.replace({
           name: PageNames.EXAM_CREATION_ROOT,
@@ -335,7 +336,6 @@
         this.showCloseConfirmation = true;
         next(false);
       } else {
-        this.clearSelectedQuestions();
         next();
       }
     },

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -204,6 +204,7 @@
       const showReplacementConfirmation = ref(false);
 
       function handleConfirmClose() {
+        replacements.value = [];
         context.emit('closePanel');
       }
 


### PR DESCRIPTION

## Summary
Fixes user selection getting lost on closing the sidepanel
Closes #12135

## References
#12135

## Reviewer guidance
1. Navigate to the select questions 
2. Check the question you want to replace 
3. Click replace icon 
4. Close the side panel

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
