### PR TITLE
fixes quizzes not showing "File size for download" value properly

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -88,7 +88,7 @@
                     :text="coachString('openQuizLabel')"
                     appearance="flat-button"
                     class="table-left-aligned-button"
-                    @click="showOpenConfirmationModal = true; modalQuizId = tableRow"
+                    @click="showOpenConfirmationModal = true; modalQuiz = tableRow"
                   />
                   <!-- Close quiz button -->
                   <KButton
@@ -96,7 +96,7 @@
                     :text="coachString('closeQuizLabel')"
                     appearance="flat-button"
                     class="table-left-aligned-button"
-                    @click="showCloseConfirmationModal = true; modalQuizId = tableRow.id;"
+                    @click="showCloseConfirmationModal = true; modalQuiz = tableRow;"
                   />
                   <div
                     v-if="tableRow.archive"
@@ -116,11 +116,11 @@
           :submitText="coreString('continueAction')"
           :cancelText="coreString('cancelAction')"
           @cancel="showOpenConfirmationModal = false"
-          @submit="handleOpenQuiz(modalQuizId)"
+          @submit="handleOpenQuiz(modalQuiz.id)"
         >
           <p>{{ coachString('openQuizModalDetail') }}</p>
           <p>{{ coachString('lodQuizDetail') }}</p>
-          <p>{{ coachString('fileSizeToDownload', { size: modalQuizId.size_string }) }}</p>
+          <p>{{ coachString('fileSizeToDownload', { size: modalQuiz.size_string }) }}</p>
         </KModal>
         <KModal
           v-if="showCloseConfirmationModal"
@@ -128,7 +128,7 @@
           :submitText="coreString('continueAction')"
           :cancelText="coreString('cancelAction')"
           @cancel="showCloseConfirmationModal = false"
-          @submit="handleCloseQuiz(modalQuizId)"
+          @submit="handleCloseQuiz(modalQuiz.id)"
         >
           <div>{{ coachString('closeQuizModalDetail') }}</div>
         </KModal>
@@ -167,7 +167,7 @@
         filter: 'allQuizzes',
         showOpenConfirmationModal: false,
         showCloseConfirmationModal: false,
-        modalQuizId: null,
+        modalQuiz: null,
       };
     },
     computed: {

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -88,7 +88,7 @@
                     :text="coachString('openQuizLabel')"
                     appearance="flat-button"
                     class="table-left-aligned-button"
-                    @click="showOpenConfirmationModal = true; modalQuizId = tableRow.id"
+                    @click="showOpenConfirmationModal = true; modalQuizId = tableRow"
                   />
                   <!-- Close quiz button -->
                   <KButton


### PR DESCRIPTION


## Summary
This PR fixes quizzes not showing "File size for download" value properly
Closes [#12163](https://github.com/learningequality/kolibri/issues/12163)

### Before
[before.webm](https://github.com/learningequality/kolibri/assets/103313919/7b3a51cf-0028-48e3-bf94-cdc952f64788)

### After

[filesize.webm](https://github.com/learningequality/kolibri/assets/103313919/4d23c871-3d5d-48e0-a841-f9deab226ff1)


…

## References
#12163

…

## Reviewer guidance
Create quiz > add resources > save quiz > click start quiz 

…

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
