### PR TITLE
EQM Fix: Use can actually select topics

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
@@ -137,7 +137,8 @@ export default function useQuizResources({ topicId } = {}) {
       // Has children, no more to load, and no children are topics
       (node.children &&
         !node.children.more &&
-        !node.children.results.some(c => c.kind === ContentNodeKinds.TOPIC))
+        !node.children.results.some(c => c.kind === ContentNodeKinds.TOPIC) &&
+        node.children.results.length <= 12)
     );
   }
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -61,7 +61,7 @@
         :selectAllChecked="selectAllChecked"
         :selectAllIndeterminate="selectAllIndeterminate"
         :contentIsChecked="contentPresentInWorkingResourcePool"
-        :contentHasCheckbox="c => hasCheckbox(c) && unusedQuestionsCount(c) > 0"
+        :contentHasCheckbox="actuallyHasCheckbox"
         :contentCardMessage="selectionMetadata"
         :contentCardLink="contentLink"
         :loadingMoreState="loadingMore"
@@ -553,6 +553,18 @@
       }
     },
     methods: {
+      /**
+       * Uses the imported `hasCheckbox` method in addition to some locally relevant conditions
+       * to identify if the content has a checkbox.
+       * Note that `hasCheckbox` handles the topic-level logic and we're only modifying how we
+       * handle the case of exercises where we want to show the checkbox if ith as no questions
+       * available
+       */
+      actuallyHasCheckbox(content) {
+        return content.kind === ContentNodeKinds.EXERCISE
+          ? this.hasCheckbox(content) && this.unusedQuestionsCount(content) > 0
+          : this.hasCheckbox(content);
+      },
       unusedQuestionsCount(content) {
         if (content.kind === ContentNodeKinds.EXERCISE) {
           const questionItems = content.assessmentmetadata.assessment_item_ids.map(

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -213,7 +213,7 @@
        */
       function selectableContentList() {
         return contentList.value.reduce((newList, content) => {
-          if (content.kind === ContentNodeKinds.TOPIC && hasCheckbox(content)) {
+          if (content.kind === ContentNodeKinds.TOPIC && actuallyHasCheckbox(content)) {
             newList = [...newList, ...content.children.results];
           } else {
             newList.push(content);
@@ -286,7 +286,7 @@
       });
 
       const showSelectAll = computed(() => {
-        return contentList.value.every(content => hasCheckbox(content));
+        return contentList.value.every(content => actuallyHasCheckbox(content));
       });
 
       function handleSelectAll(isChecked) {
@@ -505,7 +505,6 @@
         contentList,
         resources,
         showCloseConfirmation,
-        hasCheckbox,
         loading,
         hasMore,
         loadingMore,
@@ -592,7 +591,7 @@
         }
       },
       showTopicSizeWarningCard(content) {
-        return !this.hasCheckbox(content) && content.kind === ContentNodeKinds.TOPIC;
+        return !this.actuallyHasCheckbox(content) && content.kind === ContentNodeKinds.TOPIC;
       },
       showTopicSizeWarning() {
         return this.contentList.some(this.showTopicSizeWarningCard);


### PR DESCRIPTION
## Summary

Fixes issue following up from #12182 where users could not select entire topics under certain conditions.


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

When a Topic / Folder has no folders within it AND there are 12 or fewer exercises in it, then the topic should have a checkbox.

Otherwise, topics should not have checkboxes.

Also -- if a particular exercise has been added to another section _and_ all of its questions have been used in another section, then that _Exercise_ should _not_ have checkbox.