### PR TITLE
Use useNow composable in ElapsedTime component

### DIFF
--- a/kolibri/core/assets/src/views/ElapsedTime.vue
+++ b/kolibri/core/assets/src/views/ElapsedTime.vue
@@ -7,20 +7,20 @@
 
 <script>
 
-  import { now } from 'kolibri.utils.serverClock';
+  import useNow from 'kolibri.coreVue.composables.useNow';
 
   export default {
     name: 'ElapsedTime',
+    setup() {
+      const { now } = useNow();
+      return { now };
+    },
     props: {
       date: {
         type: Date,
         default: null,
       },
     },
-    data: () => ({
-      now: now(),
-      timer: null,
-    }),
     computed: {
       ceilingDate() {
         if (this.date > this.now) {
@@ -28,14 +28,6 @@
         }
         return this.date;
       },
-    },
-    mounted() {
-      this.timer = setInterval(() => {
-        this.now = now();
-      }, 10000);
-    },
-    beforeDestroy() {
-      clearInterval(this.timer);
     },
   };
 


### PR DESCRIPTION
## Summary
This PR introduces the `useNow` composable in `ElapsedTime` component

## References

Closes #12114

## Reviewer guidance
Check that everything continues working ok in the places where [ElapsedTime component is used](https://github.com/search?q=repo%3Alearningequality%2Fkolibri%20%3CElapsedTime&type=code).

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
