### PR TITLE
EQM: Post-bash quickfixes

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -30,7 +30,7 @@
           >
             <KTextbox
               ref="titleField"
-              v-model="title"
+              v-model.trim="title"
               :label="titleLabel$()"
               :maxlength="titleMaxLength"
               :autofocus="true"
@@ -257,7 +257,6 @@
     },
     watch: {
       title() {
-        this.title = this.title.trim();
         this.$emit('update', { title: this.title });
       },
       description() {

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -317,7 +317,7 @@
         this.showTitleError = true;
         this.$refs.titleField.focus();
         // Scroll to the title field in case focus() didn't do that immediately
-        this.window.scrollTo({ top: 0, behavior: 'smooth' });
+        window.scrollTo({ top: 0, behavior: 'smooth' });
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -257,6 +257,7 @@
     },
     watch: {
       title() {
+        this.title = this.title.trim();
         this.$emit('update', { title: this.title });
       },
       description() {


### PR DESCRIPTION
## Summary

Fixing misc simple issues I replicated after the bug bash that I didn't make an issue for:

- Title that is all spaces has proper error message now (previously showed uniqueness error rather than blankness error)
- `this.window.scrollTo` -> `window.scrollTo` on title invalidity


## Reviewer guidance

Make a quiz, test each of the above listed things. 