### PR TITLE
Hide Difficult questions tab if the quiz is still a draft

### DIFF
--- a/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
+++ b/kolibri/plugins/coach/assets/src/views/reports/ReportsQuizBaseListPage.vue
@@ -110,7 +110,7 @@
         return this.$route.params.groupId && this.groupMap[this.$route.params.groupId];
       },
       tabs() {
-        return [
+        const tabsList = [
           {
             id: QuizzesTabs.REPORT,
             label: this.coachString('reportLabel'),
@@ -118,14 +118,18 @@
               ? this.classRoute('ReportsGroupReportQuizLearnerListPage')
               : this.classRoute('ReportsQuizLearnerListPage'),
           },
-          {
+        ];
+        const isDraftExam = this.exam && this.exam.draft;
+        if (!isDraftExam) {
+          tabsList.push({
             id: QuizzesTabs.DIFFICULT_QUESTIONS,
             label: this.coachString('difficultQuestionsLabel'),
             to: this.group
               ? this.classRoute('ReportsGroupReportQuizQuestionListPage')
               : this.classRoute('ReportsQuizQuestionListPage'),
-          },
-        ];
+          });
+        }
+        return tabsList;
       },
     },
     mounted() {


### PR DESCRIPTION
## Summary

Hide Difficult questions tab if the exam is still a draft.

non-draft quiz:
![image](https://github.com/learningequality/kolibri/assets/51239030/90ff837c-7797-447e-b8df-ebdc88682716)

draft quiz:
![image](https://github.com/learningequality/kolibri/assets/51239030/9d03cc9c-965f-4adf-8461-b13ef276b0e7)


## References
Closes #12431.

----

## Testing checklist

- [x] Contributor has fully tested the PR manually
- [ ] If there are any front-end changes, before/after screenshots are included
- [ ] Critical user journeys are covered by Gherkin stories
- [ ] Critical and brittle code paths are covered by unit tests


## PR process

- [x] PR has the correct target branch and milestone
- [x] PR has 'needs review' or 'work-in-progress' label
- [ ] If PR is ready for review, a reviewer has been added. (Don't use 'Assignees')
- [ ] If this is an important user-facing change, PR or related issue has a 'changelog' label
- [ ] If this includes an internal dependency change, a link to the diff is provided

## Reviewer checklist

- Automated test coverage is satisfactory
- PR is fully functional
- PR has been tested for [accessibility regressions](http://kolibri-dev.readthedocs.io/en/develop/manual_testing.html#accessibility-a11y-testing)
- External dependency files were updated if necessary (`yarn` and `pip`)
- Documentation is updated
- Contributor is in AUTHORS.md
