### PR TITLE
Count descendants not ancestors

### DIFF
--- a/kolibri/core/assets/src/api-resources/contentNode.js
+++ b/kolibri/core/assets/src/api-resources/contentNode.js
@@ -83,8 +83,8 @@ export default new Resource({
   fetchRandomCollection({ getParams: params }) {
     return this.getListEndpoint('random', params);
   },
-  fetchDescendants(ids, getParams = {}) {
-    return this.getListEndpoint('descendants', { ids, ...getParams });
+  fetchDescendantCounts(getParams) {
+    return this.getListEndpoint('descendant_counts', { ...getParams });
   },
   fetchDescendantsAssessments(ids) {
     return this.getListEndpoint('descendants_assessments', { ids });

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/handlers.js
@@ -10,7 +10,14 @@ import chunk from 'lodash/chunk';
 import { LessonsPageNames } from '../../constants/lessonsConstants';
 
 async function showResourceSelectionPage(store, params) {
-  const { lessonId, contentList, pageName, bookmarksList, ancestors = [] } = params;
+  const {
+    lessonId,
+    contentList,
+    pageName,
+    bookmarksList,
+    ancestors = [],
+    descendantCounts = [],
+  } = params;
   const pendingSelections = store.state.lessonSummary.workingResources || [];
   const cache = store.state.lessonSummary.resourceCache || {};
   const initClassInfoPromise = store.dispatch('initClassInfo', params.classId);
@@ -32,14 +39,17 @@ async function showResourceSelectionPage(store, params) {
     store.commit('lessonSummary/resources/SET_BOOKMARKS_LIST', bookmarksList);
     store.commit('lessonSummary/resources/SET_STATE', {
       contentList: [],
-      ancestors: [],
+      ancestors,
     });
-    store.dispatch('notLoading');
 
     if (lessonId) {
       const loadRequirements = [store.dispatch('lessonSummary/updateCurrentLesson', lessonId)];
       return Promise.all(loadRequirements).then(([currentLesson]) => {
-        // TODO make a state mapper
+        const resourceIds = currentLesson.resources.map(resourceObj => resourceObj.contentnode_id);
+        const setResourceCachePromise = store.dispatch(
+          'lessonSummary/getResourceCache',
+          resourceIds,
+        );
         // contains selections that were commited to server prior to opening this page
         if (!pendingSelections.length) {
           store.commit('lessonSummary/SET_WORKING_RESOURCES', currentLesson.resources);
@@ -49,51 +59,29 @@ async function showResourceSelectionPage(store, params) {
           store.commit('lessonSummary/resources/SET_ANCESTORS', ancestors);
         }
 
-        const ancestorCounts = {};
+        const descendantCountsObject = {};
+        for (const descendantCount of descendantCounts.data || descendantCounts) {
+          descendantCountsObject[descendantCount.id] = descendantCount.on_device_resources;
+        }
 
-        const resourceAncestors = store.state.lessonSummary.workingResources.map(
-          resource => (cache[resource.contentnode_id] || {}).ancestors || [],
-        );
-        // store ancestor ids to get their descendants later
-        const ancestorIds = new Set();
+        store.commit('lessonSummary/resources/SET_DESCENDANT_COUNTS', descendantCountsObject);
 
-        resourceAncestors.forEach(ancestorArray =>
-          ancestorArray.forEach(ancestor => {
-            ancestorIds.add(ancestor.id);
-            if (ancestorCounts[ancestor.id]) {
-              ancestorCounts[ancestor.id].count++;
-            } else {
-              ancestorCounts[ancestor.id] = {};
-              // total number of working/added resources
-              ancestorCounts[ancestor.id].count = 1;
-              // total number of descendants
-              ancestorCounts[ancestor.id].total = 0;
-            }
-          }),
-        );
-        ContentNodeResource.fetchDescendants(Array.from(ancestorIds)).then(nodes => {
-          nodes.data.forEach(node => {
-            // exclude topics from total resource calculation
-            if (node.kind !== ContentNodeKinds.TOPIC) {
-              ancestorCounts[node.ancestor_id].total++;
-            }
+        // carry pendingSelections over from other interactions in this modal
+        store.commit('lessonSummary/resources/SET_CONTENT_LIST', contentList);
+        if (params.searchResults) {
+          store.commit('lessonSummary/resources/SET_SEARCH_RESULTS', params.searchResults);
+        }
+        store.commit('SET_PAGE_NAME', pageName);
+        if (pageName === LessonsPageNames.SELECTION_SEARCH) {
+          store.commit('SET_TOOLBAR_ROUTE', {
+            name: LessonsPageNames.SELECTION_ROOT,
           });
-          store.commit('lessonSummary/resources/SET_ANCESTOR_COUNTS', ancestorCounts);
-          // carry pendingSelections over from other interactions in this modal
-          store.commit('lessonSummary/resources/SET_CONTENT_LIST', contentList);
-          if (params.searchResults) {
-            store.commit('lessonSummary/resources/SET_SEARCH_RESULTS', params.searchResults);
-          }
-          store.commit('SET_PAGE_NAME', pageName);
-          if (pageName === LessonsPageNames.SELECTION_SEARCH) {
-            store.commit('SET_TOOLBAR_ROUTE', {
-              name: LessonsPageNames.SELECTION_ROOT,
-            });
-          } else {
-            store.commit('SET_TOOLBAR_ROUTE', {
-              name: LessonsPageNames.SUMMARY,
-            });
-          }
+        } else {
+          store.commit('SET_TOOLBAR_ROUTE', {
+            name: LessonsPageNames.SUMMARY,
+          });
+        }
+        return setResourceCachePromise.then(() => {
           store.dispatch('notLoading');
         });
       });
@@ -111,13 +99,17 @@ export function showLessonResourceSelectionRootPage(store, params) {
         is_leaf: false,
       };
     });
-
-    return showResourceSelectionPage(store, {
-      classId: params.classId,
-      lessonId: params.lessonId,
-      contentList: channelContentList,
-      pageName: LessonsPageNames.SELECTION_ROOT,
-    });
+    return ContentNodeResource.fetchDescendantCounts({ parent__isnull: true }).then(
+      descendantCounts => {
+        return showResourceSelectionPage(store, {
+          classId: params.classId,
+          lessonId: params.lessonId,
+          contentList: channelContentList,
+          pageName: LessonsPageNames.SELECTION_ROOT,
+          descendantCounts,
+        });
+      },
+    );
   });
 }
 
@@ -128,9 +120,10 @@ export function showLessonResourceSelectionTopicPage(store, params) {
     const loadRequirements = [
       ContentNodeResource.fetchModel({ id: topicId }),
       ContentNodeResource.fetchCollection({ getParams: { parent: topicId } }),
+      ContentNodeResource.fetchDescendantCounts({ parent: topicId }),
     ];
 
-    return Promise.all(loadRequirements).then(([topicNode, childNodes]) => {
+    return Promise.all(loadRequirements).then(([topicNode, childNodes, descendantCounts]) => {
       const topicContentList = childNodes.map(node => {
         return { ...node, thumbnail: getContentNodeThumbnail(node) };
       });
@@ -140,6 +133,7 @@ export function showLessonResourceSelectionTopicPage(store, params) {
         lessonId: params.lessonId,
         contentList: topicContentList,
         pageName: LessonsPageNames.SELECTION,
+        descendantCounts,
         ancestors: [...topicNode.ancestors, topicNode],
       });
     });

--- a/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
+++ b/kolibri/plugins/coach/assets/src/modules/lessonResources/index.js
@@ -5,7 +5,7 @@ import * as actions from './actions';
 function defaultState() {
   return {
     bookmarksList: [],
-    ancestorCounts: {},
+    descendantCounts: {},
     ancestors: [],
     contentList: [],
     searchResults: {
@@ -44,8 +44,8 @@ export default {
     SET_BOOKMARKS_LIST(state, bookmarks) {
       state.bookmarksList = bookmarks;
     },
-    SET_ANCESTOR_COUNTS(state, ancestorCountsObject) {
-      state.ancestorCounts = ancestorCountsObject;
+    SET_DESCENDANT_COUNTS(state, descendantCountsObject) {
+      state.descendantCounts = descendantCountsObject;
     },
     SET_CONTENT_LIST(state, contentList) {
       state.contentList = contentList;

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonCreationPage/index.vue
@@ -6,7 +6,7 @@
     authorizedRole="adminOrCoach"
     icon="close"
     :pageTitle="coachString('createLessonAction')"
-    :route="{ name: 'PLAN_LESSONS_ROOT' }"
+    :route="{ name: 'PLAN_LESSONS_ROOT', params: { classId } }"
   >
     <KPageContainer>
       <AssignmentDetailsModal

--- a/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/LessonResourceSelectionPage/index.vue
@@ -171,9 +171,9 @@
     computed: {
       ...mapState(['pageName']),
       ...mapState('classSummary', { classId: 'id' }),
-      ...mapState('lessonSummary', ['currentLesson', 'workingResources']),
+      ...mapState('lessonSummary', ['currentLesson', 'resourceCache', 'workingResources']),
       ...mapState('lessonSummary/resources', [
-        'ancestorCounts',
+        'descendantCounts',
         'contentList',
         'bookmarksList',
         'searchResults',
@@ -485,15 +485,16 @@
       },
       selectionMetadata(content) {
         let count = 0;
-        let total = 0;
-        if (this.ancestorCounts[content.id]) {
-          count = this.ancestorCounts[content.id].count;
-          total = this.ancestorCounts[content.id].total;
+        for (const wr of this.workingResources) {
+          const resource = this.resourceCache[wr.contentnode_id];
+          if (resource && resource.ancestors.find(ancestor => ancestor.id === content.id)) {
+            count += 1;
+          }
         }
         if (count) {
           return this.$tr('selectionInformation', {
             count,
-            total,
+            total: this.descendantCounts[content.id],
           });
         }
         return '';


### PR DESCRIPTION
## Summary
* Updates lesson resource page to fetch number of descendants for the currently displayed topic (a value we precompute during annotation)
* Use this to display selection metadata
* Adds selection metadata to channels as well
* Ensures that the resource cache is properly populated even on page refresh
* Does flyby fix of Lesson Creation back button behaviour, which on multi-class setups resulted in not going back to the intended page

## References
Fixes [#12387](https://github.com/learningequality/kolibri/issues/12387)

## Reviewer guidance
Manage the resources in a lesson, ensure that when resources are selected "X of Y resources selected" is always properly displayed

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
