### PR TITLE
Fix generate logs; date formatting updates (KDS related)

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -36,5 +36,8 @@
     "vuex": "^3.6.2",
     "vuex-router-sync": "^5.0.0",
     "xstate": "^4.38.3"
+  },
+  "workspaces": {
+    "nohoist": ["date-fns", "date-fns/*"]
   }
 }

--- a/kolibri/plugins/facility/package.json
+++ b/kolibri/plugins/facility/package.json
@@ -7,6 +7,6 @@
     "nohoist": ["date-fns", "date-fns/*"]
   },
   "dependencies": {
-    "date-fns": "1.30.1"
+    "date-fns": "3.6.0"
   }
 }

--- a/kolibri/plugins/facility/package.json
+++ b/kolibri/plugins/facility/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "kolibri-facility-plugin",
+  "description": "Facility",
+  "private": true,
+  "version": "0.0.1",
+  "workspaces": {
+    "nohoist": ["date-fns", "date-fns/*"]
+  },
+  "dependencies": {
+    "date-fns": "1.30.1"
+  }
+}

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -39,5 +39,8 @@
     "vuex": "^3.6.2",
     "vuex-router-sync": "^5.0.0",
     "xstate": "^4.38.3"
+  },
+  "workspaces": {
+    "nohoist": ["date-fns", "date-fns/*"]
   }
 }


### PR DESCRIPTION
## Summary

Fixes #12350 

Per @rtibbles suggestion, I've set the `date-fns` package as a dependency in a new facility package.json to the same version used in KDS currently. Also added it to other relevant packages-dot-json.

## Reviewer guidance

- [ ] Can you generate Facility logs?
- [ ] Can you select your birth year in your profile edit page?