### PR TITLE
Fixing typo in useUser composable getter (again)

### DIFF
--- a/kolibri/core/assets/src/composables/__mocks__/useUser.js
+++ b/kolibri/core/assets/src/composables/__mocks__/useUser.js
@@ -58,7 +58,7 @@ const MOCK_DEFAULTS = {
   isFacilityCoach: false,
   isLearner: true,
   isFacilityAdmin: false,
-  userIsMultipleFacilityAdmin: false,
+  userIsMultiFacilityAdmin: false,
   getUserPermissions: {},
   userFacilityId: undefined,
   getUserKind: UserKinds.ANONYMOUS,

--- a/kolibri/core/assets/src/composables/useUser.js
+++ b/kolibri/core/assets/src/composables/useUser.js
@@ -15,7 +15,7 @@ export default function useUser() {
   const isFacilityCoach = computed(() => store.getters.isFacilityCoach);
   const isLearner = computed(() => store.getters.isLearner);
   const isFacilityAdmin = computed(() => store.getters.isFacilityAdmin);
-  const userIsMultipleFacilityAdmin = computed(() => store.getters.userIsMultipleFacilityAdmin);
+  const userIsMultiFacilityAdmin = computed(() => store.getters.userIsMultiFacilityAdmin);
   const getUserPermissions = computed(() => store.getters.getUserPermissions);
   const userFacilityId = computed(() => store.getters.userFacilityId);
   const getUserKind = computed(() => store.getters.getUserKind);
@@ -46,7 +46,7 @@ export default function useUser() {
     isFacilityCoach,
     isLearner,
     isFacilityAdmin,
-    userIsMultipleFacilityAdmin,
+    userIsMultiFacilityAdmin,
     getUserPermissions,
     userFacilityId,
     getUserKind,


### PR DESCRIPTION
## Summary
This change fixes a typo in the useUser composable. Renames `userIsMultipleFacilityAdmin` to `userIsMultiFacilityAdmin`.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
