### PR TITLE
EQM: On first save, update the quiz's ID when redirecting

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -324,7 +324,7 @@ export default function useQuizCreation() {
     }
 
     return ExamResource.saveModel({ id, data: finalQuiz }).then(exam => {
-      if (!get(_quiz).id) {
+      if (id !== exam.id) {
         updateQuiz({ id: exam.id });
       }
       return exam;

--- a/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizCreation.js
@@ -323,7 +323,12 @@ export default function useQuizCreation() {
       finalQuiz.question_sources = questionSourcesWithoutResourcePool;
     }
 
-    return ExamResource.saveModel({ id, data: finalQuiz });
+    return ExamResource.saveModel({ id, data: finalQuiz }).then(exam => {
+      if (!get(_quiz).id) {
+        updateQuiz({ id: exam.id });
+      }
+      return exam;
+    });
   }
 
   /**

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -174,6 +174,9 @@
                 },
               });
             } else {
+              if (String(this.$route.params.quizId) === String(exam.id)) {
+                return;
+              }
               this.$router.replace({
                 name: PageNames.EXAM_CREATION_ROOT,
                 params: {
@@ -181,9 +184,6 @@
                   quizId: exam.id,
                 },
               });
-              // Update the quiz with the new id - there won't be if this is a new quiz,
-              // this ensures the quiz is kept up-to-date since we're replacing the route
-              this.updateQuiz({ id: exam.id });
             }
           })
           .catch(error => {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -174,9 +174,6 @@
                 },
               });
             } else {
-              if (this.$route.params.quizId === exam.id) {
-                return;
-              }
               this.$router.replace({
                 name: PageNames.EXAM_CREATION_ROOT,
                 params: {
@@ -184,6 +181,9 @@
                   quizId: exam.id,
                 },
               });
+              // Update the quiz with the new id - there won't be if this is a new quiz,
+              // this ensures the quiz is kept up-to-date since we're replacing the route
+              this.updateQuiz({ id: exam.id });
             }
           })
           .catch(error => {

--- a/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
+++ b/kolibri/plugins/coach/assets/test/useQuizCreation.spec.js
@@ -30,7 +30,7 @@ const {
 
 const _channel = { root: 'channel_1', name: 'Channel 1', kind: 'channel', is_leaf: false };
 ChannelResource.fetchCollection = jest.fn(() => Promise.resolve([_channel]));
-ExamResource.saveModel = jest.fn(() => Promise.resolve());
+ExamResource.saveModel = jest.fn(() => Promise.resolve({}));
 
 /**
  * @param num {number} - The number of questions to create


### PR DESCRIPTION
## Summary

Fixes #12263 

When the `new` quiz is saved, since we replace the route, we need to also update the ID of the quiz so that subsequent saves are updating the quiz rather than trying to save the same quiz anew.

## Reviewer guidance

- [ ] If you save a newly created quiz, then click "Save and close" or "Save" after that, you should not see errors.