### PR TITLE
Allow quiz level learners see fixed order to be edited after a quiz is opened.

### DIFF
--- a/kolibri/core/exams/serializers.py
+++ b/kolibri/core/exams/serializers.py
@@ -172,12 +172,6 @@ class ExamSerializer(ModelSerializer):
                         code=error_constants.INVALID,
                     )
 
-        if "learners_see_fixed_order" in attrs and is_non_draft_exam:
-            raise ValidationError(
-                "Cannot update learners_see_fixed_order on an Exam object",
-                code=error_constants.INVALID,
-            )
-
         return attrs
 
     def create(self, validated_data):
@@ -273,6 +267,9 @@ class ExamSerializer(ModelSerializer):
                 instance_is_draft = False
             # Update the scalar fields
             instance.title = validated_data.pop("title", instance.title)
+            instance.learners_see_fixed_order = validated_data.pop(
+                "learners_see_fixed_order", instance.learners_see_fixed_order
+            )
             if not instance_is_draft:
                 # Update the non-draft specific fields
                 instance.active = validated_data.pop("active", instance.active)
@@ -285,9 +282,6 @@ class ExamSerializer(ModelSerializer):
                 # as by this point instance_is_draft is False if we are publishing a draft
                 instance.question_sources = validated_data.pop(
                     "question_sources", instance.question_sources
-                )
-                instance.learners_see_fixed_order = validated_data.pop(
-                    "learners_see_fixed_order", instance.learners_see_fixed_order
                 )
 
             # Add/delete any new/removed Assignments

--- a/kolibri/core/exams/test/test_exam_api.py
+++ b/kolibri/core/exams/test/test_exam_api.py
@@ -495,6 +495,14 @@ class BaseExamTest:
         response = self.post_new_exam(exam)
         self.assertEqual(response.status_code, 400)
 
+    def test_admin_can_update_learner_sees_fixed_order(self):
+        self.login_as_admin()
+        response = self.patch_updated_exam(
+            self.exam.id, {"learners_see_fixed_order": True}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertExamExists(id=self.exam.id, learners_see_fixed_order=True)
+
 
 class ExamAPITestCase(BaseExamTest, APITestCase):
     class_object = models.Exam
@@ -577,19 +585,6 @@ class ExamAPITestCase(BaseExamTest, APITestCase):
         self.assertEqual(response.status_code, 400)
         self.exam.refresh_from_db()
         self.assertEqual(self.exam.question_sources, previous_sections)
-
-    def test_logged_in_admin_exam_update_cannot_update_learners_see_fixed_order(self):
-        self.login_as_admin()
-        previous_learners_see_fixed_order = self.exam.learners_see_fixed_order
-        response = self.patch_updated_exam(
-            self.exam.id,
-            {"learners_see_fixed_order": not previous_learners_see_fixed_order},
-        )
-        self.assertEqual(response.status_code, 400)
-        self.exam.refresh_from_db()
-        self.assertEqual(
-            self.exam.learners_see_fixed_order, previous_learners_see_fixed_order
-        )
 
     def test_logged_in_admin_exam_can_create_and_publish_remove_empty_sections(self):
         self.login_as_admin()


### PR DESCRIPTION
## Summary
* The API previously disallowed editing the quiz level `learner_sees_fixed_order` attribute for section randomization - but as it has no effect on the recording of data and the review of the answers for the coach, this is safe.
* The UI also allowed this, which resulted in unexpected 400s.
* This PR updates the API to allow this so the UI and the API are in step.

## References
Fixes [#12289](https://github.com/learningequality/kolibri/issues/12289)

## Reviewer guidance
Create a quiz.
Start the quiz.
Edit the quiz.
Update the Section Order property.
Save - see that it saves without errors, and that when returning to the edit page after refreshing, it is properly updated to the new value.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
