### PR TITLE
Move NotEnoughResourcesModal to CreateQuizSection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -330,6 +330,13 @@
 
     </KTabsPanel>
 
+    <NotEnoughResourcesModal
+      v-if="showNotEnoughResourcesModal"
+      :selectedQuestions="selectedActiveQuestions"
+      :availableResources="replacementQuestionPool"
+      @close="showNotEnoughResourcesModal = false"
+      @addResources="redirectToSelectResources"
+    />
     <KModal
       v-if="showDeleteConfirmation"
       :title="deleteSectionLabel$()"
@@ -363,6 +370,7 @@
   import TabsWithOverflow from './TabsWithOverflow';
   import AccordionContainer from './AccordionContainer';
   import AccordionItem from './AccordionItem';
+  import NotEnoughResourcesModal from './NotEnoughResourcesModal';
 
   const logger = logging.getLogger(__filename);
 
@@ -376,6 +384,7 @@
       DragSortWidget,
       DragHandle,
       TabsWithOverflow,
+      NotEnoughResourcesModal,
     },
     mixins: [commonCoreStrings, commonCoach],
     setup() {
@@ -491,6 +500,7 @@
     data() {
       return {
         showDeleteConfirmation: false,
+        showNotEnoughResourcesModal: false,
       };
     },
     computed: {
@@ -576,9 +586,13 @@
         this.showDeleteConfirmation = section_id;
       },
       handleReplaceSelection() {
-        const section_id = get(this.activeSection).section_id;
-        const route = this.$router.getRoute(PageNames.QUIZ_REPLACE_QUESTIONS, { section_id });
-        this.$router.push(route);
+        if (this.replacementQuestionPool.length < this.selectedActiveQuestions.length) {
+          this.showNotEnoughResourcesModal = true;
+        } else {
+          const section_id = get(this.activeSection).section_id;
+          const route = this.$router.getRoute(PageNames.QUIZ_REPLACE_QUESTIONS, { section_id });
+          this.$router.push(route);
+        }
       },
       handleActiveSectionAction(opt) {
         const section_id = this.activeSection.section_id;
@@ -662,6 +676,10 @@
             count,
           })
         );
+      },
+      redirectToSelectResources() {
+        this.showNotEnoughResourcesModal = false;
+        this.openSelectResources(this.activeSection.section_id);
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/NotEnoughResourcesModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/NotEnoughResourcesModal.vue
@@ -2,7 +2,6 @@
 
   <KModal
     :title="notEnoughReplacementsTitle$()"
-    :submitText="addResourcesAction$()"
   >
     <p>
       {{

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -122,13 +122,6 @@
         </KGridItem>
       </KGrid>
     </div>
-    <NotEnoughResourcesModal
-      v-if="showNoEnoughResources"
-      :selectedQuestions="selectedActiveQuestions"
-      :availableResources="replacementQuestionPool"
-      @close="closeNoEnoughResourcesModal"
-      @addResources="redirectToSelectResources"
-    />
     <KModal
       v-if="showReplacementConfirmation"
       :submitText="coreString('confirmAction')"
@@ -167,12 +160,10 @@
   import { PageNames } from '../../../constants/index';
   import AccordionItem from './AccordionItem';
   import AccordionContainer from './AccordionContainer';
-  import NotEnoughResourcesModal from './NotEnoughResourcesModal';
 
   export default {
     name: 'ReplaceQuestions',
     components: {
-      NotEnoughResourcesModal,
       AccordionContainer,
       AccordionItem,
     },
@@ -211,10 +202,6 @@
 
       const showCloseConfirmation = ref(false);
       const showReplacementConfirmation = ref(false);
-      const showNoEnoughResources = ref(false);
-
-      showNoEnoughResources.value =
-        replacementQuestionPool.value.length < selectedActiveQuestions.value.length;
 
       function handleConfirmClose() {
         replacements.value = [];
@@ -275,7 +262,6 @@
         selectAllIsChecked,
         replaceSelectedQuestions,
         activeResourceMap,
-        showNoEnoughResources,
         showCloseConfirmation,
         showReplacementConfirmation,
         confirmReplacement,
@@ -351,18 +337,6 @@
       } else {
         next();
       }
-    },
-    methods: {
-      redirectToSelectResources() {
-        const route = this.$router.getRoute(PageNames.QUIZ_SELECT_RESOURCES, {
-          section_id: this.activeSection.section_id,
-        });
-        this.$router.replace(route);
-      },
-      closeNoEnoughResourcesModal() {
-        this.showNoEnoughResources = false;
-        this.$emit('closePanel');
-      },
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request moves the `NotEnoughResourcesModal` component into `CreateQuizSection` to avoid displaying the replacements side panel in the background when `NotEnoughResourcesModal` is shown. Navigation to the replacements side panel will occur only if there are enough replacement questions.

Before:
<img width="1237" alt="NotEnoughResourcesModalBefore" src="https://github.com/learningequality/kolibri/assets/46411498/fe9d3347-1360-4613-953f-e570bde31e4f">

After:

https://github.com/learningequality/kolibri/assets/46411498/ee4283da-4664-4df6-ae96-d4b205ff812e


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #12229 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
1. Download resources and create a new quiz.
2. Select options and add resources to the quiz.
3. Select all questions and press the replace icon button.
4. If there are not enough replacement questions, the `NotEnoughResourcesModal` should appear without the replacements side panel in the background.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included

## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
