### PR TITLE
Revert change that prevented search redirect in all cases.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsPage/index.vue
@@ -399,24 +399,19 @@
       };
 
       function _handleTopicRedirect(route, children, id, skipped) {
-        if (children.every(c => c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
-          // if all children are leaf nodes (i.e. they have no children themselves)
+        if (!children.some(c => !c.is_leaf) && route.name !== PageNames.TOPICS_TOPIC_SEARCH) {
+          // if there are no children which are not leaf nodes (i.e. they have children themselves)
+          // which is equivalent to saying that all children are leaf nodes
           // then redirect to search results
-          if (children.every(c => c.title == '')) {
-            router.replace({
-              name: PageNames.TOPICS_TOPIC_SEARCH,
-              params: { ...route.params, id },
-              query: route.query,
-            });
-          } else {
-            sidePanelIsOpen.value = false;
-          }
+          router.replace({
+            name: PageNames.TOPICS_TOPIC_SEARCH,
+            params: { ...route.params, id },
+            query: route.query,
+          });
         } else if (skipped) {
           // If we have skipped down the topic tree, replace to the new top level topic
           router.replace({ name: route.name, params: { ...route.params, id }, query: route.query });
           return true;
-        } else {
-          sidePanelIsOpen.value = false;
         }
       }
 
@@ -489,6 +484,7 @@
           set(channel, null);
           set(contents, []);
           set(isRoot, false);
+          set(sidePanelIsOpen, false);
           const shouldResolve = samePageCheckGenerator(store);
           let promise;
           if (props.deviceId) {


### PR DESCRIPTION
## Summary
* #12019 introduced a regression that caused the search redirect never to occur for folders with only leaf nodes as children
* Reverts most of the changes in that PR to restore former behaviour
* Retains the setting of sidePanelOpen to false, but just sets this whenever topic navigation occurs

## References

Bug introduced:
![Screenshot from 2024-06-04 08-34-33](https://github.com/learningequality/kolibri/assets/1680573/f6b4c755-efe3-4e79-a608-ec21be00b481)


## Reviewer guidance
Navigate to a folder with only leaf nodes as children on desktop.
Confirm that the search side nav properly displays.
Switch to mobile browsing in dev tools.
Navigate down the topic hierarchy using the folders sidepanel.
Ensure that each time you navigate, the side panel is properly hidden once you have navigated to the next folder.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
