### PR TITLE
Correct strings that were manually edited on Crowdin

### DIFF
--- a/kolibri/core/assets/src/views/UpdateNotification.vue
+++ b/kolibri/core/assets/src/views/UpdateNotification.vue
@@ -112,9 +112,9 @@
         message: 'We have released an important update with fixes to this version of Kolibri.',
         context: 'Notification indicating an important new version of Kolibri is available.',
       },
-      upgradeMessage_0_16_0: {
+      upgradeMessage_0_17_0: {
         message:
-          'Kolibri version 0.16.0 is available! New features include practice quizzes, resource syncing across coach and learner devices, and much more.',
+          'Kolibri version 0.17.0 is available! New features include enhanced quiz editing, an updated exercise viewer and new facility creation, as well as bug fixes and improvements.',
         context: 'Notification indicating a new version of Kolibri is available.',
       },
       upgradeDownload: {

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/CreateNewFacilityModal.vue
@@ -110,7 +110,7 @@
         context: 'Title for create facility modal',
       },
       createFacilityButtonLabel: {
-        message: 'create facility',
+        message: 'Create facility',
         context: 'Label for create facility submit button.',
       },
     },

--- a/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
+++ b/kolibri/plugins/device/assets/src/views/FacilitiesPage/index.vue
@@ -457,7 +457,7 @@
           "Notification that appears after a facility has been deleted. For example, \"Removed 'Zuk Village' from this device'.",
       },
       createFacilityLabel: {
-        message: 'ADD FACILITY',
+        message: 'Add facility',
         context: 'Label for a button used to create new facility.',
       },
       importFacilityLabel: {


### PR DESCRIPTION

## Summary
Three instances where the source strings were corrected manually on Crowdin to speed-up the string freeze. Editing in the code will restore the balance 🙂 

## References
[Slack conversation](https://learningequality.slack.com/archives/CB37UM23A/p1718928958427529?thread_ts=1718915318.542139&cid=CB37UM23A)
