### PR TITLE
Fix hitherto unnoticed regression in channel upgrade

### DIFF
--- a/kolibri/core/content/tasks.py
+++ b/kolibri/core/content/tasks.py
@@ -539,7 +539,6 @@ def remoteimport(
         "network",
         channel_id,
         baseurl=baseurl,
-        update_progress=None,
     )
 
     if update:


### PR DESCRIPTION
## Summary
* The channel upgrade task passed an invalid kwarg to the channel upgrade management command
* This caused the management command invocation to error after the upgrade to Django 3.2
* Fixes this by not passing non-existent kwarg to management command.

## References
Fixes unreported error which has now been noticed, so closes #12300

## Reviewer guidance
Upgrade a channel to a newer version.
See that it works rather than breaks.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
