### PR TITLE
Fixes issue where activeTabId is not set when viewing quiz reports for a group

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupReportQuizLearnerListPage.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <ReportsQuizBaseListPage @export="exportCSV">
+  <ReportsQuizBaseListPage :activeTabId="QuizzesTabs.REPORT" @export="exportCSV">
     <ReportsLearnersTable :entries="table" :questionCount="exam.question_count" />
   </ReportsQuizBaseListPage>
 
@@ -15,6 +15,7 @@
   import { PageNames } from '../../constants';
   import CSVExporter from '../../csv/exporter';
   import * as csvFields from '../../csv/fields';
+  import { QuizzesTabs } from '../../constants/tabsConstants';
   import ReportsQuizBaseListPage from './ReportsQuizBaseListPage';
   import ReportsLearnersTable from './ReportsLearnersTable';
 
@@ -25,6 +26,11 @@
       ReportsLearnersTable,
     },
     mixins: [commonCoach, commonCoreStrings],
+    data() {
+      return {
+        QuizzesTabs,
+      };
+    },
     computed: {
       group() {
         return this.groupMap[this.$route.params.groupId];


### PR DESCRIPTION
## Summary
This change appropriately sets the `activeTabId` to `QuizzesTabs.REPORT` so that the UI is rendered properly

**Before**
![Screenshot_20240516_091235](https://github.com/learningequality/kolibri/assets/12057936/a63d98c8-2893-48e6-8a36-f3c8d2725cf9)
![Screenshot_20240516_091256](https://github.com/learningequality/kolibri/assets/12057936/18422e23-eb05-4cb3-aaba-aec33435795a)

**After**
![Screenshot_20240516_091528](https://github.com/learningequality/kolibri/assets/12057936/3a5c7bb9-6f89-489c-8db1-1b5b782b4795)
- No console errors produced

## References

- #12132 


## Reviewer guidance

To test these changes:
1. Create a Quiz
2. Create a Group
3. Go to Coach > Reports > Groups > [group] > Reports > Quizzes assigned > [quiz] and try to select the "Report" tab
4. Observe the changes fix the UI bug described in the issue, and console errors are cleared


----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
