### PR TITLE
EQM: What happens when I refresh?

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/SectionEditor.vue
@@ -305,9 +305,9 @@
       }
 
       /* Note that the use of snake_case here is to map directly to the API */
-      const learners_see_fixed_order = ref(activeSection.value.learners_see_fixed_order);
-      const description = ref(activeSection.value.description);
-      const section_title = ref(activeSection.value.section_title.trim());
+      const learners_see_fixed_order = ref(activeSection?.value?.learners_see_fixed_order || false);
+      const description = ref(activeSection?.value?.description || '');
+      const section_title = ref(activeSection?.value?.section_title?.trim() || '');
 
       const sectionTitleInvalidText = computed(() => {
         if (section_title.value.trim() === '') {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -219,6 +219,23 @@
         });
       },
     },
+    beforeRouteEnter(to, from, next) {
+      if (!from.params?.quizId) {
+        if (to.name === PageNames.QUIZ_REPLACE_QUESTIONS) {
+          next({
+            name: PageNames.EXAM_CREATION_ROOT,
+            params: {
+              classId: to.params.classId,
+              quizId: to.params.quizId,
+            },
+          });
+        } else {
+          next();
+        }
+      } else {
+        next();
+      }
+    },
     beforeRouteLeave(to, from, next) {
       if (this.quizHasChanged && !this.closeConfirmationToRoute) {
         this.closeConfirmationToRoute = to;
@@ -231,10 +248,27 @@
       this.$store.dispatch('notLoading');
     },
     async created() {
+      if (this.$route.name === PageNames.QUIZ_REPLACE_QUESTIONS) {
+        this.$router.replace({
+          name: PageNames.EXAM_CREATION_ROOT,
+          params: {
+            classId: this.$route.params.classId,
+            quizId: this.$route.params.quizId,
+          },
+        });
+      }
+      window.addEventListener('beforeunload', this.beforeUnload);
       await this.initializeQuiz(this.$route.params.classId, this.$route.params.quizId);
       this.quizInitialized = true;
     },
     methods: {
+      beforeUnload(e) {
+        if (this.quizHasChanged) {
+          if (!window.confirm(this.closeConfirmationTitle$())) {
+            e.preventDefault();
+          }
+        }
+      },
       saveQuizAndRedirect(close = true) {
         this.saveQuiz()
           .then(exam => {

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -246,15 +246,6 @@
       this.$store.dispatch('notLoading');
     },
     async created() {
-      if (this.$route.name === PageNames.QUIZ_REPLACE_QUESTIONS) {
-        this.$router.replace({
-          name: PageNames.EXAM_CREATION_ROOT,
-          params: {
-            classId: this.$route.params.classId,
-            quizId: this.$route.params.quizId,
-          },
-        });
-      }
       window.addEventListener('beforeunload', this.beforeUnload);
       await this.initializeQuiz(this.$route.params.classId, this.$route.params.quizId);
       this.quizInitialized = true;

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -220,18 +220,16 @@
       },
     },
     beforeRouteEnter(to, from, next) {
-      if (!from.params?.quizId) {
-        if (to.name === PageNames.QUIZ_REPLACE_QUESTIONS) {
-          next({
-            name: PageNames.EXAM_CREATION_ROOT,
-            params: {
-              classId: to.params.classId,
-              quizId: to.params.quizId,
-            },
-          });
-        } else {
-          next();
-        }
+      // If we're coming from no quizId and going to replace questions, redirect to exam creation
+      // then we're coming from another page altogether OR we're coming back from a refresh
+      if (!from.params?.quizId && to.name === PageNames.QUIZ_REPLACE_QUESTIONS) {
+        next({
+          name: PageNames.EXAM_CREATION_ROOT,
+          params: {
+            classId: to.params.classId,
+            quizId: to.params.quizId,
+          },
+        });
       } else {
         next();
       }

--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/index.vue
@@ -249,7 +249,7 @@
           params: {
             classId: to.params.classId,
             quizId: to.params.quizId,
-            sectionIndex: 0,
+            sectionIndex: '0',
           },
         });
       } else {
@@ -279,7 +279,7 @@
           params: {
             classId: this.$route.params.classId,
             quizId: this.$route.params.quizId,
-            sectionIndex: 0,
+            sectionIndex: '0',
           },
         });
       }


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->

Makes some changes to improve behavior on page refresh, such that:

- If you enter the route onto the "replace questions" route _and_ didn't come from quiz creation, then you'll be redirected to the quiz root page. This is because when the page loads you don't have any replacements in your pool so it'd always be empty anyway.
- Listens to the `beforeunload` event and uses the close confirmation message in it. I tried to inject our modal but the `beforeunload` event doesn't really allow for that so I used our message there.

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12390

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

Try refreshing the page in various places.

If the quiz is one you've saved before, then you should reload to the place you were at, but without your changes having been saved.
- Add sections, then refresh, they should be gone
- Delete sections, then refresh, they should return
- etc

But! When you refresh on the replacements page, you should see the page load up with the side panel having been closed.

### a11y

- [ ] Can you use the confirmation window that pops up on page refresh with keyboard nav?
- [ ] Does it announce as you'd expect, the message that is in the window on a screen reader?