### PR TITLE
EQM: Difficult questions reports fix

### DIFF
--- a/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/questionDetail/handlers.js
@@ -35,6 +35,7 @@ function showQuestionDetailView(params) {
   const { exerciseId, learnerId, interactionIndex, questionId, quizId } = params;
   let promise;
   let exerciseNodeId;
+  let questions;
   if (quizId) {
     // If this is showing for a quiz, then no exerciseId will be passed in
     // set the appropriate exerciseId here based on the question sources
@@ -42,13 +43,15 @@ function showQuestionDetailView(params) {
     // of a combination of 'question_id:exercise_id'
     const baseExam = store.state.classSummary.examMap[quizId];
     promise = fetchExamWithContent(baseExam).then(({ exam }) => {
-      exerciseNodeId = exam.question_sources.find(source => source.item === questionId).exercise_id;
+      questions = exam.question_sources.reduce((acc, sec) => [...acc, ...sec.questions], []);
+      exerciseNodeId = questions.find(question => question.item === questionId).exercise_id;
       return exam;
     });
   } else {
     // Passed in exerciseId is the content_id of the contentNode
     // Map this to the id of the content node to do this fetch
     exerciseNodeId = store.state.classSummary.contentMap[exerciseId].node_id;
+    questions = [];
     promise = Promise.resolve();
   }
   return promise
@@ -57,7 +60,7 @@ function showQuestionDetailView(params) {
         exercise.assessmentmetadata = exercise.assessmentmetadata || {};
         let title;
         if (exam) {
-          const question = exam.question_sources.find(source => source.item === questionId);
+          const question = questions.find(source => source.item === questionId);
           title = coachStrings.$tr('nthExerciseName', {
             name: question.title,
             number: question.counter_in_exercise,

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
@@ -122,14 +122,14 @@
   }
 
   h3.item {
-    margin-left: 1.5em;
+    margin-left: 2em;
   }
 
   .svg-item {
     position: absolute;
     top: 50%;
     left: 0;
-    width: 1em;
+    width: 1.5em;
     height: auto;
     transform: translateY(-50%);
   }

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
@@ -97,6 +97,7 @@
 <style lang="scss" scoped>
 
   .title {
+    position: relative;
     display: inline-block;
   }
 
@@ -120,22 +121,23 @@
     list-style-type: none;
   }
 
-  .item {
-    display: inline-block;
-    height: 24px;
+  h3.item {
+    margin-left: 1.5em;
   }
 
   .svg-item {
-    width: 32px;
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 1em;
     height: auto;
-    margin-right: 8px;
-    vertical-align: middle;
+    transform: translateY(-50%);
   }
 
   .learner-item {
     display: block;
     min-width: 120px;
-    padding-left: 20px;
+    padding-left: 1em;
     clear: both;
   }
 

--- a/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
+++ b/kolibri/plugins/coach/assets/src/views/common/QuestionDetailLearnerList.vue
@@ -24,13 +24,13 @@
               v-if="learner.noattempt"
               class="item svg-item"
               :style="{ fill: $themeTokens.annotation }"
-              icon="cancel"
+              icon="notStarted"
             />
             <KIcon
               v-else-if="!learner.correct"
               class="item svg-item"
               :style="{ fill: $themeTokens.incorrect }"
-              icon="cancel"
+              icon="incorrect"
             />
             <KIcon
               v-else-if="learner.hinted"


### PR DESCRIPTION
## Summary

Closes #12164  - where questions were needed in `questionDetail/handlers.js` we were still expecting the Exam.question_sources v2 schema. I did a cursory search for possible other uses of `question_sources` to derive questions but found nothing else.

#### 🎆 BONUS FIXES 🎆 

**Before:**

_Not all issues shown in screenshot_

- Broken icons
- Text and icon were inline-block, weird text overflow
- `px` values
- icon is a few pixels below centered

![image](https://github.com/learningequality/kolibri/assets/6356129/578fbea9-d5c0-43ae-b1cc-25d9b6c1f172)

**After:**

_Not all fixes shown in screenshot_

- Proper icons
- Icon vertical centered
- Text is padded from left, justified against icon's spacing
- Icon absolute positioned
- `em` values

![image](https://github.com/learningequality/kolibri/assets/6356129/96b8e3fd-447d-4c2c-a6c7-860874f867f6)

---

## Reviewer guidance

- [ ] Can you view Difficult questions reports?
- [ ] Does the page have working icons that look right?