### PR TITLE
Fixes progress indication bug

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/classes/ClassAssignmentsPage.vue
@@ -74,7 +74,7 @@
       }
 
       onBeforeMount(() => {
-        schedulePoll();
+        pollForUpdates();
       });
 
       onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
This change fixes the progress indication bug observed when one starts a lesson and returns to the class page without finishing. The bug occurs because polling for new lesson updates is only done after 30 seconds. This change makes it so that the app polls initially when the page is mounted, and then continues polling every 30 seconds thereafter.

### BEFORE
![Screenshot_20240518_094714](https://github.com/learningequality/kolibri/assets/12057936/7a202b31-f11a-498c-9b8f-7fcf293aa5f2)

### AFTER
![Screenshot_20240518_094748](https://github.com/learningequality/kolibri/assets/12057936/bd6754ba-2ba0-4119-a0e4-9ba25ab8b2b0)


## References
 - #11879 


## Reviewer guidance
1. Log in as a learner
2. Begin a new lesson (i.e. one that isn't already in progress)
3. Open a resource, exit without completing it, and return to the class page
4. The progress indicator should now show up for the lesson

----

## Testing checklist

- [X] Contributor has fully tested the PR manually
- [X] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
