### PR TITLE
EQM: Validation improvements

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -44,6 +44,8 @@ export default function useQuizCreation() {
   // Local state
   // -----------
 
+  const quizHasChanged = ref(false);
+
   /** @type {ref<Quiz>}
    * The "source of truth" quiz object from which all reactive properties should derive
    * This will be validated and sent to the API when the user saves the quiz */
@@ -74,6 +76,7 @@ export default function useQuizCreation() {
    * @throws {TypeError} if section is not a valid QuizSection
    **/
   function updateSection({ section_id, ...updates }) {
+    set(quizHasChanged, true);
     const targetSection = get(allSections).find(section => section.section_id === section_id);
     if (!targetSection) {
       throw new TypeError(`Section with id ${section_id} not found; cannot be updated.`);
@@ -300,6 +303,7 @@ export default function useQuizCreation() {
         setActiveSection(get(allSections)[0].section_id);
       }
     }
+    set(quizHasChanged, false);
   }
 
   /**
@@ -349,6 +353,7 @@ export default function useQuizCreation() {
    * @affects _quiz
    * Validates the input type and then updates _quiz with the given updates */
   function updateQuiz(updates) {
+    set(quizHasChanged, true);
     if (!validateQuiz(updates)) {
       throw new TypeError(`Updates are not a valid Quiz object: ${JSON.stringify(updates)}`);
     }
@@ -583,6 +588,7 @@ export default function useQuizCreation() {
     removeQuestionFromSelection,
 
     // Computed
+    quizHasChanged,
     channels,
     replacements,
     quiz,

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -324,6 +324,8 @@
       @cancel="handleShowConfirmation"
       @submit="handleConfirmDelete"
     >
+      <!-- TODO Use `displaySectionTitle` here once #12274 is merged as that PR
+        changes how we handle section indexing, which is needed for displaySectionTitle -->
       {{ deleteConfirmation$({ section_title: activeSection.section_title }) }}
     </KModal>
 
@@ -565,6 +567,8 @@
         this.$nextTick(() => {
           this.$store.dispatch(
             'createSnackbar',
+            // TODO Use `displaySectionTitle` here once #12274 is merged as that PR
+            // changes how we handle section indexing
             this.sectionDeletedNotification$({ section_title })
           );
           this.focusActiveSectionTab();

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -358,7 +358,7 @@
       const learners_see_fixed_order = ref(activeSection.value.learners_see_fixed_order);
       const question_count = ref(activeSection.value.question_count);
       const description = ref(activeSection.value.description);
-      const section_title = ref(activeSection.value.section_title);
+      const section_title = ref(activeSection.value.section_title.trim());
 
       const sectionTitleInvalidText = computed(() => {
         if (section_title.value.trim() === '') {
@@ -370,7 +370,7 @@
             // Skip the current section
             return true;
           }
-          return section.section_title !== section_title.value;
+          return section.section_title.trim() !== section_title.value.trim();
         });
         if (!titleIsUnique) {
           return sectionTitleUniqueWarning$();
@@ -383,7 +383,7 @@
             learners_see_fixed_order: learners_see_fixed_order.value,
             question_count: question_count.value,
             description: description.value,
-            section_title: section_title.value,
+            section_title: section_title.value.trim(),
           },
           pick(activeSection.value, [
             'learners_see_fixed_order',

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -88,12 +88,12 @@
     </KPageContainer>
 
     <KModal
-      v-if="goingTo"
+      v-if="closeConfirmationToRoute"
       :submitText="coreString('continueAction')"
       :cancelText="coreString('cancelAction')"
       :title="closeConfirmationTitle$()"
-      @cancel="goingTo = null"
-      @submit="$router.push(goingTo)"
+      @cancel="closeConfirmationToRoute = null"
+      @submit="$router.push(closeConfirmationToRoute)"
     >
       {{ closeConfirmationMessage$() }}
     </KModal>
@@ -134,7 +134,7 @@
     },
     mixins: [commonCoreStrings],
     setup() {
-      const goingTo = ref(null);
+      const closeConfirmationToRoute = ref(null);
       const { classId, groups } = useCoreCoach();
       const {
         quizHasChanged,
@@ -164,7 +164,7 @@
         closeConfirmationMessage$,
         classId,
         groups,
-        goingTo,
+        closeConfirmationToRoute,
         showError,
         quiz,
         quizHasChanged,
@@ -230,8 +230,8 @@
       },
     },
     beforeRouteLeave(to, from, next) {
-      if (this.quizHasChanged && !this.goingTo) {
-        this.goingTo = to;
+      if (this.quizHasChanged && !this.closeConfirmationToRoute) {
+        this.closeConfirmationToRoute = to;
         next(false);
       } else {
         next();

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -234,7 +234,7 @@
             }
           })
           .catch(error => {
-            const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE]);
+            const errors = CatchErrors(error, [ERROR_CONSTANTS.UNIQUE, 'BLANK']);
             this.$refs.detailsModal.handleSubmitFailure();
             if (errors.length) {
               this.$refs.detailsModal.handleSubmitTitleFailure();

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -319,7 +319,7 @@
         this.showTitleError = true;
         this.$refs.titleField.focus();
         // Scroll to the title field in case focus() didn't do that immediately
-        this.$refs.titleField.$el.scrollIntoView({ behavior: 'smooth' });
+        this.window.scrollTo({ top: 0, behavior: 'smooth' });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -302,7 +302,6 @@
           });
         } else {
           this.formIsSubmitted = false;
-          this.$refs.titleField.focus();
         }
       },
       /**
@@ -318,6 +317,9 @@
       handleSubmitTitleFailure() {
         this.formIsSubmitted = false;
         this.showTitleError = true;
+        this.$refs.titleField.focus();
+        // Scroll to the title field in case focus() didn't do that immediately
+        this.$refs.titleField.$el.scrollIntoView({ behavior: 'smooth' });
       },
     },
   };


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

- Scroll to and focus quiz title when blank during quiz submission
- `trim()` section_title all about so we're always testing "is this unique" correctly
- Adds "Are you sure" message when leaving quiz creation and can lose your changes.

I think that "fix the snackbars" can be done in a follow-up -- there is no change to strings, but just a need to use `displaySectionTitle` throughout.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Closes #12262 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

- Try making duplicate section titles
- Try exiting an un-edited quiz (should not see a modal)
- Try exiting a quiz you've changed something on (should see a modal)
- Do the exiting test on both a "draft" quiz and a "started" quiz
- See that when you have errors on the Title (ie, it is blank or not unique) you should be scrolled to it

