### PR TITLE
Setup Wizard: More helpful error state when trying to import from unprovisioned device

### DIFF
--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -145,6 +145,7 @@
     useDevicesWithFilter,
     useDeviceChannelFilter,
     useDeviceFacilityFilter,
+    useDeviceHasFacilitiesFilter,
     useDeviceMinimumVersionFilter,
   } from './useDevices.js';
   import useConnectionChecker from './useConnectionChecker.js';
@@ -166,9 +167,15 @@
       if (
         props.filterByFacilityId !== null ||
         props.filterByFacilityCanSignUp !== null ||
-        props.filterByOnMyOwnFacility !== null
+        props.filterByOnMyOwnFacility !== null ||
+        props.filterByHasFacilities !== null
       ) {
         apiParams.subset_of_users_device = false;
+
+        if (props.filterByHasFacilities === true) {
+          deviceFilters.push(useDeviceHasFacilitiesFilter());
+        }
+
         deviceFilters.push(
           useDeviceFacilityFilter({
             id: props.filterByFacilityId,
@@ -251,6 +258,12 @@
       // In the setup wizard, to exclude importiing facilities that are "On My Own"
       // eslint-disable-next-line kolibri/vue-no-unused-properties
       filterByOnMyOwnFacility: {
+        type: Boolean,
+        default: null,
+      },
+      // In the setup wizard, to exclude devices that do not have a facility
+      // eslint-disable-next-line kolibri/vue-no-unused-properties
+      filterByHasFacilities: {
         type: Boolean,
         default: null,
       },

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/SelectDeviceForm.vue
@@ -177,11 +177,10 @@
       );
 
       // If we're filtering a particular facility
-      if (Object.keys(facilityFilter).length > 0) {
+      if (Object.keys(facilityFilter).length > 0 || props.filterByHasFacilities) {
         apiParams.subset_of_users_device = false;
+        deviceFilters.push(useDeviceFacilityFilter(facilityFilter));
       }
-
-      deviceFilters.push(useDeviceFacilityFilter(facilityFilter));
 
       if (props.filterLODAvailable) {
         apiParams.subset_of_users_device = false;

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
@@ -28,6 +28,7 @@ export function fetchDevices(params = {}) {
  * @typedef {Object} FacilityFilter
  * @property {string} [id]
  * @property {boolean} [learner_can_sign_up]
+ * @property {boolean} [on_my_own_setup]
  */
 
 /**

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
@@ -44,16 +44,6 @@ export function deviceHasMatchingFacility(device, facility) {
 }
 
 /**
- * @param {NetworkLocation} device
- * @return {Promise<boolean>}
- */
-export function deviceHasAnyFacilities(device) {
-  return NetworkLocationResource.fetchFacilities(device.id).then(({ facilities }) => {
-    return Boolean(facilities.length);
-  });
-}
-
-/**
  * @param {string} channelId
  * @param {NetworkLocation} device
  * @return {Promise<boolean>}

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/api.js
@@ -44,6 +44,16 @@ export function deviceHasMatchingFacility(device, facility) {
 }
 
 /**
+ * @param {NetworkLocation} device
+ * @return {Promise<boolean>}
+ */
+export function deviceHasAnyFacilities(device) {
+  return NetworkLocationResource.fetchFacilities(device.id).then(({ facilities }) => {
+    return Boolean(facilities.length);
+  });
+}
+
+/**
  * @param {string} channelId
  * @param {NetworkLocation} device
  * @return {Promise<boolean>}

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/index.vue
@@ -13,6 +13,7 @@
       :filterLODAvailable="filterLODAvailable"
       :filterByFacilityCanSignUp="filterByFacilityCanSignUp"
       :filterByOnMyOwnFacility="filterByOnMyOwnFacility"
+      :filterByHasFacilities="filterByHasFacilities"
       :selectedId="addedAddressId"
       :formDisabled="$attrs.selectAddressDisabled"
       @click_add_address="goToAddAddress"
@@ -53,6 +54,10 @@
       },
       // When looking for devices for which a learner can sign up
       filterByFacilityCanSignUp: {
+        type: Boolean,
+        default: null,
+      },
+      filterByHasFacilities: {
         type: Boolean,
         default: null,
       },

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -5,7 +5,12 @@ import { ref, reactive, computed, onBeforeUnmount, watch } from 'kolibri.lib.vue
 import { get, set, useMemoize, useTimeoutPoll } from '@vueuse/core';
 
 import useMinimumKolibriVersion from 'kolibri.coreVue.composables.useMinimumKolibriVersion';
-import { fetchDevices, channelIsAvailableAtDevice, deviceHasMatchingFacility } from './api';
+import {
+  fetchDevices,
+  channelIsAvailableAtDevice,
+  deviceHasAnyFacilities,
+  deviceHasMatchingFacility,
+} from './api';
 
 const logging = logger.getLogger(__filename);
 
@@ -166,6 +171,14 @@ function useAsyncDeviceFilter(filterFunction) {
       return false;
     }
   };
+}
+
+/**
+ */
+export function useDeviceHasFacilitiesFilter() {
+  return useAsyncDeviceFilter(function deviceHasFacilitiesFilter(device) {
+    return deviceHasAnyFacilities(device);
+  });
 }
 
 /**

--- a/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
+++ b/kolibri/core/assets/src/views/sync/SelectDeviceModalGroup/useDevices.js
@@ -174,14 +174,6 @@ function useAsyncDeviceFilter(filterFunction) {
 }
 
 /**
- */
-export function useDeviceHasFacilitiesFilter() {
-  return useAsyncDeviceFilter(function deviceHasFacilitiesFilter(device) {
-    return deviceHasAnyFacilities(device);
-  });
-}
-
-/**
  * Produces a function that resolves with a boolean for a device that has the specified facility
  * @param {string|null} [id]
  * @param {bool|null} [learner_can_sign_up]
@@ -206,10 +198,6 @@ export function useDeviceFacilityFilter({
 
   if (on_my_own_setup !== null) {
     filters.on_my_own_setup = on_my_own_setup;
-  }
-
-  if (Object.keys(filters).length === 0) {
-    return () => Promise.resolve(true);
   }
 
   return useAsyncDeviceFilter(function deviceFacilityFilter(device) {

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -23,6 +23,7 @@
       v-if="showSelectAddressModal"
       :filterLODAvailable="true"
       :filterByFacilityCanSignUp="selected === Options.JOIN ? true : null"
+      :filterByHasFacilities="true"
       @cancel="showSelectAddressModal = false"
       @submit="handleContinueImport"
     />

--- a/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/JoinOrNewLOD.vue
@@ -47,7 +47,7 @@
     data() {
       return {
         Options,
-        selected: Options.JOIN,
+        selected: this.wizardService.state.context.lodImportOrJoin || Options.JOIN,
         showSelectAddressModal: false,
       };
     },

--- a/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/OnboardingStepBase.vue
@@ -118,7 +118,7 @@
             @click="wizardService.send(eventOnGoBack)"
           />
           <KButton
-            v-if="!$slots.buttons"
+            v-if="!$slots.buttons && !hideContinue"
             :text="coreString('continueAction')"
             :primary="true"
             :disabled="navDisabled"
@@ -203,6 +203,10 @@
       description: {
         type: String,
         default: null,
+      },
+      hideContinue: {
+        type: Boolean,
+        default: false,
       },
       footerMessageType: {
         type: String,

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
@@ -8,9 +8,20 @@
     :footerMessageType="loading ? null : footerMessageType"
     :step="loading ? null : 1"
     :steps="loading ? null : 5"
+    :hideContinue="true"
     @continue="handleContinue"
   >
-    <div v-if="!loading">
+    <UiAlert
+      v-if="errorMessage"
+      :dismissible="false"
+      class="alert"
+      type="error"
+      :style="{ marginBottom: 0, marginTop: '8px' }"
+    >
+      {{ errorMessage }}
+    </UiAlert>
+
+    <div v-else-if="!loading">
       <!-- TODO: Show "you cannot import from this facility" message -->
       <RadioButtonGroup
         v-if="!loadingNewAddress"
@@ -51,10 +62,15 @@
 
   import commonCoreStrings from 'kolibri.coreVue.mixins.commonCoreStrings';
   import commonSyncElements from 'kolibri.coreVue.mixins.commonSyncElements';
+  import { crossComponentTranslator } from 'kolibri.utils.i18n';
+  import UiAlert from 'kolibri-design-system/lib/keen/UiAlert';
   import { SelectDeviceModalGroup, RadioButtonGroup } from 'kolibri.coreVue.componentSets.sync';
+  import SelectFacility from '../../../../user_profile/assets/src/views/ChangeFacility/SelectFacility';
   import { FooterMessageTypes } from '../constants';
 
   import OnboardingStepBase from './OnboardingStepBase';
+
+  const SelectFacilityStrings = crossComponentTranslator(SelectFacility);
 
   export default {
     name: 'SelectFacilityForm',
@@ -62,6 +78,7 @@
       OnboardingStepBase,
       RadioButtonGroup,
       SelectDeviceModalGroup,
+      UiAlert,
     },
     inject: ['wizardService'],
     mixins: [commonCoreStrings, commonSyncElements],
@@ -77,6 +94,7 @@
         formDisabled: false,
         loadingNewAddress: false,
         showSelectAddressModal: false,
+        errorMessage: '',
       };
     },
     computed: {
@@ -99,6 +117,10 @@
         return this.fetchNetworkLocationFacilities(deviceId)
           .then(data => {
             this.facilities = [...data.facilities];
+            if (this.facilities.length === 0) {
+              this.errorMessage = 'No learning facilities found';
+              return;
+            }
             this.device = {
               name: data.device_name,
               id: data.device_id,

--- a/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
+++ b/kolibri/plugins/setup_wizard/assets/src/views/SelectFacilityForm.vue
@@ -118,7 +118,7 @@
           .then(data => {
             this.facilities = [...data.facilities];
             if (this.facilities.length === 0) {
-              this.errorMessage = 'No learning facilities found';
+              this.errorMessage = SelectFacilityStrings.$tr('noFacilitiesText');
               return;
             }
             this.device = {


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->


https://github.com/learningequality/kolibri/assets/6356129/f3bde730-74f2-490d-8479-24170660706f


- Takes string [from here](https://github.com/learningequality/kolibri/blob/2692958f7772b099cf9191ff47e685ff4ca83206/kolibri/plugins/user_profile/assets/src/views/ChangeFacility/SelectFacility.vue#L294-L298) "No learning facilities found"
- Uses that by making the "Select facility" show an error when there are no facilities
- Adds `hideContinue` prop to `OnboardingStepBase` to hide the Continue button there when we have this error state
- Fixes issue where user's selection was lost when clicking "Go back" from the error state

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->

Fixes #12066

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->

See the issue comment here for [replication path](https://github.com/learningequality/kolibri/issues/12066#issuecomment-2104315832) -- note that I kinda had to go back and forth a few times through the flow - never actually importing anything - before I got the device to show up.

Overall, does the workflow feel okay?

