### PR TITLE
Fix question listing and navigation in quiz reports

### DIFF
--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -254,3 +254,26 @@ export function getExamReport(examId, tryIndex = 0, questionNumber = 0, interact
     });
   });
 }
+
+export function annotateSections(sections, questions) {
+  if (!sections) {
+    return [
+      {
+        title: '',
+        questions: questions,
+        startQuestionNumber: 0,
+        endQuestionNumber: questions.length - 1,
+      },
+    ];
+  }
+  let startQuestionNumber = 0;
+  return sections.map(section => {
+    const annotatedSection = {
+      ...section,
+      startQuestionNumber,
+      endQuestionNumber: startQuestionNumber + section.questions.length - 1,
+    };
+    startQuestionNumber += section.questions.length;
+    return annotatedSection;
+  });
+}

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -233,8 +233,8 @@ export function getExamReport(examId, tryIndex = 0, questionNumber = 0, interact
         return exam;
       }
 
-      // TODO: Reports will eventually want to have the proper section-specific data to render
-      // the report page - but we are not updating the report UI yet.
+      // We need this array of questions to easily do questionNumber based indexing across
+      // all the sections.
       const questions = exam.question_sources.reduce((qs, sect) => {
         qs = [...qs, ...sect.questions];
         return qs;

--- a/kolibri/core/assets/src/exams/utils.js
+++ b/kolibri/core/assets/src/exams/utils.js
@@ -256,6 +256,10 @@ export function getExamReport(examId, tryIndex = 0, questionNumber = 0, interact
 }
 
 export function annotateSections(sections, questions) {
+  // Adding the additional startQuestionNumber and endQuestionNumber fields to each section
+  // allows to more easily identify the overall place in the quiz that a question is.
+  // This is useful for deciding which section is currently active based on the global
+  // question number, and also for displaying the global question number in the UI.
   if (!sections) {
     return [
       {

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -154,7 +154,7 @@
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useAccordion from 'kolibri-common/components/useAccordion';
-  import { coreStrings } from 'kolibri.coreVue.mixins.commonCoreStrings';
+  import coreStrings from 'kolibri.utils.coreStrings';
   import AccordionItem from 'kolibri-common/components/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/AccordionContainer';
   import { computed, onMounted, watch } from 'kolibri.lib.vueCompositionApi';

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -25,40 +25,38 @@
       >
         {{ selectedSection.label }}
       </h2>
+
+      <KSelect
+        class="history-select"
+        :value="selectedQuestion"
+        :label="questionsLabel$()"
+        :options="questionSelectOptions"
+        :disabled="$attrs.disabled"
+        @change="handleQuestionChange($event.value)"
+      >
+        <template #display>
+          <AttemptLogItem
+            class="attempt-selected"
+            :isSurvey="isSurvey"
+            :attemptLog="attemptLogs[selectedQuestionNumber]"
+            displayTag="span"
+          />
+        </template>
+        <template #option="{ index }">
+          <AttemptLogItem
+            class="attempt-option"
+            :isSurvey="isSurvey"
+            :attemptLog="attemptLogs[index]"
+            displayTag="span"
+          />
+        </template>
+      </KSelect>
     </div>
 
-    <KSelect
-      v-if="isMobile"
-      class="history-select"
-      :value="selectedQuestion"
-      :label="questionsLabel$()"
-      :options="questionSelectOptions"
-      :disabled="$attrs.disabled"
-      @change="handleQuestionChange($event.value)"
-    >
-      <template #display>
-        <AttemptLogItem
-          class="attempt-selected"
-          :isSurvey="isSurvey"
-          :attemptLog="attemptLogs[selectedQuestionNumber]"
-          displayTag="span"
-        />
-      </template>
-      <template #option="{ index }">
-        <AttemptLogItem
-          class="attempt-option"
-          :isSurvey="isSurvey"
-          :attemptLog="attemptLogs[index]"
-          displayTag="span"
-        />
-      </template>
-    </KSelect>
-
     <AccordionContainer
-      v-else-if="sections && sections.length"
+      v-else
       :hideTopActions="true"
       :items="sections"
-      :style="{ backgroundColor: $themeTokens.surface }"
     >
       <AccordionItem
         v-for="(section, index) in sections"
@@ -67,7 +65,10 @@
         :title="displaySectionTitle(section, index)"
         @focus="expand(index)"
       >
-        <template #heading="{ title }">
+        <template
+          v-if="sections.length > 1"
+          #heading="{ title }"
+        >
           <h3
             v-if="title"
             class="accordion-header"
@@ -90,12 +91,7 @@
           </h3>
         </template>
         <template #content>
-          <div
-            v-show="isExpanded(index)"
-            :style="{
-              backgroundColor: $themePalette.grey.v_100,
-            }"
-          >
+          <div v-show="sections.length === 1 || isExpanded(index)">
             <ul
               ref="attemptList"
               class="history-list"
@@ -114,22 +110,26 @@
                 :key="`attempt-item-${qIndex}`"
                 class="attempt-item"
                 :style="{
-                  backgroundColor: isSelected(qIndex) ? $themePalette.grey.v_100 : '',
+                  backgroundColor: isSelected(section.startQuestionNumber + qIndex)
+                    ? $themePalette.grey.v_100
+                    : '',
                 }"
               >
                 <a
                   ref="attemptListOption"
                   role="option"
                   class="attempt-item-anchor"
-                  :aria-selected="isSelected(qIndex).toString()"
-                  :tabindex="isSelected(qIndex) ? 0 : -1"
-                  @click.prevent="setSelectedAttemptLog(qIndex)"
-                  @keydown.enter="setSelectedAttemptLog(qIndex)"
-                  @keydown.space.prevent="setSelectedAttemptLog(qIndex)"
+                  :aria-selected="isSelected(section.startQuestionNumber + qIndex).toString()"
+                  :tabindex="isSelected(section.startQuestionNumber + qIndex) ? 0 : -1"
+                  @click.prevent="setSelectedAttemptLog(section.startQuestionNumber + qIndex)"
+                  @keydown.enter="setSelectedAttemptLog(section.startQuestionNumber + qIndex)"
+                  @keydown.space.prevent="
+                    setSelectedAttemptLog(section.startQuestionNumber + qIndex)
+                  "
                 >
                   <AttemptLogItem
                     :isSurvey="isSurvey"
-                    :attemptLog="attemptLogs[qIndex]"
+                    :attemptLog="attemptLogs[section.startQuestionNumber + qIndex]"
                     displayTag="p"
                   />
                 </a>
@@ -139,45 +139,6 @@
         </template>
       </AccordionItem>
     </AccordionContainer>
-
-    <ul
-      v-else
-      ref="attemptList"
-      class="history-list"
-      role="listbox"
-      @keydown.home="setSelectedAttemptLog(0)"
-      @keydown.end="setSelectedAttemptLog(attemptLogs.length - 1)"
-      @keydown.up.prevent="setSelectedAttemptLog(previousQuestion(selectedQuestionNumber))"
-      @keydown.left.prevent="setSelectedAttemptLog(previousQuestion(selectedQuestionNumber))"
-      @keydown.down.prevent="setSelectedAttemptLog(nextQuestion(selectedQuestionNumber))"
-      @keydown.right.prevent="setSelectedAttemptLog(nextQuestion(selectedQuestionNumber))"
-    >
-      <li
-        v-for="(question, qIndex) in attemptLogs"
-        :key="`attempt-item-${qIndex}`"
-        class="attempt-item"
-        :style="{
-          backgroundColor: isSelected(qIndex) ? $themePalette.grey.v_100 : '',
-        }"
-      >
-        <a
-          ref="attemptListOption"
-          role="option"
-          class="attempt-item-anchor"
-          :aria-selected="isSelected(qIndex).toString()"
-          :tabindex="isSelected(qIndex) ? 0 : -1"
-          @click.prevent="setSelectedAttemptLog(qIndex)"
-          @keydown.enter="setSelectedAttemptLog(qIndex)"
-          @keydown.space.prevent="setSelectedAttemptLog(qIndex)"
-        >
-          <AttemptLogItem
-            :isSurvey="isSurvey"
-            :attemptLog="attemptLogs[qIndex]"
-            displayTag="p"
-          />
-        </a>
-      </li>
-    </ul>
   </div>
 
 </template>
@@ -228,10 +189,6 @@
         }
       }
 
-      const allQuestionsInOrder = computed(() => {
-        return sections.value.reduce((a, s) => [...a, ...s.questions], []);
-      });
-
       const sectionSelectOptions = computed(() => {
         return sections.value.map((section, index) => ({
           value: index,
@@ -240,10 +197,12 @@
       });
 
       const currentSectionIndex = computed(() => {
-        let qCount = 0;
         for (let i = 0; i < sections.value.length; i++) {
-          qCount += sections.value[i].questions.length;
-          if (qCount >= selectedQuestionNumber.value) {
+          const section = sections.value[i];
+          if (
+            selectedQuestionNumber.value >= section.startQuestionNumber &&
+            selectedQuestionNumber.value <= section.endQuestionNumber
+          ) {
             return i;
           }
         }
@@ -256,14 +215,9 @@
 
       const questionSelectOptions = computed(() => {
         return currentSection.value.questions.map((question, index) => ({
-          value: question.item,
+          value: index,
           label: questionNumberLabel$({ questionNumber: index + 1 }),
         }));
-      });
-
-      // The question itself
-      const currentQuestion = computed(() => {
-        return allQuestionsInOrder.value[selectedQuestionNumber.value];
       });
 
       // The KSelect-shaped object for the current section
@@ -273,27 +227,18 @@
 
       // The KSelect-shaped object for the current question
       const selectedQuestion = computed(() => {
-        return questionSelectOptions.value.find(opt => opt.value === currentQuestion.value.item);
+        return questionSelectOptions.value[
+          selectedQuestionNumber.value - currentSection.value.startQuestionNumber
+        ];
       });
 
       function handleQuestionChange(item) {
-        const questionIndex = allQuestionsInOrder.value.findIndex(q => q.item === item);
-        if (questionIndex !== -1) {
-          emit('select', questionIndex);
-          expandCurrentSectionIfNeeded();
-        }
+        emit('select', item.value + currentSection.value.startQuestionNumber);
+        expandCurrentSectionIfNeeded();
       }
 
       function handleSectionChange(index) {
-        const questionIndex = sections.value.slice(0, index).reduce((acc, s, i) => {
-          if (i !== index) {
-            acc += s.questions.length;
-            return acc;
-          } else {
-            // This will always be the last iteration thanks to slice
-            return acc + 1;
-          }
-        }, 0);
+        const questionIndex = sections.value[index].startQuestionNumber;
         emit('select', questionIndex);
         expandCurrentSectionIfNeeded();
       }
@@ -319,8 +264,7 @@
     props: {
       sections: {
         type: Array,
-        required: false,
-        default: () => [],
+        required: true,
       },
       attemptLogs: {
         type: Array,

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -203,6 +203,7 @@
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { MasteryLogResource } from 'kolibri.resources';
   import { now } from 'kolibri.utils.serverClock';
+  import { annotateSections } from 'kolibri.utils.exams';
   import MissingResourceAlert from 'kolibri-common/components/MissingResourceAlert';
   import { displaySectionTitle } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import AttemptLogList from '../AttemptLogList';
@@ -361,26 +362,7 @@
     },
     computed: {
       annotatedSections() {
-        if (!this.sections) {
-          return [
-            {
-              title: '',
-              questions: this.questions,
-              startQuestionNumber: 0,
-              endQuestionNumber: this.questions.length - 1,
-            },
-          ];
-        }
-        let startQuestionNumber = 0;
-        return this.sections.map(section => {
-          const annotatedSection = {
-            ...section,
-            startQuestionNumber,
-            endQuestionNumber: startQuestionNumber + section.questions.length - 1,
-          };
-          startQuestionNumber += section.questions.length;
-          return annotatedSection;
-        });
+        return annotateSections(this.sections, this.questions);
       },
       currentSectionIndex() {
         return this.annotatedSections.findIndex(

--- a/kolibri/core/assets/src/views/ExamReport/index.vue
+++ b/kolibri/core/assets/src/views/ExamReport/index.vue
@@ -94,7 +94,7 @@
         :attemptLogs="attemptLogs"
         :selectedQuestionNumber="questionNumber"
         :isSurvey="isSurvey"
-        :sections="sections"
+        :sections="annotatedSections"
         @select="navigateToQuestion"
       />
     </template>
@@ -115,7 +115,7 @@
           :attemptLogs="attemptLogs"
           :selectedQuestionNumber="questionNumber"
           :isSurvey="isSurvey"
-          :sections="sections"
+          :sections="annotatedSections"
           @select="navigateToQuestion"
         />
         <div
@@ -124,7 +124,7 @@
           :class="windowIsSmall ? 'mobile-exercise-container' : ''"
           :style="{ backgroundColor: $themeTokens.surface }"
         >
-          <h3>{{ questionNumberInSectionLabel }}</h3>
+          <h3 v-if="questionNumberInSectionLabel">{{ questionNumberInSectionLabel }}</h3>
 
           <div
             v-if="!isSurvey"
@@ -289,7 +289,7 @@
       sections: {
         type: Array,
         required: false,
-        default: () => [],
+        default: null,
       },
       // An array of questions in the format:
       // {
@@ -353,6 +353,28 @@
       };
     },
     computed: {
+      annotatedSections() {
+        if (!this.sections) {
+          return [
+            {
+              title: this.title,
+              questions: this.questions,
+              startQuestionNumber: 0,
+              endQuestionNumber: this.questions.length - 1,
+            },
+          ];
+        }
+        let startQuestionNumber = 0;
+        return this.sections.map(section => {
+          const annotatedSection = {
+            ...section,
+            startQuestionNumber,
+            endQuestionNumber: startQuestionNumber + section.questions.length - 1,
+          };
+          startQuestionNumber += section.questions.length;
+          return annotatedSection;
+        });
+      },
       questionNumberInSectionLabel() {
         if (!this.sections) {
           return '';

--- a/kolibri/plugins/learn/assets/src/modules/examViewer/index.js
+++ b/kolibri/plugins/learn/assets/src/modules/examViewer/index.js
@@ -20,36 +20,4 @@ export default {
       Object.assign(state, defaultState());
     },
   },
-  getters: {
-    sections(state) {
-      if (!state.exam.question_sources) return [];
-      return state.exam.question_sources;
-    },
-    currentQuestion(state) {
-      if (state.questions.length === 0) return null;
-      return state.questions[state.questionNumber];
-    },
-    currentSection(state, { sections, currentSectionIndex }) {
-      return sections[currentSectionIndex];
-    },
-    currentSectionIndex(state, { currentQuestion, sections }) {
-      return sections.findIndex(section =>
-        section.questions.map(q => q.item).includes(currentQuestion.item),
-      );
-    },
-    sectionSelectOptions(state, { sections }) {
-      return (
-        sections.map((section, i) => ({
-          label: displaySectionTitle(section, i),
-          value: i,
-        })) || []
-      );
-    },
-    currentSectionOption(state, { currentSection, sectionSelectOptions }) {
-      if (!currentSection) return {};
-      return sectionSelectOptions.find(
-        (opt, i) => opt.label === displaySectionTitle(currentSection, i),
-      );
-    },
-  },
 };

--- a/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
+++ b/kolibri/plugins/learn/assets/src/views/ExamPage/AnswerHistory.vue
@@ -13,7 +13,14 @@
       @focus="expand(index)"
     >
       <template #heading="{ title }">
-        <h3 class="accordion-header">
+        <h3
+          class="accordion-header"
+          :style="
+            index === currentSectionIndex && !isExpanded(index)
+              ? { border: `2px solid ${$themeTokens.primary}` }
+              : {}
+          "
+        >
           <KButton
             tabindex="0"
             appearance="basic-link"
@@ -66,7 +73,7 @@
                   :class="buttonClass(question.item)"
                   :disabled="question.item === questionItem"
                   class="clickable"
-                  @click="$emit('goToQuestion', question.item)"
+                  @click="$emit('goToQuestion', section.startQuestionNumber + qIndex)"
                 >
                   <KIcon
                     v-if="question.missing"
@@ -83,7 +90,7 @@
                     "
                   />
                   <div class="text">
-                    {{ questionText(qIndex + 1) }}
+                    {{ questionText(section.startQuestionNumber + qIndex + 1) }}
                   </div>
                 </button>
               </li>
@@ -99,6 +106,7 @@
 
 <script>
 
+  import coreStrings from 'kolibri.utils.coreStrings';
   import {
     enhancedQuizManagementStrings,
     displaySectionTitle,
@@ -127,6 +135,8 @@
 
       const { jumpToQuestion$ } = enhancedQuizManagementStrings;
 
+      const { questionNumberLabel$ } = coreStrings;
+
       return {
         displaySectionTitle,
         collapse,
@@ -134,17 +144,18 @@
         isExpanded,
         toggle,
         jumpToQuestion$,
+        questionNumberLabel$,
       };
     },
     props: {
-      currentQuestion: {
-        type: Object,
-        required: true,
-      },
       sections: {
         type: Array,
         required: true,
         validator: value => value.every(section => Boolean(section.questions)),
+      },
+      currentSectionIndex: {
+        type: Number,
+        required: true,
       },
       pastattempts: {
         type: Array,
@@ -165,11 +176,6 @@
       },
     },
     computed: {
-      currentSection() {
-        return this.sections.find(section =>
-          section.questions.map(q => q.item).includes(this.questionItem),
-        );
-      },
       sectionCompletionMap() {
         const answeredAttemptItems = this.pastattempts.filter(a => a.answer).map(a => a.item);
         return this.sections.reduce((acc, { questions }, index) => {
@@ -188,18 +194,11 @@
       },
     },
     watch: {
-      currentSection(newSection, oldSection) {
+      currentSectionIndex(newSectionIndex, oldSectionIndex) {
         // Expand the section that contains the current question if it's closed
-        if (!isEqual(newSection, oldSection)) {
-          const index = this.sections.indexOf(newSection);
-          this.expand(index);
-          const oldIndex = this.sections.indexOf(oldSection);
-          if (oldIndex !== -1) {
-            this.collapse(oldIndex);
-          } else {
-            this.collapse(index - 1);
-            this.collapse(index + 1);
-          }
+        if (!isEqual(newSectionIndex, newSectionIndex)) {
+          this.expand(newSectionIndex);
+          this.collapse(oldSectionIndex);
         }
       },
       questionNumber() {
@@ -215,15 +214,9 @@
         }
       },
     },
-    created() {
-      // This is done here because when I did it in setup() the linter said the prop was not
-      // being used... so I moved it here and it's happy now.
-      // Expand the section that contains the current question
-      this.expand(
-        this.sections.findIndex(section =>
-          section.questions.map(q => q.item).includes(this.currentQuestion.item),
-        ),
-      );
+    mounted() {
+      // Expand the section that contains the current question on mount
+      this.expand(this.currentSectionIndex);
     },
     methods: {
       sectionQuestionsIconColor(index) {
@@ -250,7 +243,7 @@
         return `answer-history-item-${item}`;
       },
       questionText(num) {
-        return this.$tr('question', { num });
+        return this.questionNumberLabel$({ questionNumber: num });
       },
       isAnswered(question) {
         const attempt = this.pastattempts.find(attempt => attempt.item === question.item);
@@ -270,13 +263,6 @@
             backgroundColor: this.$themePalette.grey.v_100,
           },
         });
-      },
-    },
-    $trs: {
-      question: {
-        message: 'Question { num, number, integer}',
-        context:
-          "In the report section, the 'Answer history' shows the learner if they have answered questions correctly or incorrectly.\n\nOnly translate 'Question'.",
       },
     },
   };


### PR DESCRIPTION
## Summary
* Annotate sections with start and end section numbers.
* Simplify attempt log listing by requiring sections, so only having a mobile and non-mobile condition
* Fix attempt log listing by including the section context in the question numbers.
* Remove background to show selection state.
* Update question number display to show the number globally for the quiz, rather than per section.
* Update learner quiz display to be correlated.
* Cleanup cruft in learner quiz display that was making our computed props over complicated and redundant.

## References
Fixes [#12334](https://github.com/learningequality/kolibri/issues/12334)

## Reviewer guidance
* Test multi-section quiz reports to ensure that selection state is properly shown.
* Test to ensure that navigation between items occurs properly.
* Regression test practice quiz reports for learners and coaches
* Regression test exercise reports for coaches
* Ensure that multi-section quiz engagement and question selection functions properly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
