### PR TITLE
EQM: Sections for quiz detail page

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -153,8 +153,8 @@
     displaySectionTitle,
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
-  import { coreStrings } from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useAccordion from 'kolibri-common/components/useAccordion';
+  import coreStrings from 'kolibri.utils.coreStrings';
   import AccordionItem from 'kolibri-common/components/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/AccordionContainer';
   import { computed, onMounted, watch } from 'kolibri.lib.vueCompositionApi';
@@ -169,9 +169,9 @@
       AccordionItem,
     },
     setup(props, { emit }) {
-      const { sections, selectedQuestionNumber } = toRefs(props);
       const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
       const { questionNumberLabel$ } = coreStrings;
+      const { currentSectionIndex, sections, selectedQuestionNumber } = toRefs(props);
 
       const { expand, isExpanded, toggle } = useAccordion(sections);
 
@@ -187,17 +187,6 @@
           value: index,
           label: displaySectionTitle(section, index),
         }));
-      });
-
-      const currentSectionIndex = computed(() => {
-        let qCount = 0;
-        for (let i = 0; i <= sections.value.length; i++) {
-          qCount += sections.value[i].questions.length;
-          if (qCount > selectedQuestionNumber.value) {
-            return i;
-          }
-        }
-        return 0;
       });
 
       const currentSection = computed(() => {
@@ -241,7 +230,6 @@
         handleSectionChange,
         handleQuestionChange,
         displaySectionTitle,
-        questionNumberLabel$,
         quizSectionsLabel$,
         questionsLabel$,
         expand,

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -153,8 +153,8 @@
     displaySectionTitle,
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import { coreStrings } from 'kolibri.coreVue.mixins.commonCoreStrings';
   import useAccordion from 'kolibri-common/components/useAccordion';
-  import coreStrings from 'kolibri.utils.coreStrings';
   import AccordionItem from 'kolibri-common/components/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/AccordionContainer';
   import { computed, onMounted, watch } from 'kolibri.lib.vueCompositionApi';
@@ -169,9 +169,10 @@
       AccordionItem,
     },
     setup(props, { emit }) {
+      const { sections, selectedQuestionNumber } = toRefs(props);
       const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
       const { questionNumberLabel$ } = coreStrings;
-      const { currentSectionIndex, sections, selectedQuestionNumber } = toRefs(props);
+      const { sections, selectedQuestionNumber } = toRefs(props);
 
       const { expand, isExpanded, toggle } = useAccordion(sections);
 
@@ -187,6 +188,17 @@
           value: index,
           label: displaySectionTitle(section, index),
         }));
+      });
+
+      const currentSectionIndex = computed(() => {
+        let qCount = 0;
+        for (let i = 0; i <= sections.value.length; i++) {
+          qCount += sections.value[i].questions.length;
+          if (qCount > selectedQuestionNumber.value) {
+            return i;
+          }
+        }
+        return 0;
       });
 
       const currentSection = computed(() => {
@@ -230,6 +242,7 @@
         handleSectionChange,
         handleQuestionChange,
         displaySectionTitle,
+        questionNumberLabel$,
         quizSectionsLabel$,
         questionsLabel$,
         expand,

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -172,7 +172,6 @@
       const { sections, selectedQuestionNumber } = toRefs(props);
       const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
       const { questionNumberLabel$ } = coreStrings;
-      const { sections, selectedQuestionNumber } = toRefs(props);
 
       const { expand, isExpanded, toggle } = useAccordion(sections);
 

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/QuestionListPreview.vue
@@ -1,52 +1,115 @@
 <template>
 
   <KGrid>
+    <!-- Question list - side panel accordion unless mobile, then KSelects -->
     <KGridItem
-      :layout8="{ span: 4 }"
-      :layout12="{ span: 5 }"
+      :layout8="{ span: windowIsSmall ? 8 : 4 }"
+      :layout12="{ span: windowIsSmall ? 12 : 5 }"
       class="list-wrapper"
     >
-      <ul class="question-list">
-        <AssessmentQuestionListItem
-          v-for="(question, questionIndex) in annotatedQuestions"
-          :key="listKey(question)"
-          :draggable="false"
-          :isSelected="isSelected(question)"
-          :exerciseName="
-            displayQuestionTitle(question, selectedExercises[question.exercise_id].title)
-          "
-          :isCoachContent="numCoachContents(question.exercise_id)"
-          :available="available(question.exercise_id)"
-          @select="currentQuestionIndex = questionIndex"
+      <div v-if="windowIsSmall">
+        <KSelect
+          v-if="sectionSelectOptions.length > 1"
+          class="section-select"
+          :value="selectedSection"
+          :label="quizSectionsLabel$()"
+          :options="sectionSelectOptions"
+          :disabled="$attrs.disabled"
+          @change="handleSectionChange($event.value)"
         />
-      </ul>
 
-      <transition name="fade-numbers">
-        <ol
-          v-if="fixedOrder"
-          class="list-labels"
-          aria-hidden
+        <h2
+          v-else-if="selectedSection.label"
+          class="section-select"
         >
-          <li
-            v-for="(question, questionIndex) in selectedQuestions"
-            :key="questionIndex"
-          ></li>
-        </ol>
-        <ul
-          v-else
-          class="list-labels"
-          aria-hidden
+          {{ selectedSection.label }}
+        </h2>
+      </div>
+
+      <KSelect
+        v-if="windowIsSmall"
+        class="history-select"
+        :value="selectedQuestion"
+        :label="questionsLabel$()"
+        :options="questionSelectOptions"
+        :disabled="$attrs.disabled"
+        @change="handleQuestionChange($event.value)"
+      >
+        <template #display>
+          {{ selectedQuestion.label }}
+        </template>
+        <template #option="{ index }">
+          {{ questionSelectOptions[index].label }}
+        </template>
+      </KSelect>
+
+      <AccordionContainer
+        v-else-if="!windowIsSmall && sections && sections.length"
+        :hideTopActions="true"
+        :items="sections"
+        :style="{ backgroundColor: $themeTokens.surface }"
+      >
+        <AccordionItem
+          v-for="(section, index) in sections"
+          :id="`section-questions-${index}`"
+          :key="`section-questions-${index}`"
+          :title="displaySectionTitle(section, index)"
+          @focus="expand(index)"
         >
-          <li
-            v-for="(question, questionIndex) in selectedQuestions"
-            :key="questionIndex"
-          ></li>
-        </ul>
-      </transition>
+          <template #heading="{ title }">
+            <h3
+              v-if="title"
+              class="accordion-header"
+            >
+              <KButton
+                tabindex="0"
+                :style="accordionStyleOverrides"
+                appearance="basic-link"
+                class="accordion-header-label"
+                :aria-expanded="isExpanded(index)"
+                :aria-controls="`section-question-panel-${index}`"
+                @click="toggle(index)"
+              >
+                <span>{{ displaySectionTitle(section, index) }}</span>
+                <KIcon
+                  class="chevron-icon"
+                  :icon="isExpanded(index) ? 'chevronUp' : 'chevronRight'"
+                />
+              </KButton>
+            </h3>
+          </template>
+          <template #content>
+            <div
+              v-show="isExpanded(index)"
+              :style="{
+                backgroundColor: $themePalette.grey.v_100,
+              }"
+            >
+              <ul class="question-list">
+                <li v-for="(question, i) in section.questions">
+                  <KButton
+                    tabindex="0"
+                    class="question-button"
+                    appearance="basic-link"
+                    :class="{ selected: isSelected(question) }"
+                    :style="accordionStyleOverrides"
+                    @click="handleQuestionChange(question.item)"
+                  >
+                    <span class="text">
+                      {{ questionNumberLabel$({ questionNumber: i + 1 }) }}
+                    </span>
+                  </KButton>
+                </li>
+              </ul>
+            </div>
+          </template>
+        </AccordionItem>
+      </AccordionContainer>
     </KGridItem>
+
     <KGridItem
-      :layout8="{ span: 4 }"
-      :layout12="{ span: 7 }"
+      :layout8="{ span: windowIsSmall ? 8 : 4 }"
+      :layout12="{ span: windowIsSmall ? 12 : 7 }"
     >
       <h3
         v-if="content && content.available"
@@ -55,16 +118,16 @@
         {{ displayQuestionTitle(currentQuestion, content.title) }}
       </h3>
       <ContentRenderer
-        v-if="content && content.available && questionId"
+        v-if="content && content.available && currentQuestion.question_id"
         ref="contentRenderer"
         :kind="content.kind"
         :files="content.files"
         :available="content.available"
         :extraFields="content.extra_fields"
-        :itemId="questionId"
+        :itemId="currentQuestion.question_id"
         :assessment="true"
         :allowHints="false"
-        :showCorrectAnswer="true"
+        :showCorrectAnswer="false"
         :interactive="false"
       />
       <p v-else>
@@ -82,71 +145,189 @@
 
 <script>
 
+  import { ref, computed, toRefs, watch } from 'kolibri.lib.vueCompositionApi';
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
-  import { displayQuestionTitle } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import useAccordion from 'kolibri-common/components/useAccordion';
+  import AccordionItem from 'kolibri-common/components/AccordionItem';
+  import AccordionContainer from 'kolibri-common/components/AccordionContainer';
+  import coreStrings from 'kolibri.utils.coreStrings';
+  import {
+    displayQuestionTitle,
+    displaySectionTitle,
+    enhancedQuizManagementStrings,
+  } from 'kolibri-common/strings/enhancedQuizManagementStrings';
+  import useKResponsiveWindow from 'kolibri-design-system/lib/composables/useKResponsiveWindow';
   import AssessmentQuestionListItem from './AssessmentQuestionListItem';
 
   export default {
     name: 'QuestionListPreview',
     components: {
       AssessmentQuestionListItem,
+      AccordionContainer,
+      AccordionItem,
     },
     mixins: [commonCoreStrings],
-    setup() {
+    setup(props) {
+      const { windowIsSmall } = useKResponsiveWindow();
+
+      const { questionsLabel$, quizSectionsLabel$ } = enhancedQuizManagementStrings;
+      const { questionNumberLabel$ } = coreStrings;
+
+      const { sections, selectedExercises } = toRefs(props);
+
+      const { expand, isExpanded, toggle } = useAccordion(sections);
+
+      const questions = computed(() => {
+        return sections.value.reduce((acc, section) => [...acc, ...section.questions], []);
+      });
+
+      const sectionQuestionIndexOffsets = sections.value.reduce(
+        (acc, section) => {
+          acc.push(acc[acc.length - 1] + section.questions.length);
+          return acc;
+        },
+        [0],
+      );
+
+      const currentQuestionIndex = ref(0);
+
+      function expandCurrentSectionIfNeeded() {
+        if (!sections.value || !sections.value.length) {
+          return;
+        }
+        let qCount = 0;
+        for (let i = 0; i < sections?.value?.length; i++) {
+          qCount += sections?.value[i]?.questions?.length;
+          if (qCount >= currentQuestionIndex.value) {
+            if (!isExpanded(i)) {
+              expand(i);
+            }
+            break;
+          }
+        }
+      }
+
+      const sectionSelectOptions = computed(() => {
+        return sections.value.map((section, index) => ({
+          value: index,
+          label: displaySectionTitle(section, index),
+        }));
+      });
+
+      const currentSectionIndex = computed(() => {
+        let qCount = 0;
+        for (let i = 0; i <= sections.value.length; i++) {
+          console.log('qcount', qCount, currentQuestionIndex.value);
+          console.log(sections.value[i].questions.length);
+          qCount += sections.value[i].questions.length;
+          if (qCount > currentQuestionIndex.value) {
+            return i;
+          }
+        }
+        return 0;
+      });
+
+      const currentQuestion = computed(() => questions.value[currentQuestionIndex.value]);
+
+      const content = computed(() => selectedExercises.value[currentQuestion.value.exercise_id]);
+
+      const currentSection = computed(() => {
+        return sections.value[currentSectionIndex.value];
+      });
+
+      const questionSelectOptions = computed(() => {
+        return currentSection.value.questions.map((question, index) => ({
+          value: question.item,
+          label: questionNumberLabel$({ questionNumber: index + 1 }),
+        }));
+      });
+
+      // The KSelect-shaped object for the current section
+      const selectedSection = computed(() => {
+        return sectionSelectOptions.value[currentSectionIndex.value];
+      });
+
+      // The KSelect-shaped object for the current question
+      const selectedQuestion = computed(() => {
+        return questionSelectOptions.value.find(opt => opt.value === currentQuestion.value.item);
+      });
+
+      function handleQuestionChange(item) {
+        const questionIndex = questions.value.findIndex(q => q.item === item);
+        if (questionIndex !== -1) {
+          //expandCurrentSectionIfNeeded();
+          currentQuestionIndex.value = questionIndex || 0;
+          expandCurrentSectionIfNeeded();
+        }
+      }
+
+      function handleSectionChange(index) {
+        const questionIndex = sections.value.slice(0, index).reduce((acc, s, i) => {
+          if (i < index) {
+            acc += s.questions.length;
+            return acc;
+          } else {
+            // This will always be the last iteration thanks to slice
+            return acc + 1;
+          }
+        }, 0);
+        currentQuestionIndex.value = questionIndex;
+        expandCurrentSectionIfNeeded();
+      }
+
+      watch(currentQuestionIndex, () => {
+        expandCurrentSectionIfNeeded();
+      });
+
+      expandCurrentSectionIfNeeded();
+
       return {
+        content,
+        questions,
+        currentQuestion,
+
+        questionSelectOptions,
+        sectionSelectOptions,
+        selectedQuestion,
+        selectedSection,
+
+        handleSectionChange,
+        handleQuestionChange,
+
         displayQuestionTitle,
+        displaySectionTitle,
+        quizSectionsLabel$,
+        questionsLabel$,
+        questionNumberLabel$,
+
+        windowIsSmall,
+
+        expand,
+        isExpanded,
+        toggle,
       };
     },
     props: {
+      sections: {
+        type: Array,
+        required: true,
+      },
       // If set to true, question buttons will be draggable
       fixedOrder: {
         type: Boolean,
         required: true,
       },
-      // Array of { question_id, exercise_id, title } from Exam.question_sources
-      selectedQuestions: {
-        type: Array,
-        required: true,
-      },
-      // A Map(id, ContentNode)
       selectedExercises: {
         type: Object,
         required: true,
       },
     },
-    data() {
-      return {
-        currentQuestionIndex: 0,
-      };
-    },
     computed: {
-      annotatedQuestions() {
-        const counts = {};
-        const totals = {};
-        this.selectedQuestions.forEach(question => {
-          if (!totals[question.exercise_id]) {
-            totals[question.exercise_id] = 0;
-          }
-          totals[question.exercise_id] += 1;
-          counts[this.listKey(question)] = totals[question.exercise_id];
-        });
-        return this.selectedQuestions.map(question => {
-          if (totals[question.exercise_id] > 1) {
-            question.counterInExercise = counts[this.listKey(question)];
-          }
-          const node = this.selectedExercises[question.exercise_id];
-          question.missing_resource = !node || !node.available;
-          return question;
-        });
-      },
-      currentQuestion() {
-        return this.selectedQuestions[this.currentQuestionIndex] || {};
-      },
-      content() {
-        return this.selectedExercises[this.currentQuestion.exercise_id];
-      },
-      questionId() {
-        return this.currentQuestion.question_id;
+      accordionStyleOverrides() {
+        return {
+          color: this.$themeTokens.text + '!important',
+          textDecoration: 'none',
+        };
       },
       resourceMissingText() {
         return this.coreString('resourceNotFoundOnDevice');
@@ -185,8 +366,7 @@
 
   .question-list {
     padding: 0;
-    margin-top: 0;
-    margin-left: 40px;
+    margin: 0;
     list-style: none;
   }
 
@@ -213,6 +393,54 @@
 
   .fade-numbers-enter {
     opacity: 0;
+  }
+
+  .accordion-header-label {
+    display: block;
+    width: calc(100% - 1em);
+    height: 100%;
+    padding: 1em;
+
+    // Removes underline from section headings
+    /deep/.link-text {
+      text-decoration: none;
+    }
+  }
+
+  .chevron-icon {
+    position: absolute;
+    top: 50%;
+    right: 0.5em;
+    vertical-align: middle;
+    transform: translateY(-50%);
+  }
+
+  .accordion-header {
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding: 0;
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.5;
+    text-align: left;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color 0.3s ease;
+  }
+
+  .question-button {
+    width: 100%;
+    height: 100%;
+    padding: 0.5em;
+
+    &:hover {
+      background-color: white;
+    }
+
+    &.selected {
+      background-color: white;
+    }
   }
 
 </style>

--- a/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/QuizSummaryPage/index.vue
@@ -46,8 +46,8 @@
             </p>
 
             <QuestionListPreview
+              :sections="quiz.question_sources || []"
               :fixedOrder="!quizIsRandomized"
-              :selectedQuestions="selectedQuestions"
               :selectedExercises="selectedExercises"
             />
           </section>


### PR DESCRIPTION
## Summary

Updates the quiz preview/details page to allow for quiz question navigation w/ sections.

Imitates the mobile experience made for reports, but simplified as the UI is only for navigation.

This results in an accordion on > small screens, and two KSelects on small screens.

---

#### Tech Debt

There is a need to extract some of this logic out and improve the architecture of how we use accordions altogether _and_ how we manage sections & questions for UI and navigation. This introduces some duplicate code but, along with some improvements to the Accordion components altogether. 

Comments & suggestions here are greatly welcome, as I'll create a follow-up issue to this effect.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12288 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Please see and test:
- Quiz detail (click the name of the quiz on the Coach -> Plan -> Quizzes page)
- Quiz reports (click to see a learner's report for a quiz)

For:
- Quiz with one section
- Quiz with multiple sections (only name some of them to be sure our default name is applied as needed -- a la "Section 2"...)
