### PR TITLE
Update automatic download setting default to False if running in a remote content context.

### DIFF
--- a/kolibri/core/device/models.py
+++ b/kolibri/core/device/models.py
@@ -24,6 +24,7 @@ from kolibri.core.auth.models import Facility
 from kolibri.core.auth.models import FacilityUser
 from kolibri.core.auth.permissions.base import RoleBasedPermissions
 from kolibri.core.auth.permissions.general import IsOwn
+from kolibri.core.content.utils.paths import using_remote_storage
 from kolibri.core.device.utils import device_provisioned
 from kolibri.core.device.utils import get_device_setting
 from kolibri.core.fields import JSONField
@@ -117,7 +118,8 @@ extra_settings_schema = {
 
 extra_settings_default_values = {
     "allow_download_on_metered_connection": False,
-    "enable_automatic_download": True,
+    # Default to not automatically downloading content if using remote storage
+    "enable_automatic_download": not using_remote_storage(),
     "allow_learner_download_resources": False,
     "set_limit_for_autodownload": False,
     "limit_for_autodownload": 0,


### PR DESCRIPTION
## Summary
* Default to no automatic syncing if we're in a remote content context

## References


## Reviewer guidance


----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
