### PR TITLE
Remove browser search cancel button

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/SearchTools/LessonsSearchBox.vue
@@ -137,6 +137,10 @@
     &::-ms-clear {
       display: none;
     }
+    // removes the webkit browsers clear button
+    &::-webkit-search-cancel-button {
+      display: none;
+    }
   }
 
   .buttons-wrapper {


### PR DESCRIPTION
## Summary
For inputs of type "search" browsers add a search cancel button by default, but it can be styled/hidden with `::-webkit-search-cancel-button` or `::-ms-clear` for IE10+.

![image](https://github.com/learningequality/kolibri/assets/51239030/17fd405e-51c0-44af-897e-88aae8b41717)

## References
Closes #12306


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
