### PR TITLE
Update exam.question_count calculation

### DIFF
--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -60,7 +60,7 @@ class ExamSerializer(ModelSerializer):
     creator = PrimaryKeyRelatedField(
         read_only=False, queryset=FacilityUser.objects.all()
     )
-    question_count = IntegerField()
+    question_count = IntegerField(allow_null=True)
     date_archived = DateTimeTzField(allow_null=True)
     date_activated = DateTimeTzField(allow_null=True)
 
@@ -83,7 +83,7 @@ class ExamSerializer(ModelSerializer):
             "learners_see_fixed_order",
             "learner_ids",
         )
-        read_only_fields = ("data_model_version",)
+        read_only_fields = ("data_model_version", "question_count")
 
     def validate(self, attrs):
         title = attrs.get("title")
@@ -137,6 +137,12 @@ class ExamSerializer(ModelSerializer):
             else:
                 # Otherwise we are just updating the exam, so allow a partial update
                 self.partial = True
+        
+        question_sources = data.get("question_sources", [])
+        data["question_count"] = sum(
+            len(source.get("questions", [])) for source in question_sources
+        )
+
         return super(ExamSerializer, self).to_internal_value(data)
 
     def create(self, validated_data):

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -137,7 +137,7 @@ class ExamSerializer(ModelSerializer):
             else:
                 # Otherwise we are just updating the exam, so allow a partial update
                 self.partial = True
-        
+
         question_sources = data.get("question_sources", [])
         data["question_count"] = sum(
             len(source.get("questions", [])) for source in question_sources

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -553,7 +553,9 @@ class ExamAPITestCase(APITestCase):
     def test_exam_question_count_calculation(self):
         self.login_as_admin()
         exam = self.make_basic_exam()
-        question_count = sum(len(source["questions"]) for source in exam["question_sources"])
+        question_count = sum(
+            len(source["questions"]) for source in exam["question_sources"]
+        )
         response = self.post_new_exam(exam)
         exam_id = response.data["id"]
         self.assertEqual(response.status_code, 201)

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -278,7 +278,7 @@ export default function useQuizCreation() {
    */
   function saveQuiz() {
     const totalQuestions = get(allSections).reduce((acc, section) => {
-      acc += parseInt(section.question_count);
+      acc += (section.questions || []).length;
       return acc;
     }, 0);
 

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -277,15 +277,6 @@ export default function useQuizCreation() {
    * @throws {Error} if quiz is not valid
    */
   function saveQuiz() {
-    const totalQuestions = get(allSections).reduce((acc, section) => {
-      acc += (section.questions || []).length;
-      return acc;
-    }, 0);
-
-    set(_quiz, {
-      ...get(_quiz),
-      question_count: totalQuestions,
-    });
     if (!validateQuiz(get(_quiz))) {
       throw new Error(`Quiz is not valid: ${JSON.stringify(get(_quiz))}`);
     }

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/index.vue
@@ -574,6 +574,7 @@
 
   .answered {
     display: inline-block;
+    margin-right: 8px;
     margin-left: 8px;
     white-space: nowrap;
   }


### PR DESCRIPTION
## Summary

Update the calculation of `exam.question_count` to take into account the length of the `section.questions` array instead of the `section.question_count` since the latter can have a value assigned to it, but the actual value of the `section.questions` array be empty because it does not has assigned resources.

For both examples below, I created a quiz with 7 questions on the first section and 10 on the second, but in the latter I didnt assinged any resource, so no questions appears on this section.

**Before:**
Here we have an exam created before these changes:

![image](https://github.com/learningequality/kolibri/assets/51239030/23f81caa-bf96-48bb-90eb-e09fd1fd79f8)
Students see 17 total questions, and "next" button appears, but there are no more questions.

![image](https://github.com/learningequality/kolibri/assets/51239030/f5954632-9e9f-47af-90ad-fa827b91a9a0)
Coach reports show x/17 total questions answered.

**After:**

Here we have an exam created after these changes:

![image](https://github.com/learningequality/kolibri/assets/51239030/a4f711cc-0c2f-4064-8c0d-9372d2e46768)
Students see right amount of total questions.

![image](https://github.com/learningequality/kolibri/assets/51239030/006364c8-3944-41e8-b968-301ea0ec7da7)
Coach reports show "all questions answered"

## References

Closes #12149

## Reviewer guidance
* Create a quiz with sections without resources. This should not affect the number total questions shown to the students/coaches.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
