### PR TITLE
Update to allow and implement randomization of sections.

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
+++ b/kolibri/plugins/coach/assets/src/composables/quizCreationSpecs.js
@@ -180,4 +180,9 @@ export const Quiz = {
     type: Number,
     default: getRandomInt(),
   },
+  // Default to sections being shown in a fixed order
+  learners_see_fixed_order: {
+    type: Boolean,
+    default: true,
+  },
 };

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -25,6 +25,17 @@ function validateQuiz(quiz) {
   return validateObject(quiz, Quiz);
 }
 
+const fieldsToSave = [
+  'title',
+  'assignments',
+  'learner_ids',
+  'collection',
+  'learners_see_fixed_order',
+  'draft',
+  'active',
+  'archive',
+];
+
 /**
  * Composable function presenting primary interface for Quiz Creation
  */
@@ -299,16 +310,17 @@ export default function useQuizCreation() {
       return Promise.reject(`Quiz is not valid: ${JSON.stringify(get(_quiz))}`);
     }
 
-    const id = get(_quiz).id;
+    const quizData = get(_quiz);
 
-    const finalQuiz = {
-      title: get(_quiz).title,
-      assignments: get(_quiz).assignments,
-      learner_ids: get(_quiz).learner_ids,
-      collection: get(_quiz).collection,
-    };
+    const id = quizData.id;
 
-    if (get(_quiz).draft) {
+    const finalQuiz = {};
+
+    for (const field of fieldsToSave) {
+      finalQuiz[field] = quizData[field];
+    }
+
+    if (finalQuiz.draft) {
       // Here we update each section's `resource_pool` to only be the IDs of the resources
       const questionSourcesWithoutResourcePool = get(allSections).map(section => {
         const sectionToSave = { ...section };

--- a/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuizStatus.vue
@@ -162,7 +162,7 @@
           :layout8="{ span: 4 }"
           :layout12="{ span: 12 }"
         >
-          {{ $tr('questionOrderLabel') }}
+          {{ sectionOrderLabel$() }}
         </KGridItem>
         <KGridItem
           :layout4="{ span: 4 }"
@@ -265,6 +265,7 @@
   import Lockr from 'lockr';
   import { QUIZ_REPORT_VISIBILITY_MODAL_DISMISSED } from 'kolibri.coreVue.vuex.constants';
   import { mapActions } from 'vuex';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { coachStringsMixin } from './commonCoachStrings';
   import Score from './Score';
   import Recipients from './Recipients';
@@ -275,6 +276,10 @@
     name: 'QuizStatus',
     components: { Score, Recipients, ElapsedTime, StatusElapsedTime, AverageScoreTooltip },
     mixins: [coachStringsMixin, commonCoreStrings],
+    setup() {
+      const { sectionOrderLabel$ } = enhancedQuizManagementStrings;
+      return { sectionOrderLabel$ };
+    },
     props: {
       className: {
         type: String,
@@ -453,10 +458,6 @@
         message: 'Report visible to learners',
         context:
           'The label for a switch that will toggle whether or not learners can view their quiz report.',
-      },
-      questionOrderLabel: {
-        message: 'Question order',
-        context: 'A label for the place where the question order is shown.',
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -89,7 +89,7 @@
           <KRadioButton
             v-model="learners_see_fixed_order"
             :label="randomizedLabel$()"
-            :buttonValue="true"
+            :buttonValue="false"
             :description="randomizedOptionDescription$()"
           />
         </KGridItem>
@@ -101,7 +101,7 @@
           <KRadioButton
             v-model="learners_see_fixed_order"
             :label="fixedLabel$()"
-            :buttonValue="false"
+            :buttonValue="true"
             :description="fixedOptionDescription$()"
           />
         </KGridItem>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -27,6 +27,40 @@
         @update="updateQuiz"
       />
 
+      <div v-if="quizInitialized">
+        <h5 class="section-order-header">
+          {{ sectionOrderLabel$() }}
+        </h5>
+        <KGrid>
+          <KGridItem
+            :layout12="{ span: 6 }"
+            :layout8="{ span: 4 }"
+            :layout4="{ span: 2 }"
+          >
+            <KRadioButton
+              :currentValue="quiz.learners_see_fixed_order"
+              :label="randomizedLabel$()"
+              :buttonValue="false"
+              :description="randomizedSectionOptionDescription$()"
+              @input="value => updateQuiz({ learners_see_fixed_order: value })"
+            />
+          </KGridItem>
+          <KGridItem
+            :layout12="{ span: 6 }"
+            :layout8="{ span: 4 }"
+            :layout4="{ span: 2 }"
+          >
+            <KRadioButton
+              :currentValue="quiz.learners_see_fixed_order"
+              :label="fixedLabel$()"
+              :buttonValue="true"
+              :description="fixedSectionOptionDescription$()"
+              @input="value => updateQuiz({ learners_see_fixed_order: value })"
+            />
+          </KGridItem>
+        </KGrid>
+      </div>
+
       <CreateQuizSection v-if="quizInitialized && quiz.draft" />
 
       <BottomAppBar>
@@ -92,7 +126,15 @@
       const showError = ref(false);
       const quizInitialized = ref(false);
 
-      const { saveAndClose$, allSectionsEmptyWarning$ } = enhancedQuizManagementStrings;
+      const {
+        saveAndClose$,
+        allSectionsEmptyWarning$,
+        sectionOrderLabel$,
+        randomizedLabel$,
+        fixedLabel$,
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
+      } = enhancedQuizManagementStrings;
 
       return {
         classId,
@@ -106,6 +148,11 @@
         allSectionsEmpty,
         allSectionsEmptyWarning$,
         saveAndClose$,
+        sectionOrderLabel$,
+        randomizedLabel$,
+        fixedLabel$,
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
       };
     },
     provide() {
@@ -210,6 +257,11 @@
 
   .message {
     margin-right: 8px;
+  }
+
+  .section-order-header {
+    margin-top: 0;
+    margin-bottom: 0.5em;
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -74,6 +74,7 @@
   import CatchErrors from 'kolibri.utils.CatchErrors';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import { ExamResource } from 'kolibri.resources';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import { PageNames } from '../../../constants';
   import commonCoach from '../../common';
   import CoachAppBarPage from '../../CoachAppBarPage';
@@ -97,6 +98,16 @@
       QuizOptionsDropdownMenu,
     },
     mixins: [commonCoach, coachStringsMixin, commonCoreStrings],
+    setup() {
+      const {
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
+      } = enhancedQuizManagementStrings;
+      return {
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
+      };
+    },
     data() {
       return {
         quiz: {
@@ -133,8 +144,8 @@
       },
       orderDescriptionString() {
         return this.quizIsRandomized
-          ? this.coachString('orderRandomDescription')
-          : this.coachString('orderFixedDescription');
+          ? this.randomizedSectionOptionDescription$()
+          : this.fixedSectionOptionDescription$();
       },
       classId() {
         return this.$route.params.classId;

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
@@ -34,6 +34,7 @@
 <script>
 
   import fromPairs from 'lodash/fromPairs';
+  import { enhancedQuizManagementStrings } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import commonCoach from '../common';
   import CoachImmersivePage from '../CoachImmersivePage';
   import QuestionListPreview from '../plan/CreateExamPage/QuestionListPreview';
@@ -46,6 +47,16 @@
       QuestionListPreview,
     },
     mixins: [commonCoach],
+    setup() {
+      const {
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
+      } = enhancedQuizManagementStrings;
+      return {
+        randomizedSectionOptionDescription$,
+        fixedSectionOptionDescription$,
+      };
+    },
     data() {
       return {
         quiz: {
@@ -67,8 +78,8 @@
       },
       orderDescriptionString() {
         return this.quizIsRandomized
-          ? this.coachString('orderRandomDescription')
-          : this.coachString('orderFixedDescription');
+          ? this.randomizedSectionOptionDescription$()
+          : this.fixedSectionOptionDescription$();
       },
       title() {
         return this.$tr('pageTitle', { title: this.quiz.title });

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizPreviewPage.vue
@@ -71,7 +71,10 @@
     },
     computed: {
       selectedQuestions() {
-        return this.quiz.question_sources;
+        return this.quiz.question_sources.reduce((acc, section) => {
+          acc = [...acc, ...section.questions];
+          return acc;
+        }, []);
       },
       quizIsRandomized() {
         return !this.quiz.learners_see_fixed_order;

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/handlers.js
@@ -30,15 +30,20 @@ export function showExam(store, params, alreadyOnQuiz) {
           store.commit('classAssignments/SET_CURRENT_CLASSROOM', classroom);
           fetchExamWithContent(exam).then(({ exam: converted, exercises: contentNodes }) => {
             if (shouldResolve()) {
-              const { question_sources } = converted;
+              let { question_sources } = converted;
 
               // When necessary, randomize the questions for the learner.
               // Seed based on the user ID so they see a consistent order each time.
-              question_sources.forEach(section => {
+              for (const section of question_sources) {
                 if (!section.learners_see_fixed_order) {
                   section.questions = shuffled(section.questions, store.state.core.session.user_id);
                 }
-              });
+              }
+              // When necessary randomize the order of the sections
+              // Seed based on the user ID so they see a consistent order each time.
+              if (!converted.learners_see_fixed_order) {
+                question_sources = shuffled(question_sources, store.state.core.session.user_id);
+              }
               // If necessary, convert the question source info
               const allQuestions = question_sources.reduce((acc, section) => {
                 acc = [...acc, ...section.questions];

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -118,6 +118,10 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message:
       'Please choose a different resource or decrease the number of questions to be replaced.',
   },
+  sectionOrderLabel: {
+    message: 'Section order',
+    context: 'A label for the place where the section order option is shown.',
+  },
   questionOrder: {
     message: 'Question order',
   },
@@ -130,11 +134,17 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
   randomizedOptionDescription: {
     message: 'Each learner sees a different question order',
   },
+  randomizedSectionOptionDescription: {
+    message: 'Each learner sees a different section order',
+  },
   fixedLabel: {
     message: 'Fixed',
   },
   fixedOptionDescription: {
     message: 'Each learner sees the same question order',
+  },
+  fixedSectionOptionDescription: {
+    message: 'Each learner sees the same section order',
   },
   questionEditedSuccessfully: {
     message: 'Question edited successfully',


### PR DESCRIPTION
## Summary
* Changes description for the global 'learner_sees_fixed_order' flag to be about the section ordering, not questions
* Allows editing this flag in the quiz creation/editing flow
* Updates the learner experience to randomize the section order if this is set to false.

## References
Fixes [#12248](https://github.com/learningequality/kolibri/issues/12248)

## Reviewer guidance
Check that when creating a quiz, the section ordering can be randomized or set fixed, and that the learner experience of the quiz accords to this.

![Screenshot from 2024-06-13 07-46-09](https://github.com/learningequality/kolibri/assets/1680573/7e79bb72-5b5d-414b-b6e5-6de69eda47ae)


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
