### PR TITLE
Remove resource pool from exam serializer, don't send in API call

### DIFF
--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -70,7 +70,6 @@ class Exam(AbstractFacilityDataModel):
                   "section_id": <a uuid unique to this section>,
                   "section_title": <section title>,
                   "description": <section description>,
-                  "resource_pool": [ <contentnode_ids of pool of resources> ],
                   "question_count": <number of questions in section>,
                   "learners_see_fixed_order": <bool>,
                   "questions": [

--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -40,7 +40,6 @@ class QuizSectionSerializer(Serializer):
     section_id = HexUUIDField(format="hex")
     description = CharField(required=False, allow_blank=True)
     section_title = CharField(allow_blank=True, required=False)
-    resource_pool = ListField(child=HexUUIDField(format="hex"))
     question_count = IntegerField()
     learners_see_fixed_order = BooleanField(default=False)
     questions = ListField(child=QuestionSourceSerializer(), required=False)

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -64,7 +64,6 @@ class ExamAPITestCase(APITestCase):
                 "section_title": "Test Section Title",
                 "description": "Test descripton for Section",
                 "questions": questions,
-                "resource_pool": [],
                 "question_count": len(questions),
                 "learners_see_fixed_order": False,
             }
@@ -396,7 +395,6 @@ class ExamAPITestCase(APITestCase):
                 "section_title": "Test Section Title",
                 "description": "Test descripton for Section",
                 "questions": questions,
-                "resource_pool": [],
                 "question_count": 0,
                 "learners_see_fixed_order": False,
             }
@@ -415,28 +413,7 @@ class ExamAPITestCase(APITestCase):
                 "section_id": "evil ID",
                 "section_title": "Test Section Title",
                 "description": "Test descripton for Section",
-                "resource_pool": [],
                 "question_count": 0,
-                "learners_see_fixed_order": False,
-            }
-        )
-        response = self.post_new_exam(exam)
-        self.assertEqual(response.status_code, 400)
-        self.assertFalse(models.Exam.objects.filter(title=title).exists())
-
-    def test_quiz_section_with_no_resource_pool(self):
-        self.login_as_admin()
-        exam = self.make_basic_exam()
-        title = "invalid_question_sources"
-        questions = self.make_basic_questions(1)
-        exam["title"] = title
-        exam["question_sources"].append(
-            {
-                "section_id": uuid.uuid4().hex,
-                "section_title": "Test Section Title",
-                "description": "Test descripton for Section",
-                "questions": questions,
-                "question_count": len(questions),
                 "learners_see_fixed_order": False,
             }
         )
@@ -456,7 +433,6 @@ class ExamAPITestCase(APITestCase):
                 "section_title": "Test Section Title",
                 "description": "Test descripton for Section",
                 "questions": questions,
-                "resource_pool": [],
                 "learners_see_fixed_order": False,
             }
         )
@@ -474,7 +450,6 @@ class ExamAPITestCase(APITestCase):
                 "section_id": uuid.uuid4().hex,
                 "section_title": "Test Section Title",
                 "description": "Test descripton for Section",
-                "resource_pool": [],
                 "question_count": 0,
                 "learners_see_fixed_order": False,
             }

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -291,15 +291,14 @@ export default function useQuizCreation() {
     }
 
     // Here we update each section's `resource_pool` to only be the IDs of the resources
-    const sectionsWithResourcePoolAsIDs = get(allSections).map(section => {
-      const resourcePoolAsIds = get(section).resource_pool.map(content => content.id);
-      section.resource_pool = resourcePoolAsIds;
+    const questionSourcesWithoutResourcePool = get(allSections).map(section => {
+      delete section.resource_pool;
       return section;
     });
 
     const finalQuiz = get(_quiz);
 
-    finalQuiz.question_sources = sectionsWithResourcePoolAsIDs;
+    finalQuiz.question_sources = questionSourcesWithoutResourcePool;
 
     return ExamResource.saveModel({ data: finalQuiz });
   }

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -292,8 +292,9 @@ export default function useQuizCreation() {
 
     // Here we update each section's `resource_pool` to only be the IDs of the resources
     const questionSourcesWithoutResourcePool = get(allSections).map(section => {
-      delete section.resource_pool;
-      return section;
+      const sectionToSave = { ...section };
+      delete sectionToSave.resource_pool;
+      return sectionToSave;
     });
 
     const finalQuiz = get(_quiz);


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

The `resource_pool` is not used when reading exam data back from the database and can be derived from the list of questions in each section by their `exercise_id`.

This removes it from the serializer and ensures it doesn't get send to the API when saving a quiz.


