### PR TITLE
Allow redirects for file downloads

### DIFF
--- a/kolibri/utils/file_transfer.py
+++ b/kolibri/utils/file_transfer.py
@@ -747,8 +747,14 @@ class FileDownload(Transfer):
         if self._headers_set:
             return
 
-        response = self.session.head(self.source, timeout=self.timeout)
+        response = self.session.head(
+            self.source, timeout=self.timeout, allow_redirects=True
+        )
         response.raise_for_status()
+
+        if response.url != self.source:
+            logger.debug("Redirected from {} to {}".format(self.source, response.url))
+            self.source = response.url
 
         self.compressed = bool(response.headers.get("content-encoding", ""))
 


### PR DESCRIPTION
## Summary
* Development Studio uses redirects to expose resources and content databases
* Our current file download logic does not handle these properly
* Updates this to handle this properly!

## References
Fixes issue first reported here: https://github.com/learningequality/studio/issues/4416#issuecomment-1949886337

## Reviewer guidance
Try to import channels/resources from a local Studio instance - see that it works!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
