### PR TITLE
EQM: Bookmarks not linking anywhere in resource selection

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -757,8 +757,8 @@
         this.$refs.textbox.focus();
       },
       contentLink(content) {
+        const { name, params, query } = this.$route;
         if (!content.is_leaf) {
-          const { name, params } = this.$route;
           // Link folders to their page
           return {
             name,
@@ -768,7 +768,8 @@
             },
           };
         }
-        return {}; // Or this could be how we handle leaf nodes if we wanted them to link somewhere
+        // Just return the current route; router-link will handle the no-op from here
+        return { name, params, query };
       },
       topicsLink(topic_id) {
         return this.contentLink({ id: topic_id });


### PR DESCRIPTION
## Summary

Fixes #12331 

The `contentLink` method in `ResourceSelection` was returning an empty object with the expectation that it would basically serve as a no-op which worked find _except_ for the fact that we show bookmarks based on a query param.

This returns the current route's `name` `params` and `query` for non-topic content nodes. I think I worried that this approach would result in redundant navigation errors but it seems that router-link just ignores clicks on the links.

## Reviewer guidance

Test clicking bookmarks and exercise cards in EQM resource selection.