### PR TITLE
Fix white space on top of tabs dividing line

### DIFF
--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.6",
-    "kolibri-design-system": "https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed",
+    "kolibri-design-system": "4.3.2",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",

--- a/kolibri/core/package.json
+++ b/kolibri/core/package.json
@@ -21,7 +21,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.6",
-    "kolibri-design-system": "4.3.1",
+    "kolibri-design-system": "https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",

--- a/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/PlanHeader.vue
@@ -17,7 +17,6 @@
         :ariaLabel="$tr('coachPlan')"
         :activeTabId="activeTabId"
         :tabs="tabs"
-        :style="{ position: 'relative', top: '5px' }"
         @click="() => saveTabsClick(PLAN_TABS_ID)"
       />
     </HeaderTabs>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsGroupHeader.vue
@@ -24,7 +24,6 @@
         :ariaLabel="$tr('groupReports')"
         :activeTabId="activeTabId"
         :tabs="tabs"
-        :style="{ position: 'relative', top: '5px' }"
         @click="() => saveTabsClick(REPORTS_GROUP_TABS_ID)"
       />
     </HeaderTabs>

--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsHeader.vue
@@ -19,7 +19,6 @@
         :ariaLabel="$tr('coachReports')"
         :activeTabId="activeTabId"
         :tabs="tabs"
-        :style="{ position: 'relative', top: '5px' }"
         @click="() => saveTabsClick(REPORTS_TABS_ID)"
       />
     </HeaderTabs>

--- a/packages/kolibri-core-for-export/package.json
+++ b/packages/kolibri-core-for-export/package.json
@@ -24,7 +24,7 @@
     "js-cookie": "^3.0.5",
     "knuth-shuffle-seeded": "^1.0.6",
     "kolibri-constants": "0.2.6",
-    "kolibri-design-system": "4.3.1",
+    "kolibri-design-system": "4.3.2",
     "lockr": "0.8.5",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7747,6 +7747,24 @@ kolibri-design-system@4.3.1:
     vue-intl "3.1.0"
     xstate "4.38.3"
 
+"kolibri-design-system@https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed":
+  version "4.3.1"
+  resolved "https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed"
+  dependencies:
+    "@vue/composition-api" "1.7.2"
+    aphrodite "https://github.com/learningequality/aphrodite/"
+    autosize "3.0.21"
+    css-element-queries "1.2.0"
+    date-fns "1.30.1"
+    frame-throttle "3.0.0"
+    fuzzysearch "1.0.3"
+    lodash "4.17.21"
+    popper.js "1.16.1"
+    purecss "2.2.0"
+    tippy.js "4.2.1"
+    vue-intl "3.1.0"
+    xstate "4.38.3"
+
 launch-editor-middleware@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/launch-editor-middleware/-/launch-editor-middleware-2.8.0.tgz#e6021d2ceb70830fddf8bbcee5730acb5aa2db58"
@@ -10672,16 +10690,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10740,14 +10749,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -12061,16 +12063,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,15 @@ anymatch@^3.0.3, anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+"aphrodite@git+https://github.com/learningequality/aphrodite.git":
+  version "2.2.3"
+  uid fdc8d7be8912a5cf17f74ff10f124013c52c3e32
+  resolved "git+https://github.com/learningequality/aphrodite.git#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
+  dependencies:
+    asap "^2.0.3"
+    inline-style-prefixer "^4.0.2"
+    string-hash "^1.1.3"
+
 "aphrodite@https://github.com/learningequality/aphrodite/":
   version "2.2.3"
   resolved "https://github.com/learningequality/aphrodite/#fdc8d7be8912a5cf17f74ff10f124013c52c3e32"
@@ -7728,28 +7737,10 @@ kolibri-constants@0.2.6:
   resolved "https://registry.yarnpkg.com/kolibri-constants/-/kolibri-constants-0.2.6.tgz#d13762862505a3a6ec58a104870b21da96778656"
   integrity sha512-gQaY2wFNFrsB+9+xQNeEcLHixNuZEK+GHyKKr78s/hg8gFU3YVsnhlYp0u+du4XeVwewpyN1ajGb4UrrdF8rTA==
 
-kolibri-design-system@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-4.3.1.tgz#09bb207e7507fc3c27f119054151485ffde67dd5"
-  integrity sha512-umMrqXorU3UzXQZ1ZAmUjYWB02phXcX0qmWwS+FAOPbOjUEjmB6pZ/lN5TjjeE3onZfasf+pjwb3xJx3F4Nn/A==
-  dependencies:
-    "@vue/composition-api" "1.7.2"
-    aphrodite "https://github.com/learningequality/aphrodite/"
-    autosize "3.0.21"
-    css-element-queries "1.2.0"
-    date-fns "1.30.1"
-    frame-throttle "3.0.0"
-    fuzzysearch "1.0.3"
-    lodash "4.17.21"
-    popper.js "1.16.1"
-    purecss "2.2.0"
-    tippy.js "4.2.1"
-    vue-intl "3.1.0"
-    xstate "4.38.3"
-
-"kolibri-design-system@https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed":
-  version "4.3.1"
-  resolved "https://github.com/AlexVelezLl/kolibri-design-system.git#fab0b72f1734863d77ba3dd00f6ee0eadd7fe1ed"
+kolibri-design-system@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/kolibri-design-system/-/kolibri-design-system-4.3.2.tgz#1779fb5958499bd0cb1a65591a5ec8a82e0a2248"
+  integrity sha512-hsApuzPGAYxkQpcVlVLcY4GSgZAyrOzLLt+CQGj9XM1Lep99kiJuLysyNP0ZxRzmT/kKjx4jvIA8Mi81Ui5pkw==
   dependencies:
     "@vue/composition-api" "1.7.2"
     aphrodite "https://github.com/learningequality/aphrodite/"


### PR DESCRIPTION
## Summary

Note: This PR depends on https://github.com/learningequality/kolibri-design-system/pull/673.
 
Fix white space on top of coach tabs dividing line.

![image](https://github.com/learningequality/kolibri/assets/51239030/e708c3f6-4a6e-42c9-9fb1-95392feae867)
![image](https://github.com/learningequality/kolibri/assets/51239030/968ce9a4-54b7-4e6c-8881-fffa0756c8a1)

## References
Closes #12297.

## Reviewer guidance
You can go to any of these components and see that dividing line is showing correctly:
* Tabs on Coach Reports table
* Tabs on Coach Plan table
* Tabs on Coach Group Reports table
* Tabs on Coach Learner Reports table
* Tabs on Coach Lesson Reports table
* Tabs on Coach Quiz Reports table

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [x] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
