### PR TITLE
Fix ordering of quizzes on plan page.

### DIFF
--- a/kolibri/plugins/coach/assets/src/composables/useQuizzes.js
+++ b/kolibri/plugins/coach/assets/src/composables/useQuizzes.js
@@ -1,9 +1,11 @@
-import sortBy from 'lodash/sortBy';
+import orderBy from 'lodash/orderBy';
 import { computed, getCurrentInstance } from 'kolibri.lib.vueCompositionApi';
 
 export default function useQuizzes(store) {
   store = store || getCurrentInstance().proxy.$store;
-  const quizzes = computed(() => sortBy(store.getters['classSummary/exams'], 'date-created'));
+  const quizzes = computed(() =>
+    orderBy(store.getters['classSummary/exams'], 'date_created', 'desc'),
+  );
   const fetchQuizSizes = () => store.dispatch('classSummary/fetchQuizzesSizes');
 
   return {


### PR DESCRIPTION
## Summary
* Sorting was previously being done by the non-existent 'date-created' attribute, has been properly updated to `date_created`
* Also was using lodash 'sortBy' which does not allow defining a direction for ordering, this is changed to `orderBy` which allows specifying 'desc' for descending sorting

## References
Fixes [#12420](https://github.com/learningequality/kolibri/issues/12420)

## Reviewer guidance
Create a new quiz, see that it appears first!

----

## Testing checklist

- [ ] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [ ] PR has the correct target branch and milestone
- [ ] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
