### PR TITLE
Add notification for downloaded content completion

### DIFF
--- a/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
+++ b/kolibri/plugins/learn/assets/src/composables/useDownloadRequests.js
@@ -25,6 +25,10 @@ const downloadRequestsTranslator = createTranslator('DownloadRequests', {
     message: 'Resource removed from my library',
     context: 'A message shown when a user has removed a resource from their library',
   },
+  downloadComplete: {
+    message: 'Download complete',
+    context: 'A message shown to indicate that a download request has been completed',
+  },
 });
 
 // The reactive is defined in the outer scope so it can be used as a shared store
@@ -147,6 +151,17 @@ export default function useDownloadRequests(store) {
     return Promise.resolve();
   }
 
+  function showCompletedDownloadSnackbar() {
+    store.commit('CORE_CREATE_SNACKBAR', {
+      text: downloadRequestsTranslator.$tr('downloadComplete'),
+      actionText: downloadRequestsTranslator.$tr('goToDownloadsPage'),
+      actionCallback: navigateToDownloads,
+      backdrop: false,
+      forceReuse: true,
+      autoDismiss: true,
+    });
+  }
+
   function removeDownloadRequest(contentNodeId) {
     const contentRequest = downloadRequestMap[contentNodeId];
     if (!contentRequest) {
@@ -179,5 +194,6 @@ export default function useDownloadRequests(store) {
     loading,
     removeDownloadRequest,
     downloadRequestsTranslator,
+    showCompletedDownloadSnackbar,
   };
 }

--- a/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
+++ b/kolibri/plugins/learn/assets/src/views/TopicsContentPage.vue
@@ -241,6 +241,7 @@
         downloadRequestMap,
         downloadRequestsTranslator,
         pollUserDownloadRequests,
+        showCompletedDownloadSnackbar,
         loading: downloadRequestLoading,
       } = useDownloadRequests();
       const deviceFormTranslator = crossComponentTranslator(AddDeviceForm);
@@ -337,6 +338,7 @@
         isAdmin,
         isSuperuser,
         currentUserId,
+        showCompletedDownloadSnackbar,
       };
     },
     props: {
@@ -502,6 +504,11 @@
           this.stopMainScroll(true);
         } else {
           this.stopMainScroll(false);
+        }
+      },
+      isDownloading(newVal) {
+        if (newVal === false && this.isDownloaded) {
+          this.showCompletedDownloadSnackbar();
         }
       },
     },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
This pull request involves the addition of a snackbar notification with the message “Download complete” to inform learners about resource download completion.

Once a resource is selected to be downloaded, a notification with the message “Download requested” and the option to “GO TO DOWNLOADS” appears. Now, on the remote content page, the learner is also notified when the download is finished.

https://github.com/learningequality/kolibri/assets/46411498/fac5516f-6a89-480f-bfed-0c6248ce9198

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
Closes #10576 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Ensure that only after adding a new download and the content download is completed, the completed download snack-bar notification is displayed.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
