### PR TITLE
Fix coreStrings import in AttemptLogList

### DIFF
--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -212,8 +212,8 @@
         ];
       });
 
-      function handleQuestionChange(item) {
-        emit('select', item.value + currentSection.value.startQuestionNumber);
+      function handleQuestionChange(index) {
+        emit('select', index + currentSection.value.startQuestionNumber);
         expandCurrentSectionIfNeeded();
       }
 

--- a/kolibri/core/assets/src/views/AttemptLogList.vue
+++ b/kolibri/core/assets/src/views/AttemptLogList.vue
@@ -154,11 +154,11 @@
     enhancedQuizManagementStrings,
   } from 'kolibri-common/strings/enhancedQuizManagementStrings';
   import useAccordion from 'kolibri-common/components/useAccordion';
-  import coreStrings from 'kolibri.utils.coreStrings';
   import AccordionItem from 'kolibri-common/components/AccordionItem';
   import AccordionContainer from 'kolibri-common/components/AccordionContainer';
   import { computed, onMounted, watch } from 'kolibri.lib.vueCompositionApi';
   import { toRefs } from '@vueuse/core';
+  import { coreStrings } from '../mixins/commonCoreStrings';
   import AttemptLogItem from './AttemptLogItem';
 
   export default {


### PR DESCRIPTION
## Summary

For some webpack import issues, when importing coreStrings from a component inside core using `kolibri.utils.coreStrings` for some reason this import gets the default import of the file `commonCoreString` which is a mixin, instead of importing the named export of the coreStrings Translator. Referencing directly using relative import is a workaround to solve this [e.g.](https://github.com/AlexVelezLl/kolibri/blob/72297db6b321cb9c0ff7df8039da4930181c3d6d/kolibri/core/assets/src/views/BottomNavigationBar.vue#L67).

| Before | After |
| --- | --- |
| ![image](https://github.com/learningequality/kolibri/assets/51239030/acd33290-12ea-4116-961c-bee7ba22bcd3) | ![image](https://github.com/learningequality/kolibri/assets/51239030/cadcc2a0-fc33-4b58-add0-dc73f431a1f0) |

## References
Closes #12424.

## Reviewer guidance
Replicate the escenario showed in ##12424.

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [x] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
