### PR TITLE
EQM: Only show save success message when saving

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CoachExamsPage/index.vue
@@ -354,6 +354,11 @@
         return '--';
       },
     },
+    mounted() {
+      if (this.$route.query.snackbar) {
+        this.$store.dispatch('createSnackbar', this.$route.query.snackbar);
+      }
+    },
     methods: {
       handleOpenQuiz(quizId) {
         const promise = ExamResource.saveModel({

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -378,7 +378,6 @@
         numberOfReplacementsAvailable$,
         sectionDeletedNotification$,
         deleteConfirmation$,
-        changesSavedSuccessfully$,
         questionsDeletedNotification$,
         expandAll$,
         collapseAll$,
@@ -449,7 +448,6 @@
         numberOfReplacementsAvailable$,
         sectionDeletedNotification$,
         deleteConfirmation$,
-        changesSavedSuccessfully$,
         questionsDeletedNotification$,
 
         toggleQuestionInSelection,
@@ -657,7 +655,6 @@
           questions: newArray,
         };
         this.updateSection(payload);
-        this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
         this.dragActive = false;
       },
       handleAddSection() {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/CreateQuizSection.vue
@@ -572,10 +572,7 @@
         }
       },
       handleConfirmDelete() {
-        const section_title = displaySectionTitle(
-          this.activeSection.value,
-          this.activeSectionIndex.value,
-        );
+        const section_title = displaySectionTitle(this.activeSection, this.activeSectionIndex);
         const newIndex = this.activeSectionIndex > 0 ? this.activeSectionIndex - 1 : 0;
         this.setActiveSection(newIndex);
         this.removeSection(this.activeSectionIndex);

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -263,7 +263,6 @@
         numberOfSelectedBookmarks$,
         selectResourcesDescription$,
         questionsFromResources$,
-        changesSavedSuccessfully$,
         cannotSelectSomeTopicWarning$,
         closeConfirmationMessage$,
         closeConfirmationTitle$,
@@ -662,7 +661,6 @@
         cannotSelectSomeTopicWarning$,
         closeConfirmationMessage$,
         closeConfirmationTitle$,
-        changesSavedSuccessfully$,
         sectionSettings$,
         numberOfQuestionsSelected$,
         tooManyQuestions$,
@@ -809,7 +807,6 @@
             ...this.$route.params,
           },
         });
-        this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
       },
       // The message put onto the content's card when listed
       selectionMetadata(content) {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -476,6 +476,7 @@
             question_sources,
           });
         }
+        this.$emit('closePanel');
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -252,7 +252,6 @@
         closeConfirmationMessage$,
         closeConfirmationTitle$,
         deleteConfirmation$,
-        changesSavedSuccessfully$,
         addQuestionsLabel$,
         addMoreQuestionsLabel$,
         sectionDeletedNotification$,
@@ -401,7 +400,6 @@
         currentSection$,
         deleteSectionLabel$,
         applySettings$,
-        changesSavedSuccessfully$,
         closeConfirmationTitle$,
         closeConfirmationMessage$,
         deleteConfirmation$,
@@ -478,7 +476,6 @@
             question_sources,
           });
         }
-        this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
       },
     },
   };

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -142,6 +142,7 @@
         allSectionsEmptyWarning$,
         closeConfirmationTitle$,
         closeConfirmationMessage$,
+        changesSavedSuccessfully$,
         sectionOrderLabel$,
         randomizedLabel$,
         fixedLabel$,
@@ -165,6 +166,7 @@
         allSectionsEmpty,
         allSectionsEmptyWarning$,
         saveAndClose$,
+        changesSavedSuccessfully$,
         sectionOrderLabel$,
         randomizedLabel$,
         fixedLabel$,
@@ -238,11 +240,15 @@
       saveQuizAndRedirect(close = true) {
         this.saveQuiz()
           .then(exam => {
+            this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
             if (close) {
               this.$router.replace({
                 name: PageNames.EXAMS,
                 params: {
                   classId: this.$route.params.classId,
+                },
+                query: {
+                  snackbar: this.changesSavedSuccessfully$(),
                 },
               });
             } else {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -240,6 +240,7 @@
       saveQuizAndRedirect(close = true) {
         this.saveQuiz()
           .then(exam => {
+            this.$refs.detailsModal.handleSubmitSuccess();
             this.$store.dispatch('createSnackbar', this.changesSavedSuccessfully$());
             if (close) {
               this.$router.replace({

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -5,7 +5,8 @@
       <UiAlert
         v-if="showServerError"
         type="error"
-        :dismissible="false"
+        :dismissible="true"
+        @dismiss="showServerError = false"
       >
         {{ submitErrorMessage }}
       </UiAlert>

--- a/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/assignments/AssignmentDetailsModal.vue
@@ -320,6 +320,13 @@
         // Scroll to the title field in case focus() didn't do that immediately
         window.scrollTo({ top: 0, behavior: 'smooth' });
       },
+      /**
+       * @public
+       */
+      handleSubmitSuccess() {
+        this.showTitleError = false;
+        this.showServerError = false;
+      },
     },
   };
 


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Only shows the "Changes saved successfully" message when actually saving the quiz.

There are now no longer any snackbars when the user does a few things, like selecting resources or applying their new section settings, perhaps we'll want to improve on this in the next iteration.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12333 

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try to save and to save & close both in the "Select quiz" and throughout the quiz creation flow - you should only see a "Changes saved successfully" message when you've saved the quiz successfully.

