### PR TITLE
Zip the whl file before uploading for BCK step.

### DIFF
--- a/.github/workflows/release_kolibri.yml
+++ b/.github/workflows/release_kolibri.yml
@@ -196,6 +196,8 @@ jobs:
       with:
         name: ${{ needs.whl.outputs.whl-file-name }}
         path: dist
+    - name: Zip whl file
+      run: zip -j dist/kolibri.zip dist/${{ needs.whl.outputs.whl-file-name }}
     - uses: 'google-github-actions/auth@v2'
       with:
         credentials_json: '${{ secrets.GH_UPLOADER_GCP_SA_CREDENTIALS }}'
@@ -204,8 +206,9 @@ jobs:
     - name: Upload to BCK bucket
       uses: 'google-github-actions/upload-cloud-storage@v2'
       with:
-        path: 'dist/${{ needs.whl.outputs.whl-file-name }}'
+        path: 'dist/kolibri.zip'
         destination: '${{ secrets.BCK_PROD_BUILD_ARTIFACT_GCS_BUCKET }}'
+        parent: false
   android_release:
     name: Release Android App
     if: ${{ !github.event.release.prerelease }}


### PR DESCRIPTION
## Summary
Zips the whl file into a zip file called `kolibri.zip` before uploading to the BCK GCS bucket.