### PR TITLE
Fixes accessibility issue when reading epubs

### DIFF
--- a/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
+++ b/kolibri/plugins/epub_viewer/assets/src/views/EpubRendererIndex.vue
@@ -498,6 +498,13 @@
           this.errorLoading = true;
           this.reportLoadingError(err);
         });
+
+        // sets the iframe to be the first element in the tab order
+        // fixes accessibility for users using tabs to navigate the page
+        this.rendition.on(EVENTS.RENDITION.RENDERED, (_, view) => {
+          view.iframe.tabIndex = 1;
+          view.focus();
+        });
       });
     },
     beforeDestroy() {


### PR DESCRIPTION
## Summary
These changes fix the issue for those using tabs to navigate through books using the epub viewer library. Previously, one could never reach the Right Navigation button due to the tabindex terminating with the epub viewer. This change sets the first tab item to be the epubviewer, then all other tab-accessible items will follow the DOM order. 

### BEFORE
![before](https://github.com/learningequality/kolibri/assets/12057936/c73b2dac-3e38-4efa-8922-c461534fc65f)

### AFTER
![after](https://github.com/learningequality/kolibri/assets/12057936/65701747-766b-4018-b714-42f6a294febe)


## References

#10371 


## Reviewer guidance
1. Open an epub book to read
2. Press tab repeatedly until it reaches the Right navigation button
3. Trigger the Right navigation button (press tab or enter)
4. Press tab repeatedly again until it reaches the right navigation button

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
