### PR TITLE
Reduce the size of the wheel file

### DIFF
--- a/.github/workflows/build_whl.yml
+++ b/.github/workflows/build_whl.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Ubuntu dependencies
       run: |
         sudo apt-get -y -qq update
-        sudo apt-get install -y gettext sudo sqlite3
+        sudo apt-get install -y gettext sudo sqlite3 binutils-aarch64-linux-gnu binutils-arm-linux-gnueabihf
     - name: Set up Python 3.6
       uses: actions/setup-python@v5
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ cext_cache
 
 # ignore gzipped files
 *.gz
+# Ignore our special file size cache
+*.file_size

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 # List most target names as 'PHONY' to prevent Make from thinking it will be creating a file of the same name
-.PHONY: help clean clean-assets clean-build clean-pyc clean-docs lint test test-all assets coverage docs release staticdeps staticdeps-cext writeversion setrequirements buildconfig pex i18n-extract-frontend i18n-extract-backend i18n-transfer-context i18n-extract i18n-django-compilemessages i18n-upload i18n-pretranslate i18n-pretranslate-approve-all i18n-download i18n-regenerate-fonts i18n-stats i18n-install-font i18n-download-translations i18n-download-glossary i18n-upload-glossary docker-whl docker-demoserver docker-devserver docker-envlist
+.PHONY: help clean clean-assets clean-build clean-pyc clean-docs lint test test-all assets coverage docs release staticdeps staticdeps-cext strip-staticdeps writeversion setrequirements buildconfig pex i18n-extract-frontend i18n-extract-backend i18n-transfer-context i18n-extract i18n-django-compilemessages i18n-upload i18n-pretranslate i18n-pretranslate-approve-all i18n-download i18n-regenerate-fonts i18n-stats i18n-install-font i18n-download-translations i18n-download-glossary i18n-upload-glossary docker-whl docker-demoserver docker-devserver docker-envlist
 
 
 help:
@@ -17,6 +17,7 @@ help:
 	@echo "assets: builds javascript assets"
 	@echo "staticdeps: downloads/updates all static Python dependencies bundled into the dist"
 	@echo "staticdeps-cext: downloads/updates Python C extensions for all supported platforms"
+	@echo "strip-staticdeps: strips debug symbols from C extensions"
 	@echo "clean: restores code tree to a clean state"
 	@echo "clean-build: remove build artifacts"
 	@echo "clean-pyc: remove Python file artifacts"
@@ -167,6 +168,9 @@ staticdeps-cext:
 	pip install -t kolibri/dist/cext -r "requirements/cext_noarch.txt" --no-deps
 	rm -rf kolibri/dist/*.egg-info
 
+strip-staticdeps:
+	find kolibri/dist -name "*.so" -exec strip --strip-unneeded {} \;
+
 staticdeps-compileall:
 	bash -c 'python --version'
 	# Seems like the compileall module does not return a non-zero exit code when failing
@@ -190,7 +194,7 @@ buildconfig:
 	git checkout -- kolibri/utils/build_config # restore __init__.py
 	python build_tools/customize_build.py
 
-dist: setrequirements writeversion staticdeps staticdeps-cext buildconfig i18n-extract-frontend assets i18n-django-compilemessages preseeddb
+dist: setrequirements writeversion staticdeps staticdeps-cext strip-staticdeps buildconfig i18n-extract-frontend assets i18n-django-compilemessages preseeddb
 	python setup.py sdist --format=gztar > /dev/null # silence the sdist output! Too noisy!
 	python setup.py bdist_wheel
 	ls -l dist

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ staticdeps-cext:
 
 strip-staticdeps:
 	find kolibri/dist -name "*.so" -exec strip --strip-unneeded {} \;
+	find kolibri/dist -name "*.so" -exec aarch64-linux-gnu-strip --strip-unneeded {} \;
+	find kolibri/dist -name "*.so" -exec arm-linux-gnueabihf-strip --strip-unneeded {} \;
 
 staticdeps-compileall:
 	bash -c 'python --version'

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ clean: clean-build clean-pyc clean-assets clean-staticdeps
 
 clean-assets:
 	yarn run clean
-	rm -fr kolibri/core/content/static/hashi/
 
 clean-build:
 	rm -f kolibri/VERSION

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "publish-packages": "node ./packages/publish.js",
     "hashi-dev": "yarn workspace hashi run dev",
     "hashi-build": "yarn workspace hashi run build",
-    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{html,js,css,ico,svg,map,eot,woff,ttf,woff2}'"
+    "compress": "kolibri-tools compress 'kolibri/*/**/static/**/*.{html,js,css,svg,map,eot,ttf}'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "devserver-hot": "concurrently --passthrough-arguments --kill-others \"yarn:watch-hot --watchonly {1}\" yarn:python-devserver yarn:hashi-dev --",
     "devserver-with-kds": "concurrently --passthrough-arguments --kill-others \"yarn:watch --watchonly={2} --require-kds-path --kds-path={1}\" yarn:python-devserver yarn:hashi-dev --",
     "bundle-stats": "kolibri-tools build stats --file ./build_tools/build_plugins.txt --transpile",
-    "clean": "kolibri-tools build clean --file ./build_tools/build_plugins.txt",
+    "clean": "rm -fr kolibri/core/content/static/hashi/ && kolibri-tools build clean --file ./build_tools/build_plugins.txt",
     "lint-frontend": "kolibri-tools lint --pattern '{kolibri*/**/assets,packages,build_tools}/**/*.{js,vue,scss,less,css}' --ignore '**/dist/**,**/node_modules/**,**/static/**,**/kolibri-core-for-export/**'",
     "lint-frontend:format": "yarn run lint-frontend --write",
     "lint-frontend:watch": "yarn run lint-frontend --monitor",

--- a/packages/kolibri-tools/lib/cli.js
+++ b/packages/kolibri-tools/lib/cli.js
@@ -451,6 +451,9 @@ program
     } else {
       const glob = require('./glob');
       const compressFile = require('./compress');
+      logger.warn(
+        'The compress command is a destructive operation and will truncate any source files that are compressed. Please ensure you have a backup of the files you are compressing.',
+      );
       Promise.all(
         files.map(file => {
           const matches = glob.sync(file);

--- a/packages/kolibri-tools/lib/compress.js
+++ b/packages/kolibri-tools/lib/compress.js
@@ -1,6 +1,6 @@
 const { constants, createGzip } = require('node:zlib');
 const { pipeline } = require('node:stream');
-const { createReadStream, createWriteStream } = require('fs');
+const { createReadStream, createWriteStream, statSync } = require('node:fs');
 const logger = require('./logging');
 
 const logging = logger.getLogger('Kolibri Compressor');
@@ -17,7 +17,18 @@ function compressFile(input) {
         logging.error('An error occurred compressing file: ', input);
         logging.error(err);
       } else {
-        logging.info('Successfully compressed: ', input);
+        const sourceStats = statSync(input);
+        const destStats = statSync(input + '.gz');
+        logging.info(
+          'Successfully compressed:',
+          input,
+          'by',
+          (1 - destStats.size / sourceStats.size) * 100,
+          '%',
+        );
+        if (destStats.size / sourceStats.size > 0.75) {
+          logging.warn('Compressed size is more than 75% of original size');
+        }
       }
       resolve();
     });


### PR DESCRIPTION
## Summary
This is an iterative PR to do more and more aggressive things to reduce the size of the whl file.
| Change | Size Saved (MB) |
|------------|------------------------|
| Removes compression from woff and woff2 files, which had minimal effect on served asset size, but did make the file appear twice in the whl file | 6 |
| Runs strip --strip-unneeded on all .so files for the x64 architecture | 8 |
| Runs strip --strip-unneeded on all .so files for the aarch64 and arm 32bit architecture | 9 |
| Truncates all compressed files to prevent duplication of static assets | 18.6 |
| **Total** | **41.6** |

These changes bring the whl file back below the 100MB mark.

The final fix here is a cherry-pick of the final unmerged parts of this PR: https://github.com/learningequality/kolibri/pull/8958

I have sidestepped the main issue with that PR:

> The main consideration here is that if a device explicitly requests the identity Accept-Encoding header it will return an empty file instead of the actual file. The other alternative is to return a 406 status code if the identity header is passed for one of these files, but this seems to be [explicitly disallowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding).

By handling the identity Accept-Encoding header by dynamically ungzipping the compressed file when it is requested. As all of our supported browsers do allow gzip accept-encoding, this should be very much an edge case.

## References
Fixes [#12296](https://github.com/learningequality/kolibri/issues/12296)

## Reviewer guidance
Test built assets on multiple Linux architectures (x64, ARM, and aarch64) - the latter two may be a bit harder, but testing on a raspberry pi should hopefully suffice.

Ensuring static assets load in the frontend properly.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
