### PR TITLE
EQM Lesson regression fixes

### DIFF
--- a/kolibri/core/lessons/serializers.py
+++ b/kolibri/core/lessons/serializers.py
@@ -127,7 +127,7 @@ class LessonSerializer(ModelSerializer):
         # Update the scalar fields
         instance.title = validated_data.get("title", instance.title)
         instance.description = validated_data.get("description", instance.description)
-        instance.is_active = validated_data.get("active", instance.is_active)
+        instance.is_active = validated_data.get("is_active", instance.is_active)
         instance.resources = validated_data.get("resources", instance.resources)
 
         # Add/delete any new/removed Assignments

--- a/kolibri/core/lessons/test/test_lesson_api.py
+++ b/kolibri/core/lessons/test/test_lesson_api.py
@@ -529,3 +529,17 @@ class LessonAPITestCase(APITestCase):
         )
 
         self.assertEqual(response.status_code, 200)  # passing!
+
+    def test_can_update_lesson_active(self):
+        self.client.login(username=self.admin.username, password=DUMMY_PASSWORD)
+
+        response = self.client.patch(
+            reverse("kolibri:core:lesson-detail", kwargs={"pk": self.lesson.id}),
+            {
+                "active": False,
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.lesson.refresh_from_db()
+        self.assertFalse(self.lesson.is_active)

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -267,18 +267,22 @@ function _prepLessonContentPreview(store, classId, lessonId, contentId) {
     getParams: { no_available_filtering: true },
   }).then(
     contentNode => {
-      const assessmentMetadata = contentNode.assessmentmetadata;
       store.commit('lessonSummary/SET_STATE', {
         toolbarRoute: {},
         // only exist if exercises
         workingResources: null,
         resourceCache: cache,
       });
+
       store.commit('lessonSummary/resources/SET_CURRENT_CONTENT_NODE', contentNode);
-      store.commit('lessonSummary/resources/SET_PREVIEW_STATE', {
-        questions: assessmentMetadata.assessment_item_ids,
-        completionData: assessmentMetadata.mastery_model,
-      });
+
+      if (contentNode.assessmentmetadata) {
+        store.commit('lessonSummary/resources/SET_PREVIEW_STATE', {
+          questions: contentNode.assessmentmetadata.assessment_item_ids,
+          completionData: contentNode.assessmentmetadata.mastery_model,
+        });
+      }
+
       store.commit('SET_PAGE_NAME', LessonsPageNames.CONTENT_PREVIEW);
       return contentNode;
     },


### PR DESCRIPTION
## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Fixes #12349  -- Cannot set lesson to visible (9fc128d94ebbe89c9cd2914e794417d3f9b2df45)
- Reverts to use `is_active` in `validated_data.get()` call introduced in ac175410a30d40c51dea16e816b5d5fe8b49c3b4


Fixes #12351 -- Cannot preview content in lesson creation (15d63b0f106ce469fd27fd7df1d18d9ac947ce26)
- Ensures lessonRoot handler only does Exercise things when there is an exercise


## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

@pcenov - do these address the issues linked above?

