### PR TITLE
Revert ExamPage BottomAppBar to previous version (0.16.x)

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -122,98 +122,73 @@
           </main>
         </KGridItem>
       </KGrid>
-      <BottomAppBar>
-        <KGrid>
-          <KGridItem
-            :layout12="{ span: 4 }"
-            :layout8="{ span: 2 }"
-            :layout4="{ span: 1 }"
+      <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
+        <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
+          <KButton
+            :disabled="questionNumber === exam.question_count - 1"
+            :primary="true"
+            :dir="layoutDirReset"
+            :aria-label="$tr('nextQuestion')"
+            :appearanceOverrides="navigationButtonStyle"
+            @click="goToQuestion(questionNumber + 1)"
           >
-            <KButton
-              :disabled="questionNumber === 0"
-              :primary="true"
-              :dir="layoutDirReset"
-              :appearanceOverrides="navigationButtonStyle"
-              :class="{ 'left-align': windowIsSmall }"
-              :aria-label="$tr('previousQuestion')"
-              @click="goToQuestion(questionNumber - 1)"
-            >
-              <template #icon>
-                <KIcon
-                  icon="back"
-                  :color="$themeTokens.textInverted"
-                  :style="navigationIconStylePrevious"
-                />
-              </template>
-              <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
-            </KButton>
-
-          </KGridItem>
-
-          <KGridItem
-            :layout12="{ span: 4 }"
-            :layout8="{ span: 3 }"
-            :layout4="{ span: 2 }"
+            <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
+            <template #iconAfter>
+              <KIcon
+                icon="forward"
+                :color="$themeTokens.textInverted"
+                :style="navigationIconStyleNext"
+              />
+            </template>
+          </KButton>
+          <KButton
+            :disabled="questionNumber === 0"
+            :primary="true"
+            :dir="layoutDirReset"
+            :appearanceOverrides="navigationButtonStyle"
+            :class="{ 'left-align': windowIsSmall }"
+            :aria-label="$tr('previousQuestion')"
+            @click="goToQuestion(questionNumber - 1)"
           >
-            <div style="text-align:center">
-              <div v-if="!missingResources" class="answered">
+            <template #icon>
+              <KIcon
+                icon="back"
+                :color="$themeTokens.textInverted"
+                :style="navigationIconStylePrevious"
+              />
+            </template>
+            <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+          </KButton>
+        </component>
 
-                {{ answeredText }}
-                <div v-if="missingResources" class="nosubmit">
-                  {{ $tr('unableToSubmit') }}
-                </div>
-              </div>
-            </div>
-          </KGridItem>
+        <!-- below prev/next buttons in tab and DOM order, in footer -->
+        <div
+          v-if="windowIsLarge"
+          :dir="layoutDirReset"
+          class="left-align"
+        >
+          <div v-if="!missingResources" class="answered">
+            {{ answeredText }}
+          </div>
+          <KButton
+            v-if="questionsUnanswered === 0"
+            :text="$tr('submitExam')"
+            :primary="true"
+            appearance="raised-button"
+            @click="finishExam"
+          />
+          <KButton
+            v-else-if="!missingResources"
+            :text="$tr('submitExam')"
+            :primary="false"
+            appearance="flat-button"
+            @click="toggleModal"
+          />
+          <div v-if="missingResources" class="nosubmit">
+            {{ $tr('unableToSubmit') }}
+          </div>
+        </div>
 
-
-          <KGridItem
-            :layout12="{ span: 4 }"
-            :layout8="{ span: 3 }"
-            :layout4="{ span: 1 }"
-          >
-            <div class="fixed-element">
-
-              <template v-if="questionNumber !== exam.question_count - 1">
-                <KButton
-                  style="position: relative; right: 0"
-                  :disabled="questionNumber === exam.question_count - 1"
-                  :primary="true"
-                  :dir="layoutDirReset"
-                  :aria-label="$tr('nextQuestion')"
-                  :appearanceOverrides="navigationButtonStyle"
-                  @click="goToQuestion(questionNumber + 1)"
-                >
-                  <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
-                  <template #iconAfter>
-                    <KIcon
-                      icon="forward"
-                      :color="$themeTokens.textInverted"
-                      :style="navigationIconStyleNext"
-                    />
-                  </template>
-                </KButton>
-              </template>
-
-              <template v-else>
-                <KButton
-                  v-if="!missingResources && questionsUnanswered !== 0"
-                  :text="$tr('submitExam')"
-                  :primary="true"
-                  appearance="raised-button"
-                  @click="toggleModal"
-                />
-                <KButton
-                  v-if="questionsUnanswered === 0"
-                  :text="$tr('submitExam')"
-                  :primary="true"
-                  appearance="raised-button"
-                  @click="finishExam"
-                />
-              </template>
-            </div>
-          </kgriditem>
-        </KGrid>
       </BottomAppBar>
     </div>
 
@@ -603,7 +578,6 @@
 
   .answered {
     display: inline-block;
-    margin-right: 700px;
     margin-left: 8px;
     white-space: nowrap;
   }

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -226,9 +226,9 @@
           <KButton
             class="btn-size"
             primary
-            @click="toggleModal"
+            @click="finishExam"
           >
-            {{ $tr('tryAgain') }}
+            {{ $tr('submitExam') }}
           </KButton>
         </KGridItem>
       </KGrid>
@@ -563,10 +563,6 @@
         message: 'Unable to submit quiz because some resources are missing or not supported',
         context:
           'Indicates that a learner cannot submit the quiz because they are not able to see all the questions.',
-      },
-      tryAgain: {
-        message: 'Try Again',
-        context: 'Indicates that quiz can only be submitted with all questions answered.',
       },
     },
   };

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -125,23 +125,6 @@
       <BottomAppBar :dir="bottomBarLayoutDirection" :maxWidth="null">
         <component :is="windowIsSmall ? 'div' : 'KButtonGroup'">
           <KButton
-            :disabled="questionNumber === exam.question_count - 1"
-            :primary="true"
-            :dir="layoutDirReset"
-            :aria-label="$tr('nextQuestion')"
-            :appearanceOverrides="navigationButtonStyle"
-            @click="goToQuestion(questionNumber + 1)"
-          >
-            <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
-            <template #iconAfter>
-              <KIcon
-                icon="forward"
-                :color="$themeTokens.textInverted"
-                :style="navigationIconStyleNext"
-              />
-            </template>
-          </KButton>
-          <KButton
             :disabled="questionNumber === 0"
             :primary="true"
             :dir="layoutDirReset"
@@ -158,6 +141,23 @@
               />
             </template>
             <span v-if="displayNavigationButtonLabel">{{ $tr('previousQuestion') }}</span>
+          </KButton>
+          <KButton
+            :disabled="questionNumber === exam.question_count - 1"
+            :primary="true"
+            :dir="layoutDirReset"
+            :aria-label="$tr('nextQuestion')"
+            :appearanceOverrides="navigationButtonStyle"
+            @click="goToQuestion(questionNumber + 1)"
+          >
+            <span v-if="displayNavigationButtonLabel">{{ $tr('nextQuestion') }}</span>
+            <template #iconAfter>
+              <KIcon
+                icon="forward"
+                :color="$themeTokens.textInverted"
+                :style="navigationIconStyleNext"
+              />
+            </template>
           </KButton>
         </component>
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

In light of #12151 this PR reverses changes done in #11658 to the `BottomAppBar` in `ExamPage`.

![2024-05-13 16 27 56 localhost c34f294aed07](https://github.com/learningequality/kolibri/assets/6356129/b8b79144-4d78-4b11-8e57-b5ba7caf3307)

Updated:

![image](https://github.com/learningequality/kolibri/assets/6356129/5c41f2c4-e4c9-4553-90b3-ec5d39d5849b)



## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

View the same quiz in 0.16 and this PR and see that the bottom app bar looks the same.

