### PR TITLE
Move jump to question string into enhanced quiz management strings.

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -53,7 +53,7 @@
           >
           </span>
 
-          <div :aria-label="$tr('jumpToQuestion')" role="navigation">
+          <div :aria-label="jumpToQuestion$()" role="navigation">
             <ul class="history-list">
               <li
                 v-for="(question, qIndex) in section.questions"
@@ -97,7 +97,10 @@
 
 <script>
 
-  import { displaySectionTitle } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import {
+    enhancedQuizManagementStrings,
+    displaySectionTitle,
+  } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import AccordionItem from 'kolibri-common/components/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/AccordionContainer';
   import isEqual from 'lodash/isEqual';
@@ -120,12 +123,15 @@
 
       const { collapse, expand, isExpanded, toggle } = useAccordion(sections);
 
+      const { jumpToQuestion$ } = enhancedQuizManagementStrings;
+
       return {
         displaySectionTitle,
         collapse,
         expand,
         isExpanded,
         toggle,
+        jumpToQuestion$,
       };
     },
     props: {
@@ -269,11 +275,6 @@
         message: 'Question { num, number, integer}',
         context:
           "In the report section, the 'Answer history' shows the learner if they have answered questions correctly or incorrectly.\n\nOnly translate 'Question'.",
-      },
-      jumpToQuestion: {
-        message: 'Jump to question',
-        context:
-          'A label for the section of the page that contains all questions as clickable links',
       },
     },
   };

--- a/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
+++ b/packages/kolibri-common/strings/enhancedQuizManagementStrings.js
@@ -278,6 +278,10 @@ export const enhancedQuizManagementStrings = createTranslator('EnhancedQuizManag
     message: 'Questions',
     context: 'Label for dropdown list of questions',
   },
+  jumpToQuestion: {
+    message: 'Jump to question',
+    context: 'A label for the section of the page that contains all questions as clickable links',
+  },
   saveAndClose: {
     message: 'Save and close',
   },


### PR DESCRIPTION
## Summary
* Move string that may well be required for #12288

## References
In support of #12288

## Reviewer guidance
Does the quiz still render its aria-label correctly?

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
