### PR TITLE
Update folder selection logic to handle deep folders.

### DIFF
--- a/kolibri/core/assets/src/constants.js
+++ b/kolibri/core/assets/src/constants.js
@@ -198,5 +198,3 @@ export const Presets = Object.freeze({
 // This should be kept in sync with the value in
 // kolibri/core/exams/constants.py
 export const MAX_QUESTIONS_PER_QUIZ_SECTION = 50;
-// this is not used for the actual exam model
-export const MAX_QUESTION_OPTIONS_PER_QUIZ_SECTION = 500;

--- a/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizResources.js
@@ -128,22 +128,6 @@ export default function useQuizResources({ topicId, practiceQuiz = false } = {})
     });
   }
 
-  /** @returns {Boolean} Whether the given node should be displayed with a checkbox
-   *  @description Returns true for exercises and for topics that have no topic children and no
-   *  more children to load
-   */
-  function hasCheckbox(node) {
-    return (
-      node.kind === ContentNodeKinds.EXERCISE ||
-      // Has children, no more to load, and no children are topics
-      (!practiceQuiz &&
-        node.children &&
-        !node.children.more &&
-        !node.children.results.some(c => c.kind === ContentNodeKinds.TOPIC) &&
-        node.children.results.length <= 12)
-    );
-  }
-
   function setResources(r) {
     set(_resources, r);
   }
@@ -155,7 +139,6 @@ export default function useQuizResources({ topicId, practiceQuiz = false } = {})
     loadingMore: computed(() => get(_loadingMore)),
     fetchQuizResources,
     fetchMoreQuizResources,
-    hasCheckbox,
     hasMore,
     topic,
     annotateTopicsWithDescendantCounts,

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/ContentCardList.vue
@@ -22,6 +22,7 @@
           :showLabel="false"
           :checked="contentIsChecked(content)"
           :indeterminate="contentIsIndeterminate(content)"
+          :disabled="contentCheckboxDisabled(content)"
           @change="handleCheckboxChange(content, $event)"
         />
         <KRadioButton
@@ -31,6 +32,7 @@
           :showLabel="false"
           :currentValue="contentIsChecked(content) ? content.id : 'none'"
           :buttonValue="content.id"
+          :disabled="contentCheckboxDisabled(content)"
           @change="handleCheckboxChange(content, true)"
         />
         <!--
@@ -148,6 +150,11 @@
       contentHasCheckbox: {
         type: Function, // ContentNode => Boolean
         required: true,
+      },
+      // Function that returns true if the content item is disabled
+      contentCheckboxDisabled: {
+        type: Function, // ContentNode => Boolean
+        default: () => false,
       },
       // Boolean to toggle on use of radio buttons instead of checkboxes
       showRadioButtons: {


### PR DESCRIPTION
## Summary
* Removes constant for max options per section, replaces with dynamic value calculated in the ResourceSelection component
* Moves all 'can select' logic into the ResourceSelection component
* Adds function to allow determination of select all indeterminate state
* Updates select all showing, based on whether selecting every displayed node could be added and still result in fewer than or equal to the total max number of question options.
* Update select all toggling to reuse existing toggleSelect function for consistency
* Update toggleSelect function to fetch additional data from the backend in case it is not annotated onto the topic (the case when the exercises are not direct children or in the first 12 children of the topic)
* Update showing the number of questions warning to be purely based on whether we're showing select all, if not, we show the message to explain why one or more items are not selectable
* Fix indeterminate state display for folders

Change to behaviour for clarity:
* Update to always show checkboxes for folder and resources
* Instead, disable checkboxes when the folder or resource cannot be selected
* Do not disable checkboxes if the item is currently selected
* Without this change, an indeterminately selected folder cannot be selected/deselected

Point for reflection: I tried to make it so that if a folder was indeterminately selected it and selecting it would exceed the max questions, it would deselect instead - this all worked, except that the KCheckbox did not properly update to the unselected state, so it made the UI more confusing. Instead, it retains its default behaviour, and instead displays the warning that too many questions are now selected.

Change to behaviour that can be reverted:
* I updated the max questions option per section to be dynamic based on how many questions you were trying to choose, so if you were trying to choose 5 questions to add to your quiz, you could only select a total of 50 questions. I can revert this, but it seemed a little bit sensible?

## References
Fixes #12327

## Reviewer guidance
Select, deselect, select all, unselect all, select some resources in a folder, and navigate to the parent. Just do all the permutations of selecting and deselecting and make sure weird edge cases don't arise.

In spite of the disabled checkboxes, it is still possible to get into a state where you have too many resources selected, but the number of paths to get there is much smaller.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
