### PR TITLE
Use && instead of & for logical AND.

### DIFF
--- a/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
+++ b/kolibri/plugins/facility/assets/src/views/ImportCsvPage/Preview.vue
@@ -163,7 +163,7 @@
           @click="reset"
         />
         <KButton
-          v-if="!isError & hasChanges"
+          v-if="!isError && hasChanges"
           :text="$tr('import')"
           appearance="raised-button"
           primary


### PR DESCRIPTION
## Summary
* Fix tiny code typo where `&` was used instead of `&&` when a logical AND was intended

## Reviewer guidance
This probably doesn't change behaviour.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
