### PR TITLE
Load channel content on remove filter

### DIFF
--- a/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
+++ b/kolibri/plugins/learn/assets/src/views/LibraryPage/index.vue
@@ -363,6 +363,12 @@
 
       watch(() => props.deviceId, showLibrary);
 
+      watch(displayingSearchResults, () => {
+        if (!displayingSearchResults.value && !rootNodes.value.length) {
+          showLibrary();
+        }
+      });
+
       showLibrary();
 
       return {


### PR DESCRIPTION
## Summary
`showLibrary` is the method we use to load and show the channels. But if we have filters, it never sets the `rootNodes` array. The problem was that we were not calling that method again when we removed the filters, so if we had filters in the first render, these channels would never have been loaded.

https://github.com/learningequality/kolibri/assets/51239030/e4547885-62b8-464b-a0b7-6f23013cbc9a

## References
Closes #12328.

## Reviewer guidance
Replicate #12328.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
