### PR TITLE
EQM: Side panel back / close icon UX improvements

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div class="select-resource">
+  <div ref="selectResource" class="select-resource">
     <div v-if="loading && !loadingMore">
       <KCircularLoader />
     </div>
@@ -194,6 +194,7 @@
 
 <script>
 
+  import { onClickOutside } from '@vueuse/core';
   import get from 'lodash/get';
   import uniqWith from 'lodash/uniqWith';
   import isEqual from 'lodash/isEqual';
@@ -600,6 +601,10 @@
       function handleConfirmClose() {
         context.emit('closePanel');
       }
+
+      onClickOutside(context.refs.selectResource, () => {
+        context.emit('closePanel');
+      });
 
       const workingPoolHasChanged = computed(() => {
         return workingResourcePool.value.length;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -1,6 +1,6 @@
 <template>
 
-  <div ref="selectResource" class="select-resource">
+  <div class="select-resource">
     <div v-if="loading && !loadingMore">
       <KCircularLoader />
     </div>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -194,7 +194,6 @@
 
 <script>
 
-  import { onClickOutside } from '@vueuse/core';
   import get from 'lodash/get';
   import uniqWith from 'lodash/uniqWith';
   import isEqual from 'lodash/isEqual';
@@ -601,10 +600,6 @@
       function handleConfirmClose() {
         context.emit('closePanel');
       }
-
-      onClickOutside(context.refs.selectResource, () => {
-        context.emit('closePanel');
-      });
 
       const workingPoolHasChanged = computed(() => {
         return workingResourcePool.value.length;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -45,7 +45,11 @@
       function handleClosePanel() {
         router.push({
           name: PageNames.EXAM_CREATION_ROOT,
-          params: { ...route.value.params },
+          params: {
+            classId: route.value.params.classId,
+            quizId: route.value.params.quizId,
+            sectionIndex: route.value.params.sectionIndex,
+          },
           query: { ...route.value.query },
         });
       }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -64,7 +64,7 @@
           oldRoute.name !== PageNames.EXAM_CREATION_ROOT && // We didn't just get here
           newRoute.name !== PageNames.QUIZ_SECTION_EDITOR && // The new route isn't section editor // One of these is also true...
           (Boolean(newRoute.query.showBookmarks) || // We're viewing bookmarks
-          Boolean(newRoute.params.topic_id) || // We're viewing a topic
+            Boolean(newRoute.params.topic_id) || // We're viewing a topic
             oldRoute.name !== newRoute.name); // We're just not on the same page within the panel
       });
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -5,10 +5,19 @@
     ref="resourcePanel"
     alignment="right"
     sidePanelWidth="700px"
-    :closeButtonIconType="closeBackIcon"
+    closeButtonIconType="close"
     @closePanel="handleClosePanel"
     @shouldFocusFirstEl="findFirstEl()"
   >
+    <template #header>
+      <KIconButton
+        v-if="canGoBack"
+        icon="back"
+        class="back-icon"
+        :style="backButtonStyles"
+        @click="$router.go(-1)"
+      />
+    </template>
     <router-view @closePanel="handleClosePanel" />
   </SidePanelModal>
 
@@ -17,7 +26,6 @@
 
 <script>
 
-  import { onClickOutside } from '@vueuse/core';
   import SidePanelModal from 'kolibri-common/components/SidePanelModal';
   import { ref, watch, computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
   import { PageNames } from '../../../constants';
@@ -27,68 +35,62 @@
     components: {
       SidePanelModal,
     },
-    setup(_, context) {
+    setup() {
       const store = getCurrentInstance().proxy.$store;
       const router = getCurrentInstance().proxy.$router;
       const route = computed(() => store.state.route);
 
-      const routeWhenSidePanelOpened = route.value;
-      const prevRoute = ref({
-        name: PageNames.EXAM_CREATION_ROOT,
-        params: { ...route.value.params },
-      });
-      const canCloseSidePanel = ref(true);
+      const canGoBack = ref(false);
       const showSidePanel = computed(() => route.value?.name !== PageNames.EXAM_CREATION_ROOT);
 
-      watch(route, (to, from) => {
-        // We're on the same route we were on when we started so should be able to close it
-        canCloseSidePanel.value =
-          to.name === routeWhenSidePanelOpened.name &&
-          // I tried using _.isEqual on the params & query objects but it didn't work as I expected
-          // so this is hard-coded for now.
-          to.params.sectionIndex === routeWhenSidePanelOpened.params.sectionIndex &&
-          to.params.topic_id === routeWhenSidePanelOpened.params.topic_id &&
-          to.query.showBookmarks === routeWhenSidePanelOpened.query.showBookmarks &&
-          to.query.search === routeWhenSidePanelOpened.query.search;
-
-        prevRoute.value = from;
-      });
-
       function handleClosePanel() {
-        if (canCloseSidePanel.value) {
-          // Avoid redundant navigation error
-          if (prevRoute.value.name === PageNames.EXAM_CREATION_ROOT) {
-            router.back();
-          } else {
-            router.push({
-              name: PageNames.EXAM_CREATION_ROOT,
-              params: { ...prevRoute.value.params },
-            });
-          }
-        } else {
-          router.back();
-        }
+        router.push({
+          name: PageNames.EXAM_CREATION_ROOT,
+          params: { ...route.value.params },
+          query: { ...route.value.query },
+        });
       }
 
-      onClickOutside(context.refs.resourcePanel, () => {
-        canCloseSidePanel.value = true;
-        handleClosePanel();
-      });
-
-      const closeBackIcon = computed(() => {
-        if (canCloseSidePanel.value) {
-          return 'close';
-        } else {
-          return 'back';
-        }
+      watch(route, (newRoute, oldRoute) => {
+        // Here we basically handle all of the edge cases around when we do and don't show the back
+        // button in the heading of the side panel -- basically, we're going for:
+        //  - If we just loaded, no back arrow (ie, refresh the page w/ the panel open)
+        //  - If we're viewing bookmarks or have gone into a topic show the back arrow
+        //  - If we're still not on the same route as before, then show it
+        canGoBack.value =
+          oldRoute.name !== PageNames.EXAM_CREATION_ROOT && // We didn't just get here
+          newRoute.name !== PageNames.QUIZ_SECTION_EDITOR && // The new route isn't section editor // One of these is also true...
+          (Boolean(newRoute.query.showBookmarks) || // We're viewing bookmarks
+          Boolean(newRoute.params.topic_id) || // We're viewing a topic
+            oldRoute.name !== newRoute.name); // We're just not on the same page within the panel
       });
 
       return {
+        canGoBack,
         showSidePanel,
-        canCloseSidePanel,
-        closeBackIcon,
         handleClosePanel,
       };
+    },
+    computed: {
+      backButtonStyles() {
+        if (this.isRtl) {
+          return {
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            right: '1em',
+            'z-index': '24',
+          };
+        } else {
+          return {
+            position: 'absolute',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            left: '1em',
+            'z-index': '24',
+          };
+        }
+      },
     },
     methods: {
       /**
@@ -101,3 +103,15 @@
   };
 
 </script>
+
+
+<style scoped>
+
+   /* This duplicates the icon positioning in SidePanelModal */
+  .back-icon {
+    position: absolute;
+    top: 50%!important;
+    transform: translateY(-50%)!important;
+    left: 1em;
+  }
+</style>

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionSidePanel.vue
@@ -13,7 +13,6 @@
       <KIconButton
         v-if="canGoBack"
         icon="back"
-        class="back-icon"
         :style="backButtonStyles"
         @click="$router.go(-1)"
       />
@@ -103,15 +102,3 @@
   };
 
 </script>
-
-
-<style scoped>
-
-   /* This duplicates the icon positioning in SidePanelModal */
-  .back-icon {
-    position: absolute;
-    top: 50%!important;
-    transform: translateY(-50%)!important;
-    left: 1em;
-  }
-</style>

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -186,7 +186,7 @@
               position: 'absolute',
               top: '50%',
               transform: 'translateY(-50%)',
-              right: '24px',
+              right: '1em',
               'z-index': '24',
             };
           }
@@ -196,7 +196,7 @@
             position: 'absolute',
             top: '50%',
             transform: 'translateY(-50%)',
-            left: '16px',
+            left: '1em',
             'z-index': '24',
           };
         } else {

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -19,25 +19,24 @@
         >
           <!-- Fixed header -->
           <div
-            v-show="$slots.header"
             ref="fixedHeader"
             class="fixed-header"
             :style="fixedHeaderStyles"
           >
             <div class="header-content">
-              <slot name="header"> </slot>
+              <slot name="header">
+              </slot>
+              <KIconButton
+                v-if="closeButtonIconType"
+                :icon="closeButtonIconType"
+                class="close-button"
+                :style="closeButtonStyle"
+                :ariaLabel="closeButtonMessage"
+                :tooltip="closeButtonMessage"
+                @click="closePanel"
+              />
             </div>
           </div>
-
-          <KIconButton
-            v-if="closeButtonIconType"
-            :icon="closeButtonIconType"
-            class="close-button"
-            :style="closeButtonStyle"
-            :ariaLabel="closeButtonMessage"
-            :tooltip="closeButtonMessage"
-            @click="closePanel"
-          />
 
           <!-- Default slot for inserting content which will scroll on overflow -->
           <div
@@ -149,8 +148,8 @@
           position: 'fixed',
           top: 0,
           backgroundColor: this.$themeTokens.surface,
-          'border-bottom': `1px solid ${this.$themePalette.grey.v_500}`,
-          padding: '24px 32px',
+          borderBottom: `1px solid ${this.$themePalette.grey.v_400}`,
+          padding: '0 1em',
           // Header border stays over content with this, but under any tooltips
           'z-index': 16,
         };
@@ -177,14 +176,16 @@
           if (this.closeButtonIconType === 'close') {
             return {
               position: 'absolute',
-              top: '16px',
-              left: '16px',
+              top: '50%',
+              transform: 'translateY(-50%)',
+              left: '1em',
               'z-index': '24',
             };
           } else {
             return {
               position: 'absolute',
-              top: '16px',
+              top: '50%',
+              transform: 'translateY(-50%)',
               right: '24px',
               'z-index': '24',
             };
@@ -193,15 +194,17 @@
         if (this.closeButtonIconType === 'back') {
           return {
             position: 'absolute',
-            top: '16px',
+            top: '50%',
+            transform: 'translateY(-50%)',
             left: '16px',
             'z-index': '24',
           };
         } else {
           return {
             position: 'absolute',
-            top: '16px',
-            right: '24px',
+            top: '50%',
+            transform: 'translateY(-50%)',
+            right: '1em',
             'z-index': '24',
           };
         }
@@ -209,7 +212,7 @@
       contentStyles() {
         return {
           /* When the header margin is 0px from top, add 24 to accomodate close button */
-          'margin-top': this.fixedHeaderHeight === '0px' ? '24px' : this.fixedHeaderHeight,
+          'margin-top': this.fixedHeaderHeight === '0px' ? '16px' : this.fixedHeaderHeight,
           padding: '24px 32px 16px',
           'overflow-y': 'scroll',
           'overflow-x': 'hidden',

--- a/packages/kolibri-common/components/SidePanelModal/index.vue
+++ b/packages/kolibri-common/components/SidePanelModal/index.vue
@@ -24,8 +24,7 @@
             :style="fixedHeaderStyles"
           >
             <div class="header-content">
-              <slot name="header">
-              </slot>
+              <slot name="header"> </slot>
               <KIconButton
                 v-if="closeButtonIconType"
                 :icon="closeButtonIconType"


### PR DESCRIPTION
## Summary

- Removes using `onClickOutside`, reworks logic around "canGoBack"
- Moves the X icon into the "heading" slot in the side panel and sets it up so that it will match other things put into the heading the same way
- Applies changes listed in #12308 


## References

Closes #12308 

## Reviewer guidance

Please check for regressions wherever else the side panel is used in the Learn library area.

Also, see that the UX changes defined in the linked issue are applied and that the UX is improved overall while using the side panel throughout quiz creation.