### PR TITLE
Added neeeded values for BaseValuesViewset

### DIFF
--- a/kolibri/core/discovery/api.py
+++ b/kolibri/core/discovery/api.py
@@ -78,6 +78,7 @@ class StaticNetworkLocationViewSet(NetworkLocationViewSet):
 class NetworkLocationFacilitiesView(BaseValuesViewset):
     queryset = NetworkLocation.objects.all()
     permission_classes = [NetworkLocationPermissions | NotProvisionedHasPermission]
+    values = ("device_id", "instance_id", "device_name", "device_address", "facilities")
 
     def retrieve(self, request, pk=None):
         """


### PR DESCRIPTION
## Summary

`NetworkLocationFacilitiesView` had been changed to use `BaseValuesViewset` instead of `viewsets.GenericViewSet`
But reference values had not been added. This PR fixes it

## References
Closes #12299

## Reviewer guidance
Try to reproduce the use case in #12299


## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
