### PR TITLE
Don't put csrf protection on endpoint that we use to set csrf cookie.

### DIFF
--- a/kolibri/core/auth/api.py
+++ b/kolibri/core/auth/api.py
@@ -872,7 +872,7 @@ class SetNonSpecifiedPasswordView(views.APIView):
         return Response()
 
 
-@method_decorator([ensure_csrf_cookie, csrf_protect], name="dispatch")
+@method_decorator([ensure_csrf_cookie], name="dispatch")
 class SessionViewSet(viewsets.ViewSet):
     def _check_os_user(self, request, username):
         auth_token = request.COOKIES.get(APP_AUTH_TOKEN_COOKIE_NAME)

--- a/kolibri/core/auth/test/test_api.py
+++ b/kolibri/core/auth/test/test_api.py
@@ -2096,13 +2096,13 @@ class CSRFProtectedAuthTestCase(APITestCase):
         cls.facility = FacilityFactory.create()
         cls.user = FacilityUserFactory.create(facility=cls.facility)
 
-    def test_csrf_protected_session_list(self):
+    def test_not_csrf_protected_session_list(self):
         response = self.client_csrf.post(
             reverse("kolibri:core:session-list"),
             data={"username": self.user.username, "password": DUMMY_PASSWORD},
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_csrf_protected_signup_list(self):
         response = self.client_csrf.post(


### PR DESCRIPTION
## Summary
* Removes csrf_protect decorator from the session endpoint as this was preventing the csrf cookie from being set for fresh browser sessions on first page load

## References
Fixes [#12305](https://github.com/learningequality/kolibri/issues/12305)

Small regression introduced by https://github.com/learningequality/kolibri/pull/11978 - so this is new in 0.17

## Reviewer guidance
Open an incognito window
Navigate to kolibri
See that the login page renders properly

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
