### PR TITLE
Update LOD description in FullOrLearnOnlyDeviceForm component

### DIFF
--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -79,7 +79,7 @@
       },
       learnOnlyDeviceDescription: {
         message:
-          'This device will have one or more learner accounts imported from a full device that already exists. Learner accounts will auto-sync with the full device.',
+          'This device will auto-sync its learner accounts with an existing full device and only include Kolibri features for learners, excluding those for coaches or admins.',
         context: '',
       },
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/onboarding-forms/FullOrLearnOnlyDeviceForm.vue
@@ -79,7 +79,7 @@
       },
       learnOnlyDeviceDescription: {
         message:
-          'This device will auto-sync its learner accounts with an existing full device and only include Kolibri features for learners, excluding those for coaches or admins.',
+          'This device will only have the features used by learners, and it will auto-sync with the full device.',
         context: '',
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request modifies the description for Learn Only Devices in `FullOrLearnOnlyDeviceForm.vue` in order to eliminate the implication that an existing learn account is necessary.

Original phrase: 
“This device will have one or more learner accounts imported from a full device that already exists. Learner accounts will auto-sync with the full device.”

Updated wording:
“This device will only have the features used by learners, and it will auto-sync with the full device.”

Before:

![LODBefore](https://github.com/learningequality/kolibri/assets/46411498/0751afd8-c5cb-4b73-975a-c265c5ff8b44)


After:
![LODAfter](https://github.com/learningequality/kolibri/assets/46411498/b67f899d-bb22-4f0e-a608-2e5140cfa98f)


## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #11461 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

…

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
