### PR TITLE
make sure the question count v-model uses .number

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
+++ b/kolibri/plugins/coach/assets/src/views/plan/CreateExamPage/ResourceSelection.vue
@@ -32,7 +32,7 @@
           <div>
             <KTextbox
               ref="numQuest"
-              v-model="questionCount"
+              v-model.number="questionCount"
               type="number"
               :label="numberOfQuestionsLabel$()"
               :max="maxQuestions"


### PR DESCRIPTION
## Summary

Fixes #12406 by adding `.number` to the questionCount v-model. I think this is okay, but alternatively I could update the increment to `parseInt()` if that's preferable 

## References

https://github.com/learningequality/kolibri/assets/17235236/a624d512-6ba1-488a-8a65-6f14380b357a




## Reviewer guidance
In develop, input a number of questions typing into the textbox (i.e. 5) and then click the "+" button. You should see 51, rather than 6. 
Checkout PR, and do the same. It should add the value, not concat as strings

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
