### PR TITLE
Add ordering for FacilityUser viewset

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -435,6 +435,8 @@ class FacilityUserViewSet(ValuesViewset):
     def consolidate(self, items, queryset):
         output = []
         items = sorted(items, key=lambda x: x["id"])
+        ordering_param = self.request.query_params.get("ordering", self.order_by_field)
+        reverse = False
         for key, group in groupby(items, lambda x: x["id"]):
             roles = []
             for item in group:
@@ -449,16 +451,11 @@ class FacilityUserViewSet(ValuesViewset):
                     roles.append(role)
             item["roles"] = roles
             output.append(item)
-            ordering_param = self.request.query_params.get(
-                "ordering", self.order_by_field
-            )
-            reverse = False
             if ordering_param.startswith("-"):
                 self.order_by_field = ordering_param[1:]
                 reverse = True
             else:
                 self.order_by_field = ordering_param
-                reverse = False
         output = sorted(output, key=lambda x: x[self.order_by_field], reverse=reverse)
         return output
 

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -452,11 +452,10 @@ class FacilityUserViewSet(ValuesViewset):
             item["roles"] = roles
             output.append(item)
             if ordering_param.startswith("-"):
-                self.order_by_field = ordering_param[1:]
+                ordering_param = ordering_param[1:]
                 reverse = True
-            else:
-                self.order_by_field = ordering_param
-        output = sorted(output, key=lambda x: x[self.order_by_field], reverse=reverse)
+
+        output = sorted(output, key=lambda x: x[ordering_param], reverse=reverse)
         return output
 
     def perform_update(self, serializer):

--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -452,6 +452,7 @@ class FacilityUserViewSet(ValuesViewset):
             ordering_param = self.request.query_params.get(
                 "ordering", self.order_by_field
             )
+            reverse = False
             if ordering_param.startswith("-"):
                 self.order_by_field = ordering_param[1:]
                 reverse = True

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -3,6 +3,7 @@ import collections
 import time
 import uuid
 from datetime import datetime
+from datetime import timedelta
 from importlib import import_module
 
 import factory
@@ -1180,9 +1181,21 @@ class FacilityUserOrderingTestCase(APITestCase):
         cls.facility = FacilityFactory.create()
         cls.superuser = create_superuser(cls.facility)
         cls.facility.add_admin(cls.superuser)
-        cls.user1 = FacilityUserFactory.create(facility=cls.facility, username="mario")
-        cls.user2 = FacilityUserFactory.create(facility=cls.facility, username="luigi")
-        cls.user3 = FacilityUserFactory.create(facility=cls.facility, username="batman")
+
+        base_time = datetime.now() - timedelta(days=3)
+        cls.user1 = FacilityUserFactory.create(
+            facility=cls.facility, username="mario", date_joined=base_time
+        )
+        cls.user2 = FacilityUserFactory.create(
+            facility=cls.facility,
+            username="luigi",
+            date_joined=base_time + timedelta(days=1),
+        )
+        cls.user3 = FacilityUserFactory.create(
+            facility=cls.facility,
+            username="batman",
+            date_joined=base_time + timedelta(days=4),
+        )
 
     def setUp(self):
         self.client.login(

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1170,6 +1170,91 @@ class UserRetrieveTestCase(APITestCase):
         self.assertEqual(response.status_code, 404)
 
 
+class FacilityUserOrderingTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        provision_device()
+        cls.facility = FacilityFactory.create()
+        cls.superuser = create_superuser(cls.facility)
+        cls.facility.add_admin(cls.superuser)
+        cls.user1 = FacilityUserFactory.create(facility=cls.facility, username="mario")
+        cls.user2 = FacilityUserFactory.create(facility=cls.facility, username="luigi")
+        cls.user3 = FacilityUserFactory.create(facility=cls.facility, username="batman")
+
+    def setUp(self):
+        self.client.login(
+            username=self.superuser.username,
+            password=DUMMY_PASSWORD,
+            facility=self.facility,
+        )
+
+    def _sort_by_field(self, data, field, reverse=False):
+        return sorted(data, key=lambda x: x[field], reverse=reverse)
+
+    def test_default_ordering(self):
+        response = self.client.get(reverse("kolibri:core:facilityuser-list"))
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        self.assertEqual(data[0]["username"], "batman")
+        sorted_data = self._sort_by_field(data, "username")
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_username(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=username"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        sorted_data = self._sort_by_field(data, "username")
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_username_desc(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=-username"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        self.assertEqual(data[0]["username"], "superuser")
+        sorted_data = self._sort_by_field(data, "username", reverse=True)
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_date_joined(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=date_joined"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        sorted_data = self._sort_by_field(data, "date_joined")
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_date_joined_desc(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=-date_joined"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        sorted_data = self._sort_by_field(data, "date_joined", reverse=True)
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_full_name(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=full_name"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        sorted_data = self._sort_by_field(data, "full_name")
+        self.assertEqual(data, sorted_data)
+
+    def test_ordering_by_full_name_desc(self):
+        response = self.client.get(
+            reverse("kolibri:core:facilityuser-list") + "?ordering=-full_name"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+        sorted_data = self._sort_by_field(data, "full_name", reverse=True)
+        self.assertEqual(data, sorted_data)
+
+
 class FacilityUserFilterTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -1083,6 +1083,7 @@ class UserRetrieveTestCase(APITestCase):
                     "id_number": self.user.id_number,
                     "gender": self.user.gender,
                     "birth_year": self.user.birth_year,
+                    "date_joined": self.user.date_joined,
                     "is_superuser": False,
                     "roles": [],
                     "extra_demographics": None,
@@ -1094,6 +1095,7 @@ class UserRetrieveTestCase(APITestCase):
                     "facility": self.superuser.facility_id,
                     "id_number": self.superuser.id_number,
                     "gender": self.superuser.gender,
+                    "date_joined": self.superuser.date_joined,
                     "birth_year": self.superuser.birth_year,
                     "is_superuser": True,
                     "roles": [
@@ -1127,6 +1129,7 @@ class UserRetrieveTestCase(APITestCase):
                     "id_number": self.user.id_number,
                     "gender": self.user.gender,
                     "birth_year": self.user.birth_year,
+                    "date_joined": self.user.date_joined,
                     "is_superuser": False,
                     "roles": [],
                     "extra_demographics": None,


### PR DESCRIPTION
## Summary
Supports ordering from the backend for facility users.

## References
closes #12234

## Reviewer guidance
`pytest kolibri/core/auth/test/test_api.py -k FacilityUserOrderingTestCase`

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
