### PR TITLE
Properly redirect on authentication failure

### DIFF
--- a/kolibri/core/assets/src/heartbeat.js
+++ b/kolibri/core/assets/src/heartbeat.js
@@ -266,7 +266,7 @@ export class HeartBeat {
     Lockr.set(SIGNED_OUT_DUE_TO_INACTIVITY, true);
     // Redirect the user to let the server sort out where they should
     // be now
-    redirectBrowser();
+    redirectBrowser(null, true);
   }
   _sessionUrl(id) {
     return urls['kolibri:core:session-detail'](id);

--- a/kolibri/core/assets/src/utils/redirectBrowser.js
+++ b/kolibri/core/assets/src/utils/redirectBrowser.js
@@ -1,5 +1,10 @@
 import urls from 'kolibri.urls';
 
-export default function redirectBrowser(url) {
-  window.location.href = url || urls['kolibri:core:redirect_user']();
+export default function redirectBrowser(url, next = false) {
+  url = url || urls['kolibri:core:redirect_user']();
+  const urlObject = new URL(url, window.location.origin);
+  if (next) {
+    urlObject.searchParams.set('next', encodeURIComponent(window.location.href));
+  }
+  window.location.href = urlObject.href;
 }

--- a/kolibri/deployment/default/settings/dev.py
+++ b/kolibri/deployment/default/settings/dev.py
@@ -26,9 +26,11 @@ os.environ.update({"KOLIBRI_DEVELOPER_MODE": "True"})
 REST_FRAMEWORK = {
     "UNAUTHENTICATED_USER": "kolibri.core.auth.models.KolibriAnonymousUser",
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        # Always keep this first, so that we consistently return 403 responses
+        # when a request is unauthenticated.
+        "rest_framework.authentication.SessionAuthentication",
         # Activate basic auth for external API testing tools
         "rest_framework.authentication.BasicAuthentication",
-        "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_RENDERER_CLASSES": (
         "rest_framework.renderers.JSONRenderer",


### PR DESCRIPTION
## Summary
* Reorder authentication classes for consistent dev and production errors.
* Check user_id not id for forbidden redirects.
* When redirecting a user because they were logged out, persist a next parameter to return them to the last page they were on before logout

## References
Fixes #11773

## Reviewer guidance
Delete your session cookie while on the quiz creation page, make sure you get properly redirected there and back again.

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
