### PR TITLE
Link to new quiz creation properly.

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -329,7 +329,10 @@
         return this.quizzes;
       },
       newExamRoute() {
-        return { name: PageNames.EXAM_CREATION_ROOT, params: { sectionIndex: 0 } };
+        return {
+          name: PageNames.EXAM_CREATION_ROOT,
+          params: { classId: this.$route.params.classId, sectionIndex: 0, quizId: 'new' },
+        };
       },
       dropdownOptions() {
         return [
@@ -392,14 +395,12 @@
           });
       },
       handleSelect({ value }) {
+        const nextRoute = this.newExamRoute;
         const nextRouteName = {
           MAKE_NEW_QUIZ: PageNames.EXAM_CREATION_ROOT,
           SELECT_QUIZ: PageNames.QUIZ_SELECT_PRACTICE_QUIZ,
         }[value];
-        const nextRoute = {
-          name: nextRouteName,
-          params: { ...this.$route.params, quizId: 'new', sectionIndex: 0 },
-        };
+        nextRoute.name = nextRouteName;
         this.$router.push(nextRoute);
       },
     },


### PR DESCRIPTION
## Summary
* When no practice quizzes were loaded onto the local device, the simple button for 'new quiz' was using the wrong link
* This updates this, and makes sure we use the same base link object for both situations, so at least if we break it for one, we break it for both :)

## References
Fixes [#12302](https://github.com/learningequality/kolibri/issues/12302)

## Reviewer guidance
Import exercises, but no practice quizzes.
See that creating a new quiz takes you to a full URL.
See that you can select questions to add to the quiz.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
