### PR TITLE
Allow delete all questions

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -445,20 +445,18 @@ export default function useQuizCreation() {
     );
   });
 
+  const allSectionsEmpty = computed(() => {
+    return get(allSections).every(section => section.questions.length === 0);
+  });
+
   /**
 
    */
   function deleteActiveSelectedQuestions() {
     const { section_id, questions: section_questions } = get(activeSection);
     const selectedIds = get(selectedActiveQuestions);
-    let questions = section_questions.filter(q => !selectedIds.includes(q.id));
-    let question_count = questions.length;
-    if (question_count === 0) {
-      // They've deleted all of the questions. We don't allow `question_count` to be 0,
-      // so we'll randomly select 1 question for the section -- pass `true` to reseed the shuffle.
-      questions = selectRandomQuestionsFromResources(1, get(activeResourcePool), selectedIds);
-      question_count = 1;
-    }
+    const questions = section_questions.filter(q => !selectedIds.includes(q.id));
+    const question_count = questions.length;
     updateSection({
       section_id,
       questions,
@@ -509,6 +507,7 @@ export default function useQuizCreation() {
   provide('activeQuestions', activeQuestions);
   provide('selectedActiveQuestions', selectedActiveQuestions);
   provide('allQuestionsSelected', allQuestionsSelected);
+  provide('allSectionsEmpty', allSectionsEmpty);
   provide('selectAllIsIndeterminate', selectAllIsIndeterminate);
   provide('replacementQuestionPool', replacementQuestionPool);
   provide('selectAllQuestions', selectAllQuestions);
@@ -545,6 +544,7 @@ export default function useQuizCreation() {
     replacementQuestionPool,
     selectAllIsIndeterminate,
     selectAllLabel,
+    allSectionsEmpty,
     allQuestionsSelected,
     noQuestionsSelected,
   };
@@ -583,6 +583,7 @@ export function injectQuizCreation() {
   const activeQuestionsPool = inject('activeQuestionsPool');
   const activeQuestions = inject('activeQuestions');
   const allQuestionsSelected = inject('allQuestionsSelected');
+  const allSectionsEmpty = inject('allSectionsEmpty');
   const selectAllIsIndeterminate = inject('selectAllIsIndeterminate');
   const selectedActiveQuestions = inject('selectedActiveQuestions');
   const replacementQuestionPool = inject('replacementQuestionPool');
@@ -609,6 +610,7 @@ export function injectQuizCreation() {
     toggleQuestionInSelection,
 
     // Computed
+    allSectionsEmpty,
     allQuestionsSelected,
     selectAllIsIndeterminate,
     channels,

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -101,32 +101,36 @@ export default function useQuizCreation() {
           resource_pool
         );
       } else {
-        // In this case, we already had resources in the section, so we need to handle the
-        // case where a resource has been removed so that we remove & replace the questions
-        const removedResourceQuestionIds = originalResourcePool.reduce(
-          (questionIds, originalResource) => {
-            if (!resource_pool.map(r => r.id).includes(originalResource.id)) {
-              // If the resource_pool doesn't have the originalResource, we're removing it
-              questionIds = [...questionIds, ...originalResource.unique_question_ids];
+        if (question_count === 0) {
+          updates.questions = [];
+        } else {
+          // In this case, we already had resources in the section, so we need to handle the
+          // case where a resource has been removed so that we remove & replace the questions
+          const removedResourceQuestionIds = originalResourcePool.reduce(
+            (questionIds, originalResource) => {
+              if (!resource_pool.map(r => r.id).includes(originalResource.id)) {
+                // If the resource_pool doesn't have the originalResource, we're removing it
+                questionIds = [...questionIds, ...originalResource.unique_question_ids];
+                return questionIds;
+              }
               return questionIds;
-            }
-            return questionIds;
-          },
-          []
-        );
-        if (removedResourceQuestionIds.length === 0) {
-          // If no resources were removed, we don't need to update the questions
-          return;
+            },
+            []
+          );
+          if (removedResourceQuestionIds.length === 0) {
+            // If no resources were removed, we don't need to update the questions
+            return;
+          }
+          const questionsToKeep = originalQuestions.filter(
+            q => !removedResourceQuestionIds.includes(q.id)
+          );
+          const numReplacementsNeeded =
+            (question_count || originalQuestionCount) - questionsToKeep.length;
+          updates.questions = [
+            ...questionsToKeep,
+            ...selectRandomQuestionsFromResources(numReplacementsNeeded, resource_pool),
+          ];
         }
-        const questionsToKeep = originalQuestions.filter(
-          q => !removedResourceQuestionIds.includes(q.id)
-        );
-        const numReplacementsNeeded =
-          (question_count || originalQuestionCount) - questionsToKeep.length;
-        updates.questions = [
-          ...questionsToKeep,
-          ...selectRandomQuestionsFromResources(numReplacementsNeeded, resource_pool),
-        ];
       }
     } else if (question_count !== originalQuestionCount) {
       /**

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -507,7 +507,6 @@ export default function useQuizCreation() {
   provide('activeQuestions', activeQuestions);
   provide('selectedActiveQuestions', selectedActiveQuestions);
   provide('allQuestionsSelected', allQuestionsSelected);
-  provide('allSectionsEmpty', allSectionsEmpty);
   provide('selectAllIsIndeterminate', selectAllIsIndeterminate);
   provide('replacementQuestionPool', replacementQuestionPool);
   provide('selectAllQuestions', selectAllQuestions);
@@ -583,7 +582,6 @@ export function injectQuizCreation() {
   const activeQuestionsPool = inject('activeQuestionsPool');
   const activeQuestions = inject('activeQuestions');
   const allQuestionsSelected = inject('allQuestionsSelected');
-  const allSectionsEmpty = inject('allSectionsEmpty');
   const selectAllIsIndeterminate = inject('selectAllIsIndeterminate');
   const selectedActiveQuestions = inject('selectedActiveQuestions');
   const replacementQuestionPool = inject('replacementQuestionPool');
@@ -610,7 +608,6 @@ export function injectQuizCreation() {
     toggleQuestionInSelection,
 
     // Computed
-    allSectionsEmpty,
     allQuestionsSelected,
     selectAllIsIndeterminate,
     channels,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -26,7 +26,7 @@
         <span
           v-if="allSectionsEmpty"
           class="message"
-        > 
+        >
           {{ allSectionsEmptyWarning$() }}
         </span>
         <KButtonGroup>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -23,10 +23,17 @@
       <CreateQuizSection v-if="quizInitialized" />
 
       <BottomAppBar>
+        <span
+          v-if="allSectionsEmpty"
+          class="message"
+        > 
+          {{ allSectionsEmptyWarning$() }}
+        </span>
         <KButtonGroup>
           <KButton
             :text="coreString('saveAction')"
             primary
+            :disabled="allSectionsEmpty"
             @click="() => saveQuizAndRedirect()"
           />
         </KButtonGroup>
@@ -45,6 +52,7 @@
   import pickBy from 'lodash/pickBy';
   import BottomAppBar from 'kolibri.coreVue.components.BottomAppBar';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { PageNames } from '../../../constants';
   import commonCoach from '../../common';
   import CoachImmersivePage from '../../CoachImmersivePage';
@@ -60,10 +68,20 @@
     },
     mixins: [commonCoreStrings, commonCoach],
     setup() {
-      const { saveQuiz, initializeQuiz } = useQuizCreation();
+      const { saveQuiz, initializeQuiz, allSectionsEmpty } = useQuizCreation();
       const showError = ref(false);
       const quizInitialized = ref(false);
-      return { showError, saveQuiz, initializeQuiz, quizInitialized };
+
+      const { allSectionsEmptyWarning$ } = enhancedQuizManagementStrings;
+
+      return {
+        showError,
+        saveQuiz,
+        initializeQuiz,
+        quizInitialized,
+        allSectionsEmpty,
+        allSectionsEmptyWarning$,
+      };
     },
     provide() {
       return {
@@ -126,4 +144,10 @@
 </script>
 
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+
+  .message {
+    margin-right: 8px;
+  }
+
+</style>

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -197,4 +197,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   updateResources: {
     message: 'Update resources',
   },
+  allSectionsEmptyWarning: {
+    message: "You don't have any questions in the quiz",
+  },
 });


### PR DESCRIPTION
## Summary

After discussion with @rtibbles, we propose this solution to #12159. Where we have the possibility of eliminating all questions from a section. And to avoid possible unintended consequences, add a validation to disable the save quiz button if all sections are empty.

## References

Closes #12159.

## Reviewer guidance

Create an empty quiz, add sections without adding resources, and try to save it.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
