### PR TITLE
Perseus final fixes

### DIFF
--- a/kolibri/core/assets/src/logging.js
+++ b/kolibri/core/assets/src/logging.js
@@ -14,8 +14,8 @@ class Logger {
       const name = methodName.toLowerCase();
       const logFunction = this.logger[name];
       if (logFunction) {
-        this[name] = param => {
-          return this.logger[name](param);
+        this[name] = (...params) => {
+          return this.logger[name](...params);
         };
       }
     });
@@ -25,8 +25,8 @@ class Logger {
     var originalFactory = this.logger.methodFactory;
     this.logger.methodFactory = function (methodName, logLevel, loggerName) {
       var rawMethod = originalFactory(methodName, logLevel, loggerName);
-      return function (message) {
-        rawMethod(`[${methodName.toUpperCase()}: ${loggerName}] ` + message);
+      return function (message, ...args) {
+        rawMethod(`[${methodName.toUpperCase()}: ${loggerName}] ` + message, ...args);
       };
     };
     this.logger.setLevel(this.logger.getLevel());
@@ -55,7 +55,7 @@ class Logging {
     this.defaultLogger = new Logger('root');
     Object.keys(loglevel.levels).forEach(methodName => {
       const name = methodName.toLowerCase();
-      this[name] = msg => this.defaultLogger[name](msg);
+      this[name] = (...msgs) => this.defaultLogger[name](...msgs);
     });
   }
 

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -37,7 +37,7 @@
   import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import { defer } from 'underscore';
   import { createElement as e } from 'react';
-  import { render, unmountComponentAtNode } from 'react-dom';
+  import { createPortal, render, unmountComponentAtNode } from 'react-dom';
   import * as perseus from '@khanacademy/perseus';
   import {
     MathInputI18nContextProvider,
@@ -56,7 +56,7 @@
 
   const keypadStyle = StyleSheet.create({
     keypadContainer: {
-      position: 'absolute',
+      zIndex: 20,
     },
   });
 
@@ -426,12 +426,15 @@
           KeypadContext.Consumer,
           { key: 'keypadWithContext ' },
           ({ setKeypadElement, renderer }) =>
-            e(MobileKeypad, {
-              style: keypadStyle.keypadContainer,
-              onElementMounted: setKeypadElement,
-              onDismiss: () => renderer && renderer.blur(),
-              onAnalyticsEvent: async () => {},
-            }),
+            createPortal(
+              e(MobileKeypad, {
+                style: keypadStyle.keypadContainer,
+                onElementMounted: setKeypadElement,
+                onDismiss: () => renderer && renderer.blur(),
+                onAnalyticsEvent: async () => {},
+              }),
+              document.body,
+            ),
         );
         const statefulKeypadContextProviderElement = e(StatefulKeypadContextProvider, {
           children: [keypadContextConsumerElement, keypadWithContextElement],

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -537,8 +537,20 @@
           answerState = JSON.parse(
             replaceImageUrls(JSON.stringify(answerState), this.perseusFileUrl),
           );
+          const widgetIds = this.itemRenderer.getWidgetIds();
+          // Because of a switch between the input-number and numeric-input widgets
+          // it seems it is possible for us to have a serialized state with keys
+          // that do not correspond to any widgets. We need to sanitize the state
+          // before restoring it.
+          const sanitizedQuestions = {};
+          for (const key of widgetIds) {
+            if (answerState.question[key]) {
+              sanitizedQuestions[key] = answerState.question[key];
+            }
+          }
+          answerState.question = sanitizedQuestions;
           this.itemRenderer.restoreSerializedState(answerState);
-          this.itemRenderer.getWidgetIds().forEach(id => {
+          widgetIds.forEach(id => {
             if (sorterWidgetRegex.test(id)) {
               if (answerState.question[id]) {
                 const sortableComponent =

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -542,13 +542,13 @@
           // it seems it is possible for us to have a serialized state with keys
           // that do not correspond to any widgets. We need to sanitize the state
           // before restoring it.
-          const sanitizedQuestions = {};
+          const sanitizedQuestion = {};
           for (const key of widgetIds) {
             if (answerState.question[key]) {
-              sanitizedQuestions[key] = answerState.question[key];
+              sanitizedQuestion[key] = answerState.question[key];
             }
           }
-          answerState.question = sanitizedQuestions;
+          answerState.question = sanitizedQuestion;
           this.itemRenderer.restoreSerializedState(answerState);
           widgetIds.forEach(id => {
             if (sorterWidgetRegex.test(id)) {

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -391,8 +391,8 @@
             onFocusChange: this.dismissMessage,
             onInputError: logging.error,
             isMobile: this.isMobile,
-            // Only show a keypad if we are in interactive mode.
-            customKeypad: this.interactive,
+            // Always use our custom keypad implementation
+            customKeypad: true,
             readOnly: !this.interactive,
             hintProgressColor: this.$themeTokens.primary,
           },
@@ -418,7 +418,7 @@
             this.keypadElement = keypadElement;
             return e(perseus.ServerItemRenderer, {
               ...itemRenderData,
-              keypadElement: keypadElement,
+              keypadElement: this.interactive ? keypadElement : null,
             });
           },
         );

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -391,7 +391,8 @@
             onFocusChange: this.dismissMessage,
             onInputError: logging.error,
             isMobile: this.isMobile,
-            customKeypad: true,
+            // Only show a keypad if we are in interactive mode.
+            customKeypad: this.interactive,
             readOnly: !this.interactive,
             hintProgressColor: this.$themeTokens.primary,
           },

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -453,7 +453,6 @@
         render(renderStateRootElement, this.$refs.perseus);
       },
       renderNewItem() {
-        this.renderItem();
         // Clear any pending state reset calls
         this.$off('itemRendererUpdated');
         this.$once('itemRendererUpdated', () => {
@@ -466,6 +465,7 @@
           // so we need to ensure that the itemRenderer is available and up to date first.
           this.setAnswer();
         });
+        this.renderItem();
       },
       _resetState(val) {
         if (!val) {

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -293,6 +293,7 @@
     },
     created() {
       this.itemRenderer = null;
+      this.keypadElement = null;
       // This is a local object for tracking image URLs
       // we use this to clean up image URLs just for this component
       this.imageUrls = {};
@@ -412,22 +413,24 @@
         const keypadContextConsumerElement = e(
           KeypadContext.Consumer,
           { key: 'keypadContextConsumer' },
-          ({ keypadElement }) =>
-            e(perseus.ServerItemRenderer, {
+          ({ keypadElement }) => {
+            this.keypadElement = keypadElement;
+            return e(perseus.ServerItemRenderer, {
               ...itemRenderData,
               keypadElement: keypadElement,
-            }),
+            });
+          },
         );
         const keypadWithContextElement = e(
           KeypadContext.Consumer,
           { key: 'keypadWithContext ' },
-          ({ setKeypadElement }) =>
+          ({ setKeypadElement, renderer }) =>
             e('div', {
               className: 'keypad-container',
               children: e(MobileKeypad, {
                 style: keypadStyle.keypadContainer,
                 onElementMounted: setKeypadElement,
-                onDismiss: () => {},
+                onDismiss: () => renderer && renderer.blur(),
                 onAnalyticsEvent: async () => {},
               }),
             }),
@@ -455,6 +458,10 @@
       renderNewItem() {
         // Clear any pending state reset calls
         this.$off('itemRendererUpdated');
+        // Dismiss the keypad
+        if (this.keypadElement) {
+          this.keypadElement.dismiss();
+        }
         this.$once('itemRendererUpdated', () => {
           // Blur any previously focused element once we have rendered a new item
           this.itemRenderer.blur();

--- a/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
+++ b/kolibri/plugins/perseus_viewer/assets/src/views/PerseusRendererIndex.vue
@@ -56,7 +56,7 @@
 
   const keypadStyle = StyleSheet.create({
     keypadContainer: {
-      position: 'relative',
+      position: 'absolute',
     },
   });
 
@@ -426,14 +426,11 @@
           KeypadContext.Consumer,
           { key: 'keypadWithContext ' },
           ({ setKeypadElement, renderer }) =>
-            e('div', {
-              className: 'keypad-container',
-              children: e(MobileKeypad, {
-                style: keypadStyle.keypadContainer,
-                onElementMounted: setKeypadElement,
-                onDismiss: () => renderer && renderer.blur(),
-                onAnalyticsEvent: async () => {},
-              }),
+            e(MobileKeypad, {
+              style: keypadStyle.keypadContainer,
+              onElementMounted: setKeypadElement,
+              onDismiss: () => renderer && renderer.blur(),
+              onAnalyticsEvent: async () => {},
             }),
         );
         const statefulKeypadContextProviderElement = e(StatefulKeypadContextProvider, {
@@ -971,12 +968,6 @@
       border-radius: 3px;
       transition: box-shadow ease-in-out 0.15s;
     }
-  }
-
-  .keypad-container {
-    flex-shrink: 0; /* Prevent the keypad from shrinking */
-    justify-content: center; /* Center the keypad horizontally */
-    direction: ltr;
   }
 
 </style>


### PR DESCRIPTION
## Summary
* Does flyby fix of core logging module to allow multiple arguments to be sent to each logging method
* Prevents restoring of slightly mangled state by santizing question keys before restoration
* Fixes previously unnoticed issue whereby an initial refresh of the page would not restore the answer on first page load

## References
Fixes #12322
Fixes #12375

## Reviewer guidance
Use the database from referenced issue and see that the quiz responses are properly restored for all questions with no errors logged in the console.
While on the quiz page, refresh the page, and see that the answer gets properly filled in on page refresh.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
