### PR TITLE
EQM: Notify not enough resources to replace questions

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -117,19 +117,17 @@ export default function useQuizCreation() {
             },
             []
           );
-          if (removedResourceQuestionIds.length === 0) {
-            // If no resources were removed, we don't need to update the questions
-            return;
+          if (removedResourceQuestionIds.length !== 0) {
+            const questionsToKeep = originalQuestions.filter(
+              q => !removedResourceQuestionIds.includes(q.id)
+            );
+            const numReplacementsNeeded =
+              (question_count || originalQuestionCount) - questionsToKeep.length;
+            updates.questions = [
+              ...questionsToKeep,
+              ...selectRandomQuestionsFromResources(numReplacementsNeeded, resource_pool),
+            ];
           }
-          const questionsToKeep = originalQuestions.filter(
-            q => !removedResourceQuestionIds.includes(q.id)
-          );
-          const numReplacementsNeeded =
-            (question_count || originalQuestionCount) - questionsToKeep.length;
-          updates.questions = [
-            ...questionsToKeep,
-            ...selectRandomQuestionsFromResources(numReplacementsNeeded, resource_pool),
-          ];
         }
       }
     } else if (question_count !== originalQuestionCount) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/NotEnoughResourcesModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/NotEnoughResourcesModal.vue
@@ -1,0 +1,81 @@
+<template>
+
+  <KModal
+    :title="notEnoughReplacementsTitle$()"
+    :submitText="addResourcesAction$()"
+  >
+    <p>
+      {{
+        notEnoughReplacementsMessage$({
+          selected: selectedQuestions.length,
+          available: availableResources.length,
+        })
+      }}
+    </p>
+    <p v-if="availableResources.length">
+      {{
+        addMoreResourcesWithNonEmptyPool$({
+          available: availableResources.length,
+        })
+      }}
+    </p>
+    <p v-else>
+      {{ addMoreResourcesWithEmptyPool$() }}
+    </p>
+    <template #actions>
+      <KButtonGroup>
+        <KButton
+          @click="() => $emit('close')"
+        >
+          {{ goBackAction$() }}
+        </KButton>
+        <KButton
+          primary
+          @click="() => $emit('addResources')"
+        >
+          {{ addResourcesAction$() }}
+        </KButton>
+      </KButtonGroup>
+    </template>
+  </KModal>
+
+</template>
+
+
+<script>
+
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+
+  export default {
+    name: 'NotEnoughResourcesModal',
+    setup() {
+      const {
+        goBackAction$,
+        addResourcesAction$,
+        notEnoughReplacementsTitle$,
+        notEnoughReplacementsMessage$,
+        addMoreResourcesWithEmptyPool$,
+        addMoreResourcesWithNonEmptyPool$,
+      } = enhancedQuizManagementStrings;
+      return {
+        goBackAction$,
+        addResourcesAction$,
+        notEnoughReplacementsTitle$,
+        notEnoughReplacementsMessage$,
+        addMoreResourcesWithEmptyPool$,
+        addMoreResourcesWithNonEmptyPool$,
+      };
+    },
+    props: {
+      selectedQuestions: {
+        type: Array,
+        required: true,
+      },
+      availableResources: {
+        type: Array,
+        required: true,
+      },
+    },
+  };
+
+</script>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -126,7 +126,7 @@
       v-if="showNoEnoughResources"
       :selectedQuestions="selectedActiveQuestions"
       :availableResources="replacementQuestionPool"
-      @close="showNoEnoughResources = false"
+      @close="closeNoEnoughResourcesModal"
       @addResources="redirectToSelectResources"
     />
     <KModal
@@ -358,6 +358,10 @@
           section_id: this.activeSection.section_id,
         });
         this.$router.replace(route);
+      },
+      closeNoEnoughResourcesModal() {
+        this.showNoEnoughResources = false;
+        this.$emit('closePanel');
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -122,6 +122,13 @@
         </KGridItem>
       </KGrid>
     </div>
+    <NotEnoughResourcesModal
+      v-if="showNoEnoughResources"
+      :selectedQuestions="selectedActiveQuestions"
+      :availableResources="replacementQuestionPool"
+      @close="showNoEnoughResources = false"
+      @addResources="redirectToSelectResources"
+    />
     <KModal
       v-if="showReplacementConfirmation"
       :submitText="coreString('confirmAction')"
@@ -160,10 +167,12 @@
   import { PageNames } from '../../../constants/index';
   import AccordionItem from './AccordionItem';
   import AccordionContainer from './AccordionContainer';
+  import NotEnoughResourcesModal from './NotEnoughResourcesModal';
 
   export default {
     name: 'ReplaceQuestions',
     components: {
+      NotEnoughResourcesModal,
       AccordionContainer,
       AccordionItem,
     },
@@ -202,6 +211,10 @@
 
       const showCloseConfirmation = ref(false);
       const showReplacementConfirmation = ref(false);
+      const showNoEnoughResources = ref(false);
+
+      showNoEnoughResources.value =
+        replacementQuestionPool.value.length < selectedActiveQuestions.value.length;
 
       function handleConfirmClose() {
         replacements.value = [];
@@ -262,6 +275,7 @@
         selectAllIsChecked,
         replaceSelectedQuestions,
         activeResourceMap,
+        showNoEnoughResources,
         showCloseConfirmation,
         showReplacementConfirmation,
         confirmReplacement,
@@ -337,6 +351,14 @@
       } else {
         next();
       }
+    },
+    methods: {
+      redirectToSelectResources() {
+        const route = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES, {
+          section_id: this.activeSection.section_id,
+        });
+        this.$router.replace(route);
+      },
     },
   };
 

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -217,7 +217,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   },
   addMoreResourcesWithNonEmptyPool: {
     message:
-      'Please add more resources to this section, or go back and only select up to { available } questions to be replaced.',
+      'Please add more resources to this section, or go back and only select up to { available, number } { available, plural, one { question } other { questions } } to be replaced.',
     context:
       'Message of modal when a user tries to replace more questions than are available in the pool',
   },

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -200,4 +200,31 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   allSectionsEmptyWarning: {
     message: "You don't have any questions in the quiz",
   },
+  notEnoughReplacementsTitle: {
+    message: 'Not enough replacements available',
+    context:
+      'Title of modal when a user tries to replace more questions than are available in the pool',
+  },
+  notEnoughReplacementsMessage: {
+    message:
+      "You've selected { selected } questions to replace, but only has { available } questions available to replace them with.",
+    context:
+      'Message of modal when a user tries to replace more questions than are available in the pool',
+  },
+  addMoreResourcesWithEmptyPool: {
+    message: 'Please more resources to this section.',
+    context: 'Message of modal when a user tries to replace questions but the pool is empty',
+  },
+  addMoreResourcesWithNonEmptyPool: {
+    message:
+      'Please add more resources to this section, or go back and only select up to { available } questions to be replaced.',
+    context:
+      'Message of modal when a user tries to replace more questions than are available in the pool',
+  },
+  addResourcesAction: {
+    message: 'Add resources',
+  },
+  goBackAction: {
+    message: 'Go back',
+  },
 });

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -212,7 +212,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
       'Message of modal when a user tries to replace more questions than are available in the pool',
   },
   addMoreResourcesWithEmptyPool: {
-    message: 'Please more resources to this section.',
+    message: 'Please add more resources to this section.',
     context: 'Message of modal when a user tries to replace questions but the pool is empty',
   },
   addMoreResourcesWithNonEmptyPool: {

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -207,7 +207,7 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   },
   notEnoughReplacementsMessage: {
     message:
-      "You've selected { selected } questions to replace, but only has { available } questions available to replace them with.",
+      "You've selected { selected, number } { selected, plural, one { question } other { questions } } to replace, but {available, plural, =0 { don't have questions } one { only have 1 question } other { only have { available } questions } } available to replace them with.",
     context:
       'Message of modal when a user tries to replace more questions than are available in the pool',
   },


### PR DESCRIPTION
## Summary

Adds a modal to notify the user when there are no enough resources to replace the current selected questions


https://github.com/learningequality/kolibri/assets/51239030/b769d7f6-a996-41f4-ac6b-6d5a90fcb9ef



## References
Closes #12094

## Reviewer guidance
* Fill a section with almost all, or/and all available questions in the pool.
* Select them all and try to replace them. A modal should appear and inform you that there are no enough questions, and redirect you to add more resources

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
