### PR TITLE
Truncate the syncqueue table before we add the unique constraint.

### DIFF
--- a/kolibri/core/device/migrations/0019_syncqueue_and_status.py
+++ b/kolibri/core/device/migrations/0019_syncqueue_and_status.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import django.db.models.deletion
 import morango.models.fields.uuids
-from django.conf import settings
+from django.db import connection
 from django.db import migrations
 from django.db import models
 
@@ -19,6 +19,14 @@ class Migration(migrations.Migration):
         migrations.RemoveField(
             model_name="usersyncstatus",
             name="queued",
+        ),
+        migrations.RunSQL(
+            [
+                "DELETE FROM device_syncqueue;"
+                if "sqlite" in connection.vendor
+                else "TRUNCATE TABLE device_syncqueue;"
+            ],
+            hints={"is_syncqueue": True},
         ),
         migrations.AddField(
             model_name="syncqueue",

--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -483,9 +483,8 @@ class SyncQueueRouter(object):
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
         """Ensure that the SyncQueue models get created on the right database."""
-        if (
-            app_label == SyncQueue._meta.app_label
-            and model_name == SyncQueue._meta.model_name
+        if app_label == SyncQueue._meta.app_label and (
+            model_name == SyncQueue._meta.model_name or hints.get("is_syncqueue")
         ):
             # The SyncQueue model should be migrated only on the SYNC_QUEUE database.
             return db == SYNC_QUEUE


### PR DESCRIPTION
## Summary
* Adds truncation of the syncqueue table to the migration before we add a constraint

## References
Fixes #12194

## Reviewer guidance
Have I got my SQL right? I only checked the dialect of the default connection, even though technically for SQLite there are multiple databases, but we don't mix and match database types in Kolibri.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
