### PR TITLE
Consolidate list remote users api

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1134,5 +1134,4 @@ class RemoteFacilityUserAuthenticatedViewset(views.APIView):
         admin_roles = (user_kinds.ADMIN, user_kinds.SUPERUSER)
         if not any(role in roles for role in admin_roles):
             raise PermissionDenied()
-        # students = [u for u in facility_info["users"] if not u["roles"]]
         return Response(facility_info["users"])

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -1133,5 +1133,5 @@ class RemoteFacilityUserAuthenticatedViewset(views.APIView):
         roles = user_info["roles"]
         admin_roles = (user_kinds.ADMIN, user_kinds.SUPERUSER)
         if not any(role in roles for role in admin_roles):
-            raise PermissionDenied()
+            return Response([user_info])
         return Response(facility_info["users"])

--- a/kolibri/core/auth/api_urls.py
+++ b/kolibri/core/auth/api_urls.py
@@ -9,6 +9,8 @@ from .api import FacilityViewSet
 from .api import IsPINValidView
 from .api import LearnerGroupViewSet
 from .api import MembershipViewSet
+from .api import RemoteFacilityUserAuthenticatedViewset
+from .api import RemoteFacilityUserViewset
 from .api import RoleViewSet
 from .api import SessionViewSet
 from .api import SetNonSpecifiedPasswordView
@@ -54,6 +56,16 @@ urlpatterns = (
             r"^ispinvalid/(?P<pk>[a-f0-9]{32})$",
             IsPINValidView.as_view(),
             name="ispinvalid",
+        ),
+        re_path(
+            r"^remotefacilityuser$",
+            RemoteFacilityUserViewset.as_view(),
+            name="remotefacilityuser",
+        ),
+        re_path(
+            r"^remotefacilityauthenticateduserinfo$",
+            RemoteFacilityUserAuthenticatedViewset.as_view(),
+            name="remotefacilityauthenticateduserinfo",
         ),
     ]
 )

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -77,6 +77,7 @@ class StaticNetworkLocationViewSet(NetworkLocationViewSet):
 
 class NetworkLocationFacilitiesView(BaseValuesViewset):
     queryset = NetworkLocation.objects.all()
+    values = ()
     permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
     values = ("device_id", "instance_id", "device_name", "device_address", "facilities")
 

--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -77,7 +77,6 @@ class StaticNetworkLocationViewSet(NetworkLocationViewSet):
 
 class NetworkLocationFacilitiesView(BaseValuesViewset):
     queryset = NetworkLocation.objects.all()
-    values = ()
     permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
     values = ("device_id", "instance_id", "device_name", "device_address", "facilities")
 

--- a/kolibri/plugins/setup_wizard/api.py
+++ b/kolibri/plugins/setup_wizard/api.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
 from rest_framework import decorators
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.exceptions import ValidationError
@@ -14,7 +13,6 @@ from kolibri.core.auth.backends import FACILITY_CREDENTIAL_KEY
 from kolibri.core.auth.constants import user_kinds
 from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
-from kolibri.core.auth.utils.users import get_remote_users_info
 from kolibri.core.device.models import DevicePermissions
 from kolibri.core.discovery.utils.network.client import NetworkClient
 from kolibri.core.discovery.utils.network.errors import NetworkLocationResponseFailure
@@ -145,33 +143,3 @@ class FacilityImportViewSet(ViewSet):
 
         except ValidationError:
             raise ValidationError(detail="duplicate", code="duplicate_username")
-
-    @decorators.action(methods=["post"], detail=False)
-    def listfacilitylearners(self, request):
-        """
-        If the request is done by an admin user  it will return a list of the users of the
-        facility
-
-        :param baseurl: First part of the url of the server that's going to be requested
-        :param facility_id: Id of the facility to authenticate and get the list of users
-        :param username: Username of the user that's going to authenticate
-        :param password: Password of the user that's going to authenticate
-        :return: List of the learners of the facility.
-        """
-        facility_id = request.data.get("facility_id")
-        baseurl = request.data.get("baseurl")
-        password = request.data.get("password")
-        username = request.data.get("username")
-        try:
-            facility_info = get_remote_users_info(
-                baseurl, facility_id, username, password
-            )
-        except AuthenticationFailed:
-            raise PermissionDenied()
-        user_info = facility_info["user"]
-        roles = user_info["roles"]
-        admin_roles = (user_kinds.ADMIN, user_kinds.SUPERUSER)
-        if not any(role in roles for role in admin_roles):
-            raise PermissionDenied()
-        students = [u for u in facility_info["users"] if not u["roles"]]
-        return Response({"students": students, "admin": facility_info["user"]})

--- a/kolibri/plugins/setup_wizard/assets/src/api.js
+++ b/kolibri/plugins/setup_wizard/assets/src/api.js
@@ -1,3 +1,5 @@
+import client from 'kolibri.client';
+import urls from 'kolibri.urls';
 import { Resource } from 'kolibri.lib.apiResource';
 
 /**
@@ -41,9 +43,19 @@ export const FacilityImportResource = new Resource({
       return response.data;
     });
   },
-  listfacilitylearners(params) {
-    return this.postListEndpoint('listfacilitylearners', params).then(response => {
-      return response.data;
+  async listfacilitylearners(params) {
+    const { data } = await client({
+      url: urls['kolibri:core:remotefacilityauthenticateduserinfo'](),
+      method: 'POST',
+      data: params,
     });
+
+    const admin = data.find(user => user.username === params.username);
+    const students = data.filter(user => !user.roles || !user.roles.length);
+
+    return {
+      admin,
+      students,
+    };
   },
 });

--- a/kolibri/plugins/user_profile/api_urls.py
+++ b/kolibri/plugins/user_profile/api_urls.py
@@ -2,21 +2,9 @@ from django.urls import re_path
 
 from .viewsets import LoginMergedUserViewset
 from .viewsets import OnMyOwnSetupViewset
-from .viewsets import RemoteFacilityUserAuthenticatedViewset
-from .viewsets import RemoteFacilityUserViewset
 
 urlpatterns = [
     re_path(r"onmyownsetup", OnMyOwnSetupViewset.as_view(), name="onmyownsetup"),
-    re_path(
-        r"remotefacilityuser",
-        RemoteFacilityUserViewset.as_view(),
-        name="remotefacilityuser",
-    ),
-    re_path(
-        r"remotefacilityauthenticateduserinfo",
-        RemoteFacilityUserAuthenticatedViewset.as_view(),
-        name="remotefacilityauthenticateduserinfo",
-    ),
     re_path(
         r"loginmergeduser",
         LoginMergedUserViewset.as_view(),

--- a/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
+++ b/kolibri/plugins/user_profile/assets/src/composables/useRemoteFacility.js
@@ -4,22 +4,22 @@ import urls from 'kolibri.urls';
 function remoteFacilityUserData(baseurl, facility_id, username, password, userAdmin = null) {
   const params = {
     baseurl: baseurl,
-    facility: facility_id,
+    facility_id: facility_id,
     username: userAdmin === null ? username : userAdmin,
     password: password,
   };
   return client({
-    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityauthenticateduserinfo'](),
+    url: urls['kolibri:core:remotefacilityauthenticateduserinfo'](),
     method: 'POST',
     data: params,
-  }).then(response => {
-    if (response.data.error) {
-      return 'error';
-    } else {
+  })
+    .then(response => {
       const user_info = response.data.find(element => element.username === username);
       return user_info;
-    }
-  });
+    })
+    .catch(() => {
+      return 'error';
+    });
 }
 
 const remoteFacilityUsers = function (baseurl, facility_id, username) {
@@ -29,7 +29,7 @@ const remoteFacilityUsers = function (baseurl, facility_id, username) {
     username: username,
   };
   return client({
-    url: urls['kolibri:kolibri.plugins.user_profile:remotefacilityuser'](),
+    url: urls['kolibri:core:remotefacilityuser'](),
     params: params,
   }).then(response => {
     let users = response.data;

--- a/kolibri/plugins/user_profile/tasks.py
+++ b/kolibri/plugins/user_profile/tasks.py
@@ -57,7 +57,7 @@ class MergeUserValidator(PeerImportSingleSyncJobValidator):
                 # If we didn't break out of the loop, then we need to raise the original error
                 raise
 
-        job_data["args"].append(data["local_user_id"].id)
+        job_data["kwargs"]["local_user_id"] = data["local_user_id"].id
         job_data["extra_metadata"].update(user_fullname=data["local_user_id"].full_name)
         # create token to validate user in the new facility
         # after it's deleted in the current facility:
@@ -145,7 +145,11 @@ class IsSelf(BasePermission):
     status_fn=status_fn,
 )
 def mergeuser(
-    command, local_user_id, new_superuser_id=None, set_as_super_user=False, **kwargs
+    command,
+    local_user_id=None,
+    new_superuser_id=None,
+    set_as_super_user=False,
+    **kwargs
 ):
     """
     This is an example of the POST payload to create this task:


### PR DESCRIPTION
## Summary

Consolidates the logic of listing remote users from the user_profile and setup_wizard plugins, and migrates them to core auth so that they are accessible by multiple plugins.

There were some differences between both endpoints, and the following decisions were made to merge them:
* The setup wizard endpoint returned an object { admin, students }, while the user_profile endpoint returned a list of users. It was decided to keep the response the same as that of user_profile as it was more flexible, and in the setup wizard to make the admin, students filter on the frontend instead of the backend.
* The setup wizard endpoint returns a 403 error if there are authentication errors, but the user_profile endpoint returns a 200 code, but with an error object. The 403 error was maintained, and where it is called to the user_profile endpoint in the frontend the error handling was updated.
* The setup_wizard endpoint gets a "facility_id" param, while the user_profile endpoint gets a "facility" param. The naming of "facility_id" was preferred.
* The user_profile endpoint validated the input data, and the setup_wizard endpoint did not. It was preferred to validate it as the user_profile.

## Reviewer guidance
* Check the flow of importing users as administrator of the setup wizard.
* Check the flow of changing facilities for an "on my own" user, and merging users using administrator credentials.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
