### PR TITLE
Remove empty sections from quizzes on publish

### DIFF
--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -178,6 +178,10 @@ class AbstractExam(models.Model):
                 questions.append(question)
         return questions
 
+    def save(self, *args, **kwargs):
+        self.question_count = len(self.get_questions())
+        super().save(*args, **kwargs)
+
 
 class DraftExam(AbstractExam):
 

--- a/kolibri/core/exams/models.py
+++ b/kolibri/core/exams/models.py
@@ -283,6 +283,13 @@ class Exam(AbstractExam, AbstractFacilityDataModel):
         if getattr(self, "active", False) is True:
             if getattr(self, "date_activated") is None:
                 self.date_activated = timezone.now()
+        # Remove any empty sections from the question sources
+        # No need to update the question count here, as sections with no questions
+        # will not have been counted in the question count.
+        if self.data_model_version == 3:
+            self.question_sources = [
+                section for section in self.question_sources if section.get("questions")
+            ]
         super(Exam, self).save(*args, **kwargs)
 
     def infer_dataset(self, *args, **kwargs):

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -68,9 +68,25 @@ class BaseExamTest:
         cls.classroom = Classroom.objects.create(name="Classroom", parent=cls.facility)
         kwargs = dict(
             title="title",
-            question_count=1,
             collection=cls.classroom,
             creator=cls.admin,
+            question_sources=[
+                {
+                    "section_id": uuid.uuid4().hex,
+                    "section_title": "Test Section Title",
+                    "description": "Test descripton for Section",
+                    "questions": [
+                        {
+                            "exercise_id": uuid.uuid4().hex,
+                            "question_id": uuid.uuid4().hex,
+                            "title": "Test question Title",
+                            "counter_in_exercise": 0,
+                        }
+                    ],
+                    "question_count": 1,
+                    "learners_see_fixed_order": False,
+                }
+            ],
         )
         if cls.class_object == models.Exam:
             kwargs["active"] = True
@@ -508,14 +524,14 @@ class BaseExamTest:
     def test_exam_model_get_questions_v2_v1(self):
         self.login_as_admin()
         self.exam.data_model_version = 2
-        self.exam.question_sources.append(
+        self.exam.question_sources = [
             {
                 "exercise_id": uuid.uuid4().hex,
                 "question_id": uuid.uuid4().hex,
                 "title": "Title",
                 "counter_in_exercise": 0,
             }
-        )
+        ]
 
         self.exam.save()
         self.assertEqual(len(self.exam.get_questions()), 1)
@@ -647,6 +663,39 @@ class ExamAPITestCase(BaseExamTest, APITestCase):
         exam_id = response.data["id"]
         exam = models.Exam.objects.get(id=exam_id)
         self.assertEqual(len(exam.question_sources), 1)
+
+    def test_logged_in_admin_exam_cant_create_and_publish_empty_quiz(self):
+        self.login_as_admin()
+        exam = self.make_basic_exam()
+        exam["draft"] = False
+        exam["question_sources"] = []
+        response = self.post_new_exam(exam)
+        self.assertEqual(response.status_code, 400)
+
+    def test_logged_in_admin_exam_cant_create_and_publish_empty_sections(self):
+        self.login_as_admin()
+        exam = self.make_basic_exam()
+        exam["draft"] = False
+        exam["question_sources"] = [
+            {
+                "section_id": uuid.uuid4().hex,
+                "section_title": "Test Section Title",
+                "description": "Test descripton for Section",
+                "question_count": 0,
+                "questions": [],
+                "learners_see_fixed_order": False,
+            },
+            {
+                "section_id": uuid.uuid4().hex,
+                "section_title": "Test Section Title",
+                "description": "Test descripton for Section",
+                "question_count": 0,
+                "questions": [],
+                "learners_see_fixed_order": False,
+            },
+        ]
+        response = self.post_new_exam(exam)
+        self.assertEqual(response.status_code, 400)
 
 
 class ExamDraftAPITestCase(BaseExamTest, APITestCase):
@@ -821,3 +870,19 @@ class ExamDraftAPITestCase(BaseExamTest, APITestCase):
         exam_id = response.data["id"]
         exam = models.Exam.objects.get(id=exam_id)
         self.assertEqual(len(exam.question_sources), 1)
+
+    def test_logged_in_admin_exam_cant_update_and_publish_empty_quiz(self):
+        self.login_as_admin()
+        self.exam.question_sources = [
+            {
+                "section_id": uuid.uuid4().hex,
+                "section_title": "Test Section Title",
+                "description": "Test descripton for Section",
+                "question_count": 0,
+                "questions": [],
+                "learners_see_fixed_order": False,
+            }
+        ]
+        self.exam.save()
+        response = self.patch_updated_exam(self.exam.id, {"draft": False})
+        self.assertEqual(response.status_code, 400)

--- a/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
+++ b/kolibri/plugins/coach/assets/src/views/common/commonCoachStrings.js
@@ -518,10 +518,14 @@ const coachStrings = createTranslator('CommonCoachStrings', {
   },
   openQuizModalDetail: {
     message:
-      'Starting the quiz will make it visible to learners and they will be able to answer questions',
-
+      'Starting the quiz will make it visible to learners and they will be able to answer questions.',
     context:
       "Text shown on a modal pop-up window when the user clicks the 'Start Quiz' button. This explains what will happen when the user confirms the action of starting the quiz.",
+  },
+  openQuizModalEmptySections: {
+    message: 'Any sections without questions will be removed from the quiz.',
+    context:
+      "Text shown on a modal pop-up window when the user clicks the 'Start Quiz' button. This explains that empty sections will be removed from the quiz.",
   },
   closeQuizLabel: {
     message: 'End quiz',

--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -140,6 +140,13 @@
           @submit="handleOpenQuiz(activeQuiz.id)"
         >
           <p>{{ openQuizModalDetail$() }}</p>
+          <p
+            v-if="
+              activeQuiz.data_model_version === 3 &&
+                activeQuiz.question_sources.some(s => (!s.questions || s.questions.length === 0))"
+          >
+            {{ openQuizModalEmptySections$() }}
+          </p>
           <p>{{ lodQuizDetail$() }}</p>
           <p>{{ fileSizeToDownload$({ size: activeQuiz.size_string }) }}</p>
         </KModal>
@@ -222,6 +229,7 @@
         openQuizLabel$,
         closeQuizLabel$,
         openQuizModalDetail$,
+        openQuizModalEmptySections$,
         closeQuizModalDetail$,
         lodQuizDetail$,
         fileSizeToDownload$,
@@ -260,6 +268,7 @@
         openQuizLabel$,
         closeQuizLabel$,
         openQuizModalDetail$,
+        openQuizModalEmptySections$,
         closeQuizModalDetail$,
         lodQuizDetail$,
         fileSizeToDownload$,

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizListPage.vue
@@ -116,6 +116,13 @@
           @submit="handleOpenQuiz(modalQuiz.id)"
         >
           <p>{{ coachString('openQuizModalDetail') }}</p>
+          <p
+            v-if="
+              modalQuiz.data_model_version === 3 &&
+                modalQuiz.question_sources.some(s => (!s.questions || s.questions.length === 0))"
+          >
+            {{ coachString('openQuizModalEmptySections') }}
+          </p>
           <p>{{ coachString('lodQuizDetail') }}</p>
           <p>{{ coachString('fileSizeToDownload', { size: modalQuiz.size_string }) }}</p>
         </KModal>

--- a/kolibri/plugins/coach/class_summary_api.py
+++ b/kolibri/plugins/coach/class_summary_api.py
@@ -271,7 +271,7 @@ def serialize_lessons(request, pk):
 
 
 def _map_exam(item):
-    data_model_version = item.pop("data_model_version")
+    data_model_version = item.get("data_model_version")
     if data_model_version == 3:
         item["node_ids"] = [
             question["exercise_id"]


### PR DESCRIPTION
## Summary
* When saving a syncable exam, automatically remove any empty sections, in the save method.
* Move question_count setting to the save method of the AbstractExam model rather than in the serializer to ensure consistency (this was apparent when I edited question_sources in a test, but the question_count didn't update)
* Leave the data model version on the data passed to the frontend in the class summary API so that it can be used by the frontend
* Add a warning to users in the start quiz confirmation modal that empty sections will be deleted.

## References
Fixes [#12217](https://github.com/learningequality/kolibri/issues/12217)

## Reviewer guidance
1. Create a quiz, add some questions to one section, then create some blank sections.
2. Save the quiz.
3. Go back to edit it, and see that the empty sections are still there.
4. Start the quiz
5. See that the quiz only has one section after starting the quiz (this part might be trickier)

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
