### PR TITLE
Fix mis-match condition in replacement question array

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ReplaceQuestions.vue
@@ -251,7 +251,7 @@
       }
 
       function toggleInReplacements(question) {
-        const replacementIds = replacements.value.map(q => q.id);
+        const replacementIds = replacements.value.map(q => q.item);
         if (replacementIds.includes(question.item)) {
           replacements.value = replacements.value.filter(q => q.item !== question.item);
         } else {


### PR DESCRIPTION
## Summary
Fixes #12335 

## References


## Reviewer guidance
Are the proper number of replacements reflected in the replacement selection once you have added more than the current number of questions to swap?

https://github.com/learningequality/kolibri/assets/17235236/43185bb8-c66f-4da3-9a51-d2801f5f8fda



----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
